### PR TITLE
11442: Use named pipes for inter-process RPC communication

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,7 +59,6 @@
       "args": [
         "--hostname=0.0.0.0",
         "--port=3000",
-        "--no-cluster",
         "--app-project-path=${workspaceFolder}/examples/browser",
         "--plugins=local-dir:plugins",
         "--hosted-plugin-inspect=9339"

--- a/packages/core/src/node/messaging/ipc-bootstrap.ts
+++ b/packages/core/src/node/messaging/ipc-bootstrap.ts
@@ -14,14 +14,22 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import assert = require('assert');
+import { connect } from 'net';
 import 'reflect-metadata';
 import { dynamicRequire } from '../dynamic-require';
 import { IPCChannel } from './ipc-channel';
 import { checkParentAlive, IPCEntryPoint } from './ipc-protocol';
+import { THEIA_IPC_SERVER } from './ipc-server';
 
 checkParentAlive();
 
 const entryPoint = IPCEntryPoint.getScriptFromEnv();
+const ipcServer = process.env[THEIA_IPC_SERVER];
+assert(ipcServer !== undefined, `The env variable ${THEIA_IPC_SERVER} is not set!`);
+delete process.env[THEIA_IPC_SERVER];
+const socket = connect(ipcServer);
+const channel = new IPCChannel(socket);
 
-dynamicRequire<{ default: IPCEntryPoint }>(entryPoint).default(new IPCChannel());
+dynamicRequire<{ default: IPCEntryPoint }>(entryPoint).default(channel);
 

--- a/packages/core/src/node/messaging/ipc-channel.ts
+++ b/packages/core/src/node/messaging/ipc-channel.ts
@@ -16,7 +16,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as cp from 'child_process';
-import { Socket } from 'net';
 import { Duplex } from 'stream';
 import { Channel, ChannelCloseEvent, Disposable, DisposableCollection, Emitter, Event, MessageProvider, WriteBuffer } from '../../common';
 import { Uint8ArrayReadBuffer, Uint8ArrayWriteBuffer } from '../../common/message-rpc/uint8-array-message-buffer';
@@ -49,12 +48,13 @@ export class IPCChannel implements Channel {
 
     protected ipcErrorListener: (error: Error) => void = error => this.onErrorEmitter.fire(error);
 
-    constructor(childProcess?: cp.ChildProcess) {
+    constructor(pipe: Duplex, childProcess?: cp.ChildProcess) {
         if (childProcess) {
             this.setupChildProcess(childProcess);
         } else {
             this.setupProcess();
         }
+        this.messagePipe = new BinaryMessagePipe(pipe);
         this.messagePipe.onMessage(message => {
             this.onMessageEmitter.fire(() => new Uint8ArrayReadBuffer(message));
         });
@@ -63,7 +63,6 @@ export class IPCChannel implements Channel {
 
     protected setupChildProcess(childProcess: cp.ChildProcess): void {
         childProcess.once('exit', code => this.onCloseEmitter.fire({ reason: 'Child process has been terminated', code: code ?? undefined }));
-        this.messagePipe = new BinaryMessagePipe(childProcess.stdio[4] as Duplex);
         childProcess.on('error', this.ipcErrorListener);
         this.toDispose.push(Disposable.create(() => {
             childProcess.removeListener('error', this.ipcErrorListener);
@@ -73,7 +72,6 @@ export class IPCChannel implements Channel {
 
     protected setupProcess(): void {
         process.once('beforeExit', code => this.onCloseEmitter.fire({ reason: 'Process is about to be terminated', code }));
-        this.messagePipe = new BinaryMessagePipe(new Socket({ fd: 4 }));
         process.on('uncaughtException', this.ipcErrorListener);
         this.toDispose.push(Disposable.create(() => {
             (process as NodeJS.EventEmitter).removeListener('uncaughtException', this.ipcErrorListener);

--- a/packages/core/src/node/messaging/ipc-server.ts
+++ b/packages/core/src/node/messaging/ipc-server.ts
@@ -1,0 +1,49 @@
+
+// *****************************************************************************
+// Copyright (C) 2022 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+import { createServer, Server, Socket } from 'net';
+import { v4 } from 'uuid';
+export const THEIA_IPC_SERVER = 'THEIA_IPC_SERVER';
+/**
+ * Can be used to setup a named-pipe communication between processes.
+ * Used for establishing an inter-process RPC-protocol.
+ */
+export interface IpcServer {
+    name: string
+    server: Server
+    client: Promise<Socket>
+}
+
+export function createIpcServer(): IpcServer {
+    const name = createIpcServerName();
+    const server = createServer();
+    server.maxConnections = 1;
+    const client = new Promise<Socket>(resolve => {
+        server.once('connection', socket => {
+            socket.once('close', () => server.close());
+            resolve(socket);
+        });
+    });
+    server.listen(name, 0);
+    return { name, server, client };
+}
+
+export function createIpcServerName(): string {
+    return process.platform === 'win32'
+        ? `\\\\.\\pipe\\${v4()}`
+        : `/tmp/pipe-${v4()}`;
+}
+


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Refactors `IPCChannel` to use named pipe communication via sockets. Previously we used an extra process pipe on top of the standard pipes (stdin,stdout,sdterr,ipc) which does not work reliably under windows. Switching to named pipe communication ensures that inter process RPC communication works reliably on all platforms.

Fixes #11442
Fixes #11390

Contributed on behalf of STMicroelectronics

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Check that the bugs descriped in https://github.com/eclipse-theia/theia/issues/11390 and  https://github.com/eclipse-theia/theia/issues/11442#issue-1309856089  no longer occur .
**Important**: In order to launch the file watcher in a separate process the Theia application needs to be started without the `--no-cluster` flag . 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
