### PR TITLE
Fix off-center codeicons in the custom tree view

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -18,6 +18,8 @@
     padding-right: var(--theia-ui-padding);
     -webkit-font-smoothing: antialiased;
     flex-shrink: 0;
+    padding-left: 6px;
+    margin-left: -6px;
 }
 
 .theia-tree-view-inline-action {


### PR DESCRIPTION
#### What it does
Closes #11273.
Centers spinning icons for the tree-view.

#### How to test

1. Install [the test extension](https://github.com/eclipse-theia/theia/files/9292635/custom-view-samples-0.0.1.vsix.zip) ([sources](https://github.com/pluralia/vscode-extension-samples/tree/spin-icon-test/tree-view-sample))
2. Open the _File Explorer_ tab -> Icons have to be centered (and spinning)

If no icons appear at all, change the _File Icon Theme_

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)