### PR TITLE
nls: localize `no-Info` messages

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -27,6 +27,7 @@ import { CALL_HIERARCHY_LABEL } from '../callhierarchy-contribution';
 import URI from '@theia/core/lib/common/uri';
 import { Location, Range, SymbolKind, DocumentUri, SymbolTag } from '@theia/core/shared/vscode-languageserver-protocol';
 import { EditorManager } from '@theia/editor/lib/browser';
+import { nls } from '@theia/core/lib/common/nls';
 import * as React from '@theia/core/shared/react';
 
 export const HIERARCHY_TREE_CLASS = 'theia-CallHierarchyTree';
@@ -86,7 +87,7 @@ export class CallHierarchyTreeWidget extends TreeWidget {
 
     protected override renderTree(model: TreeModel): React.ReactNode {
         return super.renderTree(model)
-            || <div className='theia-widget-noInfo'>No callers have been detected.</div>;
+            || <div className='theia-widget-noInfo'>{nls.localize('theia/callhierarchy/noCallers', 'No callers have been detected.')}</div>;
     }
 
     protected override renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -148,7 +148,7 @@ export class ProblemWidget extends TreeWidget {
         if (MarkerRootNode.is(model.root) && model.root.children.length > 0) {
             return super.renderTree(model);
         }
-        return <div className='theia-widget-noInfo noMarkers'>No problems have been detected in the workspace so far.</div>;
+        return <div className='theia-widget-noInfo noMarkers'>{nls.localize('theia/markers/noProblems', 'No problems have been detected in the workspace so far.')}</div>;
     }
 
     protected override renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {

--- a/packages/property-view/src/browser/empty-property-view-widget-provider.tsx
+++ b/packages/property-view/src/browser/empty-property-view-widget-provider.tsx
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { nls } from '@theia/core/lib/common/nls';
 import { ReactWidget } from '@theia/core/lib/browser';
 import { injectable } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
@@ -46,7 +47,7 @@ class EmptyPropertyViewWidget extends ReactWidget implements PropertyViewContent
         return this.emptyComponent;
     }
 
-    protected emptyComponent: JSX.Element = <div className={'theia-widget-noInfo'}>No properties available.</div>;
+    protected emptyComponent: JSX.Element = <div className={'theia-widget-noInfo'}>{nls.localize('theia/property-view/noProperties', 'No properties available.')}</div>;
 
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit sets up the localizations for `no-Info` messages which are used by views when they do not provide any content but instead display a default message. Previously the label was hardcoded and not set up for localization.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The code sets up localization which should work when we switch languages after we run a translation of our code-base (https://github.com/eclipse-theia/theia/issues/10885).

1. start the application
2. switch language using `configure display language`
3. confirm that the three views are not localized but should be after https://github.com/eclipse-theia/theia/issues/10885.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>