### PR TITLE
task: fix problem matcher failed when kind is file

### DIFF
--- a/packages/task/src/node/task-abstract-line-matcher.ts
+++ b/packages/task/src/node/task-abstract-line-matcher.ts
@@ -295,9 +295,7 @@ export abstract class AbstractLineMatcher {
             const regexp = new RegExp(this.activePattern.regexp);
             const regexMatches = regexp.exec(line);
             if (regexMatches) {
-                if (this.activePattern.kind !== undefined && this.cachedProblemData.kind === undefined) {
-                    this.cachedProblemData.kind = this.activePattern.kind;
-                }
+                this.cachedProblemData.kind ??= this.activePattern.kind;
                 return this.fillProblemData(this.cachedProblemData, this.activePattern, regexMatches);
             }
         }

--- a/packages/task/src/node/task-abstract-line-matcher.ts
+++ b/packages/task/src/node/task-abstract-line-matcher.ts
@@ -295,7 +295,7 @@ export abstract class AbstractLineMatcher {
             const regexp = new RegExp(this.activePattern.regexp);
             const regexMatches = regexp.exec(line);
             if (regexMatches) {
-                if (this.activePattern.kind !== undefined && this.cachedProblemData.kind !== undefined) {
+                if (this.activePattern.kind !== undefined && this.cachedProblemData.kind === undefined) {
                     this.cachedProblemData.kind = this.activePattern.kind;
                 }
                 return this.fillProblemData(this.cachedProblemData, this.activePattern, regexMatches);

--- a/packages/task/src/node/task-problem-collector.spec.ts
+++ b/packages/task/src/node/task-problem-collector.spec.ts
@@ -232,7 +232,7 @@ describe('ProblemCollector', () => {
 
         expect(allMatches.length).to.eq(4);
 
-        expect((allMatches[0] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[0] as ProblemMatchData).resource?.path).eq('/home/test/test-dir.js');
         expect((allMatches[0] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Warning,

--- a/packages/task/src/node/task-problem-collector.spec.ts
+++ b/packages/task/src/node/task-problem-collector.spec.ts
@@ -60,6 +60,29 @@ const startStopMatcher2: ProblemMatcher = {
     severity: Severity.Error
 };
 
+
+const startStopMatcher3: ProblemMatcher = {
+    owner: 'test2',
+    source: 'test2',
+    applyTo: ApplyToKind.allDocuments,
+    fileLocation: FileLocationKind.Absolute,
+    pattern: [
+        {
+            regexp: /^([^\s].*)$/.source,
+            kind: ProblemLocationKind.File,
+            file: 1
+        },
+        {
+            regexp: /^\s+(\d+):(\d+)\s+(error|warning|info)\s+(.+?)(?:\s\s+(.*))?$/.source,
+            severity: 3,
+            message: 4,
+            code: 5,
+            loop: true
+        }
+    ],
+    severity: Severity.Error
+};
+
 const watchMatcher: ProblemMatcher = {
     owner: 'test3',
     applyTo: ApplyToKind.closedDocuments,
@@ -183,6 +206,62 @@ describe('ProblemCollector', () => {
         expect((allMatches[3] as ProblemMatchData).resource!.path).eq('/home/test/more-test.js');
         expect((allMatches[3] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 12, character: 8 }, end: { line: 12, character: 8 } },
+            severity: DiagnosticSeverity.Error,
+            source: 'test2',
+            message: 'Parsing error: Unexpected token 1000'
+        });
+    });
+
+    it('should find problems from start-stop task when problem matcher is associated with more than one problem pattern and kind is file', () => {
+        collector = new ProblemCollector([startStopMatcher3]);
+        collectMatches([
+            '> test@0.1.0 lint /home/test',
+            '> eslint .',
+            '',
+            '',
+            '/home/test/test-dir.js',
+            '  14:21  warning  Missing semicolon  semi',
+            '  15:23  warning  Missing semicolon  semi',
+            '  103:9  error  Parsing error: Unexpected token inte',
+            '',
+            '/home/test/more-test.js',
+            '  13:9  error  Parsing error: Unexpected token 1000',
+            '',
+            '✖ 3 problems (1 error, 2 warnings)',
+            '  0 errors and 2 warnings potentially fixable with the `--fix` option.'
+        ]);
+
+        expect(allMatches.length).to.eq(4);
+
+        expect((allMatches[0] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[0] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+            severity: DiagnosticSeverity.Warning,
+            source: 'test2',
+            message: 'Missing semicolon',
+            code: 'semi'
+        });
+
+        expect((allMatches[1] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[1] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+            severity: DiagnosticSeverity.Warning,
+            source: 'test2',
+            message: 'Missing semicolon',
+            code: 'semi'
+        });
+
+        expect((allMatches[2] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[2] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+            severity: DiagnosticSeverity.Error,
+            source: 'test2',
+            message: 'Parsing error: Unexpected token inte'
+        });
+
+        expect((allMatches[3] as ProblemMatchData).resource!.path).eq('/home/test/more-test.js');
+        expect((allMatches[3] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Error,
             source: 'test2',
             message: 'Parsing error: Unexpected token 1000'

--- a/packages/task/src/node/task-problem-collector.spec.ts
+++ b/packages/task/src/node/task-problem-collector.spec.ts
@@ -60,7 +60,6 @@ const startStopMatcher2: ProblemMatcher = {
     severity: Severity.Error
 };
 
-
 const startStopMatcher3: ProblemMatcher = {
     owner: 'test2',
     source: 'test2',

--- a/packages/task/src/node/task-problem-collector.spec.ts
+++ b/packages/task/src/node/task-problem-collector.spec.ts
@@ -241,7 +241,7 @@ describe('ProblemCollector', () => {
             code: 'semi'
         });
 
-        expect((allMatches[1] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[1] as ProblemMatchData).resource?.path).eq('/home/test/test-dir.js');
         expect((allMatches[1] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Warning,
@@ -250,7 +250,7 @@ describe('ProblemCollector', () => {
             code: 'semi'
         });
 
-        expect((allMatches[2] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[2] as ProblemMatchData).resource?.path).eq('/home/test/test-dir.js');
         expect((allMatches[2] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Error,
@@ -258,7 +258,7 @@ describe('ProblemCollector', () => {
             message: 'Parsing error: Unexpected token inte'
         });
 
-        expect((allMatches[3] as ProblemMatchData).resource!.path).eq('/home/test/more-test.js');
+        expect((allMatches[3] as ProblemMatchData).resource?.path).eq('/home/test/more-test.js');
         expect((allMatches[3] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Error,


### PR DESCRIPTION
Signed-off-by: bob <bob170731@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

It will always fails when task problem matcher `kind` is `file` as this:

```json
{
    "tasks":
    [
        {
            "command": "cat test.log",
            "label": "test",
            "problemMatcher":
            {
                "fileLocation": "absolute",
                "owner": "Test",
                "pattern":
                [
                    {
                        "file": 1,
                        "kind": "file",
                        "regexp": "^([^\\s].*)$"
                    },
                    {
                        "code": 5,
                        "loop": true,
                        "message": 4,
                        "regexp": "^\\s+(\\d+):(\\d+)\\s+(error|warning|info)\\s+(.+?)(?:\\s\\s+(.*))?$",
                        "severity": 3
                    }
                ]
            },
            "type": "shell"
        }
    ],
    "version": "2.0.0"
}
```
the test log should be 
```
> test@0.1.0 lint /home/test
> eslint .


/home/test/test-dir.js
  14:21  warning  Missing semicolon  semi
  15:23  warning  Missing semicolon  semi
  103:9  error  Parsing error: Unexpected token inte

/home/test/more-test.js
  13:9  error  Parsing error: Unexpected token 1000

✖ 3 problems (1 error 2 warnings)
  0 errors and 2 warnings potentially fixable with the `--fix` option.
```

this is the `startStopMatcher2` case from `packages/task/src/node/task-problem-collector.spec.ts`, I just changes the `kind` from `location` to `file`.

the main cause is that the `this.cachedProblemData.kind` will always be `undefined` when cachedProblemData is created. just changes the `not be undefined` to `be undefined`

```ts
protected doOneLineMatch(line: string): boolean {
    if (this.activePattern) {
        const regexp = new RegExp(this.activePattern.regexp);
        const regexMatches = regexp.exec(line);
        if (regexMatches) {
            if (this.activePattern.kind !== undefined && this.cachedProblemData.kind !== undefined) {
                this.cachedProblemData.kind = this.activePattern.kind;
            }
            return this.fillProblemData(this.cachedProblemData, this.activePattern, regexMatches);
        }
    }
    return false;
}
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
