### PR TITLE
Fix `runtime-import-check` errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.27.0 - Unreleased
+
+<a name="breaking_changes_1.27.0">[Breaking Changes:](#breaking_changes_1.27.0)</a>
+
+- [plugin-dev] moved and renamed interface from: `@theia/debug/lib/browser/debug-contribution/DebugPluginConfiguration` to: `plugin-dev/src/common/PluginDebugConfiguration` [#11224](https://github.com/eclipse-theia/theia/pull/11224)
+
 ## v1.26.0 - 5/26/2022
 
 - [application-package] introduce application config prop `validatePreferencesSchema` to control whether to validate preferences on start [#11189](https://github.com/eclipse-theia/theia/pull/11189)

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -33,6 +33,7 @@ export * from './message-service';
 export * from './message-service-protocol';
 export * from './progress-service';
 export * from './progress-service-protocol';
+export * from './quick-pick-service';
 export * from './selection';
 export * from './strings';
 export * from './application-error';

--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -23,12 +23,6 @@ export interface DebugContribution {
     register(configType: string, connection: DebugSessionConnection): void;
 }
 
-export interface DebugPluginConfiguration {
-    debugMode?: string;
-    pluginLocation?: string;
-    debugPort?: string;
-}
-
 // copied from https://github.com/microsoft/vscode-node-debug2/blob/bcd333ef87642b817ac96d28fde7ab96fee3f6a9/src/nodeDebugInterfaces.d.ts
 export interface LaunchVSCodeRequest extends DebugProtocol.Request {
     arguments: LaunchVSCodeArguments;

--- a/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
@@ -22,8 +22,8 @@ import { LabelProvider, isNative, AbstractDialog } from '@theia/core/lib/browser
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileDialogService } from '@theia/filesystem/lib/browser';
-import { PluginDevServer } from '../common/plugin-dev-protocol';
-import { DebugPluginConfiguration, LaunchVSCodeArgument, LaunchVSCodeRequest, LaunchVSCodeResult } from '@theia/debug/lib/browser/debug-contribution';
+import { PluginDebugConfiguration, PluginDevServer } from '../common/plugin-dev-protocol';
+import { LaunchVSCodeArgument, LaunchVSCodeRequest, LaunchVSCodeResult } from '@theia/debug/lib/browser/debug-contribution';
 import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
 import { HostedPluginPreferences } from './hosted-plugin-preferences';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
@@ -145,7 +145,7 @@ export class HostedPluginManagerClient {
         return undefined;
     }
 
-    async start(debugConfig?: DebugPluginConfiguration): Promise<void> {
+    async start(debugConfig?: PluginDebugConfiguration): Promise<void> {
         if (await this.hostedPluginServer.isHostedPluginInstanceRunning()) {
             this.messageService.warn(nls.localize('theia/plugin-dev/alreadyRunning', 'Hosted instance is already running.'));
             return;
@@ -181,7 +181,7 @@ export class HostedPluginManagerClient {
         }
     }
 
-    async debug(config?: DebugPluginConfiguration): Promise<string | undefined> {
+    async debug(config?: PluginDebugConfiguration): Promise<string | undefined> {
         await this.start(this.setDebugConfig(config));
         await this.startDebugSessionManager();
 
@@ -361,7 +361,7 @@ export class HostedPluginManagerClient {
         return error?.message?.substring(error.message.indexOf(':') + 1) || '';
     }
 
-    private setDebugConfig(config?: DebugPluginConfiguration): DebugPluginConfiguration {
+    private setDebugConfig(config?: PluginDebugConfiguration): PluginDebugConfiguration {
         config = Object.assign(config || {}, { debugMode: this.hostedPluginPreferences['hosted-plugin.debugMode'] });
         if (config.pluginLocation) {
             this.pluginLocation = new URI((!config.pluginLocation.startsWith('/') ? '/' : '') + config.pluginLocation.replace(/\\/g, '/')).withScheme('file');
@@ -369,7 +369,7 @@ export class HostedPluginManagerClient {
         return config;
     }
 
-    private getDebugPluginConfig(args: LaunchVSCodeArgument[]): DebugPluginConfiguration {
+    private getDebugPluginConfig(args: LaunchVSCodeArgument[]): PluginDebugConfiguration {
         let pluginLocation;
         for (const arg of args) {
             if (arg?.prefix === '--extensionDevelopmentPath=') {

--- a/packages/plugin-dev/src/common/plugin-dev-protocol.ts
+++ b/packages/plugin-dev/src/common/plugin-dev-protocol.ts
@@ -15,8 +15,6 @@
 // *****************************************************************************
 
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
-// eslint-disable-next-line @theia/runtime-import-check
-import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
 import { PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
 
 export const pluginDevServicePath = '/services/plugin-dev';
@@ -24,7 +22,7 @@ export const PluginDevServer = Symbol('PluginDevServer');
 export interface PluginDevServer extends JsonRpcServer<PluginDevClient> {
     getHostedPlugin(): Promise<PluginMetadata | undefined>;
     runHostedPluginInstance(uri: string): Promise<string>;
-    runDebugHostedPluginInstance(uri: string, debugConfig: DebugPluginConfiguration): Promise<string>;
+    runDebugHostedPluginInstance(uri: string, debugConfig: PluginDebugConfiguration): Promise<string>;
     terminateHostedPluginInstance(): Promise<void>;
     isHostedPluginInstanceRunning(): Promise<boolean>;
     getHostedPluginInstanceURI(): Promise<string>;
@@ -38,4 +36,10 @@ export interface PluginDevServer extends JsonRpcServer<PluginDevClient> {
 }
 
 export interface PluginDevClient {
+}
+
+export interface PluginDebugConfiguration {
+    debugMode?: string;
+    pluginLocation?: string;
+    debugPort?: string;
 }

--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -29,8 +29,7 @@ import { FileUri } from '@theia/core/lib/node/file-uri';
 import { LogType } from '@theia/plugin-ext/lib/common/types';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin';
 import { MetadataScanner } from '@theia/plugin-ext/lib/hosted/node/metadata-scanner';
-// eslint-disable-next-line @theia/runtime-import-check
-import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
+import { PluginDebugConfiguration } from '../common/plugin-dev-protocol';
 import { HostedPluginProcess } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin-process';
 
 const DEFAULT_HOSTED_PLUGIN_PORT = 3030;
@@ -61,7 +60,7 @@ export interface HostedInstanceManager {
      * @param debugConfig debug configuration
      * @returns uri where new Theia instance is run
      */
-    debug(pluginUri: URI, debugConfig: DebugPluginConfiguration): Promise<URI>;
+    debug(pluginUri: URI, debugConfig: PluginDebugConfiguration): Promise<URI>;
 
     /**
      * Terminates hosted plugin instance.
@@ -121,11 +120,11 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
         return this.doRun(pluginUri, port);
     }
 
-    async debug(pluginUri: URI, debugConfig: DebugPluginConfiguration): Promise<URI> {
+    async debug(pluginUri: URI, debugConfig: PluginDebugConfiguration): Promise<URI> {
         return this.doRun(pluginUri, undefined, debugConfig);
     }
 
-    private async doRun(pluginUri: URI, port?: number, debugConfig?: DebugPluginConfiguration): Promise<URI> {
+    private async doRun(pluginUri: URI, port?: number, debugConfig?: PluginDebugConfiguration): Promise<URI> {
         if (this.isPluginRunning) {
             this.hostedPluginSupport.sendLog({ data: 'Hosted plugin instance is already running.', type: LogType.Info });
             throw new Error('Hosted instance is already running.');
@@ -239,7 +238,7 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
         return false;
     }
 
-    protected async getStartCommand(port?: number, debugConfig?: DebugPluginConfiguration): Promise<string[]> {
+    protected async getStartCommand(port?: number, debugConfig?: PluginDebugConfiguration): Promise<string[]> {
 
         const processArguments = process.argv;
         let command: string[];
@@ -366,7 +365,7 @@ export class NodeHostedPluginRunner extends AbstractHostedInstanceManager {
         return options;
     }
 
-    protected override async getStartCommand(port?: number, debugConfig?: DebugPluginConfiguration): Promise<string[]> {
+    protected override async getStartCommand(port?: number, debugConfig?: PluginDebugConfiguration): Promise<string[]> {
         if (!port) {
             port = process.env.HOSTED_PLUGIN_PORT ?
                 Number(process.env.HOSTED_PLUGIN_PORT) :

--- a/packages/plugin-dev/src/node/plugin-dev-service.ts
+++ b/packages/plugin-dev/src/node/plugin-dev-service.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { PluginDevServer, PluginDevClient } from '../common/plugin-dev-protocol';
+import { PluginDebugConfiguration, PluginDevServer, PluginDevClient } from '../common/plugin-dev-protocol';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { HostedInstanceManager } from './hosted-instance-manager';
 import { PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
@@ -22,8 +22,6 @@ import URI from '@theia/core/lib/common/uri';
 import { HostedPluginReader } from './hosted-plugin-reader';
 import { HostedPluginsManager } from './hosted-plugins-manager';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin';
-// eslint-disable-next-line @theia/runtime-import-check
-import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
 
 @injectable()
 export class PluginDevServerImpl implements PluginDevServer {
@@ -66,7 +64,7 @@ export class PluginDevServerImpl implements PluginDevServer {
         return this.uriToStrPromise(this.hostedInstanceManager.run(new URI(uri)));
     }
 
-    runDebugHostedPluginInstance(uri: string, debugConfig: DebugPluginConfiguration): Promise<string> {
+    runDebugHostedPluginInstance(uri: string, debugConfig: PluginDebugConfiguration): Promise<string> {
         return this.uriToStrPromise(this.hostedInstanceManager.debug(new URI(uri), debugConfig));
     }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -99,8 +99,7 @@ import type {
 import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
 import { ThemeType } from '@theia/core/lib/common/theme';
 import { Disposable } from '@theia/core/lib/common/disposable';
-// eslint-disable-next-line @theia/runtime-import-check
-import { PickOptions, QuickInputButtonHandle, QuickPickItem, WidgetOpenerOptions } from '@theia/core/lib/browser';
+import { PickOptions, QuickInputButtonHandle, QuickPickItem } from '@theia/core/lib/common';
 import { Severity } from '@theia/core/lib/common/severity';
 
 export interface PreferenceData {
@@ -1620,12 +1619,12 @@ export interface WebviewViewsMain extends Disposable {
 }
 
 export interface CustomEditorsExt {
-    $resolveWebviewEditor(
+    $resolveWebviewEditor<T>(
         resource: UriComponents,
         newWebviewHandle: string,
         viewType: string,
         title: string,
-        widgetOpenerOptions: WidgetOpenerOptions | undefined,
+        widgetOpenerOptions: T | undefined,
         options: theia.WebviewPanelOptions,
         cancellation: CancellationToken): Promise<void>;
     $createCustomDocument(resource: UriComponents, viewType: string, openContext: theia.CustomDocumentOpenContext, cancellation: CancellationToken): Promise<{ editable: boolean }>;
@@ -1648,7 +1647,7 @@ export interface CustomEditorsMain {
     $registerTextEditorProvider(viewType: string, options: theia.WebviewPanelOptions, capabilities: CustomTextEditorCapabilities): void;
     $registerCustomEditorProvider(viewType: string, options: theia.WebviewPanelOptions, supportsMultipleEditorsPerDocument: boolean): void;
     $unregisterEditorProvider(viewType: string): void;
-    $createCustomEditorPanel(handle: string, title: string, widgetOpenerOptions: WidgetOpenerOptions | undefined, options: theia.WebviewPanelOptions & theia.WebviewOptions): Promise<void>;
+    $createCustomEditorPanel<T>(handle: string, title: string, widgetOpenerOptions: T | undefined, options: theia.WebviewPanelOptions & theia.WebviewOptions): Promise<void>;
     $onDidEdit(resource: UriComponents, viewType: string, editId: number, label: string | undefined): void;
     $onContentChange(resource: UriComponents, viewType: string): void;
 }

--- a/packages/plugin-ext/src/plugin/custom-editors.ts
+++ b/packages/plugin-ext/src/plugin/custom-editors.ts
@@ -29,7 +29,6 @@ import { WebviewImpl, WebviewsExtImpl } from './webviews';
 import { CancellationToken, CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { WorkspaceExtImpl } from './workspace';
-import { WidgetOpenerOptions } from '@theia/core/lib/browser';
 
 export class CustomEditorsExtImpl implements CustomEditorsExt {
     private readonly proxy: CustomEditorsMain;
@@ -116,12 +115,12 @@ export class CustomEditorsExtImpl implements CustomEditorsExt {
         document.dispose();
     }
 
-    async $resolveWebviewEditor(
+    async $resolveWebviewEditor<T>(
         resource: UriComponents,
         handler: string,
         viewType: string,
         title: string,
-        widgetOpenerOptions: WidgetOpenerOptions | undefined,
+        widgetOpenerOptions: T | undefined,
         options: theia.WebviewPanelOptions & theia.WebviewOptions,
         cancellation: CancellationToken
     ): Promise<void> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes `runtime-import-check` errors related to `plugin-api-rpc`
as well as from the re-use of `DebugPluginConfiguration`.

This is done by moving relevant code under their proper runtime (browser vs common vs node).
For more details see: #10418

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
There should not be a change in functionality:

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
