### PR TITLE
Ensure WidgetManager creates same key for objects that are deep equal

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "drivelist": "^9.0.2",
     "es6-promise": "^4.2.4",
     "express": "^4.16.3",
+    "fast-json-stable-stringify": "^2.1.0",
     "file-icons-js": "~1.0.3",
     "font-awesome": "^4.7.0",
     "fs-extra": "^4.0.2",

--- a/packages/core/src/browser/widget-manager.spec.ts
+++ b/packages/core/src/browser/widget-manager.spec.ts
@@ -63,4 +63,18 @@ describe('widget-manager', () => {
         expect(wA).equals(await widgetManager.getOrCreateWidget('test', 'widgetA'));
     });
 
+    it('produces the same widget key regardless of object key order', () => {
+        const options1 = {
+            factoryId: 'a',
+            key1: 1,
+            key2: 2,
+        };
+        const options2 = {
+            key2: 2,
+            key1: 1,
+            factoryId: 'a',
+        };
+        expect(widgetManager['toKey'](options1)).equals(widgetManager['toKey'](options2));
+    });
+
 });

--- a/packages/core/src/browser/widget-manager.ts
+++ b/packages/core/src/browser/widget-manager.ts
@@ -17,6 +17,7 @@
 import { inject, named, injectable } from 'inversify';
 import { Widget } from '@phosphor/widgets';
 import { ILogger, Emitter, Event, ContributionProvider, MaybePromise, WaitUntilEvent } from '../common';
+import stableJsonStringify = require('fast-json-stable-stringify');
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const WidgetFactory = Symbol('WidgetFactory');
@@ -256,7 +257,7 @@ export class WidgetManager {
      * @returns the widget construction options represented as a string.
      */
     protected toKey(options: WidgetConstructionOptions): string {
-        return JSON.stringify(options);
+        return stableJsonStringify(options);
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5577,7 +5577,7 @@ fast-glob@^3.2.5, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11309 by using a library that produces stable stringifications for deep-equal objects.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. A test command is included in the first commit of this PR (to be dropped)
> Label: `Try opening the same file with different options!`
3. Running that command without the second commit should produce a log that says that it is `false` that the two widgets are equal.
4. Running that command with the second commit of this PR should produce a log that says that it is `true` that the two widgets are equal.
5. CI should pass.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
