### PR TITLE
Don't show deprecated preferences in the UI

### DIFF
--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -98,7 +98,7 @@ export class PreferenceTreeGenerator {
         }
         for (const propertyName of propertyNames) {
             const property = preferencesSchema.properties[propertyName];
-            if (!this.preferenceConfigs.isSectionName(propertyName) && !OVERRIDE_PROPERTY_PATTERN.test(propertyName)) {
+            if (!this.preferenceConfigs.isSectionName(propertyName) && !OVERRIDE_PROPERTY_PATTERN.test(propertyName) && !property.deprecationMessage) {
                 const labels = propertyName.split('.');
                 const groupID = this.getGroupName(labels);
                 const subgroupName = this.getSubgroupName(labels, groupID);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11242 by hiding deprecated settings in the preferences UI.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the preferences UI
2. Search for a deprecated preference (e.g. `editor.gotoLocation.multiple`)
3. Observe that it does not appear in the UI.
4. Open a `settings.json` file.
5. Add a setting for a deprecated preference (e.g. `"editor.gotoLocation.multiple" : null`)
6. Observe that the line is marked with a warning decoration and on hover a message is displayed about the setting's deprecation.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
