### PR TITLE
Improve RPC message encoding

### DIFF
--- a/packages/core/src/common/message-rpc/rpc-message-encoder.spec.ts
+++ b/packages/core/src/common/message-rpc/rpc-message-encoder.spec.ts
@@ -26,6 +26,9 @@ describe('PPC Message Codex', () => {
 
             const encoder = new RpcMessageEncoder();
             const jsonMangled = JSON.parse(JSON.stringify(encoder));
+            // The RpcMessageEncoder can decode/encode collections, whereas JSON.parse can't. => We have to manually restore the set
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            jsonMangled.registeredTags = (encoder as any).registeredTags;
 
             encoder.writeTypedValue(writer, encoder);
 

--- a/packages/core/src/common/message-rpc/rpc-message-encoder.spec.ts
+++ b/packages/core/src/common/message-rpc/rpc-message-encoder.spec.ts
@@ -16,7 +16,7 @@
 
 import { expect } from 'chai';
 import { Uint8ArrayReadBuffer, Uint8ArrayWriteBuffer } from './uint8-array-message-buffer';
-import { RpcMessageDecoder, RpcMessageEncoder } from './rpc-message-encoder';
+import { EncodingError, RpcMessageDecoder, RpcMessageEncoder } from './rpc-message-encoder';
 
 describe('PPC Message Codex', () => {
     describe('RPC Message Encoder & Decoder', () => {
@@ -30,7 +30,7 @@ describe('PPC Message Codex', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             jsonMangled.registeredTags = (encoder as any).registeredTags;
 
-            encoder.writeTypedValue(writer, encoder);
+            encoder.writeTypedValue(writer, encoder, new WeakSet());
 
             const written = writer.getCurrentContents();
 
@@ -40,6 +40,16 @@ describe('PPC Message Codex', () => {
             const decoded = decoder.readTypedValue(reader);
 
             expect(decoded).deep.equal(jsonMangled);
+        });
+        it('should fail with an EncodingError when trying to encode the object ', () => {
+            const x = new Set();
+            const y = new Set();
+            x.add(y);
+            y.add(x);
+            const encoder = new RpcMessageEncoder();
+
+            const writer = new Uint8ArrayWriteBuffer();
+            expect(() => encoder.writeTypedValue(writer, x, new WeakSet())).to.throw(EncodingError);
         });
     });
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Refactor `RPCMessageEncoder` to enable detection of circular object structures. Circular structures can not be serialized. The detection enables us to fail early instead of indirectly failing once the maximum stack frame limit is reached.
- Add a custom encoder for functions. This ensures that direct function entries in arrays can be serialized.
- Add custom encoder for common collection types (maps, sets). Enables direct use of collection types as rpc call arguments (e.g. logging statements)
- Restore behavior of the old protocol if a log RPC call can not be sent to the backend due to an encoding error 
   - Add custom `EncodingError` type to explicitly catch these errors
   - Refactor `loggerFrontendModule` to catch encoding errors and continue execution normally. i.e. log call is just logged in frontend console and not sent to backend

Fixes https://github.com/eclipse-theia/theia/issues/11249
 
Contributed on behalf of STMicroelectronics
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The bug described in https://github.com/eclipse-theia/theia/issues/11249#issuecomment-1147961021 should be fixed. i.e.:

1. Add this log to DebugSessionManager set currentSession:
 ```bash
 console.log('SENTINEL FOR SETTING THE CURRENT SESSION', current);
```

2. Start a debug session inside the application.
3. Observe that the frontend (browser) logs log the message as expected.
4. Observe that no error logged in the frontend console
5. Observe that the backend logs do not show the message
( Same behavior as with the old RPC protocol)
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
