### PR TITLE
application-manager: set the `applicationName` in title

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -64,7 +64,8 @@ export class FrontendGenerator extends AbstractGenerator {
         return `
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="apple-mobile-web-app-capable" content="yes">`;
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <title>${this.pck.props.frontend.config.applicationName}</title>`;
     }
 
     protected compileIndexJs(frontendModules: Map<string, string>): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates the `frontend-generator` to initially set the `applicationName` so we do not experience a flicker in name on startup, most notably when no workspace is present.

_Before_:

https://user-images.githubusercontent.com/40359487/184887288-294abe69-9b25-4e83-9933-9f70ffe3ae4a.mov

_After_:

https://user-images.githubusercontent.com/40359487/184887322-9b991d19-3b22-45b2-942d-009ee5dab84c.mov

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the electron or browser application (confirm it works for both)
2. with no workspace the `applicationName` should be present without the `index.html` flicker
3. with a workspace present the `applicationName` should be present without the `index.html` flicker, and when the workspace is loaded should be in the format `${workspaceName} - ${applicationName}`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>