### PR TITLE
Align focused button outline to vscode

### DIFF
--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -78,11 +78,6 @@
     min-height: 21px;
 }
 
-.dialogOverlay :focus {
-  box-shadow: 0px 0px 1px 1px var(--theia-focusBorder);
-  outline: none;
-}
-
 .p-Widget.dialogOverlay.hidden {
     display: none;
 }

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -200,13 +200,15 @@ button.theia-button, .theia-button {
     cursor: pointer;
     padding: 4px 9px;
     margin-left: calc(var(--theia-ui-padding)*2);
-    border-radius: 1px;
-    box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.2), 0px 1px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 1px -2px rgba(0, 0, 0, 0.12);
-    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-button.theia-button:hover, .theia-button:hover, .theia-button:focus {
+.theia-button:hover {
   background-color: var(--theia-button-hoverBackground);
+}
+
+.theia-button:focus {
+  outline: 1px solid var(--theia-focusBorder);
+  outline-offset: 1px;
 }
 
 button.secondary, .theia-button.secondary {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11191

Removes box shadows, etc. from `theia-button` elements and adds an outline instead 

#### How to test

1. Open a dialog by - for example - trying to delete a file.
2. Assert that the buttons behave as in vscode in regards to hover/focus behavior.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
