### PR TITLE
Clean up `any` type uses

### DIFF
--- a/dev-packages/ovsx-client/src/ovsx-types.ts
+++ b/dev-packages/ovsx-client/src/ovsx-types.ts
@@ -164,10 +164,8 @@ export interface VSXResponseError extends Error {
 }
 
 export namespace VSXResponseError {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(error: any): error is VSXResponseError {
-        return !!error && typeof error === 'object'
-            && 'statusCode' in error && typeof error['statusCode'] === 'number';
+    export function is(error: unknown): error is VSXResponseError {
+        return !!error && typeof error === 'object' && typeof (error as VSXResponseError).statusCode === 'number';
     }
 }
 

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-node-selection.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-node-selection.ts
@@ -22,8 +22,8 @@ export interface BulkEditNodeSelection {
     bulkEdit: ResourceFileEdit | ResourceTextEdit;
 }
 export namespace BulkEditNodeSelection {
-    export function is(arg: Object | undefined): arg is BulkEditNodeSelection {
-        return typeof arg === 'object' && ('bulkEdit' in arg);
+    export function is(arg: unknown): arg is BulkEditNodeSelection {
+        return !!arg && typeof arg === 'object' && ('bulkEdit' in arg);
     }
 
     export class CommandHandler extends SelectionCommandHandler<BulkEditNodeSelection> {

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree.ts
@@ -108,7 +108,7 @@ export interface BulkEditInfoNode extends UriSelection, SelectableTreeNode, Expa
     fileContents?: string;
 }
 export namespace BulkEditInfoNode {
-    export function is(node: Object | undefined): node is BulkEditInfoNode {
+    export function is(node: unknown): node is BulkEditInfoNode {
         return ExpandableTreeNode.is(node) && UriSelection.is(node) && 'fileContents' in node;
     }
 }

--- a/packages/core/src/browser/decorations-service.ts
+++ b/packages/core/src/browser/decorations-service.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { injectable } from 'inversify';
+import { isThenable } from '../common/promise-util';
 import { CancellationToken, CancellationTokenSource, Disposable, Emitter, Event } from '../common';
 import { TernarySearchTree } from '../common/ternary-search-tree';
 import URI from '../common/uri';
@@ -156,12 +157,6 @@ class DecorationProviderWrapper {
 
             this.data.set(uri, request);
             return undefined;
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        function isThenable<T>(obj: any): obj is Promise<T> {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return obj && typeof (<Promise<any>>obj).then === 'function';
         }
     }
 

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -93,9 +93,8 @@ export interface URIIconReference {
     uri?: URI
 }
 export namespace URIIconReference {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(element: any | undefined): element is URIIconReference {
-        return !!element && typeof element === 'object' && 'kind' in element && element['kind'] === 'uriIconReference';
+    export function is(element: unknown): element is URIIconReference {
+        return !!element && typeof element === 'object' && 'kind' in element && (element as URIIconReference).kind === 'uriIconReference';
     }
     export function create(id: URIIconReference['id'], uri?: URI): URIIconReference {
         return { kind: 'uriIconReference', id, uri };

--- a/packages/core/src/browser/menu/browser-context-menu-renderer.ts
+++ b/packages/core/src/browser/menu/browser-context-menu-renderer.ts
@@ -14,8 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { inject, injectable } from 'inversify';
 import { Menu } from '../widgets';
 import { ContextMenuAccess, ContextMenuRenderer, coordinateFromAnchor, RenderContextMenuOptions } from '../context-menu-renderer';

--- a/packages/core/src/browser/navigatable-types.ts
+++ b/packages/core/src/browser/navigatable-types.ts
@@ -33,14 +33,14 @@ export interface Navigatable {
 }
 
 export namespace Navigatable {
-    export function is(arg: Object | undefined): arg is Navigatable {
-        return !!arg && 'getResourceUri' in arg && 'createMoveToUri' in arg;
+    export function is(arg: unknown): arg is Navigatable {
+        return !!arg && typeof arg === 'object' && 'getResourceUri' in arg && 'createMoveToUri' in arg;
     }
 }
 
 export type NavigatableWidget = BaseWidget & Navigatable;
 export namespace NavigatableWidget {
-    export function is(arg: Object | undefined): arg is NavigatableWidget {
+    export function is(arg: unknown): arg is NavigatableWidget {
         return arg instanceof BaseWidget && Navigatable.is(arg);
     }
     export function* getAffected<T extends Widget>(
@@ -76,8 +76,7 @@ export interface NavigatableWidgetOptions {
     counter?: number,
 }
 export namespace NavigatableWidgetOptions {
-    export function is(arg: Object | undefined): arg is NavigatableWidgetOptions {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return !!arg && 'kind' in arg && (arg as any).kind === 'navigatable';
+    export function is(arg: unknown): arg is NavigatableWidgetOptions {
+        return !!arg && typeof arg === 'object' && 'kind' in arg && (arg as NavigatableWidgetOptions).kind === 'navigatable';
     }
 }

--- a/packages/core/src/browser/preferences/injectable-preference-proxy.ts
+++ b/packages/core/src/browser/preferences/injectable-preference-proxy.ts
@@ -108,7 +108,7 @@ export class InjectablePreferenceProxy<T extends Record<string, JSONValue>> impl
         if (this.schema && (this.isFlat || !property.includes('.')) && this.schema.properties[preferenceName]) {
             const { overrideIdentifier } = this;
             const toGet = overrideIdentifier ? this.preferences.overridePreferenceName({ overrideIdentifier, preferenceName }) : preferenceName;
-            return this.getValue(toGet as keyof T & string, undefined as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+            return this.getValue(toGet as keyof T & string, undefined!);
         }
         switch (property) {
             case 'onPreferenceChanged':

--- a/packages/core/src/browser/preferences/preference-language-override-service.ts
+++ b/packages/core/src/browser/preferences/preference-language-override-service.ts
@@ -23,8 +23,7 @@ export interface OverridePreferenceName {
     overrideIdentifier: string
 }
 export namespace OverridePreferenceName {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(arg: any): arg is OverridePreferenceName {
+    export function is(arg: unknown): arg is OverridePreferenceName {
         return !!arg && typeof arg === 'object' && 'preferenceName' in arg && 'overrideIdentifier' in arg;
     }
 }
@@ -37,8 +36,7 @@ export const getOverridePattern = (identifier: string) => `\\[(${identifier})\\]
 export class PreferenceLanguageOverrideService {
     protected readonly overrideIdentifiers = new Set<string>();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    testOverrideValue(name: string, value: any): value is PreferenceSchemaProperties {
+    testOverrideValue(name: string, value: unknown): value is PreferenceSchemaProperties {
         return PreferenceSchemaProperties.is(value) && OVERRIDE_PROPERTY_PATTERN.test(name);
     }
 

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -59,16 +59,13 @@ export namespace Saveable {
     }
 
     export type Snapshot = { value: string } | { read(): string | null };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isSource(arg: any): arg is SaveableSource {
-        return !!arg && ('saveable' in arg) && is(arg.saveable);
+    export function isSource(arg: unknown): arg is SaveableSource {
+        return typeof arg === 'object' && !!arg && is((arg as SaveableSource).saveable);
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(arg: any): arg is Saveable {
-        return !!arg && ('dirty' in arg) && ('onDirtyChanged' in arg);
+    export function is(arg: unknown): arg is Saveable {
+        return typeof arg === 'object' && !!arg && 'dirty' in arg && 'onDirtyChanged' in arg;
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function get(arg: any): Saveable | undefined {
+    export function get(arg: unknown): Saveable | undefined {
         if (is(arg)) {
             return arg;
         }
@@ -77,20 +74,17 @@ export namespace Saveable {
         }
         return undefined;
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function getDirty(arg: any): Saveable | undefined {
+    export function getDirty(arg: unknown): Saveable | undefined {
         const saveable = get(arg);
         if (saveable && saveable.dirty) {
             return saveable;
         }
         return undefined;
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isDirty(arg: any): boolean {
+    export function isDirty(arg: unknown): boolean {
         return !!getDirty(arg);
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export async function save(arg: any, options?: SaveOptions): Promise<void> {
+    export async function save(arg: unknown, options?: SaveOptions): Promise<void> {
         const saveable = get(arg);
         if (saveable) {
             await saveable.save(options);
@@ -229,7 +223,7 @@ export namespace SaveableWidget {
         return !!widget && 'closeWithoutSaving' in widget;
     }
     export function getDirty<T extends Widget>(widgets: Iterable<T>): IterableIterator<SaveableWidget & T> {
-        return get(widgets, Saveable.isDirty);
+        return get<T>(widgets, Saveable.isDirty);
     }
     export function* get<T extends Widget>(
         widgets: Iterable<T>,

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1934,10 +1934,9 @@ export namespace ApplicationShell {
         return area === 'left' || area === 'right' || area === 'bottom';
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isValidArea(area?: any): area is ApplicationShell.Area {
+    export function isValidArea(area?: unknown): area is ApplicationShell.Area {
         const areas = ['main', 'top', 'left', 'right', 'bottom'];
-        return (area !== undefined && typeof area === 'string' && areas.includes(area));
+        return typeof area === 'string' && areas.includes(area);
     }
 
     /**
@@ -1981,8 +1980,8 @@ export namespace ApplicationShell {
      * Whether a widget should be opened to the side tab bar relatively to the reference widget.
      */
     export type OpenToSideMode = 'open-to-left' | 'open-to-right';
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isOpenToSideMode(mode: OpenToSideMode | any): mode is OpenToSideMode {
+
+    export function isOpenToSideMode(mode: unknown): mode is OpenToSideMode {
         return mode === 'open-to-left' || mode === 'open-to-right';
     }
 
@@ -2060,8 +2059,8 @@ export namespace ApplicationShell {
     }
 
     export namespace TrackableWidgetProvider {
-        export function is(widget: object | undefined): widget is TrackableWidgetProvider {
-            return !!widget && 'getTrackableWidgets' in widget;
+        export function is(widget: unknown): widget is TrackableWidgetProvider {
+            return !!widget && typeof widget === 'object' && 'getTrackableWidgets' in widget;
         }
     }
 

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -46,9 +46,8 @@ export interface StatefulWidget {
 }
 
 export namespace StatefulWidget {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(arg: any): arg is StatefulWidget {
-        return arg !== undefined && typeof arg['storeState'] === 'function' && typeof arg['restoreState'] === 'function';
+    export function is(arg: unknown): arg is StatefulWidget {
+        return !!arg && typeof arg === 'object' && typeof (arg as StatefulWidget).storeState === 'function' && typeof (arg as StatefulWidget).restoreState === 'function';
     }
 }
 

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-types.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-types.ts
@@ -171,9 +171,8 @@ export namespace TabBarToolbarItem {
         return (left.priority || 0) - (right.priority || 0);
     };
 
-    export function is(arg: Object | undefined): arg is TabBarToolbarItem {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return !!arg && 'command' in arg && typeof (arg as any).command === 'string';
+    export function is(arg: unknown): arg is TabBarToolbarItem {
+        return !!arg && typeof arg === 'object' && 'command' in arg && typeof (arg as TabBarToolbarItem).command === 'string';
     }
 
 }

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -276,7 +276,6 @@ export class TabBarRenderer extends TabBar.Renderer {
      */
     protected getDecorations(title: Title<Widget>): WidgetDecoration.Data[] {
         if (this.tabBar && this.decoratorService) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const owner: { resetTabBarDecorations?: () => void; } & Widget = title.owner;
             if (!owner.resetTabBarDecorations) {
                 owner.resetTabBarDecorations = () => this.decorations.delete(title);

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -41,8 +41,7 @@ export interface ViewContributionOptions {
     toggleKeybinding?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function bindViewContribution<T extends AbstractViewContribution<any>>(bind: interfaces.Bind, identifier: interfaces.Newable<T>): interfaces.BindingWhenOnSyntax<T> {
+export function bindViewContribution<T extends AbstractViewContribution<Widget>>(bind: interfaces.Bind, identifier: interfaces.Newable<T>): interfaces.BindingWhenOnSyntax<T> {
     const syntax = bind<T>(identifier).toSelf().inSingletonScope();
     bind(CommandContribution).toService(identifier);
     bind(KeybindingContribution).toService(identifier);

--- a/packages/core/src/browser/source-tree/tree-source.ts
+++ b/packages/core/src/browser/source-tree/tree-source.ts
@@ -38,11 +38,10 @@ export interface CompositeTreeElement extends TreeElement {
     getElements(): MaybePromise<IterableIterator<TreeElement>>
 }
 export namespace CompositeTreeElement {
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    export function is(element: CompositeTreeElement | any): element is CompositeTreeElement {
-        return !!element && 'getElements' in element;
+    export function is(element: unknown): element is CompositeTreeElement {
+        return !!element && typeof element === 'object' && 'getElements' in element;
     }
-    export function hasElements(element: CompositeTreeElement | any): element is CompositeTreeElement {
+    export function hasElements(element: unknown): element is CompositeTreeElement {
         return is(element) && element.hasElements !== false;
     }
 }

--- a/packages/core/src/browser/tree/tree-expansion.ts
+++ b/packages/core/src/browser/tree/tree-expansion.ts
@@ -69,11 +69,11 @@ export namespace ExpandableTreeNode {
         return !!node && CompositeTreeNode.is(node) && 'expanded' in node;
     }
 
-    export function isExpanded(node: Object | undefined): node is ExpandableTreeNode {
+    export function isExpanded(node: unknown): node is ExpandableTreeNode {
         return ExpandableTreeNode.is(node) && node.expanded;
     }
 
-    export function isCollapsed(node: Object | undefined): node is ExpandableTreeNode {
+    export function isCollapsed(node: unknown): node is ExpandableTreeNode {
         return ExpandableTreeNode.is(node) && !node.expanded;
     }
 }

--- a/packages/core/src/browser/tree/tree-selection-state.ts
+++ b/packages/core/src/browser/tree/tree-selection-state.ts
@@ -36,7 +36,7 @@ export namespace FocusableTreeSelection {
     /**
      * `true` if the argument is a focusable tree selection. Otherwise, `false`.
      */
-    export function is(arg: object | undefined): arg is FocusableTreeSelection {
+    export function is(arg: unknown): arg is FocusableTreeSelection {
         return TreeSelection.is(arg) && 'focus' in arg;
     }
 

--- a/packages/core/src/browser/tree/tree-selection.ts
+++ b/packages/core/src/browser/tree/tree-selection.ts
@@ -86,8 +86,8 @@ export namespace TreeSelection {
         RANGE
     }
 
-    export function is(arg: Object | undefined): arg is TreeSelection {
-        return !!arg && 'node' in arg;
+    export function is(arg: unknown): arg is TreeSelection {
+        return !!arg && typeof arg === 'object' && 'node' in arg;
     }
 
     export function isRange(arg: TreeSelection | SelectionType | undefined): boolean {
@@ -129,11 +129,11 @@ export interface SelectableTreeNode extends TreeNode {
 
 export namespace SelectableTreeNode {
 
-    export function is(node: TreeNode | undefined): node is SelectableTreeNode {
-        return !!node && 'selected' in node;
+    export function is(node: unknown): node is SelectableTreeNode {
+        return TreeNode.is(node) && 'selected' in node;
     }
 
-    export function isSelected(node: TreeNode | undefined): node is SelectableTreeNode {
+    export function isSelected(node: unknown): node is SelectableTreeNode {
         return is(node) && node.selected;
     }
 

--- a/packages/core/src/browser/tree/tree-widget-selection.ts
+++ b/packages/core/src/browser/tree/tree-widget-selection.ts
@@ -21,15 +21,14 @@ export type TreeWidgetSelection = ReadonlyArray<Readonly<SelectableTreeNode>> & 
     source: TreeWidget
 };
 export namespace TreeWidgetSelection {
-    export function isSource(selection: Object | undefined, source: TreeWidget): selection is TreeWidgetSelection {
+    export function isSource(selection: unknown, source: TreeWidget): selection is TreeWidgetSelection {
         return getSource(selection) === source;
     }
-    export function getSource(selection: Object | undefined): TreeWidget | undefined {
+    export function getSource(selection: unknown): TreeWidget | undefined {
         return is(selection) ? selection.source : undefined;
     }
-    export function is(selection: Object | undefined): selection is TreeWidgetSelection {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return Array.isArray(selection) && ('source' in selection) && <any>selection['source'] instanceof TreeWidget;
+    export function is(selection: unknown): selection is TreeWidgetSelection {
+        return Array.isArray(selection) && ('source' in selection) && (selection as TreeWidgetSelection).source instanceof TreeWidget;
     }
 
     export function create(source: TreeWidget): TreeWidgetSelection {

--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -123,7 +123,7 @@ export interface TreeNode {
 }
 
 export namespace TreeNode {
-    export function is(node: Object | undefined): node is TreeNode {
+    export function is(node: unknown): node is TreeNode {
         return !!node && typeof node === 'object' && 'id' in node && 'parent' in node;
     }
 

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -63,13 +63,13 @@ export interface BadgeWidget {
 }
 
 export namespace DescriptionWidget {
-    export function is(arg: Object | undefined): arg is DescriptionWidget {
+    export function is(arg: unknown): arg is DescriptionWidget {
         return !!arg && typeof arg === 'object' && 'onDidChangeDescription' in arg;
     }
 }
 
 export namespace BadgeWidget {
-    export function is(arg: Object | undefined): arg is BadgeWidget {
+    export function is(arg: unknown): arg is BadgeWidget {
         return !!arg && typeof arg === 'object' && 'onDidChangeBadge' in arg;
     }
 }

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -246,9 +246,8 @@ export interface EventListenerObject<K extends keyof HTMLElementEventMap> {
     handleEvent(evt: HTMLElementEventMap[K]): void;
 }
 export namespace EventListenerObject {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is<K extends keyof HTMLElementEventMap>(listener: any | undefined): listener is EventListenerObject<K> {
-        return !!listener && 'handleEvent' in listener;
+    export function is<K extends keyof HTMLElementEventMap>(listener: unknown): listener is EventListenerObject<K> {
+        return !!listener && typeof listener === 'object' && 'handleEvent' in listener;
     }
 }
 export type EventListenerOrEventListenerObject<K extends keyof HTMLElementEventMap> = EventListener<K> | EventListenerObject<K>;

--- a/packages/core/src/common/cancellation.ts
+++ b/packages/core/src/common/cancellation.ts
@@ -50,8 +50,7 @@ export namespace CancellationToken {
         onCancellationRequested: shortcutEvent
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(value: any): value is CancellationToken {
+    export function is(value: unknown): value is CancellationToken {
         const candidate = value as CancellationToken;
         return candidate && (candidate === CancellationToken.None
             || candidate === CancellationToken.Cancelled

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -49,9 +49,8 @@ export interface Command {
 
 export namespace Command {
     /* Determine whether object is a Command */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(arg: Command | any): arg is Command {
-        return !!arg && arg === Object(arg) && 'id' in arg;
+    export function is(arg: unknown): arg is Command {
+        return !!arg && typeof arg === 'object' && 'id' in arg;
     }
 
     /** Utility function to easily translate commands */

--- a/packages/core/src/common/disposable.ts
+++ b/packages/core/src/common/disposable.ts
@@ -23,9 +23,8 @@ export interface Disposable {
 }
 
 export namespace Disposable {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(arg: any): arg is Disposable {
-        return !!arg && typeof arg === 'object' && 'dispose' in arg && typeof arg['dispose'] === 'function';
+    export function is(arg: unknown): arg is Disposable {
+        return !!arg && typeof arg === 'object' && typeof (arg as Disposable).dispose === 'function';
     }
     export function create(func: () => void): Disposable {
         return { dispose: func };

--- a/packages/core/src/common/glob.ts
+++ b/packages/core/src/common/glob.ts
@@ -549,11 +549,10 @@ function listToMap(list: string[]): Record<string, true> {
     return map;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isRelativePattern(obj: any): obj is IRelativePattern {
+export function isRelativePattern(obj: unknown): obj is IRelativePattern {
     const rp = obj as IRelativePattern;
 
-    return rp && typeof rp.base === 'string' && typeof rp.pattern === 'string' && typeof rp.pathToRelative === 'function';
+    return !!rp && typeof rp === 'object' && typeof rp.base === 'string' && typeof rp.pattern === 'string' && typeof rp.pathToRelative === 'function';
 }
 
 /**

--- a/packages/core/src/common/keybinding.ts
+++ b/packages/core/src/common/keybinding.ts
@@ -101,9 +101,8 @@ export namespace Keybinding {
     }
 
     /* Determine whether object is a KeyBinding */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(arg: Keybinding | any): arg is Keybinding {
-        return !!arg && arg === Object(arg) && 'command' in arg && 'keybinding' in arg;
+    export function is(arg: unknown): arg is Keybinding {
+        return !!arg && typeof arg === 'object' && 'command' in arg && 'keybinding' in arg;
     }
 }
 

--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -488,9 +488,8 @@ export namespace SpecialCases {
 
 export namespace Key {
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isKey(arg: any): arg is Key {
-        return typeof arg === 'object' && ('code' in arg) && ('keyCode' in arg);
+    export function isKey(arg: unknown): arg is Key {
+        return !!arg && typeof arg === 'object' && 'code' in arg && 'keyCode' in arg;
     }
 
     export function getKey(arg: string | number): Key | undefined {

--- a/packages/core/src/common/lsp-types.ts
+++ b/packages/core/src/common/lsp-types.ts
@@ -23,9 +23,13 @@ export interface TextDocumentContentChangeDelta {
 }
 export namespace TextDocumentContentChangeDelta {
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(arg: any): arg is TextDocumentContentChangeDelta {
-        return !!arg && typeof arg['text'] === 'string' && (typeof arg['rangeLength'] === 'number' || typeof arg['rangeLength'] === 'undefined') && Range.is(arg['range']);
+    export function is(arg: unknown): arg is TextDocumentContentChangeDelta {
+        const changeDelta = arg as TextDocumentContentChangeDelta;
+        return !!changeDelta
+            && typeof changeDelta === 'object'
+            && typeof changeDelta.text === 'string'
+            && (typeof changeDelta.rangeLength === 'number' || typeof changeDelta.rangeLength === 'undefined')
+            && Range.is(changeDelta.range);
     }
 
 }

--- a/packages/core/src/common/menu/menu-types.ts
+++ b/packages/core/src/common/menu/menu-types.ts
@@ -36,9 +36,8 @@ export interface MenuAction extends MenuNodeRenderingData, Pick<MenuNodeMetadata
 
 export namespace MenuAction {
     /* Determine whether object is a MenuAction */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(arg: MenuAction | any): arg is MenuAction {
-        return !!arg && arg === Object(arg) && 'commandId' in arg;
+    export function is(arg: unknown): arg is MenuAction {
+        return !!arg && typeof arg === 'object' && 'commandId' in arg;
     }
 }
 

--- a/packages/core/src/common/preferences/preference-schema.ts
+++ b/packages/core/src/common/preferences/preference-schema.ts
@@ -27,8 +27,8 @@ export interface PreferenceSchema {
     properties: PreferenceSchemaProperties
 }
 export namespace PreferenceSchema {
-    export function is(obj: Object | undefined): obj is PreferenceSchema {
-        return !!obj && ('properties' in obj) && PreferenceSchemaProperties.is((<any>obj)['properties']);
+    export function is(obj: unknown): obj is PreferenceSchema {
+        return !!obj && typeof obj === 'object' && ('properties' in obj) && PreferenceSchemaProperties.is((obj as PreferenceSchema).properties);
     }
     export function getDefaultScope(schema: PreferenceSchema): PreferenceScope {
         let defaultScope: PreferenceScope = PreferenceScope.Workspace;
@@ -45,7 +45,7 @@ export interface PreferenceSchemaProperties {
     [name: string]: PreferenceSchemaProperty
 }
 export namespace PreferenceSchemaProperties {
-    export function is(obj: Object | undefined): obj is PreferenceSchemaProperties {
+    export function is(obj: unknown): obj is PreferenceSchemaProperties {
         return !!obj && typeof obj === 'object';
     }
 }

--- a/packages/core/src/common/preferences/preference-scope.spec.ts
+++ b/packages/core/src/common/preferences/preference-scope.spec.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2022 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { PreferenceScope } from './preference-scope';
+
+describe('PreferenceScope', () => {
+
+    it('getScopes() should return numbers from broadest to narrowest', () => {
+        expect(PreferenceScope.getScopes()).deep.equal([0, 1, 2, 3]);
+    });
+
+    it('getReversedScopes() should return numbers from narrowest to broadest', () => {
+        expect(PreferenceScope.getReversedScopes()).deep.equal([3, 2, 1, 0]);
+    });
+
+    it('getScopeNames() should return the names of scopes broader than the current one', () => {
+        expect(PreferenceScope.getScopeNames(PreferenceScope.Workspace)).deep.equal(['Default', 'User', 'Workspace']);
+    });
+
+    it('is() returns whether a value is a preference scope', () => {
+        /* eslint-disable no-unused-expressions */
+        expect(PreferenceScope.is(PreferenceScope.Default)).to.be.true;
+        expect(PreferenceScope.is(PreferenceScope.User)).to.be.true;
+        expect(PreferenceScope.is(PreferenceScope.Workspace)).to.be.true;
+        expect(PreferenceScope.is(PreferenceScope.Folder)).to.be.true;
+        expect(PreferenceScope.is(0)).to.be.true;
+        expect(PreferenceScope.is(1)).to.be.true;
+        expect(PreferenceScope.is(2)).to.be.true;
+        expect(PreferenceScope.is(3)).to.be.true;
+        expect(PreferenceScope.is(4)).to.be.false;
+        expect(PreferenceScope.is(-1)).to.be.false;
+        expect(PreferenceScope.is({})).to.be.false;
+        expect(PreferenceScope.is('Default')).to.be.false;
+        /* eslint-enable no-unused-expressions */
+    });
+});

--- a/packages/core/src/common/preferences/preference-scope.ts
+++ b/packages/core/src/common/preferences/preference-scope.ts
@@ -14,8 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 export enum PreferenceScope {
     Default,
     User,
@@ -24,17 +22,15 @@ export enum PreferenceScope {
 }
 
 export namespace PreferenceScope {
-    export function is(scope: any): scope is PreferenceScope {
-        return typeof scope === 'number' && getScopes().findIndex(s => s === scope) >= 0;
+    export function is(scope: unknown): scope is PreferenceScope {
+        return typeof scope === 'number' && getScopes().includes(scope);
     }
 
     /**
      * @returns preference scopes from broadest to narrowest: Default -> Folder.
      */
     export function getScopes(): PreferenceScope[] {
-        return Object.keys(PreferenceScope)
-            .filter(k => typeof PreferenceScope[k as any] === 'string')
-            .map(v => <PreferenceScope>Number(v));
+        return Object.values(PreferenceScope).filter(nameOrIndex => !isNaN(Number(nameOrIndex))) as PreferenceScope[];
     }
 
     /**
@@ -46,12 +42,11 @@ export namespace PreferenceScope {
 
     export function getScopeNames(scope?: PreferenceScope): string[] {
         const names: string[] = [];
-        const allNames = Object.keys(PreferenceScope)
-            .filter(k => typeof PreferenceScope[k as any] === 'number');
+        const scopes = getScopes();
         if (scope) {
-            for (const name of allNames) {
-                if ((<any>PreferenceScope)[name] <= scope) {
-                    names.push(name);
+            for (const scopeIndex of scopes) {
+                if (scopeIndex <= scope) {
+                    names.push(PreferenceScope[scopeIndex]);
                 }
             }
         }

--- a/packages/core/src/common/promise-util.ts
+++ b/packages/core/src/common/promise-util.ts
@@ -124,3 +124,7 @@ export function waitForEvent<T>(event: Event<T>, ms: number, thisArg?: any, disp
 
     });
 }
+
+export function isThenable<T>(obj: unknown): obj is Promise<T> {
+    return typeof obj === 'object' && !!obj && typeof (obj as Promise<unknown>).then === 'function';
+}

--- a/packages/core/src/common/selection.ts
+++ b/packages/core/src/common/selection.ts
@@ -22,12 +22,11 @@ export interface UriSelection {
 
 export namespace UriSelection {
 
-    export function is(arg: Object | undefined): arg is UriSelection {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return typeof arg === 'object' && ('uri' in arg) && (<any>arg)['uri'] instanceof URI;
+    export function is(arg: unknown): arg is UriSelection {
+        return !!arg && typeof arg === 'object' && ('uri' in arg) && (arg as UriSelection).uri instanceof URI;
     }
 
-    export function getUri(selection: Object | undefined): URI | undefined {
+    export function getUri(selection: unknown): URI | undefined {
         if (is(selection)) {
             return selection.uri;
         }
@@ -37,7 +36,7 @@ export namespace UriSelection {
         return undefined;
     }
 
-    export function getUris(selection: Object | undefined): URI[] {
+    export function getUris(selection: unknown): URI[] {
         if (is(selection)) {
             return [selection.uri];
         }

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -56,7 +56,7 @@ export interface DebugConfiguration {
      * The data is sent as the 'restart' attribute of the 'terminated' event.
      * The client should leave the data intact.
      */
-    __restart?: any;
+    __restart?: boolean;
 
     /** default: neverOpen */
     openDebug?: 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart' | 'openOnDebugBreak';
@@ -71,7 +71,7 @@ export interface DebugConfiguration {
     postDebugTask?: string | TaskIdentifier;
 }
 export namespace DebugConfiguration {
-    export function is(arg: DebugConfiguration | any): arg is DebugConfiguration {
+    export function is(arg: unknown): arg is DebugConfiguration {
         return !!arg && typeof arg === 'object' && 'type' in arg && 'name' in arg && 'request' in arg;
     }
 }

--- a/packages/debug/src/node/debug-adapter-factory.ts
+++ b/packages/debug/src/node/debug-adapter-factory.ts
@@ -66,9 +66,8 @@ export class LaunchBasedDebugAdapterFactory implements DebugAdapterFactory {
     }
 
     private childProcess(executable: DebugAdapterExecutable): RawProcess {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const isForkOptions = (forkOptions: RawForkOptions | any): forkOptions is RawForkOptions =>
-            !!forkOptions && !!forkOptions.modulePath;
+        const isForkOptions = (forkOptions: unknown): forkOptions is RawForkOptions =>
+            !!forkOptions && typeof forkOptions === 'object' && 'modulePath' in forkOptions;
 
         const processOptions: RawProcessOptions | RawForkOptions = { ...executable };
         const options: { stdio: (string | number)[], env?: object, execArgv?: string[] } = { stdio: ['pipe', 'pipe', 2] };

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -331,9 +331,8 @@ export interface ReplaceOperation {
 }
 
 export namespace TextEditorSelection {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(e: any): e is TextEditorSelection {
-        return e && e['uri'] instanceof URI;
+    export function is(e: unknown): e is TextEditorSelection {
+        return !!e && typeof e === 'object' && (e as TextEditorSelection).uri instanceof URI;
     }
 }
 

--- a/packages/filesystem/src/browser/file-selection.ts
+++ b/packages/filesystem/src/browser/file-selection.ts
@@ -22,8 +22,8 @@ export interface FileSelection {
     fileStat: FileStat
 }
 export namespace FileSelection {
-    export function is(arg: Object | undefined): arg is FileSelection {
-        return typeof arg === 'object' && ('fileStat' in arg) && FileStat.is(arg['fileStat']);
+    export function is(arg: unknown): arg is FileSelection {
+        return !!arg && typeof arg === 'object' && ('fileStat' in arg) && FileStat.is((arg as FileSelection).fileStat);
     }
     export class CommandHandler extends SelectionCommandHandler<FileSelection> {
 

--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -101,8 +101,8 @@ export class FileTree extends TreeImpl {
 export interface FileStatNode extends SelectableTreeNode, Mutable<UriSelection>, FileSelection {
 }
 export namespace FileStatNode {
-    export function is(node: object | undefined): node is FileStatNode {
-        return !!node && 'fileStat' in node;
+    export function is(node: unknown): node is FileStatNode {
+        return !!node && typeof node === 'object' && 'fileStat' in node;
     }
 
     export function getUri(node: TreeNode | undefined): string | undefined {
@@ -119,21 +119,21 @@ export type FileStatNodeData = Omit<FileStatNode, 'uri' | 'fileStat'> & {
     fileStat?: FileStat
 };
 export namespace FileStatNodeData {
-    export function is(node: object | undefined): node is FileStatNodeData {
-        return !!node && 'uri' in node && ('fileStat' in node || 'stat' in node);
+    export function is(node: unknown): node is FileStatNodeData {
+        return !!node && typeof node === 'object' && 'uri' in node && ('fileStat' in node || 'stat' in node);
     }
 }
 
 export type FileNode = FileStatNode;
 export namespace FileNode {
-    export function is(node: Object | undefined): node is FileNode {
+    export function is(node: unknown): node is FileNode {
         return FileStatNode.is(node) && !node.fileStat.isDirectory;
     }
 }
 
 export type DirNode = FileStatNode & ExpandableTreeNode;
 export namespace DirNode {
-    export function is(node: Object | undefined): node is DirNode {
+    export function is(node: unknown): node is DirNode {
         return FileStatNode.is(node) && node.fileStat.isDirectory;
     }
 

--- a/packages/filesystem/src/common/download/file-download-data.ts
+++ b/packages/filesystem/src/common/download/file-download-data.ts
@@ -19,7 +19,7 @@ export interface FileDownloadData {
 }
 
 export namespace FileDownloadData {
-    export function is(arg: Object | undefined): arg is FileDownloadData {
-        return !!arg && 'uris' in arg;
+    export function is(arg: unknown): arg is FileDownloadData {
+        return !!arg && typeof arg === 'object' && 'uris' in arg;
     }
 }

--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -200,11 +200,10 @@ export interface BaseStat {
     etag?: string;
 }
 export namespace BaseStat {
-    export function is(arg: Object | undefined): arg is BaseStat {
+    export function is(arg: unknown): arg is BaseStat {
         return !!arg && typeof arg === 'object'
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            && ('resource' in arg && <any>arg['resource'] instanceof URI)
-            && ('name' in arg && typeof arg['name'] === 'string');
+            && ('resource' in arg && (arg as BaseStat).resource instanceof URI)
+            && ('name' in arg && typeof (arg as BaseStat).name === 'string');
     }
 }
 
@@ -241,11 +240,12 @@ export interface FileStat extends BaseStat {
     children?: FileStat[];
 }
 export namespace FileStat {
-    export function is(arg: Object | undefined): arg is FileStat {
-        return BaseStat.is(arg) &&
-            ('isFile' in arg && typeof arg['isFile'] === 'boolean') &&
-            ('isDirectory' in arg && typeof arg['isDirectory'] === 'boolean') &&
-            ('isSymbolicLink' in arg && typeof arg['isSymbolicLink'] === 'boolean');
+    export function is(arg: unknown): arg is FileStat {
+        const fileStat = arg as FileStat;
+        return BaseStat.is(fileStat) &&
+            ('isFile' in fileStat && typeof fileStat.isFile === 'boolean') &&
+            ('isDirectory' in fileStat && typeof fileStat.isDirectory === 'boolean') &&
+            ('isSymbolicLink' in fileStat && typeof fileStat.isSymbolicLink === 'boolean');
     }
     export function asFileType(stat: FileStat): FileType {
         let res = 0;

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -178,14 +178,12 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
         });
 
         const viewModeEmitter = new Emitter<void>();
-        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        const extractDiffWidget = (widget: any) => {
+        const extractDiffWidget = (widget: unknown) => {
             if (widget instanceof GitDiffWidget) {
                 return widget;
             }
         };
-        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        const extractCommitDetailWidget = (widget: any) => {
+        const extractCommitDetailWidget = (widget: unknown) => {
             const ref = widget ? widget : this.editorManager.currentEditor;
             if (ref instanceof GitCommitDetailWidget) {
                 return ref;

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -28,8 +28,6 @@ import { ScmTreeWidget } from '@theia/scm/lib/browser/scm-tree-widget';
 import { ScmPreferences } from '@theia/scm/lib/browser/scm-preferences';
 import { nls } from '@theia/core';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 export const GIT_DIFF = 'git-diff';
 @injectable()
 export class GitDiffWidget extends BaseWidget implements StatefulWidget {
@@ -135,14 +133,15 @@ export class GitDiffWidget extends BaseWidget implements StatefulWidget {
         this.resourceWidget.goToNextChange();
     }
 
-    storeState(): any {
-        const state: object = {
+    storeState(): object {
+        const state = {
             commitState: this.diffHeaderWidget.storeState(),
             changesTreeState: this.resourceWidget.storeState(),
         };
         return state;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     restoreState(oldState: any): void {
         const { commitState, changesTreeState } = oldState;
         this.diffHeaderWidget.restoreState(commitState);

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -212,8 +212,8 @@ export namespace Repository {
         }
         return repository === repository2;
     }
-    export function is(repository: Object | undefined): repository is Repository {
-        return !!repository && 'localUri' in repository;
+    export function is(repository: unknown): repository is Repository {
+        return !!repository && typeof repository === 'object' && 'localUri' in repository;
     }
     export function relativePath(repository: Repository | URI, uri: URI | string): Path | undefined {
         const repositoryUri = new URI(Repository.is(repository) ? repository.localUri : String(repository));

--- a/packages/git/src/common/git-watcher.ts
+++ b/packages/git/src/common/git-watcher.ts
@@ -47,9 +47,8 @@ export namespace GitStatusChangeEvent {
      * `true` if the argument is a `GitStatusEvent`, otherwise `false`.
      * @param event the argument to check whether it is a Git status change event or not.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(event: any | undefined): event is GitStatusChangeEvent {
-        return !!event && ('source' in event) && ('status' in event);
+    export function is(event: unknown): event is GitStatusChangeEvent {
+        return !!event && typeof event === 'object' && ('source' in event) && ('status' in event);
     }
 
 }

--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -846,56 +846,50 @@ export interface Git extends Disposable {
 }
 
 /**
- * Contains a set of utility functions for [Git](#Git).
+ * Contains a set of utility functions for {@link Git}.
  */
 export namespace GitUtils {
 
     /**
      * `true` if the argument is an option for renaming an existing branch in the repository.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isBranchRename(arg: any | undefined): arg is Git.Options.BranchCommand.Rename {
-        return !!arg && ('newName' in arg);
+    export function isBranchRename(arg: unknown): arg is Git.Options.BranchCommand.Rename {
+        return !!arg && typeof arg === 'object' && ('newName' in arg);
     }
 
     /**
      * `true` if the argument is an option for deleting an existing branch in the repository.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isBranchDelete(arg: any | undefined): arg is Git.Options.BranchCommand.Delete {
-        return !!arg && ('toDelete' in arg);
+    export function isBranchDelete(arg: unknown): arg is Git.Options.BranchCommand.Delete {
+        return !!arg && typeof arg === 'object' && ('toDelete' in arg);
     }
 
     /**
      * `true` if the argument is an option for creating a new branch in the repository.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isBranchCreate(arg: any | undefined): arg is Git.Options.BranchCommand.Create {
-        return !!arg && ('toCreate' in arg);
+    export function isBranchCreate(arg: unknown): arg is Git.Options.BranchCommand.Create {
+        return !!arg && typeof arg === 'object' && ('toCreate' in arg);
     }
 
     /**
      * `true` if the argument is an option for listing the branches in a repository.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isBranchList(arg: any | undefined): arg is Git.Options.BranchCommand.List {
-        return !!arg && ('type' in arg);
+    export function isBranchList(arg: unknown): arg is Git.Options.BranchCommand.List {
+        return !!arg && typeof arg === 'object' && ('type' in arg);
     }
 
     /**
      * `true` if the argument is an option for checking out a new local branch.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isBranchCheckout(arg: any | undefined): arg is Git.Options.Checkout.CheckoutBranch {
-        return !!arg && ('branch' in arg);
+    export function isBranchCheckout(arg: unknown): arg is Git.Options.Checkout.CheckoutBranch {
+        return !!arg && typeof arg === 'object' && ('branch' in arg);
     }
 
     /**
      * `true` if the argument is an option for checking out a working tree file.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isWorkingTreeFileCheckout(arg: any | undefined): arg is Git.Options.Checkout.WorkingTreeFile {
-        return !!arg && ('paths' in arg);
+    export function isWorkingTreeFileCheckout(arg: unknown): arg is Git.Options.Checkout.WorkingTreeFile {
+        return !!arg && typeof arg === 'object' && ('paths' in arg);
     }
 
     /**
@@ -907,13 +901,11 @@ export namespace GitUtils {
      * `true` if the argument is an error indicating the absence of a local Git repository.
      * Otherwise, `false`.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function isRepositoryDoesNotExistError(error: any | undefined): boolean {
+    export function isRepositoryDoesNotExistError(error: unknown): boolean {
         // TODO this is odd here.This piece of code is already implementation specific, so this should go to the Git API.
         // But how can we ensure that the `any` type error is serializable?
         if (error instanceof Error && ('code' in error)) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return (<any>error).code === RepositoryDoesNotExistErrorCode;
+            return (error as { code: string }).code === RepositoryDoesNotExistErrorCode;
         }
         return false;
     }

--- a/packages/markers/src/browser/marker-tree.ts
+++ b/packages/markers/src/browser/marker-tree.ts
@@ -139,7 +139,7 @@ export interface MarkerInfoNode extends UriSelection, SelectableTreeNode, Expand
     severity?: DiagnosticSeverity;
 }
 export namespace MarkerInfoNode {
-    export function is(node: Object | undefined): node is MarkerInfoNode {
+    export function is(node: unknown): node is MarkerInfoNode {
         return ExpandableTreeNode.is(node) && UriSelection.is(node) && 'numberOfMarkers' in node;
     }
 }

--- a/packages/markers/src/browser/problem/problem-selection.ts
+++ b/packages/markers/src/browser/problem/problem-selection.ts
@@ -23,8 +23,8 @@ export interface ProblemSelection {
     marker: Marker<object>;
 }
 export namespace ProblemSelection {
-    export function is(arg: Object | undefined): arg is ProblemSelection {
-        return typeof arg === 'object' && ('marker' in arg) && ProblemMarker.is(arg['marker']);
+    export function is(arg: unknown): arg is ProblemSelection {
+        return !!arg && typeof arg === 'object' && ('marker' in arg) && ProblemMarker.is((arg as ProblemSelection).marker);
     }
 
     export class CommandHandler extends SelectionCommandHandler<ProblemSelection> {

--- a/packages/monaco/src/browser/monaco-indexed-db.ts
+++ b/packages/monaco/src/browser/monaco-indexed-db.ts
@@ -44,7 +44,7 @@ export interface MonacoThemeState {
     data: ThemeMix
 }
 export namespace MonacoThemeState {
-    export function is(state: Object | undefined): state is MonacoThemeState {
+    export function is(state: unknown): state is MonacoThemeState {
         return !!state && typeof state === 'object' && 'id' in state && 'label' in state && 'uiTheme' in state && 'data' in state;
     }
 }

--- a/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
+++ b/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
@@ -249,8 +249,8 @@ export interface JsonSerializedSnippet {
     description: string;
 }
 export namespace JsonSerializedSnippet {
-    export function is(obj: Object | undefined): obj is JsonSerializedSnippet {
-        return typeof obj === 'object' && 'body' in obj && 'prefix' in obj;
+    export function is(obj: unknown): obj is JsonSerializedSnippet {
+        return !!obj && typeof obj === 'object' && 'body' in obj && 'prefix' in obj;
     }
 }
 

--- a/packages/navigator/src/browser/navigator-tree.ts
+++ b/packages/navigator/src/browser/navigator-tree.ts
@@ -113,7 +113,7 @@ export interface WorkspaceRootNode extends DirNode {
 }
 export namespace WorkspaceRootNode {
 
-    export function is(node: Object | undefined): node is WorkspaceRootNode {
+    export function is(node: unknown): node is WorkspaceRootNode {
         return DirNode.is(node) && WorkspaceNode.is(node.parent);
     }
 

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-tree-model.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-tree-model.ts
@@ -38,7 +38,7 @@ export interface OpenEditorNode extends FileStatNode {
 };
 
 export namespace OpenEditorNode {
-    export function is(node: object | undefined): node is OpenEditorNode {
+    export function is(node: unknown): node is OpenEditorNode {
         return FileStatNode.is(node) && 'widget' in node;
     }
 }

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -734,7 +734,7 @@ export interface TreeViewSelection {
     treeItemId: string
 }
 export namespace TreeViewSelection {
-    export function is(arg: Object | any): arg is TreeViewSelection {
+    export function is(arg: unknown): arg is TreeViewSelection {
         return !!arg && typeof arg === 'object' && 'treeViewId' in arg && 'treeItemId' in arg;
     }
 }
@@ -780,7 +780,7 @@ export interface ScmCommandArg {
     resourceStateHandle?: number
 }
 export namespace ScmCommandArg {
-    export function is(arg: Object | undefined): arg is ScmCommandArg {
+    export function is(arg: unknown): arg is ScmCommandArg {
         return !!arg && typeof arg === 'object' && 'sourceControlHandle' in arg;
     }
 }
@@ -796,7 +796,7 @@ export interface ScmExt {
 }
 
 export namespace TimelineCommandArg {
-    export function is(arg: Object | undefined): arg is TimelineCommandArg {
+    export function is(arg: unknown): arg is TimelineCommandArg {
         return !!arg && typeof arg === 'object' && 'timelineHandle' in arg;
     }
 }
@@ -815,7 +815,7 @@ export type DecorationData = [boolean, string, string, ThemeColor];
 export interface DecorationReply { [id: number]: DecorationData; }
 
 export namespace CommentsCommandArg {
-    export function is(arg: Object | undefined): arg is CommentsCommandArg {
+    export function is(arg: unknown): arg is CommentsCommandArg {
         return !!arg && typeof arg === 'object' && 'commentControlHandle' in arg && 'commentThreadHandle' in arg && 'text' in arg && !('commentUniqueId' in arg);
     }
 }
@@ -826,7 +826,7 @@ export interface CommentsCommandArg {
 }
 
 export namespace CommentsContextCommandArg {
-    export function is(arg: Object | undefined): arg is CommentsContextCommandArg {
+    export function is(arg: unknown): arg is CommentsContextCommandArg {
         return !!arg && typeof arg === 'object' && 'commentControlHandle' in arg && 'commentThreadHandle' in arg && 'commentUniqueId' in arg && !('text' in arg);
     }
 }
@@ -837,7 +837,7 @@ export interface CommentsContextCommandArg {
 }
 
 export namespace CommentsEditCommandArg {
-    export function is(arg: Object | undefined): arg is CommentsEditCommandArg {
+    export function is(arg: unknown): arg is CommentsEditCommandArg {
         return !!arg && typeof arg === 'object' && 'commentControlHandle' in arg && 'commentThreadHandle' in arg && 'commentUniqueId' in arg && 'text' in arg;
     }
 }

--- a/packages/plugin-ext/src/common/rpc-protocol.ts
+++ b/packages/plugin-ext/src/common/rpc-protocol.ts
@@ -70,9 +70,8 @@ export namespace ConnectionClosedError {
     export function create(message: string = 'connection is closed'): ConnectionClosedError {
         return Object.assign(new Error(message), { code });
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(error: any): error is ConnectionClosedError {
-        return !!error && typeof error === 'object' && 'code' in error && error['code'] === code;
+    export function is(error: unknown): error is ConnectionClosedError {
+        return !!error && typeof error === 'object' && 'code' in error && (error as ConnectionClosedError).code === code;
     }
 }
 
@@ -469,8 +468,9 @@ enum SerializedObjectType {
     TEXT_BUFFER
 }
 
-function isSerializedObject(obj: any): obj is SerializedObject {
-    return obj && obj.$type !== undefined && obj.data !== undefined;
+function isSerializedObject(obj: unknown): obj is SerializedObject {
+    const serializedObject = obj as SerializedObject;
+    return !!obj && typeof obj === 'object' && serializedObject.$type !== undefined && serializedObject.data !== undefined;
 }
 
 export const enum MessageType {

--- a/packages/plugin-ext/src/main/browser/view/tree-view-decorator-service.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-decorator-service.ts
@@ -32,9 +32,9 @@ export class TreeViewDecoratorAdapter extends FileTreeDecoratorAdapter {
         }
     }
 
-    protected isTreeItem(node: object | undefined): node is TreeItem & { resourceUri: Uri } {
+    protected isTreeItem(node: unknown): node is TreeItem & { resourceUri: Uri } {
         const candidate = node as TreeItem;
-        return !!candidate && 'resourceUri' in candidate && !!candidate.resourceUri;
+        return !!candidate && typeof node === 'object' && 'resourceUri' in candidate && !!candidate.resourceUri;
     }
 }
 

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -145,20 +145,17 @@ export class CodeActionAdapter {
         return this.cacheId++;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private static _isCommand(smth: any): smth is theia.Command {
-        return typeof (<theia.Command>smth).command === 'string';
+    private static _isCommand(arg: unknown): arg is theia.Command {
+        return !!arg && typeof arg === 'object' && typeof (arg as theia.Command).command === 'string';
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private static _isSelection(obj: any): obj is Selection {
-        return (
-            obj
-            && (typeof obj.selectionStartLineNumber === 'number')
-            && (typeof obj.selectionStartColumn === 'number')
-            && (typeof obj.positionLineNumber === 'number')
-            && (typeof obj.positionColumn === 'number')
-        );
+    private static _isSelection(obj: unknown): obj is Selection {
+        const selection = obj as Selection;
+        return !!obj && typeof obj === 'object'
+            && typeof selection.selectionStartLineNumber === 'number'
+            && typeof selection.selectionStartColumn === 'number'
+            && typeof selection.positionLineNumber === 'number'
+            && typeof selection.positionColumn === 'number';
     }
 
 }

--- a/packages/plugin-ext/src/plugin/languages/document-highlight.ts
+++ b/packages/plugin-ext/src/plugin/languages/document-highlight.ts
@@ -55,8 +55,7 @@ export class DocumentHighlightAdapter {
         });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private isDocumentHighlightArray(array: any): array is types.DocumentHighlight[] {
+    private isDocumentHighlightArray(array: unknown): array is types.DocumentHighlight[] {
         return Array.isArray(array) && array.length > 0 && array[0] instanceof types.DocumentHighlight;
     }
 }

--- a/packages/plugin-ext/src/plugin/languages/util.ts
+++ b/packages/plugin-ext/src/plugin/languages/util.ts
@@ -17,12 +17,10 @@
 import * as theia from '@theia/plugin';
 import * as types from '../types-impl';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isLocationArray(array: any): array is types.Location[] {
+export function isLocationArray(array: unknown): array is types.Location[] {
     return Array.isArray(array) && array.length > 0 && array[0] instanceof types.Location;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isDefinitionLinkArray(array: any): array is theia.DefinitionLink[] {
+export function isDefinitionLinkArray(array: unknown): array is theia.DefinitionLink[] {
     return Array.isArray(array) && array.length > 0 && array[0].hasOwnProperty('targetUri') && array[0].hasOwnProperty('targetRange');
 }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -137,9 +137,8 @@ export function toPosition(position: Position): types.Position {
     return new types.Position(position.lineNumber - 1, position.column - 1);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isDecorationOptions(something: any): something is theia.DecorationOptions {
-    return (typeof something.range !== 'undefined');
+function isDecorationOptions(arg: unknown): arg is theia.DecorationOptions {
+    return !!arg && typeof arg === 'object' && typeof (arg as theia.DecorationOptions).range !== 'undefined';
 }
 
 export function isDecorationOptionsArr(something: theia.Range[] | theia.DecorationOptions[]): something is theia.DecorationOptions[] {
@@ -182,11 +181,10 @@ interface Codeblock {
     value: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isCodeblock(thing: any): thing is Codeblock {
-    return thing && typeof thing === 'object'
-        && typeof (<Codeblock>thing).language === 'string'
-        && typeof (<Codeblock>thing).value === 'string';
+function isCodeblock(arg: unknown): arg is Codeblock {
+    return !!arg && typeof arg === 'object'
+        && typeof (arg as Codeblock).language === 'string'
+        && typeof (arg as Codeblock).value === 'string';
 }
 
 export function fromMarkdown(markup: theia.MarkdownString | theia.MarkedString): MarkdownStringDTO {
@@ -625,64 +623,58 @@ export function toSymbolTag(kind: model.SymbolTag): types.SymbolTag {
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isModelLocation(thing: any): thing is model.Location {
-    if (!thing) {
+export function isModelLocation(arg: unknown): arg is model.Location {
+    if (!arg) {
         return false;
     }
-    return isModelRange((<model.Location>thing).range) &&
-        isUriComponents((<model.Location>thing).uri);
+    return !!arg &&
+        typeof arg === 'object' &&
+        isModelRange((arg as model.Location).range) &&
+        isUriComponents((arg as model.Location).uri);
+}
+
+export function isModelRange(arg: unknown): arg is model.Range {
+    const range = arg as model.Range;
+    return !!arg && typeof arg === 'object' &&
+        typeof range.startLineNumber === 'number' &&
+        typeof range.startColumn === 'number' &&
+        typeof range.endLineNumber === 'number' &&
+        typeof range.endColumn === 'number';
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isModelRange(thing: any): thing is model.Range {
-    if (!thing) {
-        return false;
-    }
-    return (('startLineNumber' in thing) && typeof thing.startLineNumber === 'number') &&
-        (('startColumn' in thing) && typeof thing.startColumn === 'number') &&
-        (('endLineNumber' in thing) && typeof thing.endLineNumber === 'number') &&
-        (('endColumn' in thing) && typeof thing.endColumn === 'number');
+export function isUriComponents(arg: unknown): arg is UriComponents {
+    const uriComponents = arg as UriComponents;
+    return !!arg && typeof arg === 'object' &&
+        typeof uriComponents.scheme === 'string' &&
+        typeof uriComponents.path === 'string' &&
+        typeof uriComponents.query === 'string' &&
+        typeof uriComponents.fragment === 'string';
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isUriComponents(thing: any): thing is UriComponents {
-    if (!thing) {
-        return false;
-    }
-    return (('scheme' in thing) && typeof thing.scheme === 'string') &&
-        (('path' in thing) && typeof thing.path === 'string') &&
-        (('query' in thing) && typeof thing.query === 'string') &&
-        (('fragment' in thing) && typeof thing.fragment === 'string');
+export function isModelCallHierarchyItem(arg: unknown): arg is model.CallHierarchyItem {
+    const item = arg as model.CallHierarchyItem;
+    return !!item && typeof item === 'object'
+        && isModelRange(item.range)
+        && isModelRange(item.selectionRange)
+        && isUriComponents(item.uri)
+        && !!item.name;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isModelCallHierarchyItem(thing: any): thing is model.CallHierarchyItem {
-    if (!thing) {
-        return false;
-    }
-    return isModelRange(thing.range)
-        && isModelRange(thing.selectionRange)
-        && isUriComponents(thing.uri)
-        && !!thing.name;
+export function isModelCallHierarchyIncomingCall(arg: unknown): arg is model.CallHierarchyIncomingCall {
+    const maybeIncomingCall = arg as model.CallHierarchyIncomingCall;
+    return !!arg && typeof arg === 'object' &&
+        'from' in maybeIncomingCall &&
+        'fromRanges' in maybeIncomingCall &&
+        isModelCallHierarchyItem(maybeIncomingCall.from);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isModelCallHierarchyIncomingCall(thing: any): thing is model.CallHierarchyIncomingCall {
-    if (!thing) {
-        return false;
-    }
-    const maybeIncomingCall = thing as model.CallHierarchyIncomingCall;
-    return 'from' in maybeIncomingCall && 'fromRanges' in maybeIncomingCall && isModelCallHierarchyItem(maybeIncomingCall.from);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isModelCallHierarchyOutgoingCall(thing: any): thing is model.CallHierarchyOutgoingCall {
-    if (!thing) {
-        return false;
-    }
-    const maybeOutgoingCall = thing as model.CallHierarchyOutgoingCall;
-    return 'to' in maybeOutgoingCall && 'fromRanges' in maybeOutgoingCall && isModelCallHierarchyItem(maybeOutgoingCall.to);
+export function isModelCallHierarchyOutgoingCall(arg: unknown): arg is model.CallHierarchyOutgoingCall {
+    const maybeOutgoingCall = arg as model.CallHierarchyOutgoingCall;
+    return !!arg && typeof arg === 'object' &&
+        'to' in maybeOutgoingCall &&
+        'fromRanges' in maybeOutgoingCall &&
+        isModelCallHierarchyItem(maybeOutgoingCall.to);
 }
 
 export function toLocation(value: model.Location): types.Location {

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -20,7 +20,6 @@
 *--------------------------------------------------------------------------------------------*/
 
 /* eslint-disable no-null/no-null */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { UUID } from '@theia/core/shared/@phosphor/coreutils';
 import { illegalArgument } from '../common/errors';
@@ -38,6 +37,7 @@ import { es5ClassCompat } from '../common/types';
  * A reviver that takes URI's transferred via JSON.stringify() and makes
  * instances of our local plugin API URI class (below)
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function reviver(key: string | undefined, value: any): any {
     const revived = ObjectsTransferrer.reviver(key, value);
     if (CodeURI.isUri(revived)) {
@@ -423,7 +423,7 @@ export class Position {
         return false;
     }
 
-    toJSON(): any {
+    toJSON(): unknown {
         return { line: this.line, character: this.character };
     }
 }
@@ -546,19 +546,17 @@ export class Range {
         return new Range(start, end);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    static isRange(thing: any): thing is theia.Range {
+    static isRange(thing: unknown): thing is theia.Range {
         if (thing instanceof Range) {
             return true;
         }
-        if (!thing) {
-            return false;
-        }
-        return Position.isPosition((<Range>thing).start)
-            && Position.isPosition((<Range>thing).end);
+        const range = thing as theia.Range;
+        return !!thing && typeof thing === 'object'
+            && Position.isPosition(range.start)
+            && Position.isPosition(range.end);
     }
 
-    toJSON(): any {
+    toJSON(): unknown {
         return [this.start, this.end];
     }
 }
@@ -1636,8 +1634,8 @@ export class FileSystemError extends Error {
 
         // workaround when extending builtin objects and when compiling to ES5, see:
         // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
-        if (typeof (<any>Object).setPrototypeOf === 'function') {
-            (<any>Object).setPrototypeOf(this, FileSystemError.prototype);
+        if (typeof Object.setPrototypeOf === 'function') {
+            Object.setPrototypeOf(this, FileSystemError.prototype);
         }
 
         if (typeof Error.captureStackTrace === 'function' && typeof terminator === 'function') {
@@ -2555,7 +2553,7 @@ export class SemanticTokensLegend {
     }
 }
 
-function isStrArrayOrUndefined(arg: any): arg is string[] | undefined {
+function isStrArrayOrUndefined(arg: unknown): arg is string[] | undefined {
     return ((typeof arg === 'undefined') || (Array.isArray(arg) && arg.every(e => typeof e === 'string')));
 }
 
@@ -2593,7 +2591,7 @@ export class SemanticTokensBuilder {
 
     public push(line: number, char: number, length: number, tokenType: number, tokenModifiers?: number): void;
     public push(range: Range, tokenType: string, tokenModifiers?: string[]): void;
-    public push(arg0: any, arg1: any, arg2: any, arg3?: any, arg4?: any): void {
+    public push(arg0: number | Range, arg1: number | string, arg2?: number | string[], arg3?: number, arg4?: number): void {
         if (typeof arg0 === 'number' && typeof arg1 === 'number' && typeof arg2 === 'number' && typeof arg3 === 'number' &&
             (typeof arg4 === 'number' || typeof arg4 === 'undefined')) {
             if (typeof arg4 === 'undefined') {

--- a/packages/preferences/src/browser/views/components/preference-file-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-file-input.ts
@@ -30,9 +30,8 @@ export interface FileNodeTypeDetails {
 }
 
 export namespace FileNodeTypeDetails {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(typeDetails?: any): typeDetails is FileNodeTypeDetails {
-        return !!typeDetails && !!typeDetails.isFilepath;
+    export function is(typeDetails?: unknown): typeDetails is FileNodeTypeDetails {
+        return !!typeDetails && typeof typeDetails === 'object' && !!(typeDetails as FileNodeTypeDetails).isFilepath;
     }
 }
 

--- a/packages/preview/src/browser/preview-handler.ts
+++ b/packages/preview/src/browser/preview-handler.ts
@@ -35,8 +35,8 @@ export interface RenderContentParams {
 }
 
 export namespace RenderContentParams {
-    export function is(params: object | undefined): params is RenderContentParams {
-        return !!params && 'content' in params && 'originUri' in params;
+    export function is(params: unknown): params is RenderContentParams {
+        return !!params && typeof params === 'object' && 'content' in params && 'originUri' in params;
     }
 }
 

--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -192,9 +192,8 @@ export abstract class Process {
         this.logger.error(error);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected isForkOptions(options: any): options is ForkOptions {
-        return !!options && !!options.modulePath;
+    protected isForkOptions(options: unknown): options is ForkOptions {
+        return !!options && typeof options === 'object' && !!(options as ForkOptions).modulePath;
     }
 
     protected readonly initialCwd: string;

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-items.ts
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-items.ts
@@ -22,7 +22,7 @@ export interface ResourcePropertiesRoot extends CompositeTreeNode {
     children: ResourcePropertiesCategoryNode[];
 }
 export namespace ResourcePropertiesRoot {
-    export function is(node: Object | undefined): node is ResourcePropertiesRoot {
+    export function is(node: unknown): node is ResourcePropertiesRoot {
         return CompositeTreeNode.is(node) && node.id === ROOT_ID;
     }
 }

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -46,9 +46,8 @@ export interface ScmCommitNode {
 }
 
 export namespace ScmCommitNode {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(node: any): node is ScmCommitNode {
-        return !!node && 'commitDetails' in node && 'expanded' in node && 'selected' in node;
+    export function is(node: unknown): node is ScmCommitNode {
+        return !!node && typeof node === 'object' && 'commitDetails' in node && 'expanded' in node && 'selected' in node;
     }
 }
 

--- a/packages/scm-extra/src/browser/scm-file-change-node.ts
+++ b/packages/scm-extra/src/browser/scm-file-change-node.ts
@@ -23,8 +23,8 @@ export interface ScmFileChangeNode {
     selected?: boolean;
 }
 export namespace ScmFileChangeNode {
-    export function is(node: Object | undefined): node is ScmFileChangeNode {
-        return !!node && 'fileChange' in node && 'commitId' in node;
+    export function is(node: unknown): node is ScmFileChangeNode {
+        return !!node && typeof node === 'object' && 'fileChange' in node && 'commitId' in node;
     }
 }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -59,8 +59,7 @@ export interface SearchInWorkspaceRoot extends CompositeTreeNode {
     children: SearchInWorkspaceRootFolderNode[];
 }
 export namespace SearchInWorkspaceRoot {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(node: any): node is SearchInWorkspaceRoot {
+    export function is(node: unknown): node is SearchInWorkspaceRoot {
         return CompositeTreeNode.is(node) && node.id === ROOT_ID;
     }
 }
@@ -74,8 +73,7 @@ export interface SearchInWorkspaceRootFolderNode extends ExpandableTreeNode, Sel
     uri: URI;
 }
 export namespace SearchInWorkspaceRootFolderNode {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(node: any): node is SearchInWorkspaceRootFolderNode {
+    export function is(node: unknown): node is SearchInWorkspaceRootFolderNode {
         return ExpandableTreeNode.is(node) && SelectableTreeNode.is(node) && 'path' in node && 'folderUri' in node && !('fileUri' in node);
     }
 }
@@ -90,8 +88,7 @@ export interface SearchInWorkspaceFileNode extends ExpandableTreeNode, Selectabl
     uri: URI;
 }
 export namespace SearchInWorkspaceFileNode {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(node: any): node is SearchInWorkspaceFileNode {
+    export function is(node: unknown): node is SearchInWorkspaceFileNode {
         return ExpandableTreeNode.is(node) && SelectableTreeNode.is(node) && 'path' in node && 'fileUri' in node && !('folderUri' in node);
     }
 }
@@ -100,8 +97,7 @@ export interface SearchInWorkspaceResultLineNode extends SelectableTreeNode, Sea
     parent: SearchInWorkspaceFileNode
 }
 export namespace SearchInWorkspaceResultLineNode {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(node: any): node is SearchInWorkspaceResultLineNode {
+    export function is(node: unknown): node is SearchInWorkspaceResultLineNode {
         return SelectableTreeNode.is(node) && 'line' in node && 'character' in node && 'lineText' in node;
     }
 }

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -244,8 +244,7 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             TaskCommands.TASK_RUN_BUILD,
             {
                 isEnabled: () => this.workspaceService.opened,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                execute: (...args: any[]) =>
+                execute: () =>
                     this.quickOpenTask.runBuildOrTestTask('build')
             }
         );
@@ -253,8 +252,7 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             TaskCommands.TASK_RUN_TEST,
             {
                 isEnabled: () => this.workspaceService.opened,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                execute: (...args: any[]) =>
+                execute: () =>
                     this.quickOpenTask.runBuildOrTestTask('test')
             }
         );

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -191,8 +191,7 @@ export type CursorStyleVSCode = CursorStyle | 'line';
 export type TerminalRendererType = 'canvas' | 'dom';
 export type ConfirmOnExitType = 'never' | 'always' | 'hasChildProcesses';
 export const DEFAULT_TERMINAL_RENDERER_TYPE = 'canvas';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isTerminalRendererType(arg: any): arg is TerminalRendererType {
+export function isTerminalRendererType(arg: unknown): arg is TerminalRendererType {
     return typeof arg === 'string' && (arg === 'canvas' || arg === 'dom');
 }
 

--- a/packages/typehierarchy/src/browser/tree/typehierarchy-tree.ts
+++ b/packages/typehierarchy/src/browser/tree/typehierarchy-tree.ts
@@ -97,8 +97,7 @@ export namespace TypeHierarchyTree {
 
         export function is(node: TreeNode | undefined): node is RootNode {
             if (Node.is(node) && 'direction' in node) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const { direction } = (node as any);
+                const { direction } = (node as RootNode);
                 return direction === TypeHierarchyDirection.Children || direction === TypeHierarchyDirection.Parents;
             }
             return false;
@@ -122,8 +121,7 @@ export namespace TypeHierarchyTree {
 
         export function is(node: TreeNode | undefined): node is Node {
             if (!!node && 'resolved' in node && 'item' in node) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const { resolved, item } = (node as any);
+                const { resolved, item } = (node as Node);
                 return typeof resolved === 'boolean' && !!item;
             }
             return false;

--- a/packages/workspace/src/browser/workspace-schema-updater.ts
+++ b/packages/workspace/src/browser/workspace-schema-updater.ts
@@ -114,13 +114,12 @@ export class WorkspaceSchemaUpdater implements JsonSchemaContribution {
 export type WorkspaceSchema = Required<Pick<IJSONSchema, 'properties' | 'required'>>;
 
 export namespace WorkspaceSchema {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export const is = (candidate: any): candidate is WorkspaceSchema => !!candidate
+    export const is = (candidate: unknown): candidate is WorkspaceSchema => !!candidate
         && typeof candidate === 'object'
         && 'properties' in candidate
-        && typeof candidate.properties === 'object'
+        && typeof (candidate as WorkspaceSchema).properties === 'object'
         && 'required' in candidate
-        && Array.isArray(candidate.required);
+        && Array.isArray((candidate as WorkspaceSchema).required);
 }
 
 export const workspaceSchemaId = 'vscode://schemas/workspace';

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -713,12 +713,10 @@ export interface WorkspaceData {
 export namespace WorkspaceData {
     const validateSchema = new Ajv().compile(workspaceSchema);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function is(data: any): data is WorkspaceData {
+    export function is(data: unknown): data is WorkspaceData {
         return !!validateSchema(data);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function buildWorkspaceData(folders: string[] | FileStat[], additionalFields?: Partial<WorkspaceData>): WorkspaceData {
         let roots: string[] = [];
         if (folders.length > 0) {

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -231,14 +231,12 @@ namespace RecentWorkspacePathsData {
      *
      * Returns undefined if the given `data` does not contain a `recentRoots` array property.
      */
-    export function create(data: Object | undefined): RecentWorkspacePathsData | undefined {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-null/no-null
-        if (typeof data !== 'object' || data === null || !Array.isArray((data as any)['recentRoots'])) {
+    export function create(data: unknown): RecentWorkspacePathsData | undefined {
+        if (typeof data !== 'object' || !data || !Array.isArray((data as RecentWorkspacePathsData).recentRoots)) {
             return;
         }
         return {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            recentRoots: (data as any)['recentRoots'].filter((root: unknown) => typeof root === 'string')
+            recentRoots: (data as RecentWorkspacePathsData).recentRoots.filter(root => typeof root === 'string')
         };
     }
 }


### PR DESCRIPTION
#### What it does

Removes a lot of `any` and `Object/object` references, cleans up the associated `eslint-disable` comment and replaces each instance with `unknown`, making the functions more robust against possible type-related issues.

#### How to test

1. CI is green and the application continues to work as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
