### PR TITLE
macos: fix `window.titleBarStyle` on macOS

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -500,7 +500,7 @@ export class ElectronMainApplication {
         app.on('window-all-closed', this.onWindowAllClosed.bind(this));
 
         ipcMain.on(TitleBarStyleChanged, ({ sender }, titleBarStyle: string) => {
-            this.useNativeWindowFrame = titleBarStyle === 'native';
+            this.useNativeWindowFrame = isOSX || titleBarStyle === 'native';
             const browserWindow = BrowserWindow.fromId(sender.id);
             if (browserWindow) {
                 this.saveWindowState(browserWindow);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #11583 

The commit fixes the handling when setting `window.titleBarStyle` to `custom` on macOS (which does not apply) as it has some negative side effects.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application on macOS
2. open the preferences-view
3. search for `titleBarStyle` and change from `native` to `custom` 
4. the preference change will not take effect

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>