### PR TITLE
Map 'workbench.action.saveWorkspaceAs' to SAVE_WORKSPACE_AS

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -324,6 +324,9 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.addRootFolder' }, {
             execute: () => commands.executeCommand(WorkspaceCommands.ADD_FOLDER.id)
         });
+        commands.registerCommand({ id: 'workbench.action.saveWorkspaceAs' }, {
+            execute: () => commands.executeCommand(WorkspaceCommands.SAVE_WORKSPACE_AS.id)
+        });
         commands.registerCommand({ id: 'workbench.action.gotoLine' }, {
             execute: () => commands.executeCommand(EditorCommands.GOTO_LINE_COLUMN.id)
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Map 'workbench.action.saveWorkspaceAs' to SAVE_WORKSPACE_AS so that it can be used by VS Code extensions.

#### How to test
1. Download this [sample extension](https://github.com/kaiyue-pan-work/extension-for-testing/blob/main/sample-extension-0.0.1.vsix) for testing
2. Build Theia from sources
3. Create `plugins` folder under Theia repo folder
4. Run Theia and click the `folder` icon in the activity-bar to open the view
5. Click the `small-folder` icon in the view to run the command
![image](https://user-images.githubusercontent.com/94718614/177883330-c748d23a-79c4-4cfe-a6fc-cfe338597dfd.png)
6. Confirm that the `Save Workspace As...` dialog shows up

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Kaiyue Pan <kaiyue.a.pan@ericsson.com>
