### PR TITLE
markers: update problem-widget rendering

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -177,6 +177,7 @@ export class ProblemWidget extends TreeWidget {
             if (problemMarker.data.severity) {
                 severityClass = this.getSeverityClass(problemMarker.data.severity);
             }
+            const location = nls.localizeByDefault('Ln {0}, Col {1}', problemMarker.data.range.start.line + 1, problemMarker.data.range.start.character + 1);
             return <div
                 className='markerNode'
                 title={`${problemMarker.data.message} (${problemMarker.data.range.start.line + 1}, ${problemMarker.data.range.start.character + 1})`}>
@@ -184,12 +185,14 @@ export class ProblemWidget extends TreeWidget {
                     <i className={`${severityClass} ${TREE_NODE_INFO_CLASS}`}></i>
                 </div>
                 <div className='message'>{problemMarker.data.message}
-                    <span className={'owner ' + TREE_NODE_INFO_CLASS}>
-                        {(problemMarker.data.source || problemMarker.owner)}
-                        {problemMarker.data.code ? `(${problemMarker.data.code})` : ''}
-                    </span>
+                    {(!!problemMarker.data.source || !!problemMarker.data.code) &&
+                        <span className={'owner ' + TREE_NODE_INFO_CLASS}>
+                            {problemMarker.data.source || ''}
+                            {problemMarker.data.code ? `(${problemMarker.data.code})` : ''}
+                        </span>
+                    }
                     <span className={'position ' + TREE_NODE_INFO_CLASS}>
-                        {'[' + (problemMarker.data.range.start.line + 1) + ', ' + (problemMarker.data.range.start.character + 1) + ']'}
+                        {`[${location}]`}
                     </span>
                 </div>
             </div>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates the rendering present in the **problems-widget** to align more closely with vscode:
- only adds the `source` and no longer the `owner` (no more `_generated_diagnostic_collection_name_` when `source` is undefined).
- updates the location to include `ln` and `col` for readability.
- updates to use localizations.

![image](https://user-images.githubusercontent.com/40359487/178343303-69ea161f-6468-4f0e-afcd-74c9f67d372d.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application and open a `json` file (ex: `settings.json` or `launch.json`)
2. produce error markers
3. the rendering of the nodes should behave properly

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>