### PR TITLE
Remove default icons from TreeViewWidget.createTreeNode

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -137,11 +137,14 @@
 }
 
 .theia-TreeNodeSegment {
-    display: flex;
     align-items: center;
     flex-grow: 0;
     user-select: none;
     white-space: nowrap;
+}
+
+.theia-TreeNodeSegment.flex {
+    display: flex;
 }
 
 .theia-TreeNodeSegmentGrow {

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -832,7 +832,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             {decorationsToRender.map((decoration, index) => {
                 const { tooltip, data, fontData, color, icon, iconClass } = decoration;
                 const iconToRender = icon ?? iconClass;
-                const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS].join(' ');
+                const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, 'flex'].join(' ');
                 const style = fontData ? this.applyFontStyles({}, fontData) : color ? { color } : undefined;
                 const content = data ? data : iconToRender
                     ? <span

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -155,7 +155,7 @@ export class PluginTree extends TreeImpl {
         const decorationData = this.toDecorationData(item);
         const icon = this.toIconClass(item);
         const resourceUri = item.resourceUri && URI.revive(item.resourceUri).toString();
-        const themeIcon = item.themeIcon ? item.themeIcon : item.collapsibleState !== TreeViewItemCollapsibleState.None ? { id: 'folder' } : { id: 'file' };
+        const themeIcon = item.themeIcon ? item.themeIcon : item.collapsibleState !== TreeViewItemCollapsibleState.None ? { id: 'folder' } : undefined;
         const update: Partial<TreeViewNode> = {
             name: item.label,
             decorationData,
@@ -384,10 +384,10 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
             const inlineCommands = menu.children.filter((item): item is ActionMenuNode => item instanceof ActionMenuNode);
             const tailDecorations = super.renderTailDecorations(node, props);
             return <React.Fragment>
-                {inlineCommands.length > 0 && <div className={TREE_NODE_SEGMENT_CLASS}>
+                {inlineCommands.length > 0 && <div className={TREE_NODE_SEGMENT_CLASS + ' flex'}>
                     {inlineCommands.map((item, index) => this.renderInlineCommand(item, index, this.focusService.hasFocus(node), arg))}
                 </div>}
-                {tailDecorations !== undefined && <div className={TREE_NODE_SEGMENT_CLASS}>{super.renderTailDecorations(node, props)}</div>}
+                {tailDecorations !== undefined && <div className={TREE_NODE_SEGMENT_CLASS + ' flex'}>{tailDecorations}</div>}
             </React.Fragment>;
         });
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11351 by removing default icons added in `TreeViewWidget` contrary to VSCode's practice.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

0. Set file icon setting to `Seti`
1. Perform a `Find all references` search for something
2. When the References View opens, observe that only file names and not results have icons, as in VSCode.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
