### PR TITLE
Allow SourceTree elements to accept focus

### DIFF
--- a/packages/core/src/browser/source-tree/source-tree-widget.tsx
+++ b/packages/core/src/browser/source-tree/source-tree-widget.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { injectable, postConstruct, interfaces, Container } from 'inversify';
 import { DisposableCollection } from '../../common/disposable';
-import { TreeWidget, TreeNode, createTreeContainer, TreeProps, TreeModel } from '../tree';
+import { TreeWidget, TreeNode, createTreeContainer, TreeProps, TreeModel, NodeProps } from '../tree';
 import { TreeSource, TreeElement } from './tree-source';
 import { SourceTree, TreeElementNode, TreeSourceNode } from './source-tree';
 
@@ -76,6 +76,14 @@ export class SourceTreeWidget extends TreeWidget {
         }
         return super.renderTree(model);
 
+    }
+
+    protected override createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+        const attributes = super.createNodeAttributes(node, props);
+        if (TreeElementNode.is(node) && node.element.acceptFocus) {
+            attributes.tabIndex = 0;
+        }
+        return attributes;
     }
 
     protected override renderCaption(node: TreeNode): React.ReactNode {

--- a/packages/core/src/browser/source-tree/tree-source.ts
+++ b/packages/core/src/browser/source-tree/tree-source.ts
@@ -26,7 +26,9 @@ export interface TreeElement {
     /** default: parent id + position among siblings */
     readonly id?: number | string | undefined
     /** default: true */
-    readonly visible?: boolean
+    readonly visible?: boolean;
+    /** default: false */
+    readonly acceptFocus?: boolean;
     render(): ReactNode
     open?(): MaybePromise<any>
 }

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -88,17 +88,17 @@
     transform: rotate(-90deg);
 }
 
-.theia-Tree:focus .theia-TreeNode.theia-mod-selected,
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected,
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected {
     background: var(--theia-list-activeSelectionBackground);
     color: var(--theia-list-activeSelectionForeground) !important;
 }
 
-.theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,
-.theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
-.theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo,
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo,
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo,
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeSegment {
     color: var(--theia-list-activeSelectionForeground) !important;

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -118,6 +118,10 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
 
     protected readonly data: Partial<VSXExtensionData> = {};
 
+    get acceptFocus(): boolean {
+        return true;
+    }
+
     get uri(): URI {
         return VSXExtensionUri.toUri(this.id);
     }
@@ -389,19 +393,19 @@ export abstract class AbstractVSXExtensionComponent extends React.Component<Abst
         const extension = this.props.extension;
         const { builtin, busy, installed } = extension;
         if (builtin) {
-            return <div className="codicon codicon-settings-gear action" onClick={this.manage}></div>;
+            return <div className="codicon codicon-settings-gear action" tabIndex={0} onClick={this.manage}></div>;
         }
         if (busy) {
             if (installed) {
-                return <button className="theia-button action theia-mod-disabled">Uninstalling</button>;
+                return <button className="theia-button action theia-mod-disabled" tabIndex={0}>Uninstalling</button>;
             }
-            return <button className="theia-button action prominent theia-mod-disabled">Installing</button>;
+            return <button className="theia-button action prominent theia-mod-disabled" tabIndex={0}>Installing</button>;
         }
         if (installed) {
-            return <div><button className="theia-button action" onClick={this.uninstall}>Uninstall</button>
-                <div className="codicon codicon-settings-gear action" onClick={this.manage}></div></div>;
+            return <div><button className="theia-button action" tabIndex={0} onClick={this.uninstall}>Uninstall</button>
+                <div className="codicon codicon-settings-gear action" tabIndex={0} onClick={this.manage}></div></div>;
         }
-        return <button className="theia-button prominent action" onClick={this.install}>Install</button>;
+        return <button className="theia-button prominent action" tabIndex={0} onClick={this.install}>Install</button>;
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8101 by changing the way focus is handled in the VSX trees. Previously clicking a VSX node caused focus to shift to the TreeWidget's node, triggering `TreeWidget.doFocus`, which selected the top node and scrolled to it. Since all of that occurred on `mouseDown`, it occurred before the `click` event that would select the desired node. By allowing the node itself to accept focus, we avoid the call to `TreeWidget.doFocus`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a VSX tree view with a number of elements (e.g. the builtins view) - don't select anything
2. Scroll down in the view.
3. Select a node.
4. The node should be selected, show focus-selected colors, have a focus outline, and remain in view.
> Note that in VSCode, such nodes also have a focus outline: 

![image](https://user-images.githubusercontent.com/62660806/169624927-f77fdd0b-92ad-424d-9137-fe4be0a9f1da.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
