### PR TITLE
Uplift Monaco to VSCode 1.67.2

### DIFF
--- a/examples/api-samples/package.json
+++ b/examples/api-samples/package.json
@@ -8,7 +8,7 @@
     "@theia/file-search": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/output": "1.27.0",
     "@theia/search-in-workspace": "1.27.0",
     "@theia/toolbar": "1.27.0",

--- a/examples/api-samples/package.json
+++ b/examples/api-samples/package.json
@@ -8,7 +8,7 @@
     "@theia/file-search": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/output": "1.27.0",
     "@theia/search-in-workspace": "1.27.0",
     "@theia/toolbar": "1.27.0",

--- a/packages/bulk-edit/package.json
+++ b/packages/bulk-edit/package.json
@@ -7,7 +7,7 @@
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/workspace": "1.27.0"
   },
   "publishConfig": {

--- a/packages/bulk-edit/package.json
+++ b/packages/bulk-edit/package.json
@@ -7,7 +7,7 @@
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/workspace": "1.27.0"
   },
   "publishConfig": {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@theia/core": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "anser": "^2.0.1"
   },
   "publishConfig": {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@theia/core": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "anser": "^2.0.1"
   },
   "publishConfig": {

--- a/packages/core/src/common/color.ts
+++ b/packages/core/src/common/color.ts
@@ -85,7 +85,10 @@ export interface HSLA {
 export interface ColorDefaults {
     light?: Color
     dark?: Color
+    /** @deprecated @since 1.28.0 Please use hcDark and hcLight. This field will be ignored unless `hcDark` is absent. */
     hc?: Color
+    hcDark?: Color;
+    hcLight?: Color;
 }
 
 export interface ColorDefinition {

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -9,7 +9,7 @@
     "@theia/filesystem": "1.27.0",
     "@theia/markers": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/output": "1.27.0",
     "@theia/process": "1.27.0",
     "@theia/task": "1.27.0",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -9,7 +9,7 @@
     "@theia/filesystem": "1.27.0",
     "@theia/markers": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/output": "1.27.0",
     "@theia/process": "1.27.0",
     "@theia/task": "1.27.0",

--- a/packages/debug/src/browser/editor/debug-inline-value-decorator.ts
+++ b/packages/debug/src/browser/editor/debug-inline-value-decorator.ts
@@ -162,7 +162,7 @@ export class DebugInlineValueDecorator implements FrontendApplicationContributio
     private createInlineValueDecoration(lineNumber: number, contentText: string): IDecorationOptions {
         // If decoratorText is too long, trim and add ellipses. This could happen for minified files with everything on a single line
         if (contentText.length > MAX_INLINE_DECORATOR_LENGTH) {
-            contentText = contentText.substr(0, MAX_INLINE_DECORATOR_LENGTH) + '...';
+            contentText = contentText.substring(0, MAX_INLINE_DECORATOR_LENGTH) + '...';
         }
 
         return {
@@ -210,8 +210,8 @@ export class DebugInlineValueDecorator implements FrontendApplicationContributio
                     continue;
                 }
 
-                model.forceTokenization(lineNumber);
-                const lineTokens = model.getLineTokens(lineNumber);
+                model.tokenization.forceTokenization(lineNumber);
+                const lineTokens = model.tokenization.getLineTokens(lineNumber);
                 for (let tokenIndex = 0, tokenCount = lineTokens.getCount(); tokenIndex < tokenCount; tokenIndex++) {
                     const tokenStartOffset = lineTokens.getStartOffset(tokenIndex);
                     const tokenEndOffset = lineTokens.getEndOffset(tokenIndex);

--- a/packages/editor/src/browser/editor-generated-preference-schema.ts
+++ b/packages/editor/src/browser/editor-generated-preference-schema.ts
@@ -123,54 +123,48 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.language.brackets": {
-        "default": false,
-        "description": nls.localizeByDefault("Defines the bracket symbols that increase or decrease the indentation."),
-        "anyOf": [
-            { "const": false },
-            {
-                "type": "array",
-                "items": {
-                    "type": "array",
-                    "items": [
-                        {
-                            "type": "string",
-                            "description": nls.localizeByDefault("The opening bracket character or string sequence.")
-                        },
-                        {
-                            "type": "string",
-                            "description": nls.localizeByDefault("The closing bracket character or string sequence.")
-                        }
-                    ]
-                },
-
-            },
+        "type": [
+            "array",
+            "null"
         ],
+        "default": null,
+        "description": nls.localizeByDefault("Defines the bracket symbols that increase or decrease the indentation."),
+        "items": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "string",
+                    "description": nls.localizeByDefault("The opening bracket character or string sequence.")
+                },
+                {
+                    "type": "string",
+                    "description": nls.localizeByDefault("The closing bracket character or string sequence.")
+                }
+            ]
+        },
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.language.colorizedBracketPairs": {
-        "default": false,
-        "description": nls.localize("theia/editor/editor.language.colorizedBracketPairs", "Defines the bracket pairs that are colorized by their nesting level if bracket pair colorization is enabled."),
-        "anyOf": [
-            { "const": false },
-            {
-                "type": "array",
-                "items": {
-                    "type": "array",
-                    "items": [
-                        {
-                            "type": "string",
-                            "description": nls.localizeByDefault("The opening bracket character or string sequence.")
-                        },
-                        {
-                            "type": "string",
-                            "description": nls.localizeByDefault("The closing bracket character or string sequence.")
-                        }
-                    ]
-                },
-
-            },
+        "type": [
+            "array",
+            "null"
         ],
+        "default": null,
+        "description": nls.localize("theia/editor/editor.language.colorizedBracketPairs", "Defines the bracket pairs that are colorized by their nesting level if bracket pair colorization is enabled."),
+        "items": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "string",
+                    "description": nls.localizeByDefault("The opening bracket character or string sequence.")
+                },
+                {
+                    "type": "string",
+                    "description": nls.localizeByDefault("The closing bracket character or string sequence.")
+                }
+            ]
+        },
         "scope": "language-overridable",
         "restricted": false
     },
