### PR TITLE
Fix empty menus in browser

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -290,7 +290,9 @@ export class DynamicMenuWidget extends MenuWidget {
             const role = menu === this.menu ? CompoundMenuNodeRole.Group : CompoundMenuNode.getRole(menu);
             if (role === CompoundMenuNodeRole.Submenu) {
                 const submenu = this.services.menuWidgetFactory.createMenuWidget(menu, this.options);
-                parentItems.push({ type: 'submenu', submenu });
+                if (submenu.items.length > 0) {
+                    parentItems.push({ type: 'submenu', submenu });
+                }
             } else if (role === CompoundMenuNodeRole.Group && menu.id !== 'inline') {
                 const children = CompoundMenuNode.getFlatChildren(menu.children);
                 const myItems: MenuWidget.IItemOptions[] = [];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11567

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. @vince-fugnitto pushed a commit which highlights the problem (https://github.com/eclipse-theia/theia/commit/131c0da6dc3cef9ed009d12be4c28da83a072c7c)
2. start the application in browser
3. confirm that the bug is fixed in the `Edit` menu, since `Test` is _not_ rendered because it has no items.
4. Repeat in Electron with `window.titleBarStyle` = `native`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
