### PR TITLE
Localize file save dialog

### DIFF
--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -21,6 +21,7 @@ import { MaybePromise } from '../common/types';
 import { Key } from './keyboard/keys';
 import { AbstractDialog } from './dialogs';
 import { waitForClosed } from './widgets';
+import { nls } from '../common/nls';
 
 export interface Saveable {
     readonly dirty: boolean;
@@ -290,20 +291,20 @@ export class ShouldSaveDialog extends AbstractDialog<boolean> {
 
     constructor(widget: Widget) {
         super({
-            title: `Do you want to save the changes you made to ${widget.title.label || widget.title.caption}?`
+            title: nls.localizeByDefault('Do you want to save the changes you made to {0}?', widget.title.label || widget.title.caption)
         });
 
         const messageNode = document.createElement('div');
-        messageNode.textContent = "Your changes will be lost if you don't save them.";
+        messageNode.textContent = nls.localizeByDefault("Your changes will be lost if you don't save them.");
         messageNode.setAttribute('style', 'flex: 1 100%; padding-bottom: calc(var(--theia-ui-padding)*3);');
         this.contentNode.appendChild(messageNode);
         this.dontSaveButton = this.appendDontSaveButton();
         this.appendCloseButton();
-        this.appendAcceptButton('Save');
+        this.appendAcceptButton(nls.localizeByDefault('Save'));
     }
 
     protected appendDontSaveButton(): HTMLButtonElement {
-        const button = this.createButton("Don't save");
+        const button = this.createButton(nls.localizeByDefault("Don't Save"));
         this.controlPanel.appendChild(button);
         button.classList.add('secondary');
         return button;


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11361

#### How to test

1. Change the locale of Theia
2. Set the auto save preference to `off`
3. Modify a file and try to close it without saving. The dialog should be completely and correctly localized.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
