### PR TITLE
vscode: Support `TreeItemLabel` in `TreeItem` and remove obsolete `TreeItem2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - [process] removed the deprecated getters `input`, `output` and `errorOutput` [#11185](https://github.com/eclipse-theia/theia/pull/11185)
 - [workspace] removed deprecated `getDefaultWorkspacePath` [#11185](https://github.com/eclipse-theia/theia/pull/11185)
 - [vsx-registry] removed deprecated `VSXExtensionsCommands` re-export [#11185](https://github.com/eclipse-theia/theia/pull/11185)
+- [plugin] Remove `TreeItem2` from proposed plugin API. `TreeItem` can be used instead. [#11288](https://github.com/eclipse-theia/theia/pull/11288) - Contributed on behalf of STMicroelectronics
 
 ## v1.26.0 - 5/26/2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [plugin] moved `WebviewViewResolveContext` from `window` to `root` namespace [#11216](https://github.com/eclipse-theia/theia/pull/11216) - Contributed on behalf of STMicroelectronics
 - [plugin] Add support for property `color` of `ThemeIcon`. [#11243](https://github.com/eclipse-theia/theia/pull/11243) - Contributed on behalf of STMicroelectronics
+- [plugin] Add support for `TreeItemLabel` in `TreeItem`. [#11288](https://github.com/eclipse-theia/theia/pull/11288) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.27.0">[Breaking Changes:](#breaking_changes_1.27.0)</a>
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -702,6 +702,8 @@ export interface TreeViewItem {
     id: string;
 
     label: string;
+    /** Label highlights given as tuples of inclusive start index and exclusive end index. */
+    highlights?: [number, number][];
 
     description?: string | boolean;
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -991,7 +991,6 @@ export function createAPIFactory(
             TextDocumentSaveReason,
             CodeAction,
             TreeItem,
-            TreeItem2: TreeItem,
             TreeItemCollapsibleState,
             SymbolKind,
             SymbolTag,

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -17,7 +17,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {
-    TreeDataProvider, TreeView, TreeViewExpansionEvent, TreeItem2, TreeItemLabel,
+    TreeDataProvider, TreeView, TreeViewExpansionEvent, TreeItem, TreeItemLabel,
     TreeViewSelectionChangeEvent, TreeViewVisibilityChangeEvent
 } from '@theia/plugin';
 // TODO: extract `@theia/util` for event, disposable, cancellation and common types
@@ -295,16 +295,17 @@ class TreeViewExtImpl<T> implements Disposable {
         return undefined;
     }
 
-    private getTreeItemLabel(treeItem: TreeItem2): string | undefined {
+    private getTreeItemLabel(treeItem: TreeItem): string | undefined {
         const treeItemLabel: string | TreeItemLabel | undefined = treeItem.label;
-        if (typeof treeItemLabel === 'object' && typeof treeItemLabel.label === 'string') {
-            return treeItemLabel.label;
-        } else {
-            return treeItem.label;
-        }
+        return typeof treeItemLabel === 'object' ? treeItemLabel.label : treeItemLabel;
     }
 
-    private getTreeItemIdLabel(treeItem: TreeItem2): string | undefined {
+    private getTreeItemLabelHighlights(treeItem: TreeItem): [number, number][] | undefined {
+        const treeItemLabel: string | TreeItemLabel | undefined = treeItem.label;
+        return typeof treeItemLabel === 'object' ? treeItemLabel.highlights : undefined;
+    }
+
+    private getTreeItemIdLabel(treeItem: TreeItem): string | undefined {
         let idLabel = this.getTreeItemLabel(treeItem);
         // Use resource URI if label is not set
         if (idLabel === undefined && treeItem.resourceUri) {
@@ -341,10 +342,11 @@ class TreeViewExtImpl<T> implements Disposable {
 
                 // Ask data provider for a tree item for the value
                 // Data provider must return theia.TreeItem
-                const treeItem: TreeItem2 = await this.treeDataProvider.getTreeItem(value);
+                const treeItem = await this.treeDataProvider.getTreeItem(value);
                 // Convert theia.TreeItem to the TreeViewItem
 
                 const label = this.getTreeItemLabel(treeItem);
+                const highlights = this.getTreeItemLabelHighlights(treeItem);
                 const idLabel = this.getTreeItemIdLabel(treeItem);
 
                 // Generate the ID
@@ -379,6 +381,7 @@ class TreeViewExtImpl<T> implements Disposable {
                 const treeViewItem = {
                     id,
                     label,
+                    highlights,
                     icon,
                     iconUrl,
                     themeIcon,

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -321,41 +321,6 @@ export module '@theia/plugin' {
 
     // #endregion
 
-    // #region Tree View
-    // copied from https://github.com/microsoft/vscode/blob/3ea5c9ddbebd8ec68e3b821f9c39c3ec785fde97/src/vs/vscode.proposed.d.ts#L1447-L1476
-    /**
-     * Label describing the [Tree item](#TreeItem)
-     */
-    export interface TreeItemLabel {
-
-        /**
-         * A human-readable string describing the [Tree item](#TreeItem).
-         */
-        label: string;
-
-        /**
-         * Ranges in the label to highlight. A range is defined as a tuple of two number where the
-         * first is the inclusive start index and the second the exclusive end index
-         */
-        // TODO highlights?: [number, number][];
-
-    }
-
-    export class TreeItem2 extends TreeItem {
-        /**
-         * Label describing this item. When `falsy`, it is derived from [resourceUri](#TreeItem.resourceUri).
-         */
-        label?: string | TreeItemLabel | /* for compilation */ any;
-
-        /**
-         * @param label Label describing this item
-         * @param collapsibleState [TreeItemCollapsibleState](#TreeItemCollapsibleState) of the tree item.
-         * Default is [TreeItemCollapsibleState.None](#TreeItemCollapsibleState.None)
-         */
-        constructor(label: TreeItemLabel, collapsibleState?: TreeItemCollapsibleState);
-    }
-    // #endregion
-
     // #region search in workspace
     /**
      * The parameters of a query for text search.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5349,7 +5349,7 @@ export module '@theia/plugin' {
         /**
          * A human-readable string describing this item. When `falsy`, it is derived from [resourceUri](#TreeItem.resourceUri).
          */
-        label?: string;
+        label?: string | TreeItemLabel;
 
         /**
          * Optional id for the tree item that has to be unique across tree. The id is used to preserve the selection and expansion state of the tree item.
@@ -5425,7 +5425,7 @@ export module '@theia/plugin' {
          * @param label A human-readable string describing this item
          * @param collapsibleState [TreeItemCollapsibleState](#TreeItemCollapsibleState) of the tree item. Default is [TreeItemCollapsibleState.None](#TreeItemCollapsibleState.None)
          */
-        constructor(label: string, collapsibleState?: TreeItemCollapsibleState);
+        constructor(label: string | TreeItemLabel, collapsibleState?: TreeItemCollapsibleState);
 
         /**
          * @param resourceUri The [uri](#Uri) of the resource representing this item.
@@ -5450,6 +5450,23 @@ export module '@theia/plugin' {
          * Determines an item is expanded
          */
         Expanded = 2
+    }
+
+    /**
+     * Label describing the {@link TreeItem Tree item}
+     */
+    export interface TreeItemLabel {
+
+        /**
+         * A human-readable string describing the {@link TreeItem Tree item}.
+         */
+        label: string;
+
+        /**
+         * Ranges in the label to highlight. A range is defined as a tuple of two numbers where the
+         * first is the inclusive start index and the second the exclusive end index
+         */
+        highlights?: [number, number][];
     }
 
     /**


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/11148

Support `TreeItemLabel` in `TreeItem` plugin API:

* Add `TreeItemLabel` to theia.d.ts
* Align `TreeItem.label` with VS Code API to support `TreeItemLabel` as a value
* Extend plugin tree view implementation to support showing `TreeItemLabel.highlights`
  * Extend `TreeViewNode` to also extend `DecoratedTreeNode`
  * Set highlights in tree node's decoration data to displays them

Remove obsolete, proposed `TreeItem2` and `TreeItemLabel`:

Remove `TreeItem2` and `TreeItemLabel` from proposed plugin api because all properties are now supported and aligned with VS Code by `TreeItem` and `TreeItemLabel` in `theia.d.ts`.

Contributed on behalf of STMicroelectronics
Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>

#### How to test

- Download the test extension [here](https://github.com/lucas-koehler/vscode-extension-samples/releases/download/tree-item-label-0.0.1/tree-view-sample-label-highlights-0.0.1.vsix). For reference, the source code can be found [here](https://github.com/lucas-koehler/vscode-extension-samples/tree/tree-item-label-0.0.1/tree-view-sample)
- Add extension to plugins and open Theia. In the Explorer view, you should see a TEST VIEW tree. Within the tree, the second and second to last letter of every entry with at least 2 letters should be highlighted. This is defined [here](https://github.com/lucas-koehler/vscode-extension-samples/blob/e9e70f8607afd183699330b033333363aa741bf3/tree-view-sample/src/testView.ts#L78) in the extension's source
![image](https://user-images.githubusercontent.com/6959840/173313607-bfc8fdc0-d1bf-40d6-aa0b-74fea571a0f0.png)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
