### PR TITLE
Replace `Path.toString()` with `fsPath()`

### DIFF
--- a/packages/core/src/browser/label-provider.spec.ts
+++ b/packages/core/src/browser/label-provider.spec.ts
@@ -17,6 +17,7 @@
 import { expect } from 'chai';
 import { DefaultUriLabelProviderContribution, URIIconReference } from './label-provider';
 import URI from '../common/uri';
+import { OS } from '../common/os';
 
 describe('DefaultUriLabelProviderContribution', function (): void {
 
@@ -31,7 +32,11 @@ describe('DefaultUriLabelProviderContribution', function (): void {
         const prov = new DefaultUriLabelProviderContribution();
         const longName = prov.getLongName(new URI('file:///tmp/hello/you.txt'));
 
-        expect(longName).eq('/tmp/hello/you.txt');
+        if (OS.backend.isWindows) {
+            expect(longName).eq('\\tmp\\hello\\you.txt');
+        } else {
+            expect(longName).eq('/tmp/hello/you.txt');
+        }
     });
 
     it('should return icon class for something that seems to be a file', function (): void {

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -179,7 +179,7 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
                 return this.formatUri(uri, formatting);
             }
         }
-        return uri && uri.path.toString();
+        return uri && uri.path.fsPath();
     }
 
     protected getUri(element: URI | URIIconReference): URI | undefined {

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -45,7 +45,7 @@ export class URI {
             return base;
         }
         if (this.path.isRoot) {
-            return this.path.toString();
+            return this.path.fsPath();
         }
         return '';
     }

--- a/packages/debug/src/browser/model/debug-source.ts
+++ b/packages/debug/src/browser/model/debug-source.ts
@@ -63,7 +63,7 @@ export class DebugSource extends DebugSourceData {
 
     get name(): string {
         if (this.inMemory) {
-            return this.raw.name || this.uri.path.base || this.uri.path.toString();
+            return this.raw.name || this.uri.path.base || this.uri.path.fsPath();
         }
         return this.labelProvider.getName(this.uri);
     }

--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -71,7 +71,7 @@ export class EditorWidgetFactory implements WidgetFactory {
     }
 
     private setLabels(editor: EditorWidget, uri: URI): void {
-        editor.title.caption = uri.path.toString();
+        editor.title.caption = uri.path.fsPath();
         const icon = this.labelProvider.getIcon(uri);
         editor.title.label = this.labelProvider.getName(uri);
         editor.title.iconClass = icon + ' file-icon';

--- a/packages/editor/src/browser/quick-editor-service.ts
+++ b/packages/editor/src/browser/quick-editor-service.ts
@@ -80,7 +80,7 @@ export class QuickEditorService implements QuickAccessContribution, QuickAccessP
             label: this.labelProvider.getName(uri),
             description: description,
             iconClasses,
-            ariaLabel: uri.path.toString(),
+            ariaLabel: uri.path.fsPath(),
             alwaysShow: true,
             execute: () => this.openFile(uri)
         };

--- a/packages/filesystem/src/browser/location/location-renderer.tsx
+++ b/packages/filesystem/src/browser/location/location-renderer.tsx
@@ -187,7 +187,7 @@ export class LocationListRenderer extends ReactRenderer {
     protected renderTextInput(): React.ReactNode {
         return (
             <input className={'theia-select ' + LocationListRenderer.Styles.LOCATION_TEXT_INPUT_CLASS}
-                defaultValue={this.service.location?.path.toString()}
+                defaultValue={this.service.location?.path.fsPath()}
                 onBlur={this.handleTextInputOnBlur}
                 onChange={this.handleTextInputOnChange}
                 onKeyDown={this.handleTextInputKeyDown}
@@ -278,7 +278,7 @@ export class LocationListRenderer extends ReactRenderer {
     protected renderLocation(location: LocationListRenderer.Location): React.ReactNode {
         const { uri, isDrive } = location;
         const value = uri.toString();
-        return <option value={value} key={uri.toString()}>{isDrive ? uri.path.toString() : uri.displayName}</option>;
+        return <option value={value} key={uri.toString()}>{isDrive ? uri.path.fsPath() : uri.displayName}</option>;
     }
 
     protected onLocationChanged(e: React.ChangeEvent<HTMLSelectElement>): void {

--- a/packages/markers/src/browser/marker-tree-label-provider.spec.ts
+++ b/packages/markers/src/browser/marker-tree-label-provider.spec.ts
@@ -40,6 +40,7 @@ import { FileStat } from '@theia/filesystem/lib/common/files';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { MockEnvVariablesServerImpl } from '@theia/core/lib/browser/test/mock-env-variables-server';
 import { FileUri } from '@theia/core/lib/node';
+import { OS } from '@theia/core/lib/common/os';
 import * as temp from 'temp';
 
 disableJSDOM();
@@ -131,7 +132,11 @@ describe('Marker Tree Label Provider', () => {
                 const label = markerTreeLabelProvider.getLongName(
                     createMarkerInfoNode('file:///home/b/foo.ts')
                 );
-                expect(label).equals('/home/b');
+                if (OS.backend.isWindows) {
+                    expect(label).eq('\\home\\b');
+                } else {
+                    expect(label).eq('/home/b');
+                }
             });
         });
         describe('multi-root workspace', () => {
@@ -165,7 +170,12 @@ describe('Marker Tree Label Provider', () => {
                 const label = markerTreeLabelProvider.getLongName(
                     createMarkerInfoNode('file:///home/a/b/foo.ts')
                 );
-                expect(label).equals('/home/a/b');
+
+                if (OS.backend.isWindows) {
+                    expect(label).eq('\\home\\a\\b');
+                } else {
+                    expect(label).eq('/home/a/b');
+                }
             });
         });
     });

--- a/packages/markers/src/browser/problem/problem-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-decorator.ts
@@ -109,10 +109,10 @@ export class ProblemDecorator implements TreeDecorator {
         if (parentWorkspace) {
             const relativeDirFromWorkspace = parentWorkspace.relative(nodeURIDir);
             workspacePrefixString = workspaceRoots.length > 1 ? this.labelProvider.getName(parentWorkspace) : '';
-            filePathString = relativeDirFromWorkspace?.toString() ?? '';
+            filePathString = relativeDirFromWorkspace?.fsPath() ?? '';
             separator = filePathString && workspacePrefixString ? ' \u2022 ' : ''; // add a bullet point between workspace and path
         } else {
-            workspacePrefixString = nodeURIDir.path.toString();
+            workspacePrefixString = nodeURIDir.path.fsPath();
         }
         return `${workspacePrefixString}${separator}${filePathString}`;
     }

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -143,10 +143,10 @@ export class OpenEditorsWidget extends FileTreeWidget {
         if (parentWorkspace) {
             const relativeDirFromWorkspace = parentWorkspace.relative(nodeURIDir);
             workspacePrefixString = workspaceRoots.length > 1 ? this.labelProvider.getName(parentWorkspace) : '';
-            filePathString = relativeDirFromWorkspace?.toString() ?? '';
+            filePathString = relativeDirFromWorkspace?.fsPath() ?? '';
             separator = filePathString && workspacePrefixString ? ' \u2022 ' : ''; // add a bullet point between workspace and path
         } else {
-            workspacePrefixString = nodeURIDir.path.toString();
+            workspacePrefixString = nodeURIDir.path.fsPath();
         }
         return [{
             fontData: { color },

--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -226,7 +226,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
         } else {
             const items: QuickPickItem[] = roots.map(root => ({
                 label: root.name,
-                description: root.resource.path.toString(),
+                description: root.resource.path.fsPath(),
                 execute: () => callback(root)
             }));
             this.quickInputService?.showQuickPick(items, { placeholder: 'Select workspace folder' });

--- a/packages/preferences/src/browser/views/components/preference-file-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-file-input.ts
@@ -93,7 +93,7 @@ export class PreferenceSingleFilePathInputRenderer extends PreferenceStringInput
         const title = selectionProps?.title ?? selectionProps?.canSelectFolders ? WorkspaceCommands.OPEN_FOLDER.dialogLabel : WorkspaceCommands.OPEN_FILE.dialogLabel;
         const selection = await this.fileDialogService.showOpenDialog({ title, ...selectionProps });
         if (selection) {
-            this.setPreferenceImmediately(selection.path.toString());
+            this.setPreferenceImmediately(selection.path.fsPath());
         }
     }
 

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
@@ -116,7 +116,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     }
 
     protected getLocationString(fileStat: FileStat): string {
-        return fileStat.resource.path.toString();
+        return fileStat.resource.path.fsPath();
     }
 
     protected getFileName(fileStat: FileStat): string {

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -525,10 +525,10 @@ export class ScmResourceComponent extends ScmElement<ScmResourceComponent.Props>
         const letter = decoration && decoration.letter || '';
         const tooltip = decoration && decoration.tooltip || '';
         const relativePath = parentPath.relative(resourceUri.parent);
-        const path = relativePath ? relativePath.toString() : labelProvider.getLongName(resourceUri.parent);
+        const path = relativePath ? relativePath.fsPath() : labelProvider.getLongName(resourceUri.parent);
         const title = tooltip.length !== 0
-            ? `${resourceUri.path.toString()} • ${tooltip}`
-            : resourceUri.path.toString();
+            ? `${resourceUri.path.fsPath()} • ${tooltip}`
+            : resourceUri.path.fsPath();
 
         return <div key={sourceUri}
             className={`scmItem ${TREE_NODE_SEGMENT_CLASS} ${TREE_NODE_SEGMENT_GROW_CLASS}`}
@@ -684,7 +684,7 @@ export class ScmResourceFolderElement extends ScmElement<ScmResourceFolderElemen
         const { model, treeNode, sourceUri, labelProvider, commands, menus, contextKeys, caption } = this.props;
         const sourceFileStat: FileStat = { uri: sourceUri, isDirectory: true, lastModification: 0 };
         const icon = labelProvider.getIcon(sourceFileStat);
-        const title = new URI(sourceUri).path.toString();
+        const title = new URI(sourceUri).path.fsPath();
 
         return <div key={sourceUri}
             className={`scmItem  ${TREE_NODE_SEGMENT_CLASS} ${TREE_NODE_SEGMENT_GROW_CLASS} ${ScmTreeWidget.Styles.NO_SELECT}`}

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -470,7 +470,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         const collapseValue: string = this.searchInWorkspacePreferences['search.collapseResults'];
         let path: string;
         if (result.root === this.defaultRootName) {
-            path = new URI(result.fileUri).path.dir.toString();
+            path = new URI(result.fileUri).path.dir.fsPath();
         } else {
             path = this.filenameAndPath(result.root, result.fileUri).path;
         }
@@ -662,7 +662,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         const uri = new URI(rootUri);
         return {
             selected: false,
-            path: uri.path.toString(),
+            path: uri.path.fsPath(),
             folderUri: rootUri,
             uri: new URI(rootUri),
             children: [],
@@ -718,7 +718,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         const relativePath = new URI(rootUriStr).relative(uri.parent);
         return {
             name: this.labelProvider.getName(uri),
-            path: relativePath ? relativePath.toString() : ''
+            path: relativePath ? relativePath.fsPath() : ''
         };
     }
 
@@ -980,7 +980,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         return <div className='result'>
             <div className='result-head'>
                 <div className={`result-head-info noWrapInfo noselect ${node.selected ? 'selected' : ''}`}
-                    title={new URI(node.fileUri).path.toString()}>
+                    title={new URI(node.fileUri).path.fsPath()}>
                     <span className={`file-icon ${this.toNodeIcon(node)}`}></span>
                     <div className='noWrapInfo'>
                         <span className={'file-name'}>

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -440,7 +440,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
                 await this.workspaceService.save(selected);
                 return true;
             } catch {
-                this.messageService.error(nls.localizeByDefault("Unable to save workspace '{0}'", selected.path.toString()));
+                this.messageService.error(nls.localizeByDefault("Unable to save workspace '{0}'", selected.path.fsPath()));
             }
         }
         return false;

--- a/packages/workspace/src/browser/workspace-input-dialog.ts
+++ b/packages/workspace/src/browser/workspace-input-dialog.ts
@@ -51,7 +51,7 @@ export class WorkspaceInputDialog extends SingleTextInputDialog {
         icon.style.marginRight = '0.5em';
         icon.style.verticalAlign = 'middle';
         element.style.verticalAlign = 'middle';
-        element.title = this.props.parentUri.path.toString();
+        element.title = this.props.parentUri.path.fsPath();
         element.appendChild(icon);
         element.appendChild(document.createTextNode(label));
         // Add the path and icon div before the `inputField`.

--- a/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
@@ -32,6 +32,7 @@ import { FileStat } from '@theia/filesystem/lib/common/files';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { MockEnvVariablesServerImpl } from '@theia/core/lib/browser/test/mock-env-variables-server';
 import { FileUri } from '@theia/core/lib/node';
+import { OS } from '@theia/core/lib/common/os';
 import * as temp from 'temp';
 
 after(() => disableJSDOM());
@@ -155,20 +156,35 @@ describe('WorkspaceUriLabelProviderContribution class', () => {
         it('should return the absolute path of a file from the file\'s URI if the file is not in the workspace', () => {
             const file = new URI('file:///tmp/prout.txt');
             const longName = labelProvider.getLongName(file);
-            expect(longName).eq('/tmp/prout.txt');
+
+            if (OS.backend.isWindows) {
+                expect(longName).eq('\\tmp\\prout.txt');
+            } else {
+                expect(longName).eq('/tmp/prout.txt');
+            }
         });
 
         it('should return the absolute path of a file from the file\'s FileStat if the file is not in the workspace', () => {
             const file: FileStat = FileStat.file('file:///tmp/prout.txt');
             const longName = labelProvider.getLongName(file);
-            expect(longName).eq('/tmp/prout.txt');
+
+            if (OS.backend.isWindows) {
+                expect(longName).eq('\\tmp\\prout.txt');
+            } else {
+                expect(longName).eq('/tmp/prout.txt');
+            }
         });
 
         it('should return the path of a file if WorkspaceService returns no roots', () => {
             roots = [];
             const file = new URI('file:///tmp/prout.txt');
             const longName = labelProvider.getLongName(file);
-            expect(longName).eq('/tmp/prout.txt');
+
+            if (OS.backend.isWindows) {
+                expect(longName).eq('\\tmp\\prout.txt');
+            } else {
+                expect(longName).eq('/tmp/prout.txt');
+            }
         });
     });
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/10830

Simply does as the commit says. Since we often display file system paths to the user, formatting them in the style of the backend operating system is often preferable. That's what `Path.fsPath()` does.

#### How to test

You will need a Windows system to test the improved behavior.

Assert that the paths displayed in tooltips, messages, etc. are correctly formatted for the actual backend system:

* Search in workspace view
* Editor tabs
* Open Editors view
* Navigator view
* Problem view
* Preferences (such as the `Windows Exec` with its browse functionality) 
* Property view (for files)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
