### PR TITLE
vscode: Make `TerminalLink` compatible to VS Code 1.64.2

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3097,7 +3097,7 @@ export module '@theia/plugin' {
     /**
      * A link on a terminal line.
      */
-    export interface TerminalLink {
+    export class TerminalLink {
         /**
          * The start index of the link on [TerminalLinkContext.line](#TerminalLinkContext.line].
          */
@@ -3116,6 +3116,18 @@ export module '@theia/plugin' {
          * depending on OS, user settings, and localization.
          */
         tooltip?: string;
+
+        /**
+         * Creates a new terminal link.
+         * @param startIndex The start index of the link on [TerminalLinkContext.line](#TerminalLinkContext.line].
+         * @param length The length of the link on [TerminalLinkContext.line](#TerminalLinkContext.line].
+         * @param tooltip The tooltip text when you hover over this link.
+         *
+         * If a tooltip is provided, is will be displayed in a string that includes instructions on
+         * how to trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary
+         * depending on OS, user settings, and localization.
+         */
+        constructor(startIndex: number, length: number, tooltip?: string);
     }
 
     /**


### PR DESCRIPTION
#### What it does
Replaces the out-dated definition of the `TerminalLink` interface with the current class that also provides a constructor.

In the course of fixing this, I discovered #11521. So it looks like Theia doesn't support registering `TerminalLinkProvider` at the moment. Anyway, making `TerminalLink` compatible to VS Code will help anyway, but only really gets effective once #11521 is fixed.

Fixes #11507

Contributed on behalf of STMicroelectronics.

#### How to test

There is nothing really to test as `TerminalLink` isn't used in the Theia code base anyway and now its definition is at least equivalent to how it is defined in VS Code `1.64.2`.
Also I tested that this change makes the check in the [`vscode-theia-comparator`](https://github.com/eclipse-theia/vscode-theia-comparator) happy.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