@@ -396,8 +390,15 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     },
     "editor.bracketPairColorization.enabled": {
         "type": "boolean",
+        "default": true,
+        "markdownDescription": nls.localize("theia/editor/editor.bracketPairColorization.enabled", "Controls whether bracket pair colorization is enabled or not. Use `#workbench.colorCustomizations#` to override the bracket highlight colors."),
+        "scope": "language-overridable",
+        "restricted": false
+    },
+    "editor.bracketPairColorization.independentColorPoolPerBracketType": {
+        "type": "boolean",
         "default": false,
-        "description": nls.localize("theia/editor/editor.bracketPairColorization.enabled", "Controls whether bracket pair colorization is enabled or not. Use 'workbench.colorCustomizations' to override the bracket highlight colors."),
+        "description": nls.localize("theia/editor/editor.bracketPairColorization.independentColorPoolPerBracketType", "Controls whether each bracket type has its own independent color pool."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -456,7 +457,20 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.guides.highlightActiveIndentation": {
-        "type": "boolean",
+        "type": [
+            "boolean",
+            "string"
+        ],
+        "enum": [
+            true,
+            "always",
+            false
+        ],
+        "enumDescriptions": [
+            nls.localize("theia/editor/editor.guides.highlightActiveIndentation0", "Highlights the active indent guide."),
+            nls.localize("theia/editor/editor.guides.highlightActiveIndentation1", "Highlights the active indent guide even if bracket guides are highlighted."),
+            nls.localize("theia/editor/editor.guides.highlightActiveIndentation2", "Do not highlight the active indent guide.")
+        ],
         "default": true,
         "description": nls.localizeByDefault("Controls whether the editor should highlight the active indent guide."),
         "scope": "language-overridable",
@@ -650,6 +664,12 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "description": nls.localizeByDefault('Controls the condition for turning on find in selection automatically.'),
         "scope": "language-overridable",
         "restricted": false
+    },
+    "editor.find.globalFindClipboard": {
+        "type": "boolean",
+        "default": false,
+        "description": nls.localizeByDefault("Controls whether the Find Widget should read or modify the shared find clipboard on macOS."),
+        "included": isOSX
     },
     "editor.find.addExtraSpaceOnTop": {
         "type": "boolean",
@@ -1312,29 +1332,80 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
                 "type": "object",
                 "properties": {
                     "strings": {
-                        "type": "boolean",
-                        "default": false,
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "on",
+                                    "inline",
+                                    "off"
+                                ],
+                                "enumDescriptions": [
+                                    nls.localize("theia/editor/editor.quickSuggestions0", "Quick suggestions show inside the suggest widget"),
+                                    nls.localize("theia/editor/editor.quickSuggestions1", "Quick suggestions show as ghost text"),
+                                    nls.localize("theia/editor/editor.quickSuggestions2", "Quick suggestions are disabled")
+                                ]
+                            }
+                        ],
+                        "default": "off",
                         "description": nls.localizeByDefault("Enable quick suggestions inside strings.")
                     },
                     "comments": {
-                        "type": "boolean",
-                        "default": false,
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "on",
+                                    "inline",
+                                    "off"
+                                ],
+                                "enumDescriptions": [
+                                    nls.localize("theia/editor/editor.quickSuggestions0", "Quick suggestions show inside the suggest widget"),
+                                    nls.localize("theia/editor/editor.quickSuggestions1", "Quick suggestions show as ghost text"),
+                                    nls.localize("theia/editor/editor.quickSuggestions2", "Quick suggestions are disabled")
+                                ]
+                            }
+                        ],
+                        "default": "off",
                         "description": nls.localizeByDefault("Enable quick suggestions inside comments.")
                     },
                     "other": {
-                        "type": "boolean",
-                        "default": true,
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "on",
+                                    "inline",
+                                    "off"
+                                ],
+                                "enumDescriptions": [
+                                    nls.localize("theia/editor/editor.quickSuggestions0", "Quick suggestions show inside the suggest widget"),
+                                    nls.localize("theia/editor/editor.quickSuggestions1", "Quick suggestions show as ghost text"),
+                                    nls.localize("theia/editor/editor.quickSuggestions2", "Quick suggestions are disabled")
+                                ]
+                            }
+                        ],
+                        "default": "on",
                         "description": nls.localizeByDefault("Enable quick suggestions outside of strings and comments.")
                     }
                 }
             }
         ],
         "default": {
-            "other": true,
-            "comments": false,
-            "strings": false
+            "other": "on",
+            "comments": "off",
+            "strings": "off"
         },
