### PR TITLE
Fix wrong terminal attach when switching workspaces

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -402,9 +402,18 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         throw new Error('Failed to start terminal' + (id ? ` for id: ${id}.` : '.'));
     }
 
+    async validateCWD(terminalId: number): Promise<boolean> {
+        if (!this.options.cwd) {
+            return true;
+        }
+        const expectedCWD = this.options.cwd.toString();
+        const terminalCWD = await this.shellTerminalServer.getCwdURI(terminalId);
+        return expectedCWD === terminalCWD;
+    }
+
     protected async attachTerminal(id: number): Promise<number> {
         const terminalId = await this.shellTerminalServer.attach(id);
-        if (IBaseTerminalServer.validateId(terminalId)) {
+        if (IBaseTerminalServer.validateId(terminalId) && await this.validateCWD(terminalId)) {
             return terminalId;
         }
         this.logger.warn(`Failed attaching to terminal id ${id}, the terminal is most likely gone. Starting up a new terminal instead.`);


### PR DESCRIPTION
#### What it does
Fix wrong terminal attach when switching workspaces with preserve window option

This issue was reported here initially: https://github.com/eclipse-theia/theia-blueprint/issues/218

Analysis:
The `ProcessManager` starts assigning ids starting from 0. 
When a user opens a new workspace and opens a terminal this will get process id 0. 
This state is also stored, so when reopening the workspace, we will attempt to restore/attach to the terminal with id 0. 

When switching to a different workspace, that also had an open terminal with id 0 before, the terminal-widget attaches to the terminal from the previous workspace. This means that e.g. the current working directory is pointing to the old workspace. 

In the proposed fix I've added a validation check for the cwd and will create a new terminal in case it's unexpected. 

#### How to test
I was using the electron app for testing. 
Prepare Test:
* Enable "Preserve Window" option in Preferences
* Create two new workspaces and open a terminal in each workspace. When you hover over the terminals the tooltip should say "Terminal 0"
* Close Theia

Test:
* Start electron app
* Open the first workspace. A Terminal should be restored with cwd being the workspace directory. Enter some commands in the terminal
* File > Open Folder... > Switch to the second workspace
* A terminal should be restored with cwd being the workspace directory of the second workspace. You should not see any of the commands you entered in step 2. 
* Switch back to the first workspace and verify that the initial terminal is restored showing the commands you entered before. 

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
