### PR TITLE
core: update `caption` for `ViewContainer`

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -282,16 +282,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
             }
         }
         this.updateToolbarItems(allParts);
-        const caption = title?.caption || title?.label;
-        if (caption) {
-            this.title.caption = caption;
-            if (visibleParts.length === 1) {
-                const partCaption = visibleParts[0].wrapped.title.caption || visibleParts[0].wrapped.title.label;
-                if (partCaption) {
-                    this.title.caption += ': ' + partCaption;
-                }
-            }
-        }
+        this.title.caption = title?.caption || title?.label;
         if (title.iconClass) {
             this.title.iconClass = title.iconClass;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11420.

The pull-request updates the `caption` for `ViewContainer` by removing the extra unnecessary handling to compute the caption based on visible parts. The behavior is now updated to more closely align with that of vscode, and prevent odd results from happening (ex: "Search: Search"). 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. hover over the search-in-workspace widget - confirm that the tooltip/title is correct
3. hide all parts in the explorer - the widget title should be `Explorer: {Folder Name}` - the tooltip/title should be `Explorer`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>