### PR TITLE
[theme]: Dispatch the IDE's theme based on the OS' theme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 <a name="breaking_changes_1.30.0">[Breaking Changes:](#breaking_changes_1.30.0)</a>
 
 - [core] Added constructor injection to `ApplicationShell`: `SecondaryWindowHandler`. [#11048](https://github.com/eclipse-theia/theia/pull/11048) - Contributed on behalf of ST Microelectronics and Ericsson and by ARM and EclipseSource
+- [core] Changed type of `FrontendApplicationConfig#defaultTheme` from `string` to `DefaultTheme`. From now on, the default theme can be dispatched based on the OS theme. Use `DefaultTheme#defaultForOSTheme` to derive the `string` theme ID.
 
 ## v1.29.0 - 8/25/2022
 

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -45,6 +45,23 @@ export namespace ElectronFrontendApplicationConfig {
     }
 }
 
+export type DefaultTheme = string | Readonly<{ light: string, dark: string }>;
+export namespace DefaultTheme {
+    export function defaultForOSTheme(theme: DefaultTheme): string {
+        if (typeof theme === 'string') {
+            return theme;
+        }
+        if (
+            typeof window !== 'undefined' &&
+            window.matchMedia &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches
+        ) {
+            return theme.dark;
+        }
+        return theme.light;
+    }
+}
+
 /**
  * Application configuration for the frontend. The following properties will be injected into the `index.html`.
  */
@@ -52,7 +69,7 @@ export type FrontendApplicationConfig = RequiredRecursive<FrontendApplicationCon
 export namespace FrontendApplicationConfig {
     export const DEFAULT: FrontendApplicationConfig = {
         applicationName: 'Eclipse Theia',
-        defaultTheme: 'dark',
+        defaultTheme: { light: 'light', dark: 'dark' },
         defaultIconTheme: 'none',
         electron: ElectronFrontendApplicationConfig.DEFAULT,
         defaultLocale: '',
@@ -63,9 +80,9 @@ export namespace FrontendApplicationConfig {
         /**
          * The default theme for the application.
          *
-         * Defaults to `dark`.
+         * Defaults to `dark` if the OS's theme is dark. Otherwise `light`.
          */
-        readonly defaultTheme?: string;
+        readonly defaultTheme?: DefaultTheme;
 
         /**
          * The default icon theme for the application.

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -21,6 +21,7 @@ import { SUPPORTED_ENCODINGS } from './supported-encodings';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 import { isOSX } from '../common/os';
 import { nls } from '../common/nls';
+import { DefaultTheme } from '@theia/application-package/lib/application-props';
 
 export const corePreferenceSchema: PreferenceSchema = {
     'type': 'object',
@@ -151,7 +152,7 @@ export const corePreferenceSchema: PreferenceSchema = {
         },
         'workbench.colorTheme': {
             type: 'string',
-            default: FrontendApplicationConfigProvider.get().defaultTheme,
+            default: DefaultTheme.defaultForOSTheme(FrontendApplicationConfigProvider.get().defaultTheme),
             description: nls.localizeByDefault('Specifies the color theme used in the workbench.')
         },
         'workbench.iconTheme': {

--- a/packages/core/src/browser/frontend-application-config-provider.spec.ts
+++ b/packages/core/src/browser/frontend-application-config-provider.spec.ts
@@ -39,7 +39,7 @@ describe('FrontendApplicationConfigProvider', function (): void {
         expect(config.applicationName).not.equal(DEFAULT.applicationName);
         // defaults
         expect(config.defaultIconTheme).equal(DEFAULT.defaultIconTheme);
-        expect(config.defaultTheme).equal(DEFAULT.defaultTheme);
+        expect(config.defaultTheme).deep.equal(DEFAULT.defaultTheme);
         expect(config.electron.windowOptions).deep.equal(DEFAULT.electron.windowOptions);
     });
 });

--- a/packages/core/src/browser/preloader.ts
+++ b/packages/core/src/browser/preloader.ts
@@ -58,7 +58,10 @@ async function loadBackendOS(): Promise<void> {
 }
 
 function initBackground(): void {
-    const value = window.localStorage.getItem(DEFAULT_BACKGROUND_COLOR_STORAGE_KEY) || '#1d1d1d';
+    // The default light background color is based on the `colors#editor.background` value from
+    // `packages/monaco/data/monaco-themes/vscode/dark_vs.json` and the dark background comes from the `light_vs.json`.
+    const dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const value = window.localStorage.getItem(DEFAULT_BACKGROUND_COLOR_STORAGE_KEY) || (dark ? '#1E1E1E' : '#FFFFFF');
     const documentElement = document.documentElement;
     documentElement.style.setProperty('--theia-editor-background', value);
 }

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -17,7 +17,7 @@
 import { Emitter, Event } from '../common/event';
 import { Disposable } from '../common/disposable';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
-import { ApplicationProps } from '@theia/application-package/lib/application-props';
+import { ApplicationProps, DefaultTheme } from '@theia/application-package/lib/application-props';
 import { Theme, ThemeChangeEvent } from '../common/theme';
 import { inject, injectable, postConstruct } from 'inversify';
 import { Deferred } from '../common/promise-util';
@@ -136,7 +136,8 @@ export class ThemeService {
      * The default theme. If that is not applicable, returns with the fallback theme.
      */
     get defaultTheme(): Theme {
-        return this.tryGetTheme(FrontendApplicationConfigProvider.get().defaultTheme) ?? this.getTheme(ApplicationProps.DEFAULT.frontend.config.defaultTheme);
+        return this.tryGetTheme(DefaultTheme.defaultForOSTheme(FrontendApplicationConfigProvider.get().defaultTheme))
+            ?? this.getTheme(DefaultTheme.defaultForOSTheme(ApplicationProps.DEFAULT.frontend.config.defaultTheme));
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

From now on, the default IDE theme may dispatch on the OS theme.

In action:

https://user-images.githubusercontent.com/1405703/184612250-c4aebb72-5d64-4b65-b47c-79b8960d1cc1.mp4

Changed the `defaultTheme` type from `string` to `string | { light: string, dark: string }`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

 - `workbench.colorTheme` is not present in workspace/user `settings.json`,
 - set the OS theme light, load the IDE, the `light` theme will be active,
 - set the OS theme dark, load the IDE, the `dark` theme is active. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
