### PR TITLE
Support ThemeIcon's `color` property of the VS Code API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.27.0 - Unreleased
 
 - [plugin] moved `WebviewViewResolveContext` from `window` to `root` namespace [#11216](https://github.com/eclipse-theia/theia/pull/11216) - Contributed on behalf of STMicroelectronics
+- [plugin] Add support for property `color` of `ThemeIcon`. [#11243](https://github.com/eclipse-theia/theia/pull/11243) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.27.0">[Breaking Changes:](#breaking_changes_1.27.0)</a>
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -709,7 +709,7 @@ export interface TreeViewItem {
     icon?: string;
     iconUrl?: IconUrl;
 
-    themeIconId?: string;
+    themeIcon?: ThemeIcon;
 
     resourceUri?: UriComponents;
 
@@ -1075,6 +1075,11 @@ export interface ApplyEditsOptions extends UndoStopOptions {
 
 export interface ThemeColor {
     id: string;
+}
+
+export interface ThemeIcon {
+    id: string;
+    color?: ThemeColor;
 }
 
 /**

--- a/packages/plugin-ext/src/main/browser/view/plugin-tree-view-node-label-provider.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-tree-view-node-label-provider.ts
@@ -33,7 +33,7 @@ export class PluginTreeViewNodeLabelProvider implements LabelProviderContributio
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     canHandle(element: TreeViewNode | any): number {
-        if (TreeNode.is(element) && ('resourceUri' in element || 'themeIconId' in element)) {
+        if (TreeNode.is(element) && ('resourceUri' in element || 'themeIcon' in element)) {
             return this.treeLabelProvider.canHandle(element) + 1;
         }
         return 0;
@@ -43,12 +43,14 @@ export class PluginTreeViewNodeLabelProvider implements LabelProviderContributio
         if (node.icon) {
             return node.icon;
         }
-        if (node.themeIconId) {
-            if (node.themeIconId === 'file' || node.themeIconId === 'folder') {
+        if (node.themeIcon) {
+            if (node.themeIcon.id === 'file' || node.themeIcon.id === 'folder') {
                 const uri = node.resourceUri && new URI(node.resourceUri) || undefined;
-                return this.labelProvider.getIcon(URIIconReference.create(node.themeIconId, uri));
+                if (uri) {
+                    return this.labelProvider.getIcon(URIIconReference.create(node.themeIcon.id, uri));
+                }
             }
-            return ThemeIcon.asClassName({ id: node.themeIconId });
+            return ThemeIcon.asClassName(node.themeIcon);
         }
         if (node.resourceUri) {
             return this.labelProvider.getIcon(new URI(node.resourceUri));

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -366,12 +366,12 @@ class TreeViewExtImpl<T> implements Disposable {
 
                 let icon;
                 let iconUrl;
-                let themeIconId;
+                let themeIcon;
                 const { iconPath } = treeItem;
                 if (typeof iconPath === 'string' && iconPath.indexOf('fa-') !== -1) {
                     icon = iconPath;
                 } else if (ThemeIcon.is(iconPath)) {
-                    themeIconId = iconPath.id;
+                    themeIcon = iconPath;
                 } else {
                     iconUrl = PluginIconPath.toUrl(<PluginIconPath | undefined>iconPath, this.plugin);
                 }
@@ -381,7 +381,7 @@ class TreeViewExtImpl<T> implements Disposable {
                     label,
                     icon,
                     iconUrl,
-                    themeIconId,
+                    themeIcon,
                     description: treeItem.description,
                     resourceUri: treeItem.resourceUri,
                     tooltip: treeItem.tooltip,

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -732,7 +732,7 @@ export class ThemeIcon {
 
     static readonly Folder: ThemeIcon = new ThemeIcon('folder');
 
-    private constructor(public id: string) {
+    private constructor(public id: string, public color?: ThemeColor) {
     }
 
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2652,7 +2652,22 @@ export module '@theia/plugin' {
          */
         static readonly Folder: ThemeIcon;
 
-        private constructor(public id: string);
+        /**
+         * The id of the icon. The available icons are listed in https://code.visualstudio.com/api/references/icons-in-labels#icon-listing.
+         */
+        readonly id: string;
+
+        /**
+         * The optional ThemeColor of the icon. The color is currently only used in {@link TreeItem}.
+         */
+        readonly color?: ThemeColor | undefined;
+
+        /**
+         * Creates a reference to a theme icon.
+         * @param id id of the icon. The available icons are listed in https://code.visualstudio.com/api/references/icons-in-labels#icon-listing.
+         * @param color optional `ThemeColor` for the icon. The color is currently only used in {@link TreeItem}.
+         */
+        private constructor(public id: string, public color?: ThemeColor);
     }
 
     /**


### PR DESCRIPTION
#### What it does
Fixes #11128

* Add optional `color` property to `ThemeIcon` of the VS Code API
* Hand over the `ThemeIcon` instead of just its id from plugin Ext to Main
* Apply the color in the `PluginTree`
* Adapt `TreeViewNode.is` to also recognize sub types such as `CompositeTreeViewNode`

Contributed on behalf of STMicroelectronics

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>

#### How to test

* Download the [test extension](https://github.com/lucas-koehler/vscode-extension-samples/releases/download/theme-icon-color-test-0.0.1/custom-view-samples-0.0.1.vsix). [Source](https://github.com/lucas-koehler/vscode-extension-samples/tree/theme-icon-color-test/tree-view-sample) for reference.
* Launch and open the `TEST VIEW' in the Explorer:
![image](https://user-images.githubusercontent.com/6959840/171616886-c44f083f-bf54-494a-b9b8-2d194d305500.png)

* Expand the tree nodes. See that the tree nodes use file icons in the editor's warning color (usually some kind of yellow or orange)
* See that file icons in other views (e.g. the File Explorer) still have their original color
* Switch themes to see that the icons in the Test View use the warning color of the selected theme (select high contrast theme to see a noticeable difference)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
