### PR TITLE
Upgrade vscode-ripgrep to @vscode/ripgrep

### DIFF
--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -8,7 +8,7 @@
     "@theia/filesystem": "1.27.0",
     "@theia/process": "1.27.0",
     "@theia/workspace": "1.27.0",
-    "vscode-ripgrep": "^1.2.4"
+    "@vscode/ripgrep": "^1.14.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -17,7 +17,7 @@
 import * as cp from 'child_process';
 import * as fuzzy from '@theia/core/shared/fuzzy';
 import * as readline from 'readline';
-import { rgPath } from 'vscode-ripgrep';
+import { rgPath } from '@vscode/ripgrep';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node/file-uri';

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -9,8 +9,8 @@
     "@theia/navigator": "1.27.0",
     "@theia/process": "1.27.0",
     "@theia/workspace": "1.27.0",
-    "minimatch": "^3.0.4",
-    "vscode-ripgrep": "^1.2.4"
+    "@vscode/ripgrep": "^1.14.2",
+    "minimatch": "^3.0.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -25,7 +25,7 @@ import * as path from 'path';
 import * as temp from 'temp';
 import * as fs from 'fs';
 import { expect } from 'chai';
-import { rgPath as realRgPath } from 'vscode-ripgrep';
+import { rgPath as realRgPath } from '@vscode/ripgrep';
 
 // Allow creating temporary files, but remove them when we are done.
 const track = temp.track();

--- a/packages/search-in-workspace/src/node/search-in-workspace-backend-module.ts
+++ b/packages/search-in-workspace/src/node/search-in-workspace-backend-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
 import { SearchInWorkspaceServer, SearchInWorkspaceClient, SIW_WS_PATH } from '../common/search-in-workspace-interface';
 import { RipgrepSearchInWorkspaceServer, RgPath } from './ripgrep-search-in-workspace-server';
-import { rgPath } from 'vscode-ripgrep';
+import { rgPath } from '@vscode/ripgrep';
 
 export default new ContainerModule(bind => {
     bind(SearchInWorkspaceServer).to(RipgrepSearchInWorkspaceServer);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,6 +2813,14 @@
   resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.30.tgz#67c265c1f3ff7214da475333efa6d381710b0335"
   integrity sha512-/quu8pLXEyrShoDjTImQwJ2H28y1XhANigyw7E7JvN9NNWc3XCkoIWpcb/tUhdf7XQpopLVVYbkMjXpdPPuMXg==
 
+"@vscode/ripgrep@^1.14.2":
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.14.2.tgz#47c0eec2b64f53d8f7e1b5ffd22a62e229191c34"
+  integrity sha512-KDaehS8Jfdg1dqStaIPDKYh66jzKd5jy5aYEPzIv0JYFLADPsCSQPBUdsJVXnr0t72OlDcj96W05xt/rSnNFFQ==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    proxy-from-env "^1.1.0"
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -11493,14 +11501,6 @@ vscode-proxy-agent@^0.11.0:
     socks-proxy-agent "^5.0.0"
   optionalDependencies:
     vscode-windows-ca-certs "^0.3.0"
-
-vscode-ripgrep@^1.2.4:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.13.2.tgz#8ccebc33f14d54442c4b11962aead163c55b506e"
-  integrity sha512-RlK9U87EokgHfiOjDQ38ipQQX936gWOcWPQaJpYf+kAkz1PQ1pK2n7nhiscdOmLu6XGjTs7pWFJ/ckonpN7twQ==
-  dependencies:
-    https-proxy-agent "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 vscode-textmate@5.2.0:
   version "5.2.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fix build issues behind proxies by upgrading vscode-ripgrep. Microsoft is maintaining an own branch of vscode-ripgrep. This PR updates all dependecies to the new name @vscode/ripgrep and upgrades it.

Contributed by STMicroelectronics

Signed-off-by: Niklas DAHLQUIST <niklas.dahlquist@st.com>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
