### PR TITLE
core: bind `UntitledResourceResolver` in core

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -30,7 +30,8 @@ import {
     MessageClient,
     InMemoryResources,
     messageServicePath,
-    InMemoryTextResourceResolver
+    InMemoryTextResourceResolver,
+    UntitledResourceResolver
 } from '../common';
 import { KeybindingRegistry, KeybindingContext, KeybindingContribution } from './keybinding';
 import { FrontendApplication, FrontendApplicationContribution, DefaultFrontendApplicationContribution } from './frontend-application';
@@ -222,6 +223,9 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
 
     bind(InMemoryTextResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(InMemoryTextResourceResolver);
+
+    bind(UntitledResourceResolver).toSelf().inSingletonScope();
+    bind(ResourceResolver).toService(UntitledResourceResolver);
 
     bind(SelectionService).toSelf().inSingletonScope();
     bind(CommandRegistry).toSelf().inSingletonScope().onActivation(({ container }, registry) => {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -35,7 +35,6 @@ import { PluginWidget } from './plugin-ext-widget';
 import { PluginFrontendViewContribution } from './plugin-frontend-view-contribution';
 import { PluginExtDeployCommandService } from './plugin-ext-deploy-command';
 import { EditorModelService } from './text-editor-model-service';
-import { UntitledResourceResolver } from './editor/untitled-resource';
 import { CodeEditorWidgetUtil, MenusContributionPointHandler } from './menus/menus-contribution-handler';
 import { PluginContributionHandler } from './plugin-contribution-handler';
 import { PluginViewRegistry, PLUGIN_VIEW_CONTAINER_FACTORY_ID, PLUGIN_VIEW_FACTORY_ID, PLUGIN_VIEW_DATA_FACTORY_ID } from './view/plugin-view-registry';
@@ -107,9 +106,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(CommandContribution).toService(PluginApiFrontendContribution);
 
     bind(EditorModelService).toSelf().inSingletonScope();
-
-    bind(UntitledResourceResolver).toSelf().inSingletonScope();
-    bind(ResourceResolver).toService(UntitledResourceResolver);
 
     bind(FrontendApplicationContribution).toDynamicValue(ctx => ({
         onStart(): MaybePromise<void> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit updates the binding of `UntitledResourceResolver` so that it is bound in `core` as it was moved around previously to be accessible outside of the plugin-system. Since the old binding was not updated the untitled functionality would break for apps that did not depend on plugin dependencies ([forum discussion](https://community.theia-ide.org/t/error-child-node-open-editors-root-does-not-belong-to-this-open-editors-root-tree/2407))


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. confirm that the `untitled` behavior still works well (`new editor` in the application).
2. a little trickier to test but the idea is if an application does not have `plugin` dependencies then the `new editor` functionality should still work.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>