### PR TITLE
[vscode] Support optional property TaskPresentationOptions#clear #11133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [plugin] Add support for `TreeItemLabel` in `TreeItem`. [#11288](https://github.com/eclipse-theia/theia/pull/11288) - Contributed on behalf of STMicroelectronics
 - [plugin] Support `TextEditor#show()` and `TextEditor#hide()` [#11168](https://github.com/eclipse-theia/theia/pull/11168) - Contributed on behalf of STMicroelectronics
 - [core, monaco] refactored theme initialization to occur within application lifecycle rather than at import time. [#11213](https://github.com/eclipse-theia/theia/pull/11213)
+- [plugin] Support optional property `TaskPresentationOptions#clear` [#11298](https://github.com/eclipse-theia/theia/pull/11298) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.27.0">[Breaking Changes:](#breaking_changes_1.27.0)</a>
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1416,6 +1416,7 @@ export interface TaskPresentationOptionsDTO {
     echo?: boolean;
     panel?: number;
     showReuseMessage?: boolean;
+    clear?: boolean;
 }
 
 export interface TaskExecutionDto {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10767,6 +10767,9 @@ export module '@theia/plugin' {
 
         /** Controls whether to show the "Terminal will be reused by tasks, press any key to close it" message. */
         showReuseMessage?: boolean;
+
+        /** Controls whether the terminal is cleared before executing the task. */
+        clear?: boolean;
     }
 
     export class Task {


### PR DESCRIPTION
#### What it does
Adds the clear property to the API and the data transfer object. 
The functionality was working already as far as I could see, since the flag was available on `TaskOutputPresentation` already and the conversion code kept this flag in. 

Fixes #11133

Contributed on behalf of STMicroelectronics

#### How to test
I've created an extension (https://github.com/jfaltermeier/vscode-playground/blob/main/tasks-clear/src/extension.ts, https://github.com/jfaltermeier/vscode-playground/releases/download/tasks-clear-0.0.1/tasks-clear-0.0.1.vsix) that adds two commands, "Task with clear" and "Task without clear",
Both will execute a task programmatically that will print text to the terminal. The terminal is cleared depending on the `clear` flag.

I've also checked with a `tasks.json`-file:
```
{
    // See https://go.microsoft.com/fwlink/?LinkId=733558
    // for the documentation about the tasks.json format
    "version": "2.0.0",
    "tasks": [
      {
        "label": "Task with clear",
        "type": "shell",
        "command": "echo 1 && echo 2 && echo 3",
        "presentation": {
          "reveal": "always",
          "panel": "shared",
          "clear": true
        },
        "problemMatcher": []
      },
      {
        "label": "Task without clear",
        "type": "shell",
        "command": "echo 1 && echo 2 && echo 3",
        "presentation": {
          "reveal": "always",
          "panel": "shared",
          "clear": false
        },
        "problemMatcher": []
      },
    ]
  }
  
```

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
