### PR TITLE
plugin: Support Cancellation token in file events

### DIFF
--- a/packages/plugin-ext/src/plugin/file-system-event-service-ext-impl.ts
+++ b/packages/plugin-ext/src/plugin/file-system-event-service-ext-impl.ts
@@ -209,13 +209,13 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
     async $onWillRunFileOperation(operation: FileOperation, target: UriComponents, source: UriComponents | undefined, timeout: number, token: CancellationToken): Promise<any> {
         switch (operation) {
             case FileOperation.MOVE:
-                await this._fireWillEvent(this._onWillRenameFile, { files: [{ oldUri: URI.revive(source!), newUri: URI.revive(target) }] }, timeout, token);
+                await this._fireWillEvent(this._onWillRenameFile, { files: [{ oldUri: URI.revive(source!), newUri: URI.revive(target) }], token: token }, timeout, token);
                 break;
             case FileOperation.DELETE:
-                await this._fireWillEvent(this._onWillDeleteFile, { files: [URI.revive(target)] }, timeout, token);
+                await this._fireWillEvent(this._onWillDeleteFile, { files: [URI.revive(target)], token: token }, timeout, token);
                 break;
             case FileOperation.CREATE:
-                await this._fireWillEvent(this._onWillCreateFile, { files: [URI.revive(target)] }, timeout, token);
+                await this._fireWillEvent(this._onWillCreateFile, { files: [URI.revive(target)], token: token }, timeout, token);
                 break;
             default:
             // ignore, dont send

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1696,6 +1696,11 @@ export module '@theia/plugin' {
     export interface FileWillCreateEvent {
 
         /**
+         * A cancellation token.
+         */
+        readonly token: CancellationToken;
+
+        /**
          * The files that are going to be created.
          */
         readonly files: ReadonlyArray<Uri>;
@@ -1751,6 +1756,11 @@ export module '@theia/plugin' {
     export interface FileWillDeleteEvent {
 
         /**
+         * A cancellation token.
+         */
+        readonly token: CancellationToken;
+
+        /**
          * The files that are going to be deleted.
          */
         readonly files: ReadonlyArray<Uri>;
@@ -1804,6 +1814,11 @@ export module '@theia/plugin' {
      * thenable that resolves to a [workspace edit](#WorkspaceEdit).
      */
     export interface FileWillRenameEvent {
+
+        /**
+         * A cancellation token.
+         */
+        readonly token: CancellationToken;
 
         /**
          * The files that are going to be renamed.


### PR DESCRIPTION
This closes #11508

Signed-off-by: Morten Engelhardt Olsen <MortenEngelhardt.Olsen@microchip.com>

#### What it does
Adds `token` to the `Will` file events, in accordance with https://code.visualstudio.com/api/references/vscode-api#FileWillCreateEvent

#### How to test


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
