### PR TITLE
Fix missing character and missing icon in SiW results

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -747,7 +747,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
 
     protected renderReplaceButton(node: TreeNode): React.ReactNode {
         const isResultLineNode = SearchInWorkspaceResultLineNode.is(node);
-        return <span className={isResultLineNode ? 'replace-result' : 'replace-all-result'}
+        return <span className={isResultLineNode ? codicon('replace') : codicon('replace-all')}
             onClick={e => this.doReplace(node, e)}
             title={isResultLineNode
                 ? nls.localizeByDefault('Replace')
@@ -1015,14 +1015,14 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
 
         const before = lineText.slice(start, character - 1).trimLeft();
 
-        return <div className={`resultLine noWrapInfo noselect ${node.selected ? 'selected' : ''}`} title={lineText}>
+        return <div className={`resultLine noWrapInfo noselect ${node.selected ? 'selected' : ''}`} title={lineText.trim()}>
             {this.searchInWorkspacePreferences['search.lineNumbers'] && <span className='theia-siw-lineNumber'>{node.line}</span>}
             <span>
                 {before}
             </span>
             {this.renderMatchLinePart(node)}
             <span>
-                {lineText.slice(node.character + node.length, 250 - before.length + node.length)}
+                {lineText.slice(node.character + node.length - 1, 250 - before.length + node.length)}
             </span>
         </div>;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes a missing character after the highlight in search results and fixes references to a now-undefined icon for replace and replace all.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Perform a search in the Search in Workspace widget
2. In the text results, assert that the text immediately after the highlighted portion is complete - no characters are omitted.
3. Add replace text.
4. Hover over a file result.
5. Assert that a 'Replace All' icon appears next to the `X` icon.
7. Hover over a text result.
8. Assert that a 'Replace' icon appears next to the `X` icon.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
