### PR TITLE
Move Theme Loading into Inversify Lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - [workspace] removed deprecated `getDefaultWorkspacePath` [#11185](https://github.com/eclipse-theia/theia/pull/11185)
 - [vsx-registry] removed deprecated `VSXExtensionsCommands` re-export [#11185](https://github.com/eclipse-theia/theia/pull/11185)
 - [plugin] Remove `TreeItem2` from proposed plugin API. `TreeItem` can be used instead. [#11288](https://github.com/eclipse-theia/theia/pull/11288) - Contributed on behalf of STMicroelectronics
-- [core] removed `ThemeService.get()`; inject the `ThemeService` instead. Removed `ColorApplicationContribution.initBackground()`; by default the `editor.background` color variable will be initialized through the normal theme initialization process. [#11213](https://github.com/eclipse-theia/theia/pull/11213)
+- [core] removed `ThemeService.get()`; inject the `ThemeService` instead. Removed `ColorApplicationContribution.initBackground()`; by default the `editor.background` color variable will be initialized through the normal theme initialization process. It is now expected that the `ThemeService` will call `this.deferredInitializer.resolve()` when the `ThemeService` finishes its initialization. Failure to do so in any overrides may cause failures to apply default themes.  [#11213](https://github.com/eclipse-theia/theia/pull/11213)
 - [monaco] removed static methods `init()`, `register()`, `restore(), `updateBodyUiTheme()` from `MonacoThemingService`; use instance methods `initialize()`, `registerParsedTheme()`, `restore()`, `updateBodyUiTheme()` instead. Removed `MonacoThemeRegistry.SINGLETON`, inject `MonacoThemeRegistry` instead. [#11213](https://github.com/eclipse-theia/theia/pull/11213)
 
 ## v1.26.0 - 5/26/2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [plugin] Add support for property `color` of `ThemeIcon`. [#11243](https://github.com/eclipse-theia/theia/pull/11243) - Contributed on behalf of STMicroelectronics
 - [plugin] Add support for `TreeItemLabel` in `TreeItem`. [#11288](https://github.com/eclipse-theia/theia/pull/11288) - Contributed on behalf of STMicroelectronics
 - [plugin] Support `TextEditor#show()` and `TextEditor#hide()` [#11168](https://github.com/eclipse-theia/theia/pull/11168) - Contributed on behalf of STMicroelectronics
+- [core, monaco] refactored theme initialization to occur within application lifecycle rather than at import time. [#11213](https://github.com/eclipse-theia/theia/pull/11213)
 
 <a name="breaking_changes_1.27.0">[Breaking Changes:](#breaking_changes_1.27.0)</a>
 
@@ -54,6 +55,8 @@
 - [workspace] removed deprecated `getDefaultWorkspacePath` [#11185](https://github.com/eclipse-theia/theia/pull/11185)
 - [vsx-registry] removed deprecated `VSXExtensionsCommands` re-export [#11185](https://github.com/eclipse-theia/theia/pull/11185)
 - [plugin] Remove `TreeItem2` from proposed plugin API. `TreeItem` can be used instead. [#11288](https://github.com/eclipse-theia/theia/pull/11288) - Contributed on behalf of STMicroelectronics
+- [core] removed `ThemeService.get()`; inject the `ThemeService` instead. Removed `ColorApplicationContribution.initBackground()`; by default the `editor.background` color variable will be initialized through the normal theme initialization process. [#11213](https://github.com/eclipse-theia/theia/pull/11213)
+- [monaco] removed static methods `init()`, `register()`, `restore(), `updateBodyUiTheme()` from `MonacoThemingService`; use instance methods `initialize()`, `registerParsedTheme()`, `restore()`, `updateBodyUiTheme()` instead. Removed `MonacoThemeRegistry.SINGLETON`, inject `MonacoThemeRegistry` instead. [#11213](https://github.com/eclipse-theia/theia/pull/11213)
 
 ## v1.26.0 - 5/26/2022
 

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -89,9 +89,6 @@ self.MonacoEnvironment = {
 }
 `)}
 
-const { ThemeService } = require('@theia/core/lib/browser/theming');
-ThemeService.get().loadUserTheme();
-
 const preloader = require('@theia/core/lib/browser/preloader');
 
 // We need to fetch some data from the backend before the frontend starts (nls, os)

--- a/packages/core/src/browser/color-application-contribution.ts
+++ b/packages/core/src/browser/color-application-contribution.ts
@@ -46,6 +46,7 @@ export class ColorApplicationContribution implements FrontendApplicationContribu
         for (const contribution of this.colorContributions.getContributions()) {
             contribution.registerColors(this.colors);
         }
+        this.themeService.initialized.then(() => this.update());
         this.themeService.onDidColorThemeChange(() => {
             this.update();
             this.updateThemeBackground();

--- a/packages/core/src/browser/color-application-contribution.ts
+++ b/packages/core/src/browser/color-application-contribution.ts
@@ -21,6 +21,7 @@ import { ThemeService } from './theming';
 import { FrontendApplicationContribution } from './frontend-application';
 import { ContributionProvider } from '../common/contribution-provider';
 import { Disposable, DisposableCollection } from '../common/disposable';
+import { DEFAULT_BACKGROUND_COLOR_STORAGE_KEY } from './frontend-application-config-provider';
 
 export const ColorContribution = Symbol('ColorContribution');
 export interface ColorContribution {
@@ -39,18 +40,16 @@ export class ColorApplicationContribution implements FrontendApplicationContribu
     @inject(ContributionProvider) @named(ColorContribution)
     protected readonly colorContributions: ContributionProvider<ColorContribution>;
 
-    private static themeBackgroundId = 'theme.background';
+    @inject(ThemeService) protected readonly themeService: ThemeService;
 
     onStart(): void {
         for (const contribution of this.colorContributions.getContributions()) {
             contribution.registerColors(this.colors);
         }
-
-        this.updateThemeBackground();
-        ThemeService.get().onDidColorThemeChange(() => this.updateThemeBackground());
-
-        this.update();
-        ThemeService.get().onDidColorThemeChange(() => this.update());
+        this.themeService.onDidColorThemeChange(() => {
+            this.update();
+            this.updateThemeBackground();
+        });
         this.colors.onDidChange(() => this.update());
     }
 
@@ -60,7 +59,7 @@ export class ColorApplicationContribution implements FrontendApplicationContribu
             return;
         }
         this.toUpdate.dispose();
-        const theme = 'theia-' + ThemeService.get().getCurrentTheme().type;
+        const theme = 'theia-' + this.themeService.getCurrentTheme().type;
         document.body.classList.add(theme);
         this.toUpdate.push(Disposable.create(() => document.body.classList.remove(theme)));
 
@@ -81,16 +80,9 @@ export class ColorApplicationContribution implements FrontendApplicationContribu
     protected updateThemeBackground(): void {
         const color = this.colors.getCurrentColor('editor.background');
         if (color) {
-            window.localStorage.setItem(ColorApplicationContribution.themeBackgroundId, color);
+            window.localStorage.setItem(DEFAULT_BACKGROUND_COLOR_STORAGE_KEY, color);
         } else {
-            window.localStorage.removeItem(ColorApplicationContribution.themeBackgroundId);
+            window.localStorage.removeItem(DEFAULT_BACKGROUND_COLOR_STORAGE_KEY);
         }
     }
-
-    static initBackground(): void {
-        const value = window.localStorage.getItem(this.themeBackgroundId) || '#1d1d1d';
-        const documentElement = document.documentElement;
-        documentElement.style.setProperty('--theia-editor-background', value);
-    }
-
 }

--- a/packages/core/src/browser/frontend-application-config-provider.ts
+++ b/packages/core/src/browser/frontend-application-config-provider.ts
@@ -16,6 +16,8 @@
 
 import { FrontendApplicationConfig, deepmerge } from '@theia/application-package/lib/application-props';
 
+export const DEFAULT_BACKGROUND_COLOR_STORAGE_KEY = 'theme.background';
+
 export class FrontendApplicationConfigProvider {
 
     private static KEY = Symbol('FrontendApplicationConfigProvider');

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -129,8 +129,6 @@ import { MarkdownRenderer, MarkdownRendererFactory, MarkdownRendererImpl } from 
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
-ColorApplicationContribution.initBackground();
-
 export const frontendApplicationModule = new ContainerModule((bind, _unbind, _isBound, _rebind) => {
     bind(NoneIconTheme).toSelf().inSingletonScope();
     bind(LabelProviderContribution).toService(NoneIconTheme);
@@ -338,7 +336,7 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
         return connection.createProxy<EnvVariablesServer>(envVariablesPath);
     }).inSingletonScope();
 
-    bind(ThemeService).toDynamicValue(() => ThemeService.get());
+    bind(ThemeService).toSelf().inSingletonScope();
 
     bindCorePreferences(bind);
 

--- a/packages/core/src/browser/preloader.ts
+++ b/packages/core/src/browser/preloader.ts
@@ -17,7 +17,7 @@
 import { nls } from '../common/nls';
 import { Endpoint } from './endpoint';
 import { OS } from '../common/os';
-import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
+import { DEFAULT_BACKGROUND_COLOR_STORAGE_KEY, FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 
 function fetchFrom(path: string): Promise<Response> {
     const endpoint = new Endpoint({ path }).getRestUrl().toString();
@@ -47,9 +47,16 @@ async function loadBackendOS(): Promise<void> {
     OS.backend.type = () => osType;
 }
 
+function initBackground(): void {
+    const value = window.localStorage.getItem(DEFAULT_BACKGROUND_COLOR_STORAGE_KEY) || '#1d1d1d';
+    const documentElement = document.documentElement;
+    documentElement.style.setProperty('--theia-editor-background', value);
+}
+
 export async function preload(): Promise<void> {
     await Promise.allSettled([
         loadTranslations(),
-        loadBackendOS()
+        loadBackendOS(),
+        initBackground(),
     ]);
 }

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -123,11 +123,9 @@ export class ShellLayoutRestorer implements CommandContribution {
     protected storageKey = 'layout';
     protected shouldStoreLayout: boolean = true;
 
-    @inject(ContributionProvider) @named(ApplicationShellLayoutMigration)
-    protected readonly migrations: ContributionProvider<ApplicationShellLayoutMigration>;
-
-    @inject(WindowService)
-    protected readonly windowService: WindowService;
+    @inject(ContributionProvider) @named(ApplicationShellLayoutMigration) protected readonly migrations: ContributionProvider<ApplicationShellLayoutMigration>;
+    @inject(WindowService) protected readonly windowService: WindowService;
+    @inject(ThemeService) protected readonly themeService: ThemeService;
 
     constructor(
         @inject(WidgetManager) protected widgetManager: WidgetManager,
@@ -145,7 +143,7 @@ export class ShellLayoutRestorer implements CommandContribution {
             this.logger.info('>>> Resetting layout...');
             this.shouldStoreLayout = false;
             this.storageService.setData(this.storageKey, undefined);
-            ThemeService.get().reset(); // Theme service cannot use DI, so the current theme ID is stored elsewhere. Hence the explicit reset.
+            this.themeService.reset();
             this.logger.info('<<< The layout has been successfully reset.');
             this.windowService.reload();
         }

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -20,6 +20,7 @@ import { FrontendApplicationConfigProvider } from './frontend-application-config
 import { ApplicationProps } from '@theia/application-package/lib/application-props';
 import { Theme, ThemeChangeEvent } from '../common/theme';
 import { injectable, postConstruct } from 'inversify';
+import { Deferred } from '../common/promise-util';
 
 @injectable()
 export class ThemeService {
@@ -27,6 +28,10 @@ export class ThemeService {
     protected themes: { [id: string]: Theme } = {};
     protected activeTheme: Theme | undefined;
     protected readonly themeChange = new Emitter<ThemeChangeEvent>();
+    protected readonly deferredInitializer = new Deferred();
+    get initialized(): Promise<void> {
+        return this.deferredInitializer.promise;
+    }
 
     readonly onDidColorThemeChange: Event<ThemeChangeEvent> = this.themeChange.event;
 
@@ -84,6 +89,7 @@ export class ThemeService {
     loadUserTheme(): void {
         const theme = this.getCurrentTheme();
         this.setCurrentTheme(theme.id);
+        this.deferredInitializer.resolve();
     }
 
     setCurrentTheme(themeId: string): void {

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -19,9 +19,9 @@ import { Disposable } from '../common/disposable';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 import { ApplicationProps } from '@theia/application-package/lib/application-props';
 import { Theme, ThemeChangeEvent } from '../common/theme';
+import { injectable, postConstruct } from 'inversify';
 
-export const ThemeServiceSymbol = Symbol('ThemeService');
-
+@injectable()
 export class ThemeService {
 
     protected themes: { [id: string]: Theme } = {};
@@ -30,15 +30,10 @@ export class ThemeService {
 
     readonly onDidColorThemeChange: Event<ThemeChangeEvent> = this.themeChange.event;
 
-    static get(): ThemeService {
-        const global = window as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-        if (!global[ThemeServiceSymbol]) {
-            const themeService = new ThemeService();
-            themeService.register(...BuiltinThemeProvider.themes);
-            themeService.startupTheme();
-            global[ThemeServiceSymbol] = themeService;
-        }
-        return global[ThemeServiceSymbol];
+    @postConstruct()
+    protected init(): void {
+        this.register(...BuiltinThemeProvider.themes);
+        this.loadUserTheme();
     }
 
     register(...themes: Theme[]): Disposable {
@@ -126,7 +121,6 @@ export class ThemeService {
     reset(): void {
         this.setCurrentTheme(this.defaultTheme.id);
     }
-
 }
 
 export class BuiltinThemeProvider {

--- a/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
+++ b/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject } from '@theia/core/shared/inversify';
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { FrontendApplicationContribution, PreferenceSchemaProvider, QuickAccessRegistry } from '@theia/core/lib/browser';
 import { MonacoSnippetSuggestProvider } from './monaco-snippet-suggest-provider';
 import * as monaco from '@theia/monaco-editor-core';
@@ -29,6 +29,7 @@ import { ITextModelService } from '@theia/monaco-editor-core/esm/vs/editor/commo
 import { IContextKeyService } from '@theia/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from '@theia/monaco-editor-core/esm/vs/platform/contextview/browser/contextView';
 import { MonacoContextMenuService } from './monaco-context-menu';
+import { MonacoThemingService } from './monaco-theming-service';
 
 @injectable()
 export class MonacoFrontendApplicationContribution implements FrontendApplicationContribution {
@@ -54,7 +55,10 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
     @inject(MonacoContextMenuService)
     protected readonly contextMenuService: MonacoContextMenuService;
 
-    async initialize(): Promise<void> {
+    @inject(MonacoThemingService) protected readonly monacoThemingService: MonacoThemingService;
+
+    @postConstruct()
+    protected init(): void {
         const { codeEditorService, textModelService, contextKeyService, contextMenuService } = this;
         StandaloneServices.initialize({
             [ICodeEditorService.toString()]: codeEditorService,
@@ -77,6 +81,9 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
             this.preferenceSchema.registerOverrideIdentifier(language.id);
             registerLanguage(language);
         };
+
+        this.monacoThemingService.initialize();
     }
 
+    initialize(): void { }
 }

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -88,10 +88,10 @@ import { StandaloneConfigurationService, StandaloneServices } from '@theia/monac
 import { Configuration } from '@theia/monaco-editor-core/esm/vs/platform/configuration/common/configurationModels';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { MonacoMarkdownRenderer } from './markdown-renderer/monaco-markdown-renderer';
+import { ThemeService } from '@theia/core/lib/browser/theming';
+import { ThemeServiceWithDB } from './monaco-indexed-db';
 
 decorate(injectable(), VSCodeContextKeyService);
-
-MonacoThemingService.init();
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MonacoThemingService).toSelf().inSingletonScope();
@@ -183,6 +183,9 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(MonacoColorRegistry).toSelf().inSingletonScope();
     rebind(ColorRegistry).toService(MonacoColorRegistry);
+
+    bind(ThemeServiceWithDB).toSelf().inSingletonScope();
+    rebind(ThemeService).toService(ThemeServiceWithDB);
 });
 
 export const MonacoConfigurationService = Symbol('MonacoConfigurationService');

--- a/packages/monaco/src/browser/monaco-indexed-db.ts
+++ b/packages/monaco/src/browser/monaco-indexed-db.ts
@@ -16,11 +16,11 @@
 
 import * as idb from 'idb';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
-import { BuiltinThemeProvider, ThemeService, ThemeServiceSymbol } from '@theia/core/lib/browser/theming';
-import { Theme } from '@theia/core/lib/common/theme';
+import { BuiltinThemeProvider, ThemeService } from '@theia/core/lib/browser/theming';
 import * as monaco from '@theia/monaco-editor-core';
-
-type ThemeMix = import('./textmate/monaco-theme-registry').ThemeMix;
+import { injectable } from '@theia/core/shared/inversify';
+import type { ThemeMix } from './textmate/monaco-theme-registry';
+import { Theme } from '@theia/core/lib/common/theme';
 
 let _monacoDB: Promise<idb.IDBPDatabase> | undefined;
 if ('indexedDB' in window) {
@@ -111,18 +111,8 @@ async function getThemeFromDB(id: string): Promise<Theme | undefined> {
     return matchingState && stateToTheme(matchingState);
 }
 
+@injectable()
 export class ThemeServiceWithDB extends ThemeService {
-    static override get(): ThemeService {
-        const global = window as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-        if (!global[ThemeServiceSymbol]) {
-            const themeService = new ThemeServiceWithDB();
-            themeService.register(...BuiltinThemeProvider.themes);
-            themeService.startupTheme();
-            global[ThemeServiceSymbol] = themeService;
-        }
-        return global[ThemeServiceSymbol];
-    }
-
     override loadUserTheme(): void {
         this.loadUserThemeWithDB();
     }
@@ -133,5 +123,3 @@ export class ThemeServiceWithDB extends ThemeService {
         this.setCurrentTheme(theme.id);
     }
 }
-
-ThemeService.get = ThemeServiceWithDB.get;

--- a/packages/monaco/src/browser/monaco-indexed-db.ts
+++ b/packages/monaco/src/browser/monaco-indexed-db.ts
@@ -120,6 +120,11 @@ export class ThemeServiceWithDB extends ThemeService {
     protected async loadUserThemeWithDB(): Promise<void> {
         const themeId = window.localStorage.getItem('theme') || this.defaultTheme.id;
         const theme = this.themes[themeId] ?? await getThemeFromDB(themeId) ?? this.defaultTheme;
+        // In case the theme comes from the DB.
+        if (!this.themes[theme.id]) {
+            this.themes[theme.id] = theme;
+        }
         this.setCurrentTheme(theme.id);
+        this.deferredInitializer.resolve();
     }
 }

--- a/packages/monaco/src/browser/textmate/monaco-textmate-frontend-bindings.ts
+++ b/packages/monaco/src/browser/textmate/monaco-textmate-frontend-bindings.ts
@@ -39,7 +39,7 @@ export default (bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: inter
     bind(FrontendApplicationContribution).toService(MonacoTextmateService);
     bindContributionProvider(bind, LanguageGrammarDefinitionContribution);
     bind(TextmateRegistry).toSelf().inSingletonScope();
-    bind(MonacoThemeRegistry).toDynamicValue(() => MonacoThemeRegistry.SINGLETON).inSingletonScope();
+    bind(MonacoThemeRegistry).toSelf().inSingletonScope();
 };
 
 export async function dynamicOnigasmLib(ctx: interfaces.Context): Promise<IOnigLib> {

--- a/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
@@ -33,6 +33,20 @@ export interface MixStandaloneTheme extends IStandaloneTheme {
 @injectable()
 export class MonacoThemeRegistry {
 
+    initializeDefaultThemes(): void {
+        this.register(require('../../../data/monaco-themes/vscode/dark_theia.json'), {
+            './dark_vs.json': require('../../../data/monaco-themes/vscode/dark_vs.json'),
+            './dark_plus.json': require('../../../data/monaco-themes/vscode/dark_plus.json')
+        }, 'dark-theia', 'vs-dark');
+        this.register(require('../../../data/monaco-themes/vscode/light_theia.json'), {
+            './light_vs.json': require('../../../data/monaco-themes/vscode/light_vs.json'),
+            './light_plus.json': require('../../../data/monaco-themes/vscode/light_plus.json'),
+        }, 'light-theia', 'vs');
+        this.register(require('../../../data/monaco-themes/vscode/hc_theia.json'), {
+            './hc_black.json': require('../../../data/monaco-themes/vscode/hc_black.json')
+        }, 'hc-theia', 'hc-black');
+    }
+
     getThemeData(): ThemeMix;
     getThemeData(name: string): ThemeMix | undefined;
     getThemeData(name?: string): ThemeMix | undefined {
@@ -155,17 +169,7 @@ export class MonacoThemeRegistry {
 }
 
 export namespace MonacoThemeRegistry {
-    export const SINGLETON = new MonacoThemeRegistry();
-
-    export const DARK_DEFAULT_THEME: string = SINGLETON.register(require('../../../data/monaco-themes/vscode/dark_theia.json'), {
-        './dark_vs.json': require('../../../data/monaco-themes/vscode/dark_vs.json'),
-        './dark_plus.json': require('../../../data/monaco-themes/vscode/dark_plus.json')
-    }, 'dark-theia', 'vs-dark').name!;
-    export const LIGHT_DEFAULT_THEME: string = SINGLETON.register(require('../../../data/monaco-themes/vscode/light_theia.json'), {
-        './light_vs.json': require('../../../data/monaco-themes/vscode/light_vs.json'),
-        './light_plus.json': require('../../../data/monaco-themes/vscode/light_plus.json'),
-    }, 'light-theia', 'vs').name!;
-    export const HC_DEFAULT_THEME: string = SINGLETON.register(require('../../../data/monaco-themes/vscode/hc_theia.json'), {
-        './hc_black.json': require('../../../data/monaco-themes/vscode/hc_black.json')
-    }, 'hc-theia', 'hc-black').name!;
+    export const DARK_DEFAULT_THEME = 'dark-theia';
+    export const LIGHT_DEFAULT_THEME = 'light-theia';
+    export const HC_DEFAULT_THEME = 'hc-theia';
 }

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -58,6 +58,7 @@ import { WebviewViewsMainImpl } from './webview-views/webview-views-main';
 import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
 import { NotificationExtImpl } from '../../plugin/notification';
 import { UntitledResourceResolver } from '@theia/core/lib/common/resource';
+import { ThemeService } from '@theia/core/lib/browser/theming';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const authenticationMain = new AuthenticationMainImpl(rpc, container);
@@ -178,7 +179,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const timelineMain = new TimelineMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.TIMELINE_MAIN, timelineMain);
 
-    const themingMain = new ThemingMainImpl(rpc);
+    const themingMain = new ThemingMainImpl(rpc, container.get(ThemeService));
     rpc.set(PLUGIN_RPC_CONTEXT.THEMING_MAIN, themingMain);
 
     const commentsMain = new CommentsMainImp(rpc, container);

--- a/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import { ThemeService } from '@theia/core/lib/browser/theming';
 import { Theme } from '@theia/core/lib/common/theme';
@@ -34,15 +34,18 @@ export interface PluginIcon extends Disposable {
 @injectable()
 export class PluginSharedStyle {
 
+    @inject(ThemeService) protected readonly themeService: ThemeService;
+
     protected style: HTMLStyleElement;
     protected readonly rules: {
         selector: string;
         body: (theme: Theme) => string
     }[] = [];
 
-    constructor() {
+    @postConstruct()
+    protected init(): void {
         this.update();
-        ThemeService.get().onDidColorThemeChange(() => this.update());
+        this.themeService.onDidColorThemeChange(() => this.update());
     }
 
     protected readonly toUpdate = new DisposableCollection();
@@ -79,7 +82,7 @@ export class PluginSharedStyle {
         body: (theme: Theme) => string
     }): void {
         const sheet = (<CSSStyleSheet>this.style.sheet);
-        const cssBody = body(ThemeService.get().getCurrentTheme());
+        const cssBody = body(this.themeService.getCurrentTheme());
         sheet.insertRule(selector + ' {\n' + cssBody + '\n}', 0);
     }
     deleteRule(selector: string): void {

--- a/packages/plugin-ext/src/main/browser/theming-main.ts
+++ b/packages/plugin-ext/src/main/browser/theming-main.ts
@@ -30,14 +30,10 @@ export class ThemingMainImpl implements ThemingMain {
     private readonly proxy: ThemingExt;
     private readonly themeChangeListener: Disposable;
 
-    constructor(
-        rpc: RPCProtocol
-    ) {
+    constructor(rpc: RPCProtocol, themeService: ThemeService) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.THEMING_EXT);
-        this.themeChangeListener = ThemeService.get().onDidColorThemeChange(e => {
-            this.proxy.$onColorThemeChange(e.newTheme.type);
-        });
-        this.proxy.$onColorThemeChange(ThemeService.get().getCurrentTheme().type);
+        this.themeChangeListener = themeService.onDidColorThemeChange(e => this.proxy.$onColorThemeChange(e.newTheme.type));
+        this.proxy.$onColorThemeChange(themeService.getCurrentTheme().type);
     }
 
     dispose(): void {

--- a/packages/plugin-ext/src/main/browser/webview/webview-theme-data-provider.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-theme-data-provider.ts
@@ -40,14 +40,10 @@ export class WebviewThemeDataProvider {
     protected readonly onDidChangeThemeDataEmitter = new Emitter<void>();
     readonly onDidChangeThemeData = this.onDidChangeThemeDataEmitter.event;
 
-    @inject(EditorPreferences)
-    protected readonly editorPreferences: EditorPreferences;
-
-    @inject(ColorRegistry)
-    protected readonly colors: ColorRegistry;
-
-    @inject(ColorApplicationContribution)
-    protected readonly colorContribution: ColorApplicationContribution;
+    @inject(EditorPreferences) protected readonly editorPreferences: EditorPreferences;
+    @inject(ColorRegistry) protected readonly colors: ColorRegistry;
+    @inject(ColorApplicationContribution) protected readonly colorContribution: ColorApplicationContribution;
+    @inject(ThemeService) protected readonly themeService: ThemeService;
 
     protected themeData: WebviewThemeData | undefined;
 
@@ -114,7 +110,7 @@ export class WebviewThemeDataProvider {
     }
 
     protected getActiveTheme(): Theme {
-        return ThemeService.get().getCurrentTheme();
+        return this.themeService.getCurrentTheme();
     }
 
     protected getThemeType(theme: Theme): WebviewThemeType {

--- a/packages/terminal/src/browser/terminal-theme-service.ts
+++ b/packages/terminal/src/browser/terminal-theme-service.ts
@@ -19,6 +19,8 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 import { ColorDefaults } from '@theia/core/lib/common/color';
 import { ThemeService } from '@theia/core/lib/browser/theming';
+import { ThemeChangeEvent } from '@theia/core/lib/common/theme';
+import { Event } from '@theia/core';
 
 /**
  * It should be aligned with https://github.com/microsoft/vscode/blob/0dfa355b3ad185a6289ba28a99c141ab9e72d2be/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts#L40
@@ -157,10 +159,12 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
 @injectable()
 export class TerminalThemeService {
 
-    @inject(ColorRegistry)
-    protected readonly colorRegistry: ColorRegistry;
+    @inject(ColorRegistry) protected readonly colorRegistry: ColorRegistry;
+    @inject(ThemeService) protected readonly themeService: ThemeService;
 
-    readonly onDidChange = ThemeService.get().onDidColorThemeChange;
+    get onDidChange(): Event<ThemeChangeEvent> {
+        return this.themeService.onDidColorThemeChange;
+    }
 
     get theme(): ITheme {
         const foregroundColor = this.colorRegistry.getCurrentColor('terminal.foreground');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

At the moment, the initialization of theming happens outside of the application's `inversify` lifecycle. That makes it difficult to override and difficult to integrate into the management of `monaco`'s initialization lifecycle. Part of the reason for attempting to complete theme initialization outside of the `inversify` lifecycle is to ensure that themes applied accurately even to the loading screen. That seems unnecessary to me: the point of a loading screen is to give the application time to do its work. This PR sets the background of the loading screen to a constant.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Changing themes should work as before.
2. On restart / reload, theme restoration should work as before (with the caveat that the loading screen will be dark regardless of restored theme).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
