### PR TITLE
Use same replacement text for entire replacement cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,8 @@
 - [plugin-ext] method `registerDebuggersContributions` has an additional parameter in the signature `pluginType` to specify `frontend` or `backend` [#10748](https://github.com/eclipse-theia/theia/pull/10748)
 - [plugin-ext] file `debug` renamed to `debug-ext` [#10748](https://github.com/eclipse-theia/theia/pull/10748)
 - [debug] debug files not unique to the backend have been moved from `node` to `common` [#10748](https://github.com/eclipse-theia/theia/pull/10748)
-- [core] `TreeImpl.refresh` accepts a cancellation token as a secord parameter. Extensions that added their own second parameter may be marked as no longer class conforming. [#11340](https://github.com/eclipse-theia/theia/pull/11340) 
+- [core] `TreeImpl.refresh` accepts a cancellation token as a secord parameter. Extensions that added their own second parameter may be marked as no longer class conforming. [#11340](https://github.com/eclipse-theia/theia/pull/11340)
+- [search-in-workspace] `replaceResult` and `confirmReplaceAll` now require a parameter `replacementText` [#11374](https://github.com/eclipse-theia/theia/pull/11374)
 
 ## v1.26.0 - 5/26/2022
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

In our current code for `Replace All` actions in the SiW widget, the code is `async` but refers to `this._replaceTerm`, which can be updated by user actions while the replacement is running, resulting in different values being inserted in different editors. This PR caches the value present at the start of the operation and uses it in everywhere where reference to it is required.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Search for something with many results.
2. Input a replacement term.
3. Select 'Replace All' and immediately modify the value of the replace input.
4. The original value should be used in all the editors where a replacement has been performed (on `master`, later editors might get the new value, depending on number of results and speed of file actions)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
