### PR TITLE
Allow @ in deployed plugin identifiers

### DIFF
--- a/packages/plugin-ext/src/common/plugin-identifiers.ts
+++ b/packages/plugin-ext/src/common/plugin-identifiers.ts
@@ -56,7 +56,7 @@ export namespace PluginIdentifiers {
      * @returns a string in the format `<publisher>.<name>`.
      */
     export function unversionedFromVersioned(id: VersionedId): UnversionedId {
-        const endOfId = id.indexOf('@');
+        const endOfId = id.lastIndexOf('@');
         return id.slice(0, endOfId) as UnversionedId;
     }
     /**
@@ -64,7 +64,7 @@ export namespace PluginIdentifiers {
      */
     export function identifiersFromVersionedId(probablyId: string): Components | undefined {
         const endOfPublisher = probablyId.indexOf('.');
-        const endOfName = probablyId.indexOf('@', endOfPublisher);
+        const endOfName = probablyId.lastIndexOf('@');
         if (endOfPublisher === -1 || endOfName === -1) {
             return undefined;
         }
@@ -75,7 +75,7 @@ export namespace PluginIdentifiers {
      */
     export function idAndVersionFromVersionedId(probablyId: string): IdAndVersion | undefined {
         const endOfPublisher = probablyId.indexOf('.');
-        const endOfName = probablyId.indexOf('@', endOfPublisher);
+        const endOfName = probablyId.lastIndexOf('@');
         if (endOfPublisher === -1 || endOfName === -1) {
             return undefined;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11419

As noted [here](https://github.com/eclipse-theia/theia/issues/11419#issuecomment-1184529919), `@` is not permitted in official plugin identifiers, but previously it was nevertheless possible to deploy plugins that used `@`, and this PR restores that ability without otherwise affecting plugin deployment.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

0. Build this branch and download builtin plugins.
1. Move two plugins from the `plugins` folder to your user plugin directory (`~/.theia/extensions`)
2. Open the JSON manifests of those two plugins and add the same `@experiment/` scope to the `name` field of the JSON.
3. Start the example application.
4. Both plugins should be shown as installed in the VSX Registry view, and both should remain in the `~/.theia/extensions` folder.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
