### PR TITLE
Wait for plugins to deploy before restoring the current language

### DIFF
--- a/packages/core/src/node/i18n/localization-backend-contribution.ts
+++ b/packages/core/src/node/i18n/localization-backend-contribution.ts
@@ -16,7 +16,7 @@
 
 import * as express from 'express';
 import { inject, injectable } from 'inversify';
-import { Deferred } from 'src/common/promise-util';
+import { Deferred } from '../../common/promise-util';
 import { BackendApplicationContribution } from '../backend-application';
 import { LocalizationRegistry } from './localization-contribution';
 import { LocalizationProvider } from './localization-provider';

--- a/packages/core/src/node/i18n/localization-backend-contribution.ts
+++ b/packages/core/src/node/i18n/localization-backend-contribution.ts
@@ -16,12 +16,14 @@
 
 import * as express from 'express';
 import { inject, injectable } from 'inversify';
+import { Deferred } from 'src/common/promise-util';
 import { BackendApplicationContribution } from '../backend-application';
 import { LocalizationRegistry } from './localization-contribution';
 import { LocalizationProvider } from './localization-provider';
 
 @injectable()
 export class LocalizationBackendContribution implements BackendApplicationContribution {
+    protected readonly initialized = new Deferred<void>();
 
     @inject(LocalizationRegistry)
     protected readonly localizationRegistry: LocalizationRegistry;
@@ -31,15 +33,20 @@ export class LocalizationBackendContribution implements BackendApplicationContri
 
     async initialize(): Promise<void> {
         await this.localizationRegistry.initialize();
+        this.initialized.resolve();
+    }
+
+    waitForInitialization(): Promise<void> {
+        return this.initialized.promise;
     }
 
     configure(app: express.Application): void {
-        app.get('/i18n/:locale', (req, res) => {
+        app.get('/i18n/:locale', async (req, res) => {
+            await this.waitForInitialization();
             let locale = req.params.locale;
             locale = this.localizationProvider.getAvailableLanguages().some(e => e.languageId === locale) ? locale : 'en';
             this.localizationProvider.setCurrentLanguage(locale);
             res.send(this.localizationProvider.loadLocalization(locale));
         });
     }
-
 }

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -40,7 +40,7 @@ import { PluginTheiaEnvironment } from '../common/plugin-theia-environment';
 import { PluginTheiaDeployerParticipant } from './plugin-theia-deployer-participant';
 import { WebviewBackendSecurityWarnings } from './webview-backend-security-warnings';
 import { PluginUninstallationManager } from './plugin-uninstallation-manager';
-import { LocalizationBackendContribution } from '@theia/core/src/node/i18n/localization-backend-contribution';
+import { LocalizationBackendContribution } from '@theia/core/lib/node/i18n/localization-backend-contribution';
 import { PluginLocalizationBackendContribution } from './plugin-localization-backend-contribution';
 
 export function bindMainBackend(bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind): void {

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -40,8 +40,10 @@ import { PluginTheiaEnvironment } from '../common/plugin-theia-environment';
 import { PluginTheiaDeployerParticipant } from './plugin-theia-deployer-participant';
 import { WebviewBackendSecurityWarnings } from './webview-backend-security-warnings';
 import { PluginUninstallationManager } from './plugin-uninstallation-manager';
+import { LocalizationBackendContribution } from '@theia/core/src/node/i18n/localization-backend-contribution';
+import { PluginLocalizationBackendContribution } from './plugin-localization-backend-contribution';
 
-export function bindMainBackend(bind: interfaces.Bind): void {
+export function bindMainBackend(bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(PluginApiContribution);
     bind(WsRequestValidatorContribution).toService(PluginApiContribution);
@@ -87,4 +89,7 @@ export function bindMainBackend(bind: interfaces.Bind): void {
 
     bind(WebviewBackendSecurityWarnings).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(WebviewBackendSecurityWarnings);
+
+    rebind(LocalizationBackendContribution).to(PluginLocalizationBackendContribution).inSingletonScope();
+
 }

--- a/packages/plugin-ext/src/main/node/plugin-localization-backend-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-localization-backend-contribution.ts
@@ -1,21 +1,42 @@
+// *****************************************************************************
+// Copyright (C) 2021 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { LocalizationBackendContribution } from '@theia/core/lib/node/i18n/localization-backend-contribution';
 import { PluginDeployer } from '../../common/plugin-protocol';
 import { PluginDeployerImpl } from './plugin-deployer-impl';
-import { Deferred } from '@theia/core/src/common/promise-util';
+import { Deferred } from '@theia/core/lib/common/promise-util';
 
 @injectable()
 export class PluginLocalizationBackendContribution extends LocalizationBackendContribution {
     @inject(PluginDeployer)
     protected readonly pluginDeployer: PluginDeployerImpl;
+    protected readonly pluginsDeployed = new Deferred();
 
     override async initialize(): Promise<void> {
-        const pluginsDeployed = new Deferred();
         this.pluginDeployer.onDidDeploy(() => {
-            pluginsDeployed.resolve();
+            this.pluginsDeployed.resolve();
         });
+        await super.initialize();
+    }
 
-        await Promise.all([this.localizationRegistry.initialize(), pluginsDeployed.promise]);
-        this.initialized.resolve();
+    override async waitForInitialization(): Promise<void> {
+        await Promise.all([
+            super.waitForInitialization(),
+            this.pluginsDeployed.promise,
+        ]);
     }
 }

--- a/packages/plugin-ext/src/main/node/plugin-localization-backend-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-localization-backend-contribution.ts
@@ -1,0 +1,35 @@
+import * as express from 'express';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { LocalizationBackendContribution } from '@theia/core/lib/node/i18n/localization-backend-contribution';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { PluginDeployer } from '../../common/plugin-protocol';
+import { PluginDeployerImpl } from './plugin-deployer-impl';
+
+@injectable()
+export class PluginLocalizationBackendContribution extends LocalizationBackendContribution {
+  @inject(PluginDeployer)
+  protected readonly pluginDeployer: PluginDeployerImpl;
+
+  protected readonly initialized = new Deferred<void>();
+
+  override async initialize(): Promise<void> {
+    this.pluginDeployer.onDidDeploy(() => {
+      this.initialized.resolve();
+    });
+    return super.initialize();
+  }
+
+  override configure(app: express.Application): void {
+    app.get('/i18n/:locale', async (req, res) => {
+      let locale = req.params.locale;
+      await this.initialized.promise;
+      locale = this.localizationProvider
+        .getAvailableLanguages()
+        .some((e) => e.languageId === locale)
+        ? locale
+        : 'en';
+      this.localizationProvider.setCurrentLanguage(locale);
+      res.send(this.localizationProvider.loadLocalization(locale));
+    });
+  }
+}

--- a/packages/plugin-ext/src/main/node/plugin-localization-backend-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-localization-backend-contribution.ts
@@ -1,35 +1,21 @@
-import * as express from 'express';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { LocalizationBackendContribution } from '@theia/core/lib/node/i18n/localization-backend-contribution';
-import { Deferred } from '@theia/core/lib/common/promise-util';
 import { PluginDeployer } from '../../common/plugin-protocol';
 import { PluginDeployerImpl } from './plugin-deployer-impl';
+import { Deferred } from '@theia/core/src/common/promise-util';
 
 @injectable()
 export class PluginLocalizationBackendContribution extends LocalizationBackendContribution {
-  @inject(PluginDeployer)
-  protected readonly pluginDeployer: PluginDeployerImpl;
+    @inject(PluginDeployer)
+    protected readonly pluginDeployer: PluginDeployerImpl;
 
-  protected readonly initialized = new Deferred<void>();
+    override async initialize(): Promise<void> {
+        const pluginsDeployed = new Deferred();
+        this.pluginDeployer.onDidDeploy(() => {
+            pluginsDeployed.resolve();
+        });
 
-  override async initialize(): Promise<void> {
-    this.pluginDeployer.onDidDeploy(() => {
-      this.initialized.resolve();
-    });
-    return super.initialize();
-  }
-
-  override configure(app: express.Application): void {
-    app.get('/i18n/:locale', async (req, res) => {
-      let locale = req.params.locale;
-      await this.initialized.promise;
-      locale = this.localizationProvider
-        .getAvailableLanguages()
-        .some((e) => e.languageId === locale)
-        ? locale
-        : 'en';
-      this.localizationProvider.setCurrentLanguage(locale);
-      res.send(this.localizationProvider.loadLocalization(locale));
-    });
-  }
+        await Promise.all([this.localizationRegistry.initialize(), pluginsDeployed.promise]);
+        this.initialized.resolve();
+    }
 }

--- a/packages/plugin-ext/src/plugin-ext-backend-electron-module.ts
+++ b/packages/plugin-ext/src/plugin-ext-backend-electron-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { bindElectronBackend } from './hosted/node-electron/plugin-ext-hosted-electron-backend-module';
 import { bindMainBackend } from './main/node/plugin-ext-backend-module';
 
-export default new ContainerModule(bind => {
-    bindMainBackend(bind);
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bindMainBackend(bind, unbind, isBound, rebind);
     bindElectronBackend(bind);
 });

--- a/packages/plugin-ext/src/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/plugin-ext-backend-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { bindHostedBackend } from './hosted/node/plugin-ext-hosted-backend-module';
 import { bindMainBackend } from './main/node/plugin-ext-backend-module';
 
-export default new ContainerModule(bind => {
-    bindMainBackend(bind);
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bindMainBackend(bind, unbind, isBound, rebind);
     bindHostedBackend(bind);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Wait for the plugins to be deployed before restoring the current language.

Fixes #11471

#### How to test
- Open IDE select `de` as the default
 - IDE reloads, it shows `de`
 - Quit IDE
 - Start IDE, it still shows `de` ✅
 - Select `zh-cn` as the default language
 - IDE reloads and shows `zh-cn` ✅
 - Quit IDE
 - Open IDE
 - The language is still `zh-cn` ✅

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
