### PR TITLE
keymaps: fix search when keybindings are updated

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -146,6 +146,9 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
     protected updateItemsAndRerender = debounce(() => {
         this.items = this.getItems();
         this.update();
+        if (this.hasSearch()) {
+            this.doSearchKeybindings();
+        }
     }, 100, { leading: false, trailing: true });
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #11365.

The pull-request fixes a minor regression from https://github.com/eclipse-theia/theia/pull/11102 where the update of keybindings would cause the keyboard shortcuts view from re-rendering but not respecting the search field if a user has a query present. The change preserves the search on update:

https://user-images.githubusercontent.com/40359487/176446697-8f14211b-d394-48a7-9509-43b977664a31.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open the keyboard shortcuts view (F1 > Preferences: Open Keyboard Shortcuts)
3. type a search query
4. update a default keybinding and accept the dialog - confirm that the search results are preserved

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>