### PR TITLE
Replace non-breaking with normal spaces

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -122,7 +122,7 @@ module.exports = preloader.preload().then(() => {
     }
 
     function start() {
-        (window['theia'] = window['theia'] || {}).container = container;
+        (window['theia'] = window['theia'] || {}).container = container;
         return container.get(FrontendApplication).start();
     }
 });

--- a/doc/api-management.md
+++ b/doc/api-management.md
@@ -44,7 +44,7 @@ An API without a stability tag is considered to be experimental and does not req
 /**
  * One does not need any annotations while working on experimental APIs.
  */
-export interface ExperimentalInterface {
+export interface ExperimentalInterface {
 }
 
 /**

--- a/examples/api-tests/src/find-replace.spec.js
+++ b/examples/api-tests/src/find-replace.spec.js
@@ -46,7 +46,7 @@ describe('Find and Replace', function () {
 
     /**
      * @template T
-     * @param {() => Promise<T> | T} condition
+     * @param {() => Promise<T> | T} condition
      * @returns {Promise<T>}
      */
     function waitForAnimation(condition) {

--- a/examples/api-tests/src/navigator.spec.js
+++ b/examples/api-tests/src/navigator.spec.js
@@ -44,12 +44,12 @@ describe('Navigator', function () {
         await fileService.delete(targetUri.parent, { fromUserGesture: false, useTrash: false, recursive: true });
     });
 
-    /** @type {Array<['copy' | 'move', boolean]>} */
+    /** @type {Array<['copy' | 'move', boolean]>} */
     const operations = [
         ['copy', false],
         ['move', false]
     ];
-    /** @type {Array<['file' | 'dir', boolean]>} */
+    /** @type {Array<['file' | 'dir', boolean]>} */
     const fileTypes = [
         ['file', false],
         ['dir', false],

--- a/examples/api-tests/src/saveable.spec.js
+++ b/examples/api-tests/src/saveable.spec.js
@@ -66,7 +66,7 @@ describe('Saveable', function () {
 
     const toTearDown = new DisposableCollection();
 
-    /** @type {string | undefined} */
+    /** @type {string | undefined} */
     const autoSave = preferences.get('files.autoSave', undefined, rootUri.toString());
 
     beforeEach(async () => {

--- a/examples/api-tests/src/undo-redo-selectAll.spec.js
+++ b/examples/api-tests/src/undo-redo-selectAll.spec.js
@@ -94,7 +94,7 @@ describe('Undo, Redo and Select All', function () {
      */
     async function assertInEditor(widget) {
         const originalContent = widget.editor.document.getText();
-        const editor = /** @type {MonacoEditor} */ (MonacoEditor.get(widget));
+        const editor = /** @type {MonacoEditor} */ (MonacoEditor.get(widget));
         editor.getControl().pushUndoStop();
         editor.getControl().executeEdits('test', [{
             range: new Range(1, 1, 1, 1),

--- a/packages/debug/src/browser/debug-call-stack-item-type-key.ts
+++ b/packages/debug/src/browser/debug-call-stack-item-type-key.ts
@@ -17,4 +17,4 @@
 import { ContextKey } from '@theia/core/lib/browser/context-key-service';
 
 export const DebugCallStackItemTypeKey = Symbol('DebugCallStackItemTypeKey');
-export type DebugCallStackItemTypeKey = ContextKey<'session' | 'thread' | 'stackFrame'>;
+export type DebugCallStackItemTypeKey = ContextKey<'session' | 'thread' | 'stackFrame'>;

--- a/packages/filesystem/src/browser/file-selection.ts
+++ b/packages/filesystem/src/browser/file-selection.ts
@@ -25,7 +25,7 @@ export namespace FileSelection {
     export function is(arg: Object | undefined): arg is FileSelection {
         return typeof arg === 'object' && ('fileStat' in arg) && FileStat.is(arg['fileStat']);
     }
-    export class CommandHandler extends SelectionCommandHandler<FileSelection> {
+    export class CommandHandler extends SelectionCommandHandler<FileSelection> {
 
         constructor(
             protected override readonly selectionService: SelectionService,

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -715,7 +715,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
     }
 
     /**
-     * retrieve restored layout state from previous user session but close widgets
+     * retrieve restored layout state from previous user session but close widgets
      * widgets should be opened only when view data providers are registered
      */
     onDidInitializeLayout(): void {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6535,7 +6535,7 @@ export module '@theia/plugin' {
          * the port forwarding tunnel is managed by VS Code and the tunnel can be closed by the user.
          *
          * Extensions should not cache the result of `asExternalUri` as the resolved uri may become invalid due to
-         * a system or user action — for example, in remote cases, a user may close a port forwarding tunnel
+         * a system or user action — for example, in remote cases, a user may close a port forwarding tunnel
          * that was opened by `asExternalUri`.
          *
          * *Note* that uris passed through `openExternal` are automatically resolved and you should not call `asExternalUri`

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -106,7 +106,7 @@
     padding-left: var(--theia-ui-padding);
 }
 
-.theia-vsx-extension-description {
+.theia-vsx-extension-description {
     padding-right: calc(var(--theia-ui-padding)*2);
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR replaces a number of instances of non-breaking spaces (U+00A0) with normal spaces (U+0020). VSCode now highlights characters that look like but are not identical to more common characters, and non-breaking spaces fall into that category. This just cleans them up so they don't produce visual distraction.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. No effective changes - CI should pass.
2. Search for non-breaking spaces (`" "` <-- you can copy that).
3. There should only be two in `packages/core/src/common/keyboard/layouts/fr-Canadian_French-mac.json`, where it looked like they might be intentional.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
