### PR TITLE
Modify theme services to use preference service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.29.0 - unreleased
+
+<a name="breaking_changes_1.29.0">[Breaking Changes:](#breaking_changes_1.29.0)</a>
+
+- [core] `updateThemePreference` and `updateThemeFromPreference` removed from `CommonFrontendContribution`. Corresponding functionality as been moved to the respective theme service. `load` removed from `IconThemeService` [#11473](https://github.com/eclipse-theia/theia/issues/11473)
+
 ## v1.28.0 - 7/28/2022
 
 - [cli] improved error handling when interacting with the API [#11454](https://github.com/eclipse-theia/theia/issues/11454)

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -92,6 +92,10 @@ export interface PreferenceService extends Disposable {
      */
     readonly ready: Promise<void>;
     /**
+     * Indicates whether the service has successfully initialized. Will be `true` when {@link PreferenceService.ready the `ready` Promise} resolves.
+     */
+    readonly isReady: boolean;
+    /**
      * Retrieve the stored value for the given preference.
      *
      * @param preferenceName the preference identifier.
@@ -298,6 +302,7 @@ export class PreferenceServiceImpl implements PreferenceService {
                 await provider.ready;
             }
             this._ready.resolve();
+            this._isReady = true;
         } catch (e) {
             this._ready.reject(e);
         }
@@ -316,6 +321,11 @@ export class PreferenceServiceImpl implements PreferenceService {
     protected readonly _ready = new Deferred<void>();
     get ready(): Promise<void> {
         return this._ready.promise;
+    }
+
+    protected _isReady = false;
+    get isReady(): boolean {
+        return this._isReady;
     }
 
     protected reconcilePreferences(changes: PreferenceProviderDataChanges): void {

--- a/packages/core/src/browser/preferences/test/mock-preference-service.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-service.ts
@@ -43,7 +43,8 @@ export class MockPreferenceService implements PreferenceService {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     set(preferenceName: string, value: any): Promise<void> { return Promise.resolve(); }
     updateValue(): Promise<void> { return Promise.resolve(); }
-    ready: Promise<void> = Promise.resolve();
+    readonly ready: Promise<void> = Promise.resolve();
+    readonly isReady = true;
     readonly onPreferenceChanged: Event<PreferenceChange> = new Emitter<PreferenceChange>().event;
     readonly onPreferencesChanged: Event<PreferenceChanges> = new Emitter<PreferenceChanges>().event;
     overridePreferenceName(options: OverridePreferenceName): string {

--- a/packages/monaco/src/browser/monaco-color-registry.ts
+++ b/packages/monaco/src/browser/monaco-color-registry.ts
@@ -38,7 +38,7 @@ export class MonacoColorRegistry extends ColorRegistry {
 
     override getCurrentColor(id: string): string | undefined {
         const color = this.monacoThemeService.getColorTheme().getColor(id);
-        return color && color.toString();
+        return color?.toString();
     }
 
     protected override doRegister(definition: ColorDefinition): Disposable {

--- a/packages/monaco/src/browser/monaco-theming-service.ts
+++ b/packages/monaco/src/browser/monaco-theming-service.ts
@@ -19,11 +19,10 @@
 import { injectable, inject } from '@theia/core/shared/inversify';
 import * as jsoncparser from 'jsonc-parser';
 import * as plistparser from 'fast-plist';
-import { ThemeService } from '@theia/core/lib/browser/theming';
 import URI from '@theia/core/lib/common/uri';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import { MonacoThemeRegistry } from './textmate/monaco-theme-registry';
-import { getThemes, putTheme, MonacoThemeState, stateToTheme } from './monaco-indexed-db';
+import { getThemes, putTheme, MonacoThemeState, stateToTheme, ThemeServiceWithDB } from './monaco-indexed-db';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import * as monaco from '@theia/monaco-editor-core';
 
@@ -61,7 +60,7 @@ export class MonacoThemingService {
 
     @inject(FileService) protected readonly fileService: FileService;
     @inject(MonacoThemeRegistry) protected readonly monacoThemeRegistry: MonacoThemeRegistry;
-    @inject(ThemeService) protected readonly themeService: ThemeService;
+    @inject(ThemeServiceWithDB) protected readonly themeService: ThemeServiceWithDB;
 
     /** Register themes whose configuration needs to be loaded */
     register(theme: MonacoTheme, pending: { [uri: string]: Promise<any> } = {}): Disposable {
@@ -143,6 +142,7 @@ export class MonacoThemingService {
         this.monacoThemeRegistry.initializeDefaultThemes();
         this.updateBodyUiTheme();
         this.themeService.onDidColorThemeChange(() => this.updateBodyUiTheme());
+        this.themeService.onDidRetrieveTheme(theme => this.monacoThemeRegistry.setTheme(MonacoThemingService.toCssSelector(theme.id), theme.data));
         this.restore();
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR's primary objective is to modify the `ThemeService` and `IconThemeService` to interact directly with the `PreferenceService` as their primary source of truth. Previously, neither service was `injectable`, and so neither had access to the `PreferenceService` directly. As a consequence, their interactions with the `PreferenceService` were mediated by the `CommonFrontendContribution` and both services relied heavily on local storage for persistence.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open your user `settings.json` and execute one of the commands `Preferences: Color Theme` or `Preferences: Icon Theme`.
1. Move the selector to preview themes.
1. Note that the `settings.json` file is _not_ modified.
1. Select a theme from the quick pick.
1. Note that your `settings.json` _is_ modified.
1. In the `settings.json` file, set a nonsensical value (`"Definitely not any kind of theme!"`) for the preference.
1. Note that the theme you selected remains in place.
1. Reload the page.
1. Note that the theme you selected (if it was a color theme - we don't store assets of icon themes) still remains in place.
> This is different from VSCode's behavior where the theme is reset to default on restart. It would be possible to implement this behavior, if preferable.
---
Check for #10938
1. Remove the Material Icon Theme from your plugins, if you have it.
1. Open the application, and in your user `settings.json`, set `workbench.iconTheme` to `"material-icon-theme"`.
1. No change should be immediately observable.
1. Install the Material Icon Theme from Open VSX.
1. The theme should immediately take effect.
---
1. Set your theme to `Red` or something else with a distinctive editor background color.
1. Reload the application.
1. There should be no theme flashes.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
