### PR TITLE
core: add support for typed `Command`

### DIFF
--- a/examples/api-samples/src/browser/toolbar/sample-toolbar-contribution.tsx
+++ b/examples/api-samples/src/browser/toolbar/sample-toolbar-contribution.tsx
@@ -113,15 +113,14 @@ export class SampleToolbarContribution extends AbstractToolbarContribution
         registry.registerCommand(FIND_IN_WORKSPACE_ROOT, {
             execute: async () => {
                 const wsRoots = await this.workspaceService.roots;
-                if (!wsRoots.length) {
-                    await this.commandService.executeCommand(SearchInWorkspaceCommands.FIND_IN_FOLDER.id);
-                } else if (wsRoots.length === 1) {
+                if (wsRoots.length === 1) {
                     const { resource } = wsRoots[0];
                     await this.commandService.executeCommand(SearchInWorkspaceCommands.FIND_IN_FOLDER.id, [resource]);
                 } else {
                     this.searchPickService.open();
                 }
             },
+            isEnabled: () => !!this.workspaceService.tryGetRoots().length
         });
     }
 

--- a/packages/bulk-edit/src/browser/bulk-edit-commands.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-commands.ts
@@ -19,12 +19,12 @@ import { Command } from '@theia/core/lib/common';
 
 export namespace BulkEditCommands {
 
-    export const APPLY = Command.as<[widget: Widget], void>({
+    export const APPLY = Command.as<(widget: Widget) => void>({
         id: 'bulk-edit:apply',
         iconClass: codicon('check')
     });
 
-    export const DISCARD = Command.as<[widget: Widget], void>({
+    export const DISCARD = Command.as<(widget: Widget) => void>({
         id: 'bulk-edit:discard',
         iconClass: codicon('clear-all')
     });

--- a/packages/bulk-edit/src/browser/bulk-edit-commands.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-commands.ts
@@ -14,21 +14,18 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { codicon } from '@theia/core/lib/browser';
+import { codicon, Widget } from '@theia/core/lib/browser';
 import { Command } from '@theia/core/lib/common';
 
 export namespace BulkEditCommands {
-    export const TOGGLE_VIEW: Command = {
-        id: 'bulk-edit:toggleView'
-    };
 
-    export const APPLY: Command = {
+    export const APPLY = Command.as<[widget: Widget], void>({
         id: 'bulk-edit:apply',
         iconClass: codicon('check')
-    };
+    });
 
-    export const DISCARD: Command = {
+    export const DISCARD = Command.as<[widget: Widget], void>({
         id: 'bulk-edit:discard',
         iconClass: codicon('clear-all')
-    };
+    });
 }

--- a/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
@@ -51,12 +51,16 @@ export class BulkEditContribution extends AbstractViewContribution<BulkEditTreeW
         registry.registerCommand(BulkEditCommands.APPLY, {
             isEnabled: widget => this.withWidget(widget, () => true),
             isVisible: widget => this.withWidget(widget, () => true),
-            execute: widget => this.withWidget(widget, () => this.apply())
+            execute: widget => {
+                this.withWidget(widget, () => this.apply());
+            }
         });
         registry.registerCommand(BulkEditCommands.DISCARD, {
             isEnabled: widget => this.withWidget(widget, () => true),
             isVisible: widget => this.withWidget(widget, () => true),
-            execute: widget => this.withWidget(widget, () => this.discard())
+            execute: widget => {
+                this.withWidget(widget, () => this.discard());
+            }
         });
     }
 

--- a/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
@@ -28,7 +28,7 @@ export const CALL_HIERARCHY_TOGGLE_COMMAND_ID = 'callhierarchy:toggle';
 export const CALL_HIERARCHY_LABEL = nls.localizeByDefault('Call Hierarchy');
 
 export namespace CallHierarchyCommands {
-    export const OPEN = Command.toLocalizedCommand<[], CallHierarchyTreeWidget>({
+    export const OPEN = Command.toLocalizedCommand<() => CallHierarchyTreeWidget>({
         id: 'callhierarchy:open',
         label: 'Open Call Hierarchy'
     }, 'theia/callhierarchy/open');

--- a/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
@@ -28,7 +28,7 @@ export const CALL_HIERARCHY_TOGGLE_COMMAND_ID = 'callhierarchy:toggle';
 export const CALL_HIERARCHY_LABEL = nls.localizeByDefault('Call Hierarchy');
 
 export namespace CallHierarchyCommands {
-    export const OPEN = Command.toLocalizedCommand({
+    export const OPEN = Command.toLocalizedCommand<[], CallHierarchyTreeWidget>({
         id: 'callhierarchy:open',
         label: 'Open Call Hierarchy'
     }, 'theia/callhierarchy/open');

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -148,13 +148,13 @@ export namespace CommonCommands {
         label: 'Select All'
     });
 
-    // ???
-    export const FIND = Command.toDefaultLocalizedCommand<[], void>({
+    // TODO: type command
+    export const FIND = Command.toDefaultLocalizedCommand({
         id: 'core.find',
         label: 'Find'
     });
-    // ???
-    export const REPLACE = Command.toDefaultLocalizedCommand<[], void>({
+    // TODO: type command
+    export const REPLACE = Command.toDefaultLocalizedCommand({
         id: 'core.replace',
         label: 'Replace'
     });

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -117,216 +117,218 @@ export namespace CommonCommands {
         id: 'core.open',
     };
 
-    export const CUT = Command.toDefaultLocalizedCommand({
+    export const CUT = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.cut',
         label: 'Cut'
     });
-    export const COPY = Command.toDefaultLocalizedCommand({
+    export const COPY = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.copy',
         label: 'Copy'
     });
-    export const PASTE = Command.toDefaultLocalizedCommand({
+    export const PASTE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.paste',
         label: 'Paste'
     });
 
-    export const COPY_PATH = Command.toDefaultLocalizedCommand({
+    export const COPY_PATH = Command.toDefaultLocalizedCommand<[uris: URI[]], void>({
         id: 'core.copy.path',
         label: 'Copy Path'
     });
 
-    export const UNDO = Command.toDefaultLocalizedCommand({
+    export const UNDO = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.undo',
         label: 'Undo'
     });
-    export const REDO = Command.toDefaultLocalizedCommand({
+    export const REDO = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.redo',
         label: 'Redo'
     });
-    export const SELECT_ALL = Command.toDefaultLocalizedCommand({
+    export const SELECT_ALL = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.selectAll',
         label: 'Select All'
     });
 
-    export const FIND = Command.toDefaultLocalizedCommand({
+    // ???
+    export const FIND = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.find',
         label: 'Find'
     });
-    export const REPLACE = Command.toDefaultLocalizedCommand({
+    // ???
+    export const REPLACE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.replace',
         label: 'Replace'
     });
 
-    export const NEXT_TAB = Command.toDefaultLocalizedCommand({
+    export const NEXT_TAB = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.nextTab',
         category: VIEW_CATEGORY,
         label: 'Show Next Tab'
     });
-    export const PREVIOUS_TAB = Command.toDefaultLocalizedCommand({
+    export const PREVIOUS_TAB = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.previousTab',
         category: VIEW_CATEGORY,
         label: 'Show Previous Tab'
     });
-    export const NEXT_TAB_IN_GROUP = Command.toLocalizedCommand({
+    export const NEXT_TAB_IN_GROUP = Command.toLocalizedCommand<[], void>({
         id: 'core.nextTabInGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Next Tab in Group'
     }, 'theia/core/common/showNextTabInGroup', VIEW_CATEGORY_KEY);
-    export const PREVIOUS_TAB_IN_GROUP = Command.toLocalizedCommand({
+    export const PREVIOUS_TAB_IN_GROUP = Command.toLocalizedCommand<[], void>({
         id: 'core.previousTabInGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab in Group'
     }, 'theia/core/common/showPreviousTabInGroup', VIEW_CATEGORY_KEY);
-    export const NEXT_TAB_GROUP = Command.toLocalizedCommand({
+    export const NEXT_TAB_GROUP = Command.toLocalizedCommand<[], void>({
         id: 'core.nextTabGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Next Tab Group'
     }, 'theia/core/common/showNextTabGroup', VIEW_CATEGORY_KEY);
-    export const PREVIOUS_TAB_GROUP = Command.toLocalizedCommand({
+    export const PREVIOUS_TAB_GROUP = Command.toLocalizedCommand<[], void>({
         id: 'core.previousTabBar',
         category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab Group'
     }, 'theia/core/common/showPreviousTabGroup', VIEW_CATEGORY_KEY);
-    export const CLOSE_TAB = Command.toLocalizedCommand({
+    export const CLOSE_TAB = Command.toLocalizedCommand<[event: Event], void>({
         id: 'core.close.tab',
         category: VIEW_CATEGORY,
         label: 'Close Tab'
     }, 'theia/core/common/closeTab', VIEW_CATEGORY_KEY);
-    export const CLOSE_OTHER_TABS = Command.toLocalizedCommand({
+    export const CLOSE_OTHER_TABS = Command.toLocalizedCommand<[event: Event], void>({
         id: 'core.close.other.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Other Tabs'
     }, 'theia/core/common/closeOthers', VIEW_CATEGORY_KEY);
-    export const CLOSE_SAVED_TABS = Command.toDefaultLocalizedCommand({
+    export const CLOSE_SAVED_TABS = Command.toDefaultLocalizedCommand<[event: Event], void>({
         id: 'workbench.action.closeUnmodifiedEditors',
         category: VIEW_CATEGORY,
         label: 'Close Saved Editors in Group',
     });
-    export const CLOSE_RIGHT_TABS = Command.toLocalizedCommand({
+    export const CLOSE_RIGHT_TABS = Command.toLocalizedCommand<[event: Event], void>({
         id: 'core.close.right.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Tabs to the Right'
     }, 'theia/core/common/closeRight', VIEW_CATEGORY_KEY);
-    export const CLOSE_ALL_TABS = Command.toLocalizedCommand({
+    export const CLOSE_ALL_TABS = Command.toLocalizedCommand<[event: Event], void>({
         id: 'core.close.all.tabs',
         category: VIEW_CATEGORY,
         label: 'Close All Tabs'
     }, 'theia/core/common/closeAll', VIEW_CATEGORY_KEY);
-    export const CLOSE_MAIN_TAB = Command.toLocalizedCommand({
+    export const CLOSE_MAIN_TAB = Command.toLocalizedCommand<[], void>({
         id: 'core.close.main.tab',
         category: VIEW_CATEGORY,
         label: 'Close Tab in Main Area'
     }, 'theia/core/common/closeTabMain', VIEW_CATEGORY_KEY);
-    export const CLOSE_OTHER_MAIN_TABS = Command.toLocalizedCommand({
+    export const CLOSE_OTHER_MAIN_TABS = Command.toLocalizedCommand<[], void>({
         id: 'core.close.other.main.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Other Tabs in Main Area'
     }, 'theia/core/common/closeOtherTabMain', VIEW_CATEGORY_KEY);
-    export const CLOSE_ALL_MAIN_TABS = Command.toLocalizedCommand({
+    export const CLOSE_ALL_MAIN_TABS = Command.toLocalizedCommand<[], void>({
         id: 'core.close.all.main.tabs',
         category: VIEW_CATEGORY,
         label: 'Close All Tabs in Main Area'
     }, 'theia/core/common/closeAllTabMain', VIEW_CATEGORY_KEY);
-    export const COLLAPSE_PANEL = Command.toLocalizedCommand({
+    export const COLLAPSE_PANEL = Command.toLocalizedCommand<[event: Event], void>({
         id: 'core.collapse.tab',
         category: VIEW_CATEGORY,
         label: 'Collapse Side Panel'
     }, 'theia/core/common/collapseTab', VIEW_CATEGORY_KEY);
-    export const COLLAPSE_ALL_PANELS = Command.toLocalizedCommand({
+    export const COLLAPSE_ALL_PANELS = Command.toLocalizedCommand<[], void>({
         id: 'core.collapse.all.tabs',
         category: VIEW_CATEGORY,
         label: 'Collapse All Side Panels'
     }, 'theia/core/common/collapseAllTabs', VIEW_CATEGORY_KEY);
-    export const TOGGLE_BOTTOM_PANEL = Command.toLocalizedCommand({
+    export const TOGGLE_BOTTOM_PANEL = Command.toLocalizedCommand<[], void>({
         id: 'core.toggle.bottom.panel',
         category: VIEW_CATEGORY,
         label: 'Toggle Bottom Panel'
     }, 'theia/core/common/collapseBottomPanel', VIEW_CATEGORY_KEY);
-    export const TOGGLE_STATUS_BAR = Command.toDefaultLocalizedCommand({
+    export const TOGGLE_STATUS_BAR = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.toggleStatusbarVisibility',
         category: VIEW_CATEGORY,
         label: 'Toggle Status Bar Visibility'
     });
-    export const PIN_TAB = Command.toDefaultLocalizedCommand({
+    export const PIN_TAB = Command.toDefaultLocalizedCommand<[event: Event], void>({
         id: 'workbench.action.pinEditor',
         category: VIEW_CATEGORY,
         label: 'Pin Editor'
     });
-    export const UNPIN_TAB = Command.toDefaultLocalizedCommand({
+    export const UNPIN_TAB = Command.toDefaultLocalizedCommand<[event: Event], void>({
         id: 'workbench.action.unpinEditor',
         category: VIEW_CATEGORY,
         label: 'Unpin Editor'
     });
-    export const TOGGLE_MAXIMIZED = Command.toLocalizedCommand({
+    export const TOGGLE_MAXIMIZED = Command.toLocalizedCommand<[event: Event], void>({
         id: 'core.toggleMaximized',
         category: VIEW_CATEGORY,
         label: 'Toggle Maximized'
     }, 'theia/core/common/toggleMaximized', VIEW_CATEGORY_KEY);
-    export const OPEN_VIEW = Command.toDefaultLocalizedCommand({
+    export const OPEN_VIEW = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.openView',
         category: VIEW_CATEGORY,
         label: 'Open View...'
     });
-    export const SHOW_MENU_BAR = Command.toDefaultLocalizedCommand({
+    export const SHOW_MENU_BAR = Command.toDefaultLocalizedCommand<[], void>({
         id: 'window.menuBarVisibility',
         category: VIEW_CATEGORY,
         label: 'Show Menu Bar'
     });
-    export const NEW_UNTITLED_FILE = Command.toDefaultLocalizedCommand({
+    export const NEW_UNTITLED_FILE = Command.toDefaultLocalizedCommand<[], object | undefined>({
         id: 'workbench.action.files.newUntitledFile',
         category: FILE_CATEGORY,
         label: 'New Untitled File'
     });
-    export const SAVE = Command.toDefaultLocalizedCommand({
+    export const SAVE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.save',
         category: FILE_CATEGORY,
         label: 'Save',
     });
-    export const SAVE_AS = Command.toDefaultLocalizedCommand({
+    export const SAVE_AS = Command.toDefaultLocalizedCommand<[], void>({
         id: 'file.saveAs',
         category: FILE_CATEGORY,
         label: 'Save As...',
     });
-    export const SAVE_WITHOUT_FORMATTING = Command.toDefaultLocalizedCommand({
+    export const SAVE_WITHOUT_FORMATTING = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.saveWithoutFormatting',
         category: FILE_CATEGORY,
         label: 'Save without Formatting',
     });
-    export const SAVE_ALL = Command.toDefaultLocalizedCommand({
+    export const SAVE_ALL = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.saveAll',
         category: FILE_CATEGORY,
         label: 'Save All',
     });
 
-    export const AUTO_SAVE = Command.toDefaultLocalizedCommand({
+    export const AUTO_SAVE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'textEditor.commands.autosave',
         category: FILE_CATEGORY,
         label: 'Auto Save',
     });
 
-    export const ABOUT_COMMAND = Command.toDefaultLocalizedCommand({
+    export const ABOUT_COMMAND = Command.toDefaultLocalizedCommand<[], void>({
         id: 'core.about',
         label: 'About'
     });
 
-    export const OPEN_PREFERENCES = Command.toDefaultLocalizedCommand({
+    export const OPEN_PREFERENCES = Command.toDefaultLocalizedCommand<[query?: string], void>({
         id: 'preferences:open',
         category: PREFERENCES_CATEGORY,
         label: 'Open Settings (UI)',
     });
 
-    export const SELECT_COLOR_THEME = Command.toDefaultLocalizedCommand({
+    export const SELECT_COLOR_THEME = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.selectTheme',
         label: 'Color Theme',
         category: PREFERENCES_CATEGORY
     });
-    export const SELECT_ICON_THEME = Command.toDefaultLocalizedCommand({
+    export const SELECT_ICON_THEME = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.selectIconTheme',
         label: 'File Icon Theme',
         category: PREFERENCES_CATEGORY
     });
 
-    export const CONFIGURE_DISPLAY_LANGUAGE = Command.toDefaultLocalizedCommand({
+    export const CONFIGURE_DISPLAY_LANGUAGE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.configureLanguage',
         label: 'Configure Display Language'
     });
@@ -740,13 +742,19 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         }));
 
         commandRegistry.registerCommand(CommonCommands.UNDO, {
-            execute: () => document.execCommand('undo')
+            execute: () => {
+                document.execCommand('undo');
+            }
         });
         commandRegistry.registerCommand(CommonCommands.REDO, {
-            execute: () => document.execCommand('redo')
+            execute: () => {
+                document.execCommand('redo');
+            }
         });
         commandRegistry.registerCommand(CommonCommands.SELECT_ALL, {
-            execute: () => document.execCommand('selectAll')
+            execute: () => {
+                document.execCommand('selectAll');
+            }
         });
 
         commandRegistry.registerCommand(CommonCommands.FIND, {
@@ -758,27 +766,39 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
 
         commandRegistry.registerCommand(CommonCommands.NEXT_TAB, {
             isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => this.shell.activateNextTab()
+            execute: () => {
+                this.shell.activateNextTab();
+            }
         });
         commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB, {
             isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => this.shell.activatePreviousTab()
+            execute: () => {
+                this.shell.activatePreviousTab();
+            }
         });
         commandRegistry.registerCommand(CommonCommands.NEXT_TAB_IN_GROUP, {
             isEnabled: () => this.shell.nextTabIndexInTabBar() !== -1,
-            execute: () => this.shell.activateNextTabInTabBar()
+            execute: () => {
+                this.shell.activateNextTabInTabBar();
+            }
         });
         commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB_IN_GROUP, {
             isEnabled: () => this.shell.previousTabIndexInTabBar() !== -1,
-            execute: () => this.shell.activatePreviousTabInTabBar()
+            execute: () => {
+                this.shell.activatePreviousTabInTabBar();
+            }
         });
         commandRegistry.registerCommand(CommonCommands.NEXT_TAB_GROUP, {
             isEnabled: () => this.shell.nextTabBar() !== undefined,
-            execute: () => this.shell.activateNextTabBar()
+            execute: () => {
+                this.shell.activateNextTabBar();
+            }
         });
         commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB_GROUP, {
             isEnabled: () => this.shell.previousTabBar() !== undefined,
-            execute: () => this.shell.activatePreviousTabBar()
+            execute: () => {
+                this.shell.activatePreviousTabBar();
+            }
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_TAB, new CurrentWidgetCommandAdapter(this.shell, {
             isEnabled: title => Boolean(title?.closable),

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -117,33 +117,33 @@ export namespace CommonCommands {
         id: 'core.open',
     };
 
-    export const CUT = Command.toDefaultLocalizedCommand<[], void>({
+    export const CUT = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.cut',
         label: 'Cut'
     });
-    export const COPY = Command.toDefaultLocalizedCommand<[], void>({
+    export const COPY = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.copy',
         label: 'Copy'
     });
-    export const PASTE = Command.toDefaultLocalizedCommand<[], void>({
+    export const PASTE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.paste',
         label: 'Paste'
     });
 
-    export const COPY_PATH = Command.toDefaultLocalizedCommand<[uris: URI[]], void>({
+    export const COPY_PATH = Command.toDefaultLocalizedCommand<(uris: URI[]) => void>({
         id: 'core.copy.path',
         label: 'Copy Path'
     });
 
-    export const UNDO = Command.toDefaultLocalizedCommand<[], void>({
+    export const UNDO = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.undo',
         label: 'Undo'
     });
-    export const REDO = Command.toDefaultLocalizedCommand<[], void>({
+    export const REDO = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.redo',
         label: 'Redo'
     });
-    export const SELECT_ALL = Command.toDefaultLocalizedCommand<[], void>({
+    export const SELECT_ALL = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.selectAll',
         label: 'Select All'
     });
@@ -159,176 +159,176 @@ export namespace CommonCommands {
         label: 'Replace'
     });
 
-    export const NEXT_TAB = Command.toDefaultLocalizedCommand<[], void>({
+    export const NEXT_TAB = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.nextTab',
         category: VIEW_CATEGORY,
         label: 'Show Next Tab'
     });
-    export const PREVIOUS_TAB = Command.toDefaultLocalizedCommand<[], void>({
+    export const PREVIOUS_TAB = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.previousTab',
         category: VIEW_CATEGORY,
         label: 'Show Previous Tab'
     });
-    export const NEXT_TAB_IN_GROUP = Command.toLocalizedCommand<[], void>({
+    export const NEXT_TAB_IN_GROUP = Command.toLocalizedCommand<() => void>({
         id: 'core.nextTabInGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Next Tab in Group'
     }, 'theia/core/common/showNextTabInGroup', VIEW_CATEGORY_KEY);
-    export const PREVIOUS_TAB_IN_GROUP = Command.toLocalizedCommand<[], void>({
+    export const PREVIOUS_TAB_IN_GROUP = Command.toLocalizedCommand<() => void>({
         id: 'core.previousTabInGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab in Group'
     }, 'theia/core/common/showPreviousTabInGroup', VIEW_CATEGORY_KEY);
-    export const NEXT_TAB_GROUP = Command.toLocalizedCommand<[], void>({
+    export const NEXT_TAB_GROUP = Command.toLocalizedCommand<() => void>({
         id: 'core.nextTabGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Next Tab Group'
     }, 'theia/core/common/showNextTabGroup', VIEW_CATEGORY_KEY);
-    export const PREVIOUS_TAB_GROUP = Command.toLocalizedCommand<[], void>({
+    export const PREVIOUS_TAB_GROUP = Command.toLocalizedCommand<() => void>({
         id: 'core.previousTabBar',
         category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab Group'
     }, 'theia/core/common/showPreviousTabGroup', VIEW_CATEGORY_KEY);
-    export const CLOSE_TAB = Command.toLocalizedCommand<[event: Event], void>({
+    export const CLOSE_TAB = Command.toLocalizedCommand<(event: Event) => void>({
         id: 'core.close.tab',
         category: VIEW_CATEGORY,
         label: 'Close Tab'
     }, 'theia/core/common/closeTab', VIEW_CATEGORY_KEY);
-    export const CLOSE_OTHER_TABS = Command.toLocalizedCommand<[event: Event], void>({
+    export const CLOSE_OTHER_TABS = Command.toLocalizedCommand<(event: Event) => void>({
         id: 'core.close.other.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Other Tabs'
     }, 'theia/core/common/closeOthers', VIEW_CATEGORY_KEY);
-    export const CLOSE_SAVED_TABS = Command.toDefaultLocalizedCommand<[event: Event], void>({
+    export const CLOSE_SAVED_TABS = Command.toDefaultLocalizedCommand<(event: Event) => void>({
         id: 'workbench.action.closeUnmodifiedEditors',
         category: VIEW_CATEGORY,
         label: 'Close Saved Editors in Group',
     });
-    export const CLOSE_RIGHT_TABS = Command.toLocalizedCommand<[event: Event], void>({
+    export const CLOSE_RIGHT_TABS = Command.toLocalizedCommand<(event: Event) => void>({
         id: 'core.close.right.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Tabs to the Right'
     }, 'theia/core/common/closeRight', VIEW_CATEGORY_KEY);
-    export const CLOSE_ALL_TABS = Command.toLocalizedCommand<[event: Event], void>({
+    export const CLOSE_ALL_TABS = Command.toLocalizedCommand<(event: Event) => void>({
         id: 'core.close.all.tabs',
         category: VIEW_CATEGORY,
         label: 'Close All Tabs'
     }, 'theia/core/common/closeAll', VIEW_CATEGORY_KEY);
-    export const CLOSE_MAIN_TAB = Command.toLocalizedCommand<[], void>({
+    export const CLOSE_MAIN_TAB = Command.toLocalizedCommand<() => void>({
         id: 'core.close.main.tab',
         category: VIEW_CATEGORY,
         label: 'Close Tab in Main Area'
     }, 'theia/core/common/closeTabMain', VIEW_CATEGORY_KEY);
-    export const CLOSE_OTHER_MAIN_TABS = Command.toLocalizedCommand<[], void>({
+    export const CLOSE_OTHER_MAIN_TABS = Command.toLocalizedCommand<() => void>({
         id: 'core.close.other.main.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Other Tabs in Main Area'
     }, 'theia/core/common/closeOtherTabMain', VIEW_CATEGORY_KEY);
-    export const CLOSE_ALL_MAIN_TABS = Command.toLocalizedCommand<[], void>({
+    export const CLOSE_ALL_MAIN_TABS = Command.toLocalizedCommand<() => void>({
         id: 'core.close.all.main.tabs',
         category: VIEW_CATEGORY,
         label: 'Close All Tabs in Main Area'
     }, 'theia/core/common/closeAllTabMain', VIEW_CATEGORY_KEY);
-    export const COLLAPSE_PANEL = Command.toLocalizedCommand<[event: Event], void>({
+    export const COLLAPSE_PANEL = Command.toLocalizedCommand<(event: Event) => void>({
         id: 'core.collapse.tab',
         category: VIEW_CATEGORY,
         label: 'Collapse Side Panel'
     }, 'theia/core/common/collapseTab', VIEW_CATEGORY_KEY);
-    export const COLLAPSE_ALL_PANELS = Command.toLocalizedCommand<[], void>({
+    export const COLLAPSE_ALL_PANELS = Command.toLocalizedCommand<() => void>({
         id: 'core.collapse.all.tabs',
         category: VIEW_CATEGORY,
         label: 'Collapse All Side Panels'
     }, 'theia/core/common/collapseAllTabs', VIEW_CATEGORY_KEY);
-    export const TOGGLE_BOTTOM_PANEL = Command.toLocalizedCommand<[], void>({
+    export const TOGGLE_BOTTOM_PANEL = Command.toLocalizedCommand<() => void>({
         id: 'core.toggle.bottom.panel',
         category: VIEW_CATEGORY,
         label: 'Toggle Bottom Panel'
     }, 'theia/core/common/collapseBottomPanel', VIEW_CATEGORY_KEY);
-    export const TOGGLE_STATUS_BAR = Command.toDefaultLocalizedCommand<[], void>({
+    export const TOGGLE_STATUS_BAR = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.toggleStatusbarVisibility',
         category: VIEW_CATEGORY,
         label: 'Toggle Status Bar Visibility'
     });
-    export const PIN_TAB = Command.toDefaultLocalizedCommand<[event: Event], void>({
+    export const PIN_TAB = Command.toDefaultLocalizedCommand<(event: Event) => void>({
         id: 'workbench.action.pinEditor',
         category: VIEW_CATEGORY,
         label: 'Pin Editor'
     });
-    export const UNPIN_TAB = Command.toDefaultLocalizedCommand<[event: Event], void>({
+    export const UNPIN_TAB = Command.toDefaultLocalizedCommand<(event: Event) => void>({
         id: 'workbench.action.unpinEditor',
         category: VIEW_CATEGORY,
         label: 'Unpin Editor'
     });
-    export const TOGGLE_MAXIMIZED = Command.toLocalizedCommand<[event: Event], void>({
+    export const TOGGLE_MAXIMIZED = Command.toLocalizedCommand<(event: Event) => void>({
         id: 'core.toggleMaximized',
         category: VIEW_CATEGORY,
         label: 'Toggle Maximized'
     }, 'theia/core/common/toggleMaximized', VIEW_CATEGORY_KEY);
-    export const OPEN_VIEW = Command.toDefaultLocalizedCommand<[], void>({
+    export const OPEN_VIEW = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.openView',
         category: VIEW_CATEGORY,
         label: 'Open View...'
     });
-    export const SHOW_MENU_BAR = Command.toDefaultLocalizedCommand<[], void>({
+    export const SHOW_MENU_BAR = Command.toDefaultLocalizedCommand<() => void>({
         id: 'window.menuBarVisibility',
         category: VIEW_CATEGORY,
         label: 'Show Menu Bar'
     });
-    export const NEW_UNTITLED_FILE = Command.toDefaultLocalizedCommand<[], object | undefined>({
+    export const NEW_UNTITLED_FILE = Command.toDefaultLocalizedCommand<() => object | undefined>({
         id: 'workbench.action.files.newUntitledFile',
         category: FILE_CATEGORY,
         label: 'New Untitled File'
     });
-    export const SAVE = Command.toDefaultLocalizedCommand<[], void>({
+    export const SAVE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.save',
         category: FILE_CATEGORY,
         label: 'Save',
     });
-    export const SAVE_AS = Command.toDefaultLocalizedCommand<[], void>({
+    export const SAVE_AS = Command.toDefaultLocalizedCommand<() => void>({
         id: 'file.saveAs',
         category: FILE_CATEGORY,
         label: 'Save As...',
     });
-    export const SAVE_WITHOUT_FORMATTING = Command.toDefaultLocalizedCommand<[], void>({
+    export const SAVE_WITHOUT_FORMATTING = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.saveWithoutFormatting',
         category: FILE_CATEGORY,
         label: 'Save without Formatting',
     });
-    export const SAVE_ALL = Command.toDefaultLocalizedCommand<[], void>({
+    export const SAVE_ALL = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.saveAll',
         category: FILE_CATEGORY,
         label: 'Save All',
     });
 
-    export const AUTO_SAVE = Command.toDefaultLocalizedCommand<[], void>({
+    export const AUTO_SAVE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'textEditor.commands.autosave',
         category: FILE_CATEGORY,
         label: 'Auto Save',
     });
 
-    export const ABOUT_COMMAND = Command.toDefaultLocalizedCommand<[], void>({
+    export const ABOUT_COMMAND = Command.toDefaultLocalizedCommand<() => void>({
         id: 'core.about',
         label: 'About'
     });
 
-    export const OPEN_PREFERENCES = Command.toDefaultLocalizedCommand<[query?: string], void>({
+    export const OPEN_PREFERENCES = Command.toDefaultLocalizedCommand<(query?: string) => void>({
         id: 'preferences:open',
         category: PREFERENCES_CATEGORY,
         label: 'Open Settings (UI)',
     });
 
-    export const SELECT_COLOR_THEME = Command.toDefaultLocalizedCommand<[], void>({
+    export const SELECT_COLOR_THEME = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.selectTheme',
         label: 'Color Theme',
         category: PREFERENCES_CATEGORY
     });
-    export const SELECT_ICON_THEME = Command.toDefaultLocalizedCommand<[], void>({
+    export const SELECT_ICON_THEME = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.selectIconTheme',
         label: 'File Icon Theme',
         category: PREFERENCES_CATEGORY
     });
 
-    export const CONFIGURE_DISPLAY_LANGUAGE = Command.toDefaultLocalizedCommand<[], void>({
+    export const CONFIGURE_DISPLAY_LANGUAGE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.configureLanguage',
         label: 'Configure Display Language'
     });

--- a/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
+++ b/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
@@ -26,7 +26,7 @@ export namespace KeyboardCommands {
     const KEYBOARD_CATEGORY = 'Keyboard';
     const KEYBOARD_CATEGORY_KEY = nls.getDefaultKey(KEYBOARD_CATEGORY);
 
-    export const CHOOSE_KEYBOARD_LAYOUT = Command.toLocalizedCommand({
+    export const CHOOSE_KEYBOARD_LAYOUT = Command.toLocalizedCommand<[], KeyboardLayoutData | undefined>({
         id: 'core.keyboard.choose',
         category: KEYBOARD_CATEGORY,
         label: 'Choose Keyboard Layout',

--- a/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
+++ b/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
@@ -26,7 +26,7 @@ export namespace KeyboardCommands {
     const KEYBOARD_CATEGORY = 'Keyboard';
     const KEYBOARD_CATEGORY_KEY = nls.getDefaultKey(KEYBOARD_CATEGORY);
 
-    export const CHOOSE_KEYBOARD_LAYOUT = Command.toLocalizedCommand<[], KeyboardLayoutData | undefined>({
+    export const CHOOSE_KEYBOARD_LAYOUT = Command.toLocalizedCommand<() => KeyboardLayoutData | undefined>({
         id: 'core.keyboard.choose',
         category: KEYBOARD_CATEGORY,
         label: 'Choose Keyboard Layout',

--- a/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
+++ b/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
@@ -31,9 +31,7 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickCommand, {
-            execute: () => {
-                this.quickInputService?.open('>');
-            }
+            execute: () => this.quickInputService?.open('>')
         });
         commands.registerCommand(CLEAR_COMMAND_HISTORY, {
             execute: () => commands.clearCommandHistory(),

--- a/packages/core/src/browser/quick-input/quick-command-service.ts
+++ b/packages/core/src/browser/quick-input/quick-command-service.ts
@@ -24,11 +24,11 @@ import { filterItems, QuickPickItem, QuickPicks } from './quick-input-service';
 import { KeySequence } from '../keys';
 import { codiconArray } from '../widgets';
 
-export const quickCommand: Command = {
+export const quickCommand = Command.as<[], void>({
     id: 'workbench.action.showCommands'
-};
+});
 
-export const CLEAR_COMMAND_HISTORY = Command.toDefaultLocalizedCommand({
+export const CLEAR_COMMAND_HISTORY = Command.toDefaultLocalizedCommand<[], void>({
     id: 'clear.command.history',
     label: 'Clear Command History'
 });

--- a/packages/core/src/browser/quick-input/quick-command-service.ts
+++ b/packages/core/src/browser/quick-input/quick-command-service.ts
@@ -24,11 +24,11 @@ import { filterItems, QuickPickItem, QuickPicks } from './quick-input-service';
 import { KeySequence } from '../keys';
 import { codiconArray } from '../widgets';
 
-export const quickCommand = Command.as<[], void>({
+export const quickCommand = Command.as<() => void>({
     id: 'workbench.action.showCommands'
 });
 
-export const CLEAR_COMMAND_HISTORY = Command.toDefaultLocalizedCommand<[], void>({
+export const CLEAR_COMMAND_HISTORY = Command.toDefaultLocalizedCommand<() => void>({
     id: 'clear.command.history',
     label: 'Clear Command History'
 });

--- a/packages/core/src/browser/shell/current-widget-command-adapter.ts
+++ b/packages/core/src/browser/shell/current-widget-command-adapter.ts
@@ -18,12 +18,12 @@ import { MaybePromise, CommandHandler } from '../../common';
 import { TabBar, Title, Widget } from '../widgets';
 import { ApplicationShell } from './application-shell';
 
-export type TabBarContextMenuCommandHandler<T = unknown> = CommandHandler<[title: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event], T>;
+export type TabBarContextMenuCommandHandler<T = unknown> = CommandHandler<(title: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event) => T>;
 
 /**
  * Creates a command handler that acts on either the widget targeted by a DOM event or the current widget.
  */
-export class CurrentWidgetCommandAdapter<T = unknown> implements CommandHandler<[event: Event], T> {
+export class CurrentWidgetCommandAdapter<T = unknown> implements CommandHandler<(event: Event) => T> {
 
     execute: (event: Event) => MaybePromise<T>;
     isEnabled?: (event: Event) => boolean;

--- a/packages/core/src/browser/shell/current-widget-command-adapter.ts
+++ b/packages/core/src/browser/shell/current-widget-command-adapter.ts
@@ -14,29 +14,23 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { CommandHandler } from '../../common';
+import { MaybePromise, CommandHandler } from '../../common';
 import { TabBar, Title, Widget } from '../widgets';
 import { ApplicationShell } from './application-shell';
 
-type CurrentWidgetCommandAdapterBooleanCheck = (event: Event) => boolean;
-type CurrentWidgetCommandHandlerBooleanCheck = (title: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event) => boolean;
-
-export interface TabBarContextMenuCommandHandler extends CommandHandler {
-    execute(title: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event): unknown;
-    isEnabled?: CurrentWidgetCommandHandlerBooleanCheck;
-    isVisible?: CurrentWidgetCommandHandlerBooleanCheck;
-    isToggled?: CurrentWidgetCommandHandlerBooleanCheck;
-}
+export type TabBarContextMenuCommandHandler<T = unknown> = CommandHandler<[title: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event], T>;
 
 /**
  * Creates a command handler that acts on either the widget targeted by a DOM event or the current widget.
  */
-export class CurrentWidgetCommandAdapter implements CommandHandler {
-    execute: (event: Event) => unknown;
-    isEnabled?: CurrentWidgetCommandAdapterBooleanCheck;
-    isVisible?: CurrentWidgetCommandAdapterBooleanCheck;
-    isToggled?: CurrentWidgetCommandAdapterBooleanCheck;
-    constructor(shell: ApplicationShell, handler: TabBarContextMenuCommandHandler) {
+export class CurrentWidgetCommandAdapter<T = unknown> implements CommandHandler<[event: Event], T> {
+
+    execute: (event: Event) => MaybePromise<T>;
+    isEnabled?: (event: Event) => boolean;
+    isVisible?: (event: Event) => boolean;
+    isToggled?: (event: Event) => boolean;
+
+    constructor(shell: ApplicationShell, handler: TabBarContextMenuCommandHandler<T>) {
         this.execute = (event: Event) => handler.execute(...this.transformArguments(shell, event));
         if (handler.isEnabled) {
             this.isEnabled = (event: Event) => !!handler.isEnabled?.(...this.transformArguments(shell, event));

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -111,7 +111,7 @@ export interface ApplicationShellLayoutMigration {
     onWillInflateWidget?(desc: WidgetDescription, context: ApplicationShellLayoutMigrationContext): MaybePromise<WidgetDescription | undefined>;
 }
 
-export const RESET_LAYOUT = Command.toLocalizedCommand({
+export const RESET_LAYOUT = Command.toLocalizedCommand<[], void>({
     id: 'reset.layout',
     category: CommonCommands.VIEW_CATEGORY,
     label: 'Reset Workbench Layout'

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -111,7 +111,7 @@ export interface ApplicationShellLayoutMigration {
     onWillInflateWidget?(desc: WidgetDescription, context: ApplicationShellLayoutMigrationContext): MaybePromise<WidgetDescription | undefined>;
 }
 
-export const RESET_LAYOUT = Command.toLocalizedCommand<[], void>({
+export const RESET_LAYOUT = Command.toLocalizedCommand<() => void>({
     id: 'reset.layout',
     category: CommonCommands.VIEW_CATEGORY,
     label: 'Reset Workbench Layout'

--- a/packages/core/src/browser/window-contribution.ts
+++ b/packages/core/src/browser/window-contribution.ts
@@ -23,7 +23,7 @@ import { CommonMenus } from '../browser/common-frontend-contribution';
 
 export namespace WindowCommands {
 
-    export const NEW_WINDOW = Command.toDefaultLocalizedCommand({
+    export const NEW_WINDOW = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.newWindow',
         label: 'New Window'
     });
@@ -37,9 +37,7 @@ export class WindowContribution implements CommandContribution, KeybindingContri
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(WindowCommands.NEW_WINDOW, {
-            execute: () => {
-                this.windowService.openNewDefaultWindow();
-            }
+            execute: () => this.windowService.openNewDefaultWindow()
         });
     }
 

--- a/packages/core/src/browser/window-contribution.ts
+++ b/packages/core/src/browser/window-contribution.ts
@@ -23,7 +23,7 @@ import { CommonMenus } from '../browser/common-frontend-contribution';
 
 export namespace WindowCommands {
 
-    export const NEW_WINDOW = Command.toDefaultLocalizedCommand<[], void>({
+    export const NEW_WINDOW = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.newWindow',
         label: 'New Window'
     });

--- a/packages/core/src/common/command.spec.ts
+++ b/packages/core/src/common/command.spec.ts
@@ -193,7 +193,7 @@ describe('Commands', () => {
         });
 
         it('Can properly type commands', () => {
-            const command = Command.as<[a: number, b: string], symbol>({ id: 'typedCommand1' });
+            const command = Command.as<(a: number, b: string) => symbol>({ id: 'typedCommand1' });
             commandRegistry.registerCommand(command, {
                 // @ts-expect-error
                 execute: () => 'wrong return type'
@@ -203,11 +203,11 @@ describe('Commands', () => {
         });
 
         it('Can extend command typings', () => {
-            const command = Command.as<[], void>({ id: 'typedCommand2' });
+            const command = Command.as<() => void>({ id: 'typedCommand2' });
             commandRegistry.registerCommand(command, {
                 execute: () => { }
             });
-            const extended = Command.extend(command).as<[a: number], number>();
+            const extended = Command.extend(command).as<(a: number) => number>();
             commandRegistry.registerHandler(extended.id, {
                 // previous signature should work
                 execute: () => { }

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -105,6 +105,23 @@ export namespace Command {
     }
 
     /**
+     * Use this to extend {@link command}'s typings to support a supplementary signature.
+     *
+     * This will return {@link command} as-is but with the new typings.
+     *
+     * @example
+     *
+     * const extended = Command.extend(original).as<NewArguments, NewReturnType>();
+     */
+    export function extend<Cmd extends Command>(command: Cmd): {
+        as<A extends any[], R>(): Command<CommandId<Arguments<Cmd> | A, ReturnType<Cmd> | R>>
+    } {
+        return {
+            as: () => as(command)
+        };
+    }
+
+    /**
      * Utility function to easily translate commands.
      */
     export function toLocalizedCommand(command: Command, nlsLabelKey?: string, nlsCategoryKey?: string): Command;
@@ -177,16 +194,22 @@ export interface CommandHandler<Arguments extends any[] = any, ReturnType = any>
     execute(...args: Arguments): MaybePromise<ReturnType>;
     /**
      * Test whether this handler is enabled (active).
+     *
+     * Return value will be tested for truthfulness.
      */
-    isEnabled?(...args: Arguments): boolean;
+    isEnabled?(...args: Arguments): unknown;
     /**
      * Test whether menu items for this handler should be visible.
+     *
+     * Return value will be tested for truthfulness.
      */
-    isVisible?(...args: Arguments): boolean;
+    isVisible?(...args: Arguments): unknown;
     /**
      * Test whether menu items for this handler should be toggled.
+     *
+     * Return value will be tested for truthfulness.
      */
-    isToggled?(...args: Arguments): boolean;
+    isToggled?(...args: Arguments): unknown;
 }
 
 export const CommandContribution = Symbol('CommandContribution');

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -100,6 +100,10 @@ export namespace Command {
         return !!arg && typeof arg === 'object' && 'id' in arg;
     }
 
+    export function as<A extends any[], R = any>(command: Command<string>): Command<CommandId<A, R>> {
+        return command as Command<CommandId<A, R>>;
+    }
+
     /**
      * Utility function to easily translate commands.
      */

--- a/packages/core/src/common/menu/menu-adapter.ts
+++ b/packages/core/src/common/menu/menu-adapter.ts
@@ -66,7 +66,8 @@ export class MenuCommandExecutorImpl implements MenuCommandExecutor {
         const adapter = this.adapterRegistry.getAdapterFor(menuPath, command, commandArgs);
         return (adapter
             ? adapter[method](menuPath, command, ...commandArgs)
-            : this.commandRegistry[method](command, ...commandArgs)) as ReturnType<MenuCommandExecutor[T]>;
+            : (this.commandRegistry[method] as (command: string, ...args: unknown[]) => unknown)(command, ...commandArgs)
+        ) as ReturnType<MenuCommandExecutor[T]>;
     }
 }
 

--- a/packages/core/src/common/uri-command-handler.spec.ts
+++ b/packages/core/src/common/uri-command-handler.spec.ts
@@ -22,7 +22,8 @@ import { UriAwareCommandHandler, UriCommandHandler } from './uri-command-handler
 
 const expect = chai.expect;
 
-interface CommandHandlerMock extends UriCommandHandler<MaybeArray<URI>> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+interface CommandHandlerMock extends UriCommandHandler<MaybeArray<URI>, any> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     lastCall: any[];
 }

--- a/packages/core/src/common/uri-command-handler.ts
+++ b/packages/core/src/common/uri-command-handler.ts
@@ -22,7 +22,7 @@ import { CommandHandler } from './command';
 import URI from './uri';
 import { MaybeArray } from './types';
 
-export interface UriCommandHandler<T extends MaybeArray<URI>, R = any> extends CommandHandler<[uri: T, ...args: any[]], R> {
+export interface UriCommandHandler<T extends MaybeArray<URI>, R = any> extends CommandHandler<(uri: T, ...args: any[]) => R> {
 
     execute(uri: T, ...args: any[]): R;
 

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -129,9 +129,10 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
         return electronRemote.Menu.buildFromTemplate(template);
     }
 
-    protected fillMenuTemplate(parentItems: Electron.MenuItemConstructorOptions[],
+    protected fillMenuTemplate(
+        parentItems: Electron.MenuItemConstructorOptions[],
         menu: MenuNode,
-        args: unknown[] = [],
+        args: any[] = [],
         options: ElectronMenuOptions
     ): Electron.MenuItemConstructorOptions[] {
         const showDisabled = options?.showDisabled !== false;

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -36,31 +36,31 @@ import { WindowService } from '../../browser/window/window-service';
 import '../../../src/electron-browser/menu/electron-menu-style.css';
 
 export namespace ElectronCommands {
-    export const TOGGLE_DEVELOPER_TOOLS = Command.toDefaultLocalizedCommand<[], void>({
+    export const TOGGLE_DEVELOPER_TOOLS = Command.toDefaultLocalizedCommand<() => void>({
         id: 'theia.toggleDevTools',
         label: 'Toggle Developer Tools'
     });
-    export const RELOAD = Command.toDefaultLocalizedCommand<[], void>({
+    export const RELOAD = Command.toDefaultLocalizedCommand<() => void>({
         id: 'view.reload',
         label: 'Reload Window'
     });
-    export const ZOOM_IN = Command.toDefaultLocalizedCommand<[], void>({
+    export const ZOOM_IN = Command.toDefaultLocalizedCommand<() => void>({
         id: 'view.zoomIn',
         label: 'Zoom In'
     });
-    export const ZOOM_OUT = Command.toDefaultLocalizedCommand<[], void>({
+    export const ZOOM_OUT = Command.toDefaultLocalizedCommand<() => void>({
         id: 'view.zoomOut',
         label: 'Zoom Out'
     });
-    export const RESET_ZOOM = Command.toDefaultLocalizedCommand<[], void>({
+    export const RESET_ZOOM = Command.toDefaultLocalizedCommand<() => void>({
         id: 'view.resetZoom',
         label: 'Reset Zoom'
     });
-    export const CLOSE_WINDOW = Command.toDefaultLocalizedCommand<[], void>({
+    export const CLOSE_WINDOW = Command.toDefaultLocalizedCommand<() => void>({
         id: 'close.window',
         label: 'Close Window'
     });
-    export const TOGGLE_FULL_SCREEN = Command.toDefaultLocalizedCommand<[], void>({
+    export const TOGGLE_FULL_SCREEN = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.toggleFullScreen',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Full Screen'

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -36,31 +36,31 @@ import { WindowService } from '../../browser/window/window-service';
 import '../../../src/electron-browser/menu/electron-menu-style.css';
 
 export namespace ElectronCommands {
-    export const TOGGLE_DEVELOPER_TOOLS = Command.toDefaultLocalizedCommand({
+    export const TOGGLE_DEVELOPER_TOOLS = Command.toDefaultLocalizedCommand<[], void>({
         id: 'theia.toggleDevTools',
         label: 'Toggle Developer Tools'
     });
-    export const RELOAD = Command.toDefaultLocalizedCommand({
+    export const RELOAD = Command.toDefaultLocalizedCommand<[], void>({
         id: 'view.reload',
         label: 'Reload Window'
     });
-    export const ZOOM_IN = Command.toDefaultLocalizedCommand({
+    export const ZOOM_IN = Command.toDefaultLocalizedCommand<[], void>({
         id: 'view.zoomIn',
         label: 'Zoom In'
     });
-    export const ZOOM_OUT = Command.toDefaultLocalizedCommand({
+    export const ZOOM_OUT = Command.toDefaultLocalizedCommand<[], void>({
         id: 'view.zoomOut',
         label: 'Zoom Out'
     });
-    export const RESET_ZOOM = Command.toDefaultLocalizedCommand({
+    export const RESET_ZOOM = Command.toDefaultLocalizedCommand<[], void>({
         id: 'view.resetZoom',
         label: 'Reset Zoom'
     });
-    export const CLOSE_WINDOW = Command.toDefaultLocalizedCommand({
+    export const CLOSE_WINDOW = Command.toDefaultLocalizedCommand<[], void>({
         id: 'close.window',
         label: 'Close Window'
     });
-    export const TOGGLE_FULL_SCREEN = Command.toDefaultLocalizedCommand({
+    export const TOGGLE_FULL_SCREEN = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.toggleFullScreen',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Full Screen'

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -52,6 +52,7 @@ import { DebugFunctionBreakpoint } from './model/debug-function-breakpoint';
 import { DebugBreakpoint } from './model/debug-breakpoint';
 import { nls } from '@theia/core/lib/common/nls';
 import { DebugInstructionBreakpoint } from './model/debug-instruction-breakpoint';
+import { DebugProtocol } from 'vscode-debugprotocol';
 
 export namespace DebugMenus {
     export const DEBUG = [...MAIN_MENU_BAR, '6_debug'];
@@ -85,298 +86,298 @@ export namespace DebugCommands {
     export const DEBUG_CATEGORY = 'Debug';
     export const DEBUG_CATEGORY_KEY = nls.getDefaultKey(DEBUG_CATEGORY);
 
-    export const START = Command.toDefaultLocalizedCommand({
+    export const START = Command.toDefaultLocalizedCommand<[config?: DebugSessionOptions], void>({
         id: 'workbench.action.debug.start',
         category: DEBUG_CATEGORY,
         label: 'Start Debugging',
         iconClass: codicon('debug-alt')
     });
-    export const START_NO_DEBUG = Command.toDefaultLocalizedCommand({
+    export const START_NO_DEBUG = Command.toDefaultLocalizedCommand<[config?: DebugSessionOptions], void>({
         id: 'workbench.action.debug.run',
         category: DEBUG_CATEGORY,
         label: 'Start Without Debugging'
     });
-    export const STOP = Command.toDefaultLocalizedCommand({
+    export const STOP = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.debug.stop',
         category: DEBUG_CATEGORY,
         label: 'Stop',
         iconClass: codicon('debug-stop')
     });
-    export const RESTART = Command.toDefaultLocalizedCommand({
+    export const RESTART = Command.toDefaultLocalizedCommand<[], DebugSession | undefined>({
         id: 'workbench.action.debug.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart',
     });
 
-    export const OPEN_CONFIGURATIONS = Command.toDefaultLocalizedCommand({
+    export const OPEN_CONFIGURATIONS = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.configurations.open',
         category: DEBUG_CATEGORY,
         label: 'Open Configurations'
     });
-    export const ADD_CONFIGURATION = Command.toDefaultLocalizedCommand({
+    export const ADD_CONFIGURATION = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.configurations.add',
         category: DEBUG_CATEGORY,
         label: 'Add Configuration...'
     });
 
-    export const STEP_OVER = Command.toDefaultLocalizedCommand({
+    export const STEP_OVER = Command.toDefaultLocalizedCommand<[], DebugProtocol.NextResponse | undefined>({
         id: 'workbench.action.debug.stepOver',
         category: DEBUG_CATEGORY,
         label: 'Step Over',
         iconClass: codicon('debug-step-over')
     });
-    export const STEP_INTO = Command.toDefaultLocalizedCommand({
+    export const STEP_INTO = Command.toDefaultLocalizedCommand<[], DebugProtocol.StepInResponse | undefined>({
         id: 'workbench.action.debug.stepInto',
         category: DEBUG_CATEGORY,
         label: 'Step Into',
         iconClass: codicon('debug-step-into')
     });
-    export const STEP_OUT = Command.toDefaultLocalizedCommand({
+    export const STEP_OUT = Command.toDefaultLocalizedCommand<[], DebugProtocol.StepOutResponse | undefined>({
         id: 'workbench.action.debug.stepOut',
         category: DEBUG_CATEGORY,
         label: 'Step Out',
         iconClass: codicon('debug-step-out')
     });
-    export const CONTINUE = Command.toDefaultLocalizedCommand({
+    export const CONTINUE = Command.toDefaultLocalizedCommand<[], DebugProtocol.ContinueResponse | undefined>({
         id: 'workbench.action.debug.continue',
         category: DEBUG_CATEGORY,
         label: 'Continue',
         iconClass: codicon('debug-continue')
     });
-    export const PAUSE = Command.toDefaultLocalizedCommand({
+    export const PAUSE = Command.toDefaultLocalizedCommand<[], DebugProtocol.PauseResponse | undefined>({
         id: 'workbench.action.debug.pause',
         category: DEBUG_CATEGORY,
         label: 'Pause',
         iconClass: codicon('debug-pause')
     });
-    export const CONTINUE_ALL = Command.toLocalizedCommand({
+    export const CONTINUE_ALL = Command.toLocalizedCommand<[], void>({
         id: 'debug.thread.continue.all',
         category: DEBUG_CATEGORY,
         label: 'Continue All',
         iconClass: codicon('debug-continue')
     }, 'theia/debug/continueAll', DEBUG_CATEGORY_KEY);
-    export const PAUSE_ALL = Command.toLocalizedCommand({
+    export const PAUSE_ALL = Command.toLocalizedCommand<[], void>({
         id: 'debug.thread.pause.all',
         category: DEBUG_CATEGORY,
         label: 'Pause All',
         iconClass: codicon('debug-pause')
     }, 'theia/debug/pauseAll', DEBUG_CATEGORY_KEY);
 
-    export const TOGGLE_BREAKPOINT = Command.toDefaultLocalizedCommand({
+    export const TOGGLE_BREAKPOINT = Command.toDefaultLocalizedCommand<[], void>({
         id: 'editor.debug.action.toggleBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Toggle Breakpoint',
     });
-    export const INLINE_BREAKPOINT = Command.toDefaultLocalizedCommand({
+    export const INLINE_BREAKPOINT = Command.toDefaultLocalizedCommand<[], void>({
         id: 'editor.debug.action.inlineBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Inline Breakpoint',
     });
-    export const ADD_CONDITIONAL_BREAKPOINT = Command.toDefaultLocalizedCommand({
+    export const ADD_CONDITIONAL_BREAKPOINT = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.breakpoint.add.conditional',
         category: DEBUG_CATEGORY,
         label: 'Add Conditional Breakpoint...',
     });
-    export const ADD_LOGPOINT = Command.toDefaultLocalizedCommand({
+    export const ADD_LOGPOINT = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.breakpoint.add.logpoint',
         category: DEBUG_CATEGORY,
         label: 'Add Logpoint...',
     });
-    export const ADD_FUNCTION_BREAKPOINT = Command.toDefaultLocalizedCommand({
+    export const ADD_FUNCTION_BREAKPOINT = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
         id: 'debug.breakpoint.add.function',
         category: DEBUG_CATEGORY,
         label: 'Add Function Breakpoint',
     });
-    export const ENABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
+    export const ENABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.breakpoint.enableAll',
         category: DEBUG_CATEGORY,
         label: 'Enable All Breakpoints',
     });
-    export const DISABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
+    export const DISABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.breakpoint.disableAll',
         category: DEBUG_CATEGORY,
         label: 'Disable All Breakpoints',
     });
-    export const EDIT_BREAKPOINT = Command.toLocalizedCommand({
+    export const EDIT_BREAKPOINT = Command.toLocalizedCommand<[], void>({
         id: 'debug.breakpoint.edit',
         category: DEBUG_CATEGORY,
         originalLabel: 'Edit Breakpoint...',
         label: nlsEditBreakpoint('Breakpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const EDIT_LOGPOINT = Command.toLocalizedCommand({
+    export const EDIT_LOGPOINT = Command.toLocalizedCommand<[], void>({
         id: 'debug.logpoint.edit',
         category: DEBUG_CATEGORY,
         originalLabel: 'Edit Logpoint...',
         label: nlsEditBreakpoint('Logpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const REMOVE_BREAKPOINT = Command.toLocalizedCommand({
+    export const REMOVE_BREAKPOINT = Command.toLocalizedCommand<[], void>({
         id: 'debug.breakpoint.remove',
         category: DEBUG_CATEGORY,
         originalLabel: 'Remove Breakpoint',
         label: nlsRemoveBreakpoint('Breakpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const REMOVE_LOGPOINT = Command.toLocalizedCommand({
+    export const REMOVE_LOGPOINT = Command.toLocalizedCommand<[], void>({
         id: 'debug.logpoint.remove',
         category: DEBUG_CATEGORY,
         originalLabel: 'Remove Logpoint',
         label: nlsRemoveBreakpoint('Logpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const REMOVE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
+    export const REMOVE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
         id: 'debug.breakpoint.removeAll',
         category: DEBUG_CATEGORY,
         label: 'Remove All Breakpoints',
     });
-    export const TOGGLE_BREAKPOINTS_ENABLED = Command.toLocalizedCommand({
+    export const TOGGLE_BREAKPOINTS_ENABLED = Command.toLocalizedCommand<[arg: unknown], void>({
         id: 'debug.breakpoint.toggleEnabled'
     });
-    export const SHOW_HOVER = Command.toDefaultLocalizedCommand({
+    export const SHOW_HOVER = Command.toDefaultLocalizedCommand<[], void>({
         id: 'editor.debug.action.showDebugHover',
         category: DEBUG_CATEGORY,
         label: 'Show Hover'
     });
 
-    export const RESTART_FRAME = Command.toDefaultLocalizedCommand({
+    export const RESTART_FRAME = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.frame.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart Frame',
     });
-    export const COPY_CALL_STACK = Command.toDefaultLocalizedCommand({
+    export const COPY_CALL_STACK = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.callStack.copy',
         category: DEBUG_CATEGORY,
         label: 'Copy Call Stack',
     });
 
-    export const SET_VARIABLE_VALUE = Command.toDefaultLocalizedCommand({
+    export const SET_VARIABLE_VALUE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.variable.setValue',
         category: DEBUG_CATEGORY,
         label: 'Set Value',
     });
-    export const COPY_VARIABLE_VALUE = Command.toDefaultLocalizedCommand({
+    export const COPY_VARIABLE_VALUE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.variable.copyValue',
         category: DEBUG_CATEGORY,
         label: 'Copy Value',
     });
-    export const COPY_VARIABLE_AS_EXPRESSION = Command.toDefaultLocalizedCommand({
+    export const COPY_VARIABLE_AS_EXPRESSION = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.variable.copyAsExpression',
         category: DEBUG_CATEGORY,
         label: 'Copy as Expression',
     });
-    export const WATCH_VARIABLE = Command.toDefaultLocalizedCommand({
+    export const WATCH_VARIABLE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.variable.watch',
         category: DEBUG_CATEGORY,
         label: 'Add to Watch',
     });
 
-    export const ADD_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand({
+    export const ADD_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
         id: 'debug.watch.addExpression',
         category: DEBUG_CATEGORY,
         label: 'Add Expression'
     });
-    export const EDIT_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand({
+    export const EDIT_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.watch.editExpression',
         category: DEBUG_CATEGORY,
         label: 'Edit Expression'
     });
-    export const COPY_WATCH_EXPRESSION_VALUE = Command.toLocalizedCommand({
+    export const COPY_WATCH_EXPRESSION_VALUE = Command.toLocalizedCommand<[], void>({
         id: 'debug.watch.copyExpressionValue',
         category: DEBUG_CATEGORY,
         label: 'Copy Expression Value'
     }, 'theia/debug/copyExpressionValue', DEBUG_CATEGORY_KEY);
-    export const REMOVE_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand({
+    export const REMOVE_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<[], void>({
         id: 'debug.watch.removeExpression',
         category: DEBUG_CATEGORY,
         label: 'Remove Expression'
     });
-    export const COLLAPSE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand({
+    export const COLLAPSE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
         id: 'debug.watch.collapseAllExpressions',
         category: DEBUG_CATEGORY,
         label: 'Collapse All'
     });
-    export const REMOVE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand({
+    export const REMOVE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
         id: 'debug.watch.removeAllExpressions',
         category: DEBUG_CATEGORY,
         label: 'Remove All Expressions'
     });
 }
 export namespace DebugThreadContextCommands {
-    export const STEP_OVER = {
+    export const STEP_OVER = Command.as<[], DebugProtocol.NextResponse | undefined>({
         id: 'debug.thread.context.context.next'
-    };
-    export const STEP_INTO = {
+    });
+    export const STEP_INTO = Command.as<[], DebugProtocol.StepInResponse | undefined>({
         id: 'debug.thread.context.stepin'
-    };
-    export const STEP_OUT = {
+    });
+    export const STEP_OUT = Command.as<[], DebugProtocol.StepOutResponse | undefined>({
         id: 'debug.thread.context.stepout'
-    };
-    export const CONTINUE = {
+    });
+    export const CONTINUE = Command.as<[], DebugProtocol.ContinueResponse | undefined>({
         id: 'debug.thread.context.continue'
-    };
-    export const PAUSE = {
+    });
+    export const PAUSE = Command.as<[], DebugProtocol.PauseResponse | undefined>({
         id: 'debug.thread.context.pause'
-    };
-    export const TERMINATE = {
+    });
+    export const TERMINATE = Command.as<[], void>({
         id: 'debug.thread.context.terminate'
-    };
+    });
 }
 export namespace DebugSessionContextCommands {
-    export const STOP = {
+    export const STOP = Command.as<[], void>({
         id: 'debug.session.context.stop'
-    };
-    export const RESTART = {
+    });
+    export const RESTART = Command.as<[], DebugSession | undefined>({
         id: 'debug.session.context.restart'
-    };
-    export const PAUSE_ALL = {
+    });
+    export const PAUSE_ALL = Command.as<[], void>({
         id: 'debug.session.context.pauseAll'
-    };
-    export const CONTINUE_ALL = {
+    });
+    export const CONTINUE_ALL = Command.as<[], void>({
         id: 'debug.session.context.continueAll'
-    };
-    export const REVEAL = {
+    });
+    export const REVEAL = Command.as<[], DebugSessionWidget | undefined>({
         id: 'debug.session.context.reveal'
-    };
+    });
 }
 export namespace DebugEditorContextCommands {
-    export const ADD_BREAKPOINT = {
+    export const ADD_BREAKPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.addBreakpoint'
-    };
-    export const ADD_CONDITIONAL_BREAKPOINT = {
+    });
+    export const ADD_CONDITIONAL_BREAKPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.addBreakpoint.conditional'
-    };
-    export const ADD_LOGPOINT = {
+    });
+    export const ADD_LOGPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.add.logpoint'
-    };
-    export const REMOVE_BREAKPOINT = {
+    });
+    export const REMOVE_BREAKPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.removeBreakpoint'
-    };
-    export const EDIT_BREAKPOINT = {
+    });
+    export const EDIT_BREAKPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.edit.breakpoint'
-    };
-    export const ENABLE_BREAKPOINT = {
+    });
+    export const ENABLE_BREAKPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.enableBreakpoint'
-    };
-    export const DISABLE_BREAKPOINT = {
+    });
+    export const DISABLE_BREAKPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.disableBreakpoint'
-    };
-    export const REMOVE_LOGPOINT = {
+    });
+    export const REMOVE_LOGPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.logpoint.remove'
-    };
-    export const EDIT_LOGPOINT = {
+    });
+    export const EDIT_LOGPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.logpoint.edit'
-    };
-    export const ENABLE_LOGPOINT = {
+    });
+    export const ENABLE_LOGPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.logpoint.enable'
-    };
-    export const DISABLE_LOGPOINT = {
+    });
+    export const DISABLE_LOGPOINT = Command.as<[position: monaco.Position], void>({
         id: 'debug.editor.context.logpoint.disable'
-    };
+    });
 }
 export namespace DebugBreakpointWidgetCommands {
-    export const ACCEPT = {
+    export const ACCEPT = Command.as<[], void>({
         id: 'debug.breakpointWidget.accept'
-    };
-    export const CLOSE = {
+    });
+    export const CLOSE = Command.as<[], void>({
         id: 'debug.breakpointWidget.close'
-    };
+    });
 }
 
 @injectable()
@@ -623,61 +624,61 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         });
 
         registry.registerCommand(DebugCommands.STEP_OVER, {
-            execute: () => this.manager.currentThread && this.manager.currentThread.stepOver(),
+            execute: () => this.manager.currentThread?.stepOver(),
             isEnabled: () => this.manager.state === DebugState.Stopped
         });
         registry.registerCommand(DebugCommands.STEP_INTO, {
-            execute: () => this.manager.currentThread && this.manager.currentThread.stepIn(),
+            execute: () => this.manager.currentThread?.stepIn(),
             isEnabled: () => this.manager.state === DebugState.Stopped
         });
         registry.registerCommand(DebugCommands.STEP_OUT, {
-            execute: () => this.manager.currentThread && this.manager.currentThread.stepOut(),
+            execute: () => this.manager.currentThread?.stepOut(),
             isEnabled: () => this.manager.state === DebugState.Stopped
         });
         registry.registerCommand(DebugCommands.CONTINUE, {
-            execute: () => this.manager.currentThread && this.manager.currentThread.continue(),
+            execute: () => this.manager.currentThread?.continue(),
             isEnabled: () => this.manager.state === DebugState.Stopped
         });
         registry.registerCommand(DebugCommands.PAUSE, {
-            execute: () => this.manager.currentThread && this.manager.currentThread.pause(),
+            execute: () => this.manager.currentThread?.pause(),
             isEnabled: () => this.manager.state === DebugState.Running
         });
         registry.registerCommand(DebugCommands.PAUSE_ALL, {
-            execute: () => this.manager.currentSession && this.manager.currentSession.pauseAll(),
+            execute: () => this.manager.currentSession?.pauseAll(),
             isEnabled: () => !!this.manager.currentSession && !!this.manager.currentSession.runningThreads.next().value
         });
         registry.registerCommand(DebugCommands.CONTINUE_ALL, {
-            execute: () => this.manager.currentSession && this.manager.currentSession.continueAll(),
+            execute: () => this.manager.currentSession?.continueAll(),
             isEnabled: () => !!this.manager.currentSession && !!this.manager.currentSession.stoppedThreads.next().value
         });
 
         registry.registerCommand(DebugThreadContextCommands.STEP_OVER, {
-            execute: () => this.selectedThread && this.selectedThread.stepOver(),
+            execute: () => this.selectedThread?.stepOver(),
             isEnabled: () => !!this.selectedThread && this.selectedThread.stopped,
             isVisible: () => !!this.selectedThread
         });
         registry.registerCommand(DebugThreadContextCommands.STEP_INTO, {
-            execute: () => this.selectedThread && this.selectedThread.stepIn(),
+            execute: () => this.selectedThread?.stepIn(),
             isEnabled: () => !!this.selectedThread && this.selectedThread.stopped,
             isVisible: () => !!this.selectedThread
         });
         registry.registerCommand(DebugThreadContextCommands.STEP_OUT, {
-            execute: () => this.selectedThread && this.selectedThread.stepOut(),
+            execute: () => this.selectedThread?.stepOut(),
             isEnabled: () => !!this.selectedThread && this.selectedThread.stopped,
             isVisible: () => !!this.selectedThread
         });
         registry.registerCommand(DebugThreadContextCommands.CONTINUE, {
-            execute: () => this.selectedThread && this.selectedThread.continue(),
+            execute: () => this.selectedThread?.continue(),
             isEnabled: () => !!this.selectedThread && this.selectedThread.stopped,
             isVisible: () => !!this.selectedThread && this.selectedThread.stopped,
         });
         registry.registerCommand(DebugThreadContextCommands.PAUSE, {
-            execute: () => this.selectedThread && this.selectedThread.pause(),
+            execute: () => this.selectedThread?.pause(),
             isEnabled: () => !!this.selectedThread && !this.selectedThread.stopped,
             isVisible: () => !!this.selectedThread && !this.selectedThread.stopped,
         });
         registry.registerCommand(DebugThreadContextCommands.TERMINATE, {
-            execute: () => this.selectedThread && this.selectedThread.terminate(),
+            execute: () => this.selectedThread?.terminate(),
             isEnabled: () => !!this.selectedThread && this.selectedThread.supportsTerminate,
             isVisible: () => !!this.selectedThread && this.selectedThread.supportsTerminate
         });
@@ -788,7 +789,9 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             isVisible: widget => !(widget instanceof Widget) || (widget instanceof DebugBreakpointsWidget)
         });
         registry.registerCommand(DebugCommands.TOGGLE_BREAKPOINTS_ENABLED, {
-            execute: () => this.breakpointManager.breakpointsEnabled = !this.breakpointManager.breakpointsEnabled,
+            execute: () => {
+                this.breakpointManager.breakpointsEnabled = !this.breakpointManager.breakpointsEnabled;
+            },
             isVisible: arg => arg instanceof DebugBreakpointsWidget
         });
         registry.registerCommand(DebugCommands.SHOW_HOVER, {
@@ -814,17 +817,17 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         });
 
         registry.registerCommand(DebugCommands.SET_VARIABLE_VALUE, {
-            execute: () => this.selectedVariable && this.selectedVariable.open(),
+            execute: () => this.selectedVariable?.open(),
             isEnabled: () => !!this.selectedVariable && this.selectedVariable.supportSetVariable,
             isVisible: () => !!this.selectedVariable && this.selectedVariable.supportSetVariable
         });
         registry.registerCommand(DebugCommands.COPY_VARIABLE_VALUE, {
-            execute: () => this.selectedVariable && this.selectedVariable.copyValue(),
+            execute: () => this.selectedVariable?.copyValue(),
             isEnabled: () => !!this.selectedVariable && this.selectedVariable.supportCopyValue,
             isVisible: () => !!this.selectedVariable && this.selectedVariable.supportCopyValue
         });
         registry.registerCommand(DebugCommands.COPY_VARIABLE_AS_EXPRESSION, {
-            execute: () => this.selectedVariable && this.selectedVariable.copyAsExpression(),
+            execute: () => this.selectedVariable?.copyAsExpression(),
             isEnabled: () => !!this.selectedVariable && this.selectedVariable.supportCopyAsExpression,
             isVisible: () => !!this.selectedVariable && this.selectedVariable.supportCopyAsExpression
         });
@@ -841,57 +844,101 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
         // Debug context menu commands
         registry.registerCommand(DebugEditorContextCommands.ADD_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(position),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.toggleBreakpoint(position);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(position),
             isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(position)
         });
         registry.registerCommand(DebugEditorContextCommands.ADD_CONDITIONAL_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.addBreakpoint('condition', position),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.addBreakpoint('condition', position);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(position),
             isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(position)
         });
         registry.registerCommand(DebugEditorContextCommands.ADD_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.addBreakpoint('logMessage', position),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.addBreakpoint('logMessage', position);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(position),
             isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(position)
         });
         registry.registerCommand(DebugEditorContextCommands.REMOVE_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(position),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.toggleBreakpoint(position);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpoint(position),
             isVisible: position => this.isPosition(position) && !!this.editors.getBreakpoint(position)
         });
         registry.registerCommand(DebugEditorContextCommands.EDIT_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.editBreakpoint(position),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.editBreakpoint(position);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpoint(position),
             isVisible: position => this.isPosition(position) && !!this.editors.getBreakpoint(position)
         });
         registry.registerCommand(DebugEditorContextCommands.ENABLE_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(position, true),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.setBreakpointEnabled(position, true);
+                }
+            },
             isEnabled: position => this.isPosition(position) && this.editors.getBreakpointEnabled(position) === false,
             isVisible: position => this.isPosition(position) && this.editors.getBreakpointEnabled(position) === false
         });
         registry.registerCommand(DebugEditorContextCommands.DISABLE_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(position, false),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.setBreakpointEnabled(position, false);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpointEnabled(position),
             isVisible: position => this.isPosition(position) && !!this.editors.getBreakpointEnabled(position)
         });
         registry.registerCommand(DebugEditorContextCommands.REMOVE_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(position),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.toggleBreakpoint(position);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !!this.editors.getLogpoint(position),
             isVisible: position => this.isPosition(position) && !!this.editors.getLogpoint(position)
         });
         registry.registerCommand(DebugEditorContextCommands.EDIT_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.editBreakpoint(position),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.editBreakpoint(position);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !!this.editors.getLogpoint(position),
             isVisible: position => this.isPosition(position) && !!this.editors.getLogpoint(position)
         });
         registry.registerCommand(DebugEditorContextCommands.ENABLE_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(position, true),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.setBreakpointEnabled(position, true);
+                }
+            },
             isEnabled: position => this.isPosition(position) && this.editors.getLogpointEnabled(position) === false,
             isVisible: position => this.isPosition(position) && this.editors.getLogpointEnabled(position) === false
         });
         registry.registerCommand(DebugEditorContextCommands.DISABLE_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(position, false),
+            execute: position => {
+                if (this.isPosition(position)) {
+                    this.editors.setBreakpointEnabled(position, false);
+                }
+            },
             isEnabled: position => this.isPosition(position) && !!this.editors.getLogpointEnabled(position),
             isVisible: position => this.isPosition(position) && !!this.editors.getLogpointEnabled(position)
         });
@@ -927,7 +974,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             isVisible: () => !!this.watchExpression
         });
         registry.registerCommand(DebugCommands.COPY_WATCH_EXPRESSION_VALUE, {
-            execute: () => this.watchExpression && this.watchExpression.copyValue(),
+            execute: () => this.watchExpression?.copyValue(),
             isEnabled: () => !!this.watchExpression && this.watchExpression.supportCopyValue,
             isVisible: () => !!this.watchExpression && this.watchExpression.supportCopyValue
         });

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -86,296 +86,296 @@ export namespace DebugCommands {
     export const DEBUG_CATEGORY = 'Debug';
     export const DEBUG_CATEGORY_KEY = nls.getDefaultKey(DEBUG_CATEGORY);
 
-    export const START = Command.toDefaultLocalizedCommand<[config?: DebugSessionOptions], void>({
+    export const START = Command.toDefaultLocalizedCommand<(config?: DebugSessionOptions) => void>({
         id: 'workbench.action.debug.start',
         category: DEBUG_CATEGORY,
         label: 'Start Debugging',
         iconClass: codicon('debug-alt')
     });
-    export const START_NO_DEBUG = Command.toDefaultLocalizedCommand<[config?: DebugSessionOptions], void>({
+    export const START_NO_DEBUG = Command.toDefaultLocalizedCommand<(config?: DebugSessionOptions) => void>({
         id: 'workbench.action.debug.run',
         category: DEBUG_CATEGORY,
         label: 'Start Without Debugging'
     });
-    export const STOP = Command.toDefaultLocalizedCommand<[], void>({
+    export const STOP = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.debug.stop',
         category: DEBUG_CATEGORY,
         label: 'Stop',
         iconClass: codicon('debug-stop')
     });
-    export const RESTART = Command.toDefaultLocalizedCommand<[], DebugSession | undefined>({
+    export const RESTART = Command.toDefaultLocalizedCommand<() => DebugSession | undefined>({
         id: 'workbench.action.debug.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart',
     });
 
-    export const OPEN_CONFIGURATIONS = Command.toDefaultLocalizedCommand<[], void>({
+    export const OPEN_CONFIGURATIONS = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.configurations.open',
         category: DEBUG_CATEGORY,
         label: 'Open Configurations'
     });
-    export const ADD_CONFIGURATION = Command.toDefaultLocalizedCommand<[], void>({
+    export const ADD_CONFIGURATION = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.configurations.add',
         category: DEBUG_CATEGORY,
         label: 'Add Configuration...'
     });
 
-    export const STEP_OVER = Command.toDefaultLocalizedCommand<[], DebugProtocol.NextResponse | undefined>({
+    export const STEP_OVER = Command.toDefaultLocalizedCommand<() => DebugProtocol.NextResponse | undefined>({
         id: 'workbench.action.debug.stepOver',
         category: DEBUG_CATEGORY,
         label: 'Step Over',
         iconClass: codicon('debug-step-over')
     });
-    export const STEP_INTO = Command.toDefaultLocalizedCommand<[], DebugProtocol.StepInResponse | undefined>({
+    export const STEP_INTO = Command.toDefaultLocalizedCommand<() => DebugProtocol.StepInResponse | undefined>({
         id: 'workbench.action.debug.stepInto',
         category: DEBUG_CATEGORY,
         label: 'Step Into',
         iconClass: codicon('debug-step-into')
     });
-    export const STEP_OUT = Command.toDefaultLocalizedCommand<[], DebugProtocol.StepOutResponse | undefined>({
+    export const STEP_OUT = Command.toDefaultLocalizedCommand<() => DebugProtocol.StepOutResponse | undefined>({
         id: 'workbench.action.debug.stepOut',
         category: DEBUG_CATEGORY,
         label: 'Step Out',
         iconClass: codicon('debug-step-out')
     });
-    export const CONTINUE = Command.toDefaultLocalizedCommand<[], DebugProtocol.ContinueResponse | undefined>({
+    export const CONTINUE = Command.toDefaultLocalizedCommand<() => DebugProtocol.ContinueResponse | undefined>({
         id: 'workbench.action.debug.continue',
         category: DEBUG_CATEGORY,
         label: 'Continue',
         iconClass: codicon('debug-continue')
     });
-    export const PAUSE = Command.toDefaultLocalizedCommand<[], DebugProtocol.PauseResponse | undefined>({
+    export const PAUSE = Command.toDefaultLocalizedCommand<() => DebugProtocol.PauseResponse | undefined>({
         id: 'workbench.action.debug.pause',
         category: DEBUG_CATEGORY,
         label: 'Pause',
         iconClass: codicon('debug-pause')
     });
-    export const CONTINUE_ALL = Command.toLocalizedCommand<[], void>({
+    export const CONTINUE_ALL = Command.toLocalizedCommand<() => void>({
         id: 'debug.thread.continue.all',
         category: DEBUG_CATEGORY,
         label: 'Continue All',
         iconClass: codicon('debug-continue')
     }, 'theia/debug/continueAll', DEBUG_CATEGORY_KEY);
-    export const PAUSE_ALL = Command.toLocalizedCommand<[], void>({
+    export const PAUSE_ALL = Command.toLocalizedCommand<() => void>({
         id: 'debug.thread.pause.all',
         category: DEBUG_CATEGORY,
         label: 'Pause All',
         iconClass: codicon('debug-pause')
     }, 'theia/debug/pauseAll', DEBUG_CATEGORY_KEY);
 
-    export const TOGGLE_BREAKPOINT = Command.toDefaultLocalizedCommand<[], void>({
+    export const TOGGLE_BREAKPOINT = Command.toDefaultLocalizedCommand<() => void>({
         id: 'editor.debug.action.toggleBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Toggle Breakpoint',
     });
-    export const INLINE_BREAKPOINT = Command.toDefaultLocalizedCommand<[], void>({
+    export const INLINE_BREAKPOINT = Command.toDefaultLocalizedCommand<() => void>({
         id: 'editor.debug.action.inlineBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Inline Breakpoint',
     });
-    export const ADD_CONDITIONAL_BREAKPOINT = Command.toDefaultLocalizedCommand<[], void>({
+    export const ADD_CONDITIONAL_BREAKPOINT = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.breakpoint.add.conditional',
         category: DEBUG_CATEGORY,
         label: 'Add Conditional Breakpoint...',
     });
-    export const ADD_LOGPOINT = Command.toDefaultLocalizedCommand<[], void>({
+    export const ADD_LOGPOINT = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.breakpoint.add.logpoint',
         category: DEBUG_CATEGORY,
         label: 'Add Logpoint...',
     });
-    export const ADD_FUNCTION_BREAKPOINT = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
+    export const ADD_FUNCTION_BREAKPOINT = Command.toDefaultLocalizedCommand<(widget: unknown) => void>({
         id: 'debug.breakpoint.add.function',
         category: DEBUG_CATEGORY,
         label: 'Add Function Breakpoint',
     });
-    export const ENABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<[], void>({
+    export const ENABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.breakpoint.enableAll',
         category: DEBUG_CATEGORY,
         label: 'Enable All Breakpoints',
     });
-    export const DISABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<[], void>({
+    export const DISABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.breakpoint.disableAll',
         category: DEBUG_CATEGORY,
         label: 'Disable All Breakpoints',
     });
-    export const EDIT_BREAKPOINT = Command.toLocalizedCommand<[], void>({
+    export const EDIT_BREAKPOINT = Command.toLocalizedCommand<() => void>({
         id: 'debug.breakpoint.edit',
         category: DEBUG_CATEGORY,
         originalLabel: 'Edit Breakpoint...',
         label: nlsEditBreakpoint('Breakpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const EDIT_LOGPOINT = Command.toLocalizedCommand<[], void>({
+    export const EDIT_LOGPOINT = Command.toLocalizedCommand<() => void>({
         id: 'debug.logpoint.edit',
         category: DEBUG_CATEGORY,
         originalLabel: 'Edit Logpoint...',
         label: nlsEditBreakpoint('Logpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const REMOVE_BREAKPOINT = Command.toLocalizedCommand<[], void>({
+    export const REMOVE_BREAKPOINT = Command.toLocalizedCommand<() => void>({
         id: 'debug.breakpoint.remove',
         category: DEBUG_CATEGORY,
         originalLabel: 'Remove Breakpoint',
         label: nlsRemoveBreakpoint('Breakpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const REMOVE_LOGPOINT = Command.toLocalizedCommand<[], void>({
+    export const REMOVE_LOGPOINT = Command.toLocalizedCommand<() => void>({
         id: 'debug.logpoint.remove',
         category: DEBUG_CATEGORY,
         originalLabel: 'Remove Logpoint',
         label: nlsRemoveBreakpoint('Logpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const REMOVE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
+    export const REMOVE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand<(widget: unknown) => void>({
         id: 'debug.breakpoint.removeAll',
         category: DEBUG_CATEGORY,
         label: 'Remove All Breakpoints',
     });
-    export const TOGGLE_BREAKPOINTS_ENABLED = Command.toLocalizedCommand<[arg: unknown], void>({
+    export const TOGGLE_BREAKPOINTS_ENABLED = Command.toLocalizedCommand<(arg: unknown) => void>({
         id: 'debug.breakpoint.toggleEnabled'
     });
-    export const SHOW_HOVER = Command.toDefaultLocalizedCommand<[], void>({
+    export const SHOW_HOVER = Command.toDefaultLocalizedCommand<() => void>({
         id: 'editor.debug.action.showDebugHover',
         category: DEBUG_CATEGORY,
         label: 'Show Hover'
     });
 
-    export const RESTART_FRAME = Command.toDefaultLocalizedCommand<[], void>({
+    export const RESTART_FRAME = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.frame.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart Frame',
     });
-    export const COPY_CALL_STACK = Command.toDefaultLocalizedCommand<[], void>({
+    export const COPY_CALL_STACK = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.callStack.copy',
         category: DEBUG_CATEGORY,
         label: 'Copy Call Stack',
     });
 
-    export const SET_VARIABLE_VALUE = Command.toDefaultLocalizedCommand<[], void>({
+    export const SET_VARIABLE_VALUE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.variable.setValue',
         category: DEBUG_CATEGORY,
         label: 'Set Value',
     });
-    export const COPY_VARIABLE_VALUE = Command.toDefaultLocalizedCommand<[], void>({
+    export const COPY_VARIABLE_VALUE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.variable.copyValue',
         category: DEBUG_CATEGORY,
         label: 'Copy Value',
     });
-    export const COPY_VARIABLE_AS_EXPRESSION = Command.toDefaultLocalizedCommand<[], void>({
+    export const COPY_VARIABLE_AS_EXPRESSION = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.variable.copyAsExpression',
         category: DEBUG_CATEGORY,
         label: 'Copy as Expression',
     });
-    export const WATCH_VARIABLE = Command.toDefaultLocalizedCommand<[], void>({
+    export const WATCH_VARIABLE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.variable.watch',
         category: DEBUG_CATEGORY,
         label: 'Add to Watch',
     });
 
-    export const ADD_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
+    export const ADD_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<(widget: unknown) => void>({
         id: 'debug.watch.addExpression',
         category: DEBUG_CATEGORY,
         label: 'Add Expression'
     });
-    export const EDIT_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<[], void>({
+    export const EDIT_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.watch.editExpression',
         category: DEBUG_CATEGORY,
         label: 'Edit Expression'
     });
-    export const COPY_WATCH_EXPRESSION_VALUE = Command.toLocalizedCommand<[], void>({
+    export const COPY_WATCH_EXPRESSION_VALUE = Command.toLocalizedCommand<() => void>({
         id: 'debug.watch.copyExpressionValue',
         category: DEBUG_CATEGORY,
         label: 'Copy Expression Value'
     }, 'theia/debug/copyExpressionValue', DEBUG_CATEGORY_KEY);
-    export const REMOVE_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<[], void>({
+    export const REMOVE_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand<() => void>({
         id: 'debug.watch.removeExpression',
         category: DEBUG_CATEGORY,
         label: 'Remove Expression'
     });
-    export const COLLAPSE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
+    export const COLLAPSE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand<(widget: unknown) => void>({
         id: 'debug.watch.collapseAllExpressions',
         category: DEBUG_CATEGORY,
         label: 'Collapse All'
     });
-    export const REMOVE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand<[widget: unknown], void>({
+    export const REMOVE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand<(widget: unknown) => void>({
         id: 'debug.watch.removeAllExpressions',
         category: DEBUG_CATEGORY,
         label: 'Remove All Expressions'
     });
 }
 export namespace DebugThreadContextCommands {
-    export const STEP_OVER = Command.as<[], DebugProtocol.NextResponse | undefined>({
+    export const STEP_OVER = Command.as<() => DebugProtocol.NextResponse | undefined>({
         id: 'debug.thread.context.context.next'
     });
-    export const STEP_INTO = Command.as<[], DebugProtocol.StepInResponse | undefined>({
+    export const STEP_INTO = Command.as<() => DebugProtocol.StepInResponse | undefined>({
         id: 'debug.thread.context.stepin'
     });
-    export const STEP_OUT = Command.as<[], DebugProtocol.StepOutResponse | undefined>({
+    export const STEP_OUT = Command.as<() => DebugProtocol.StepOutResponse | undefined>({
         id: 'debug.thread.context.stepout'
     });
-    export const CONTINUE = Command.as<[], DebugProtocol.ContinueResponse | undefined>({
+    export const CONTINUE = Command.as<() => DebugProtocol.ContinueResponse | undefined>({
         id: 'debug.thread.context.continue'
     });
-    export const PAUSE = Command.as<[], DebugProtocol.PauseResponse | undefined>({
+    export const PAUSE = Command.as<() => DebugProtocol.PauseResponse | undefined>({
         id: 'debug.thread.context.pause'
     });
-    export const TERMINATE = Command.as<[], void>({
+    export const TERMINATE = Command.as<() => void>({
         id: 'debug.thread.context.terminate'
     });
 }
 export namespace DebugSessionContextCommands {
-    export const STOP = Command.as<[], void>({
+    export const STOP = Command.as<() => void>({
         id: 'debug.session.context.stop'
     });
-    export const RESTART = Command.as<[], DebugSession | undefined>({
+    export const RESTART = Command.as<() => DebugSession | undefined>({
         id: 'debug.session.context.restart'
     });
-    export const PAUSE_ALL = Command.as<[], void>({
+    export const PAUSE_ALL = Command.as<() => void>({
         id: 'debug.session.context.pauseAll'
     });
-    export const CONTINUE_ALL = Command.as<[], void>({
+    export const CONTINUE_ALL = Command.as<() => void>({
         id: 'debug.session.context.continueAll'
     });
-    export const REVEAL = Command.as<[], DebugSessionWidget | undefined>({
+    export const REVEAL = Command.as<() => DebugSessionWidget | undefined>({
         id: 'debug.session.context.reveal'
     });
 }
 export namespace DebugEditorContextCommands {
-    export const ADD_BREAKPOINT = Command.as<[position: monaco.Position], void>({
+    export const ADD_BREAKPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.addBreakpoint'
     });
-    export const ADD_CONDITIONAL_BREAKPOINT = Command.as<[position: monaco.Position], void>({
+    export const ADD_CONDITIONAL_BREAKPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.addBreakpoint.conditional'
     });
-    export const ADD_LOGPOINT = Command.as<[position: monaco.Position], void>({
+    export const ADD_LOGPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.add.logpoint'
     });
-    export const REMOVE_BREAKPOINT = Command.as<[position: monaco.Position], void>({
+    export const REMOVE_BREAKPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.removeBreakpoint'
     });
-    export const EDIT_BREAKPOINT = Command.as<[position: monaco.Position], void>({
+    export const EDIT_BREAKPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.edit.breakpoint'
     });
-    export const ENABLE_BREAKPOINT = Command.as<[position: monaco.Position], void>({
+    export const ENABLE_BREAKPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.enableBreakpoint'
     });
-    export const DISABLE_BREAKPOINT = Command.as<[position: monaco.Position], void>({
+    export const DISABLE_BREAKPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.disableBreakpoint'
     });
-    export const REMOVE_LOGPOINT = Command.as<[position: monaco.Position], void>({
+    export const REMOVE_LOGPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.logpoint.remove'
     });
-    export const EDIT_LOGPOINT = Command.as<[position: monaco.Position], void>({
+    export const EDIT_LOGPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.logpoint.edit'
     });
-    export const ENABLE_LOGPOINT = Command.as<[position: monaco.Position], void>({
+    export const ENABLE_LOGPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.logpoint.enable'
     });
-    export const DISABLE_LOGPOINT = Command.as<[position: monaco.Position], void>({
+    export const DISABLE_LOGPOINT = Command.as<(position: monaco.Position) => void>({
         id: 'debug.editor.context.logpoint.disable'
     });
 }
 export namespace DebugBreakpointWidgetCommands {
-    export const ACCEPT = Command.as<[], void>({
+    export const ACCEPT = Command.as<() => void>({
         id: 'debug.breakpointWidget.accept'
     });
-    export const CLOSE = Command.as<[], void>({
+    export const CLOSE = Command.as<() => void>({
         id: 'debug.breakpointWidget.close'
     });
 }

--- a/packages/debug/src/browser/debug-prefix-configuration.ts
+++ b/packages/debug/src/browser/debug-prefix-configuration.ts
@@ -61,7 +61,7 @@ export class DebugPrefixConfiguration implements CommandContribution, CommandHan
 
     readonly statusBarId = 'select-run-debug-statusbar-item';
 
-    private readonly command = Command.toDefaultLocalizedCommand({
+    private readonly command = Command.toDefaultLocalizedCommand<[], void>({
         id: 'select.debug.configuration',
         category: DebugCommands.DEBUG_CATEGORY,
         label: 'Select and Start Debugging'

--- a/packages/debug/src/browser/debug-prefix-configuration.ts
+++ b/packages/debug/src/browser/debug-prefix-configuration.ts
@@ -61,7 +61,7 @@ export class DebugPrefixConfiguration implements CommandContribution, CommandHan
 
     readonly statusBarId = 'select-run-debug-statusbar-item';
 
-    private readonly command = Command.toDefaultLocalizedCommand<[], void>({
+    private readonly command = Command.toDefaultLocalizedCommand<() => void>({
         id: 'select.debug.configuration',
         category: DebugCommands.DEBUG_CATEGORY,
         label: 'Select and Start Debugging'

--- a/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
@@ -26,7 +26,7 @@ import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
 import { nls } from '@theia/core/lib/common/nls';
 
 export namespace ExternalTerminalCommands {
-    export const OPEN_NATIVE_CONSOLE = Command.toDefaultLocalizedCommand<[], void>({
+    export const OPEN_NATIVE_CONSOLE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.terminal.openNativeConsole',
         label: 'Open New External Terminal'
     });

--- a/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
@@ -26,7 +26,7 @@ import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
 import { nls } from '@theia/core/lib/common/nls';
 
 export namespace ExternalTerminalCommands {
-    export const OPEN_NATIVE_CONSOLE = Command.toDefaultLocalizedCommand({
+    export const OPEN_NATIVE_CONSOLE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.terminal.openNativeConsole',
         label: 'Open New External Terminal'
     });

--- a/packages/filesystem/src/browser/download/file-download-command-contribution.ts
+++ b/packages/filesystem/src/browser/download/file-download-command-contribution.ts
@@ -68,7 +68,7 @@ export class FileDownloadCommandContribution implements CommandContribution {
 
 export namespace FileDownloadCommands {
 
-    export const DOWNLOAD = Command.toDefaultLocalizedCommand({
+    export const DOWNLOAD = Command.toDefaultLocalizedCommand<[], void>({
         id: 'file.download',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Download'

--- a/packages/filesystem/src/browser/download/file-download-command-contribution.ts
+++ b/packages/filesystem/src/browser/download/file-download-command-contribution.ts
@@ -68,7 +68,7 @@ export class FileDownloadCommandContribution implements CommandContribution {
 
 export namespace FileDownloadCommands {
 
-    export const DOWNLOAD = Command.toDefaultLocalizedCommand<[], void>({
+    export const DOWNLOAD = Command.toDefaultLocalizedCommand<() => void>({
         id: 'file.download',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Download'

--- a/packages/getting-started/src/browser/getting-started-contribution.ts
+++ b/packages/getting-started/src/browser/getting-started-contribution.ts
@@ -24,7 +24,7 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 /**
  * Triggers opening the `GettingStartedWidget`.
  */
-export const GettingStartedCommand = Command.as<[], GettingStartedWidget>({
+export const GettingStartedCommand = Command.as<() => GettingStartedWidget>({
     id: GettingStartedWidget.ID,
     label: GettingStartedWidget.LABEL
 });

--- a/packages/getting-started/src/browser/getting-started-contribution.ts
+++ b/packages/getting-started/src/browser/getting-started-contribution.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { CommandRegistry, MenuModelRegistry } from '@theia/core/lib/common';
+import { Command, CommandRegistry, MenuModelRegistry } from '@theia/core/lib/common';
 import { CommonMenus, AbstractViewContribution, FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
 import { GettingStartedWidget } from './getting-started-widget';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
@@ -24,10 +24,10 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 /**
  * Triggers opening the `GettingStartedWidget`.
  */
-export const GettingStartedCommand = {
+export const GettingStartedCommand = Command.as<[], GettingStartedWidget>({
     id: GettingStartedWidget.ID,
     label: GettingStartedWidget.LABEL
-};
+});
 
 @injectable()
 export class GettingStartedContribution extends AbstractViewContribution<GettingStartedWidget> implements FrontendApplicationContribution {

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -31,21 +31,21 @@ import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/li
 import { nls } from '@theia/core/lib/common/nls';
 
 export namespace KeymapsCommands {
-    export const OPEN_KEYMAPS = Command.toDefaultLocalizedCommand<[], KeybindingWidget>({
+    export const OPEN_KEYMAPS = Command.toDefaultLocalizedCommand<() => KeybindingWidget>({
         id: 'keymaps:open',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Keyboard Shortcuts',
     });
-    export const OPEN_KEYMAPS_JSON = Command.toDefaultLocalizedCommand<[], void>({
+    export const OPEN_KEYMAPS_JSON = Command.toDefaultLocalizedCommand<() => void>({
         id: 'keymaps:openJson',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Keyboard Shortcuts (JSON)',
     });
-    export const OPEN_KEYMAPS_JSON_TOOLBAR = Command.as<[widget: Widget], void>({
+    export const OPEN_KEYMAPS_JSON_TOOLBAR = Command.as<(widget: Widget) => void>({
         id: 'keymaps:openJson.toolbar',
         iconClass: codicon('json')
     });
-    export const CLEAR_KEYBINDINGS_SEARCH = Command.as<[widget: Widget], void>({
+    export const CLEAR_KEYBINDINGS_SEARCH = Command.as<(widget: Widget) => void>({
         id: 'keymaps.clearSearch',
         iconClass: codicon('clear-all')
     });

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -31,24 +31,24 @@ import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/li
 import { nls } from '@theia/core/lib/common/nls';
 
 export namespace KeymapsCommands {
-    export const OPEN_KEYMAPS = Command.toDefaultLocalizedCommand({
+    export const OPEN_KEYMAPS = Command.toDefaultLocalizedCommand<[], KeybindingWidget>({
         id: 'keymaps:open',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Keyboard Shortcuts',
     });
-    export const OPEN_KEYMAPS_JSON = Command.toDefaultLocalizedCommand({
+    export const OPEN_KEYMAPS_JSON = Command.toDefaultLocalizedCommand<[], void>({
         id: 'keymaps:openJson',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Keyboard Shortcuts (JSON)',
     });
-    export const OPEN_KEYMAPS_JSON_TOOLBAR: Command = {
+    export const OPEN_KEYMAPS_JSON_TOOLBAR = Command.as<[widget: Widget], void>({
         id: 'keymaps:openJson.toolbar',
         iconClass: codicon('json')
-    };
-    export const CLEAR_KEYBINDINGS_SEARCH: Command = {
+    });
+    export const CLEAR_KEYBINDINGS_SEARCH = Command.as<[widget: Widget], void>({
         id: 'keymaps.clearSearch',
         iconClass: codicon('clear-all')
-    };
+    });
 }
 
 @injectable()
@@ -79,12 +79,16 @@ export class KeymapsFrontendContribution extends AbstractViewContribution<Keybin
         commands.registerCommand(KeymapsCommands.OPEN_KEYMAPS_JSON_TOOLBAR, {
             isEnabled: w => this.withWidget(w, () => true),
             isVisible: w => this.withWidget(w, () => true),
-            execute: w => this.withWidget(w, widget => this.keymaps.open(widget)),
+            execute: w => {
+                this.withWidget(w, widget => this.keymaps.open(widget));
+            }
         });
         commands.registerCommand(KeymapsCommands.CLEAR_KEYBINDINGS_SEARCH, {
             isEnabled: w => this.withWidget(w, widget => widget.hasSearch()),
             isVisible: w => this.withWidget(w, () => true),
-            execute: w => this.withWidget(w, widget => widget.clearSearch()),
+            execute: w => {
+                this.withWidget(w, widget => widget.clearSearch());
+            }
         });
     }
 

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -37,20 +37,20 @@ export namespace ProblemsMenu {
 }
 
 export namespace ProblemsCommands {
-    export const COLLAPSE_ALL: Command = {
+    export const COLLAPSE_ALL = Command.as<[], void>({
         id: 'problems.collapse.all'
-    };
-    export const COLLAPSE_ALL_TOOLBAR: Command = {
+    });
+    export const COLLAPSE_ALL_TOOLBAR = Command.as<[widget: Widget], void>({
         id: 'problems.collapse.all.toolbar',
         iconClass: codicon('collapse-all')
-    };
-    export const COPY: Command = {
+    });
+    export const COPY = Command.as({
         id: 'problems.copy'
-    };
-    export const COPY_MESSAGE: Command = {
+    });
+    export const COPY_MESSAGE = Command.as({
         id: 'problems.copy.message',
-    };
-    export const CLEAR_ALL = Command.toLocalizedCommand({
+    });
+    export const CLEAR_ALL = Command.toLocalizedCommand<[widget: Widget], void>({
         id: 'problems.clear.all',
         category: 'Problems',
         label: 'Clear All',
@@ -134,7 +134,9 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         commands.registerCommand(ProblemsCommands.COLLAPSE_ALL_TOOLBAR, {
             isEnabled: widget => this.withWidget(widget, () => true),
             isVisible: widget => this.withWidget(widget, () => true),
-            execute: widget => this.withWidget(widget, () => this.collapseAllProblems())
+            execute: widget => {
+                this.withWidget(widget, () => this.collapseAllProblems());
+            }
         });
         commands.registerCommand(ProblemsCommands.COPY,
             new ProblemSelection.CommandHandler(this.selectionService, {
@@ -155,7 +157,9 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         commands.registerCommand(ProblemsCommands.CLEAR_ALL, {
             isEnabled: widget => this.withWidget(widget, () => true),
             isVisible: widget => this.withWidget(widget, () => true),
-            execute: widget => this.withWidget(widget, () => this.problemManager.cleanAllMarkers())
+            execute: widget => {
+                this.withWidget(widget, () => this.problemManager.cleanAllMarkers());
+            }
         });
     }
 

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -37,10 +37,10 @@ export namespace ProblemsMenu {
 }
 
 export namespace ProblemsCommands {
-    export const COLLAPSE_ALL = Command.as<[], void>({
+    export const COLLAPSE_ALL = Command.as<() => void>({
         id: 'problems.collapse.all'
     });
-    export const COLLAPSE_ALL_TOOLBAR = Command.as<[widget: Widget], void>({
+    export const COLLAPSE_ALL_TOOLBAR = Command.as<(widget: Widget) => void>({
         id: 'problems.collapse.all.toolbar',
         iconClass: codicon('collapse-all')
     });
@@ -50,7 +50,7 @@ export namespace ProblemsCommands {
     export const COPY_MESSAGE = Command.as({
         id: 'problems.copy.message',
     });
-    export const CLEAR_ALL = Command.toLocalizedCommand<[widget: Widget], void>({
+    export const CLEAR_ALL = Command.toLocalizedCommand<(widget: Widget) => void>({
         id: 'problems.clear.all',
         category: 'Problems',
         label: 'Clear All',

--- a/packages/messages/src/browser/notifications-commands.ts
+++ b/packages/messages/src/browser/notifications-commands.ts
@@ -22,26 +22,26 @@ export namespace NotificationsCommands {
     const NOTIFICATIONS_CATEGORY = 'Notifications';
     const NOTIFICATIONS_CATEGORY_KEY = nls.getDefaultKey(NOTIFICATIONS_CATEGORY);
 
-    export const TOGGLE = Command.toLocalizedCommand({
+    export const TOGGLE = Command.toLocalizedCommand<[], void>({
         id: 'notifications.commands.toggle',
         category: NOTIFICATIONS_CATEGORY,
         iconClass: codicon('list-unordered'),
         label: 'Toggle Notifications'
     }, 'theia/messages/toggleNotifications', NOTIFICATIONS_CATEGORY_KEY);
 
-    export const SHOW = Command.toDefaultLocalizedCommand({
+    export const SHOW = Command.toDefaultLocalizedCommand<[], void>({
         id: 'notifications.commands.show',
         category: NOTIFICATIONS_CATEGORY,
         label: 'Show Notifications'
     });
 
-    export const HIDE = Command.toDefaultLocalizedCommand({
+    export const HIDE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'notifications.commands.hide',
         category: NOTIFICATIONS_CATEGORY,
         label: 'Hide Notifications'
     });
 
-    export const CLEAR_ALL = Command.toDefaultLocalizedCommand({
+    export const CLEAR_ALL = Command.toDefaultLocalizedCommand<[], void>({
         id: 'notifications.commands.clearAll',
         category: NOTIFICATIONS_CATEGORY,
         iconClass: codicon('clear-all'),

--- a/packages/messages/src/browser/notifications-commands.ts
+++ b/packages/messages/src/browser/notifications-commands.ts
@@ -22,26 +22,26 @@ export namespace NotificationsCommands {
     const NOTIFICATIONS_CATEGORY = 'Notifications';
     const NOTIFICATIONS_CATEGORY_KEY = nls.getDefaultKey(NOTIFICATIONS_CATEGORY);
 
-    export const TOGGLE = Command.toLocalizedCommand<[], void>({
+    export const TOGGLE = Command.toLocalizedCommand<() => void>({
         id: 'notifications.commands.toggle',
         category: NOTIFICATIONS_CATEGORY,
         iconClass: codicon('list-unordered'),
         label: 'Toggle Notifications'
     }, 'theia/messages/toggleNotifications', NOTIFICATIONS_CATEGORY_KEY);
 
-    export const SHOW = Command.toDefaultLocalizedCommand<[], void>({
+    export const SHOW = Command.toDefaultLocalizedCommand<() => void>({
         id: 'notifications.commands.show',
         category: NOTIFICATIONS_CATEGORY,
         label: 'Show Notifications'
     });
 
-    export const HIDE = Command.toDefaultLocalizedCommand<[], void>({
+    export const HIDE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'notifications.commands.hide',
         category: NOTIFICATIONS_CATEGORY,
         label: 'Hide Notifications'
     });
 
-    export const CLEAR_ALL = Command.toDefaultLocalizedCommand<[], void>({
+    export const CLEAR_ALL = Command.toDefaultLocalizedCommand<() => void>({
         id: 'notifications.commands.clearAll',
         category: NOTIFICATIONS_CATEGORY,
         iconClass: codicon('clear-all'),

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -38,16 +38,16 @@ export namespace MiniBrowserCommands {
     export const PREVIEW_CATEGORY = 'Preview';
     export const PREVIEW_CATEGORY_KEY = nls.getDefaultKey(PREVIEW_CATEGORY);
 
-    export const PREVIEW = Command.toLocalizedCommand({
+    export const PREVIEW = Command.toLocalizedCommand<[widget: Widget], void>({
         id: 'mini-browser.preview',
         label: 'Open Preview',
         iconClass: codicon('open-preview')
     }, 'vscode.markdown-language-features/package/markdown.preview.title');
-    export const OPEN_SOURCE: Command = {
+    export const OPEN_SOURCE = Command.as<[widget: Widget], void>({
         id: 'mini-browser.open.source',
         iconClass: codicon('go-to-file')
-    };
-    export const OPEN_URL = Command.toDefaultLocalizedCommand({
+    });
+    export const OPEN_URL = Command.toDefaultLocalizedCommand<[arg?: string], void>({
         id: 'mini-browser.openUrl',
         category: PREVIEW_CATEGORY,
         label: 'Open URL'

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -38,16 +38,16 @@ export namespace MiniBrowserCommands {
     export const PREVIEW_CATEGORY = 'Preview';
     export const PREVIEW_CATEGORY_KEY = nls.getDefaultKey(PREVIEW_CATEGORY);
 
-    export const PREVIEW = Command.toLocalizedCommand<[widget: Widget], void>({
+    export const PREVIEW = Command.toLocalizedCommand<(widget: Widget) => void>({
         id: 'mini-browser.preview',
         label: 'Open Preview',
         iconClass: codicon('open-preview')
     }, 'vscode.markdown-language-features/package/markdown.preview.title');
-    export const OPEN_SOURCE = Command.as<[widget: Widget], void>({
+    export const OPEN_SOURCE = Command.as<(widget: Widget) => void>({
         id: 'mini-browser.open.source',
         iconClass: codicon('go-to-file')
     });
-    export const OPEN_URL = Command.toDefaultLocalizedCommand<[arg?: string], void>({
+    export const OPEN_URL = Command.toDefaultLocalizedCommand<(arg?: string) => void>({
         id: 'mini-browser.openUrl',
         category: PREVIEW_CATEGORY,
         label: 'Open URL'

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -362,7 +362,9 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             isVisible: widget => this.withOpenEditorsWidget(widget, () => !!this.editorWidgets.length)
         });
         registry.registerCommand(OpenEditorsCommands.SAVE_ALL_TABS_FROM_TOOLBAR, {
-            execute: widget => this.withOpenEditorsWidget(widget, () => registry.executeCommand(CommonCommands.SAVE_ALL.id)),
+            execute: widget => {
+                this.withOpenEditorsWidget(widget, () => registry.executeCommand(CommonCommands.SAVE_ALL.id));
+            },
             isEnabled: widget => this.withOpenEditorsWidget(widget, () => !!this.editorWidgets.length),
             isVisible: widget => this.withOpenEditorsWidget(widget, () => !!this.editorWidgets.length)
         });

--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -35,7 +35,7 @@ export namespace OutlineViewCommands {
      * Command which collapses all nodes
      * from the `outline-view` tree.
      */
-    export const COLLAPSE_ALL = Command.as<[widget: Widget], void>({
+    export const COLLAPSE_ALL = Command.as<(widget: Widget) => void>({
         id: 'outlineView.collapse.all',
         iconClass: codicon('collapse-all')
     });

--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -35,10 +35,10 @@ export namespace OutlineViewCommands {
      * Command which collapses all nodes
      * from the `outline-view` tree.
      */
-    export const COLLAPSE_ALL: Command = {
+    export const COLLAPSE_ALL = Command.as<[widget: Widget], void>({
         id: 'outlineView.collapse.all',
         iconClass: codicon('collapse-all')
-    };
+    });
 }
 
 @injectable()

--- a/packages/output/src/browser/output-commands.ts
+++ b/packages/output/src/browser/output-commands.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { codicon } from '@theia/core/lib/browser';
+import { codicon, Widget } from '@theia/core/lib/browser';
 import { Command, nls } from '@theia/core/lib/common';
 
 export namespace OutputCommands {
@@ -25,76 +25,73 @@ export namespace OutputCommands {
     /* #region VS Code `OutputChannel` API */
     // Based on: https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/vscode.d.ts#L4692-L4745
 
-    export const APPEND: Command = {
+    export const APPEND = Command.as<[{ name: string, text: string }], void>({
         id: 'output:append'
-    };
+    });
 
-    export const APPEND_LINE: Command = {
+    export const APPEND_LINE = Command.as<[{ name: string, text: string}], void>({
         id: 'output:appendLine'
-    };
+    });
 
-    export const CLEAR: Command = {
+    export const CLEAR = Command.as<[{ name: string }], void>({
         id: 'output:clear'
-    };
+    });
 
-    export const SHOW: Command = {
+    export const SHOW = Command.as<[{ name: string, options?: { preserveFocus?: boolean } }], void>({
         id: 'output:show'
-    };
+    });
 
-    export const HIDE: Command = {
+    export const HIDE = Command.as<[{ name: string }], void>({
         id: 'output:hide'
-    };
+    });
 
-    export const DISPOSE: Command = {
+    export const DISPOSE = Command.as<[ { name: string }], void>({
         id: 'output:dispose'
-    };
+    });
 
     /* #endregion VS Code `OutputChannel` API */
 
-    export const CLEAR__WIDGET = Command.toLocalizedCommand({
+    export const CLEAR__WIDGET = Command.as<[widget: unknown], void>({
         id: 'output:widget:clear',
-        category: OUTPUT_CATEGORY,
         iconClass: codicon('clear-all')
-    }, '', OUTPUT_CATEGORY_KEY);
+    });
 
-    export const LOCK__WIDGET = Command.toLocalizedCommand({
+    export const LOCK__WIDGET = Command.as<[widget: Widget], void>({
         id: 'output:widget:lock',
-        category: OUTPUT_CATEGORY,
         iconClass: codicon('unlock')
-    }, '', OUTPUT_CATEGORY_KEY);
+    });
 
-    export const UNLOCK__WIDGET = Command.toLocalizedCommand({
+    export const UNLOCK__WIDGET = Command.as<[widget: Widget], void>({
         id: 'output:widget:unlock',
-        category: OUTPUT_CATEGORY,
         iconClass: codicon('lock')
-    }, '', OUTPUT_CATEGORY_KEY);
+    });
 
-    export const CLEAR__QUICK_PICK = Command.toLocalizedCommand({
+    export const CLEAR__QUICK_PICK = Command.toLocalizedCommand<[], void>({
         id: 'output:pick-clear',
         label: 'Clear Output Channel...',
         category: OUTPUT_CATEGORY
     }, 'theia/output/clearOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const SHOW__QUICK_PICK = Command.toLocalizedCommand({
+    export const SHOW__QUICK_PICK = Command.toLocalizedCommand<[], void>({
         id: 'output:pick-show',
         label: 'Show Output Channel...',
         category: OUTPUT_CATEGORY
     }, 'theia/output/showOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const HIDE__QUICK_PICK = Command.toLocalizedCommand({
+    export const HIDE__QUICK_PICK = Command.toLocalizedCommand<[], void>({
         id: 'output:pick-hide',
         label: 'Hide Output Channel...',
         category: OUTPUT_CATEGORY
     }, 'theia/output/hideOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const DISPOSE__QUICK_PICK = Command.toLocalizedCommand({
+    export const DISPOSE__QUICK_PICK = Command.toLocalizedCommand<[], void>({
         id: 'output:pick-dispose',
         label: 'Close Output Channel...',
         category: OUTPUT_CATEGORY
     }, 'theia/output/closeOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const COPY_ALL: Command = {
+    export const COPY_ALL = Command.as<[], void>({
         id: 'output:copy-all',
-    };
+    });
 
 }

--- a/packages/output/src/browser/output-commands.ts
+++ b/packages/output/src/browser/output-commands.ts
@@ -25,72 +25,72 @@ export namespace OutputCommands {
     /* #region VS Code `OutputChannel` API */
     // Based on: https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/vscode.d.ts#L4692-L4745
 
-    export const APPEND = Command.as<[{ name: string, text: string }], void>({
+    export const APPEND = Command.as<(arg: { name: string, text: string }) => void>({
         id: 'output:append'
     });
 
-    export const APPEND_LINE = Command.as<[{ name: string, text: string}], void>({
+    export const APPEND_LINE = Command.as<(arg: { name: string, text: string }) => void>({
         id: 'output:appendLine'
     });
 
-    export const CLEAR = Command.as<[{ name: string }], void>({
+    export const CLEAR = Command.as<(arg: { name: string }) => void>({
         id: 'output:clear'
     });
 
-    export const SHOW = Command.as<[{ name: string, options?: { preserveFocus?: boolean } }], void>({
+    export const SHOW = Command.as<(arg: { name: string, options?: { preserveFocus?: boolean } }) => void>({
         id: 'output:show'
     });
 
-    export const HIDE = Command.as<[{ name: string }], void>({
+    export const HIDE = Command.as<(arg: { name: string }) => void>({
         id: 'output:hide'
     });
 
-    export const DISPOSE = Command.as<[ { name: string }], void>({
+    export const DISPOSE = Command.as<(arg: { name: string }) => void>({
         id: 'output:dispose'
     });
 
     /* #endregion VS Code `OutputChannel` API */
 
-    export const CLEAR__WIDGET = Command.as<[widget: unknown], void>({
+    export const CLEAR__WIDGET = Command.as<(widget: unknown) => void>({
         id: 'output:widget:clear',
         iconClass: codicon('clear-all')
     });
 
-    export const LOCK__WIDGET = Command.as<[widget: Widget], void>({
+    export const LOCK__WIDGET = Command.as<(widget: Widget) => void>({
         id: 'output:widget:lock',
         iconClass: codicon('unlock')
     });
 
-    export const UNLOCK__WIDGET = Command.as<[widget: Widget], void>({
+    export const UNLOCK__WIDGET = Command.as<(widget: Widget) => void>({
         id: 'output:widget:unlock',
         iconClass: codicon('lock')
     });
 
-    export const CLEAR__QUICK_PICK = Command.toLocalizedCommand<[], void>({
+    export const CLEAR__QUICK_PICK = Command.toLocalizedCommand<() => void>({
         id: 'output:pick-clear',
         label: 'Clear Output Channel...',
         category: OUTPUT_CATEGORY
     }, 'theia/output/clearOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const SHOW__QUICK_PICK = Command.toLocalizedCommand<[], void>({
+    export const SHOW__QUICK_PICK = Command.toLocalizedCommand<() => void>({
         id: 'output:pick-show',
         label: 'Show Output Channel...',
         category: OUTPUT_CATEGORY
     }, 'theia/output/showOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const HIDE__QUICK_PICK = Command.toLocalizedCommand<[], void>({
+    export const HIDE__QUICK_PICK = Command.toLocalizedCommand<() => void>({
         id: 'output:pick-hide',
         label: 'Hide Output Channel...',
         category: OUTPUT_CATEGORY
     }, 'theia/output/hideOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const DISPOSE__QUICK_PICK = Command.toLocalizedCommand<[], void>({
+    export const DISPOSE__QUICK_PICK = Command.toLocalizedCommand<() => void>({
         id: 'output:pick-dispose',
         label: 'Close Output Channel...',
         category: OUTPUT_CATEGORY
     }, 'theia/output/closeOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const COPY_ALL = Command.as<[], void>({
+    export const COPY_ALL = Command.as<() => void>({
         id: 'output:copy-all',
     });
 

--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -95,18 +95,22 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
         registry.registerCommand(OutputCommands.LOCK__WIDGET, {
             isEnabled: widget => this.withWidget(widget, output => !output.isLocked),
             isVisible: widget => this.withWidget(widget, output => !output.isLocked),
-            execute: widget => this.withWidget(widget, output => {
-                output.lock();
-                return true;
-            })
+            execute: widget => {
+                this.withWidget(widget, output => {
+                    output.lock();
+                    return true;
+                });
+            }
         });
         registry.registerCommand(OutputCommands.UNLOCK__WIDGET, {
             isEnabled: widget => this.withWidget(widget, output => output.isLocked),
             isVisible: widget => this.withWidget(widget, output => output.isLocked),
-            execute: widget => this.withWidget(widget, output => {
-                output.unlock();
-                return true;
-            })
+            execute: widget => {
+                this.withWidget(widget, output => {
+                    output.unlock();
+                    return true;
+                });
+            }
         });
         registry.registerCommand(OutputCommands.COPY_ALL, {
             execute: () => {

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -735,7 +735,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({
             id: 'copyFilePath'
         }, {
-            execute: () => commands.executeCommand(CommonCommands.COPY_PATH.id)
+            execute: () => commands.executeCommand(CommonCommands.COPY_PATH.id, [])
         });
         commands.registerCommand({
             id: 'copyRelativeFilePath'

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -32,19 +32,15 @@ import { nls } from '@theia/core/lib/common/nls';
 import debounce = require('@theia/core/shared/lodash.debounce');
 
 export namespace PreviewCommands {
-    /**
-     * No `label`. Otherwise, it would show up in the `Command Palette` and we already have the `Preview` open handler.
-     * See in (`WorkspaceCommandContribution`)[https://bit.ly/2DncrSD].
-     */
-    export const OPEN = Command.toLocalizedCommand({
+    export const OPEN = Command.toLocalizedCommand<[widget: Widget], void>({
         id: 'preview:open',
         label: 'Open Preview',
         iconClass: codicon('open-preview')
     }, 'vscode.markdown-language-features/package/markdown.preview.title');
-    export const OPEN_SOURCE: Command = {
+    export const OPEN_SOURCE = Command.as<[widget: Widget], void>({
         id: 'preview.open.source',
         iconClass: codicon('go-to-file')
-    };
+    });
 }
 
 export interface PreviewOpenerOptions extends WidgetOpenerOptions {
@@ -213,7 +209,11 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
             isVisible: widget => this.canHandleEditorUri(widget)
         });
         registry.registerCommand(PreviewCommands.OPEN_SOURCE, {
-            execute: widget => this.openSource(widget),
+            execute: widget => {
+                if (widget instanceof PreviewWidget) {
+                    this.openSource(widget);
+                }
+            },
             isEnabled: widget => widget instanceof PreviewWidget,
             isVisible: widget => widget instanceof PreviewWidget
         });

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -32,12 +32,12 @@ import { nls } from '@theia/core/lib/common/nls';
 import debounce = require('@theia/core/shared/lodash.debounce');
 
 export namespace PreviewCommands {
-    export const OPEN = Command.toLocalizedCommand<[widget: Widget], void>({
+    export const OPEN = Command.toLocalizedCommand<(widget: Widget) => void>({
         id: 'preview:open',
         label: 'Open Preview',
         iconClass: codicon('open-preview')
     }, 'vscode.markdown-language-features/package/markdown.preview.title');
-    export const OPEN_SOURCE = Command.as<[widget: Widget], void>({
+    export const OPEN_SOURCE = Command.as<(widget: Widget) => void>({
         id: 'preview.open.source',
         iconClass: codicon('go-to-file')
     });

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -39,65 +39,65 @@ import { isHighContrast } from '@theia/core/lib/common/theme';
 
 export namespace SearchInWorkspaceCommands {
     const SEARCH_CATEGORY = 'Search';
-    export const TOGGLE_SIW_WIDGET = {
+    export const TOGGLE_SIW_WIDGET = Command.as({
         id: 'search-in-workspace.toggle'
-    };
-    export const OPEN_SIW_WIDGET = Command.toDefaultLocalizedCommand({
+    });
+    export const OPEN_SIW_WIDGET = Command.toDefaultLocalizedCommand<[], void>({
         id: 'search-in-workspace.open',
         category: SEARCH_CATEGORY,
         label: 'Find in Files'
     });
-    export const REPLACE_IN_FILES = Command.toDefaultLocalizedCommand({
+    export const REPLACE_IN_FILES = Command.toDefaultLocalizedCommand<[], void>({
         id: 'search-in-workspace.replace',
         category: SEARCH_CATEGORY,
         label: 'Replace in Files'
     });
-    export const FIND_IN_FOLDER = Command.toDefaultLocalizedCommand({
+    export const FIND_IN_FOLDER = Command.toDefaultLocalizedCommand<[uris: URI[]], void>({
         id: 'search-in-workspace.in-folder',
         category: SEARCH_CATEGORY,
         label: 'Find in Folder...'
     });
-    export const REFRESH_RESULTS = Command.toDefaultLocalizedCommand({
+    export const REFRESH_RESULTS = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
         id: 'search-in-workspace.refresh',
         category: SEARCH_CATEGORY,
         label: 'Refresh',
         iconClass: codicon('refresh')
     });
-    export const CANCEL_SEARCH = Command.toDefaultLocalizedCommand({
+    export const CANCEL_SEARCH = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
         id: 'search-in-workspace.cancel',
         category: SEARCH_CATEGORY,
         label: 'Cancel Search',
         iconClass: codicon('search-stop')
     });
-    export const COLLAPSE_ALL = Command.toDefaultLocalizedCommand({
+    export const COLLAPSE_ALL = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
         id: 'search-in-workspace.collapse-all',
         category: SEARCH_CATEGORY,
         label: 'Collapse All',
         iconClass: codicon('collapse-all')
     });
-    export const EXPAND_ALL = Command.toDefaultLocalizedCommand({
+    export const EXPAND_ALL = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
         id: 'search-in-workspace.expand-all',
         category: SEARCH_CATEGORY,
         label: 'Expand All',
         iconClass: codicon('expand-all')
     });
-    export const CLEAR_ALL = Command.toDefaultLocalizedCommand({
+    export const CLEAR_ALL = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
         id: 'search-in-workspace.clear-all',
         category: SEARCH_CATEGORY,
         label: 'Clear Search Results',
         iconClass: codicon('clear-all')
     });
-    export const COPY_ALL = Command.toDefaultLocalizedCommand({
+    export const COPY_ALL = Command.toDefaultLocalizedCommand<[], void>({
         id: 'search.action.copyAll',
         category: SEARCH_CATEGORY,
         label: 'Copy All',
     });
-    export const COPY_ONE = Command.toDefaultLocalizedCommand({
+    export const COPY_ONE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'search.action.copyMatch',
         category: SEARCH_CATEGORY,
         label: 'Copy',
     });
-    export const DISMISS_RESULT = Command.toDefaultLocalizedCommand({
+    export const DISMISS_RESULT = Command.toDefaultLocalizedCommand<[], void>({
         id: 'search.action.remove',
         category: SEARCH_CATEGORY,
         label: 'Dismiss',
@@ -182,27 +182,37 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         }));
 
         commands.registerCommand(SearchInWorkspaceCommands.CANCEL_SEARCH, {
-            execute: w => this.withWidget(w, widget => widget.getCancelIndicator() && widget.getCancelIndicator()!.cancel()),
+            execute: w => {
+                this.withWidget(w, widget => widget.getCancelIndicator() && widget.getCancelIndicator()!.cancel());
+            },
             isEnabled: w => this.withWidget(w, widget => widget.getCancelIndicator() !== undefined),
             isVisible: w => this.withWidget(w, widget => widget.getCancelIndicator() !== undefined)
         });
         commands.registerCommand(SearchInWorkspaceCommands.REFRESH_RESULTS, {
-            execute: w => this.withWidget(w, widget => widget.refresh()),
+            execute: w => {
+                this.withWidget(w, widget => widget.refresh());
+            },
             isEnabled: w => this.withWidget(w, widget => (widget.hasResultList() || widget.hasSearchTerm()) && this.workspaceService.tryGetRoots().length > 0),
             isVisible: w => this.withWidget(w, () => true)
         });
         commands.registerCommand(SearchInWorkspaceCommands.COLLAPSE_ALL, {
-            execute: w => this.withWidget(w, widget => widget.collapseAll()),
+            execute: w => {
+                this.withWidget(w, widget => widget.collapseAll());
+            },
             isEnabled: w => this.withWidget(w, widget => widget.hasResultList()),
             isVisible: w => this.withWidget(w, widget => !widget.areResultsCollapsed())
         });
         commands.registerCommand(SearchInWorkspaceCommands.EXPAND_ALL, {
-            execute: w => this.withWidget(w, widget => widget.expandAll()),
+            execute: w => {
+                this.withWidget(w, widget => widget.expandAll());
+            },
             isEnabled: w => this.withWidget(w, widget => widget.hasResultList()),
             isVisible: w => this.withWidget(w, widget => widget.areResultsCollapsed())
         });
         commands.registerCommand(SearchInWorkspaceCommands.CLEAR_ALL, {
-            execute: w => this.withWidget(w, widget => widget.clear()),
+            execute: w => {
+                this.withWidget(w, widget => widget.clear());
+            },
             isEnabled: w => this.withWidget(w, widget => widget.hasResultList()),
             isVisible: w => this.withWidget(w, () => true)
         });
@@ -215,12 +225,14 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
                 const { selection } = this.selectionService;
                 return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
             }),
-            execute: () => this.withWidget(undefined, widget => {
-                const { selection } = this.selectionService;
-                if (TreeWidgetSelection.is(selection)) {
-                    widget.resultTreeWidget.removeNode(selection[0]);
-                }
-            })
+            execute: () => {
+                this.withWidget(undefined, widget => {
+                    const { selection } = this.selectionService;
+                    if (TreeWidgetSelection.is(selection)) {
+                        widget.resultTreeWidget.removeNode(selection[0]);
+                    }
+                });
+            }
         });
         commands.registerCommand(SearchInWorkspaceCommands.COPY_ONE, {
             isEnabled: () => this.withWidget(undefined, widget => {
@@ -231,15 +243,17 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
                 const { selection } = this.selectionService;
                 return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
             }),
-            execute: () => this.withWidget(undefined, widget => {
-                const { selection } = this.selectionService;
-                if (TreeWidgetSelection.is(selection)) {
-                    const string = widget.resultTreeWidget.nodeToString(selection[0], true);
-                    if (string.length !== 0) {
-                        this.clipboardService.writeText(string);
+            execute: () => {
+                this.withWidget(undefined, widget => {
+                    const { selection } = this.selectionService;
+                    if (TreeWidgetSelection.is(selection)) {
+                        const string = widget.resultTreeWidget.nodeToString(selection[0], true);
+                        if (string.length !== 0) {
+                            this.clipboardService.writeText(string);
+                        }
                     }
-                }
-            })
+                });
+            }
         });
         commands.registerCommand(SearchInWorkspaceCommands.COPY_ALL, {
             isEnabled: () => this.withWidget(undefined, widget => {
@@ -250,15 +264,17 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
                 const { selection } = this.selectionService;
                 return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
             }),
-            execute: () => this.withWidget(undefined, widget => {
-                const { selection } = this.selectionService;
-                if (TreeWidgetSelection.is(selection)) {
-                    const string = widget.resultTreeWidget.treeToString();
-                    if (string.length !== 0) {
-                        this.clipboardService.writeText(string);
+            execute: () => {
+                this.withWidget(undefined, widget => {
+                    const { selection } = this.selectionService;
+                    if (TreeWidgetSelection.is(selection)) {
+                        const string = widget.resultTreeWidget.treeToString();
+                        if (string.length !== 0) {
+                            this.clipboardService.writeText(string);
+                        }
                     }
-                }
-            })
+                });
+            }
         });
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -42,62 +42,62 @@ export namespace SearchInWorkspaceCommands {
     export const TOGGLE_SIW_WIDGET = Command.as({
         id: 'search-in-workspace.toggle'
     });
-    export const OPEN_SIW_WIDGET = Command.toDefaultLocalizedCommand<[], void>({
+    export const OPEN_SIW_WIDGET = Command.toDefaultLocalizedCommand<() => void>({
         id: 'search-in-workspace.open',
         category: SEARCH_CATEGORY,
         label: 'Find in Files'
     });
-    export const REPLACE_IN_FILES = Command.toDefaultLocalizedCommand<[], void>({
+    export const REPLACE_IN_FILES = Command.toDefaultLocalizedCommand<() => void>({
         id: 'search-in-workspace.replace',
         category: SEARCH_CATEGORY,
         label: 'Replace in Files'
     });
-    export const FIND_IN_FOLDER = Command.toDefaultLocalizedCommand<[uris: URI[]], void>({
+    export const FIND_IN_FOLDER = Command.toDefaultLocalizedCommand<(uris: URI[]) => void>({
         id: 'search-in-workspace.in-folder',
         category: SEARCH_CATEGORY,
         label: 'Find in Folder...'
     });
-    export const REFRESH_RESULTS = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
+    export const REFRESH_RESULTS = Command.toDefaultLocalizedCommand<(widget: Widget) => void>({
         id: 'search-in-workspace.refresh',
         category: SEARCH_CATEGORY,
         label: 'Refresh',
         iconClass: codicon('refresh')
     });
-    export const CANCEL_SEARCH = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
+    export const CANCEL_SEARCH = Command.toDefaultLocalizedCommand<(widget: Widget) => void>({
         id: 'search-in-workspace.cancel',
         category: SEARCH_CATEGORY,
         label: 'Cancel Search',
         iconClass: codicon('search-stop')
     });
-    export const COLLAPSE_ALL = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
+    export const COLLAPSE_ALL = Command.toDefaultLocalizedCommand<(widget: Widget) => void>({
         id: 'search-in-workspace.collapse-all',
         category: SEARCH_CATEGORY,
         label: 'Collapse All',
         iconClass: codicon('collapse-all')
     });
-    export const EXPAND_ALL = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
+    export const EXPAND_ALL = Command.toDefaultLocalizedCommand<(widget: Widget) => void>({
         id: 'search-in-workspace.expand-all',
         category: SEARCH_CATEGORY,
         label: 'Expand All',
         iconClass: codicon('expand-all')
     });
-    export const CLEAR_ALL = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
+    export const CLEAR_ALL = Command.toDefaultLocalizedCommand<(widget: Widget) => void>({
         id: 'search-in-workspace.clear-all',
         category: SEARCH_CATEGORY,
         label: 'Clear Search Results',
         iconClass: codicon('clear-all')
     });
-    export const COPY_ALL = Command.toDefaultLocalizedCommand<[], void>({
+    export const COPY_ALL = Command.toDefaultLocalizedCommand<() => void>({
         id: 'search.action.copyAll',
         category: SEARCH_CATEGORY,
         label: 'Copy All',
     });
-    export const COPY_ONE = Command.toDefaultLocalizedCommand<[], void>({
+    export const COPY_ONE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'search.action.copyMatch',
         category: SEARCH_CATEGORY,
         label: 'Copy',
     });
-    export const DISMISS_RESULT = Command.toDefaultLocalizedCommand<[], void>({
+    export const DISMISS_RESULT = Command.toDefaultLocalizedCommand<() => void>({
         id: 'search.action.remove',
         category: SEARCH_CATEGORY,
         label: 'Dismiss',

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -68,17 +68,17 @@ export namespace TerminalMenus {
 
 export namespace TerminalCommands {
     const TERMINAL_CATEGORY = 'Terminal';
-    export const NEW = Command.toDefaultLocalizedCommand<[], void>({
+    export const NEW = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:new',
         category: TERMINAL_CATEGORY,
         label: 'Create New Integrated Terminal'
     });
-    export const NEW_ACTIVE_WORKSPACE = Command.toDefaultLocalizedCommand<[], void>({
+    export const NEW_ACTIVE_WORKSPACE = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:new:active:workspace',
         category: TERMINAL_CATEGORY,
         label: 'Create New Integrated Terminal (In Active Workspace)'
     });
-    export const TERMINAL_CLEAR = Command.toDefaultLocalizedCommand<[], void>({
+    export const TERMINAL_CLEAR = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:clear',
         category: TERMINAL_CATEGORY,
         label: 'Clear'
@@ -88,48 +88,48 @@ export namespace TerminalCommands {
         category: TERMINAL_CATEGORY,
         label: 'Open in Terminal'
     });
-    export const SPLIT = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
+    export const SPLIT = Command.toDefaultLocalizedCommand<(widget: Widget) => void>({
         id: 'terminal:split',
         category: TERMINAL_CATEGORY,
         label: 'Split Terminal'
     });
-    export const TERMINAL_FIND_TEXT = Command.toDefaultLocalizedCommand<[], void>({
+    export const TERMINAL_FIND_TEXT = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:find',
         category: TERMINAL_CATEGORY,
         label: 'Find'
     });
-    export const TERMINAL_FIND_TEXT_CANCEL = Command.toDefaultLocalizedCommand<[], void>({
+    export const TERMINAL_FIND_TEXT_CANCEL = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:find:cancel',
         category: TERMINAL_CATEGORY,
         label: 'Hide Find'
     });
 
-    export const SCROLL_LINE_UP = Command.toDefaultLocalizedCommand<[], void>({
+    export const SCROLL_LINE_UP = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:scroll:line:up',
         category: TERMINAL_CATEGORY,
         label: 'Scroll Up (Line)'
     });
-    export const SCROLL_LINE_DOWN = Command.toDefaultLocalizedCommand<[], void>({
+    export const SCROLL_LINE_DOWN = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:scroll:line:down',
         category: TERMINAL_CATEGORY,
         label: 'Scroll Down (Line)'
     });
-    export const SCROLL_TO_TOP = Command.toDefaultLocalizedCommand<[], void>({
+    export const SCROLL_TO_TOP = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:scroll:top',
         category: TERMINAL_CATEGORY,
         label: 'Scroll to Top'
     });
-    export const SCROLL_PAGE_UP = Command.toDefaultLocalizedCommand<[], void>({
+    export const SCROLL_PAGE_UP = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:scroll:page:up',
         category: TERMINAL_CATEGORY,
         label: 'Scroll Up (Page)'
     });
-    export const SCROLL_PAGE_DOWN = Command.toDefaultLocalizedCommand<[], void>({
+    export const SCROLL_PAGE_DOWN = Command.toDefaultLocalizedCommand<() => void>({
         id: 'terminal:scroll:page:down',
         category: TERMINAL_CATEGORY,
         label: 'Scroll Down (Page)'
     });
-    export const TOGGLE_TERMINAL = Command.toDefaultLocalizedCommand<[], void>({
+    export const TOGGLE_TERMINAL = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.terminal.toggleTerminal',
         category: TERMINAL_CATEGORY,
         label: 'Toggle Terminal'
@@ -138,7 +138,7 @@ export namespace TerminalCommands {
     /**
      * Command that displays all terminals that are currently opened
      */
-    export const SHOW_ALL_OPENED_TERMINALS = Command.toDefaultLocalizedCommand<[], void>({
+    export const SHOW_ALL_OPENED_TERMINALS = Command.toDefaultLocalizedCommand<() => void>({
         id: 'workbench.action.showAllTerminals',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Show All Opened Terminals'

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -68,17 +68,17 @@ export namespace TerminalMenus {
 
 export namespace TerminalCommands {
     const TERMINAL_CATEGORY = 'Terminal';
-    export const NEW = Command.toDefaultLocalizedCommand({
+    export const NEW = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:new',
         category: TERMINAL_CATEGORY,
         label: 'Create New Integrated Terminal'
     });
-    export const NEW_ACTIVE_WORKSPACE = Command.toDefaultLocalizedCommand({
+    export const NEW_ACTIVE_WORKSPACE = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:new:active:workspace',
         category: TERMINAL_CATEGORY,
         label: 'Create New Integrated Terminal (In Active Workspace)'
     });
-    export const TERMINAL_CLEAR = Command.toDefaultLocalizedCommand({
+    export const TERMINAL_CLEAR = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:clear',
         category: TERMINAL_CATEGORY,
         label: 'Clear'
@@ -88,48 +88,48 @@ export namespace TerminalCommands {
         category: TERMINAL_CATEGORY,
         label: 'Open in Terminal'
     });
-    export const SPLIT = Command.toDefaultLocalizedCommand({
+    export const SPLIT = Command.toDefaultLocalizedCommand<[widget: Widget], void>({
         id: 'terminal:split',
         category: TERMINAL_CATEGORY,
         label: 'Split Terminal'
     });
-    export const TERMINAL_FIND_TEXT = Command.toDefaultLocalizedCommand({
+    export const TERMINAL_FIND_TEXT = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:find',
         category: TERMINAL_CATEGORY,
         label: 'Find'
     });
-    export const TERMINAL_FIND_TEXT_CANCEL = Command.toDefaultLocalizedCommand({
+    export const TERMINAL_FIND_TEXT_CANCEL = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:find:cancel',
         category: TERMINAL_CATEGORY,
         label: 'Hide Find'
     });
 
-    export const SCROLL_LINE_UP = Command.toDefaultLocalizedCommand({
+    export const SCROLL_LINE_UP = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:scroll:line:up',
         category: TERMINAL_CATEGORY,
         label: 'Scroll Up (Line)'
     });
-    export const SCROLL_LINE_DOWN = Command.toDefaultLocalizedCommand({
+    export const SCROLL_LINE_DOWN = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:scroll:line:down',
         category: TERMINAL_CATEGORY,
         label: 'Scroll Down (Line)'
     });
-    export const SCROLL_TO_TOP = Command.toDefaultLocalizedCommand({
+    export const SCROLL_TO_TOP = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:scroll:top',
         category: TERMINAL_CATEGORY,
         label: 'Scroll to Top'
     });
-    export const SCROLL_PAGE_UP = Command.toDefaultLocalizedCommand({
+    export const SCROLL_PAGE_UP = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:scroll:page:up',
         category: TERMINAL_CATEGORY,
         label: 'Scroll Up (Page)'
     });
-    export const SCROLL_PAGE_DOWN = Command.toDefaultLocalizedCommand({
+    export const SCROLL_PAGE_DOWN = Command.toDefaultLocalizedCommand<[], void>({
         id: 'terminal:scroll:page:down',
         category: TERMINAL_CATEGORY,
         label: 'Scroll Down (Page)'
     });
-    export const TOGGLE_TERMINAL = Command.toDefaultLocalizedCommand({
+    export const TOGGLE_TERMINAL = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.terminal.toggleTerminal',
         category: TERMINAL_CATEGORY,
         label: 'Toggle Terminal'
@@ -138,7 +138,7 @@ export namespace TerminalCommands {
     /**
      * Command that displays all terminals that are currently opened
      */
-    export const SHOW_ALL_OPENED_TERMINALS = Command.toDefaultLocalizedCommand({
+    export const SHOW_ALL_OPENED_TERMINALS = Command.toDefaultLocalizedCommand<[], void>({
         id: 'workbench.action.showAllTerminals',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Show All Opened Terminals'

--- a/packages/timeline/src/browser/timeline-contribution.ts
+++ b/packages/timeline/src/browser/timeline-contribution.ts
@@ -44,18 +44,21 @@ export class TimelineContribution implements CommandContribution, TabBarToolbarC
     @inject(ApplicationShell)
     protected readonly shell: ApplicationShell;
 
-    public static readonly LOAD_MORE_COMMAND: Command = {
+    public static readonly LOAD_MORE_COMMAND = Command.as<[], void>({
         id: 'timeline-load-more'
-    };
+    });
+
     private readonly toolbarItem = {
         id: 'timeline-refresh-toolbar-item',
         command: 'timeline-refresh',
         tooltip: 'Refresh',
         icon: codicon('refresh')
     };
+
     registerToolbarItems(registry: TabBarToolbarRegistry): void {
         registry.registerItem(this.toolbarItem);
     }
+
     registerCommands(commands: CommandRegistry): void {
         const attachTimeline = async (explorer: Widget) => {
             const timeline = await this.widgetManager.getOrCreateWidget(TimelineWidget.ID);

--- a/packages/timeline/src/browser/timeline-contribution.ts
+++ b/packages/timeline/src/browser/timeline-contribution.ts
@@ -44,7 +44,7 @@ export class TimelineContribution implements CommandContribution, TabBarToolbarC
     @inject(ApplicationShell)
     protected readonly shell: ApplicationShell;
 
-    public static readonly LOAD_MORE_COMMAND = Command.as<[], void>({
+    public static readonly LOAD_MORE_COMMAND = Command.as<() => void>({
         id: 'timeline-load-more'
     });
 


### PR DESCRIPTION
There is currently no typings for commands, which means users that wish
to execute commands must know/guess what the command arguments and
return value are without much telling them what those are precisely.

Add a new type `CommandId<Arguments, ReturnType>`.

Have support optional generics `Command<Arguments, ReturnType>`.

Update `CommandService` and `CommandRegistry` to deal with this new
information.

#### How to test

TBD

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
