### PR TITLE
Prevent Output widget from handling any drag/drop events

### DIFF
--- a/packages/output/src/browser/output-widget.ts
+++ b/packages/output/src/browser/output-widget.ts
@@ -17,7 +17,6 @@
 import '../../src/browser/style/output.css';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { toArray } from '@theia/core/shared/@phosphor/algorithm';
-import { IDragEvent } from '@theia/core/shared/@phosphor/dragdrop';
 import { EditorWidget } from '@theia/editor/lib/browser';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
@@ -255,17 +254,8 @@ export const OUTPUT_WIDGET_KIND = OutputWidget.ID;
 
 /**
  * Customized `DockPanel` that does not allow dropping widgets into it.
- * Intercepts `'p-dragover'` events, and sets the desired drop action to `'none'`.
  */
-class NoopDragOverDockPanel extends DockPanel {
-
-    constructor(options?: DockPanel.IOptions) {
-        super(options);
-        NoopDragOverDockPanel.prototype['_evtDragOver'] = (event: IDragEvent) => {
-            event.preventDefault();
-            event.stopPropagation();
-            event.dropAction = 'none';
-        };
-    }
-
-}
+class NoopDragOverDockPanel extends DockPanel { }
+NoopDragOverDockPanel.prototype['_evtDragOver'] = () => { };
+NoopDragOverDockPanel.prototype['_evtDrop'] = () => { };
+NoopDragOverDockPanel.prototype['_evtDragLeave'] = () => { };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10932 by preventing the Output widget from interfering in its parent's handling of drag-drop events.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Try dragging and dropping widgets onto the Output widget.
2. Observe that the behavior is the same as dragging/dropping on top of other widgets: you can can drop in the middle to put a new widget on the same tabbar, or to one side / top / bottom to split the panel.
3. Ensure that you don't see the behavior from the second cast [here](https://github.com/eclipse-theia/theia/pull/7570#discussion_r892726604) where the Output widget accepts the drop of the new widget as though it were an output channel.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
