### PR TITLE
terminal: buffer the output before sending

### DIFF
--- a/packages/terminal/src/node/buffering-stream.spec.ts
+++ b/packages/terminal/src/node/buffering-stream.spec.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { wait } from '@theia/core/lib/common/promise-util';
+import { expect } from 'chai';
+import { BufferingStream } from './buffering-stream';
+
+describe('BufferringStream', () => {
+
+    it('should emit whatever data was buffered before the timeout', async () => {
+        const buffer = new BufferingStream({ emitInterval: 1000 });
+        const chunkPromise = waitForChunk(buffer);
+        buffer.push(Buffer.from([0]));
+        await wait(100);
+        buffer.push(Buffer.from([1]));
+        await wait(100);
+        buffer.push(Buffer.from([2, 3, 4]));
+        const chunk = await chunkPromise;
+        expect(chunk).deep.eq(Buffer.from([0, 1, 2, 3, 4]));
+    });
+
+    it('should not emit chunks bigger than maxChunkSize', async () => {
+        const buffer = new BufferingStream({ maxChunkSize: 2 });
+        buffer.push(Buffer.from([0, 1, 2, 3, 4, 5]));
+        expect(await waitForChunk(buffer)).deep.eq(Buffer.from([0, 1]));
+        expect(await waitForChunk(buffer)).deep.eq(Buffer.from([2, 3]));
+        expect(await waitForChunk(buffer)).deep.eq(Buffer.from([4, 5]));
+    });
+
+    function waitForChunk(buffer: BufferingStream): Promise<Buffer> {
+        return new Promise(resolve => buffer.onData(resolve));
+    }
+});

--- a/packages/terminal/src/node/buffering-stream.ts
+++ b/packages/terminal/src/node/buffering-stream.ts
@@ -18,12 +18,12 @@ import { Emitter, Event } from '@theia/core/lib/common/event';
 
 export interface BufferingStreamOptions {
     /**
-     * Max size of the chunks being emitted.
+     * Max size in bytes of the chunks being emitted.
      */
     maxChunkSize?: number
     /**
-     * Amount of time to wait between the moment we start buffering data
-     * and when we emit the buffered chunk.
+     * Amount of time in milliseconds to wait between the moment we start
+     * buffering data and when we emit the buffered chunk.
      */
     emitInterval?: number
 }
@@ -44,7 +44,7 @@ export class BufferingStream {
 
     constructor(options?: BufferingStreamOptions) {
         this.emitInterval = options?.emitInterval ?? 16; // ms
-        this.maxChunkSize = options?.maxChunkSize ?? 16384; // bytes
+        this.maxChunkSize = options?.maxChunkSize ?? (256 * 1024); // bytes
     }
 
     get onData(): Event<Buffer> {

--- a/packages/terminal/src/node/buffering-stream.ts
+++ b/packages/terminal/src/node/buffering-stream.ts
@@ -1,0 +1,77 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, Event } from '@theia/core/lib/common/event';
+
+export interface BufferingStreamOptions {
+    /**
+     * Max size of the chunks being emitted.
+     */
+    maxChunkSize?: number
+    /**
+     * Amount of time to wait between the moment we start buffering data
+     * and when we emit the buffered chunk.
+     */
+    emitInterval?: number
+}
+
+/**
+ * This component will buffer whatever is pushed to it and emit chunks back
+ * every {@link BufferingStreamOptions.emitInterval}. It will also ensure that
+ * the emitted chunks never exceed {@link BufferingStreamOptions.maxChunkSize}.
+ */
+export class BufferingStream {
+
+    protected buffer?: Buffer;
+    protected timeout?: NodeJS.Timeout;
+    protected maxChunkSize: number;
+    protected emitInterval: number;
+
+    protected onDataEmitter = new Emitter<Buffer>();
+
+    constructor(options?: BufferingStreamOptions) {
+        this.emitInterval = options?.emitInterval ?? 16; // ms
+        this.maxChunkSize = options?.maxChunkSize ?? 16384; // bytes
+    }
+
+    get onData(): Event<Buffer> {
+        return this.onDataEmitter.event;
+    }
+
+    push(chunk: Buffer): void {
+        if (this.buffer) {
+            this.buffer = Buffer.concat([this.buffer, chunk]);
+        } else {
+            this.buffer = chunk;
+            this.timeout = setTimeout(() => this.emitBufferedChunk(), this.emitInterval);
+        }
+    }
+
+    dispose(): void {
+        clearTimeout(this.timeout);
+        this.buffer = undefined;
+    }
+
+    protected emitBufferedChunk(): void {
+        this.onDataEmitter.fire(this.buffer!.slice(0, this.maxChunkSize));
+        if (this.buffer!.byteLength <= this.maxChunkSize) {
+            this.buffer = undefined;
+        } else {
+            this.buffer = this.buffer!.slice(this.maxChunkSize);
+            this.timeout = setTimeout(() => this.emitBufferedChunk(), this.emitInterval);
+        }
+    }
+}

--- a/packages/terminal/src/node/buffering-stream.ts
+++ b/packages/terminal/src/node/buffering-stream.ts
@@ -63,6 +63,7 @@ export class BufferingStream {
     dispose(): void {
         clearTimeout(this.timeout);
         this.buffer = undefined;
+        this.onDataEmitter.dispose();
     }
 
     protected emitBufferedChunk(): void {


### PR DESCRIPTION
In order to not overload the websocket channel opened between the
frontend and the backend we should chunk and buffer the output of
terminals.

Add `BufferingStream` that will buffer data for some time before
emitting it.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

Closes https://github.com/eclipse-theia/theia/pull/11181

#### How to test

Terminals should still work.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
