### PR TITLE
drop support for node 12

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, ubuntu-18.04, macos-10.15]
-        node: ['14.x', '16.x', '18.x']
+        node: [14.x, 16.x]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, ubuntu-18.04, macos-10.15]
-        node: ['12.x', '14.x', '16.x']
+        node: ['14.x', '16.x', '18.x']
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        node: ['12.x']
+        node: ['16.x']
         java: ['11']
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [plugin-dev] moved and renamed interface from: `@theia/debug/lib/browser/debug-contribution/DebugPluginConfiguration` to: `plugin-dev/src/common/PluginDebugConfiguration` [#11224](https://github.com/eclipse-theia/theia/pull/11224)
 - [debug, plugin-ext] [Debug view] Add dynamic debug configurations [#10212](https://github.com/eclipse-theia/theia/pull/10212)
-  - Changed signature of `DebugConfigurationManager.find` to receive a target DebugConfiguration instead of a configuration's name.  
+  - Changed signature of `DebugConfigurationManager.find` to receive a target DebugConfiguration instead of a configuration's name.
     NOTE: The original signature is still available but no longer used inside the framework and therefore marked as `deprecated`
   - Multiple methods related to the selection of Debug configuration options were relocated from `debug-configuration-widget.tsx` to the new file `debug-configuration-select.tsx`.
   - Removed optional interface property `DebugConfiguration.dynamic`.
@@ -26,6 +26,8 @@
   - `RemoteFileSystemServer`: Use `UInt8Array` instead of plain number arrays for all arguments and return type that store binary data
   - `DebugAdapter`: Replaced the debug-service internal `Channel` implementation with the newly introduced generic `Channel`.
   [#11228](https://github.com/eclipse-theia/theia/pull/11228) - Contributed on behalf of STMicroelectronics.
+- [core] Drop support for Node 12.x, recommend Node 16.x.
+  - Update CI/CD matrix to run on Node 14.x, 16.x and 18.x.
 
 ## v1.26.0 - 5/26/2022
 

--- a/dev-packages/application-manager/src/rebuild.ts
+++ b/dev-packages/application-manager/src/rebuild.ts
@@ -225,7 +225,7 @@ async function runElectronRebuild(modules: string[], forceAbi: NodeABI | undefin
             if (signal) {
                 reject(new Error(`electron-rebuild exited with "${signal}"`));
             } else {
-                resolve(code);
+                resolve(code!);
             }
         });
     });

--- a/dev-packages/ffmpeg/README.md
+++ b/dev-packages/ffmpeg/README.md
@@ -1,3 +1,3 @@
 # `ffmeg.node`
 
