### PR TITLE
Run automatic translation on `workflow_dispatch`

### DIFF
--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -42,11 +42,20 @@ jobs:
         env:
           DEEPL_API_TOKEN: ${{ secrets.DEEPL_API_TOKEN }}
 
+      - name: Get Actor User Data
+        uses: octokit/request-action@v2.x
+        id: actor_user_data
+        with:
+          route: GET /users/{user}
+          user: ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          commiter: Mark Sujew <mark.sujew@typefox.io>
-          author: Mark Sujew <mark.sujew@typefox.io>
+          commiter: ${{ github.actor }} <${{ fromJson(steps.actor_user_data.outputs.data).email }}>
+          author: ${{ github.actor }} <${{ fromJson(steps.actor_user_data.outputs.data).email }}>
           branch: bot/translation-update
           title: Translation update for version ${{ env.NEXT_VERSION_NUMBER }}
           commit-message: Translation update for version ${{ env.NEXT_VERSION_NUMBER }}

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -1,6 +1,6 @@
 name: Automatic Translation
 
-on: push
+on: workflow_dispatch
 
 jobs:
   translation:
@@ -31,8 +31,24 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
 
+      - id: compute-next-version
+        run: |
+          export THEIA_CORE_VERSION=$(node -p "require(\"./packages/core/package.json\").version")
+          echo "NEXT_VERSION_NUMBER=$(npx -q semver@7 --increment minor $THEIA_CORE_VERSION)" >> $GITHUB_ENV
+
       - name: Perform Automatic Translation
         run: |
           node ./scripts/translation-update.js
         env:
           DEEPL_API_TOKEN: ${{ secrets.DEEPL_API_TOKEN }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commiter: Mark Sujew <mark.sujew@typefox.io>
+          author: Mark Sujew <mark.sujew@typefox.io>
+          branch: bot/translation-update
+          title: Translation update for version ${{ env.NEXT_VERSION_NUMBER }}
+          commit-message: Translation update for version ${{ env.NEXT_VERSION_NUMBER }}
+          body: Automated translation update for Theia version ${{ env.NEXT_VERSION_NUMBER }}. Triggered by @${{ github.actor }}.
+          labels: localization

--- a/doc/Publishing.md
+++ b/doc/Publishing.md
@@ -46,6 +46,7 @@ Here is an [example](https://community.theia-ide.org/t/0-11-0-release/373).
     - Entries should be in the past tense (ex: 'Added support...').
 - Ensure that merged pull-requests for the given release are added to the corresponding release [milestone](https://github.com/eclipse-theia/theia/milestones):
   - Generally, milestones are automatically added on merge however not for forks. It is therefore important to manually add such contributions to the milestone for the time being.
+- Run the [automatic translation workflow](https://github.com/eclipse-theia/theia/actions/workflows/translation.yml) and merge the created pull request if necessary.
 
 
 ## Pre-Publishing Steps

--- a/scripts/translation-update.js
+++ b/scripts/translation-update.js
@@ -7,8 +7,6 @@ if (hasNlsFileChanged()) {
     if (token) {
         console.log('Performing DeepL translation...');
         performDeepLTranslation(token);
-        console.log('Committing and pushing changes...');
-        commitChanges();
         console.log('Translation finished successfully!');
     } else {
         console.log('No DeepL API token found in env');
@@ -47,31 +45,4 @@ function performDeepLTranslation(token) {
     ], {
         shell: true
     });
-}
-
-function commitChanges() {
-    // Set user and email
-    const { author, email } = getLastUserInfo();
-    cp.spawnSync('git', ['config', 'user.name', author]);
-    cp.spawnSync('git', ['config', 'user.email', `<${email}>`]);
-    // Stage everything
-    cp.spawnSync('git', ['add', '-A']);
-    // Commit and push the changes
-    cp.spawnSync('git', ['commit', '-m', 'Automatic translation update']);
-    cp.spawnSync('git', ['push']);
-}
-
-function getLastUserInfo() {
-    const result = cp.spawnSync('git', ['log', '-1']);
-    const lines = result.stdout.toString().split('\n');
-    const authorText = 'Author:';
-    const authorLine = lines.find(line => line.startsWith(authorText)).substring(authorText.length);
-    const emailStart = authorLine.indexOf('<');
-    const emailEnd = authorLine.indexOf('>');
-    const author = authorLine.substring(0, emailStart).trim();
-    const email = authorLine.substring(emailStart + 1, emailEnd).trim();
-    return {
-        author,
-        email
-    }
 }


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/11525

Instead of running on `push` (which only really works in our own repo), we instead create a workflow, which we'll manually start before creating a new release.

#### How to test

After merging this, a new workflow dispatch should be available, which automatically performs the translation update and creates a new PR based on the results. See https://github.com/msujew/theia/pull/7 for an example of how this would look like.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
