### PR TITLE
Remove `virtuoso-dev` from the license check baseline

### DIFF
--- a/dependency-check-baseline.json
+++ b/dependency-check-baseline.json
@@ -3,6 +3,5 @@
   "npm/npmjs/-/jschardet/2.3.0": "Approved for Eclipse Theia: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22481",
   "npm/npmjs/-/jsdom/11.12.0": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640",
   "npm/npmjs/-/lzma-native/8.0.6": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1850",
-  "npm/npmjs/-/playwright-core/1.22.2": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/2734",
-  "npm/npmjs/-/virtuoso.dev/0.2.13": "Approved manually: https://github.com/eclipse-theia/theia/pull/11553"
+  "npm/npmjs/-/playwright-core/1.22.2": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/2734"
 }


### PR DESCRIPTION
#### What it does

After https://github.com/eclipse-theia/theia/pull/11553, we had to add `virtuoso-dev` to the license check baseline due to a minor issue in the license check tool. Wayne fixed the underlying issue (see [here](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/3157)) and now we can remove it again.

#### How to test

The 3PP license check github action succeeds

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
