### PR TITLE
Unload language pack correctly

### DIFF
--- a/packages/core/src/browser/preloader.ts
+++ b/packages/core/src/browser/preloader.ts
@@ -18,6 +18,7 @@ import { nls } from '../common/nls';
 import { Endpoint } from './endpoint';
 import { OS } from '../common/os';
 import { DEFAULT_BACKGROUND_COLOR_STORAGE_KEY, FrontendApplicationConfigProvider } from './frontend-application-config-provider';
+import { Localization } from '../common/i18n/localization';
 
 function fetchFrom(path: string): Promise<Response> {
     const endpoint = new Endpoint({ path }).getRestUrl().toString();
@@ -33,7 +34,16 @@ async function loadTranslations(): Promise<void> {
     }
     if (nls.locale) {
         const response = await fetchFrom(`/i18n/${nls.locale}`);
-        nls.localization = await response.json();
+        const localization = await response.json() as Localization;
+        if (localization.languagePack) {
+            nls.localization = localization;
+        } else {
+            // In case the localization that we've loaded doesn't localize Theia completely (languagePack is false)
+            // We simply reset the locale to the default again
+            Object.assign(nls, {
+                locale: defaultLocale || undefined
+            });
+        }
     }
 }
 

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -197,6 +197,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             await Promise.all(Array.from(sourceLocations,
                 location => fs.remove(location).catch(err => console.error(`Failed to remove source for ${pluginId} at ${location}`, err))));
             this.sourceLocations.delete(pluginId);
+            this.localizationService.undeployLocalizations(pluginId);
             this.uninstallationManager.markAsUninstalled(pluginId);
             return true;
         } catch (e) {

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -60,6 +60,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(BackendApplicationContribution).toService(HostedPluginReader);
 
     bind(HostedPluginLocalizationService).toSelf().inSingletonScope();
+    bind(BackendApplicationContribution).toService(HostedPluginLocalizationService);
     bind(HostedPluginDeployerHandler).toSelf().inSingletonScope();
     bind(PluginDeployerHandler).toService(HostedPluginDeployerHandler);
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11044

Refactors the `LocalizationProvider` to only merge localizations when requesting them. This facilitates easier removal later.

#### How to test

1. Install a language pack and change to that language
2. Uninstall it again and reload the application
3. The app should be completely in English (`nls.locale` being `undefined`)
4. Running the `Configure Display Language` command should not show the language as being installed

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
