### PR TITLE
editor: add `next group` and `previous group`

### DIFF
--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -55,6 +55,8 @@ export namespace EditorMainMenu {
      * Submenu for switching panes in the main area.
      */
     export const PANE_GROUP = [...CONTEXT_GROUP, '2_pane_group'];
+    export const BY_NUMBER = [...EditorMainMenu.PANE_GROUP, '1_by_number'];
+    export const NEXT_PREVIOUS = [...EditorMainMenu.PANE_GROUP, '2_by_location'];
 
     /**
      * Workspace menu group in the `Go` main-menu.
@@ -70,6 +72,7 @@ export namespace EditorMainMenu {
      * Location menu group in the `Go` main-menu.
      */
     export const LOCATION_GROUP = [...GO, '4_locations'];
+
 }
 
 @injectable()
@@ -115,26 +118,37 @@ export class EditorMenuContribution implements MenuContribution {
         });
 
         registry.registerSubmenu(EditorMainMenu.PANE_GROUP, nls.localizeByDefault('Switch Group'));
-        const BY_NUMBER = [...EditorMainMenu.PANE_GROUP, '1_by_number'];
-        registry.registerMenuAction(BY_NUMBER, {
+
+        registry.registerMenuAction(EditorMainMenu.BY_NUMBER, {
             commandId: 'workbench.action.focusFirstEditorGroup',
             label: nls.localizeByDefault('Group 1'),
         });
-        registry.registerMenuAction(BY_NUMBER, {
+        registry.registerMenuAction(EditorMainMenu.BY_NUMBER, {
             commandId: 'workbench.action.focusSecondEditorGroup',
             label: nls.localizeByDefault('Group 2'),
         });
-        registry.registerMenuAction(BY_NUMBER, {
+        registry.registerMenuAction(EditorMainMenu.BY_NUMBER, {
             commandId: 'workbench.action.focusThirdEditorGroup',
             label: nls.localizeByDefault('Group 3'),
         });
-        registry.registerMenuAction(BY_NUMBER, {
+        registry.registerMenuAction(EditorMainMenu.BY_NUMBER, {
             commandId: 'workbench.action.focusFourthEditorGroup',
             label: nls.localizeByDefault('Group 4'),
         });
-        registry.registerMenuAction(BY_NUMBER, {
+        registry.registerMenuAction(EditorMainMenu.BY_NUMBER, {
             commandId: 'workbench.action.focusFifthEditorGroup',
             label: nls.localizeByDefault('Group 5'),
+        });
+
+        registry.registerMenuAction(EditorMainMenu.NEXT_PREVIOUS, {
+            commandId: CommonCommands.NEXT_TAB_GROUP.id,
+            label: nls.localizeByDefault('Next Group'),
+            order: '1'
+        });
+        registry.registerMenuAction(EditorMainMenu.NEXT_PREVIOUS, {
+            commandId: CommonCommands.PREVIOUS_TAB_GROUP.id,
+            label: nls.localizeByDefault('Previous Group'),
+            order: '2'
         });
 
         registry.registerMenuAction(EditorMainMenu.LOCATION_GROUP, {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11544.

The pull-request adds **Next Group** and **Previous Group** to the `Go` > `Switch Group` submenu.
The change also refactors the `BY_NUMBER` submenu path so it is accessible by extenders.


![Screen Shot 2022-08-08 at 12 19 05 PM](https://user-images.githubusercontent.com/40359487/183465061-207275a2-8ff1-4580-8e32-f458fdaaa2cf.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open a file and create a split group <kbd>ctrlcmd</kbd>+<kbd>\</kbd>
3. confirm both `Next Group` and `Previous Group` from the `Go` > `Switch Group` menu work well

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>