### PR TITLE
Add errors handling for plugins downloading

### DIFF
--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -147,13 +147,17 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
             // De-duplicate extension ids to only download each once:
             const ids = new Set<string>(dependencies.flat());
             await parallelOrSequence(...Array.from(ids, id => async () => {
-                const extension = await client.getLatestCompatibleExtensionVersion(id);
-                const version = extension?.version;
-                const downloadUrl = extension?.files.download;
-                if (downloadUrl) {
-                    await downloadPlugin({ id, downloadUrl, version });
-                } else {
-                    failures.push(`No download url for extension pack ${id} (${version})`);
+                try {
+                    const extension = await client.getLatestCompatibleExtensionVersion(id);
+                    const version = extension?.version;
+                    const downloadUrl = extension?.files.download;
+                    if (downloadUrl) {
+                        await downloadPlugin({ id, downloadUrl, version });
+                    } else {
+                        failures.push(`No download url for extension pack ${id} (${version})`);
+                    }
+                } catch (err) {
+                    failures.push(err.message);
                 }
             }));
         };


### PR DESCRIPTION
#### What it does
Closes #11260.
Catches and collects errors that occur when loading plugins. This allows to try to load all plugins and not terminate the load after the first fail. Does not interact with the user (what was suggested in the issue), because the loading of plugins goes in parallel and, as a consequence, it is difficult to stop loading if the user wants to.

#### How to test
Run `yarn download:plugins --api-url https://google.com` -- plugins downloading is failed. Before the change you get an error after loading the first plugin. After the change, you should see attempts to load all plugins.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)