### PR TITLE
core: update cursor for custom select-component

### DIFF
--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -16,6 +16,7 @@
 
 .theia-select-component {
     background-color: var(--theia-dropdown-background);
+    cursor: pointer;
     outline: var(--theia-dropdown-border) solid 1px;
     outline-offset: -1px;
     min-height: 23px;
@@ -83,6 +84,7 @@
 
 .theia-select-component-dropdown .theia-select-component-option.selected {
     color: var(--theia-list-activeSelectionForeground);
+    cursor: pointer;
     background: var(--theia-list-activeSelectionBackground);
     outline: var(--theia-focusBorder) solid 1px;
     outline-offset: -1px;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Playing around with the framework today I noticed that the cursor when interacting with the custom `select-component` was incorrect, instead we should display a `pointer` like other applications including vscode.

The commit updates the cursor for our custom `select-component` when an option is selected. 

https://user-images.githubusercontent.com/40359487/174130783-f335b3ea-a029-47ec-9bbd-99c050b1a4c4.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application using `theia` as a workspace
2. open the debug-view, interact with the launch configuration dropdown and confirm the cursor when hovering and selecting options is correct
3. do the same as step 2 for the preferences-view (which also uses the custom select-component)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>