### PR TITLE
[workspace]: Pass `WorkspaceInput` argument into `reloadWindow`/`openNewWindow` methods

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -366,7 +366,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
             if (preserveWindow) {
                 this._workspace = stat;
             }
-            this.openWindow(stat, { preserveWindow });
+            this.openWindow(stat, Object.assign(options ?? {}, { preserveWindow }));
             return;
         }
         throw new Error('Invalid workspace root URI. Expected an existing directory or workspace file.');
@@ -497,10 +497,10 @@ export class WorkspaceService implements FrontendApplicationContribution {
         const workspacePath = uri.resource.path.toString();
 
         if (this.shouldPreserveWindow(options)) {
-            this.reloadWindow();
+            this.reloadWindow(options);
         } else {
             try {
-                this.openNewWindow(workspacePath);
+                this.openNewWindow(workspacePath, options);
             } catch (error) {
                 // Fall back to reloading the current window in case the browser has blocked the new window
                 this._workspace = uri;
@@ -509,7 +509,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
         }
     }
 
-    protected reloadWindow(): void {
+    protected reloadWindow(options?: WorkspaceInput): void {
         // Set the new workspace path as the URL fragment.
         if (this._workspace !== undefined) {
             this.setURLFragment(this._workspace.resource.path.toString());
@@ -520,7 +520,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
         this.windowService.reload();
     }
 
-    protected openNewWindow(workspacePath: string): void {
+    protected openNewWindow(workspacePath: string, options?: WorkspaceInput): void {
         const url = new URL(window.location.href);
         url.hash = encodeURI(workspacePath);
         this.windowService.openNewWindow(url.toString());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR changes the workspace service API and passes the `WorkspaceInput` argument down to the `openNewWindow` and `reloadWindow` methods.

I would like to extend the functionality of the workspace service without unnecessarily copy-pasting logic that is irrelevant. I need the original `WorkspaceInput` to customize the app's behavior after opening a new or reloading the current window. for example, I want to reload a window and run a series of custom commands or open/reveal widgets.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

I added a sample in a separate commit to demo the desired behavior.
 - Use the `Reload Window and Open New Terminal` command to reload the workspace and open a new terminal,
 - Use the `Open New Workspace and Reveal Explorer` command to open a new workspace and activate the Explorer view.
 - The examples are made-up samples and have nothing to do with the requested API changes. With the new APIs, the workspace customization can be simplified into a couple of lines of code. Please see the [sample example](https://github.com/eclipse-theia/theia/compare/master...kittaakos:ws-service-pass-options?expand=1#diff-f36fb1a0e913ea06a31998757f31c1f5a1841dd8ee33352257c9beb89771b818R64-R76).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
