### PR TITLE
Pass `StopReason` to `OnWillStopAction` methods

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -26,6 +26,7 @@ import { preventNavigation, parseCssTime, animationFrame } from './browser';
 import { CorePreferences } from './core-preferences';
 import { WindowService } from './window/window-service';
 import { TooltipService } from './tooltip-service';
+import { StopReason } from '../common/frontend-application-state';
 
 /**
  * Clients can implement to get a callback for contributing widgets to a shell on start.
@@ -81,11 +82,11 @@ export interface OnWillStopAction<T = unknown> {
     /**
      * @resolves to a prepared value to be passed into the `action` function.
      */
-    prepare?: () => MaybePromise<T>;
+    prepare?: (stopReason?: StopReason) => MaybePromise<T>;
     /**
      * @resolves to `true` if it is safe to close the application; `false` otherwise.
      */
-    action: (prepared: T) => MaybePromise<boolean>;
+    action: (prepared: T, stopReason?: StopReason) => MaybePromise<boolean>;
     /**
      * A descriptive string for the reason preventing close.
      */

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -27,6 +27,7 @@ import { MaybePromise } from '../../common/types';
 import { ApplicationShell, applicationShellLayoutVersion, ApplicationShellLayoutVersion } from './application-shell';
 import { CommonCommands } from '../common-frontend-contribution';
 import { WindowService } from '../window/window-service';
+import { StopReason } from '../../common/frontend-application-state';
 
 /**
  * A contract for widgets that want to store and restore their inner state, between sessions.
@@ -139,7 +140,7 @@ export class ShellLayoutRestorer implements CommandContribution {
     }
 
     protected async resetLayout(): Promise<void> {
-        if (await this.windowService.isSafeToShutDown()) {
+        if (await this.windowService.isSafeToShutDown(StopReason.Reload)) {
             this.logger.info('>>> Resetting layout...');
             this.shouldStoreLayout = false;
             this.storageService.setData(this.storageKey, undefined);

--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { StopReason } from '../../common/frontend-application-state';
 import { Event } from '../../common/event';
 import { NewWindowOptions } from '../../common/window';
 
@@ -49,7 +50,7 @@ export interface WindowService {
      * will not be called again in the current session. I.e. if this return `true`, the shutdown should proceed without
      * further condition.
      */
-    isSafeToShutDown(): Promise<boolean>;
+    isSafeToShutDown(reason: StopReason): Promise<boolean>;
 
     /**
      * Will prevent subsequent checks of `FrontendApplicationContribution#willStop`. Should only be used after requesting

--- a/packages/core/src/common/frontend-application-state.ts
+++ b/packages/core/src/common/frontend-application-state.ts
@@ -21,3 +21,18 @@ export type FrontendApplicationState =
     | 'initialized_layout'
     | 'ready'
     | 'closing_window';
+
+export enum StopReason {
+    /**
+     * Closing the window with no prospect of restart.
+     */
+    Close,
+    /**
+     * Reload without closing the window.
+     */
+    Reload,
+    /**
+     * Reload that includes closing the window.
+     */
+    Restart,
+}

--- a/packages/core/src/electron-browser/window/electron-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-window-service.ts
@@ -72,7 +72,7 @@ export class ElectronWindowService extends DefaultWindowService {
      * after running FrontendApplication `onWillStop` handlers or on the `cancelChannel` if it is not safe to exit.
      */
     protected async handleCloseRequestedEvent(event: CloseRequestArguments): Promise<void> {
-        const safeToClose = await this.isSafeToShutDown();
+        const safeToClose = await this.isSafeToShutDown(event.reason);
         if (safeToClose) {
             console.debug(`Shutting down because of ${StopReason[event.reason]} request.`);
             electron.ipcRenderer.send(event.confirmChannel);

--- a/packages/core/src/electron-common/messaging/electron-messages.ts
+++ b/packages/core/src/electron-common/messaging/electron-messages.ts
@@ -14,6 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { StopReason } from '../../common/frontend-application-state';
+/** @deprecated @since 1.28 import from common/frontend-application-state instead */
+export { StopReason };
+
 export const RequestTitleBarStyle = 'requestTitleBarStyle';
 export const TitleBarStyleChanged = 'titleBarStyleChanged';
 export const TitleBarStyleAtStartup = 'titleBarStyleAtStartup';
@@ -30,21 +34,6 @@ export const RELOAD_REQUESTED_SIGNAL = 'reload-requested';
  * Emitted by the window when the application changes state
  */
 export const APPLICATION_STATE_CHANGE_SIGNAL = 'application-state-changed';
-
-export enum StopReason {
-    /**
-     * Closing the window with no prospect of restart.
-     */
-    Close,
-    /**
-     * Reload without closing the window.
-     */
-    Reload,
-    /**
-     * Reload that includes closing the window.
-     */
-    Restart, // eslint-disable-line @typescript-eslint/no-shadow
-}
 
 export interface CloseRequestArguments {
     confirmChannel: string;

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -681,6 +681,10 @@ export class WorkspaceService implements FrontendApplicationContribution {
         return this.utils.isUntitledWorkspace(candidate);
     }
 
+    async isSafeToReload(withURI?: URI): Promise<boolean> {
+        return !withURI || !this.utils.isUntitledWorkspace(withURI) || new URI(await this.getDefaultWorkspaceUri()).isEqual(withURI);
+    }
+
     /**
      *
      * @param key the property key under which to store the schema (e.g. tasks, launch)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The proximate motivation for this PR is a difference between the behavior of our `Open Folder` + multiselect behavior and VSCode's, as well as a small problem in state restoration produced by the difference, but in general it makes the veto system more flexible.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

0. On non-MacOS (relevant command is not available on MacOS)
1. Open an empty workspace or set `workspace.preserveWindow` to `true`
2. Use the 'Open Folder' command (for example from the 'Getting Started' view) and select multiple folders.
3. Observe that the window reloads with the new, untitled workspace, and does not prompt to save that workspace.
> On `master`, you would be prompted to save at this stage, which differs from VSCode's behavior.
4. Close the window.
5. Observe that shutdown is prevented (browser) and a dialog is shown to save the file (Electron)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
