### PR TITLE
Respect `included` property on preferences

### DIFF
--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -201,11 +201,11 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
         const changes: PreferenceProviderDataChange[] = [];
         const defaultScope = PreferenceSchema.getDefaultScope(schema);
         const overridable = schema.overridable || false;
-        for (const preferenceName of Object.keys(schema.properties)) {
+        for (const [preferenceName, rawSchemaProps] of Object.entries(schema.properties)) {
             if (this.combinedSchema.properties[preferenceName]) {
                 console.error('Preference name collision detected in the schema for property: ' + preferenceName);
-            } else {
-                const schemaProps = PreferenceDataProperty.fromPreferenceSchemaProperty(schema.properties[preferenceName], defaultScope);
+            } else if (!rawSchemaProps.hasOwnProperty('included') || rawSchemaProps.included) {
+                const schemaProps = PreferenceDataProperty.fromPreferenceSchemaProperty(rawSchemaProps, defaultScope);
                 if (typeof schemaProps.overridable !== 'boolean' && overridable) {
                     schemaProps.overridable = true;
                 }

--- a/packages/core/src/common/preferences/preference-schema.ts
+++ b/packages/core/src/common/preferences/preference-schema.ts
@@ -79,6 +79,7 @@ export interface PreferenceDataProperty extends PreferenceItem {
     description?: string;
     markdownDescription?: string;
     scope?: PreferenceScope;
+    included?: boolean;
     typeDetails?: any;
 }
 export namespace PreferenceDataProperty {

--- a/packages/core/src/common/preferences/preference-schema.ts
+++ b/packages/core/src/common/preferences/preference-schema.ts
@@ -67,6 +67,7 @@ export interface PreferenceItem extends IJSONSchema {
      */
     defaultValue?: JSONValue;
     overridable?: boolean;
+    included?: boolean;
     [key: string]: any;
 }
 export interface PreferenceSchemaProperty extends PreferenceItem {
@@ -79,7 +80,6 @@ export interface PreferenceDataProperty extends PreferenceItem {
     description?: string;
     markdownDescription?: string;
     scope?: PreferenceScope;
-    included?: boolean;
     typeDetails?: any;
 }
 export namespace PreferenceDataProperty {

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -181,7 +181,7 @@ export class PreferenceTreeGenerator {
             id: `${group}@${property}`,
             preferenceId: property,
             parent: preferencesGroup,
-            visible: true,
+            visible: data.included !== false,
             preference: { data },
             depth: Preference.TreeNode.isTopLevel(preferencesGroup) ? 1 : 2,
         };

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -181,7 +181,6 @@ export class PreferenceTreeGenerator {
             id: `${group}@${property}`,
             preferenceId: property,
             parent: preferencesGroup,
-            visible: data.included !== false,
             preference: { data },
             depth: Preference.TreeNode.isTopLevel(preferencesGroup) ? 1 : 2,
         };


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11587. Tree nodes belonging to a not included preference are no longer visible.

#### How to test

1. Start the application on Mac (or set one of the preferences `included` properties to `false`)
2. Assert that the preference is not rendered/does not appear in the search

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
