### PR TITLE
Only show "New File/Folder" on folders

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -486,10 +486,12 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         });
 
         registry.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
-            commandId: WorkspaceCommands.NEW_FILE.id
+            commandId: WorkspaceCommands.NEW_FILE.id,
+            when: 'explorerResourceIsFolder'
         });
         registry.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
-            commandId: WorkspaceCommands.NEW_FOLDER.id
+            commandId: WorkspaceCommands.NEW_FOLDER.id,
+            when: 'explorerResourceIsFolder'
         });
         registry.registerMenuAction(NavigatorContextMenu.COMPARE, {
             commandId: WorkspaceCommands.FILE_COMPARE.id


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11452

Adds the `explorerResourceIsFolder` context so that these commands only appear on folders in the explorer.

#### How to test

1. Open the file explorer
2. Assert that the command isn't shown on files but continues to show on folders

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
