### PR TITLE
Add missing vscode api in env namespace

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/worker/worker-env-ext.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-env-ext.ts
@@ -34,4 +34,8 @@ export class WorkerEnvExtImpl extends EnvExtImpl {
         throw new Error('There is no app root in worker context');
     }
 
+    get isNewAppInstall(): boolean {
+        throw new Error('Cannot determine the installation date in worker context');
+    }
+
 }

--- a/packages/plugin-ext/src/plugin/env.ts
+++ b/packages/plugin-ext/src/plugin/env.ts
@@ -19,6 +19,7 @@ import { RPCProtocol } from '../common/rpc-protocol';
 import { EnvMain, PLUGIN_RPC_CONTEXT } from '../common/plugin-api-rpc';
 import { QueryParameters } from '../common/env';
 import { v4 } from 'uuid';
+import { Emitter, Event } from '@theia/core/lib/common/event';
 
 export abstract class EnvExtImpl {
     private proxy: EnvMain;
@@ -29,11 +30,20 @@ export abstract class EnvExtImpl {
     private ui: theia.UIKind;
     private envMachineId: string;
     private envSessionId: string;
+    private host: string;
+    private _isTelemetryEnabled: boolean;
+    private _remoteName: string | undefined;
+    private onDidChangeTelemetryEnabledEmitter: Emitter<boolean>;
 
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.ENV_MAIN);
         this.envSessionId = v4();
         this.envMachineId = v4();
+        this.host = 'desktop';
+        // we don't support telemetry at the moment
+        this._isTelemetryEnabled = false;
+        this._remoteName = undefined;
+        this.onDidChangeTelemetryEnabledEmitter = new Emitter();
     }
 
     getEnvVariable(envVarName: string): Promise<string | undefined> {
@@ -82,6 +92,24 @@ export abstract class EnvExtImpl {
     }
 
     abstract get appRoot(): string;
+
+    abstract get isNewAppInstall(): boolean;
+
+    get appHost(): string {
+        return this.host;
+    }
+
+    get isTelemetryEnabled(): boolean {
+        return this._isTelemetryEnabled;
+    }
+
+    get onDidChangeTelemetryEnabled(): Event<boolean> {
+        return this.onDidChangeTelemetryEnabledEmitter.event;
+    }
+
+    get remoteName(): string | undefined {
+        return this._remoteName;
+    }
 
     get language(): string {
         return this.lang;

--- a/packages/plugin-ext/src/plugin/node/env-node-ext.ts
+++ b/packages/plugin-ext/src/plugin/node/env-node-ext.ts
@@ -19,6 +19,7 @@ import { EnvExtImpl } from '../env';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { createHash } from 'crypto';
 import { v4 } from 'uuid';
+import fs = require('fs');
 
 /**
  * Provides machineId using mac address. It's only possible on node side
@@ -27,6 +28,7 @@ import { v4 } from 'uuid';
 export class EnvNodeExtImpl extends EnvExtImpl {
 
     private macMachineId: string;
+    private _isNewAppInstall: boolean;
 
     constructor(rpc: RPCProtocol) {
         super(rpc);
@@ -37,7 +39,14 @@ export class EnvNodeExtImpl extends EnvExtImpl {
                 this.macMachineId = createHash('sha256').update(macAddress, 'utf8').digest('hex');
             }
         });
+        this._isNewAppInstall = this.computeIsNewAppInstall();
+    }
 
+    private computeIsNewAppInstall(): boolean {
+        const creation = fs.statSync(__filename).birthtimeMs;
+        const current = Date.now();
+        const dayMs = 24 * 3600 * 1000;
+        return (current - creation) < dayMs;
     }
 
     /**
@@ -52,6 +61,10 @@ export class EnvNodeExtImpl extends EnvExtImpl {
      */
     get appRoot(): string {
         return __dirname;
+    }
+
+    get isNewAppInstall(): boolean {
+        return this._isNewAppInstall;
     }
 
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -639,7 +639,14 @@ export function createAPIFactory(
         const env: typeof theia.env = Object.freeze({
             get appName(): string { return envExt.appName; },
             get appRoot(): string { return envExt.appRoot; },
+            get appHost(): string { return envExt.appHost; },
             get language(): string { return envExt.language; },
+            get isNewAppInstall(): boolean { return envExt.isNewAppInstall; },
+            get isTelemetryEnabled(): boolean { return envExt.isTelemetryEnabled; },
+            get onDidChangeTelemetryEnabled(): theia.Event<boolean> {
+                return envExt.onDidChangeTelemetryEnabled;
+            },
+            get remoteName(): string | undefined { return envExt.remoteName; },
             get machineId(): string { return envExt.machineId; },
             get sessionId(): string { return envExt.sessionId; },
             get uriScheme(): string { return envExt.uriScheme; },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6474,6 +6474,14 @@ export module '@theia/plugin' {
         export const appRoot: string;
 
         /**
+         * The hosted location of the application
+         * On desktop this is 'desktop'
+         * In the web this is the specified embedder i.e. 'github.dev', 'codespaces', or 'web' if the embedder
+         * does not provide that information
+         */
+        export const appHost: string;
+
+        /**
          * The custom uri scheme the editor registers to in the operating system.
          */
         export const uriScheme: string;
@@ -6482,6 +6490,35 @@ export module '@theia/plugin' {
          * Represents the preferred user-language, like `de-CH`, `fr`, or `en-US`.
          */
         export const language: string;
+
+        /**
+         * Indicates that this is a fresh install of the application.
+         * `true` if within the first day of installation otherwise `false`.
+         */
+        export const isNewAppInstall: boolean;
+
+        /**
+         * Indicates whether the users has telemetry enabled.
+         * Can be observed to determine if the extension should send telemetry.
+         */
+        export const isTelemetryEnabled: boolean;
+
+        /**
+         * An {@link Event} which fires when the user enabled or disables telemetry.
+         * `true` if the user has enabled telemetry or `false` if the user has disabled telemetry.
+         */
+        export const onDidChangeTelemetryEnabled: Event<boolean>;
+
+        /**
+         * The name of a remote. Defined by extensions, popular samples are `wsl` for the Windows
+         * Subsystem for Linux or `ssh-remote` for remotes using a secure shell.
+         *
+         * *Note* that the value is `undefined` when there is no remote extension host but that the
+         * value is defined in all extension hosts (local and remote) in case a remote extension host
+         * exists. Use {@link Extension.extensionKind} to know if
+         * a specific extension runs remote or not.
+         */
+        export const remoteName: string | undefined;
 
         /**
          * The detected default shell for the extension host.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Relevant issues: https://github.com/eclipse-theia/theia/issues/10662

Added appHost, isNewAppInstall, isTelemetryEnabled, onDidChangeTelemetryEnabled, and remoteName APIs to our missing vscode API implementation.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Using the electron app, notifications indicating the value of those APIs would pop up.
The appHost is set to 'desktop', the remoteName is set to 'undefined'. For isNewAppInstall, we use the creation date of a random theia file as the installation date. Moreover, since theia doesn't support telemetry, we implemented stubs for the API related to telemetry. The isTelemetryEnabled API is set to false. The onDidChangeTelemetryEnabled always fires an empty event.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
