### PR TITLE
Ensure proper null-value encoding in new RPC

### DIFF
--- a/packages/core/src/common/message-rpc/rpc-message-encoder.ts
+++ b/packages/core/src/common/message-rpc/rpc-message-encoder.ts
@@ -92,17 +92,18 @@ export enum ObjectType {
     JSON = 0,
     ByteArray = 1,
     ObjectArray = 2,
-    Undefined = 3,
-    Object = 4,
-    String = 5,
-    Boolean = 6,
-    Number = 7,
+    Null = 3,
+    Undefined = 4,
+    Object = 5,
+    String = 6,
+    Boolean = 7,
+    Number = 8,
     // eslint-disable-next-line @typescript-eslint/no-shadow
-    ResponseError = 8,
-    Error = 9,
-    Map = 10,
-    Set = 11,
-    Function = 12
+    ResponseError = 9,
+    Error = 10,
+    Map = 11,
+    Set = 12,
+    Function = 13
 
 }
 
@@ -110,7 +111,7 @@ export enum ObjectType {
  * A value encoder writes javascript values to a write buffer. Encoders will be asked
  * in turn (ordered by their tag value, descending) whether they can encode a given value
  * This means encoders with higher tag values have priority. Since the default encoders
- * have tag values from 1-12, they can be easily overridden.
+ * have tag values from 1-13, they can be easily overridden.
  */
 export interface ValueEncoder {
     /**
@@ -198,6 +199,11 @@ export class RpcMessageDecoder {
 
         this.registerDecoder(ObjectType.Undefined, {
             read: () => undefined
+        });
+
+        this.registerDecoder(ObjectType.Null, {
+            // eslint-disable-next-line no-null/no-null
+            read: () => null
         });
 
         this.registerDecoder(ObjectType.Object, {
@@ -429,9 +435,14 @@ export class RpcMessageEncoder {
             write: (buf, value: Set<any>, visitedObjects) => this.writeArray(buf, [...value], visitedObjects)
         });
 
-        this.registerEncoder(ObjectType.Undefined, {
+        this.registerEncoder(ObjectType.Null, {
             // eslint-disable-next-line no-null/no-null
-            is: value => value == null,
+            is: value => value === null,
+            write: () => { }
+        });
+
+        this.registerEncoder(ObjectType.Undefined, {
+            is: value => value === undefined,
             write: () => { }
         });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the bug described in #11392 by ensuring that null-values are properly encoded/decoded when sending them over the wire with the new RPC protocol.
Previously null-values were converted to `undefined` which could result in incorrect/faulty behavior. (see #11392)

Fixes #11392
Contributed on behalf of STMicroelectronics

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Follow the `Steps to reproduce` in the description of #11392 and check that no error occurs/ the correct toast message is displayed.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
