### PR TITLE
terminal: allow `terminal clear` without it being active

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -347,8 +347,7 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
         });
         commands.registerCommand(TerminalCommands.TERMINAL_CLEAR);
         commands.registerHandler(TerminalCommands.TERMINAL_CLEAR.id, {
-            isEnabled: () => this.shell.activeWidget instanceof TerminalWidget,
-            execute: () => (this.shell.activeWidget as TerminalWidget).clearOutput()
+            execute: () => this.currentTerminal?.clearOutput()
         });
         commands.registerCommand(TerminalCommands.TERMINAL_CONTEXT, UriAwareCommandHandler.MonoSelect(this.selectionService, {
             execute: uri => this.openInTerminal(uri)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates the command handler for `Terminal: Clear` so it does not rely on the terminal actually being the `activeWidget`. Instead, the handler will clear the `currentTerminal`.

_**Note**_: if the terminal is hidden the output will not be cleared (I'm not sure I agree with VS Code's decision to clear).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. spawn multiple terminals and produce output in them (ex: `ls -al`)
3. open an editor or focus another widget
4. <kbd>F1</kbd> > `Terminal: Close` should be enabled, and it should clear the last active terminal (`currentTerminal`).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>