### PR TITLE
debug: add ability to dismiss exception widgets

### DIFF
--- a/packages/debug/src/browser/editor/debug-exception-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-exception-widget.tsx
@@ -22,6 +22,8 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposa
 import { MonacoEditorZoneWidget } from '@theia/monaco/lib/browser/monaco-editor-zone-widget';
 import { DebugEditor } from './debug-editor';
 import { DebugExceptionInfo } from '../model/debug-thread';
+import { nls } from '@theia/core/lib/common/nls';
+import { codicon } from '@theia/core/lib/browser/widgets';
 
 export interface ShowDebugExceptionParams {
     info: DebugExceptionInfo
@@ -89,8 +91,14 @@ export class DebugExceptionWidget implements Disposable {
 
     protected render(info: DebugExceptionInfo, cb: () => void): void {
         const stackTrace = info.details && info.details.stackTrace;
+        const exceptionTitle = info.id ?
+            nls.localizeByDefault('Exception has occurred: {0}', info.id) :
+            nls.localizeByDefault('Exception has occurred.');
         ReactDOM.render(<React.Fragment>
-            <div className='title'>{info.id ? `Exception has occurred: ${info.id}` : 'Exception has occurred.'}</div>
+            <div className='title'>
+                {exceptionTitle}
+                <span id="exception-close" className={codicon('close', true)} onClick={() => this.hide()} title={nls.localizeByDefault('Close')}></span>
+            </div>
             {info.description && <div className='description'>{info.description}</div>}
             {stackTrace && <div className='stack-trace'>{stackTrace}</div>}
         </React.Fragment>, this.zone.containerNode, cb);

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -211,7 +211,7 @@
 }
 
 .codicon-debug-hint {
-	cursor: pointer;
+    cursor: pointer;
 }
 
 .codicon-debug-breakpoint,
@@ -227,7 +227,7 @@
 }
 
 .codicon[class*='-disabled'] {
-	color: var(--theia-debugIcon-breakpointDisabledForeground) !important;
+    color: var(--theia-debugIcon-breakpointDisabledForeground) !important;
 }
 
 .codicon[class*='-unverified'] {
@@ -245,41 +245,41 @@
 
 .codicon-debug-breakpoint.codicon-debug-stackframe-focused::after,
 .codicon-debug-breakpoint.codicon-debug-stackframe::after {
-	content: '\eb8a';
-	position: absolute;
+    content: '\eb8a';
+    position: absolute;
 }
 
 .monaco-editor .theia-debug-breakpoint-column::before {
-	height: .9em;
-	display: inline-flex;
-	vertical-align: middle;
+    height: .9em;
+    display: inline-flex;
+    vertical-align: middle;
 }
 
 .monaco-editor .theia-debug-top-stack-frame-column::before {
-	content: ' ';
-	width: 0.9em;
-	display: inline-flex;
-	vertical-align: middle;
-	margin-top: -1px; /* TODO @misolori: figure out a way to not use negative margin for alignment */
+    content: ' ';
+    width: 0.9em;
+    display: inline-flex;
+    vertical-align: middle;
+    margin-top: -1px; /* TODO @misolori: figure out a way to not use negative margin for alignment */
 }
 
 .monaco-editor .theia-debug-top-stack-frame-column {
-	display: inline-flex;
-	vertical-align: middle;
+    display: inline-flex;
+    vertical-align: middle;
 }
 
 .monaco-editor .theia-debug-top-stack-frame-column::before {
-	content: '\eb8b';
-	font: normal normal normal 16px/1 codicon;
-	text-rendering: auto;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	margin-left: 0;
-	margin-right: 4px;
+    content: '\eb8b';
+    font: normal normal normal 16px/1 codicon;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    margin-left: 0;
+    margin-right: 4px;
 }
 
 .codicon-debug-hint:not([class*='codicon-debug-breakpoint']):not([class*='codicon-debug-stackframe']) {
-	opacity: 0.4 !important;
+    opacity: 0.4 !important;
 }
 
 .monaco-editor .view-overlays .theia-debug-top-stack-frame-line {
@@ -368,17 +368,17 @@
 }
 
 .theia-debug-breakpoint-select {
-	display: flex;
-	justify-content: center;
-	flex-direction: column;
-	padding: 0 10px;
-	flex-shrink: 0;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    padding: 0 10px;
+    flex-shrink: 0;
 }
 
 .theia-debug-breakpoint-input {
-	flex: 1;
-	margin-top: var(--theia-ui-padding);
-	margin-bottom: var(--theia-ui-padding);
+    flex: 1;
+    margin-top: var(--theia-ui-padding);
+    margin-bottom: var(--theia-ui-padding);
 }
 
 /* Status Bar */
@@ -401,15 +401,22 @@
     border-bottom-color: var(--theia-debugExceptionWidget-border);
     background-color: var(--theia-debugExceptionWidget-background);
     padding: var(--theia-ui-padding) calc(var(--theia-ui-padding)*1.5);
-	white-space: pre-wrap;
-	user-select: text;
+    white-space: pre-wrap;
+    user-select: text;
     overflow: hidden;
 }
 
 .theia-debug-exception-widget .title {
-	font-weight: bold;
+    font-family: var(--theia-ui-font-family);
+    font-weight: bold;
 }
 
 .theia-debug-exception-widget .stack-trace {
-	margin-top: 0.5em;
+    margin-top: 0.5em;
+}
+
+.theia-debug-exception-widget #exception-close {
+    cursor: pointer;
+    margin-left: 5px;
+    vertical-align: middle;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10888.

The pull-request adds the ability to dismiss the exception widget which would otherwise require a workaround to completely close the editor by users. 

https://user-images.githubusercontent.com/40359487/179779404-143b9814-869f-4019-a074-58aac0e52327.mov

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. use the following test workspace ([test.zip](https://github.com/eclipse-theia/theia/files/9142132/test.zip))
2. open `a.ts`
3. set a breakpoint at line 1
4. open the `debug view` and start a debug session with `launch program`
5. when the breakpoint is hit in the `breakpoints` tree-view part, tick `caught exceptions`
6. `step over`
7. the debug exception widget should appear, confirm it can be dismissed with `x`
8. confirm that it also works for future debug sessions (re-trying the steps) 
9. confirm that localization works

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>