### PR TITLE
[electron]: Moved the menu creation/update to electron-main.

### DIFF
--- a/examples/api-samples/src/electron-browser/menu/sample-electron-menu-module.ts
+++ b/examples/api-samples/src/electron-browser/menu/sample-electron-menu-module.ts
@@ -16,6 +16,7 @@
 
 import { injectable, ContainerModule } from '@theia/core/shared/inversify';
 import { CompositeMenuNode } from '@theia/core/lib/common/menu';
+import type { MenuItemConstructorOptions } from '@theia/core/lib/electron-common/menu';
 import { ElectronMainMenuFactory, ElectronMenuOptions } from '@theia/core/lib/electron-browser/menu/electron-main-menu-factory';
 import { PlaceholderMenuNode } from '../../browser/menu/sample-menu-contribution';
 
@@ -27,7 +28,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 class SampleElectronMainMenuFactory extends ElectronMainMenuFactory {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected override handleElectronDefault(menuNode: CompositeMenuNode, args: any[] = [], options?: ElectronMenuOptions): Electron.MenuItemConstructorOptions[] {
+    protected override handleElectronDefault(menuNode: CompositeMenuNode, args: any[] = [], options?: ElectronMenuOptions): MenuItemConstructorOptions[] {
         if (menuNode instanceof PlaceholderMenuNode) {
             return [{
                 label: menuNode.label,

--- a/examples/api-samples/src/electron-browser/updater/sample-updater-frontend-contribution.ts
+++ b/examples/api-samples/src/electron-browser/updater/sample-updater-frontend-contribution.ts
@@ -14,10 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import * as electronRemote from '@theia/core/electron-shared/@electron/remote';
-import { Menu, BrowserWindow } from '@theia/core/electron-shared/electron';
+import { ipcRenderer } from '@theia/core/electron-shared/electron';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { isOSX } from '@theia/core/lib/common/os';
 import { CommonMenus } from '@theia/core/lib/browser';
 import {
     Emitter,
@@ -32,6 +30,7 @@ import {
 import { ElectronMainMenuFactory } from '@theia/core/lib/electron-browser/menu/electron-main-menu-factory';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { SampleUpdater, UpdateStatus, SampleUpdaterClient } from '../../common/updater/sample-updater';
+import { SetMenu } from '@theia/core/lib/electron-common/messaging/electron-messages';
 
 export namespace SampleUpdaterCommands {
 
@@ -88,15 +87,8 @@ export class ElectronMenuUpdater {
     protected readonly factory: ElectronMainMenuFactory;
 
     public update(): void {
-        this.setMenu();
-    }
-
-    private setMenu(menu: Menu | null = this.factory.createElectronMenuBar(), electronWindow: BrowserWindow = electronRemote.getCurrentWindow()): void {
-        if (isOSX) {
-            electronRemote.Menu.setApplicationMenu(menu);
-        } else {
-            electronWindow.setMenu(menu);
-        }
+        const template = this.factory.createElectronMenuBar();
+        ipcRenderer.send(SetMenu.Signal, { template });
     }
 
 }

--- a/packages/core/src/electron-common/menu.ts
+++ b/packages/core/src/electron-common/menu.ts
@@ -1,0 +1,39 @@
+// *****************************************************************************
+// Copyright (C) 2022 Arduino SA and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import type { MenuItemConstructorOptions as ElectronMenuItemConstructorOptions } from '../../electron-shared/electron';
+
+export type MenuItemConstructorOptions = Omit<ElectronMenuItemConstructorOptions, 'click' | 'accelerator' | 'icon' | 'sharingItem' | 'submenu'> & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    click?: { commandId: string, args?: any[] };
+    accelerator?: string,
+    icon?: string,
+    submenu?: MenuItemConstructorOptions[],
+};
+export namespace MenuItemConstructorOptions {
+    export function toElectron(
+        options: MenuItemConstructorOptions,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        clickHandler: ({ commandId, args }: { commandId: string, args?: any[] }) => () => void
+    ): ElectronMenuItemConstructorOptions {
+        const { click, submenu, ...rest } = options;
+        return {
+            ...rest,
+            ...click && { click: clickHandler(click) },
+            ...submenu && { submenu: submenu.map(subOption => toElectron(subOption, clickHandler)) }
+        };
+    }
+}

--- a/packages/core/src/electron-common/messaging/electron-messages.ts
+++ b/packages/core/src/electron-common/messaging/electron-messages.ts
@@ -14,6 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import type { MenuItemConstructorOptions } from '../menu';
+
 export const RequestTitleBarStyle = 'requestTitleBarStyle';
 export const TitleBarStyleChanged = 'titleBarStyleChanged';
 export const TitleBarStyleAtStartup = 'titleBarStyleAtStartup';
@@ -50,4 +52,71 @@ export interface CloseRequestArguments {
     confirmChannel: string;
     cancelChannel: string;
     reason: StopReason;
+}
+
+/**
+ * Request is sent by the render to the main to rebuild and set the menu.
+ */
+export namespace SetMenu {
+    export const Signal = 'setMenu';
+    export interface Params {
+        readonly template: MenuItemConstructorOptions[] | undefined;
+    }
+}
+/**
+ * Request sent by the render to the main to build and show the context menu.
+ */
+export namespace ShowContextMenu {
+    export const Signal = 'showContextMenu';
+    export interface Params {
+        readonly template: MenuItemConstructorOptions[];
+        /** Must be an integer. */
+        readonly x: number;
+        /** Must be an integer. */
+        readonly y: number;
+        readonly contextMenuId: string;
+    }
+};
+/**
+ * Sent by the renderer to main to programmatically close an open context menu identified by the unique `contextMenuId`.
+ * This request might be ignored by the recipient if no open context menu exists with the ID. For example, the context menu was closed by user clicking away.
+ */
+export namespace CloseContextMenu {
+    export const Signal = 'closeContextMenu';
+    export interface Params {
+        readonly contextMenuId: string;
+    }
+}
+/**
+ * Event sent by the main to the render when a context menu was closed.
+ */
+export namespace ContextMenuDidClose {
+    export const Signal = 'contextMenuDidClose';
+    export interface Params {
+        readonly contextMenuId: string;
+    }
+}
+/**
+ * Event sent by the main to the renderer when one of the menu items was clicked.
+ */
+export namespace MenuItemDidClick {
+    export const Signal = 'menuItemDidClick';
+    export interface Params {
+        readonly commandId: string;
+        /**
+         * The arguments will be serialized with the [_Structured Clone Algorithm_](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+         * Sending Functions, Promises, Symbols, DOM or special electron objects, WeakMaps, or WeakSets will throw an exception.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        readonly args?: any[];
+    }
+}
+/**
+ * Sent by the renderer to the main to updated the `checked` state of the menu item IDs.
+ */
+export namespace UpdateMenuItems {
+    export const Signal = 'updateMenuItems';
+    export interface Params {
+        readonly menuItems: { id: string, checked: boolean }[];
+    }
 }

--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -27,6 +27,7 @@ import { ElectronMessagingService } from './messaging/electron-messaging-service
 import { ElectronConnectionHandler } from '../electron-common/messaging/electron-connection-handler';
 import { ElectronSecurityTokenService } from './electron-security-token-service';
 import { TheiaBrowserWindowOptions, TheiaElectronWindow, TheiaElectronWindowFactory, WindowApplicationConfig } from './theia-electron-window';
+import { ElectronMainMenu } from './electron-main-menu';
 
 const electronSecurityToken: ElectronSecurityToken = { value: v4() };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,4 +60,6 @@ export default new ContainerModule(bind => {
         child.bind(WindowApplicationConfig).toConstantValue(config);
         return child.get(TheiaElectronWindow);
     });
+    bind(ElectronMainMenu).toSelf().inSingletonScope();
+    bind(ElectronMainApplicationContribution).toService(ElectronMainMenu);
 });

--- a/packages/core/src/electron-main/electron-main-menu.ts
+++ b/packages/core/src/electron-main/electron-main-menu.ts
@@ -1,0 +1,238 @@
+// *****************************************************************************
+// Copyright (C) 2022 Arduino SA and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from 'inversify';
+import { app, BrowserWindow, ipcMain, WebContents } from '../../electron-shared/electron';
+import { Menu } from '../../electron-shared/electron/index';
+import { isOSX } from '../common';
+import { MenuItemConstructorOptions } from '../electron-common/menu';
+import {
+    CloseContextMenu,
+    ContextMenuDidClose, MenuItemDidClick, SetMenu, ShowContextMenu, UpdateMenuItems
+} from '../electron-common/messaging/electron-messages';
+import { ElectronMainApplicationContribution } from './electron-main-application';
+
+@injectable()
+export class ElectronMainMenu implements ElectronMainApplicationContribution {
+
+    // keys are the sender IDS, values are the current menu per window.
+    protected readonly menus = new Map<number, Menu | null>();
+    // keys are sender IDs, values are the open context menus per sender.
+    protected readonly openContextMenus = new Map<number, Map<string, Menu>>();
+
+    onStart(): void {
+        ipcMain.on(SetMenu.Signal, ({ sender }, params: SetMenu.Params) => this.setMenu({ sender }, params));
+        ipcMain.on(UpdateMenuItems.Signal, ({ sender }, params: UpdateMenuItems.Params) => this.updateMenuItems({ sender }, params));
+        ipcMain.on(ShowContextMenu.Signal, ({ sender }, params: ShowContextMenu.Params) => this.showContextMenu({ sender }, params));
+        ipcMain.on(CloseContextMenu.Signal, ({ sender }, params: CloseContextMenu.Params) => this.closeContextMenu({ sender }, params));
+        if (isOSX) {
+            // OSX: Recreate the menus when changing windows.
+            // OSX only has one menu bar for all windows, so we need to swap
+            // between them as the user switches windows.
+            app.on('browser-window-focus', (_event, browserWindow) => {
+                const { id } = browserWindow;
+                const menu = this.menus.get(id);
+                if (menu !== undefined) {
+                    Menu.setApplicationMenu(menu);
+                }
+            });
+        }
+        app.on('browser-window-created', (_event, browserWindow) => {
+            const { id } = browserWindow;
+            browserWindow.once('closed', () => {
+                this.menus.delete(id);
+                this.openContextMenus.delete(id);
+            });
+        });
+    }
+
+    onStop(): void {
+        this.menus.clear();
+        this.openContextMenus.clear();
+    }
+
+    async setMenu(
+        { sender }: { sender: WebContents },
+        params: SetMenu.Params
+    ): Promise<void> {
+        const { template } = params;
+        console.debug(SetMenu.Signal, `sender ID: ${sender.id}`);
+        const browserWindow = BrowserWindow.fromId(sender.id);
+        if (!browserWindow) {
+            console.warn(SetMenu.Signal, `Could not find BrowserWindow with ID: <${sender.id}>.`);
+            return;
+        }
+        // eslint-disable-next-line no-null/no-null
+        let menu: Menu | null = null;
+        if (template) {
+            menu = buildFromTemplate(sender, template);
+        }
+        this.doSetMenu({ sender }, { menu, browserWindow });
+    }
+
+    async updateMenuItems(
+        { sender }: { sender: WebContents },
+        params: UpdateMenuItems.Params
+    ): Promise<void> {
+        const { id } = sender;
+        const { menuItems } = params;
+        console.debug(UpdateMenuItems.Signal, `Sender ID: <${id}>, menu items to update: <${JSON.stringify(menuItems)}>.`);
+        const browserWindow = BrowserWindow.fromId(sender.id);
+        if (!browserWindow) {
+            console.warn(UpdateMenuItems.Signal, `Could not find BrowserWindow with ID: <${id}>.`);
+            return;
+        }
+        const menu = this.menus.get(id);
+        if (!menu) {
+            console.warn(UpdateMenuItems.Signal, `Could not update menu items toggle state. Sender <${id}> does not have a registered menu.`);
+            return;
+        }
+        for (const { id: menuItemId, checked } of menuItems) {
+            const menuItem = menu.getMenuItemById(menuItemId);
+            if (menuItem) {
+                menuItem.checked = checked;
+            }
+        }
+        this.doSetMenu({ sender }, { menu, browserWindow });
+    }
+
+    async showContextMenu(
+        { sender }: { sender: WebContents },
+        params: ShowContextMenu.Params
+    ): Promise<void> {
+        const { template, x, y, contextMenuId } = params;
+        console.debug(ShowContextMenu.Signal, `Sender ID: <${sender.id}>, context menu ID: <${contextMenuId}>.`);
+        const browserWindow = BrowserWindow.fromId(sender.id);
+        if (!browserWindow) {
+            console.warn(ShowContextMenu.Signal, `Could not find BrowserWindow with ID: <${sender.id}>.`);
+            return;
+        }
+        const contextMenu = buildFromTemplate(sender, template);
+        contextMenu.once('menu-will-show', () => this.register({ sender, contextMenuId, contextMenu }));
+        contextMenu.popup({
+            window: browserWindow,
+            x,
+            y,
+            callback: () => this.unregister({ sender, contextMenuId })
+        });
+    }
+
+    async closeContextMenu(
+        { sender }: { sender: WebContents },
+        params: CloseContextMenu.Params
+    ): Promise<void> {
+        const { contextMenuId } = params;
+        console.debug(CloseContextMenu.Signal, `Sender ID: <${sender.id}>, context menu ID: <${contextMenuId}>.`);
+        this.unregister({ sender, contextMenuId });
+    }
+
+    private register({ sender, contextMenuId, contextMenu }: { sender: WebContents, contextMenuId: string, contextMenu: Menu }): boolean {
+        const { id } = sender;
+        console.debug(`>>> Registering open context meu for sender <${id}> with context menu ID: <${contextMenuId}>.`);
+        this.dumpOpenContextMenus();
+        let contextMenusPerSender = this.openContextMenus.get(id);
+        if (!contextMenusPerSender) {
+            contextMenusPerSender = new Map<string, Menu>();
+            this.openContextMenus.set(id, contextMenusPerSender);
+        } else {
+            const existingOpenMenu = contextMenusPerSender.get(contextMenuId);
+            if (existingOpenMenu) {
+                console.warn(`<<< Context menu was already registered for sender <${id}> with context menu ID: <${contextMenuId}>.`);
+                return false;
+            }
+        }
+        contextMenusPerSender.set(contextMenuId, contextMenu);
+        console.debug(`<<< Registered open context meu for sender <${id}> with context menu ID: <${contextMenuId}>.`);
+        this.dumpOpenContextMenus();
+        return true;
+    }
+
+    private unregister({ sender, contextMenuId, silent }: { sender: WebContents, contextMenuId: string, silent?: boolean }): boolean {
+        const { id } = sender;
+        console.debug(`>>> Removing open context meu for sender <${id}> with context menu ID: <${contextMenuId}>.`);
+        this.dumpOpenContextMenus('before unregister');
+        const contextMenusPerSender = this.openContextMenus.get(id);
+        if (!contextMenusPerSender) {
+            console.warn(`Sender <${id}> does not have any opened context menu registered.`);
+            return false;
+        }
+        const contextMenu = contextMenusPerSender.get(contextMenuId);
+        if (!contextMenu) {
+            // It might happen that a context menu was gracefully closed (eg. user clicked away), but still the renderer request a close on `dispose`.
+            if (silent) {
+                console.warn(`Sender <${id}> does not have an opened context menu registered with ID <${contextMenuId}>.`);
+            }
+            return false;
+        }
+        contextMenusPerSender.delete(contextMenuId);
+        const browserWindow = BrowserWindow.fromId(id);
+        if (!browserWindow) {
+            console.warn(`Could not find browser window for sender <${id}>.`);
+            return false;
+        }
+        contextMenu.closePopup(browserWindow);
+        sender.send(ContextMenuDidClose.Signal, { contextMenuId });
+        if (!contextMenusPerSender.size) {
+            this.openContextMenus.delete(id);
+        }
+        console.debug(`>>> Removed open context meu for sender <${id}> with context menu ID: <${contextMenuId}>.`);
+        this.dumpOpenContextMenus('after unregister');
+        return true;
+    }
+
+    private doSetMenu(
+        { sender }: { sender: WebContents },
+        { menu, browserWindow }: { menu: Menu | null, browserWindow: Electron.BrowserWindow }
+    ): void {
+        const { id } = sender;
+        this.menus.set(id, menu);
+        if (isOSX) {
+            Menu.setApplicationMenu(menu);
+        } else {
+            // Unix/Windows: Set the per-window menus
+            browserWindow.setMenu(menu);
+        }
+    }
+
+    private dumpOpenContextMenus(message: string = ''): void {
+        console.debug(`------- Open context menus ${message ? `[${message}] ` : ''}-------`);
+        for (const [id, contextMenusPerSender] of this.openContextMenus.entries()) {
+            if (contextMenusPerSender.size) {
+                console.debug(`Open context menus for sender <${id}>:`);
+            }
+            for (const contextMenuId of contextMenusPerSender.keys()) {
+                console.debug(` - <${contextMenuId}>`);
+            }
+        }
+        console.debug('----------------------------------');
+    }
+
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildFromTemplate(
+    sender: WebContents,
+    options: MenuItemConstructorOptions[]
+): Menu {
+    const template = options.map(o => MenuItemConstructorOptions.toElectron(o, menuItemClickHandler(sender)));
+    return Menu.buildFromTemplate(template);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function menuItemClickHandler(sender: WebContents): ({ commandId, args }: { commandId: string; args?: any[]; }) => () => void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return ({ commandId, args }: { commandId: string; args?: any[]; }) => () => sender.send(MenuItemDidClick.Signal, { commandId, args });
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR moves the electron menu creation/update to the electron-main process.

OK but why?
 - Electron `remote` has been deprecated and will be moved outside of electron, (https://github.com/electron/electron/issues/21408)
 - `getCurrentWindow` is a synchronous call and blocks the thread. This is problematic when Theia (or its customization) opens with several browser windows at startup,
 - This will help to remove the rest of the Electron `remote` code from Theia and use IPC between the main and the renderers.

One of my top priorities during the development was to reduce the amount of breaking changes. Please chime in and propose changes. Feedback is welcome. Thank you! 🧁

#### How to test
 - Start the Electron app in debug mode, and check the console how the context menu items are cleaned up on the main process,
 - TBD,

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
