### PR TITLE
Improve TreeWidget Focus Handling and Keyboard Navigation

### DIFF
--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
@@ -69,8 +69,8 @@ export class BulkEditTreeWidget extends TreeWidget {
         this.quickView?.showItem(BULK_EDIT_WIDGET_NAME);
     }
 
-    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
-        super.handleClickEvent(node, event);
+    protected override tapNode(node?: TreeNode): void {
+        super.tapNode(node);
         if (BulkEditNode.is(node)) {
             this.doOpen(node);
         }

--- a/packages/core/src/browser/source-tree/source-tree-widget.tsx
+++ b/packages/core/src/browser/source-tree/source-tree-widget.tsx
@@ -81,7 +81,7 @@ export class SourceTreeWidget extends TreeWidget {
     protected override renderCaption(node: TreeNode): React.ReactNode {
         if (TreeElementNode.is(node)) {
             const classNames = this.createTreeElementNodeClassNames(node);
-            return <div className={classNames.join(' ')}>{node.element.render()}</div>;
+            return <div className={classNames.join(' ')}>{node.element.render(this)}</div>;
         }
         return undefined;
     }

--- a/packages/core/src/browser/source-tree/tree-source.ts
+++ b/packages/core/src/browser/source-tree/tree-source.ts
@@ -21,13 +21,14 @@ import { injectable, unmanaged } from 'inversify';
 import { Emitter, Event } from '../../common/event';
 import { MaybePromise } from '../../common/types';
 import { Disposable, DisposableCollection } from '../../common/disposable';
+import { TreeWidget } from '../tree';
 
 export interface TreeElement {
     /** default: parent id + position among siblings */
     readonly id?: number | string | undefined
     /** default: true */
     readonly visible?: boolean
-    render(): ReactNode
+    render(host: TreeWidget): ReactNode
     open?(): MaybePromise<any>
 }
 

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -27,7 +27,16 @@
     position: relative;
 }
 
-.theia-Tree:focus .theia-TreeContainer.empty {
+.theia-Tree:focus .theia-TreeContainer.empty::before,
+.theia-Tree:focus .theia-TreeContainer.focused::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 10;
+    content: "";
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -1px;

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -88,20 +88,24 @@
     transform: rotate(-90deg);
 }
 
-.theia-Tree:focus .theia-TreeNode.theia-mod-selected,
-.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected {
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected {
     background: var(--theia-list-activeSelectionBackground);
     color: var(--theia-list-activeSelectionForeground) !important;
 }
 
-.theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,
-.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,
-.theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
-.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
-.theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo,
-.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo,
-.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeSegment {
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo,
+.theia-Tree:focus-within .theia-TreeNode.theia-mod-selected .theia-TreeNodeSegment {
     color: var(--theia-list-activeSelectionForeground) !important;
+}
+
+.theia-Tree:focus .theia-TreeNode.theia-mod-focus,
+.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-focus {
+    outline-width: 1px;
+    outline-style: solid;
+    outline-offset: -1px;
+    outline-color: var(--theia-focusBorder);
 }
 
 .theia-TreeNodeInfo {

--- a/packages/core/src/browser/tree/test/tree-test-container.ts
+++ b/packages/core/src/browser/tree/test/tree-test-container.ts
@@ -26,6 +26,7 @@ import { FuzzySearch } from '../fuzzy-search';
 import { MockLogger } from '../../../common/test/mock-logger';
 import { ILogger, bindContributionProvider } from '../../../common';
 import { LabelProviderContribution, LabelProvider } from '../../label-provider';
+import { TreeFocusService, TreeFocusServiceImpl } from '../tree-focus-service';
 
 export function createTreeTestContainer(): Container {
     const container = new Container({ defaultScope: 'Singleton' });
@@ -41,6 +42,7 @@ export function createTreeTestContainer(): Container {
     container.bind(TreeSearch).toSelf();
     container.bind(FuzzySearch).toSelf();
     container.bind(MockLogger).toSelf();
+    container.bind(TreeFocusService).to(TreeFocusServiceImpl);
     container.bind(ILogger).to(MockLogger);
     bindContributionProvider(container, LabelProviderContribution);
     container.bind(LabelProvider).toSelf().inSingletonScope();

--- a/packages/core/src/browser/tree/tree-compression/compressed-tree-model.ts
+++ b/packages/core/src/browser/tree/tree-compression/compressed-tree-model.ts
@@ -38,8 +38,14 @@ export class CompressedTreeModel extends TreeModelImpl {
     @inject(CompressionToggle) protected readonly compressionToggle: CompressionToggle;
     @inject(TreeCompressionService) protected readonly compressionService: TreeCompressionService;
 
-    protected selectAdjacentRow(direction: BackOrForward, type: TreeSelection.SelectionType = TreeSelection.SelectionType.DEFAULT): void {
-        let startingPoint: TreeNode | undefined = this.getFocusedNode();
+    protected selectAdjacentRow(
+        direction: BackOrForward,
+        type: TreeSelection.SelectionType = TreeSelection.SelectionType.DEFAULT,
+        startingPoint: Readonly<TreeNode> | undefined = this.getFocusedNode()
+    ): void {
+        if (!startingPoint && this.root) {
+            this.selectAdjacentRow(BackOrForward.Forward, type, this.root);
+        }
         if (this.compressionService.isCompressionParticipant(startingPoint)) {
             const chain = this.compressionService.getCompressionChain(startingPoint);
             startingPoint = (direction === BackOrForward.Backward ? chain?.head() : chain?.tail()) ?? startingPoint;

--- a/packages/core/src/browser/tree/tree-compression/compressed-tree-model.ts
+++ b/packages/core/src/browser/tree/tree-compression/compressed-tree-model.ts
@@ -39,7 +39,7 @@ export class CompressedTreeModel extends TreeModelImpl {
     @inject(TreeCompressionService) protected readonly compressionService: TreeCompressionService;
 
     protected selectAdjacentRow(direction: BackOrForward, type: TreeSelection.SelectionType = TreeSelection.SelectionType.DEFAULT): void {
-        let startingPoint: TreeNode = this.selectedNodes[0];
+        let startingPoint: TreeNode | undefined = this.getFocusedNode();
         if (this.compressionService.isCompressionParticipant(startingPoint)) {
             const chain = this.compressionService.getCompressionChain(startingPoint);
             startingPoint = (direction === BackOrForward.Backward ? chain?.head() : chain?.tail()) ?? startingPoint;

--- a/packages/core/src/browser/tree/tree-compression/compressed-tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-compression/compressed-tree-widget.tsx
@@ -132,12 +132,14 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
         if (!this.compressionToggle.compress) { return super.handleUp(event); }
         const type = this.props.multiSelect && this.hasShiftMask(event) ? TreeSelection.SelectionType.RANGE : undefined;
         this.model.selectPrevRow(type);
+        this.node.focus();
     }
 
     protected override handleDown(event: KeyboardEvent): void {
         if (!this.compressionToggle.compress) { return super.handleDown(event); }
         const type = this.props.multiSelect && this.hasShiftMask(event) ? TreeSelection.SelectionType.RANGE : undefined;
         this.model.selectNextRow(type);
+        this.node.focus();
     }
 
     protected override async handleLeft(event: KeyboardEvent): Promise<void> {
@@ -145,7 +147,7 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
         if (Boolean(this.props.multiSelect) && (this.hasCtrlCmdMask(event) || this.hasShiftMask(event))) {
             return;
         }
-        const active = this.model.selectedNodes[0];
+        const active = this.focusService.focusedNode;
         if (ExpandableTreeNode.isExpanded(active)
             && (
                 this.compressionService.isCompressionHead(active)
@@ -162,7 +164,7 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
         if (Boolean(this.props.multiSelect) && (this.hasCtrlCmdMask(event) || this.hasShiftMask(event))) {
             return;
         }
-        const active = this.model.selectedNodes[0];
+        const active = this.focusService.focusedNode;
 
         if (ExpandableTreeNode.isCollapsed(active)
             && (

--- a/packages/core/src/browser/tree/tree-container.ts
+++ b/packages/core/src/browser/tree/tree-container.ts
@@ -27,6 +27,7 @@ import { TreeSearch } from './tree-search';
 import { FuzzySearch } from './fuzzy-search';
 import { SearchBox, SearchBoxFactory } from './search-box';
 import { SearchBoxDebounce } from './search-box-debounce';
+import { TreeFocusService, TreeFocusServiceImpl } from './tree-focus-service';
 
 export function isTreeServices(candidate?: Partial<TreeProps> | Partial<TreeContainerProps>): candidate is TreeContainerProps {
     if (candidate) {
@@ -110,6 +111,7 @@ interface TreeServices {
     search: TreeSearch,
     fuzzy: FuzzySearch,
     decoratorService: TreeDecoratorService,
+    focusService: TreeFocusService,
 }
 
 interface TreeTypes extends TreeServices, TreeConstants { }
@@ -132,6 +134,7 @@ const defaultImplementations: TreeContainerProps & { props: TreeProps } = {
     search: TreeSearch,
     fuzzy: FuzzySearch,
     decoratorService: NoopTreeDecoratorService,
+    focusService: TreeFocusServiceImpl,
     props: defaultTreeProps,
     searchBoxFactory: defaultSearchBoxFactoryFactory,
 };
@@ -148,4 +151,5 @@ const serviceIdentifiers: TreeIdentifiers = {
     fuzzy: FuzzySearch,
     searchBoxFactory: SearchBoxFactory,
     decoratorService: TreeDecoratorService,
+    focusService: TreeFocusService
 };

--- a/packages/core/src/browser/tree/tree-focus-service.ts
+++ b/packages/core/src/browser/tree/tree-focus-service.ts
@@ -1,0 +1,55 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from 'inversify';
+import { Emitter, Event } from '../../common';
+import { Tree, TreeNode } from './tree';
+import { SelectableTreeNode } from './tree-selection';
+
+export interface TreeFocusService {
+    readonly focusedNode: SelectableTreeNode | undefined;
+    onDidChangeFocus: Event<SelectableTreeNode | undefined>;
+    setFocus(node?: SelectableTreeNode): void;
+    hasFocus(node?: TreeNode): boolean;
+}
+export const TreeFocusService = Symbol('TreeFocusService');
+
+@injectable()
+export class TreeFocusServiceImpl implements TreeFocusService {
+    protected focusedId: string | undefined;
+    protected onDidChangeFocusEmitter = new Emitter<SelectableTreeNode | undefined>();
+    get onDidChangeFocus(): Event<SelectableTreeNode | undefined> { return this.onDidChangeFocusEmitter.event; }
+
+    @inject(Tree) protected readonly tree: Tree;
+
+    get focusedNode(): SelectableTreeNode | undefined {
+        const candidate = this.tree.getNode(this.focusedId);
+        if (SelectableTreeNode.is(candidate)) {
+            return candidate;
+        }
+    }
+
+    setFocus(node?: SelectableTreeNode): void {
+        if (node?.id !== this.focusedId) {
+            this.focusedId = node?.id;
+            this.onDidChangeFocusEmitter.fire(node);
+        }
+    }
+
+    hasFocus(node?: TreeNode): boolean {
+        return !!node && node?.id === this.focusedId;
+    }
+}

--- a/packages/core/src/browser/tree/tree-focus-service.ts
+++ b/packages/core/src/browser/tree/tree-focus-service.ts
@@ -21,7 +21,7 @@ import { SelectableTreeNode } from './tree-selection';
 
 export interface TreeFocusService {
     readonly focusedNode: SelectableTreeNode | undefined;
-    onDidChangeFocus: Event<SelectableTreeNode | undefined>;
+    readonly onDidChangeFocus: Event<SelectableTreeNode | undefined>;
     setFocus(node?: SelectableTreeNode): void;
     hasFocus(node?: TreeNode): boolean;
 }

--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -26,6 +26,7 @@ import { TreeExpansionService, ExpandableTreeNode } from './tree-expansion';
 import { TreeNavigationService } from './tree-navigation';
 import { TreeIterator, BottomUpTreeIterator, TopDownTreeIterator, Iterators } from './tree-iterator';
 import { TreeSearch } from './tree-search';
+import { TreeFocusService } from './tree-focus-service';
 
 /**
  * The tree model.
@@ -134,6 +135,11 @@ export interface TreeModel extends Tree, TreeSelectionService, TreeExpansionServ
      * If no node was selected previously, invoking this method does nothing.
      */
     selectRange(node: Readonly<SelectableTreeNode>): void;
+
+    /**
+     * Returns the node currently in focus in this tree, or undefined if no node is focused.
+     */
+    getFocusedNode(): SelectableTreeNode | undefined
 }
 
 @injectable()
@@ -144,6 +150,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     @inject(TreeSelectionService) protected readonly selectionService: TreeSelectionService;
     @inject(TreeExpansionService) protected readonly expansionService: TreeExpansionService;
     @inject(TreeNavigationService) protected readonly navigationService: TreeNavigationService;
+    @inject(TreeFocusService) protected readonly focusService: TreeFocusService;
     @inject(TreeSearch) protected readonly treeSearch: TreeSearch;
 
     protected readonly onChangedEmitter = new Emitter<void>();
@@ -215,6 +222,10 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         return this.tree.getNode(id);
     }
 
+    getFocusedNode(): SelectableTreeNode | undefined {
+        return this.focusService.focusedNode;
+    }
+
     validateNode(node: TreeNode | undefined): TreeNode | undefined {
         return this.tree.validateNode(node);
     }
@@ -241,7 +252,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     }
 
     async expandNode(raw?: Readonly<ExpandableTreeNode>): Promise<ExpandableTreeNode | undefined> {
-        for (const node of raw ? [raw] : this.selectedNodes) {
+        for (const node of this.getExpansionCandidates(raw)) {
             if (ExpandableTreeNode.is(node)) {
                 return this.expansionService.expandNode(node);
             }
@@ -249,8 +260,14 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         return undefined;
     }
 
+    protected *getExpansionCandidates(raw?: Readonly<TreeNode>): IterableIterator<TreeNode | undefined> {
+        yield raw;
+        yield this.getFocusedNode();
+        yield* this.selectedNodes;
+    }
+
     async collapseNode(raw?: Readonly<ExpandableTreeNode>): Promise<boolean> {
-        for (const node of raw ? [raw] : this.selectedNodes) {
+        for (const node of this.getExpansionCandidates(raw)) {
             if (ExpandableTreeNode.is(node)) {
                 return this.expansionService.collapseNode(node);
             }
@@ -259,7 +276,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     }
 
     async collapseAll(raw?: Readonly<CompositeTreeNode>): Promise<boolean> {
-        const node = raw || this.selectedNodes[0];
+        const node = raw || this.getFocusedNode();
         if (SelectableTreeNode.is(node)) {
             this.selectNode(node);
         }
@@ -284,7 +301,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         }
     }
 
-    getPrevSelectableNode(node: TreeNode = this.selectedNodes[0]): SelectableTreeNode | undefined {
+    getPrevSelectableNode(node: TreeNode | undefined = this.getFocusedNode()): SelectableTreeNode | undefined {
         const iterator = this.createBackwardIterator(node);
         return iterator && this.doGetNextNode(iterator, this.isVisibleSelectableNode.bind(this));
     }
@@ -296,7 +313,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         }
     }
 
-    getNextSelectableNode(node: TreeNode = this.selectedNodes[0]): SelectableTreeNode | undefined {
+    getNextSelectableNode(node: TreeNode | undefined = this.getFocusedNode()): SelectableTreeNode | undefined {
         const iterator = this.createIterator(node);
         return iterator && this.doGetNextNode(iterator, this.isVisibleSelectableNode.bind(this));
     }
@@ -345,7 +362,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     }
 
     openNode(raw?: TreeNode | undefined): void {
-        const node = raw || this.selectedNodes[0];
+        const node = raw ?? this.focusService.focusedNode;
         if (node) {
             this.doOpenNode(node);
             this.onOpenNodeEmitter.fire(node);
@@ -359,8 +376,8 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     }
 
     selectParent(): void {
-        if (this.selectedNodes.length === 1) {
-            const node = this.selectedNodes[0];
+        const node = this.getFocusedNode();
+        if (node) {
             const parent = SelectableTreeNode.getVisibleParent(node);
             if (parent) {
                 this.selectNode(parent);
@@ -414,6 +431,10 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
 
     addSelection(selectionOrTreeNode: TreeSelection | Readonly<SelectableTreeNode>): void {
         this.selectionService.addSelection(selectionOrTreeNode);
+    }
+
+    clearSelection(): void {
+        this.selectionService.clearSelection();
     }
 
     selectNode(node: Readonly<SelectableTreeNode>): void {

--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -302,6 +302,9 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     }
 
     getPrevSelectableNode(node: TreeNode | undefined = this.getFocusedNode()): SelectableTreeNode | undefined {
+        if (!node) {
+            return this.getNextSelectableNode(this.root);
+        }
         const iterator = this.createBackwardIterator(node);
         return iterator && this.doGetNextNode(iterator, this.isVisibleSelectableNode.bind(this));
     }
@@ -313,7 +316,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         }
     }
 
-    getNextSelectableNode(node: TreeNode | undefined = this.getFocusedNode()): SelectableTreeNode | undefined {
+    getNextSelectableNode(node: TreeNode | undefined = this.getFocusedNode() ?? this.root): SelectableTreeNode | undefined {
         const iterator = this.createIterator(node);
         return iterator && this.doGetNextNode(iterator, this.isVisibleSelectableNode.bind(this));
     }

--- a/packages/core/src/browser/tree/tree-selection-state.ts
+++ b/packages/core/src/browser/tree/tree-selection-state.ts
@@ -95,8 +95,13 @@ export class TreeSelectionState {
 
     get focus(): SelectableTreeNode | undefined {
         const copy = this.checkNoDefaultSelection(this.selectionStack);
-        const candidate = copy[copy.length - 1].focus;
+        const candidate = copy[copy.length - 1]?.focus;
         return this.toSelectableTreeNode(candidate);
+    }
+
+    get node(): SelectableTreeNode | undefined {
+        const copy = this.checkNoDefaultSelection(this.selectionStack);
+        return this.toSelectableTreeNode(copy[copy.length - 1]?.node);
     }
 
     protected handleDefault(state: TreeSelectionState, node: Readonly<SelectableTreeNode>): TreeSelectionState {
@@ -116,7 +121,7 @@ export class TreeSelectionState {
             for (let i = allRanges.length - 1; i >= 0; i--) {
                 const latestRangeIndex = copy.indexOf(allRanges[i]);
                 const latestRangeSelection = copy[latestRangeIndex];
-                const latestRange = latestRangeSelection && latestRangeSelection.focus ? this.selectionRange(latestRangeSelection) : [];
+                const latestRange = latestRangeSelection?.focus ? this.selectionRange(latestRangeSelection) : [];
                 if (latestRange.indexOf(node) !== -1) {
                     if (this.focus === latestRangeSelection.focus) {
                         return latestRangeSelection.focus || node;

--- a/packages/core/src/browser/tree/tree-selection.ts
+++ b/packages/core/src/browser/tree/tree-selection.ts
@@ -42,6 +42,11 @@ export interface TreeSelectionService extends Disposable, SelectionProvider<Read
     addSelection(selectionOrTreeNode: TreeSelection | Readonly<SelectableTreeNode>): void;
 
     /**
+     * Clears all selected nodes
+     */
+    clearSelection(): void;
+
+    /**
      * Store selection state.
      */
     storeState(): object;
@@ -114,6 +119,8 @@ export interface SelectableTreeNode extends TreeNode {
     selected: boolean;
 
     /**
+     * @deprecated @since 1.27.0. Use TreeFocusService to track the focused node.
+     *
      * `true` if the tree node has the focus. Otherwise, `false`. Defaults to `false`.
      */
     focus?: boolean;
@@ -130,6 +137,9 @@ export namespace SelectableTreeNode {
         return is(node) && node.selected;
     }
 
+    /**
+     * @deprecated @since 1.27.0. Use TreeFocusService to track the focused node.
+     */
     export function hasFocus(node: TreeNode | undefined): boolean {
         return is(node) && node.focus === true;
     }

--- a/packages/core/src/browser/tree/tree-widget-selection.ts
+++ b/packages/core/src/browser/tree/tree-widget-selection.ts
@@ -31,7 +31,16 @@ export namespace TreeWidgetSelection {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return Array.isArray(selection) && ('source' in selection) && <any>selection['source'] instanceof TreeWidget;
     }
+
     export function create(source: TreeWidget): TreeWidgetSelection {
-        return Object.assign(source.model.selectedNodes, { source });
+        const focusedNode = source.model.getFocusedNode();
+        const selectedNodes = source.model.selectedNodes;
+        const focusedIndex = selectedNodes.indexOf(focusedNode as SelectableTreeNode);
+        // Ensure that the focused node is at index 0 - used as default single selection.
+        if (focusedNode && focusedIndex > 0) {
+            const selection = [focusedNode, ...selectedNodes.slice(0, focusedIndex), ...selectedNodes.slice(focusedIndex + 1)];
+            return Object.assign(selection, { source });
+        }
+        return Object.assign(selectedNodes, { source });
     }
 }

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -450,6 +450,9 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         if (!this.rows.size) {
             classNames.push('empty');
         }
+        if (this.model.selectedNodes.length === 0 && !this.focusService.focusedNode) {
+            classNames.push('focused');
+        }
         return {
             className: classNames.join(' '),
             onContextMenu: event => this.handleContextMenuEvent(this.getContainerTreeNode(), event)
@@ -1201,12 +1204,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     protected handleEscape(event: KeyboardEvent): void {
-        if (this.model.selectedNodes.length) {
-            this.model.clearSelection();
-        } else {
+        if (this.model.selectedNodes.length <= 1) {
             this.focusService.setFocus(undefined);
             this.node.focus();
         }
+        this.model.clearSelection();
     }
 
     /**

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -41,6 +41,7 @@ import { TreeWidgetSelection } from './tree-widget-selection';
 import { MaybePromise } from '../../common/types';
 import { LabelProvider } from '../label-provider';
 import { CorePreferences } from '../core-preferences';
+import { TreeFocusService } from './tree-focus-service';
 
 const debounce = require('lodash.debounce');
 
@@ -164,6 +165,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected readonly treeSearch: TreeSearch;
     @inject(SearchBoxFactory)
     protected readonly searchBoxFactory: SearchBoxFactory;
+    @inject(TreeFocusService)
+    protected readonly focusService: TreeFocusService;
 
     protected decorations: Map<string, TreeDecoration.Data[]> = new Map();
 
@@ -242,7 +245,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         this.toDispose.pushAll([
             this.model,
             this.model.onChanged(() => this.updateRows()),
-            this.model.onSelectionChanged(() => this.updateScrollToRow({ resize: false })),
+            this.model.onSelectionChanged(() => this.scheduleUpdateScrollToRow({ resize: false })),
+            this.focusService.onDidChangeFocus(() => this.scheduleUpdateScrollToRow({ resize: false })),
             this.model.onDidChangeBusy(() => this.update()),
             this.model.onNodeRefreshed(() => this.updateDecorations()),
             this.model.onExpansionChanged(() => this.updateDecorations()),
@@ -265,6 +269,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             this.toDispose.pushAll([
                 this.model.onSelectionChanged(() => {
                     if (this.node.contains(document.activeElement)) {
+                        this.updateGlobalSelection();
+                    }
+                }),
+                this.focusService.onDidChangeFocus(focus => {
+                    if (focus && this.node.contains(document.activeElement) && this.model.selectedNodes[0] !== focus && this.model.selectedNodes.includes(focus)) {
                         this.updateGlobalSelection();
                     }
                 }),
@@ -342,6 +351,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         this.forceUpdate(updateOptions);
     }
 
+    protected scheduleUpdateScrollToRow = debounce(this.updateScrollToRow);
+
     /**
      * Get the `scrollToRow`.
      *
@@ -351,10 +362,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         if (!this.shouldScrollToRow) {
             return undefined;
         }
-        const selected = this.model.selectedNodes;
-        const node: TreeNode | undefined = selected.find(SelectableTreeNode.hasFocus) || selected[0];
-        const row = node && this.rows.get(node.id);
-        return row && row.index;
+        const { focusedNode } = this.focusService;
+        return focusedNode && this.rows.get(focusedNode.id)?.index;
     }
 
     /**
@@ -398,11 +407,6 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 this.model.selectNode(node);
             }
         }
-        // It has to be called after nodes are selected.
-        if (this.props.globalSelection) {
-            this.updateGlobalSelection();
-        }
-        this.forceUpdate();
     }
 
     /**
@@ -411,7 +415,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
      * @returns the node to focus if available.
      */
     protected getNodeToFocus(): SelectableTreeNode | undefined {
-        const root = this.model.root;
+        const { focusedNode } = this.focusService;
+        if (focusedNode) {
+            return focusedNode;
+        }
+        const { root } = this.model;
         if (SelectableTreeNode.isVisible(root)) {
             return root;
         }
@@ -932,7 +940,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             style,
             onClick: event => this.handleClickEvent(node, event),
             onDoubleClick: event => this.handleDblClickEvent(node, event),
-            onContextMenu: event => this.handleContextMenuEvent(node, event)
+            onContextMenu: event => this.handleContextMenuEvent(node, event),
         };
     }
 
@@ -954,7 +962,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         if (this.rowIsSelected(node, props)) {
             classNames.push(SELECTED_CLASS);
         }
-        if (SelectableTreeNode.hasFocus(node)) {
+        if (this.focusService.hasFocus(node)) {
             classNames.push(FOCUS_CLASS);
         }
         return classNames;
@@ -1108,6 +1116,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         this.addKeyListener(this.node, up, event => this.handleUp(event));
         this.addKeyListener(this.node, down, event => this.handleDown(event));
         this.addKeyListener(this.node, Key.ENTER, event => this.handleEnter(event));
+        this.addKeyListener(this.node, Key.SPACE, event => this.handleSpace(event));
+        this.addKeyListener(this.node, Key.ESCAPE, event => this.handleEscape(event));
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.addEventListener<any>(this.node, 'ps-scroll-y', (e: Event & { target: { scrollTop: number } }) => {
             if (this.view && this.view.list && this.view.list.Grid) {
@@ -1115,7 +1125,6 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 this.view.list.Grid.handleScrollEvent({ scrollTop });
             }
         });
-        this.addEventListener(this.node, 'focus', () => this.doFocus());
     }
 
     /**
@@ -1154,6 +1163,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         } else {
             this.model.selectPrevNode();
         }
+        this.node.focus();
     }
 
     /**
@@ -1166,6 +1176,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         } else {
             this.model.selectNextNode();
         }
+        this.node.focus();
     }
 
     /**
@@ -1178,35 +1189,57 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     /**
+     * Handle the `space key` keyboard event.
+     * - By default should be similar to a single-click action.
+     * @param event the `space key` keyboard event.
+     */
+    protected handleSpace(event: KeyboardEvent): void {
+        const { focusedNode } = this.focusService;
+        if (!this.props.multiSelect || (!event.ctrlKey && !event.metaKey && !event.shiftKey)) {
+            this.tapNode(focusedNode);
+        }
+    }
+
+    protected handleEscape(event: KeyboardEvent): void {
+        if (this.model.selectedNodes.length) {
+            this.model.clearSelection();
+        } else {
+            this.focusService.setFocus(undefined);
+            this.node.focus();
+        }
+    }
+
+    /**
      * Handle the single-click mouse event.
      * @param node the tree node if available.
      * @param event the mouse single-click event.
      */
     protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         if (node) {
+            event.stopPropagation();
             const shiftMask = this.hasShiftMask(event);
             const ctrlCmdMask = this.hasCtrlCmdMask(event);
-            if (!!this.props.multiSelect) {
-                if (SelectableTreeNode.is(node)) {
-                    if (shiftMask) {
-                        this.model.selectRange(node);
-                    } else if (ctrlCmdMask) {
-                        this.model.toggleNode(node);
-                    } else {
-                        this.model.selectNode(node);
-                    }
+            if (this.props.multiSelect && (shiftMask || ctrlCmdMask) && SelectableTreeNode.is(node)) {
+                if (shiftMask) {
+                    this.model.selectRange(node);
+                } else if (ctrlCmdMask) {
+                    this.model.toggleNode(node);
                 }
             } else {
-                if (SelectableTreeNode.is(node)) {
-                    this.model.selectNode(node);
-                }
+                this.tapNode(node);
             }
-            if (!this.props.expandOnlyOnExpansionToggleClick) {
-                if (this.isExpandable(node) && !shiftMask && !ctrlCmdMask) {
-                    this.model.toggleNodeExpansion(node);
-                }
-            }
-            event.stopPropagation();
+        }
+    }
+
+    /**
+     * The effective handler of an unmodified single-click event.
+     */
+    protected tapNode(node?: TreeNode): void {
+        if (SelectableTreeNode.is(node)) {
+            this.model.selectNode(node);
+        }
+        if (node && !this.props.expandOnlyOnExpansionToggleClick && this.isExpandable(node)) {
+            this.model.toggleNodeExpansion(node);
         }
     }
 
@@ -1233,19 +1266,17 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 const type = !!this.props.multiSelect && this.hasCtrlCmdMask(event) ? TreeSelection.SelectionType.TOGGLE : TreeSelection.SelectionType.DEFAULT;
                 this.model.addSelection({ node, type });
             }
+            this.focusService.setFocus(node);
             const contextMenuPath = this.props.contextMenuPath;
             if (contextMenuPath) {
                 const { x, y } = event.nativeEvent;
                 const args = this.toContextMenuArgs(node);
-                this.onRender.push(Disposable.create(() =>
-                    setTimeout(() => this.contextMenuRenderer.render({
-                        menuPath: contextMenuPath,
-                        anchor: { x, y },
-                        args
-                    }))
-                ));
+                setTimeout(() => this.contextMenuRenderer.render({
+                    menuPath: contextMenuPath,
+                    anchor: { x, y },
+                    args
+                }), 10);
             }
-            this.doFocus();
         }
         event.stopPropagation();
         event.preventDefault();
@@ -1360,7 +1391,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             state = {
                 ...state,
                 root: this.deflateForStorage(this.model.root),
-                model: this.model.storeState()
+                model: this.model.storeState(),
+                focusedNodeId: this.focusService.focusedNode?.id
             };
         }
 
@@ -1373,7 +1405,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
      */
     restoreState(oldState: object): void {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { root, decorations, model } = (oldState as any);
+        const { root, decorations, model, focusedNodeId } = (oldState as any);
         if (root) {
             this.model.root = this.inflateFromStorage(root);
         }
@@ -1382,6 +1414,12 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         }
         if (model) {
             this.model.restoreState(model);
+        }
+        if (focusedNodeId) {
+            const candidate = this.model.getNode(focusedNodeId);
+            if (SelectableTreeNode.is(candidate)) {
+                this.focusService.setFocus(candidate);
+            }
         }
     }
 

--- a/packages/debug/src/browser/view/debug-stack-frames-widget.ts
+++ b/packages/debug/src/browser/view/debug-stack-frames-widget.ts
@@ -120,11 +120,11 @@ export class DebugStackFramesWidget extends SourceTreeWidget {
         return undefined;
     }
 
-    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override tapNode(node?: TreeNode): void {
         if (TreeElementNode.is(node) && node.element instanceof LoadMoreStackFrames) {
             node.element.open();
         }
-        super.handleClickEvent(node, event);
+        super.tapNode(node);
     }
 
     protected override getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {

--- a/packages/filesystem/src/browser/breadcrumbs/filepath-breadcrumbs-container.ts
+++ b/packages/filesystem/src/browser/breadcrumbs/filepath-breadcrumbs-container.ts
@@ -55,11 +55,11 @@ export class BreadcrumbsFileTreeWidget extends FileTreeWidget {
         };
     }
 
-    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override tapNode(node?: TreeNode): void {
         if (FileStatNode.is(node) && !node.fileStat.isDirectory) {
             open(this.openerService, node.uri, { preview: true });
         } else {
-            super.handleClickEvent(node, event);
+            super.tapNode(node);
         }
     }
 }

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-model.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-model.ts
@@ -69,7 +69,7 @@ export class FileDialogModel extends FileTreeModel {
         }
     }
 
-    override getNextSelectableNode(node: SelectableTreeNode = this.selectedNodes[0]): SelectableTreeNode | undefined {
+    override getNextSelectableNode(node: SelectableTreeNode | undefined = this.getFocusedNode()): SelectableTreeNode | undefined {
         let nextNode: SelectableTreeNode | undefined = node;
         do {
             nextNode = super.getNextSelectableNode(nextNode);
@@ -77,7 +77,7 @@ export class FileDialogModel extends FileTreeModel {
         return nextNode;
     }
 
-    override getPrevSelectableNode(node: SelectableTreeNode = this.selectedNodes[0]): SelectableTreeNode | undefined {
+    override getPrevSelectableNode(node: SelectableTreeNode | undefined = this.getFocusedNode()): SelectableTreeNode | undefined {
         let prevNode: SelectableTreeNode | undefined = node;
         do {
             prevNode = super.getPrevSelectableNode(prevNode);

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -113,8 +113,8 @@ export class ProblemWidget extends TreeWidget {
         return;
     }
 
-    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
-        super.handleClickEvent(node, event);
+    protected override tapNode(node?: TreeNode): void {
+        super.tapNode(node);
         if (MarkerNode.is(node)) {
             this.model.revealNode(node);
         }

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -316,7 +316,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
                     return false;
                 }
                 const navigator = this.tryGetWidget();
-                const selection = navigator?.model.selectedNodes[0];
+                const selection = navigator?.model.getFocusedNode();
                 // The node that is selected when the user clicks in empty space.
                 const root = navigator?.getContainerTreeNode();
                 return selection === root;

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -226,12 +226,11 @@ export class FileNavigatorWidget extends FileTreeWidget {
         return WorkspaceNode.is(model.root) && model.root.children.length === 0;
     }
 
-    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
-        const modifierKeyCombined: boolean = isOSX ? (event.shiftKey || event.metaKey) : (event.shiftKey || event.ctrlKey);
-        if (!modifierKeyCombined && node && this.corePreferences['workbench.list.openMode'] === 'singleClick') {
+    protected override tapNode(node?: TreeNode): void {
+        if (node && this.corePreferences['workbench.list.openMode'] === 'singleClick') {
             this.model.previewNode(node);
         }
-        super.handleClickEvent(node, event);
+        super.tapNode(node);
     }
 
     protected override onAfterShow(msg: Message): void {

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -256,12 +256,11 @@ export class OpenEditorsWidget extends FileTreeWidget {
         }
     }
 
-    protected override handleClickEvent(node: OpenEditorNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override tapNode(node?: TreeNode): void {
         if (OpenEditorNode.is(node)) {
-            const { widget } = node;
-            this.applicationShell.activateWidget(widget.id);
+            this.applicationShell.activateWidget(node.widget.id);
         }
-        super.handleClickEvent(node, event);
+        super.tapNode(node);
     }
 
     protected override handleContextMenuEvent(node: OpenEditorNode | undefined, event: React.MouseEvent<HTMLElement>): void {

--- a/packages/outline-view/src/browser/outline-breadcrumbs-contribution.tsx
+++ b/packages/outline-view/src/browser/outline-breadcrumbs-contribution.tsx
@@ -14,7 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import * as React from '@theia/core/shared/react';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { LabelProvider, BreadcrumbsService, Widget, TreeNode, OpenerService, open, SelectableTreeNode, BreadcrumbsContribution, Breadcrumb } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
@@ -31,11 +30,11 @@ export interface BreadcrumbPopupOutlineViewFactory {
 export class BreadcrumbPopupOutlineView extends OutlineViewWidget {
     @inject(OpenerService) protected readonly openerService: OpenerService;
 
-    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override tapNode(node?: TreeNode): void {
         if (UriSelection.is(node) && OutlineSymbolInformationNode.hasRange(node)) {
             open(this.openerService, node.uri, { selection: node.range });
         } else {
-            super.handleClickEvent(node, event);
+            super.tapNode(node);
         }
     }
 

--- a/packages/outline-view/src/browser/outline-view-tree-model.ts
+++ b/packages/outline-view/src/browser/outline-view-tree-model.ts
@@ -31,7 +31,7 @@ export class OutlineViewTreeModel extends TreeModelImpl {
     }
 
     override async collapseAll(raw?: Readonly<CompositeTreeNode>): Promise<boolean> {
-        const node = raw || this.selectedNodes[0];
+        const node = raw || this.getFocusedNode();
         if (CompositeTreeNode.is(node)) {
             return this.expansionService.collapseAll(node);
         }
@@ -44,7 +44,7 @@ export class OutlineViewTreeModel extends TreeModelImpl {
      * allow for the `onOpenNode` event to still fire on a double-click event.
      */
     override openNode(raw?: TreeNode | undefined): void {
-        const node = raw || this.selectedNodes[0];
+        const node = raw || this.getFocusedNode();
         if (node) {
             this.onOpenNodeEmitter.fire(node);
         }

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -358,7 +358,9 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
             const inlineCommands = menu.children.filter((item): item is ActionMenuNode => item instanceof ActionMenuNode);
             const tailDecorations = super.renderTailDecorations(node, props);
             return <React.Fragment>
-                {inlineCommands.length > 0 && <div className={TREE_NODE_SEGMENT_CLASS}>{inlineCommands.map((item, index) => this.renderInlineCommand(item, index, arg))}</div>}
+                {inlineCommands.length > 0 && <div className={TREE_NODE_SEGMENT_CLASS}>
+                    {inlineCommands.map((item, index) => this.renderInlineCommand(item, index, this.focusService.hasFocus(node), arg))}
+                </div>}
                 {tailDecorations !== undefined && <div className={TREE_NODE_SEGMENT_CLASS}>{super.renderTailDecorations(node, props)}</div>}
             </React.Fragment>;
         });
@@ -369,13 +371,14 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected renderInlineCommand(node: ActionMenuNode, index: number, arg: any): React.ReactNode {
+    protected renderInlineCommand(node: ActionMenuNode, index: number, tabbable: boolean, arg: any): React.ReactNode {
         const { icon } = node;
         if (!icon || !this.commands.isVisible(node.action.commandId, arg) || !node.action.when || !this.contextKeys.match(node.action.when)) {
             return false;
         }
         const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, icon, ACTION_ITEM, 'theia-tree-view-inline-action'].join(' ');
-        return <div key={index} className={className} title={node.label} onClick={e => {
+        const tabIndex = tabbable ? 0 : undefined;
+        return <div key={index} className={className} title={node.label} tabIndex={tabIndex} onClick={e => {
             e.stopPropagation();
             this.commands.executeCommand(node.action.commandId, arg);
         }} />;
@@ -404,13 +407,12 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         this.tryExecuteCommand();
     }
 
-    override handleClickEvent(node: TreeNode, event: React.MouseEvent<HTMLElement>): void {
-        super.handleClickEvent(node, event);
-        // If clicked on item (not collapsable icon) - execute command or toggle expansion if item has no command
+    protected override tapNode(node?: TreeNode): void {
+        super.tapNode(node);
         const commandMap = this.findCommands(node);
         if (commandMap.size > 0) {
             this.tryExecuteCommandMap(commandMap);
-        } else if (this.isExpandable(node) && !this.hasShiftMask(event) && !this.hasCtrlCmdMask(event)) {
+        } else if (node && this.isExpandable(node)) {
             this.model.toggleNodeExpansion(node);
         }
     }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -618,7 +618,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     }
 
     protected override handleUp(event: KeyboardEvent): void {
-        if (!this.model.getPrevSelectableNode(this.model.selectedNodes[0])) {
+        if (!this.model.getPrevSelectableNode(this.model.getFocusedNode())) {
             this.focusInputEmitter.fire(true);
         } else {
             super.handleUp(event);

--- a/packages/timeline/src/browser/timeline-tree-widget.tsx
+++ b/packages/timeline/src/browser/timeline-tree-widget.tsx
@@ -53,16 +53,15 @@ export class TimelineTreeWidget extends TreeWidget {
             timelineItem={node.timelineItem}
             commandRegistry={this.commandRegistry}
             contextKeys={this.contextKeys}
-            contextMenuRenderer={this.contextMenuRenderer}/>;
+            contextMenuRenderer={this.contextMenuRenderer} />;
         return React.createElement('div', attributes, content);
     }
 
     protected override handleEnter(event: KeyboardEvent): void {
-        const node = this.model.selectedNodes[0] as TimelineNode;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const command: any = node.timelineItem.command;
+        const node = this.model.getFocusedNode() as TimelineNode;
+        const command = node?.timelineItem?.command;
         if (command) {
-            this.commandRegistry.executeCommand(command.id, ...command.arguments ? command.arguments : []);
+            this.commandRegistry.executeCommand(command.id, ...(command.arguments ? command.arguments : []));
         }
     }
 
@@ -84,9 +83,9 @@ export class TimelineItemNode extends React.Component<TimelineItemNode.Props> {
     override render(): JSX.Element | undefined {
         const { label, description, detail } = this.props.timelineItem;
         return <div className='timeline-item'
-                    title={detail}
-                    onContextMenu={this.renderContextMenu}
-                    onClick={this.open}>
+            title={detail}
+            onContextMenu={this.renderContextMenu}
+            onClick={this.open}>
             <div className={`noWrapInfo ${TREE_NODE_SEGMENT_GROW_CLASS}`} >
                 <span className='name'>{label}</span>
                 <span className='label'>{description}</span>

--- a/packages/timeline/src/common/timeline-model.ts
+++ b/packages/timeline/src/common/timeline-model.ts
@@ -32,7 +32,7 @@ export interface TimelineItem {
     id?: string;
     description?: string;
     detail?: string;
-    command?: Command;
+    command?: Command & { arguments?: unknown[] };
     contextValue?: string;
 }
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
@@ -80,9 +80,9 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
         }
     }
 
-    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
-        super.handleClickEvent(node, event);
-        this.model.openNode(node); // Open the editor view on a single click.
+    protected override tapNode(node?: TreeNode): void {
+        super.tapNode(node);
+        this.model.openNode(node);
     }
 
     protected override handleDblClickEvent(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8101, fixes #10280.

The fundamental change of this PR is to introduce a `TreeFocusService` interface and implementation, and use that service to track a unique focused tree node in `TreeWidgets`. Previously, the field `SelectableTreeNode.focus` and the node `selectedNodes[0]` were used as proxies for tracking the focused node, but it's really a piece of `TreeWidget` state separate from selection and not one that should be assigned as a field of a particular node.

There are quite a few changes that follow from that basic change, however, and I'd be grateful for hands-on testing and feedback.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

##### No Scroll Jumps (the bugfixes)

###### #10280 

1. In a plugin tree (e.g. the file tree from [this copy](https://github.com/eclipse-theia/theia/files/8772980/custom-view-samples-0.0.1.zip) of the VSCode example tree view plugin)
2. Select a node.
3. Scroll that node out of view.
4. Expand / collapse a node in the new view area by clicking on its toggle.
5. You should not jump back to the selected node.

###### #8101

1. Open the Built-In ViewContainerPart of the VSX Registry view (don't select anything)
2. Scroll down and select a plugin.
3. The plugin you click should be selected, and you should not jump up to the top of the view.

##### Focused Element

> When a tree widget is focused and some nodes are selected, exactly one node should have a focus outline, and that node should be used a reference for automatic scrolling.
1. Select a node in e.g. the file tree and use <kbd>shift</kbd>+<kbd>up</kbd> / <kbd>shift</kbd>+<kbd>down</kbd> to select multiple nodes.
2. The most recently selected node should bear focus, and if you reach the top or bottom of the view, the view should scroll to keep up. 
> On `master`, the view would not scroll when selection went beyond the top or bottom in this scenario.
3. <kbd>Ctrl</kbd> select / deselect elements. The most recently clicked should bear focus.
> On `master`, any <kbd>ctrl</kbd>+clicked nodes would be marked with the focus class, although there was no visible marking of that fact.
4. <kbd>Shift</kbd> select several folders. <kbd>Ctrl</kbd>+rightclick on one of the selected folders in the middle of the selection and select 'New file'.
5. Observe that the file creation dialog indicates that the file will be created in the folder clicked on, and that node bears focus.
> On `master`, the command would always target one of the edge nodes of the selection, depending on its direction.

##### Keyboard
> Hitting `space` should trigger the same action (by default) as a single click. Hitting `escape` should clear the selection, or, if there is no selection, clear the focused element. In VSX Registry and plugin `TreeViewsWidgets`, interactive elements in the focused node should be accessible via keyboard navigation.

1. Test that hitting <kbd>Space</kbd> when a node is focused executes the same action on the focused node as a single click in various trees.
2. Test that when nodes are selected, <kbd>Esc</kbd> clears the selection but leaves the focused element focused, and when no nodes are selected, <kbd>Esc</kbd> clears the focused element.
3. Test that when there is no selection but there is a focused element, the arrow keys behave as expected.
4. Test that in the the VSX Registry and `TreeViewWidget`, interactive elements in the focused node are accessible via <kbd>Tab</kbd> and that interactive elements in other nodes are not.


#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
