### PR TITLE
Use Number.MAX_SAFE_INTEGER in file quick search

### DIFF
--- a/examples/api-tests/src/file-search.spec.js
+++ b/examples/api-tests/src/file-search.spec.js
@@ -58,8 +58,8 @@ describe('file-search', function () {
             });
 
             it('should not place very good matches above exact matches', () => {
-                const exactMatch = 'aa_bb_cc_dd.file';
-                const veryGoodMatch = 'aa_bb_cc_ed_fd.file';
+                const exactMatch = 'almost_absurdly_long_file_name_with_many_parts.file';
+                const veryGoodMatch = 'almost_absurdly_long_file_name_with_many_parts_plus_one.file';
                 quickFileOpenService['filterAndRange'] = { filter: exactMatch };
                 /** @type import ('@theia/file-search/lib/browser/quick-file-open').FileQuickPickItem*/
                 const a = { label: exactMatch, uri: new Uri.default(exactMatch) };

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -19,7 +19,7 @@ import { OpenerService, KeybindingRegistry, QuickAccessRegistry, QuickAccessProv
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { FileSearchService, WHITESPACE_QUERY_SEPARATOR } from '../common/file-search-service';
-import { CancellationToken, Command, nls, MAX_SAFE_INTEGER } from '@theia/core/lib/common';
+import { CancellationToken, Command, nls } from '@theia/core/lib/common';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { NavigationLocationService } from '@theia/editor/lib/browser/navigation/navigation-location-service';
 import * as fuzzy from '@theia/core/shared/fuzzy';
@@ -245,7 +245,7 @@ export class QuickFileOpenService implements QuickAccessProvider {
             // Check fuzzy matches.
             const fuzzyMatch = fuzzy.match(queryJoin, str) ?? { score: 0 };
             if (fuzzyMatch.score === Infinity && exactMatch) {
-                return MAX_SAFE_INTEGER;
+                return Number.MAX_SAFE_INTEGER;
             }
 
             return fuzzyMatch.score + partialMatches + (exactMatch ? QuickFileOpenService.Scores.exact : 0);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Despite #10694, it is still possible to get good matches ranked ahead of perfect matches, because the `MAX_SAFE_INTEGER` constant used was not necessarily the actual maximum safe integer available in the browser, and fuzzy search could still return larger numbers.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Tests should pass.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
