### PR TITLE
add indent_size for tsx in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ insert_final_newline = true
 end_of_line = lf
 indent_style = space
 
-[*.{js,ts,md}]
+[*.{js,ts,tsx,md}]
 indent_size = 4
 
 [*.{json,yml}]


### PR DESCRIPTION
Signed-off-by: yiliang114 <1204183885@qq.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
1. set the indent size of `tsx` file  `4`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open `theia` source code in editor such as vscode or webstorm.
2. open any `tsx` file,  change and save
3. eslint will not make this `tsx` file to be `2` indent_size.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
