### PR TITLE
Fix for #11401

### DIFF
--- a/packages/filesystem/src/common/files.spec.ts
+++ b/packages/filesystem/src/common/files.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2022 EclipseSource and others.
+// Copyright (C) 2022 Texas Instruments and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,7 +25,7 @@ describe('FileChangesEvent', () => {
         const event = new FileChangesEvent([{ resource: parent, type: FileChangeType.DELETED }]);
         expect(event.contains(child, FileChangeType.DELETED)).to.eq(true);
     });
-    it('deleting grantparent folder - event contains grandchild', () => {
+    it('deleting grandparent folder - event contains grandchild', () => {
         const grandparent = new URI('file:///grandparent');
         const grandchild = new URI('file:///grandparent/parent/child');
         const event = new FileChangesEvent([{ resource: grandparent, type: FileChangeType.DELETED }]);

--- a/packages/filesystem/src/common/files.spec.ts
+++ b/packages/filesystem/src/common/files.spec.ts
@@ -1,0 +1,51 @@
+// *****************************************************************************
+// Copyright (C) 2022 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FileChangesEvent, FileChangeType } from './files';
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+
+describe('FileChangesEvent', () => {
+    it('deleting parent folder - event contains child', () => {
+        const parent = new URI('file:///grandparent/parent');
+        const child = new URI('file:///grandparent/parent/child');
+        const event = new FileChangesEvent([{ resource: parent, type: FileChangeType.DELETED }]);
+        expect(event.contains(child, FileChangeType.DELETED)).to.eq(true);
+    });
+    it('deleting grantparent folder - event contains grandchild', () => {
+        const grandparent = new URI('file:///grandparent');
+        const grandchild = new URI('file:///grandparent/parent/child');
+        const event = new FileChangesEvent([{ resource: grandparent, type: FileChangeType.DELETED }]);
+        expect(event.contains(grandchild, FileChangeType.DELETED)).to.eq(true);
+    });
+    it('deleting child file - event does not contain parent', () => {
+        const parent = new URI('file:///grandparent/parent');
+        const child = new URI('file:///grandparent/parent/child');
+        const event = new FileChangesEvent([{ resource: child, type: FileChangeType.DELETED }]);
+        expect(event.contains(parent, FileChangeType.DELETED)).to.eq(false);
+    });
+    it('deleting grandchild file - event does not contain grandchild', () => {
+        const grandparent = new URI('file:///grandparent');
+        const grandchild = new URI('file:///grandparent/parent/child');
+        const event = new FileChangesEvent([{ resource: grandchild, type: FileChangeType.DELETED }]);
+        expect(event.contains(grandparent, FileChangeType.DELETED)).to.eq(false);
+    });
+    it('deleting self - event contains self', () => {
+        const self = new URI('file:///grandparent/parent/self');
+        const event = new FileChangesEvent([{ resource: self, type: FileChangeType.DELETED }]);
+        expect(event.contains(self, FileChangeType.DELETED)).to.eq(true);
+    });
+});

--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2022 TypeFox and others.
+// Copyright (C) 2020 TypeFox and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2020 TypeFox and others.
+// Copyright (C) 2022 TypeFox and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -95,10 +95,10 @@ export class FileChangesEvent {
 
             // For deleted also return true when deleted folder is parent of target path
             if (change.type === FileChangeType.DELETED) {
-                return resource.isEqualOrParent(change.resource);
+                return change.resource.isEqualOrParent(resource);
             }
 
-            return resource.toString() === change.resource.toString();
+            return change.resource.toString() === resource.toString();
         });
     }
 


### PR DESCRIPTION
Signed-off-by: Baltasar Belyavsky <bbelyavsky@ti.com>

#### What it does
Fixes: #11401

#### How to test
Unit tests implemented and included in this PR. In addition to that, in our own implementation of a Theia-based IDE, I've tested the fix using our implementation of a C++ error-parser which contributes markers to the Problems view when a C++ project is built. This bug was causing all markers on a C++ project scope to be cleared every time any file is deleted within the project. For more context - the class MarkerManager uses the FileChangesEvent.contains() method to clear markers associated with any deleted files. The FileChangesEvent.contains() intends to check if a file's ancestor directory has been deleted, as can be seen in the code comments. But this bug is causing the opposite effect, causing markers to be cleared on a project when any contained file is deleted.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
