### PR TITLE
vertical center icons in getting started (#11369)

### DIFF
--- a/packages/getting-started/src/browser/style/index.css
+++ b/packages/getting-started/src/browser/style/index.css
@@ -75,6 +75,8 @@ html, body {
     font-size: var(--theia-ui-font-size2);
     font-weight: 600;
     margin-bottom: 5px;
+    display: flex;
+    align-items: center;
 }
 
 .gs-section-header i {


### PR DESCRIPTION
Signed-off-by: yiliang114 <1204183885@qq.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Just vertical center icons in getting started.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the browser application.
2. Use `Cmd+Shift+P` call out `Command Palette`.
3. Enter `Getting Started` to open `Getting Started` Tab.
4. Check icons alignment.

before:
![image](https://user-images.githubusercontent.com/11473889/176468620-ef91023d-c9e0-49e4-8527-9ddc34888270.png)

after:
<img width="579" alt="image" src="https://user-images.githubusercontent.com/11473889/176468677-2d76e06a-687a-4022-a595-1aa1b0ce0358.png">


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
