### PR TITLE
Ensure breadcrumbs are updated when Tabbar is maximized

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -686,7 +686,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
             if (this.breadcrumbsContainer) {
                 this.node.appendChild(this.breadcrumbsContainer);
             }
-            this.breadcrumbsRenderer?.refresh();
+            this.updateBreadcrumbs();
         }
         super.onAfterAttach(msg);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
fixes #11231 by ensuring `updateBreadcrumbs()` is called when maximizing/minimizing editor (onAfterAttach is called during the attach/detach)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open 2 files/editors and observe that each editor has a breadcrumbs widget
2. Double click editor tab 1 to maximize
3. Observe breadcrumbs are still visible
4. Minimize the editor
5. Observe breadcrumbs are still visible

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
