### PR TITLE
filsystem: fix #11401

### DIFF
--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2020 TypeFox and others.
+// Copyright (C) 2022 TypeFox and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -95,7 +95,7 @@ export class FileChangesEvent {
 
             // For deleted also return true when deleted folder is parent of target path
             if (change.type === FileChangeType.DELETED) {
-                return resource.isEqualOrParent(change.resource);
+                return change.resource.isEqualOrParent(resource);
             }
 
             return resource.toString() === change.resource.toString();


### PR DESCRIPTION
#### What it does

Fixes: #11401

#### How to test
I hope simple code-inspection would suffice.  However, in our own implementation of a Theia-based IDE, I've tested the fix using our implementation of a C++ error-parser which contributes markers to the Problems view when a C++ project is built.  This bug was causing all markers on a C++ project scope to be cleared every time any file is deleted within the project.  For more context - the class MarkerManager uses the FileChangesEvent.contains() method to clear markers associated with any deleted files.  The FileChangesEvent.contains() intends to check if a file's ancestor directory has been deleted, as can be seen in the code comments.  But this bug is causing the opposite effect, causing markers to be cleared on a project when any contained file is deleted.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
