### PR TITLE
plugin: add `keys` support for `Memento`

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-storage.ts
+++ b/packages/plugin-ext/src/plugin/plugin-storage.ts
@@ -38,6 +38,10 @@ export class Memento implements theia.Memento {
         }
     }
 
+    keys(): string[] {
+        return Object.entries(this.cache).filter(([, value]) => value !== undefined).map(([key]) => key);
+    }
+
     get<T>(key: string): T | undefined;
     get<T>(key: string, defaultValue: T): T;
     get<T>(key: string, defaultValue?: T): T | undefined {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3470,6 +3470,13 @@ export module '@theia/plugin' {
     export interface Memento {
 
         /**
+         * Returns the stored keys.
+         *
+         * @return The stored keys.
+         */
+        keys(): readonly string[];
+
+        /**
          * Return a value.
          *
          * @param key A string.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and reviewthe requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for `keys()` in the `Memento` VS Code API.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test plugin ([vscode-memento-keys-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/9221698/vscode-memento-keys-0.0.1.vsix.zip)).
2. start the application with a workspace.
3. execute the command `Memento: Workspace Keys` - a notification should appear with workspace keys (denoted by `w-` prefix.
4. execute the command `Memento: Global Keys` - a notification should appear with global keys (workspace keys should also appear).

The result should be the same as in VS Code:

![Screen Shot 2022-07-29 at 12 33 19 PM](https://user-images.githubusercontent.com/40359487/181804330-9af52dfc-e941-497f-b15d-29d3a8292e76.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>