### PR TITLE
Hide toolbars on inactive tabbars

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -384,6 +384,10 @@
   background: var(--theia-icon-close) no-repeat;
 }
 
+#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-toolbar {
+  display: none;
+}
+
 .theia-tabBar-breadcrumb-row {
   min-width: 100%;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9593

Theia displays toolbars on all tabbars in the main area, whether the tabbar is active or not. VSCode only displays the toolbar on the active tabbar. As a consequence, plugin toolbar items can have unexpected effects if the user clicks on toolbar item for an inactive tab. This PR aligns Theia's behavior with VSCode's by hiding toolbars on inactive tabbars.

> An alternative would be to try to focus the relevant widget before executing the command if the user clicks on a toolbar item for an inactive tabbar. That way, we could continue to display toolbars as we currently do, but the behavior when executing commands would (probably) be compatible with plugins' expectations.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open e.g. two markdown files in different columns in the main area.
1. Observe that the 'Open preview to side' icon(s) appear on the tabbar for the active widget and not for the other tabbar.
1. Focus the other widget, and observe that the icon(s) appear there.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
