### PR TITLE
scm: select node based on active editor

### DIFF
--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -21,10 +21,7 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { isOSX } from '@theia/core/lib/common/os';
 import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
-import {
-    TreeWidget, TreeNode, SelectableTreeNode, TreeModel, TreeProps,
-    NodeProps, TREE_NODE_SEGMENT_CLASS, TREE_NODE_SEGMENT_GROW_CLASS, DepthFirstTreeIterator
-} from '@theia/core/lib/browser/tree';
+import { TreeWidget, TreeNode, SelectableTreeNode, TreeModel, TreeProps, NodeProps, TREE_NODE_SEGMENT_CLASS, TREE_NODE_SEGMENT_GROW_CLASS } from '@theia/core/lib/browser/tree';
 import { ScmTreeModel, ScmFileChangeRootNode, ScmFileChangeGroupNode, ScmFileChangeFolderNode, ScmFileChangeNode } from './scm-tree-model';
 import { MenuModelRegistry, ActionMenuNode, CompositeMenuNode, MenuPath } from '@theia/core/lib/common/menu';
 import { ScmResource } from './scm-provider';
@@ -359,10 +356,11 @@ export class ScmTreeWidget extends TreeWidget {
     }
 
     selectNodeByUri(uri: URI): void {
-        const root = this.model.root;
-        if (!root) { return; }
-        for (const node of new DepthFirstTreeIterator(root)) {
-            if (ScmFileChangeNode.is(node) && node.sourceUri.includes(uri.path.toString())) {
+        for (const group of this.model.groups) {
+            const sourceUri = new URI(uri.path.toString());
+            const id = `${group.id}:${sourceUri.toString()}`;
+            const node = this.model.getNode(id);
+            if (SelectableTreeNode.is(node)) {
                 this.model.selectNode(node);
                 return;
             }

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -21,7 +21,10 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { isOSX } from '@theia/core/lib/common/os';
 import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
-import { TreeWidget, TreeNode, SelectableTreeNode, TreeModel, TreeProps, NodeProps, TREE_NODE_SEGMENT_CLASS, TREE_NODE_SEGMENT_GROW_CLASS } from '@theia/core/lib/browser/tree';
+import {
+    TreeWidget, TreeNode, SelectableTreeNode, TreeModel, TreeProps,
+    NodeProps, TREE_NODE_SEGMENT_CLASS, TREE_NODE_SEGMENT_GROW_CLASS, DepthFirstTreeIterator
+} from '@theia/core/lib/browser/tree';
 import { ScmTreeModel, ScmFileChangeRootNode, ScmFileChangeGroupNode, ScmFileChangeFolderNode, ScmFileChangeNode } from './scm-tree-model';
 import { MenuModelRegistry, ActionMenuNode, CompositeMenuNode, MenuPath } from '@theia/core/lib/common/menu';
 import { ScmResource } from './scm-provider';
@@ -351,6 +354,17 @@ export class ScmTreeWidget extends TreeWidget {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    selectNodeByUri(uri: URI): void {
+        const root = this.model.root;
+        if (!root) { return; }
+        for (const node of new DepthFirstTreeIterator(root)) {
+            if (ScmFileChangeNode.is(node) && node.sourceUri.includes(uri.path.toString())) {
+                this.model.selectNode(node);
+                return;
             }
         }
     }

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -20,7 +20,7 @@ import { Message } from '@theia/core/shared/@phosphor/messaging';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import {
-    BaseWidget, Widget, StatefulWidget, Panel, PanelLayout, MessageLoop, CompositeTreeNode, SelectableTreeNode,
+    BaseWidget, Widget, StatefulWidget, Panel, PanelLayout, MessageLoop, CompositeTreeNode, SelectableTreeNode, ApplicationShell, NavigatableWidget,
 } from '@theia/core/lib/browser';
 import { ScmCommitWidget } from './scm-commit-widget';
 import { ScmAmendWidget } from './scm-amend-widget';
@@ -37,6 +37,7 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
 
     static ID = 'scm-view';
 
+    @inject(ApplicationShell) protected readonly shell: ApplicationShell;
     @inject(ScmService) protected readonly scmService: ScmService;
     @inject(ScmCommitWidget) protected readonly commitWidget: ScmCommitWidget;
     @inject(ScmTreeWidget) readonly resourceWidget: ScmTreeWidget;
@@ -82,6 +83,12 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         this.toDispose.push(this.scmPreferences.onPreferenceChanged(e => {
             if (e.preferenceName === 'scm.defaultViewMode') {
                 this.updateViewMode(e.newValue);
+            }
+        }));
+        this.toDispose.push(this.shell.onDidChangeCurrentWidget(({ newValue }) => {
+            const uri = NavigatableWidget.getUri(newValue || undefined);
+            if (uri) {
+                this.resourceWidget.selectNodeByUri(uri);
             }
         }));
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11558.

The pull-request updates the `scm-view` to properly select the appropriate `node` in the changes tree based on the active editor. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with a workspace under git version control
2. perform changes in two files
3. open the `scm-view` and open the `working tree` changes for both
4. switching between the two files should now properly set the tree selection
5. confirm it works for `list` and `tree` view modes
6. confirm it works for deep nested files
7. confirm it works for working tree, regular editors, and preview editors

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>