### PR TITLE
Update extension readme styling

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -48,8 +48,10 @@ code {
 }
 
 blockquote {
-    background: var(--vscode-textBlockQuote-background);
-    border: var(--theia-border-width) solid var(--theia-textBlockQuote-border);
+    margin: 0 7px 0 5px;
+    padding: 0px 16px 0px 10px;
+    background: var(--theia-textBlockQuote-background);
+    border-left: 5px solid var(--theia-textBlockQuote-border);
 }
 
 .theia-input {

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -10,10 +10,8 @@
     "@theia/plugin-ext-vscode": "1.26.0",
     "@theia/preferences": "1.26.0",
     "@theia/workspace": "1.26.0",
-    "@types/showdown": "^1.7.1",
     "p-debounce": "^2.1.0",
     "semver": "^5.4.1",
-    "showdown": "^1.9.1",
     "uuid": "^8.0.0"
   },
   "publishConfig": {

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -167,9 +167,10 @@
     padding-top: 0;
     max-width: 1000px;
     margin: 0 auto;
+    line-height: 22px;
 }
 
-.theia-vsx-extension-editor .body h2:first-of-type {
+.theia-vsx-extension-editor .body h1 {
     padding-bottom: var(--theia-ui-padding);
     border-bottom: 1px solid hsla(0, 0%, 50%, .5);
     margin-top: calc(var(--theia-ui-padding) * 5);

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -176,6 +176,34 @@
     margin-top: calc(var(--theia-ui-padding) * 5);
 }
 
+.theia-vsx-extension-editor .body a {
+	text-decoration: none;
+}
+
+.theia-vsx-extension-editor .body a:hover {
+	text-decoration: underline;
+}
+
+.theia-vsx-extension-editor .body table {
+	border-collapse: collapse;
+}
+
+.theia-vsx-extension-editor .body table > thead > tr > th {
+	text-align: left;
+	border-bottom: 1px solid var(--theia-extensionEditor-tableHeadBorder);
+}
+
+.theia-vsx-extension-editor .body table > thead > tr > th,
+.theia-vsx-extension-editor .body table > thead > tr > td,
+.theia-vsx-extension-editor .body table > tbody > tr > th,
+.theia-vsx-extension-editor .body table > tbody > tr > td {
+	padding: 5px 10px;
+}
+
+.theia-vsx-extension-editor .body table > tbody > tr + tr > td {
+	border-top: 1px solid var(--theia-extensionEditor-tableCellBorder);
+}
+
 .theia-vsx-extension-editor .scroll-container .body pre {
     white-space: normal;
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -138,7 +138,21 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
                     dark: '#28632b',
                     light: '#28632b'
                 }, description: 'Button background hover color for actions extension that stand out (e.g. install button).'
-            }
+            },
+            {
+                id: 'extensionEditor.tableHeadBorder', defaults: {
+                    dark: Color.transparent('#ffffff', 0.7),
+                    light: Color.transparent('#000000', 0.7),
+                    hc: Color.white
+                }, description: 'Border color for the table head row of the extension editor view'
+            },
+            {
+                id: 'extensionEditor.tableCellBorder', defaults: {
+                    dark: Color.transparent('#ffffff', 0.2),
+                    light: Color.transparent('#000000', 0.2),
+                    hc: Color.white
+                }, description: 'Border color for a table row of the extension editor view'
+            },
         );
     }
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import debounce from 'p-debounce';
-import * as showdown from 'showdown';
+import * as markdownit from '@theia/core/shared/markdown-it';
 import * as DOMPurify from '@theia/core/shared/dompurify';
 import { Emitter } from '@theia/core/lib/common/event';
 import { CancellationToken, CancellationTokenSource } from '@theia/core/lib/common/cancellation';
@@ -285,15 +285,7 @@ export class VSXExtensionsModel {
     }
 
     protected compileReadme(readmeMarkdown: string): string {
-        const markdownConverter = new showdown.Converter({
-            headerLevelStart: 2,
-            noHeaderId: true,
-            strikethrough: true,
-            tables: true,
-            underline: true
-        });
-
-        const readmeHtml = markdownConverter.makeHtml(readmeMarkdown);
+        const readmeHtml = markdownit({ html: true }).render(readmeMarkdown);
         return DOMPurify.sanitize(readmeHtml);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,11 +2690,6 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/showdown@^1.7.1":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@types/showdown/-/showdown-1.9.4.tgz#5385adf34143abad9309561661fa6c781d2ab962"
-  integrity sha512-50ehC3IAijfkvoNqmQ+VL73S7orOxmAK8ljQAFBv8o7G66lAZyxQj1L3BAv2dD86myLXI+sgKP1kcxAaxW356w==
-
 "@types/sinon@^10.0.6":
   version "10.0.11"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.11.tgz#8245827b05d3fc57a6601bd35aee1f7ad330fc42"
@@ -10468,13 +10463,6 @@ shiki@^0.10.1:
     vscode-oniguruma "^1.6.1"
     vscode-textmate "5.2.0"
 
-showdown@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.1.tgz#134e148e75cd4623e09c21b0511977d79b5ad0ef"
-  integrity sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==
-  dependencies:
-    yargs "^14.2"
-
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -12289,14 +12277,6 @@ yargs-parser@20.2.4:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs-parser@^15.0.1:
-  version "15.0.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.3.tgz#316e263d5febe8b38eef61ac092b33dfcc9b1115"
-  integrity sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -12339,23 +12319,6 @@ yargs@13.3.2, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
-
-yargs@^14.2:
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
-  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
-  dependencies:
-    cliui "^5.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^15.0.1"
 
 yargs@^15.0.2, yargs@^15.3.1:
   version "15.4.1"


### PR DESCRIPTION
#### What it does

Updates the styling of the extension readme widget and fixing some glaring markdown rendering issues. Also removes the dependency to `showdown` in favor of using `markdown-it` for rendering.

See some updates here:

<details>

Theia (before):

![grafik](https://user-images.githubusercontent.com/4377073/173819632-687b7482-19dc-4b9b-8d7c-ae333cb7e5a6.png)

![grafik](https://user-images.githubusercontent.com/4377073/173819651-d42ab221-108d-4ebe-b78f-bf3716b08222.png)

Theia (after):

![grafik](https://user-images.githubusercontent.com/4377073/173819683-d9ace810-edd3-4bb2-a33e-2a18c30cd12e.png)

![grafik](https://user-images.githubusercontent.com/4377073/173819699-e758e543-5891-4514-b09b-67990d59c498.png)


</details>

#### How to test

1. Open the readme for an extension (I used `redhat.java` and `gitlens`)
2. Compare the rendered readme with the extension readme shown in vscode

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
