### PR TITLE
Harmonize definition of `LocationLink` with VSCode

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -617,7 +617,7 @@ export module '@theia/plugin' {
      * Provides additional metadata over normal [location](#Location) definitions, including the range of
      * the defining symbol
      */
-    export interface DefinitionLink {
+    export interface LocationLink {
         /**
          * Span of the symbol being defined in the source file.
          *
@@ -7852,10 +7852,12 @@ export module '@theia/plugin' {
     }
 
     /**
-     * Represents the connection of two locations. Provides additional metadata over normal {@link Location locations},
-     * including an origin range.
+     * Information about where a symbol is defined.
+     *
+     * Provides additional metadata over normal {@link Location} definitions, including the range of
+     * the defining symbol
      */
-    export type LocationLink = DefinitionLink;
+    export type DefinitionLink = LocationLink;
 
     /**
      * The declaration of a symbol representation as one or many {@link Location locations}


### PR DESCRIPTION
#### What it does

This change makes the definition of `LocationLink` equivalent to the definition in VSCode.
With that, the definition is easier to maintain/compare with respect to VSCode and also makes the [VSCode comparator report](https://eclipse-theia.github.io/vscode-theia-comparator/filtered-status.html) happy.

Fixes #11464

Contributed on behalf of STMicroelectronics.

#### How to test
You can check out this change and clone the [vscode-theia-comparator](https://github.com/eclipse-theia/vscode-theia-comparator) locally and then run:

```bash
yarn
GITHUB_TOKEN=<your-token> yarn run generate theia-path=<path-to-local-theia-clone>
```

The resulting report should show that `LocationLink` is now supported:
![image](https://user-images.githubusercontent.com/588090/181041165-ac7cfa07-ffa0-48e4-bad3-ea5ce48ef373.png)

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
