### PR TITLE
fix: Omit _All Files_ filter in Electron on Linux

### DIFF
--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -135,11 +135,8 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     /**
      * Specifies whether an _All Files_ filter should be added to the dialog.
      *
-     * We shouldn't add an _All Files_ filter, if we are on Linux and no other filter is specified.
-     * Otherwise, we run into a [bug](https://github.com/eclipse-theia/theia/issues/11321) in Electron
-     * which causes an extension filter `['*']` to hide files without extensions. Once we are on Electron >18,
-     * we should be able to add the _All Files_ filter again in all cases, as this bug seems to be resolved in
-     * Electron above >18.
+     * On Linux, the _All Files_ filter [hides](https://github.com/eclipse-theia/theia/issues/11321) files without an extension.
+     * The bug is resolved in Electron >=18.
      */
     protected shouldAddAllFilesFilter(electronProps: electron.FileDialogProps): boolean {
         const foundFilters = !!electronProps.filters && electronProps.filters.length > 0;


### PR DESCRIPTION
#### What it does
Omits adding the _All Files_ filter, if we are on Linux and no other filter is specified. Otherwise, we run into https://github.com/eclipse-theia/theia/issues/11321 which causes an extension filter `['*']` to hide files without extensions. Once we are on Electron >18, we should be able to add the _All Files_ filter again in all cases, as this Electron bug seems to be resolved in Electron above >18.

Fixes https://github.com/eclipse-theia/theia/issues/11321

Change-Id: Iec3120a6260f20b7f0d42c091aa00bde33fa915a
Signed-off-by: Philip Langer <planger@eclipsesource.com>

#### How to test
1. Use Ubuntu Linux
2. Start Electron Example App
3. _Open Settings (UI)_
4. Navigate to _Terminal › External: Windows Exec_
5. Click _Browse_
6. Navigate to a folder that contains a file without an extension
7. Observe how the file without extension shows up in the dialog

We should also ensure that other OSs aren't affected (OSX and Windows), as well as that the _All Files_ filter still shows up when a specific filter is specified. Unfortunately, I could only test the latter myself (when specific filters are specified) but not the former, because I don't have a Windows or OSX machine.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
