### PR TITLE
Added activeParameter to SignatureInformation

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -230,6 +230,7 @@ export interface SignatureInformation {
     label: string;
     documentation?: string | MarkdownStringDTO;
     parameters: ParameterInformation[];
+    activeParameter?: number;
 }
 
 export interface SignatureHelp extends IdObject {

--- a/packages/plugin-ext/src/plugin/languages/signature.ts
+++ b/packages/plugin-ext/src/plugin/languages/signature.ts
@@ -52,6 +52,7 @@ export class SignatureHelpAdapter {
         if (!value) {
             return undefined;
         }
+        value.activeParameter = value.signatures[value.activeSignature].activeParameter ?? value.activeParameter;
         const id = this.idSequence++;
         this.cache.set(id, value);
         return Converter.SignatureHelp.from(id, value);
@@ -65,7 +66,8 @@ export class SignatureHelpAdapter {
             if (saved) {
                 activeSignatureHelp = saved;
                 activeSignatureHelp.activeSignature = revivedSignatureHelp.activeSignature;
-                activeSignatureHelp.activeParameter = revivedSignatureHelp.activeParameter;
+                const { activeSignature } = revivedSignatureHelp;
+                activeSignatureHelp.activeParameter = revivedSignatureHelp.signatures[activeSignature].activeParameter ?? revivedSignatureHelp.activeParameter;
             } else {
                 activeSignatureHelp = revivedSignatureHelp;
             }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -482,7 +482,8 @@ export namespace SignatureInformation {
         return {
             label: info.label,
             documentation: info.documentation ? fromMarkdown(info.documentation) : undefined,
-            parameters: info.parameters && info.parameters.map(ParameterInformation.from)
+            parameters: info.parameters && info.parameters.map(ParameterInformation.from),
+            activeParameter: info.activeParameter
         };
     }
 
@@ -490,7 +491,8 @@ export namespace SignatureInformation {
         return {
             label: info.label,
             documentation: MarkdownStringDTO.is(info.documentation) ? toMarkdown(info.documentation) : info.documentation,
-            parameters: info.parameters && info.parameters.map(ParameterInformation.to)
+            parameters: info.parameters && info.parameters.map(ParameterInformation.to),
+            activeParameter: info.activeParameter
         };
     }
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1071,6 +1071,7 @@ export class SignatureInformation {
     label: string;
     documentation?: string | theia.MarkdownString;
     parameters: ParameterInformation[];
+    activeParameter?: number;
 
     constructor(label: string, documentation?: string | theia.MarkdownString) {
         this.label = label;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6890,6 +6890,13 @@ export module '@theia/plugin' {
         parameters: ParameterInformation[];
 
         /**
+         * The index of the active parameter.
+         *
+         * If provided, this is used in place of SignatureHelp.activeParameter.
+         */
+        activeParameter?: number;
+
+        /**
          * Creates a new signature information object.
          *
          * @param label A label string.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This fixes https://github.com/eclipse-theia/theia/issues/11134.
It is now possible to set the `activeParameter` directly in the `SignatureInformation`. When set, it is used instead of `SignatureHelp#activeParameter`.  
This reflects the current behaviour of VSCode.

Note: the current VSCode documentation has a small error here.

> When specified, this is used instead of [SignatureHelp.activeSignature](https://code.visualstudio.com/api/references/vscode-api#SignatureHelp.activeSignature).

According to the actual behaviour, it must be called SignatureHelp.activeParameter, because we do not jump to the first signature in which activeParameter is set directly (would also make little sense in my eyes).

VSCode:
![vscode-signature](https://user-images.githubusercontent.com/28291421/179050303-9d0494ce-e520-43b2-acc1-ecb5fe8c95c6.gif)

Theia:
![theia-signature](https://user-images.githubusercontent.com/28291421/179050396-5d5b22e9-53b4-4b7f-aa95-4384fcf6bd98.gif)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Download this little test extension
[md-test-0.0.3.zip](https://github.com/eclipse-theia/theia/files/9114075/md-test-0.0.3.zip)
or create it here: https://github.com/jbicker/md-test-extension.

2. Install it in theia and open a Markdown file.

3. Type a `#` and step through the shown signatures.

The SignatureHelp has the first parameter as activeParameter.
The first SignatureInformation has no activeParameter set. 
The second has directly set the second parameter as active and the third has set the fourth. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
