### PR TITLE
Add keys to Toolbar renderers

### DIFF
--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -133,7 +133,7 @@ export class ToolbarImpl extends TabBarToolbar {
         const nodes: React.ReactNodeArray = [];
         groups.forEach((group, groupIndex) => {
             if (nodes.length && group.length) {
-                nodes.push(<div className='separator' />);
+                nodes.push(<div key={`toolbar-separator-${groupIndex}`} className='separator' />);
             }
             group.forEach((item, itemIndex) => {
                 const position = { alignment, groupIndex, itemIndex };
@@ -216,6 +216,7 @@ export class ToolbarImpl extends TabBarToolbar {
                 onDrop={this.handleOnDrop}
                 onDragEnter={this.handleOnDragEnter}
                 onDragLeave={this.handleOnDragLeave}
+                key={`column-space-${alignment}-${position}`}
             />
         );
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Since #10731, there has been an error logged about missing `key` properties in a React-rendered `div`:
![image](https://user-images.githubusercontent.com/62660806/175616283-ef2daab8-e9ec-4619-afae-5375c1aa5f23.png)

This PR adds key properties to several `div`s rendered by the Toolbar, and removes the error log. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start the application.
2. Assert that there are no React errors about missing keys.
3. Show and hide the Toolbar.
4. Assert that there are still no React errors about missing keys. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
