### PR TITLE
fix(10602): remove duplicate margin property in breadcrumb

### DIFF
--- a/packages/core/src/browser/style/breadcrumbs.css
+++ b/packages/core/src/browser/style/breadcrumbs.css
@@ -28,7 +28,6 @@
     justify-content: flex-start;
     align-items: center;
     outline-style: none;
-    margin: .5rem;
     list-style-type: none;
     overflow: hidden;
     padding: 0;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10602

The pull-request removes a duplicate margin property in the breadcrumb CSS file that was having no effect on the application.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Confirm the styling is correct.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Hemant Hemmady <hemanthemmady@gmail.com>