### PR TITLE
fix(navigator-contribution): close #11425, show NEW_FILE and NEW_FOLDER

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -102,6 +102,17 @@ export namespace FileNavigatorCommands {
         label: 'Collapse Folders in Explorer',
         iconClass: codicon('collapse-all')
     });
+    // for these new commands in front of navigator toolbar with icons
+    export const NEW_FILE = Command.toDefaultLocalizedCommand({
+        ...CommonCommands.NEW_FILE,
+        id: `${CommonCommands.NEW_FILE.id}.withIconClass`,
+        iconClass: codicon('new-file')
+    });
+    export const NEW_FOLDER = Command.toDefaultLocalizedCommand({
+        ...WorkspaceCommands.NEW_FOLDER,
+        id: `${WorkspaceCommands.NEW_FOLDER.id}.withIconClass`,
+        iconClass: codicon('new-folder')
+    });
     export const ADD_ROOT_FOLDER: Command = {
         id: 'navigator.addRootFolder'
     };
@@ -305,6 +316,16 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         });
         registry.registerCommand(FileNavigatorCommands.REFRESH_NAVIGATOR, {
             execute: widget => this.withWidget(widget, () => this.refreshWorkspace()),
+            isEnabled: widget => this.withWidget(widget, () => this.workspaceService.opened),
+            isVisible: widget => this.withWidget(widget, () => this.workspaceService.opened)
+        });
+        registry.registerCommand(FileNavigatorCommands.NEW_FILE, {
+            execute: (...args) => registry.executeCommand(CommonCommands.NEW_FILE.id, ...args),
+            isEnabled: widget => this.withWidget(widget, () => this.workspaceService.opened),
+            isVisible: widget => this.withWidget(widget, () => this.workspaceService.opened)
+        });
+        registry.registerCommand(FileNavigatorCommands.NEW_FOLDER, {
+            execute: (...args) => registry.executeCommand(WorkspaceCommands.NEW_FOLDER.id, ...args),
             isEnabled: widget => this.withWidget(widget, () => this.workspaceService.opened),
             isVisible: widget => this.withWidget(widget, () => this.workspaceService.opened)
         });
@@ -561,28 +582,28 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     async registerToolbarItems(toolbarRegistry: TabBarToolbarRegistry): Promise<void> {
         toolbarRegistry.registerItem({
+            id: FileNavigatorCommands.NEW_FILE.id,
+            command: FileNavigatorCommands.NEW_FILE.id,
+            tooltip: FileNavigatorCommands.NEW_FILE.label,
+            priority: 0,
+        });
+        toolbarRegistry.registerItem({
+            id: FileNavigatorCommands.NEW_FOLDER.id,
+            command: FileNavigatorCommands.NEW_FOLDER.id,
+            tooltip: FileNavigatorCommands.NEW_FOLDER.label,
+            priority: 1,
+        });
+        toolbarRegistry.registerItem({
             id: FileNavigatorCommands.REFRESH_NAVIGATOR.id,
             command: FileNavigatorCommands.REFRESH_NAVIGATOR.id,
             tooltip: nls.localizeByDefault('Refresh Explorer'),
-            priority: 0,
+            priority: 2,
         });
         toolbarRegistry.registerItem({
             id: FileNavigatorCommands.COLLAPSE_ALL.id,
             command: FileNavigatorCommands.COLLAPSE_ALL.id,
             tooltip: nls.localizeByDefault('Collapse All'),
-            priority: 1,
-        });
-        this.registerMoreToolbarItem({
-            id: CommonCommands.NEW_FILE.id,
-            command: CommonCommands.NEW_FILE.id,
-            tooltip: CommonCommands.NEW_FILE.label,
-            group: NavigatorMoreToolbarGroups.NEW_OPEN,
-        });
-        this.registerMoreToolbarItem({
-            id: WorkspaceCommands.NEW_FOLDER.id,
-            command: WorkspaceCommands.NEW_FOLDER.id,
-            tooltip: WorkspaceCommands.NEW_FOLDER.label,
-            group: NavigatorMoreToolbarGroups.NEW_OPEN,
+            priority: 3,
         });
         this.registerMoreToolbarItem({
             id: FileNavigatorCommands.TOGGLE_AUTO_REVEAL.id,


### PR DESCRIPTION
NEW_FILE and NEW_FOLDER in front of navigator toolbar should show with icons like vscode

Signed-off-by: yiliang114 <1204183885@qq.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

close #11425.

Make `NEW_FILE` and `NEW_FOLDER` Commands in front of navigator toolbar show at the beginning, instead of manually clicking to expand the menu.

Take `NEW_FILE` for example. At first I just added `iconClass` to `CommonCommands.NEW_FILE`, but it would make show its icon anywhere, such as  in `filetree right menu` and `File` Menu. So I have forked `CommonCommands.NEW_FILE` and the previous configuration remains unchanged.

The final behavior:

![image](https://user-images.githubusercontent.com/11473889/179051074-6b9e6163-d164-41de-a5f3-4e2fef605fc3.png)
![image](https://user-images.githubusercontent.com/11473889/179051089-08e08a54-f46e-4d71-801b-6a42a35f7da0.png)
![image](https://user-images.githubusercontent.com/11473889/179051116-b4b0b2fe-5196-4764-b67e-9f96e3b8121f.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Hover mouse to projectName of treeview.
2. Click Top Menu `File`.
3. Right Click some files or folders on File Tree.
4. Have a look with menu show behavior. What needs to be guaranteed most is these two commands in these places can run normally just like before.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
