### PR TITLE
Move WebviewViewResolveContext to root namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## v1.27.0 - Unreleased
 
+- [plugin] moved `WebviewViewResolveContext` from `window` to `root` namespace [#11216](https://github.com/eclipse-theia/theia/pull/11216) - Contributed on behalf of STMicroelectronics
+
 <a name="breaking_changes_1.27.0">[Breaking Changes:](#breaking_changes_1.27.0)</a>
 
 - [plugin-dev] moved and renamed interface from: `@theia/debug/lib/browser/debug-contribution/DebugPluginConfiguration` to: `plugin-dev/src/common/PluginDebugConfiguration` [#11224](https://github.com/eclipse-theia/theia/pull/11224)

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4269,6 +4269,44 @@ export module '@theia/plugin' {
     }
 
     /**
+     * Additional information the webview view being resolved.
+     *
+     * @param T Type of the webview's state.
+     */
+    interface WebviewViewResolveContext<T = unknown> {
+        /**
+         * Persisted state from the webview content.
+         *
+         * To save resources, VS Code normally deallocates webview documents (the iframe content) that are not visible.
+         * For example, when the user collapse a view or switches to another top level activity in the sidebar, the
+         * `WebviewView` itself is kept alive but the webview's underlying document is deallocated. It is recreated when
+         * the view becomes visible again.
+         *
+         * You can prevent this behavior by setting `retainContextWhenHidden` in the `WebviewOptions`. However this
+         * increases resource usage and should be avoided wherever possible. Instead, you can use persisted state to
+         * save off a webview's state so that it can be quickly recreated as needed.
+         *
+         * To save off a persisted state, inside the webview call `acquireVsCodeApi().setState()` with
+         * any json serializable object. To restore the state again, call `getState()`. For example:
+         *
+         * ```js
+         * // Within the webview
+         * const vscode = acquireVsCodeApi();
+         *
+         * // Get existing state
+         * const oldState = vscode.getState() || { value: 0 };
+         *
+         * // Update state
+         * setState({ value: oldState.value + 1 })
+         * ```
+         *
+         * VS Code ensures that the persisted state is saved correctly when a webview is hidden and across
+         * editor restarts.
+         */
+        readonly state: T | undefined;
+    }
+
+    /**
      * Common namespace for dealing with window and editor, showing messages and user input.
      */
     export namespace window {
@@ -4608,44 +4646,6 @@ export module '@theia/plugin' {
          * @param viewType Type of the webview panel that can be serialized.
          * @param serializer Webview serializer.
          */
-
-        /**
-         * Additional information the webview view being resolved.
-         *
-         * @param T Type of the webview's state.
-         */
-        interface WebviewViewResolveContext<T = unknown> {
-            /**
-             * Persisted state from the webview content.
-             *
-             * To save resources, VS Code normally deallocates webview documents (the iframe content) that are not visible.
-             * For example, when the user collapse a view or switches to another top level activity in the sidebar, the
-             * `WebviewView` itself is kept alive but the webview's underlying document is deallocated. It is recreated when
-             * the view becomes visible again.
-             *
-             * You can prevent this behavior by setting `retainContextWhenHidden` in the `WebviewOptions`. However this
-             * increases resource usage and should be avoided wherever possible. Instead, you can use persisted state to
-             * save off a webview's state so that it can be quickly recreated as needed.
-             *
-             * To save off a persisted state, inside the webview call `acquireVsCodeApi().setState()` with
-             * any json serializable object. To restore the state again, call `getState()`. For example:
-             *
-             * ```js
-             * // Within the webview
-             * const vscode = acquireVsCodeApi();
-             *
-             * // Get existing state
-             * const oldState = vscode.getState() || { value: 0 };
-             *
-             * // Update state
-             * setState({ value: oldState.value + 1 })
-             * ```
-             *
-             * VS Code ensures that the persisted state is saved correctly when a webview is hidden and across
-             * editor restarts.
-             */
-            readonly state: T | undefined;
-        }
 
         export function registerWebviewViewProvider(viewId: string, provider: WebviewViewProvider, options?: {
             /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
To be compatable with the VSCode API the `WebviewViewResolveContext` needs to be in the root namespace. See [here](https://github.com/microsoft/vscode/blob/6faebbe7302eee4a0909849a795b3861b1940d65/src/vscode-dts/vscode.d.ts#L8576).

The WebviewViewResolveContext was previously in the window namespace.
Removed it from the window namespace and added it to root namespace.

Fixes #11149.

Contributed on behalf of STMicroelectronics.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
