### PR TITLE
vscode: Support `languages.configuration.onEnterRules` and add `OnEnterRule#previousLineText`

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1317,6 +1317,7 @@ export interface EnterAction {
 export interface SerializedOnEnterRule {
     beforeText: SerializedRegExp;
     afterText?: SerializedRegExp;
+    previousLineText?: SerializedRegExp;
     action: EnterAction;
 }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -26,9 +26,9 @@ import {
     TextEditorLineNumbersStyle,
     EndOfLine,
     OverviewRulerLane,
-    IndentAction,
     FileOperationOptions,
     TextDocumentChangeReason,
+    IndentAction,
 } from '../plugin/types-impl';
 import { UriComponents } from './uri-components';
 import {
@@ -1307,18 +1307,18 @@ export interface SerializedIndentationRule {
     unIndentedLinePattern?: SerializedRegExp;
 }
 
-export interface EnterAction {
-    indentAction: IndentAction;
-    outdentCurrentLine?: boolean;
-    appendText?: string;
-    removeText?: number;
-}
-
 export interface SerializedOnEnterRule {
     beforeText: SerializedRegExp;
     afterText?: SerializedRegExp;
     previousLineText?: SerializedRegExp;
-    action: EnterAction;
+    action: SerializedEnterAction;
+}
+
+export interface SerializedEnterAction {
+    indentAction: IndentAction;
+    outdentCurrentLine?: boolean;
+    appendText?: string;
+    removeText?: number;
 }
 
 export interface SerializedLanguageConfiguration {

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -271,6 +271,7 @@ export interface PluginPackageLanguageContributionConfiguration {
     wordPattern?: string;
     indentationRules?: IndentationRules;
     folding?: FoldingRules;
+    onEnterRules?: OnEnterRule[];
 }
 
 export interface PluginTaskDefinitionContribution {
@@ -622,6 +623,7 @@ export interface LanguageConfiguration {
     comments?: CommentRule;
     folding?: FoldingRules;
     wordPattern?: string;
+    onEnterRules?: OnEnterRule[];
 }
 
 /**
@@ -668,6 +670,19 @@ export interface FoldingMarkers {
 export interface FoldingRules {
     offSide?: boolean;
     markers?: FoldingMarkers;
+}
+
+export interface OnEnterRule {
+    beforeText: string;
+    afterText?: string;
+    previousLineText?: string;
+    action: EnterAction;
+}
+
+export interface EnterAction {
+    indent: 'none' | 'indent' | 'outdent' | 'indentOutdent';
+    appendText?: string;
+    removeText?: number;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -660,7 +660,8 @@ export class TheiaPluginScanner implements PluginScanner {
                     wordPattern: rawConfiguration.wordPattern,
                     autoClosingPairs: this.extractValidAutoClosingPairs(rawLang.id, rawConfiguration),
                     indentationRules: rawConfiguration.indentationRules,
-                    surroundingPairs: this.extractValidSurroundingPairs(rawLang.id, rawConfiguration)
+                    surroundingPairs: this.extractValidSurroundingPairs(rawLang.id, rawConfiguration),
+                    onEnterRules: rawConfiguration.onEnterRules,
                 };
                 result.configuration = configuration;
             }

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -1075,7 +1075,8 @@ function reviveOnEnterRule(onEnterRule: SerializedOnEnterRule): monaco.languages
     return {
         beforeText: reviveRegExp(onEnterRule.beforeText)!,
         afterText: reviveRegExp(onEnterRule.afterText),
-        action: onEnterRule.action
+        previousLineText: reviveRegExp(onEnterRule.previousLineText),
+        action: onEnterRule.action,
     };
 }
 

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -20,7 +20,7 @@ import { TextmateRegistry, getEncodedLanguageId, MonacoTextmateService, GrammarD
 import { MenusContributionPointHandler } from './menus/menus-contribution-handler';
 import { PluginViewRegistry } from './view/plugin-view-registry';
 import { PluginCustomEditorRegistry } from './custom-editors/plugin-custom-editor-registry';
-import { PluginContribution, IndentationRules, FoldingRules, ScopeMap, DeployedPlugin, GrammarsContribution } from '../../common';
+import { PluginContribution, IndentationRules, FoldingRules, ScopeMap, DeployedPlugin, GrammarsContribution, EnterAction, OnEnterRule } from '../../common';
 import {
     DefaultUriLabelProviderContribution,
     LabelProviderContribution,
@@ -172,7 +172,8 @@ export class PluginContributionHandler {
                         comments: langConfiguration.comments,
                         folding: this.convertFolding(langConfiguration.folding),
                         surroundingPairs: langConfiguration.surroundingPairs,
-                        indentationRules: this.convertIndentationRules(langConfiguration.indentationRules)
+                        indentationRules: this.convertIndentationRules(langConfiguration.indentationRules),
+                        onEnterRules: this.convertOnEnterRules(langConfiguration.onEnterRules),
                     }));
                 }
             }
@@ -484,7 +485,6 @@ export class PluginContributionHandler {
         }
 
         return result;
-
     }
 
     private convertTokenTypes(tokenTypes?: ScopeMap): ITokenTypeMap | undefined {
@@ -528,6 +528,44 @@ export class PluginContributionHandler {
             }
         }
         return result;
+    }
+
+    private convertOnEnterRules(onEnterRules?: OnEnterRule[]): monaco.languages.OnEnterRule[] | undefined {
+        if (!onEnterRules) {
+            return undefined;
+        }
+
+        const result: monaco.languages.OnEnterRule[] = [];
+        for (const onEnterRule of onEnterRules) {
+            const rule: monaco.languages.OnEnterRule = {
+                beforeText: this.createRegex(onEnterRule.beforeText)!,
+                afterText: this.createRegex(onEnterRule.afterText),
+                previousLineText: this.createRegex(onEnterRule.previousLineText),
+                action: this.createEnterAction(onEnterRule.action),
+            };
+            result.push(rule);
+        }
+
+        return result;
+    }
+
+    private createEnterAction(action: EnterAction): monaco.languages.EnterAction {
+        let indentAction: monaco.languages.IndentAction;
+        switch (action.indent) {
+            case 'indent':
+                indentAction = monaco.languages.IndentAction.Indent;
+                break;
+            case 'indentOutdent':
+                indentAction = monaco.languages.IndentAction.IndentOutdent;
+                break;
+            case 'outdent':
+                indentAction = monaco.languages.IndentAction.Outdent;
+                break;
+            default:
+                indentAction = monaco.languages.IndentAction.None;
+                break;
+        }
+        return { indentAction, appendText: action.appendText, removeText: action.removeText };
     }
 
 }

--- a/packages/plugin-ext/src/plugin/languages-utils.ts
+++ b/packages/plugin-ext/src/plugin/languages-utils.ts
@@ -24,9 +24,10 @@ export function serializeEnterRules(rules?: theia.OnEnterRule[]): SerializedOnEn
 
     return rules.map(r =>
     ({
-        action: r.action,
         beforeText: serializeRegExp(r.beforeText),
-        afterText: serializeRegExp(r.afterText)
+        afterText: serializeRegExp(r.afterText),
+        previousLineText: serializeRegExp(r.previousLineText),
+        action: r.action,
     } as SerializedOnEnterRule));
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6710,6 +6710,10 @@ export module '@theia/plugin' {
          */
         afterText?: RegExp;
         /**
+         * This rule will only execute if the text above the current line matches this regular expression.
+         */
+        previousLineText?: RegExp;
+        /**
          * The action to execute.
          */
         action: EnterAction;


### PR DESCRIPTION
#### What it does

With this change, we read `languages.configuration.onEnterRules` defined via the package.json in a VS Code extension and pass them on to the language configuration for Monaco, which was previously only supported for programmatically added language configurations (https://github.com/eclipse-theia/theia/issues/11202), and add support for the optional property `OnEnterRule#previousLineText` in enter rules, which was missing before (https://github.com/eclipse-theia/theia/issues/11131).

Fixes https://github.com/eclipse-theia/theia/issues/11202
Fixes https://github.com/eclipse-theia/theia/issues/11131

Contributed on behalf of STMicroelectronics

#### How to test

The [Theia example app](https://github.com/eclipse-theia/theia/tree/master/examples/browser) includes the `vscode.python` extension, which defines the following `onEnterRules` in its `package.json`.

`vscode.python` defines that hitting enter after e.g. `if TRUE:` the next line should indent once:
```json
  "onEnterRules": [
    {
      "beforeText": "^\\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async).*?:\\s*$",
      "action": {
        "indent": "indent"
      }
    }
  ]
```

Before this change, the indentation didn't work:
![Peek 2022-05-25 20-46](https://user-images.githubusercontent.com/588090/170345257-1e3713d4-24ee-4ff8-bddd-6a62fafedba2.gif)

After this change, the indentation should work:
![Peek 2022-05-31 11-04](https://user-images.githubusercontent.com/588090/171136444-6f76c5b5-beea-4e79-9631-8252677acf12.gif)

To test `OnEnterRule#previousLineText`, we can add the following rule to `plugins/vscode.python/extension/language-configuration.json` and restart the Theia backend:

```json
    {
      "beforeText": "^\\s*(?:DONALD)$",
      "previousLineText": "^\\s*(?:WHOIS)$",
      "action": {
        "indent": "none",
        "appendText": "DUCK"
      }
    }
```

After that the `previousLineText` should be considered as follows:
![Peek 2022-05-31 11-07](https://user-images.githubusercontent.com/588090/171137018-e6c4a2ff-0167-4368-8f74-a51209d857eb.gif)

Finally, it'd be good to very that programmatically defined enter rules are still working as expected, which can be verified e.g. with an HTML file in the Theia example app:
![Peek 2022-05-31 11-08](https://user-images.githubusercontent.com/588090/171137384-9f7f34dc-af2c-4c2e-9aad-d0af7f3783bf.gif)

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
