### PR TITLE
Add confirmation message for debug exit

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -18,7 +18,7 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, MessageService, isWindows, MaybeArray } from '@theia/core/lib/common';
 import { isOSX, environment, OS } from '@theia/core';
 import {
-    open, OpenerService, CommonMenus, ConfirmDialog, KeybindingRegistry, KeybindingContribution,
+    open, OpenerService, CommonMenus, KeybindingRegistry, KeybindingContribution,
     FrontendApplicationContribution, SHELL_TABBAR_CONTEXT_COPY, OnWillStopAction, Navigatable, SaveableSource, Widget
 } from '@theia/core/lib/browser';
 import { FileDialogService, OpenFileDialogProps, FileDialogTreeFilters } from '@theia/filesystem/lib/browser';
@@ -403,13 +403,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
     }
 
     protected async closeWorkspace(): Promise<void> {
-        const dialog = new ConfirmDialog({
-            title: WorkspaceCommands.CLOSE.label!,
-            msg: nls.localize('theia/workspace/closeWorkspace', 'Do you really want to close the workspace?')
-        });
-        if (await dialog.open()) {
-            await this.workspaceService.close();
-        }
+        await this.workspaceService.close();
     }
 
     /**

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -34,6 +34,7 @@ import { WindowTitleService } from '@theia/core/lib/browser/window/window-title-
 import { FileSystemPreferences } from '@theia/filesystem/lib/browser';
 import { workspaceSchema, WorkspaceSchemaUpdater } from './workspace-schema-updater';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
+import { StopReason } from '@theia/core/lib/common/frontend-application-state';
 
 /**
  * The workspace service.
@@ -464,11 +465,14 @@ export class WorkspaceService implements FrontendApplicationContribution {
      * Clears current workspace root.
      */
     async close(): Promise<void> {
-        this._workspace = undefined;
-        this._roots.length = 0;
+        if (await this.windowService.isSafeToShutDown(StopReason.Reload)) {
+            this.windowService.setSafeToShutDown();
+            this._workspace = undefined;
+            this._roots.length = 0;
 
-        await this.server.setMostRecentlyUsedWorkspace('');
-        this.reloadWindow();
+            await this.server.setMostRecentlyUsedWorkspace('');
+            this.reloadWindow();
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

At the moment, if the preferences are set to prevent exit with running debug sessions, we have no message specifically for that case. This PR adds such a message.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start a debug session.
2. Set the preference `debug.confirmOnExit` to `always`
3. Try to exit with the debug session running.
4. You should get a confirmation that mentions the running session.
5. Select an option. If you choose to cancel, the application should not exit and the debug session should not be terminated; if you choose to stop debugging, the application should exit.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
