### PR TITLE
Update `Configure Display Language` command

### DIFF
--- a/dev-packages/ovsx-client/src/ovsx-types.ts
+++ b/dev-packages/ovsx-client/src/ovsx-types.ts
@@ -76,6 +76,7 @@ export interface VSXSearchEntry {
     readonly url: string;
     readonly files: {
         download: string
+        manifest?: string
         readme?: string
         license?: string
         icon?: string

--- a/packages/core/src/browser/i18n/i18n-frontend-module.ts
+++ b/packages/core/src/browser/i18n/i18n-frontend-module.ts
@@ -17,9 +17,11 @@
 import { ContainerModule } from 'inversify';
 import { AsyncLocalizationProvider, localizationPath } from '../../common/i18n/localization';
 import { WebSocketConnectionProvider } from '../messaging/ws-connection-provider';
+import { LanguageQuickPickService } from './language-quick-pick-service';
 
 export default new ContainerModule(bind => {
     bind(AsyncLocalizationProvider).toDynamicValue(
         ctx => ctx.container.get(WebSocketConnectionProvider).createProxy(localizationPath)
     ).inSingletonScope();
+    bind(LanguageQuickPickService).toSelf().inSingletonScope();
 });

--- a/packages/core/src/browser/i18n/language-quick-pick-service.ts
+++ b/packages/core/src/browser/i18n/language-quick-pick-service.ts
@@ -33,9 +33,9 @@ export class LanguageQuickPickService {
     @inject(WindowService) protected readonly windowService: WindowService;
 
     async pickDisplayLanguage(): Promise<string | undefined> {
-        const quickInput = this.quickInputService.createQuickPick();
+        const quickInput = this.quickInputService.createQuickPick<LanguageQuickPickItem>();
         const installedItems = await this.getInstalledLanguages();
-        const quickInputItems: (QuickPickItem | QuickPickSeparator)[] = [
+        const quickInputItems: (LanguageQuickPickItem | QuickPickSeparator)[] = [
             {
                 type: 'separator',
                 label: nls.localize('theia/core/installedLanguages', 'Installed languages')
@@ -72,11 +72,15 @@ export class LanguageQuickPickService {
 
         return new Promise(resolve => {
             quickInput.onDidAccept(async () => {
-                const selectedItem = quickInput.selectedItems[0] as LanguageQuickPickItem;
-                // Some language quick pick items want to install additional languages
-                // We have to await that before returning the selected locale
-                await selectedItem.execute?.();
-                resolve(selectedItem.languageId);
+                const selectedItem = quickInput.selectedItems[0];
+                if (selectedItem) {
+                    // Some language quick pick items want to install additional languages
+                    // We have to await that before returning the selected locale
+                    await selectedItem.execute?.();
+                    resolve(selectedItem.languageId);
+                } else {
+                    resolve(undefined);
+                }
             });
             quickInput.onDidHide(() => {
                 resolve(undefined);

--- a/packages/core/src/browser/i18n/language-quick-pick-service.ts
+++ b/packages/core/src/browser/i18n/language-quick-pick-service.ts
@@ -1,0 +1,124 @@
+// *****************************************************************************
+// Copyright (C) 2022 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from 'inversify';
+import { nls } from '../../common/nls';
+import { AsyncLocalizationProvider, LanguageInfo } from '../../common/i18n/localization';
+import { QuickInputService, QuickPickItem, QuickPickSeparator } from '../quick-input';
+import { WindowService } from '../window/window-service';
+
+export interface LanguageQuickPickItem extends QuickPickItem {
+    languageId: string
+    execute?(): Promise<void>
+}
+
+@injectable()
+export class LanguageQuickPickService {
+
+    @inject(QuickInputService) protected readonly quickInputService: QuickInputService;
+    @inject(AsyncLocalizationProvider) protected readonly localizationProvider: AsyncLocalizationProvider;
+    @inject(WindowService) protected readonly windowService: WindowService;
+
+    async pickDisplayLanguage(): Promise<string | undefined> {
+        const quickInput = this.quickInputService.createQuickPick();
+        const installedItems = await this.getInstalledLanguages();
+        const quickInputItems: (QuickPickItem | QuickPickSeparator)[] = [
+            {
+                type: 'separator',
+                label: nls.localize('theia/core/installedLanguages', 'Installed languages')
+            },
+            ...installedItems
+        ];
+        quickInput.items = quickInputItems;
+        quickInput.busy = true;
+        const selected = installedItems.find(item => nls.isSelectedLocale(item.languageId));
+        if (selected) {
+            quickInput.activeItems = [selected];
+        }
+        quickInput.placeholder = nls.localizeByDefault('Configure Display Language');
+        quickInput.show();
+
+        this.getAvailableLanguages().then(availableItems => {
+            if (availableItems.length > 0) {
+                quickInputItems.push({
+                    type: 'separator',
+                    label: nls.localize('theia/core/availableLanguages', 'Available languages')
+                });
+                const installed = new Set(installedItems.map(e => e.languageId));
+                for (const available of availableItems) {
+                    // Exclude already installed languages
+                    if (!installed.has(available.languageId)) {
+                        quickInputItems.push(available);
+                    }
+                }
+                quickInput.items = quickInputItems;
+            }
+        }).finally(() => {
+            quickInput.busy = false;
+        });
+
+        return new Promise(resolve => {
+            quickInput.onDidAccept(async () => {
+                const selectedItem = quickInput.selectedItems[0] as LanguageQuickPickItem;
+                // Some language quick pick items want to install additional languages
+                // We have to await that before returning the selected locale
+                await selectedItem.execute?.();
+                resolve(selectedItem.languageId);
+            });
+            quickInput.onDidHide(() => {
+                resolve(undefined);
+            });
+        });
+    }
+
+    protected async getInstalledLanguages(): Promise<LanguageQuickPickItem[]> {
+        const languageInfos = await this.localizationProvider.getAvailableLanguages();
+        const items: LanguageQuickPickItem[] = [];
+        const en: LanguageInfo = {
+            languageId: 'en',
+            languageName: 'English',
+            localizedLanguageName: 'English'
+        };
+        languageInfos.push(en);
+        for (const language of languageInfos.filter(e => !!e.languageId)) {
+            items.push(this.createLanguageQuickPickItem(language));
+        }
+        return items;
+    }
+
+    protected async getAvailableLanguages(): Promise<LanguageQuickPickItem[]> {
+        return [];
+    }
+
+    protected createLanguageQuickPickItem(language: LanguageInfo): LanguageQuickPickItem {
+        let label: string;
+        let description: string | undefined;
+        const languageName = language.localizedLanguageName || language.languageName;
+        const id = language.languageId;
+        const idLabel = id + (nls.isSelectedLocale(id) ? ` (${nls.localizeByDefault('Current')})` : '');
+        if (languageName) {
+            label = languageName;
+            description = idLabel;
+        } else {
+            label = idLabel;
+        }
+        return {
+            label,
+            description,
+            languageId: id
+        };
+    }
+}

--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -55,6 +55,17 @@ export namespace nls {
     export function localize(key: string, defaultValue: string, ...args: FormatType[]): string {
         return Localization.localize(localization, key, defaultValue, ...args);
     }
+
+    export function isSelectedLocale(id: string): boolean {
+        if (locale === undefined && id === 'en') {
+            return true;
+        }
+        return locale === id;
+    }
+
+    export function setLocale(id: string): void {
+        window.localStorage.setItem(localeId, id);
+    }
 }
 
 interface NlsKeys {

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -242,22 +242,8 @@
 }
 
 .theia-notification-item-progressbar.indeterminate {
+    /* `progress-animation` is defined in `packages/core/src/browser/style/progress-bar.css` */
     animation: progress-animation 1.3s 0s infinite cubic-bezier(0.645, 0.045, 0.355, 1);
-}
-
-@keyframes progress-animation {
-    0% {
-        margin-left: 0%;
-        width: 3%;
-    }
-    60% {
-        margin-left: 45%;
-        width: 20%;
-    }
-    100% {
-        margin-left: 99%;
-        width: 1%;
-    }
 }
 
 /* Perfect scrollbar */

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -488,13 +488,17 @@ class MonacoQuickPick<T extends QuickPickItem> extends MonacoQuickInput implemen
     }
 
     set items(itms: readonly (T | QuickPickSeparator)[]) {
+        // We need to store and apply the currently selected active items.
+        // Since monaco compares these items by reference equality, creating new wrapped items will unmark any active items.
+        // Assigning the `activeItems` again will restore all active items even after the items array has changed.
+        // See also the `findMonacoItemReferences` method.
         const active = this.activeItems;
         this.wrapped.items = itms.map(item => QuickPickSeparator.is(item) ? item : new MonacoQuickPickItem<T>(item, this.keybindingRegistry));
         this.activeItems = active;
     }
 
     set activeItems(itms: readonly T[]) {
-        this.wrapped.activeItems = findActualItems(this.wrapped.items, itms);
+        this.wrapped.activeItems = this.findMonacoItemReferences(this.wrapped.items, itms);
     }
 
     get activeItems(): readonly (T)[] {
@@ -502,7 +506,7 @@ class MonacoQuickPick<T extends QuickPickItem> extends MonacoQuickInput implemen
     }
 
     set selectedItems(itms: readonly T[]) {
-        this.wrapped.selectedItems = findActualItems(this.wrapped.items, itms);
+        this.wrapped.selectedItems = this.findMonacoItemReferences(this.wrapped.items, itms);
     }
 
     get selectedItems(): readonly (T)[] {
@@ -522,18 +526,22 @@ class MonacoQuickPick<T extends QuickPickItem> extends MonacoQuickInput implemen
         (items: MonacoQuickPickItem<T>[]) => items.map(item => item.item));
     readonly onDidChangeSelection: Event<T[]> = Event.map(
         this.wrapped.onDidChangeSelection, (items: MonacoQuickPickItem<T>[]) => items.map(item => item.item));
-}
 
-function findActualItems<T extends QuickPickItem>(source: readonly (MonacoQuickPickItem<T> | IQuickPickSeparator)[], items: readonly QuickPickItem[]): MonacoQuickPickItem<T>[] {
-    const actualItems: MonacoQuickPickItem<T>[] = [];
-    for (const item of items) {
-        for (const wrappedItem of source) {
-            if (!QuickPickSeparator.is(wrappedItem) && wrappedItem.item === item) {
-                actualItems.push(wrappedItem);
+    /**
+     * Monaco doesn't check for deep equality when setting the `activeItems` or `selectedItems`.
+     * Instead we have to find the references of the monaco wrappers that contain the selected/active items
+     */
+    protected findMonacoItemReferences(source: readonly (MonacoQuickPickItem<T> | IQuickPickSeparator)[], items: readonly QuickPickItem[]): MonacoQuickPickItem<T>[] {
+        const monacoReferences: MonacoQuickPickItem<T>[] = [];
+        for (const item of items) {
+            for (const wrappedItem of source) {
+                if (!QuickPickSeparator.is(wrappedItem) && wrappedItem.item === item) {
+                    monacoReferences.push(wrappedItem);
+                }
             }
         }
+        return monacoReferences;
     }
-    return actualItems;
 }
 
 export class MonacoQuickPickItem<T extends QuickPickItem> implements IQuickPickItem {

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -227,6 +227,13 @@
   cursor: pointer !important;
 }
 
+.quick-input-progress.active.infinite {
+    background-color: var(--theia-progressBar-background);
+    width: 3%;
+    /* `progress-animation` is defined in `packages/core/src/browser/style/progress-bar.css` */
+    animation: progress-animation 1.3s 0s infinite cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
 .monaco-list:not(.drop-target) .monaco-list-row:hover:not(.selected):not(.focused) {
   background: var(--theia-list-hoverBackground);
 }

--- a/packages/plugin-ext-vscode/src/common/plugin-vscode-uri.ts
+++ b/packages/plugin-ext-vscode/src/common/plugin-vscode-uri.ts
@@ -29,8 +29,14 @@ export namespace VSCodeExtensionUri {
     export function toVsxExtensionUriString(id: string): string {
         return `${VSCODE_PREFIX}${id}`;
     }
-    export function toUri(id: string): URI {
-        return new URI(toVsxExtensionUriString(id));
+    export function toUri(name: string, namespace: string): URI;
+    export function toUri(id: string): URI;
+    export function toUri(idOrName: string, namespace?: string): URI {
+        if (typeof namespace === 'string') {
+            return new URI(toVsxExtensionUriString(`${namespace}.${idOrName}`));
+        } else {
+            return new URI(toVsxExtensionUriString(idOrName));
+        }
     }
     export function toId(uri: URI): string | undefined {
         if (uri.scheme === 'vscode' && uri.path.dir.toString() === 'extension') {

--- a/packages/vsx-registry/src/browser/vsx-language-quick-pick-service.ts
+++ b/packages/vsx-registry/src/browser/vsx-language-quick-pick-service.ts
@@ -1,0 +1,103 @@
+// *****************************************************************************
+// Copyright (C) 2022 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { LanguageQuickPickItem, LanguageQuickPickService } from '@theia/core/lib/browser/i18n/language-quick-pick-service';
+import { RequestContext, RequestService } from '@theia/core/shared/@theia/request';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { LanguageInfo } from '@theia/core/lib/common/i18n/localization';
+import { PluginPackage, PluginServer } from '@theia/plugin-ext';
+import { OVSXClientProvider } from '../common/ovsx-client-provider';
+import { VSXSearchEntry } from '@theia/ovsx-client';
+import { VSXExtensionUri } from '../common/vsx-extension-uri';
+
+@injectable()
+export class VSXLanguageQuickPickService extends LanguageQuickPickService {
+
+    @inject(OVSXClientProvider)
+    protected readonly clientProvider: OVSXClientProvider;
+
+    @inject(RequestService)
+    protected readonly requestService: RequestService;
+
+    @inject(PluginServer)
+    protected readonly pluginServer: PluginServer;
+
+    protected override async getAvailableLanguages(): Promise<LanguageQuickPickItem[]> {
+        const client = await this.clientProvider();
+        const searchResult = await client.search({
+            category: 'Language Packs',
+            sortBy: 'downloadCount',
+            sortOrder: 'desc',
+            size: 20
+        });
+        if (searchResult.error) {
+            throw new Error('Error while loading available languages: ' + searchResult.error);
+        }
+
+        const extensionLanguages = await Promise.all(
+            searchResult.extensions.map(async extension => ({
+                extension,
+                languages: await this.loadExtensionLanguages(extension)
+            }))
+        );
+
+        const languages = new Map<string, { language: LanguageInfo, extensionUri: string }>();
+
+        for (const extension of extensionLanguages) {
+            for (const localizationContribution of extension.languages) {
+                if (!languages.has(localizationContribution.languageId)) {
+                    languages.set(localizationContribution.languageId, {
+                        language: localizationContribution,
+                        extensionUri: VSXExtensionUri.toUri(extension.extension.name, extension.extension.namespace).toString()
+                    });
+                }
+            }
+        }
+        const items: LanguageQuickPickItem[] = [];
+
+        for (const { language, extensionUri } of Array.from(languages.values())) {
+            const item: LanguageQuickPickItem = {
+                ...this.createLanguageQuickPickItem(language),
+                execute: async () => {
+                    await this.pluginServer.deploy(extensionUri);
+                }
+            };
+            items.push(item);
+        }
+        return items;
+    }
+
+    protected async loadExtensionLanguages(extension: VSXSearchEntry): Promise<LanguageInfo[]> {
+        // When searching for extensions on ovsx, we don't receive the `manifest` property.
+        // This property is only set when querying a specific extension.
+        // To improve performance, we assume that a manifest exists at `/package.json`.
+        const downloadUrl = extension.files.download;
+        const parentUrl = downloadUrl.substring(0, downloadUrl.lastIndexOf('/'));
+        const manifestUrl = parentUrl + '/package.json';
+        const manifestRequest = await this.requestService.request({ url: manifestUrl });
+        const manifestContent = RequestContext.asJson<PluginPackage>(manifestRequest);
+        const localizations = manifestContent.contributes?.localizations;
+        if (localizations) {
+            return localizations.map(e => ({
+                languageId: e.languageId,
+                languageName: e.languageName,
+                localizedLanguageName: e.localizedLanguageName,
+                languagePack: true
+            }));
+        }
+        return [];
+    }
+}

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -36,8 +36,10 @@ import { bindPreferenceProviderOverrides } from './recommended-extensions/prefer
 import { OVSXClientProvider, createOVSXClient } from '../common/ovsx-client-provider';
 import { VSXEnvironment, VSX_ENVIRONMENT_PATH } from '../common/vsx-environment';
 import { RequestService } from '@theia/core/shared/@theia/request';
+import { LanguageQuickPickService } from '@theia/core/lib/browser/i18n/language-quick-pick-service';
+import { VSXLanguageQuickPickService } from './vsx-language-quick-pick-service';
 
-export default new ContainerModule((bind, unbind) => {
+export default new ContainerModule((bind, unbind, _, rebind) => {
     bind<OVSXClientProvider>(OVSXClientProvider).toDynamicValue(ctx => {
         const clientPromise = createOVSXClient(ctx.container.get(VSXEnvironment), ctx.container.get(RequestService));
         return () => clientPromise;
@@ -99,6 +101,8 @@ export default new ContainerModule((bind, unbind) => {
 
     bind(VSXExtensionsSearchModel).toSelf().inSingletonScope();
     bind(VSXExtensionsSearchBar).toSelf().inSingletonScope();
+
+    rebind(LanguageQuickPickService).to(VSXLanguageQuickPickService).inSingletonScope();
 
     bindViewContribution(bind, VSXExtensionsContribution);
     bind(FrontendApplicationContribution).toService(VSXExtensionsContribution);


### PR DESCRIPTION
#### What it does

Updates the UX of the `Configure Display Language` command to align to VSCode version 1.68 (see [changelogs](https://code.visualstudio.com/updates/v1_68#_configure-display-language-improvements)).

VSCode:

![image](https://user-images.githubusercontent.com/4377073/173326949-949ba99e-7cf1-4dc8-a930-4263e7de4db7.png)

Theia (new):

![image](https://user-images.githubusercontent.com/4377073/173342216-1132d2bc-fc1a-4655-885d-2f3d774e1054.png)

#### How to test

1. Run the `Configure Display Language` command
2. Assert that the new functionality (displaying available languages from ovsx) works as it does in vscode
    * Selecting one of the "Available" languages should install it and ask to confirm the language change
    * Selecting one of the "Installed" language should show no regressions

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
