### PR TITLE
Preserve recent commands for different locales

### DIFF
--- a/packages/core/src/browser/quick-input/quick-command-service.ts
+++ b/packages/core/src/browser/quick-input/quick-command-service.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable } from 'inversify';
 import { KeybindingRegistry } from '../keybinding';
-import { Disposable, Command, CommandRegistry, CancellationToken } from '../../common';
+import { Disposable, Command, CommandRegistry, CancellationToken, nls } from '../../common';
 import { ContextKeyService } from '../context-key-service';
 import { CorePreferences } from '../core-preferences';
 import { QuickAccessContribution, QuickAccessProvider, QuickAccessRegistry } from './quick-access';
@@ -86,12 +86,12 @@ export class QuickCommandService implements QuickAccessContribution, QuickAccess
         const otherItems = filterItems(this.otherItems.slice(), filter);
 
         if (recentItems.length > 0) {
-            items.push({ type: 'separator', label: 'recently used' }, ...recentItems);
+            items.push({ type: 'separator', label: nls.localizeByDefault('recently used') }, ...recentItems);
         }
 
         if (otherItems.length > 0) {
             if (recentItems.length > 0) {
-                items.push({ type: 'separator', label: 'other commands' });
+                items.push({ type: 'separator', label: nls.localizeByDefault('other commands') });
             }
             items.push(...otherItems);
         }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11335

Makes the internal list of recently used commands a simple `string` array containing the IDs of these commands. This allows us to have them independent from the selected locale.

#### How to test

1. Run the `Configure Display Language` command
2. Select another locale
3. Open the command palette, the `Configure Display Language` command should still be in the list of recently used commands.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
