### PR TITLE
plugin: add support for `InputBoxValidationMessage`

### DIFF
--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -216,7 +216,7 @@ export interface InputOptions {
     placeHolder?: string;
     password?: boolean;
     ignoreFocusLost?: boolean;
-    validateInput?(input: string): Promise<string | null | undefined> | undefined;
+    validateInput?(input: string): Promise<string | { content: string; severity: number; }  | null | undefined> | undefined;
 }
 
 export interface QuickPickItemButtonEvent<T extends QuickPickItemOrSeparator> {

--- a/packages/monaco/src/browser/monaco-color-registry.ts
+++ b/packages/monaco/src/browser/monaco-color-registry.ts
@@ -37,8 +37,11 @@ export class MonacoColorRegistry extends ColorRegistry {
     }
 
     override getCurrentColor(id: string): string | undefined {
-        const color = this.monacoThemeService.getColorTheme().getColor(id);
-        return color?.toString();
+        return this.monacoThemeService.getColorTheme().getColor(id)?.toString();
+    }
+
+    getColor(id: string): MonacoColor | undefined {
+        return this.monacoThemeService.getColorTheme().getColor(id);
     }
 
     protected override doRegister(definition: ColorDefinition): Disposable {

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -278,3 +278,9 @@
   align-self: center;
   margin-right: 4px;
 }
+
+.monaco-inputbox.error > .ibwrapper > .input,
+.monaco-inputbox.warning > .ibwrapper > .input,
+.monaco-inputbox.info > .ibwrapper > .input {
+    outline: 0 !important;
+}

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -424,7 +424,7 @@ export type Item = string | theia.QuickPickItem;
 
 export interface QuickOpenExt {
     $onItemSelected(handle: number): void;
-    $validateInput(input: string): Promise<string | null | undefined> | undefined;
+    $validateInput(input: string): Promise<string | { content: string; severity: Severity; } | null | undefined> | undefined;
 
     $acceptOnDidAccept(sessionId: number): Promise<void>;
     $acceptDidChangeValue(sessionId: number, changedValue: string): Promise<void>;

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -143,7 +143,8 @@ import {
     ExtensionMode,
     LinkedEditingRanges,
     LanguageStatusSeverity,
-    TextDocumentChangeReason
+    TextDocumentChangeReason,
+    InputBoxValidationSeverity
 } from './types-impl';
 import { AuthenticationExtImpl } from './authentication-ext';
 import { SymbolKind } from '../common/plugin-api-rpc-model';
@@ -1056,7 +1057,8 @@ export function createAPIFactory(
             FileDecoration,
             CancellationError,
             ExtensionMode,
-            LinkedEditingRanges
+            LinkedEditingRanges,
+            InputBoxValidationSeverity
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2756,4 +2756,10 @@ export class SemanticTokensEdits {
     }
 }
 
+export enum InputBoxValidationSeverity {
+    Info = 1,
+    Warning = 2,
+    Error = 3
+}
+
 // #endregion

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2354,6 +2354,32 @@ export module '@theia/plugin' {
     }
 
     /**
+     * Impacts the behavior and appearance of the validation message.
+     */
+    export enum InputBoxValidationSeverity {
+        Info = 1,
+        Warning = 2,
+        Error = 3
+    }
+
+    /**
+     * Object to configure the behavior of the validation message.
+     */
+    export interface InputBoxValidationMessage {
+        /**
+         * The validation message to display.
+         */
+        readonly message: string;
+
+        /**
+         * The severity of the validation message.
+         * NOTE: When using `InputBoxValidationSeverity.Error`, the user will not be allowed to accept (hit ENTER) the input.
+         * `Info` and `Warning` will still allow the InputBox to accept the input.
+         */
+        readonly severity: InputBoxValidationSeverity;
+    }
+
+    /**
      * Options to configure the behavior of the input box UI.
      */
     export interface InputBoxOptions {
@@ -2401,10 +2427,10 @@ export module '@theia/plugin' {
          * to the user.
          *
          * @param value The current value of the input box.
-         * @return A human readable string which is presented as diagnostic message.
-         * Return `undefined`, or the empty string when 'value' is valid.
+         * @return Either a human-readable string which is presented as an error message or an {@link InputBoxValidationMessage}
+         *  which can provide a specific message severity. Return `undefined`, `null`, or the empty string when 'value' is valid.
          */
-        validateInput?: (input: string) => Promise<string | null | undefined> | undefined;
+        validateInput?: (input: string) => Promise<string | InputBoxValidationMessage | null | undefined> | undefined;
 
         /**
          * An optional function that will be called on Enter key.
@@ -5058,8 +5084,10 @@ export module '@theia/plugin' {
 
         /**
          * An optional validation message indicating a problem with the current input value.
+         * By returning a string, the InputBox will use a default {@link InputBoxValidationSeverity} of Error.
+         * Returning undefined clears the validation message.
          */
-        validationMessage: string | undefined;
+        validationMessage: string | InputBoxValidationMessage | undefined;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->


#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for `InputBoxValidationMessage` and `InputBoxValidationSeverity`.
The changes now properly set some styling information that Monaco expects based on theming.

![Screen Shot 2022-08-02 at 6 59 26 PM](https://user-images.githubusercontent.com/40359487/182487665-a4305a40-e655-422d-942e-81cc378bd3f3.png)
![Screen Shot 2022-08-02 at 6 59 19 PM](https://user-images.githubusercontent.com/40359487/182487666-22cf24e7-a547-4973-b057-f1cb56ab311c.png)
![Screen Shot 2022-08-02 at 6 59 09 PM](https://user-images.githubusercontent.com/40359487/182487668-10a5e1d8-fc71-4738-b3f3-85aecd33d220.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with the following extension ([vscode-inputbox-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/9237469/vscode-inputbox-0.0.1.vsix.zip)).
2. execute the command `InputBox: Select Number`.
3. confirm that "abc" as input will produce an **error** validation - it should not be possible to accept an error input
4. confirm that 9 as input will produce a **warning** - it should be possible to accept the input
5. confirm that the empty string will produce an **info** - it should be possible to accept the input
6. confirm that the styling of all three validations is correct when themes are changed

7. different values (ex: string, larger than 5) will produce validations which should appear and be styled properly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>