### PR TITLE
Fix: Display failed when text document content provider return empty string ('')

### DIFF
--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -367,7 +367,7 @@ export class TextContentResource implements Resource {
             return content;
         } else {
             const content = await this.proxy.$provideTextDocumentContent(this.uri.toString());
-            if (content !== undefined && content !== null) {
+            if (typeof content === 'string') {
                 return content;
             }
         }

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -367,9 +367,7 @@ export class TextContentResource implements Resource {
             return content;
         } else {
             const content = await this.proxy.$provideTextDocumentContent(this.uri.toString());
-            if (typeof content === 'string') {
-                return content;
-            }
+            return content ?? '';
         }
 
         return Promise.reject(new Error(`Unable to get content for '${this.uri.toString()}'`));

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -367,7 +367,7 @@ export class TextContentResource implements Resource {
             return content;
         } else {
             const content = await this.proxy.$provideTextDocumentContent(this.uri.toString());
-            if (content) {
+            if (content !== undefined && content !== null) {
                 return content;
             }
         }

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -369,8 +369,6 @@ export class TextContentResource implements Resource {
             const content = await this.proxy.$provideTextDocumentContent(this.uri.toString());
             return content ?? '';
         }
-
-        return Promise.reject(new Error(`Unable to get content for '${this.uri.toString()}'`));
     }
 
     dispose(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-theia/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fix：Display failed when text document content provider return empty string ('')
![image](https://user-images.githubusercontent.com/34715914/181436316-37f842fe-c057-4764-a5c5-5fc956ffbdf3.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. install [text-document-demo-0.0.1.vsix](https://github.com/hyy215/vsx-demo/blob/master/text-document-demo/text-document-demo-0.0.1.vsix)
2. run 'Show Custom Text Document' command
3. show empty string in editor
![image](https://user-images.githubusercontent.com/34715914/181438800-72321997-3677-4c78-a0ae-80e58401f876.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)