### PR TITLE
test: fix spec files so they are debuggable

### DIFF
--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -14,8 +14,14 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { enableJSDOM } from '../browser/test/jsdom';
+import { enableJSDOM } from './test/jsdom';
 let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
+import { ApplicationProps } from '@theia/application-package/lib/application-props';
+FrontendApplicationConfigProvider.set({
+    ...ApplicationProps.DEFAULT.frontend.config
+});
 
 import { Container, injectable, ContainerModule } from 'inversify';
 import { bindContributionProvider } from '../common/contribution-provider';
@@ -36,10 +42,8 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import { Emitter, Event } from '../common/event';
 import { bindPreferenceService } from './frontend-application-bindings';
-import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
-import { ApplicationProps } from '@theia/application-package/lib/';
-import { bindStatusBar } from './status-bar';
 import { MarkdownRenderer, MarkdownRendererFactory, MarkdownRendererImpl } from './markdown-rendering/markdown-renderer';
+import { StatusBar } from './status-bar';
 
 disableJSDOM();
 
@@ -51,7 +55,11 @@ let keybindingRegistry: KeybindingRegistry;
 let commandRegistry: CommandRegistry;
 let testContainer: Container;
 
+let stub: sinon.SinonStub;
+
 before(async () => {
+    disableJSDOM = enableJSDOM();
+
     testContainer = new Container();
     const module = new ContainerModule((bind, unbind, isBound, rebind) => {
 
@@ -84,7 +92,7 @@ before(async () => {
             }
         });
 
-        bindStatusBar(bind);
+        bind(StatusBar).toConstantValue({} as StatusBar);
         bind(MarkdownRendererImpl).toSelf().inSingletonScope();
         bind(MarkdownRenderer).toService(MarkdownRendererImpl);
         bind(MarkdownRendererFactory).toFactory(({ container }) => container.get(MarkdownRenderer));
@@ -103,31 +111,21 @@ before(async () => {
 
 });
 
+after(() => {
+    disableJSDOM();
+});
+
+beforeEach(async () => {
+    stub = sinon.stub(os, 'isOSX').value(false);
+    keybindingRegistry = testContainer.get<KeybindingRegistry>(KeybindingRegistry);
+    await keybindingRegistry.onStart();
+});
+
+afterEach(() => {
+    stub.restore();
+});
+
 describe('keybindings', () => {
-
-    let stub: sinon.SinonStub;
-
-    before(() => {
-        disableJSDOM = enableJSDOM();
-        FrontendApplicationConfigProvider.set({
-            ...ApplicationProps.DEFAULT.frontend.config,
-            'applicationName': 'test'
-        });
-    });
-
-    after(() => {
-        disableJSDOM();
-    });
-
-    beforeEach(async () => {
-        stub = sinon.stub(os, 'isOSX').value(false);
-        keybindingRegistry = testContainer.get<KeybindingRegistry>(KeybindingRegistry);
-        await keybindingRegistry.onStart();
-    });
-
-    afterEach(() => {
-        stub.restore();
-    });
 
     it('should register the default keybindings', () => {
         const keybinding = keybindingRegistry.getKeybindingsForCommand(TEST_COMMAND.id);

--- a/packages/markers/src/browser/problem/problem-composite-tree-node.spec.ts
+++ b/packages/markers/src/browser/problem/problem-composite-tree-node.spec.ts
@@ -17,6 +17,12 @@
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
 
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { ApplicationProps } from '@theia/application-package/lib/application-props';
+FrontendApplicationConfigProvider.set({
+    ...ApplicationProps.DEFAULT.frontend.config
+});
+
 import URI from '@theia/core/lib/common/uri';
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';

--- a/packages/markers/src/browser/problem/problem-tree-model.spec.ts
+++ b/packages/markers/src/browser/problem/problem-tree-model.spec.ts
@@ -17,6 +17,12 @@
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
 
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { ApplicationProps } from '@theia/application-package/lib/application-props';
+FrontendApplicationConfigProvider.set({
+    ...ApplicationProps.DEFAULT.frontend.config
+});
+
 import URI from '@theia/core/lib/common/uri';
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request fixes the `*.spec.ts` files which were previously not debuggable through the `run mocha tests` debug configuration.

The main issue was the following error:

```
The configuration is not set. Did you call FrontendApplicationConfigProvider#set?
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. CI should pass (build and especially unit tests)
2. For the three `*.spec.ts` files, it should be possible to run the debug configuration `run mocha tests` in vscode, and even set breakpoints (not possible on master). 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

