### PR TITLE
file-search: fix test case

### DIFF
--- a/packages/file-search/src/node/file-search-service-impl.spec.ts
+++ b/packages/file-search/src/node/file-search-service-impl.spec.ts
@@ -164,8 +164,9 @@ describe('search-service', function (): void {
         const rootUri = FileUri.create(path.resolve(__dirname, '../../../..'));
 
         it('not fuzzy', async () => {
-            const searchPattern = rootUri.path.dir.base;
+            const searchPattern = 'package'; // package.json should produce a result.
             const matches = await service.find(searchPattern, { rootUris: [rootUri.toString()], fuzzyMatch: false, useGitIgnore: true, limit: 200 });
+            expect(matches).not.empty;
             for (const match of matches) {
                 const relativeUri = rootUri.relative(new URI(match));
                 assert.notStrictEqual(relativeUri, undefined);
@@ -176,6 +177,7 @@ describe('search-service', function (): void {
 
         it('fuzzy', async () => {
             const matches = await service.find('shell', { rootUris: [rootUri.toString()], fuzzyMatch: true, useGitIgnore: true, limit: 200 });
+            expect(matches).not.empty;
             for (const match of matches) {
                 const relativeUri = rootUri.relative(new URI(match));
                 assert.notStrictEqual(relativeUri, undefined);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit fixes the test-case which was not producing results but was passing as a false positive.
The previous implementation was relying on where `theia` was cloned and meant that the test could fail.

The test was updated to harcode the `searchPattern` rather than use the `path` to determine it.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- confirm that the `file-search` tests pass.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>