### PR TITLE
Add tooltip for tab close button

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -34,7 +34,7 @@ import { FrontendApplicationStateService } from '../frontend-application-state';
 import { TabBarToolbarRegistry, TabBarToolbarFactory } from './tab-bar-toolbar';
 import { ContextKeyService } from '../context-key-service';
 import { Emitter } from '../../common/event';
-import { waitForRevealed, waitForClosed } from '../widgets';
+import { waitForRevealed, waitForClosed, PINNED_CLASS } from '../widgets';
 import { CorePreferences } from '../core-preferences';
 import { BreadcrumbsRendererFactory } from '../breadcrumbs/breadcrumbs-renderer';
 import { Deferred } from '../../common/promise-util';
@@ -622,7 +622,7 @@ export class ApplicationShell extends Widget {
         const pinned: boolean[] = [];
 
         toArray(this.mainPanel.widgets()).forEach((a, i) => {
-            pinned[i] = a.title.className.indexOf('theia-mod-pinned') >= 0;
+            pinned[i] = a.title.className.includes(PINNED_CLASS);
         });
 
         return pinned;
@@ -633,7 +633,7 @@ export class ApplicationShell extends Widget {
         const pinned: boolean[] = [];
 
         toArray(this.bottomPanel.widgets()).forEach((a, i) => {
-            pinned[i] = a.title.className.indexOf('theia-mod-pinned') >= 0;
+            pinned[i] = a.title.className.includes(PINNED_CLASS);
         });
 
         return pinned;
@@ -700,7 +700,7 @@ export class ApplicationShell extends Widget {
             if (bottomPanel.pinned && bottomPanel.pinned.length === widgets.length) {
                 widgets.forEach((a, i) => {
                     if (bottomPanel.pinned![i]) {
-                        a.title.className += ' theia-mod-pinned';
+                        a.title.className += ` ${PINNED_CLASS}`;
                         a.title.closable = false;
                     }
                 });
@@ -719,7 +719,7 @@ export class ApplicationShell extends Widget {
             if (mainPanelPinned && mainPanelPinned.length === widgets.length) {
                 widgets.forEach((a, i) => {
                     if (mainPanelPinned[i]) {
-                        a.title.className += ' theia-mod-pinned';
+                        a.title.className += ` ${PINNED_CLASS}`;
                         a.title.closable = false;
                     }
                 });

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -33,6 +33,7 @@ import { ContextMenuRenderer } from '../context-menu-renderer';
 import { MenuPath } from '../../common/menu';
 import { SidebarBottomMenuWidget } from './sidebar-bottom-menu-widget';
 import { SidebarTopMenuWidget } from './sidebar-top-menu-widget';
+import { PINNED_CLASS } from '../widgets';
 
 /** The class name added to the left and right area panels. */
 export const LEFT_RIGHT_AREA_CLASS = 'theia-app-sides';
@@ -274,7 +275,7 @@ export class SidePanelHandler {
             widget: title.owner,
             rank: SidePanelHandler.rankProperty.get(title.owner),
             expanded: title === currentTitle,
-            pinned: title.className.indexOf('theia-mod-pinned') >= 0
+            pinned: title.className.includes(PINNED_CLASS)
         }));
         // eslint-disable-next-line no-null/no-null
         const size = currentTitle !== null ? this.getPanelSize() : this.state.lastPanelSize;
@@ -299,7 +300,7 @@ export class SidePanelHandler {
                         currentTitle = widget.title;
                     }
                     if (pinned) {
-                        widget.title.className += ' theia-mod-pinned';
+                        widget.title.className += ` ${PINNED_CLASS}`;
                         widget.title.closable = false;
                     }
                     // Add the widgets directly to the tab bar in the same order as they are stored

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -17,7 +17,7 @@
 import PerfectScrollbar from 'perfect-scrollbar';
 import { TabBar, Title, Widget } from '@phosphor/widgets';
 import { VirtualElement, h, VirtualDOM, ElementInlineStyle } from '@phosphor/virtualdom';
-import { Disposable, DisposableCollection, MenuPath, notEmpty, SelectionService, CommandService } from '../../common';
+import { Disposable, DisposableCollection, MenuPath, notEmpty, SelectionService, CommandService, nls } from '../../common';
 import { ContextMenuRenderer } from '../context-menu-renderer';
 import { Signal, Slot } from '@phosphor/signaling';
 import { Message, MessageLoop } from '@phosphor/messaging';
@@ -148,6 +148,9 @@ export class TabBarRenderer extends TabBar.Renderer {
         const style = this.createTabStyle(data);
         const className = this.createTabClass(data);
         const dataset = this.createTabDataset(data);
+        const closeIconTitle = data.title.className.includes(PINNED_CLASS)
+            ? nls.localizeByDefault('Unpin')
+            : nls.localizeByDefault('Close');
         return h.li(
             {
                 key, className, id, title: title.caption, style, dataset,
@@ -166,6 +169,7 @@ export class TabBarRenderer extends TabBar.Renderer {
             ),
             h.div({
                 className: 'p-TabBar-tabCloseIcon action-label',
+                title: closeIconTitle,
                 onclick: this.handleCloseClickEvent
             })
         );

--- a/packages/editor-preview/src/browser/editor-preview-widget.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget.ts
@@ -53,7 +53,7 @@ export class EditorPreviewWidget extends EditorWidget {
         });
         oneTimeListeners.push(oneTimeDirtyChangeListener);
         const oneTimeTitleChangeHandler = () => {
-            if (this.title.className.indexOf(PINNED_CLASS) >= 0) {
+            if (this.title.className.includes(PINNED_CLASS)) {
                 this.convertToNonPreview();
                 oneTimeListeners.dispose();
             }


### PR DESCRIPTION
#### What it does

Adds a tooltip/title for the tab close button. Previously it showed the tooltip of the tab, now either "Close" or "Unpin", depending on whether it is closable or pinned.

Also cleans up some `className` manipulation sorrounding the pin feature.

#### How to test

1. Hover over the close/unpin button
2. Assert that the tooltip is updated correctly based on the state
3. Assert that the pinning/unpinning feature hasn't experienced any regressions

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
