### PR TITLE
Provide all selected URIs for command execution

### DIFF
--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -82,7 +82,7 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
         const firstArgOnly: ArgumentAdapter = (...args) => [args[0]];
         const noArgs: ArgumentAdapter = () => [];
         const toScmArgs: ArgumentAdapter = (...args) => this.toScmArgs(...args);
-        const selectedResource = () => this.getSelectedResource();
+        const selectedResource = () => this.getSelectedResources();
         const widgetURI: ArgumentAdapter = widget => this.codeEditorUtil.is(widget) ? [this.codeEditorUtil.getResourceUri(widget)] : [];
         (<Array<[ContributionPoint, ArgumentAdapter | undefined]>>[
             ['comments/comment/context', toCommentArgs],
@@ -245,13 +245,15 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
         return treeArgs;
     }
 
-    protected getSelectedResource(): [CodeUri | TreeViewSelection | undefined] {
+    protected getSelectedResources(): [CodeUri | TreeViewSelection | undefined, CodeUri[] | undefined] {
         const selection = this.selectionService.selection;
-        if (TreeWidgetSelection.is(selection) && selection.source instanceof TreeViewWidget && selection[0]) {
-            return [selection.source.toTreeViewSelection(selection[0])];
-        }
-        const uri = UriSelection.getUri(selection) ?? this.resourceContextKey.get();
-        return [uri ? uri['codeUri'] : undefined];
+        const firstMember = TreeWidgetSelection.is(selection) && selection.source instanceof TreeViewWidget && selection[0]
+            ? selection.source.toTreeViewSelection(selection[0])
+            : (UriSelection.getUri(selection) ?? this.resourceContextKey.get())?.['codeUri'];
+        const secondMember = TreeWidgetSelection.is(selection)
+            ? UriSelection.getUris(selection).map(uri => uri['codeUri'])
+            : undefined;
+        return [firstMember, secondMember];
     }
     /* eslint-enable @typescript-eslint/no-explicit-any */
 }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/pull/10198

See also https://github.com/eclipse-theia/theia/pull/11424. Somehow I managed again to completely destroy the git history by rebasing...

VSCode provides in addition to the URI of the last selected file in the explorer also an array of all selected URIs. This change aligns Theia to this behavior.

#### How to test

1. Install the [test extension](https://github.com/msujew/theia-test-10198/raw/main/theia-test-10198-0.0.1.vsix) ([source](https://github.com/msujew/theia-test-10198/blob/main/theia-test-10198-0.0.1.vsix))
2. Select multiple/one file in the file explorer
3. Use the `Show URIs` command in the context menu of the file explorer
4. It should show the same output as if installed in vscode, including all selected URIs

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
