### PR TITLE
siw: update `find in folder` menu to only apply for folders

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -298,12 +298,18 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             command: SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id,
             keybinding: 'ctrlcmd+shift+f'
         });
+        keybindings.registerKeybinding({
+            command: SearchInWorkspaceCommands.FIND_IN_FOLDER.id,
+            keybinding: 'shift+alt+f',
+            when: 'explorerResourceIsFolder'
+        });
     }
 
     override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
         menus.registerMenuAction(NavigatorContextMenu.SEARCH, {
-            commandId: SearchInWorkspaceCommands.FIND_IN_FOLDER.id
+            commandId: SearchInWorkspaceCommands.FIND_IN_FOLDER.id,
+            when: 'explorerResourceIsFolder'
         });
         menus.registerMenuAction(CommonMenus.EDIT_FIND, {
             commandId: SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/3614.

Inspired by https://github.com/eclipse-theia/theia/pull/11453, the pull-request updates the **Find in Folder** menu item for the explorer to only apply to folders and not files. The changes also include registering a keybinding for the command similarly to vscode. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with a workspace.
2. open the explorer.
3. with a folder selected, confirm that `find in folder` is present in the context-menu and triggering it will populate the search-in-workspace with the appropriate `include` section.
4. confirm with multiple folders selected that step 3 works.
5. confirm that the keybinding works for the command (<kbd>shift</kbd>+<kbd>alt</kbd>+<kbd>f</kbd>)
6. confirm with a file selected the `find in folder` does not appear.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>