-        "description": nls.localizeByDefault("Controls whether suggestions should automatically show up while typing."),
+        "markdownDescription": nls.localizeByDefault("Controls whether suggestions should automatically show up while typing."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -2132,16 +2203,28 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.inlayHints.enabled": {
-        "type": "boolean",
-        "default": true,
+        "type": "string",
+        "default": "on",
         "description": nls.localize("theia/editor/editor.inlayHints.enabled", "Enables the inlay hints in the editor."),
+        "enum": [
+            "on",
+            "onUnlessPressed",
+            "offUnlessPressed",
+            "off"
+        ],
+        "markdownEnumDescriptions": [
+            nls.localize("theia/editor/editor.inlayHints.enabled0", "Inlay hints are enabled"),
+            nls.localize("theia/editor/editor.inlayHints.enabled1", "Inlay hints are showing by default and hide when holding `Ctrl+Alt`"),
+            nls.localize("theia/editor/editor.inlayHints.enabled2", "Inlay hints are hidden by default and show when holding `Ctrl+Alt`"),
+            nls.localize("theia/editor/editor.inlayHints.enabled3", "Inlay hints are disabled")
+        ],
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.inlayHints.fontSize": {
         "type": "number",
         "default": 0,
-        "markdownDescription": nls.localize("theia/editor/editor.inlayHints.fontSize", "Controls font size of inlay hints in the editor. A default of 90% of `#editor.fontSize#` is used when the configured value is less than `5` or greater than the editor font size."),
+        "markdownDescription": nls.localize("theia/editor/editor.inlayHints.fontSize", "Controls font size of inlay hints in the editor. As default the `#editor.fontSize#` is used when the configured value is less than `5` or greater than the editor font size."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -2151,12 +2234,6 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "markdownDescription": nls.localize("theia/editor/editor.inlayHints.fontFamily", "Controls font family of inlay hints in the editor. When set to empty, the `#editor.fontFamily#` is used."),
         "scope": "language-overridable",
         "restricted": false
-    },
-    "editor.find.globalFindClipboard": {
-        "type": "boolean",
-        "default": false,
-        "description": nls.localizeByDefault("Controls whether the Find Widget should read or modify the shared find clipboard on macOS."),
-        "included": isOSX
     },
     "editor.selectionClipboard": {
         "type": "boolean",
@@ -2180,8 +2257,8 @@ export interface GeneratedEditorPreferences {
     'editor.semanticHighlighting.enabled': true | false | 'configuredByTheme';
     'editor.stablePeek': boolean;
     'editor.maxTokenizationLineLength': number;
-    'editor.language.brackets': Array<[string, string]> | false;
-    'editor.language.colorizedBracketPairs': Array<[string, string]> | false;
+    'editor.language.brackets': Array<[string, string]> | null;
+    'editor.language.colorizedBracketPairs': Array<[string, string]> | null;
     'diffEditor.maxComputationTime': number;
     'diffEditor.maxFileSize': number;
     'diffEditor.renderSideBySide': boolean;
@@ -2200,11 +2277,12 @@ export interface GeneratedEditorPreferences {
     'editor.autoIndent': 'none' | 'keep' | 'brackets' | 'advanced' | 'full';
     'editor.autoSurround': 'languageDefined' | 'quotes' | 'brackets' | 'never';
     'editor.bracketPairColorization.enabled': boolean;
+    'editor.bracketPairColorization.independentColorPoolPerBracketType': boolean;
     'editor.guides.bracketPairs': true | 'active' | false;
     'editor.guides.bracketPairsHorizontal': true | 'active' | false;
     'editor.guides.highlightActiveBracketPair': boolean;
     'editor.guides.indentation': boolean;
-    'editor.guides.highlightActiveIndentation': boolean;
+    'editor.guides.highlightActiveIndentation': true | 'always' | false;
     'editor.codeLens': boolean;
     'editor.codeLensFontFamily': string;
     'editor.codeLensFontSize': number;
@@ -2237,7 +2315,7 @@ export interface GeneratedEditorPreferences {
     'editor.fontFamily': string;
     'editor.fontLigatures': boolean | string;
     'editor.fontSize': number;
-    'editor.fontWeight': number | string;
+    'editor.fontWeight': number | string | 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
     'editor.formatOnPaste': boolean;
     'editor.formatOnType': boolean;
     'editor.glyphMargin': boolean;
@@ -2370,7 +2448,7 @@ export interface GeneratedEditorPreferences {
     'editor.wrappingIndent': 'none' | 'same' | 'indent' | 'deepIndent';
     'editor.wrappingStrategy': 'simple' | 'advanced';
     'editor.showDeprecated': boolean;
-    'editor.inlayHints.enabled': boolean;
+    'editor.inlayHints.enabled': 'on' | 'onUnlessPressed' | 'offUnlessPressed' | 'off';
     'editor.inlayHints.fontSize': number;
     'editor.inlayHints.fontFamily': string;
     'editor.selectionClipboard': boolean;

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -6,7 +6,7 @@
     "@theia/core": "1.27.0",
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/navigator": "1.27.0",
     "@theia/scm": "1.27.0",
     "@theia/scm-extra": "1.27.0",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -6,7 +6,7 @@
     "@theia/core": "1.27.0",
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/navigator": "1.27.0",
     "@theia/scm": "1.27.0",
     "@theia/scm-extra": "1.27.0",

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@theia/core": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/preferences": "1.27.0",
     "@theia/userstorage": "1.27.0",
     "jsonc-parser": "^2.2.0"

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@theia/core": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/preferences": "1.27.0",
     "@theia/userstorage": "1.27.0",
     "jsonc-parser": "^2.2.0"

--- a/packages/monaco/README.md
+++ b/packages/monaco/README.md
@@ -19,6 +19,62 @@ This includes:
 - code snippets
 - textmate grammars (theme registry, service)
 
+## Monaco Uplifts
+
+This package is intended to be the interface between the `@theia/monaco-editor-core` package, the project's bundling of the `monaco-editor-core` package published by the VSCode
+team, and the rest of the application. When we uplift to a new version of `monaco-editor-core`, this package will need to be checked particularly thoroughly. To facilitate that
+process, the steps for undertaking a Monaco uplift are outlined here.
+
+### Setting up the VSCode side
+
+1. Clone the VSCode repo and make sure you have the following remotes:
+ - https://github.com/microsoft/vscode.git - the official VSCode repo.
+ - https://github.com/theia-ide/vscode.git - Theia's fork.
+2. Find the latest release tag in the official VSCode repo, and the most recent uplift branch in the Theia fork.
+ > At the time of this writing the latest release tag is `1.67.2`, and the uplift branch is `monaco-uplift-2022-6`
+3. Check out the release tag, cherry pick the tip of the uplift branch, and resolve any conflicts.
+ > As you resolve conflicts and make changes to the VSCode repo, make sure you end up with a single commit on the uplift branch to make it easier for the next person to rebase.
+4. Try to build. At the moment, this means running `yarn` and `yarn run gulp editor-distro`.
+5. Fix any build errors that arise.
+6. Change the version in `build/monaco/package.json`
+
+#### Current State
+
+ - build/gulpfile.editor.js: various changes to modify the treeshaking and output destinations.
+ - build/lib/standalone.js/ts: changes to output sourcemaps etc. One small change to fix a build error due to having a directory named `model` and a file named `model.ts` in the same folder.
+ - src/vs/base/browser/dompurify/dompurify.js changes for CommonJS rather than ESM
+ - src/vs/base/common/marked/marked.js changes for CommonJS rather than ESM
+
+### Setting up the Theia side
+
+For initial testing, it's easier to point dependencies to your local VSCode.
+
+1. Having built `monaco-editor-core` using the steps [above](#setting-up-the-vscode-side).
+2. Find all references to `@theia/monaco-editor-core` in `package.json`s and replace their version with `"link:<path to your local build of monaco-editor-core>"`.
+> Using `link:` means that if you subsequently make changes on hte VSCode side, you only need to rebuild VSCode and then rebuild Theia to see the effects. 
+3. Delete your `node_modules` and `yarn` and build Theia.
+4. Fix any build errors.
+5. Uncomment the `bindMonacoPreferenceExtractor` function in `examples/api-samples/src/browser/monaco-editor-preferences/monaco-editor-preference-extractor.ts` and run the commands there. Fix the `EditorGeneratedPreferenceSchema` as necessary, and add or remove validations from the `MonacoFrontendApplicationContribution` as appropriate.
+6. Look for comments that indicate forced types or other code smells that would prevent a build error from being thrown where it should be thrown and check that the assertion still applies.
+> If you add these, mark them with @monaco-uplift - that'll make them easier to find in the future. Better: if you can remove them, do! Typically, the cause is mixing imports from
+private API and public API. Often public API fails to satisfy private declarations.
+7. Test the application thoroughly - make sure everything's still working.
+> It may also be necessary to update our various `vscode` dependencies to match the current state of VSCode. It may not be necessary to upgrade all (or any) of these to successfully adopt a new Monaco version, but if something is misbehaving inexplicably, checking dependencies is a reasonable place to start. Check on:
+> - `vscode-debugprotocol`
+> - `vscode-languageserver-protocol`
+> - `vscode-oniguruma`
+> - `vscode-proxy-agent`
+> - `vscode-ripgrep`
+> - `vscode-textmate`
+> - `vscode-uri`
+
+### Publishing for testing
+
+Once you believe that everything is in working order, you'll need to publish the new `@theia/monaco-editor-core` for testing. The instructions for doing so are
+[here](https://github.com/theia-ide/vscode/wiki/Publish-%60@theia-monaco-editor-core%60). Once the package is published, point your `package.json`s at the testing version and make
+sure everything still works, then make a PR.
+
+
 ## Additional Information
 
 - [API documentation for `@theia/monaco`](https://eclipse-theia.github.io/theia/docs/next/modules/monaco.html)

--- a/packages/monaco/README.md
+++ b/packages/monaco/README.md
@@ -51,7 +51,7 @@ For initial testing, it's easier to point dependencies to your local VSCode.
 
 1. Having built `monaco-editor-core` using the steps [above](#setting-up-the-vscode-side).
 2. Find all references to `@theia/monaco-editor-core` in `package.json`s and replace their version with `"link:<path to your local build of monaco-editor-core>"`.
-> Using `link:` means that if you subsequently make changes on hte VSCode side, you only need to rebuild VSCode and then rebuild Theia to see the effects. 
+> Using `link:` means that if you subsequently make changes on the VSCode side, you only need to rebuild VSCode and then rebuild Theia to see the effects. 
 3. Delete your `node_modules` and `yarn` and build Theia.
 4. Fix any build errors.
 5. Uncomment the `bindMonacoPreferenceExtractor` function in `examples/api-samples/src/browser/monaco-editor-preferences/monaco-editor-preference-extractor.ts` and run the commands there. Fix the `EditorGeneratedPreferenceSchema` as necessary, and add or remove validations from the `MonacoFrontendApplicationContribution` as appropriate.

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -7,7 +7,7 @@
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/markers": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/outline-view": "1.27.0",
     "fast-plist": "^0.1.2",
     "idb": "^4.0.5",

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -7,13 +7,13 @@
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/markers": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/outline-view": "1.27.0",
     "fast-plist": "^0.1.2",
     "idb": "^4.0.5",
     "jsonc-parser": "^2.2.0",
-    "onigasm": "^2.2.0",
-    "vscode-textmate": "^4.4.0"
+    "vscode-oniguruma": "1.6.1",
+    "vscode-textmate": "^7.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/monaco/src/browser/monaco-color-registry.ts
+++ b/packages/monaco/src/browser/monaco-color-registry.ts
@@ -45,7 +45,8 @@ export class MonacoColorRegistry extends ColorRegistry {
         const defaults: ColorDefaults = {
             dark: this.toColor(definition.defaults?.dark),
             light: this.toColor(definition.defaults?.light),
-            hc: this.toColor(definition.defaults?.hc),
+            hcDark: this.toColor(definition.defaults?.hcDark ?? definition.defaults?.hc),
+            hcLight: this.toColor(definition.defaults?.hcLight),
         };
         const identifier = this.monacoColorRegistry.registerColor(definition.id, defaults, definition.description);
         return Disposable.create(() => this.monacoColorRegistry.deregisterColor(identifier));

--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -63,6 +63,10 @@ export class MonacoDiffEditor extends MonacoEditor {
 
     protected override create(options?: IDiffEditorConstructionOptions, override?: EditorServiceOverrides): Disposable {
         const instantiator = this.getInstantiatorWithOverrides(override);
+        /**
+         *  @monaco-uplift. Should be guaranteed to work.
+         *  Incomparable enums prevent TypeScript from believing that public IStandaloneDiffEditor is satisfied by private StandaloneDiffEditor
+         */
         this._diffEditor = instantiator
             .createInstance(StandaloneDiffEditor, this.node, { ...options, fixedOverflowWidgets: true }) as unknown as monaco.editor.IStandaloneDiffEditor;
         this.editor = this._diffEditor.getModifiedEditor();

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -142,7 +142,10 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
             }
         } as IStandaloneEditorConstructionOptions;
         const instantiator = this.getInstantiatorWithOverrides(override);
-        // Incomparability of internal and external interfaces.
+        /**
+         * @monaco-uplift. Should be guaranteed to work.
+         * Incomparable enums prevent TypeScript from believing that public IStandaloneCodeEditor is satisfied by private StandaloneCodeEditor
+         */
         return this.editor = instantiator.createInstance(StandaloneEditor, this.node, combinedOptions) as unknown as monaco.editor.IStandaloneCodeEditor;
     }
 

--- a/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
+++ b/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
@@ -74,7 +74,10 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
         // Monaco registers certain quick access providers (e.g. QuickCommandAccess) at import time, but we want to use our own.
         this.quickAccessRegistry.clear();
 
-        // Incomparability of enum types between public and private API's
+        /**
+         * @monaco-uplift.Should be guaranteed to work.
+         * Incomparable enums prevent TypeScript from believing that public ITextModel satisfied private ITextModel
+         */
         setSnippetSuggestSupport(this.snippetSuggestProvider as unknown as CompletionItemProvider);
 
         for (const language of monaco.languages.getLanguages()) {
@@ -167,7 +170,7 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
                 new editorBoolConstructor(id++, 'wordBasedSuggestions', true, editorGeneratedPreferenceProperties['editor.wordBasedSuggestions']),
                 new editorStringEnumConstructor(id++, 'wordBasedSuggestionsMode', 'matchingDocuments', editorGeneratedPreferenceProperties['editor.wordBasedSuggestionsMode'].enum, editorGeneratedPreferenceProperties['editor.wordBasedSuggestionsMode']),
                 new editorBoolConstructor(id++, 'stablePeek', false, editorGeneratedPreferenceProperties['editor.stablePeek']),
-                new editorIntConstructor(id++, 'maxTokenizationLength', 20000, 1, MAX_SAFE_INTEGER, editorGeneratedPreferenceProperties['editor.maxTokenizationLength']),
+                new editorIntConstructor(id++, 'maxTokenizationLineLength', 20000, 1, MAX_SAFE_INTEGER, editorGeneratedPreferenceProperties['editor.maxTokenizationLineLength']),
             );
         }
     }

--- a/packages/monaco/src/browser/monaco-indexed-db.ts
+++ b/packages/monaco/src/browser/monaco-indexed-db.ts
@@ -19,7 +19,7 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposa
 import { ThemeService } from '@theia/core/lib/browser/theming';
 import * as monaco from '@theia/monaco-editor-core';
 import { injectable } from '@theia/core/shared/inversify';
-import type { ThemeMix } from './textmate/monaco-theme-registry';
+import type { ThemeMix } from './textmate/monaco-theme-types';
 import { Theme } from '@theia/core/lib/common/theme';
 
 let _monacoDB: Promise<idb.IDBPDatabase> | undefined;

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -214,7 +214,7 @@ export class MonacoQuickInputService implements QuickInputService {
     }
 
     createInputBox(): InputBox {
-        return this.monacoService.createInputBox() as unknown as InputBox;
+        return this.monacoService.createInputBox();
     }
 
     input(options?: InputOptions, token?: monaco.CancellationToken): Promise<string | undefined> {

--- a/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
@@ -17,21 +17,19 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { injectable } from '@theia/core/shared/inversify';
-import { IRawTheme, Registry, IRawThemeSetting } from 'vscode-textmate';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { IRawThemeSetting } from 'vscode-textmate';
 import * as monaco from '@theia/monaco-editor-core';
-import { IStandaloneTheme, IStandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
+import { IStandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import { StandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneThemeService';
 import { Color } from '@theia/monaco-editor-core/esm/vs/base/common/color';
-
-export interface ThemeMix extends IRawTheme, monaco.editor.IStandaloneThemeData { }
-export interface MixStandaloneTheme extends IStandaloneTheme {
-    themeData: ThemeMix
-}
+import { MixStandaloneTheme, TextmateRegistryFactory, ThemeMix } from './monaco-theme-types';
 
 @injectable()
 export class MonacoThemeRegistry {
+
+    @inject(TextmateRegistryFactory) protected readonly registryFactory: TextmateRegistryFactory;
 
     initializeDefaultThemes(): void {
         this.register(require('../../../data/monaco-themes/vscode/dark_theia.json'), {
@@ -129,8 +127,7 @@ export class MonacoThemeRegistry {
                 }
             });
 
-            const reg = new Registry();
-            reg.setTheme(result);
+            const reg = this.registryFactory(result);
             result.encodedTokensColors = reg.getColorMap();
             // index 0 has to be set to null as it is 'undefined' by default, but monaco code expects it to be null
             // eslint-disable-next-line no-null/no-null

--- a/packages/monaco/src/browser/textmate/monaco-theme-types.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-types.ts
@@ -25,7 +25,7 @@ export interface MixStandaloneTheme extends IStandaloneTheme {
 
 export const OnigasmPromise = Symbol('OnigasmPromise');
 export type OnigasmPromise = Promise<IOnigLib>;
-export const TextmateRegistryFactory = Symbol('TextmadeRegistryFactory');
+export const TextmateRegistryFactory = Symbol('TextmateRegistryFactory');
 export type TextmateRegistryFactory = (currentTheme?: ThemeMix) => Registry;
 
 export type MonacoThemeColor = monaco.editor.IColors;

--- a/packages/monaco/src/browser/textmate/monaco-theme-types.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-types.ts
@@ -15,6 +15,18 @@
 // *****************************************************************************
 
 import * as monaco from '@theia/monaco-editor-core';
+import { IStandaloneTheme } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
+import { IOnigLib, IRawTheme, Registry } from 'vscode-textmate';
+
+export interface ThemeMix extends IRawTheme, monaco.editor.IStandaloneThemeData { }
+export interface MixStandaloneTheme extends IStandaloneTheme {
+    themeData: ThemeMix
+}
+
+export const OnigasmPromise = Symbol('OnigasmPromise');
+export type OnigasmPromise = Promise<IOnigLib>;
+export const TextmateRegistryFactory = Symbol('TextmadeRegistryFactory');
+export type TextmateRegistryFactory = (currentTheme?: ThemeMix) => Registry;
 
 export type MonacoThemeColor = monaco.editor.IColors;
 export interface MonacoTokenRule extends monaco.editor.ITokenThemeRule { };

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -6,7 +6,7 @@
     "@theia/core": "1.27.0",
     "@theia/editor": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@types/p-queue": "^2.3.1",
     "p-queue": "^2.4.2"
   },

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -6,7 +6,7 @@
     "@theia/core": "1.27.0",
     "@theia/editor": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@types/p-queue": "^2.3.1",
     "p-queue": "^2.4.2"
   },

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -8,7 +8,7 @@
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/navigator": "1.27.0",
     "@theia/plugin": "1.27.0",
     "@theia/plugin-ext": "1.27.0",

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -8,7 +8,7 @@
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/navigator": "1.27.0",
     "@theia/plugin": "1.27.0",
     "@theia/plugin-ext": "1.27.0",

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -31,9 +31,7 @@ import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/appl
 import { CommandService } from '@theia/core/lib/common/command';
 import TheiaURI from '@theia/core/lib/common/uri';
 import { EditorManager, EditorCommands } from '@theia/editor/lib/browser';
-import {
-    CodeEditorWidgetUtil
-} from '@theia/plugin-ext/lib/main/browser/menus/menus-contribution-handler';
+import { CodeEditorWidgetUtil } from '@theia/plugin-ext/lib/main/browser/menus/menus-contribution-handler';
 import {
     TextDocumentShowOptions,
     Location,

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -16,7 +16,7 @@
     "@theia/markers": "1.27.0",
     "@theia/messages": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/navigator": "1.27.0",
     "@theia/output": "1.27.0",
     "@theia/plugin": "1.27.0",

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -16,7 +16,7 @@
     "@theia/markers": "1.27.0",
     "@theia/messages": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/navigator": "1.27.0",
     "@theia/output": "1.27.0",
     "@theia/plugin": "1.27.0",
@@ -44,7 +44,7 @@
     "vhost": "^3.0.2",
     "vscode-debugprotocol": "^1.32.0",
     "vscode-proxy-agent": "^0.11.0",
-    "vscode-textmate": "^4.0.1"
+    "vscode-textmate": "^7.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -604,6 +604,8 @@ export interface GrammarsContribution {
     embeddedLanguages?: ScopeMap;
     tokenTypes?: ScopeMap;
     injectTo?: string[];
+    balancedBracketScopes?: string[];
+    unbalancedBracketScopes?: string[];
 }
 
 /**

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -67,6 +67,11 @@ import { IRelativePattern } from '@theia/monaco-editor-core/esm/vs/base/common/g
 import { EditorLanguageStatusService, LanguageStatus as EditorLanguageStatus } from '@theia/editor/lib/browser/language-status/editor-language-status-service';
 import { LanguageSelector, RelativePattern } from '@theia/editor/lib/common/language-selector';
 
+/**
+ * @monaco-uplift The public API declares these functions as (languageId: string, service).
+ * Confirm that the functions delegate to a handler that accepts a LanguageSelector rather than just a string.
+ * Relevant code in node_modules/@theia/monaco-editor-core/src/vs/editor/standalone/browser/standaloneLanguages.ts
+ */
 interface RegistrationFunction<T> {
     (languageId: MonacoLanguageSelector.LanguageSelector, service: T): Disposable;
 }

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -222,7 +222,9 @@ export class PluginContributionHandler {
                     pushContribution(`grammar.language.${language}.scope`, () => this.grammarsRegistry.mapLanguageIdToTextmateGrammar(language, grammar.scope));
                     pushContribution(`grammar.language.${language}.configuration`, () => this.grammarsRegistry.registerGrammarConfiguration(language, {
                         embeddedLanguages: this.convertEmbeddedLanguages(grammar.embeddedLanguages, logWarning),
-                        tokenTypes: this.convertTokenTypes(grammar.tokenTypes)
+                        tokenTypes: this.convertTokenTypes(grammar.tokenTypes),
+                        balancedBracketSelectors: grammar.balancedBracketScopes ?? ['*'],
+                        unbalancedBracketSelectors: grammar.balancedBracketScopes,
                     }));
                 }
                 // activate grammars only once everything else is loaded.

--- a/packages/plugin-metrics/package.json
+++ b/packages/plugin-metrics/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@theia/core": "1.27.0",
     "@theia/metrics": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/plugin": "1.27.0",
     "@theia/plugin-ext": "1.27.0"
   },

--- a/packages/plugin-metrics/package.json
+++ b/packages/plugin-metrics/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@theia/core": "1.27.0",
     "@theia/metrics": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/plugin": "1.27.0",
     "@theia/plugin-ext": "1.27.0"
   },

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -7,7 +7,7 @@
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/userstorage": "1.27.0",
     "@theia/workspace": "1.27.0",
     "async-mutex": "^0.3.1",

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -7,7 +7,7 @@
     "@theia/editor": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/userstorage": "1.27.0",
     "@theia/workspace": "1.27.0",
     "async-mutex": "^0.3.1",

--- a/packages/preferences/src/browser/folders-preferences-provider.ts
+++ b/packages/preferences/src/browser/folders-preferences-provider.ts
@@ -229,10 +229,7 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
     protected createProvider(uri: URI, section: string, folder: FileStat): FolderPreferenceProvider {
         const provider = this.folderPreferenceProviderFactory(uri, section, folder);
         this.toDispose.push(provider);
-        this.toDispose.push(provider.onDidPreferencesChanged(change => {
-            this.onDidPreferencesChangedEmitter.fire(change);
-        }
-        ));
+        this.toDispose.push(provider.onDidPreferencesChanged(change => this.onDidPreferencesChangedEmitter.fire(change)));
         return provider;
     }
 

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -8,7 +8,7 @@
     "@theia/filesystem": "1.27.0",
     "@theia/markers": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/process": "1.27.0",
     "@theia/terminal": "1.27.0",
     "@theia/userstorage": "1.27.0",

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -8,7 +8,7 @@
     "@theia/filesystem": "1.27.0",
     "@theia/markers": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/process": "1.27.0",
     "@theia/terminal": "1.27.0",
     "@theia/userstorage": "1.27.0",

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -32,7 +32,7 @@
     "@theia/file-search": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.67.2-alpha1",
+    "@theia/monaco-editor-core": "1.67.2",
     "@theia/search-in-workspace": "1.27.0",
     "@theia/userstorage": "1.27.0",
     "@theia/workspace": "1.27.0",

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -32,7 +32,7 @@
     "@theia/file-search": "1.27.0",
     "@theia/filesystem": "1.27.0",
     "@theia/monaco": "1.27.0",
-    "@theia/monaco-editor-core": "1.65.2",
+    "@theia/monaco-editor-core": "1.67.2-alpha1",
     "@theia/search-in-workspace": "1.27.0",
     "@theia/userstorage": "1.27.0",
     "@theia/workspace": "1.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2118,10 +2118,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@theia/monaco-editor-core@1.65.2":
-  version "1.65.2"
-  resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.65.2.tgz#91bc9ce2afe1b6011789ce83a5bee898f0153430"
-  integrity sha512-2UmGjcEW/YpZ2DsFuVevKR3CBMe44Rd6DgwP/5s4pyOe6K/s6TKY7Sh24lO0BXetQKofAEx3zh+ldEvjwhNwDw==
+"@theia/monaco-editor-core@1.67.2-alpha1":
+  version "1.67.2-alpha1"
+  resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.67.2-alpha1.tgz#74e44e5fdc822ac1d5fec43cc6822984602b9484"
+  integrity sha512-2bYVILobL3RTmdT4zI8DlKIwjVv3JdhZ3B6Ri/782Q37lj1NDQxKjPvEBjt4O8j/08B5F0OI/XqOq/Q3wuY91Q==
 
 "@tootallnate/once@1", "@tootallnate/once@^1.1.2":
   version "1.1.2"
@@ -7539,13 +7539,6 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-cache@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
-  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  dependencies:
-    yallist "^3.0.2"
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -8649,20 +8642,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-onigasm@^2.2.0:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
-  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
-  dependencies:
-    lru-cache "^5.1.1"
-
-oniguruma@^7.2.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/oniguruma/-/oniguruma-7.2.3.tgz#e0b0b415302de8cdd6564e57a1a822ac0ab57012"
-  integrity sha512-PZZcE0yfg8Q1IvaJImh21RUTHl8ep0zwwyoE912KqlWVrsGByjjj29sdACcD1BFyX2bLkfuOJeP+POzAGVWtbA==
-  dependencies:
-    nan "^2.14.0"
 
 optimist@~0.3.5:
   version "0.3.7"
@@ -11482,6 +11461,11 @@ vscode-languageserver-types@3.15.1:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
 
+vscode-oniguruma@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz#2bf4dfcfe3dd2e56eb549a3068c8ee39e6c30ce5"
+  integrity sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==
+
 vscode-oniguruma@^1.6.1:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz#aeb9771a2f1dbfc9083c8a7fdd9cccaa3f386607"
@@ -11507,12 +11491,10 @@ vscode-textmate@5.2.0:
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
   integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
-vscode-textmate@^4.0.1, vscode-textmate@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.4.0.tgz#14032afeb50152e8f53258c95643e555f2948305"
-  integrity sha512-dFpm2eK0HwEjeFSD1DDh3j0q47bDSVuZt20RiJWxGqjtm73Wu2jip3C2KaZI3dQx/fSeeXCr/uEN4LNaNj7Ytw==
-  dependencies:
-    oniguruma "^7.2.0"
+vscode-textmate@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-7.0.1.tgz#8118a32b02735dccd14f893b495fa5389ad7de79"
+  integrity sha512-zQ5U/nuXAAMsh691FtV0wPz89nSkHbs+IQV8FDk+wew9BlSDhf4UmWGlWJfTR2Ti6xZv87Tj5fENzKf6Qk7aLw==
 
 vscode-uri@^2.1.1:
   version "2.1.2"
@@ -11937,7 +11919,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.1.1:
+yallist@^3.0.0, yallist@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2118,10 +2118,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@theia/monaco-editor-core@1.67.2-alpha1":
-  version "1.67.2-alpha1"
-  resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.67.2-alpha1.tgz#74e44e5fdc822ac1d5fec43cc6822984602b9484"
-  integrity sha512-2bYVILobL3RTmdT4zI8DlKIwjVv3JdhZ3B6Ri/782Q37lj1NDQxKjPvEBjt4O8j/08B5F0OI/XqOq/Q3wuY91Q==
+"@theia/monaco-editor-core@1.67.2":
+  version "1.67.2"
+  resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-1.67.2.tgz#d89163fa4f15560e72413791dc6a406a7c732807"
+  integrity sha512-KjDqHiTSOvnQOkV5qOJaUYwOaMjzpbqJZNRi0RKlBkCjcd/wjGlu5kjsgSDu6BbMnk51oQ9GgoDq/ppjJVaa7A==
 
 "@tootallnate/once@1", "@tootallnate/once@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Uplifts `@theia/monaco-editor-core` to the state of VSCode@1.67.2 and makes a few adjustments. In particular, it updates the `vscode-textmate` dependency to `7.0.1` to match VSCode in order to provide the accustomed theme experience, and it replaces `onigasm` with `vscode-oniguruma` for the same reason. The former change required some reorganization of code to account for breaking changes in `vscode-textmate`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Test your accustomed workflows in the application and make sure they're still working.
2. Test bracket pair colorization in various languages.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
