### PR TITLE
Add original labels for monaco commands

### DIFF
--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -179,8 +179,8 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                     return true;
                 }
             };
-            const action = editorActions.get(id);
-            this.commandRegistry.registerCommand({ id, label: action?.label, originalLabel: action?.alias }, handler);
+            const commandAction = editorActions.get(id);
+            this.commandRegistry.registerCommand({ id, label: commandAction?.label, originalLabel: commandAction?.alias }, handler);
             const coreCommand = MonacoCommands.COMMON_ACTIONS.get(id);
             if (coreCommand) {
                 this.commandRegistry.registerHandler(coreCommand, handler);

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -135,7 +135,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
      * and execute them using the instantiation service of the current editor.
      */
     protected registerMonacoCommands(): void {
-        const editorActions = new Map(EditorExtensionsRegistry.getEditorActions().map(({ id, label }) => [id, label]));
+        const editorActions = new Map(EditorExtensionsRegistry.getEditorActions().map(({ id, label, alias }) => [id, { label, alias }]));
 
         const { codeEditorService } = this;
         const globalInstantiationService = StandaloneServices.initialize({});
@@ -179,8 +179,8 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                     return true;
                 }
             };
-            const label = editorActions.get(id);
-            this.commandRegistry.registerCommand({ id, label }, handler);
+            const action = editorActions.get(id);
+            this.commandRegistry.registerCommand({ id, label: action?.label, originalLabel: action?.alias }, handler);
             const coreCommand = MonacoCommands.COMMON_ACTIONS.get(id);
             if (coreCommand) {
                 this.commandRegistry.registerHandler(coreCommand, handler);


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11349

Monaco stores its original labels in an `alias` property that we can use to set the original label.

#### How to test

1. Change your locale to another language than English
2. Open an editor view
3. Open the command palette and search for a command contributed by monaco (such as `Add cursor below`)
4. The command should appear with its translated title and its original name below in the command palette

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
