### PR TITLE
eslint: disable `no-unused-expressions` for tests

### DIFF
--- a/configs/errors.eslintrc.json
+++ b/configs/errors.eslintrc.json
@@ -157,7 +157,8 @@
       "rules": {
         "@theia/runtime-import-check": "off",
         "@theia/shared-dependencies": "off",
-        "import/no-extraneous-dependencies": "off"
+        "import/no-extraneous-dependencies": "off",
+        "no-unused-expressions": "off"
       }
     },
     {

--- a/examples/api-tests/src/launch-preferences.spec.js
+++ b/examples/api-tests/src/launch-preferences.spec.js
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 // @ts-check
-/* eslint-disable no-unused-expressions, @typescript-eslint/no-explicit-any */
+/* @typescript-eslint/no-explicit-any */
 
 /**
  * @typedef {'.vscode' | '.theia' | ['.theia', '.vscode']} ConfigMode

--- a/examples/electron/test/basic-example.espec.ts
+++ b/examples/electron/test/basic-example.espec.ts
@@ -36,7 +36,6 @@ describe.skip('basic-example-spec', () => {
             mainWindow.webContents.openDevTools();
             mainWindow.loadURL(`file://${path.join(__dirname, 'index.html')}`);
 
-            // eslint-disable-next-line no-unused-expressions
             expect(mainWindow.isVisible()).to.be.true;
         });
     });

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -44,8 +44,6 @@ import { StatusBar } from './status-bar';
 
 disableJSDOM();
 
-/* eslint-disable no-unused-expressions */
-
 const expect = chai.expect;
 
 let keybindingRegistry: KeybindingRegistry;

--- a/packages/core/src/browser/keyboard/keys.spec.ts
+++ b/packages/core/src/browser/keyboard/keys.spec.ts
@@ -24,8 +24,6 @@ import * as sinon from 'sinon';
 
 disableJSDOM();
 
-/* eslint-disable no-unused-expressions */
-
 const expect = chai.expect;
 
 describe('keys api', () => {

--- a/packages/core/src/browser/label-parser.spec.ts
+++ b/packages/core/src/browser/label-parser.spec.ts
@@ -18,8 +18,6 @@ import { CommandService } from './../common';
 import { Container } from 'inversify';
 import { expect } from 'chai';
 
-/* eslint-disable no-unused-expressions */
-
 let statusBarEntryUtility: LabelParser;
 
 before(() => {

--- a/packages/core/src/browser/preferences/preference-proxy.spec.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.spec.ts
@@ -15,7 +15,6 @@
 // *****************************************************************************
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-unused-expressions */
 
 import { enableJSDOM } from '../test/jsdom';
 

--- a/packages/core/src/browser/preferences/preference-service.spec.ts
+++ b/packages/core/src/browser/preferences/preference-service.spec.ts
@@ -15,7 +15,6 @@
 // *****************************************************************************
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-unused-expressions */
 
 import { enableJSDOM } from '../test/jsdom';
 

--- a/packages/core/src/browser/preferences/preference-validation-service.spec.ts
+++ b/packages/core/src/browser/preferences/preference-validation-service.spec.ts
@@ -22,7 +22,7 @@ import * as assert from 'assert';
 import { JSONValue } from '@phosphor/coreutils';
 import { IJSONSchema, JsonType } from '../../common/json-schema';
 
-/* eslint-disable no-unused-expressions,no-null/no-null */
+/* eslint-disable no-null/no-null */
 
 describe('Preference Validation Service', () => {
     const container = new Container();

--- a/packages/core/src/browser/tree/tree-decorator.spec.ts
+++ b/packages/core/src/browser/tree/tree-decorator.spec.ts
@@ -17,8 +17,6 @@
 import { expect } from 'chai';
 import { TreeDecoratorService, AbstractTreeDecoratorService, TreeDecoration } from './tree-decorator';
 
-/* eslint-disable no-unused-expressions */
-
 class MockTreeDecoratorService extends AbstractTreeDecoratorService {
 
     constructor() {

--- a/packages/core/src/browser/tree/tree-expansion.spec.ts
+++ b/packages/core/src/browser/tree/tree-expansion.spec.ts
@@ -22,7 +22,6 @@ import { ExpandableTreeNode } from './tree-expansion';
 import { createTreeTestContainer } from './test/tree-test-container';
 import { timeout } from '../../common/promise-util';
 
-/* eslint-disable no-unused-expressions */
 describe('TreeExpansionService', () => {
     let model: TreeModel;
     beforeEach(() => {

--- a/packages/core/src/browser/tree/tree-iterator.spec.ts
+++ b/packages/core/src/browser/tree/tree-iterator.spec.ts
@@ -22,9 +22,6 @@ import { DepthFirstTreeIterator, BreadthFirstTreeIterator, BottomUpTreeIterator,
 import { createTreeTestContainer } from './test/tree-test-container';
 import { ExpandableTreeNode } from './tree-expansion';
 
-/* eslint-disable no-unused-expressions */
-/* eslint-disable max-len */
-
 describe('tree-iterator', () => {
 
     const model = createTreeModel();

--- a/packages/core/src/browser/tree/tree-selection-state.spec.ts
+++ b/packages/core/src/browser/tree/tree-selection-state.spec.ts
@@ -21,8 +21,6 @@ import { createTreeTestContainer } from './test/tree-test-container';
 import { SelectableTreeNode, TreeSelection } from './tree-selection';
 import { TreeModel } from './tree-model';
 
-/* eslint-disable no-unused-expressions */
-
 namespace TreeSelectionState {
 
     export interface Expectation {

--- a/packages/core/src/browser/tree/tree.spec.ts
+++ b/packages/core/src/browser/tree/tree.spec.ts
@@ -21,7 +21,6 @@ import { MockTreeModel } from './test/mock-tree-model';
 import { expect } from 'chai';
 import { createTreeTestContainer } from './test/tree-test-container';
 
-/* eslint-disable no-unused-expressions */
 describe('Tree', () => {
 
     it('addChildren', () => {

--- a/packages/core/src/browser/widget-manager.spec.ts
+++ b/packages/core/src/browser/widget-manager.spec.ts
@@ -40,7 +40,6 @@ class TestWidgetFactory implements WidgetFactory {
     }
 }
 
-/* eslint-disable no-unused-expressions */
 describe('widget-manager', () => {
     let widgetManager: WidgetManager;
     before(() => {

--- a/packages/core/src/common/command.spec.ts
+++ b/packages/core/src/common/command.spec.ts
@@ -21,8 +21,6 @@ import * as chai from 'chai';
 const expect = chai.expect;
 let commandRegistry: CommandRegistry;
 
-/* eslint-disable no-unused-expressions */
-
 describe('Commands', () => {
 
     beforeEach(() => {

--- a/packages/core/src/common/disposable.spec.ts
+++ b/packages/core/src/common/disposable.spec.ts
@@ -18,7 +18,6 @@ import { expect } from 'chai';
 import { DisposableCollection, Disposable } from './disposable';
 
 describe('Disposables', () => {
-    /* eslint-disable no-unused-expressions */
     it('Is safe to use Disposable.NULL', () => {
         const collectionA = new DisposableCollection(Disposable.NULL);
         const collectionB = new DisposableCollection(Disposable.NULL);

--- a/packages/core/src/common/logger.spec.ts
+++ b/packages/core/src/common/logger.spec.ts
@@ -18,8 +18,6 @@ import { expect } from 'chai';
 import { MockLogger } from './test/mock-logger';
 import { setRootLogger, unsetRootLogger } from './logger';
 
-/* eslint-disable no-unused-expressions */
-
 describe('logger', () => {
 
     it('window is not defined', () => {

--- a/packages/core/src/common/menu/menu.spec.ts
+++ b/packages/core/src/common/menu/menu.spec.ts
@@ -59,7 +59,6 @@ describe('menu-model-registry', () => {
             expect(file.label, 'File');
             const openGroup = file.children[0] as CompositeMenuNode;
             expect(openGroup.children.length).equals(2);
-            // eslint-disable-next-line no-unused-expressions
             expect(openGroup.label).undefined;
         });
     });

--- a/packages/core/src/common/preferences/preference-scope.spec.ts
+++ b/packages/core/src/common/preferences/preference-scope.spec.ts
@@ -32,7 +32,6 @@ describe('PreferenceScope', () => {
     });
 
     it('is() returns whether a value is a preference scope', () => {
-        /* eslint-disable no-unused-expressions */
         expect(PreferenceScope.is(PreferenceScope.Default)).to.be.true;
         expect(PreferenceScope.is(PreferenceScope.User)).to.be.true;
         expect(PreferenceScope.is(PreferenceScope.Workspace)).to.be.true;
@@ -45,6 +44,5 @@ describe('PreferenceScope', () => {
         expect(PreferenceScope.is(-1)).to.be.false;
         expect(PreferenceScope.is({})).to.be.false;
         expect(PreferenceScope.is('Default')).to.be.false;
-        /* eslint-enable no-unused-expressions */
     });
 });

--- a/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
@@ -32,8 +32,6 @@ import { NavigationLocationService } from './navigation-location-service';
 
 disableJSDOM();
 
-/* eslint-disable no-unused-expressions */
-
 describe('navigation-location-service', () => {
 
     let stack: NavigationLocationService;

--- a/packages/editor/src/browser/navigation/navigation-location-similarity.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-similarity.spec.ts
@@ -18,8 +18,6 @@ import { expect } from 'chai';
 import { NavigationLocation } from './navigation-location';
 import { NavigationLocationSimilarity } from './navigation-location-similarity';
 
-/* eslint-disable no-unused-expressions */
-
 describe('navigation-location-similarity', () => {
 
     const similarity = new NavigationLocationSimilarity();

--- a/packages/editor/src/browser/navigation/navigation-location-updater.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-updater.spec.ts
@@ -19,8 +19,6 @@ import { NavigationLocation, Range } from './navigation-location';
 import { TextDocumentContentChangeDelta } from '../editor';
 import { MockNavigationLocationUpdater } from './test/mock-navigation-location-updater';
 
-/* eslint-disable no-unused-expressions */
-
 describe('navigation-location-updater', () => {
 
     const updater = new MockNavigationLocationUpdater();

--- a/packages/file-search/src/node/file-search-service-impl.spec.ts
+++ b/packages/file-search/src/node/file-search-service-impl.spec.ts
@@ -26,8 +26,6 @@ import URI from '@theia/core/lib/common/uri';
 import { FileSearchService } from '../common/file-search-service';
 import { RawProcessFactory } from '@theia/process/lib/node';
 
-/* eslint-disable no-unused-expressions */
-
 const testContainer = new Container();
 
 bindLogger(testContainer.bind.bind(testContainer));

--- a/packages/filesystem/src/common/remote-file-system-provider.ts
+++ b/packages/filesystem/src/common/remote-file-system-provider.ts
@@ -500,7 +500,6 @@ export class FileSystemProviderServer implements RemoteFileSystemServer {
             stream.on('error', error => {
                 const code = error instanceof FileSystemProviderError ? error.code : undefined;
                 const { name, message, stack } = error;
-                // eslint-disable-next-line no-unused-expressions
                 this.client?.onFileStreamEnd(handle, { code, name, message, stack });
             });
             stream.on('end', () => this.client?.onFileStreamEnd(handle, undefined));

--- a/packages/filesystem/src/node/download/directory-archiver.spec.ts
+++ b/packages/filesystem/src/node/download/directory-archiver.spec.ts
@@ -23,8 +23,6 @@ import URI from '@theia/core/lib/common/uri';
 import { MockDirectoryArchiver } from './test/mock-directory-archiver';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 
-/* eslint-disable no-unused-expressions */
-
 const track = temp.track();
 
 describe('directory-archiver', () => {

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
@@ -23,7 +23,6 @@ import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node';
 import { NsfwFileSystemWatcherService } from './nsfw-filesystem-service';
 import { DidFilesChangedParams, FileChange, FileChangeType } from '../../common/filesystem-watcher-protocol';
-/* eslint-disable no-unused-expressions */
 
 const expect = chai.expect;
 const track = temp.track();

--- a/packages/git/src/node/dugite-git-watcher.slow-spec.ts
+++ b/packages/git/src/node/dugite-git-watcher.slow-spec.ts
@@ -27,8 +27,6 @@ import { DugiteGitWatcherServer } from './dugite-git-watcher';
 import { bindGit, bindRepositoryWatcher } from './git-backend-module';
 import { GitWatcherServer, GitStatusChangeEvent } from '../common/git-watcher';
 
-/* eslint-disable no-unused-expressions */
-
 const track = temp.track();
 
 describe('git-watcher-slow', () => {

--- a/packages/git/src/node/dugite-git.slow-spec.ts
+++ b/packages/git/src/node/dugite-git.slow-spec.ts
@@ -20,8 +20,6 @@ import { FileUri } from '@theia/core/lib/node/file-uri';
 import { GitFileStatus } from '../common';
 import { createGit } from './test/binding-helper';
 
-/* eslint-disable no-unused-expressions */
-
 const track = temp.track();
 
 describe('git-slow', async function (): Promise<void> {

--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -28,7 +28,7 @@ import { initRepository, createTestRepository } from 'dugite-extra/lib/command/t
 import { createGit } from './test/binding-helper';
 import { isWindows } from '@theia/core/lib/common/os';
 
-/* eslint-disable max-len, no-unused-expressions */
+/* eslint-disable max-len */
 
 const track = temp.track();
 

--- a/packages/messages/src/browser/notification-content-renderer.spec.ts
+++ b/packages/messages/src/browser/notification-content-renderer.spec.ts
@@ -17,8 +17,6 @@
 import { expect } from 'chai';
 import { NotificationContentRenderer } from './notification-content-renderer';
 
-/* eslint-disable no-unused-expressions */
-
 describe('notification-content-renderer', () => {
 
     const contentRenderer = new NotificationContentRenderer();

--- a/packages/metrics/src/node/prometheus.spec.ts
+++ b/packages/metrics/src/node/prometheus.spec.ts
@@ -19,8 +19,6 @@ import { PROMETHEUS_REGEXP, toPrometheusValidName } from './prometheus';
 
 const expect = chai.expect;
 
-/* eslint-disable no-unused-expressions */
-
 describe('Prometheus helper module', () => {
     /* According to https://prometheus.io/docs/concepts/data_model/ */
 

--- a/packages/navigator/src/browser/navigator-diff.spec.ts
+++ b/packages/navigator/src/browser/navigator-diff.spec.ts
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
-/* eslint-disable no-unused-expressions */
+
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 const disableJSDOM = enableJSDOM();
 

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -490,7 +490,6 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         const currentDataWidget = widget.widgets[0];
         const viewDataWidget = await this.createViewDataWidget(view.id, webviewId);
         if (widget.isDisposed) {
-            // eslint-disable-next-line no-unused-expressions
             viewDataWidget?.dispose();
             return;
         }

--- a/packages/plugin-ext/src/plugin/preference-registry.spec.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.spec.ts
@@ -112,7 +112,6 @@ describe('PreferenceRegistryExtImpl:', () => {
         });
     });
 
-    /* eslint-disable no-unused-expressions */
     describe('toConfigurationChangeEvent', () => {
         // E.g. deletion of a `tasks.json`.
         it('Handles deletion of a section', () => {

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.spec.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.spec.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-/* eslint-disable @typescript-eslint/no-explicit-any,no-unused-expressions */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 const disableJSDOM = enableJSDOM();

--- a/packages/process/src/node/multi-ring-buffer.spec.ts
+++ b/packages/process/src/node/multi-ring-buffer.spec.ts
@@ -25,7 +25,6 @@ describe('MultiRingBuffer', function (): void {
         const size = 2;
         const compareTo = Buffer.from('0000', 'hex');
         const ringBuffer = new MultiRingBuffer({ size });
-        // eslint-disable-next-line no-unused-expressions
         expect(ringBuffer['buffer'].equals(compareTo)).to.be.true;
     });
 

--- a/packages/scm/src/browser/dirty-diff/diff-computer.spec.ts
+++ b/packages/scm/src/browser/dirty-diff/diff-computer.spec.ts
@@ -27,8 +27,6 @@ before(() => {
     diffComputer = new DiffComputer();
 });
 
-/* eslint-disable no-unused-expressions */
-
 describe('dirty-diff-computer', () => {
 
     it('remove single line', () => {

--- a/packages/task/src/browser/task-definition-registry.spec.ts
+++ b/packages/task/src/browser/task-definition-registry.spec.ts
@@ -18,7 +18,6 @@ import { expect } from 'chai';
 import { PanelKind, RevealKind, TaskScope, TaskDefinition } from '../common';
 import { TaskDefinitionRegistry } from './task-definition-registry';
 
-/* eslint-disable no-unused-expressions */
 describe('TaskDefinitionRegistry', () => {
     let registry: TaskDefinitionRegistry;
     const definitionContributionA: TaskDefinition = {

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -14,8 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-/* eslint-disable no-unused-expressions */
-
 // tslint:disable-next-line:no-implicit-dependencies
 import 'reflect-metadata';
 import { createTaskTestContainer } from './test/task-test-container';

--- a/packages/variable-resolver/src/browser/variable.spec.ts
+++ b/packages/variable-resolver/src/browser/variable.spec.ts
@@ -20,8 +20,6 @@ import { ILogger, Disposable } from '@theia/core/lib/common';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { Variable, VariableRegistry } from './variable';
 
-/* eslint-disable no-unused-expressions */
-
 const expect = chai.expect;
 let variableRegistry: VariableRegistry;
 

--- a/packages/workspace/src/node/default-workspace-server.spec.ts
+++ b/packages/workspace/src/node/default-workspace-server.spec.ts
@@ -25,8 +25,6 @@ import { expect } from 'chai';
 import * as temp from 'temp';
 import * as fs from 'fs';
 
-/* eslint-disable no-unused-expressions */
-
 describe('DefaultWorkspaceServer', function (): void {
 
     describe('getRecentWorkspaces()', async () => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The eslint rule `no-unused-expressions` does not work well with mocha and is often disabled per file. Rather than continuously disabling the rule we now turn it off for all test files.

The rule for instance did not like `expect(true).to.not.be.undefined`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- CI should pass (most notably `yarn lint`).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>