### PR TITLE
#10027 Support EvaluatableExpressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## v1.29.0 - unreleased
 
+- [plugin] added support for `EvaluatableExpressions` [#11484](https://github.com/eclipse-theia/theia/pull/11484) - Contributed on behalf of STMicroelectronics
+
 <a name="breaking_changes_1.29.0">[Breaking Changes:](#breaking_changes_1.29.0)</a>
 
 - [core] `updateThemePreference` and `updateThemeFromPreference` removed from `CommonFrontendContribution`. Corresponding functionality as been moved to the respective theme service. `load` removed from `IconThemeService` [#11473](https://github.com/eclipse-theia/theia/issues/11473)

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -162,6 +162,13 @@ export namespace ArrayUtils {
         }
         return -(low + 1);
     }
+
+    /**
+     * @returns New array with all falsy values removed. The original array IS NOT modified.
+     */
+    export function coalesce<T>(array: ReadonlyArray<T | undefined | null>): T[] {
+        return <T[]>array.filter(e => !!e);
+    }
 }
 
 /**

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -255,6 +255,16 @@ export interface HoverProvider {
     provideHover(model: monaco.editor.ITextModel, position: monaco.Position, token: monaco.CancellationToken): Hover | undefined | Thenable<Hover | undefined>;
 }
 
+export interface EvaluatableExpression {
+    range: Range;
+    expression?: string;
+}
+
+export interface EvaluatableExpressionProvider {
+    provideEvaluatableExpression(model: monaco.editor.ITextModel, position: monaco.Position,
+        token: monaco.CancellationToken): EvaluatableExpression | undefined | Thenable<EvaluatableExpression | undefined>;
+}
+
 export enum DocumentHighlightKind {
     Text = 0,
     Read = 1,

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -41,6 +41,7 @@ import {
     MarkerData,
     SignatureHelp,
     Hover,
+    EvaluatableExpression,
     DocumentHighlight,
     FormattingOptions,
     ChainedCacheId,
@@ -1470,6 +1471,7 @@ export interface LanguagesExt {
     ): Promise<SignatureHelp | undefined>;
     $releaseSignatureHelp(handle: number, id: number): void;
     $provideHover(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<Hover | undefined>;
+    $provideEvaluatableExpression(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<EvaluatableExpression | undefined>;
     $provideDocumentHighlights(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<DocumentHighlight[] | undefined>;
     $provideDocumentFormattingEdits(handle: number, resource: UriComponents,
         options: FormattingOptions, token: CancellationToken): Promise<TextEdit[] | undefined>;
@@ -1546,6 +1548,7 @@ export interface LanguagesMain {
     $registerReferenceProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerSignatureHelpProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void;
     $registerHoverProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerEvaluatableExpressionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[], documentation?: CodeActionProviderDocumentation): void;
     $clearDiagnostics(id: string): void;

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -62,11 +62,13 @@ import {
     CallHierarchyIncomingCall,
     CallHierarchyOutgoingCall,
     LinkedEditingRanges,
+    EvaluatableExpression
 } from '../common/plugin-api-rpc-model';
 import { CompletionAdapter } from './languages/completion';
 import { Diagnostics } from './languages/diagnostics';
 import { SignatureHelpAdapter } from './languages/signature';
 import { HoverAdapter } from './languages/hover';
+import { EvaluatableExpressionAdapter } from './languages/evaluatable-expression';
 import { DocumentHighlightAdapter } from './languages/document-highlight';
 import { DocumentFormattingAdapter } from './languages/document-formatting';
 import { RangeFormattingAdapter } from './languages/range-formatting';
@@ -100,6 +102,7 @@ import { serializeEnterRules, serializeIndentation, serializeRegExp } from './la
 type Adapter = CompletionAdapter |
     SignatureHelpAdapter |
     HoverAdapter |
+    EvaluatableExpressionAdapter |
     DocumentHighlightAdapter |
     DocumentFormattingAdapter |
     RangeFormattingAdapter |
@@ -349,6 +352,18 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, HoverAdapter, adapter => adapter.provideHover(URI.revive(resource), position, token), undefined);
     }
     // ### Hover Provider end
+
+    // ### EvaluatableExpression Provider begin
+    registerEvaluatableExpressionProvider(selector: theia.DocumentSelector, provider: theia.EvaluatableExpressionProvider, pluginInfo: PluginInfo): theia.Disposable {
+        const callId = this.addNewAdapter(new EvaluatableExpressionAdapter(provider, this.documents));
+        this.proxy.$registerEvaluatableExpressionProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
+        return this.createDisposable(callId);
+    }
+
+    $provideEvaluatableExpression(handle: number, resource: UriComponents, position: Position, token: theia.CancellationToken): Promise<EvaluatableExpression | undefined> {
+        return this.withAdapter(handle, EvaluatableExpressionAdapter, adapter => adapter.provideEvaluatableExpression(URI.revive(resource), position, token), undefined);
+    }
+    // ### EvaluatableExpression Provider end
 
     // ### Document Highlight Provider begin
     registerDocumentHighlightProvider(selector: theia.DocumentSelector, provider: theia.DocumentHighlightProvider, pluginInfo: PluginInfo): theia.Disposable {

--- a/packages/plugin-ext/src/plugin/languages/evaluatable-expression.ts
+++ b/packages/plugin-ext/src/plugin/languages/evaluatable-expression.ts
@@ -1,0 +1,47 @@
+// *****************************************************************************
+// Copyright (C) 2022 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { URI } from '@theia/core/shared/vscode-uri';
+import * as theia from '@theia/plugin';
+import { Position } from '../../common/plugin-api-rpc';
+import { EvaluatableExpression } from '../../common/plugin-api-rpc-model';
+import { DocumentsExtImpl } from '../documents';
+import * as Converter from '../type-converters';
+
+export class EvaluatableExpressionAdapter {
+
+    constructor(
+        private readonly provider: theia.EvaluatableExpressionProvider,
+        private readonly documents: DocumentsExtImpl
+    ) { }
+
+    async provideEvaluatableExpression(resource: URI, position: Position, token: theia.CancellationToken): Promise<EvaluatableExpression | undefined> {
+        const documentData = this.documents.getDocumentData(resource);
+        if (!documentData) {
+            return Promise.reject(new Error(`There is no document data for ${resource}`));
+        }
+
+        const document = documentData.document;
+        const pos = Converter.toPosition(position);
+
+        return Promise.resolve(this.provider.provideEvaluatableExpression(document, pos, token)).then(expression => {
+            if (!expression) {
+                return undefined;
+            }
+            return Converter.fromEvaluatableExpression(expression);
+        });
+    }
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -78,6 +78,7 @@ import {
     SignatureHelp,
     SignatureHelpTriggerKind,
     Hover,
+    EvaluatableExpression,
     DocumentHighlightKind,
     DocumentHighlight,
     DocumentLink,
@@ -731,6 +732,9 @@ export function createAPIFactory(
             registerHoverProvider(selector: theia.DocumentSelector, provider: theia.HoverProvider): theia.Disposable {
                 return languagesExt.registerHoverProvider(selector, provider, pluginToPluginInfo(plugin));
             },
+            registerEvaluatableExpressionProvider(selector: theia.DocumentSelector, provider: theia.EvaluatableExpressionProvider): theia.Disposable {
+                return languagesExt.registerEvaluatableExpressionProvider(selector, provider, pluginToPluginInfo(plugin));
+            },
             registerDocumentHighlightProvider(selector: theia.DocumentSelector, provider: theia.DocumentHighlightProvider): theia.Disposable {
                 return languagesExt.registerDocumentHighlightProvider(selector, provider, pluginToPluginInfo(plugin));
             },
@@ -991,6 +995,7 @@ export function createAPIFactory(
             SignatureHelp,
             SignatureHelpTriggerKind,
             Hover,
+            EvaluatableExpression,
             DocumentHighlightKind,
             DocumentHighlight,
             DocumentLink,

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -396,6 +396,13 @@ export function fromHover(hover: theia.Hover): model.Hover {
     };
 }
 
+export function fromEvaluatableExpression(evaluatableExpression: theia.EvaluatableExpression): model.EvaluatableExpression {
+    return <model.EvaluatableExpression>{
+        range: fromRange(evaluatableExpression.range),
+        expression: evaluatableExpression.expression
+    };
+}
+
 export function fromLocation(location: theia.Location): model.Location {
     return <model.Location>{
         uri: location.uri,

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1119,6 +1119,24 @@ export class Hover {
     }
 }
 
+@es5ClassCompat
+export class EvaluatableExpression {
+
+    public range: Range;
+    public expression?: string;
+
+    constructor(
+        range: Range,
+        expression?: string
+    ) {
+        if (!range) {
+            illegalArgument('range must be defined');
+        }
+        this.range = range;
+        this.expression = expression;
+    }
+}
+
 export enum DocumentHighlightKind {
     Text = 0,
     Read = 1,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9270,6 +9270,18 @@ export module '@theia/plugin' {
         export function registerHoverProvider(selector: DocumentSelector, provider: HoverProvider): Disposable;
 
         /**
+         * Register a provider that locates evaluatable expressions in text documents.
+         * The editor will evaluate the expression in the active debug session and will show the result in the debug hover.
+         *
+         * If multiple providers are registered for a language an arbitrary provider will be used.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider An evaluatable expression provider.
+         * @return A {@link Disposable} that unregisters this provider when being disposed.
+         */
+        export function registerEvaluatableExpressionProvider(selector: DocumentSelector, provider: EvaluatableExpressionProvider): Disposable;
+
+        /**
          * Register a workspace symbol provider.
          *
          * Multiple providers can be registered for a language. In that case providers are asked in
@@ -9580,6 +9592,54 @@ export module '@theia/plugin' {
          * signaled by returning `undefined` or `null`.
          */
         provideHover(document: TextDocument, position: Position, token: CancellationToken | undefined): ProviderResult<Hover>;
+    }
+
+    /**
+     * An EvaluatableExpression represents an expression in a document that can be evaluated by an active debugger or runtime.
+     * The result of this evaluation is shown in a tooltip-like widget.
+     * If only a range is specified, the expression will be extracted from the underlying document.
+     * An optional expression can be used to override the extracted expression.
+     * In this case the range is still used to highlight the range in the document.
+     */
+    export class EvaluatableExpression {
+
+        /*
+         * The range is used to extract the evaluatable expression from the underlying document and to highlight it.
+         */
+        readonly range: Range;
+
+        /*
+         * If specified the expression overrides the extracted expression.
+         */
+        readonly expression?: string | undefined;
+
+        /**
+         * Creates a new evaluatable expression object.
+         *
+         * @param range The range in the underlying document from which the evaluatable expression is extracted.
+         * @param expression If specified overrides the extracted expression.
+         */
+        constructor(range: Range, expression?: string);
+    }
+
+    /**
+     * The evaluatable expression provider interface defines the contract between extensions and
+     * the debug hover. In this contract the provider returns an evaluatable expression for a given position
+     * in a document and the editor evaluates this expression in the active debug session and shows the result in a debug hover.
+     */
+    export interface EvaluatableExpressionProvider {
+        /**
+         * Provide an evaluatable expression for the given document and position.
+         * The editor will evaluate this expression in the active debug session and will show the result in the debug hover.
+         * The expression can be implicitly specified by the range in the underlying document or by explicitly returning an expression.
+         *
+         * @param document The document for which the debug hover is about to appear.
+         * @param position The line and character position in the document where the debug hover is about to appear.
+         * @param token A cancellation token.
+         * @return An EvaluatableExpression or a thenable that resolves to such. The lack of a result can be
+         * signaled by returning `undefined` or `null`.
+         */
+        provideEvaluatableExpression(document: TextDocument, position: Position, token: CancellationToken | undefined): ProviderResult<EvaluatableExpression>;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Implement support for plugins providing evalutable epressions
- Update the debug hover widget to consume evaluatable expressions from the registered providers. Keep the former implementation of guessing the expression from the current line as fallback.

Contributed on behalf of STMicroelectronics

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>

Fixes #10027

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

To test, I created a simple evalutable expression provider for the `java` language, available via the custom vscode extension: [evaluatable-expression-extension-10027-0.0.1.zip](https://github.com/eclipse-theia/theia/files/9219279/evaluatable-expression-extension-10027-0.0.1.zip)

1. Install the extensions `Language Support for Java(TM) by Red Hat` (identifier: `redhat.java`) and `Debugger for Java` (identifier: `vscjava.vscode-java-debug`) from the Open VSX Registry (`Extensions` view) in your Theia test workspace.
On startup, it will show an information message that the provider was registered.
2. Download and install the test extension `terminal-message-extension-11145.vsix` in your Theia test workspace (via `Extensions` view - top menu bar `More actions...` - Install from VSIX).
3. Create a simple Java application to debug
<details><summary>Simple Test application</summary>

```java
package myproject;

public class Test {

    public static void main(String[] args) {
        for (int i = 0; i < 2; i++) {
            String logMessage = "logging a message for i=" + i;
            System.out.println(logMessage);
        }
    }
}
```
</details>

4. Set a breakpoint in line 8 (sysout) and launch the file debugging
<details><summary>Launch config</summary>

```json
 {
   "type": "java",
   "name": "Launch Current File",
   "request": "launch",
   "mainClass": "${file}"
 }
```
</details>

5. Once the breakpoint is hit, hover over the local variable `logMessage`, the extension shows an information message with the cursor position and the provided word range of the expression.
e.g. `[TestEvaluatableExpressionExtension] provide word range for position { "line": 6, "character": 26 } > [ { "line": 6, "character": 19   },   { "line": 6, "character": 29 } ]`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
