### PR TITLE
lint: add `no-unreachable` eslint rule

### DIFF
--- a/configs/errors.eslintrc.json
+++ b/configs/errors.eslintrc.json
@@ -62,6 +62,7 @@
     "no-throw-literal": "error",
     "no-trailing-spaces": "error",
     "no-underscore-dangle": "off",
+    "no-unreachable": "error",
     "no-unused-expressions": "error",
     "no-var": "error",
     "no-void": "error",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds the **`no-unreachable`** eslint rule as an error.

> This rule disallows unreachable code after return, throw, continue, and break statements.

![image](https://user-images.githubusercontent.com/40359487/181519782-351807f0-23f9-4a26-8083-70d04d6c5ebb.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- the CI checks should be green
- adding unreachable code should produce an error.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>