-This is a [Node Native Addon](https://nodejs.org/docs/latest-v12.x/api/n-api.html) to dynamically link to Electron's `ffmpeg.dll` and fetch a list of included codecs.
+This is a [Node Native Addon](https://nodejs.org/docs/latest-v14.x/api/n-api.html) to dynamically link to Electron's `ffmpeg.dll` and fetch a list of included codecs.

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -52,9 +52,8 @@ For Windows instructions [click here](#building-on-windows).
 
 ## Prerequisites
 
- - Node.js `>= 12.14.1`.
-   - For now, **use** Node 12.
-   - Node 14 is supported, Node 16 _should_ work.
+ - Node.js `>= 14`.
+   - We recommend using Node's LTS: currently 16.x
    - If you are interested in Theia's VS Code Extension support then you should use a Node version at least compatible with the one included in the version of Electron used by [VS Code](https://github.com/microsoft/vscode).
  - [Yarn package manager](https://yarnpkg.com/en/docs/install)  `>= 1.7.0` **AND** `< 2.x.x`.
  - git (If you would like to use the Git-extension too, you will need to have git version 2.11.0 or higher.)

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "version": "0.0.0",
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=12.14.1"
+    "node": ">=14"
   },
   "resolutions": {
-    "**/@types/node": "12"
+    "**/@types/node": "14"
   },
   "devDependencies": {
     "@types/chai": "4.3.0",
     "@types/chai-spies": "1.0.3",
     "@types/chai-string": "^1.4.0",
     "@types/jsdom": "^11.0.4",
-    "@types/node": "12",
+    "@types/node": "14",
     "@types/puppeteer": "^2.0.0",
     "@types/sinon": "^10.0.6",
     "@types/temp": "^0.8.29",

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -105,7 +105,7 @@ export class HostedPluginProcess implements ServerPluginRunner {
 
         const waitForTerminated = new Deferred<void>();
         cp.on('message', message => {
-            const msg = JSON.parse(message);
+            const msg = JSON.parse(message as string);
             if ('type' in msg && msg.type === MessageType.Terminated) {
                 waitForTerminated.resolve();
             }
@@ -158,7 +158,7 @@ export class HostedPluginProcess implements ServerPluginRunner {
         });
         this.childProcess.on('message', message => {
             if (this.client) {
-                this.client.postMessage(PLUGIN_HOST_BACKEND, message);
+                this.client.postMessage(PLUGIN_HOST_BACKEND, message as string);
             }
         });
     }

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -114,7 +114,7 @@ export class PluginHostRPC {
                 console.log('PLUGIN_HOST(' + process.pid + '): PluginManagerExtImpl/loadPlugin(' + plugin.pluginPath + ')');
                 // cleaning the cache for all files of that plug-in.
                 Object.keys(require.cache).forEach(function (key): void {
-                    const mod: NodeJS.Module = require.cache[key];
+                    const mod: NodeJS.Module = require.cache[key]!;
 
                     // attempting to reload a native module will throw an error, so skip them
                     if (mod.id.endsWith('.node')) {

--- a/packages/process/src/node/multi-ring-buffer.ts
+++ b/packages/process/src/node/multi-ring-buffer.ts
@@ -33,7 +33,7 @@ export class MultiRingBufferReadableStream extends stream.Readable implements Di
 
     constructor(protected readonly ringBuffer: MultiRingBuffer,
         protected readonly reader: number,
-        protected readonly encoding = 'utf8'
+        protected readonly encoding: BufferEncoding = 'utf8'
     ) {
         super();
         this.setEncoding(encoding);
@@ -81,7 +81,7 @@ export class MultiRingBufferReadableStream extends stream.Readable implements Di
 export const MultiRingBufferOptions = Symbol('MultiRingBufferOptions');
 export interface MultiRingBufferOptions {
     readonly size: number,
-    readonly encoding?: string,
+    readonly encoding?: BufferEncoding,
 }
 
 export interface WrappedPosition { newPos: number, wrap: boolean }
@@ -93,7 +93,7 @@ export class MultiRingBuffer implements Disposable {
     protected head: number = -1;
     protected tail: number = -1;
     protected readonly maxSize: number;
-    protected readonly encoding: string;
+    protected readonly encoding: BufferEncoding;
 
     /* <id, position> */
     protected readonly readers: Map<number, number>;
@@ -160,7 +160,7 @@ export class MultiRingBuffer implements Disposable {
         this.readers.delete(id);
     }
 
-    getStream(encoding?: string): MultiRingBufferReadableStream {
+    getStream(encoding?: BufferEncoding): MultiRingBufferReadableStream {
         const reader = this.getReader();
         const readableStream = new MultiRingBufferReadableStream(this, reader, encoding);
         this.streams.set(readableStream, reader);
@@ -185,7 +185,7 @@ export class MultiRingBuffer implements Disposable {
         }
     }
 
-    deq(id: number, size = -1, encoding = 'utf8'): string | undefined {
+    deq(id: number, size = -1, encoding: BufferEncoding = 'utf8'): string | undefined {
         const pos = this.readers.get(id);
         if (pos === undefined || pos === -1) {
             return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,12 +2489,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@12", "@types/node@>=10.0.0", "@types/node@^10.14.22", "@types/node@^14.6.2":
-  version "12.20.49"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.49.tgz#97897a33dd145490f514bbcbccefc178534e360f"
-  integrity sha512-5e6QNb9bkeh4Hni4ktLqUZuUqnGTX/kou2aZkXyxtuYaHXgBm+In1SHR9V+7kDzWzjB08KC2uqt2doDi7cuAAA==
-
-"@types/node@14":
+"@types/node@*", "@types/node@14", "@types/node@>=10.0.0", "@types/node@^10.14.22", "@types/node@^14.6.2":
   version "14.18.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
   integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,6 +2494,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.49.tgz#97897a33dd145490f514bbcbccefc178534e360f"
   integrity sha512-5e6QNb9bkeh4Hni4ktLqUZuUqnGTX/kou2aZkXyxtuYaHXgBm+In1SHR9V+7kDzWzjB08KC2uqt2doDi7cuAAA==
 
+"@types/node@14":
+  version "14.18.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
+  integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"


### PR DESCRIPTION
Keep supporting Node 14.x but recommend Node 16.x.

Closes https://github.com/eclipse-theia/theia/issues/10013

#### How to test

Nothing should have changed. Everything should work like before with Node 14 or Node 16.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)