### PR TITLE
vscode: add `hcLight` support

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1228,22 +1228,44 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         const setTheme = (id: string, persist: boolean) => this.themeService.setCurrentTheme(id, persist);
         const previewTheme = debounce(setTheme, 200);
         type QuickPickWithId = QuickPickItem & { id: string };
-        const itemsByTheme: { light: Array<QuickPickWithId>, dark: Array<QuickPickWithId>, hc: Array<QuickPickWithId> } = { light: [], dark: [], hc: [] };
+        const itemsByTheme: {
+            light: Array<QuickPickWithId>,
+            dark: Array<QuickPickWithId>,
+            hc: Array<QuickPickWithId>,
+            hcLight: Array<QuickPickWithId>
+        } = { light: [], dark: [], hc: [], hcLight: [] };
+
+        const lightThemesSeparator = nls.localizeByDefault('light themes');
+        const darkThemesSeparator = nls.localizeByDefault('dark themes');
+        const highContrastThemesSeparator = nls.localizeByDefault('high contrast themes');
+
         for (const theme of this.themeService.getThemes().sort((a, b) => a.label.localeCompare(b.label))) {
             const themeItems: QuickPickItemOrSeparator[] = itemsByTheme[theme.type];
-            if (themeItems.length === 0) {
+
+            // Add a separator for the first item in the respective group.
+            // High Contrast Themes despite dark or light should be grouped together.
+            if (themeItems.length === 0 && theme.type !== 'hcLight') {
+                let label = '';
+                if (theme.type === 'light') {
+                    label = lightThemesSeparator;
+                } else if (theme.type === 'dark') {
+                    label = darkThemesSeparator;
+                } else {
+                    label = highContrastThemesSeparator;
+                }
                 themeItems.push({
                     type: 'separator',
-                    label: (theme.type === 'hc' ? 'high contrast' : theme.type) + ' themes'
+                    label
                 });
             }
+
             themeItems.push({
                 id: theme.id,
                 label: theme.label,
                 description: theme.description,
             });
         }
-        const items = [...itemsByTheme.light, ...itemsByTheme.dark, ...itemsByTheme.hc];
+        const items = [...itemsByTheme.light, ...itemsByTheme.dark, ...itemsByTheme.hc, ...itemsByTheme.hcLight];
         this.quickInputService?.showQuickPick(items,
             {
                 placeholder: nls.localizeByDefault('Select Color Theme (Up/Down Keys to Preview)'),
@@ -1268,26 +1290,28 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             // Base Colors should be aligned with https://code.visualstudio.com/api/references/theme-color#base-colors
             // if not yet contributed by Monaco, check runtime css variables to learn
             { id: 'selection.background', defaults: { dark: '#217daf', light: '#c0dbf1' }, description: 'Overall border color for focused elements. This color is only used if not overridden by a component.' },
-            { id: 'icon.foreground', defaults: { dark: '#C5C5C5', light: '#424242', hc: '#FFFFFF' }, description: 'The default color for icons in the workbench.' },
-            { id: 'sash.hoverBorder', defaults: { dark: Color.transparent('focusBorder', 0.99), light: Color.transparent('focusBorder', 0.99), hc: Color.transparent('focusBorder', 0.99) }, description: 'The hover border color for draggable sashes.' },
-            { id: 'sash.activeBorder', defaults: { dark: 'focusBorder', light: 'focusBorder', hc: 'focusBorder' }, description: 'The active border color for draggable sashes.' },
+            { id: 'icon.foreground', defaults: { dark: '#C5C5C5', light: '#424242', hcDark: '#FFFFFF', hcLight: '#292929' }, description: 'The default color for icons in the workbench.' },
+            { id: 'sash.hoverBorder', defaults: { dark: Color.transparent('focusBorder', 0.99), light: Color.transparent('focusBorder', 0.99), hcDark: 'focusBorder', hcLight: 'focusBorder' }, description: 'The hover border color for draggable sashes.' },
+            { id: 'sash.activeBorder', defaults: { dark: 'focusBorder', light: 'focusBorder', hcDark: 'focusBorder' }, description: 'The active border color for draggable sashes.' },
             // Window border colors should be aligned with https://code.visualstudio.com/api/references/theme-color#window-border
             {
                 id: 'window.activeBorder', defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 }, description: 'The color used for the border of the window when it is active.'
             },
             {
                 id: 'window.inactiveBorder', defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 },
                 description: 'The color used for the border of the window when it is inactive.'
             },
 
             // Buttons should be aligned with https://code.visualstudio.com/api/references/theme-color#button-control
             // if not yet contributed by Monaco, check runtime css variables to learn
-            { id: 'button.foreground', defaults: { dark: Color.white, light: Color.white, hc: Color.white }, description: 'Button foreground color.' },
-            { id: 'button.background', defaults: { dark: '#0E639C', light: '#007ACC' }, description: 'Button background color.' },
+            { id: 'button.foreground', defaults: { dark: Color.white, light: Color.white, hcDark: Color.white, hcLight: Color.white }, description: 'Button foreground color.' },
+            { id: 'button.background', defaults: { dark: '#0E639C', light: '#007ACC', hcDark: undefined, hcLight: '#0F4A85' }, description: 'Button background color.' },
             { id: 'button.hoverBackground', defaults: { dark: Color.lighten('button.background', 0.2), light: Color.darken('button.background', 0.2) }, description: 'Button background color when hovering.' },
 
             // Activity Bar colors should be aligned with https://code.visualstudio.com/api/references/theme-color#activity-bar
@@ -1295,68 +1319,76 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'activityBar.background', defaults: {
                     dark: '#333333',
                     light: '#2C2C2C',
-                    hc: '#000000'
+                    hcDark: '#000000',
+                    hcLight: '#FFFFFF'
                 }, description: 'Activity bar background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
             {
                 id: 'activityBar.foreground', defaults: {
                     dark: Color.white,
                     light: Color.white,
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: 'editor.foreground'
                 }, description: 'Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar.',
             },
             {
                 id: 'activityBar.inactiveForeground', defaults: {
                     dark: Color.transparent('activityBar.foreground', 0.4),
                     light: Color.transparent('activityBar.foreground', 0.4),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: 'editor.foreground'
                 }, description: 'Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
             {
                 id: 'activityBar.border', defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 }, description: 'Activity bar border color separating to the side bar. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
             {
                 id: 'activityBar.activeBorder', defaults: {
                     dark: 'activityBar.foreground',
                     light: 'activityBar.foreground',
+                    hcLight: 'contrastBorder'
                 }, description: 'Activity bar border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
             {
-                id: 'activityBar.activeFocusBorder',
-                description: 'Activity bar focus border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
+                id: 'activityBar.activeFocusBorder', defaults: {
+                    hcLight: '#B5200D'
+                }, description: 'Activity bar focus border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
             { id: 'activityBar.activeBackground', description: 'Activity bar background color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.' },
             {
                 id: 'activityBar.dropBackground', defaults: {
                     dark: Color.transparent('#ffffff', 0.12),
                     light: Color.transparent('#ffffff', 0.12),
-                    hc: Color.transparent('#ffffff', 0.12),
+                    hcDark: Color.transparent('#ffffff', 0.12),
                 }, description: 'Drag and drop feedback color for the activity bar items. The color should have transparency so that the activity bar entries can still shine through. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
             {
                 id: 'activityBarBadge.background', defaults: {
                     dark: '#007ACC',
                     light: '#007ACC',
-                    hc: '#000000'
+                    hcDark: '#000000',
+                    hcLight: '#0F4A85'
                 }, description: 'Activity notification badge background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
             {
                 id: 'activityBarBadge.foreground', defaults: {
                     dark: Color.white,
                     light: Color.white,
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: Color.white
                 }, description: 'Activity notification badge foreground color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
 
             // Side Bar should be aligned with https://code.visualstudio.com/api/references/theme-color#side-bar
             // if not yet contributed by Monaco, check runtime css variables to learn
-            { id: 'sideBar.background', defaults: { dark: '#252526', light: '#F3F3F3', hc: '#000000' }, description: 'Side bar background color. The side bar is the container for views like explorer and search.' },
+            { id: 'sideBar.background', defaults: { dark: '#252526', light: '#F3F3F3', hcDark: '#000000', hcLight: '#FFFFFF' }, description: 'Side bar background color. The side bar is the container for views like explorer and search.' },
             { id: 'sideBar.foreground', description: 'Side bar foreground color. The side bar is the container for views like explorer and search.' },
             { id: 'sideBarSectionHeader.background', defaults: { dark: '#80808033', light: '#80808033' }, description: 'Side bar section header background color. The side bar is the container for views like explorer and search.' },
             { id: 'sideBarSectionHeader.foreground', description: 'Side bar foreground color. The side bar is the container for views like explorer and search.' },
-            { id: 'sideBarSectionHeader.border', defaults: { hc: '#6FC3DF' }, description: 'Side bar section header border color. The side bar is the container for views like explorer and search.' },
+            { id: 'sideBarSectionHeader.border', defaults: { dark: 'contrastBorder', light: 'contrastBorder', hcDark: 'contrastBorder', hcLight: 'contrastBorder' }, description: 'Side bar section header border color. The side bar is the container for views like explorer and search.' },
 
             // Lists and Trees colors should be aligned with https://code.visualstudio.com/api/references/theme-color#lists-and-trees
             // if not yet contributed by Monaco, check runtime css variables to learn.
@@ -1364,18 +1396,18 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             // list.focusBackground, list.focusForeground, list.inactiveFocusBackground, list.filterMatchBorder,
             // list.dropBackground, listFilterWidget.outline, listFilterWidget.noMatchesOutline
             // list.invalidItemForeground => tree node needs an respective class
-            { id: 'list.activeSelectionBackground', defaults: { dark: '#094771', light: '#0074E8' }, description: 'List/Tree background color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.' },
+            { id: 'list.activeSelectionBackground', defaults: { dark: '#094771', light: '#0074E8', hcLight: Color.transparent('#0F4A85', 0.1) }, description: 'List/Tree background color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.' },
             { id: 'list.activeSelectionForeground', defaults: { dark: '#FFF', light: '#FFF' }, description: 'List/Tree foreground color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.' },
-            { id: 'list.inactiveSelectionBackground', defaults: { dark: '#37373D', light: '#E4E6F1' }, description: 'List/Tree background color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.' },
+            { id: 'list.inactiveSelectionBackground', defaults: { dark: '#37373D', light: '#E4E6F1', hcLight: Color.transparent('#0F4A85', 0.1) }, description: 'List/Tree background color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.' },
             { id: 'list.inactiveSelectionForeground', description: 'List/Tree foreground color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.' },
-            { id: 'list.hoverBackground', defaults: { dark: '#2A2D2E', light: '#F0F0F0' }, description: 'List/Tree background when hovering over items using the mouse.' },
+            { id: 'list.hoverBackground', defaults: { dark: '#2A2D2E', light: '#F0F0F0', hcLight: Color.transparent('#0F4A85', 0.1) }, description: 'List/Tree background when hovering over items using the mouse.' },
             { id: 'list.hoverForeground', description: 'List/Tree foreground when hovering over items using the mouse.' },
             { id: 'list.errorForeground', defaults: { dark: '#F88070', light: '#B01011' }, description: 'Foreground color of list items containing errors.' },
             { id: 'list.warningForeground', defaults: { dark: '#CCA700', light: '#855F00' }, description: 'Foreground color of list items containing warnings.' },
             { id: 'list.filterMatchBackground', defaults: { dark: 'editor.findMatchHighlightBackground', light: 'editor.findMatchHighlightBackground' }, description: 'Background color of the filtered match.' },
-            { id: 'list.highlightForeground', defaults: { dark: '#18A3FF', light: '#0066BF', hc: 'focusBorder' }, description: 'List/Tree foreground color of the match highlights when searching inside the list/tree.' },
-            { id: 'list.focusHighlightForeground', defaults: { dark: 'list.highlightForeground', light: 'list.activeSelectionForeground', hc: 'list.highlightForeground' }, description: 'List/Tree foreground color of the match highlights on actively focused items when searching inside the list/tree.' },
-            { id: 'tree.inactiveIndentGuidesStroke', defaults: { dark: Color.transparent('tree.indentGuidesStroke', 0.4), light: Color.transparent('tree.indentGuidesStroke', 0.4), hc: Color.transparent('tree.indentGuidesStroke', 0.4) }, description: 'Tree stroke color for the inactive indentation guides.' },
+            { id: 'list.highlightForeground', defaults: { dark: '#18A3FF', light: '#0066BF', hcDark: 'focusBorder', hcLight: 'focusBorder' }, description: 'List/Tree foreground color of the match highlights when searching inside the list/tree.' },
+            { id: 'list.focusHighlightForeground', defaults: { dark: 'list.highlightForeground', light: 'list.activeSelectionForeground', hcDark: 'list.highlightForeground', hcLight: 'list.highlightForeground' }, description: 'List/Tree foreground color of the match highlights on actively focused items when searching inside the list/tree.' },
+            { id: 'tree.inactiveIndentGuidesStroke', defaults: { dark: Color.transparent('tree.indentGuidesStroke', 0.4), light: Color.transparent('tree.indentGuidesStroke', 0.4), hcDark: Color.transparent('tree.indentGuidesStroke', 0.4) }, description: 'Tree stroke color for the inactive indentation guides.' },
 
             // Editor Group & Tabs colors should be aligned with https://code.visualstudio.com/api/references/theme-color#editor-groups-tabs
             {
@@ -1383,7 +1415,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: '#444444',
                     light: '#E7E7E7',
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 },
                 description: 'Color to separate multiple editor groups from each other. Editor groups are the containers of editors.'
             },
@@ -1391,7 +1424,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'editorGroup.dropBackground',
                 defaults: {
                     dark: Color.transparent('#53595D', 0.5),
-                    light: Color.transparent('#2677CB', 0.18)
+                    light: Color.transparent('#2677CB', 0.18),
+                    hcLight: Color.transparent('#0F4A85', 0.50)
                 },
                 description: 'Background color when dragging editors around. The color should have transparency so that the editor contents can still shine through.'
             },
@@ -1399,14 +1433,14 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'editorGroupHeader.tabsBackground',
                 defaults: {
                     dark: '#252526',
-                    light: '#F3F3F3'
+                    light: '#F3F3F3',
                 },
                 description: 'Background color of the editor group title header when tabs are enabled. Editor groups are the containers of editors.'
             },
             {
                 id: 'editorGroupHeader.tabsBorder',
                 defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder'
                 },
                 description: 'Border color of the editor group title header when tabs are enabled. Editor groups are the containers of editors.'
             },
@@ -1415,7 +1449,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'editor.background',
                     light: 'editor.background',
-                    hc: 'editor.background'
+                    hcDark: 'editor.background',
+                    hcLight: 'editor.background'
                 },
                 description: 'Active tab background color. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
@@ -1424,7 +1459,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'tab.activeBackground',
                     light: 'tab.activeBackground',
-                    hc: 'tab.activeBackground'
+                    hcDark: 'tab.activeBackground',
+                    hcLight: 'tab.activeBackground'
                 },
                 description: 'Active tab background color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
@@ -1441,35 +1477,40 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.white,
                     light: '#333333',
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: '#292929'
                 }, description: 'Active tab foreground color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.inactiveForeground', defaults: {
                     dark: Color.transparent('tab.activeForeground', 0.5),
                     light: Color.transparent('tab.activeForeground', 0.7),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: '#292929'
                 }, description: 'Inactive tab foreground color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.unfocusedActiveForeground', defaults: {
                     dark: Color.transparent('tab.activeForeground', 0.5),
                     light: Color.transparent('tab.activeForeground', 0.7),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: '#292929'
                 }, description: 'Active tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.unfocusedInactiveForeground', defaults: {
                     dark: Color.transparent('tab.inactiveForeground', 0.5),
                     light: Color.transparent('tab.inactiveForeground', 0.5),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: '#292929'
                 }, description: 'Inactive tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.border', defaults: {
                     dark: '#252526',
                     light: '#F3F3F3',
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 }, description: 'Border to separate tabs from each other. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
@@ -1486,12 +1527,16 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 id: 'tab.activeBorderTop',
+                defaults: {
+                    hcLight: '#B5200D'
+                },
                 description: 'Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.unfocusedActiveBorderTop', defaults: {
                     dark: Color.transparent('tab.activeBorderTop', 0.5),
-                    light: Color.transparent('tab.activeBorderTop', 0.7)
+                    light: Color.transparent('tab.activeBorderTop', 0.7),
+                    hcLight: '#B5200D'
                 }, description: 'Border to the top of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
@@ -1511,34 +1556,39 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             {
                 id: 'tab.unfocusedHoverBorder', defaults: {
                     dark: Color.transparent('tab.hoverBorder', 0.5),
-                    light: Color.transparent('tab.hoverBorder', 0.7)
+                    light: Color.transparent('tab.hoverBorder', 0.7),
+                    hcLight: 'contrastBorder'
                 }, description: 'Border to highlight tabs in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.activeModifiedBorder', defaults: {
                     dark: '#3399CC',
-                    light: '#33AAEE'
+                    light: '#33AAEE',
+                    hcLight: 'contrastBorder'
                 }, description: 'Border on the top of modified (dirty) active tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.inactiveModifiedBorder', defaults: {
                     dark: Color.transparent('tab.activeModifiedBorder', 0.5),
                     light: Color.transparent('tab.activeModifiedBorder', 0.5),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: 'contrastBorder'
                 }, description: 'Border on the top of modified (dirty) inactive tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.unfocusedActiveModifiedBorder', defaults: {
                     dark: Color.transparent('tab.activeModifiedBorder', 0.5),
                     light: Color.transparent('tab.activeModifiedBorder', 0.7),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: 'contrastBorder'
                 }, description: 'Border on the top of modified (dirty) active tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {
                 id: 'tab.unfocusedInactiveModifiedBorder', defaults: {
                     dark: Color.transparent('tab.inactiveModifiedBorder', 0.5),
                     light: Color.transparent('tab.inactiveModifiedBorder', 0.5),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: 'contrastBorder'
                 }, description: 'Border on the top of modified (dirty) inactive tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
 
@@ -1549,7 +1599,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'statusBar.foreground', defaults: {
                     dark: '#FFFFFF',
                     light: '#FFFFFF',
-                    hc: '#FFFFFF'
+                    hcDark: '#FFFFFF',
+                    hcLight: 'editor.foreground'
                 }, description: 'Status bar foreground color when a workspace is opened. The status bar is shown in the bottom of the window.'
             },
             {
@@ -1562,7 +1613,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'statusBar.noFolderForeground', defaults: {
                     dark: 'statusBar.foreground',
                     light: 'statusBar.foreground',
-                    hc: 'statusBar.foreground'
+                    hcDark: 'statusBar.foreground',
+                    hcLight: 'statusBar.foreground'
                 }, description: 'Status bar foreground color when no folder is opened. The status bar is shown in the bottom of the window.'
             },
             {
@@ -1573,56 +1625,64 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 id: 'statusBar.border', defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 }, description: 'Status bar border color separating to the sidebar and editor. The status bar is shown in the bottom of the window.'
             },
             {
                 id: 'statusBar.noFolderBorder', defaults: {
                     dark: 'statusBar.border',
                     light: 'statusBar.border',
-                    hc: 'statusBar.border'
+                    hcDark: 'statusBar.border',
+                    hcLight: 'statusBar.border'
                 }, description: 'Status bar border color separating to the sidebar and editor when no folder is opened. The status bar is shown in the bottom of the window.'
             },
             {
                 id: 'statusBarItem.activeBackground', defaults: {
                     dark: Color.rgba(255, 255, 255, 0.18),
                     light: Color.rgba(255, 255, 255, 0.18),
-                    hc: Color.rgba(255, 255, 255, 0.18)
+                    hcDark: Color.rgba(255, 255, 255, 0.18),
+                    hcLight: Color.rgba(0, 0, 0, 0.18)
                 }, description: 'Status bar item background color when clicking. The status bar is shown in the bottom of the window.'
             },
             {
                 id: 'statusBarItem.hoverBackground', defaults: {
                     dark: Color.rgba(255, 255, 255, 0.12),
                     light: Color.rgba(255, 255, 255, 0.12),
-                    hc: Color.rgba(255, 255, 255, 0.12)
+                    hcDark: Color.rgba(255, 255, 255, 0.12),
+                    hcLight: Color.rgba(0, 0, 0, 0.12)
                 }, description: 'Status bar item background color when hovering. The status bar is shown in the bottom of the window.'
             },
             {
                 id: 'statusBarItem.errorBackground', defaults: {
                     dark: Color.darken('errorBackground', 0.4),
                     light: Color.darken('errorBackground', 0.4),
-                    hc: undefined,
+                    hcDark: undefined,
+                    hcLight: '#B5200D'
                 }, description: 'Status bar error items background color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.'
             },
             {
                 id: 'statusBarItem.errorForeground', defaults: {
                     dark: Color.white,
                     light: Color.white,
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: Color.white
                 }, description: 'Status bar error items foreground color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.'
             },
             {
                 id: 'statusBarItem.warningBackground', defaults: {
                     dark: Color.darken('warningBackground', 0.4),
                     light: Color.darken('warningBackground', 0.4),
-                    hc: undefined
+                    hcDark: undefined,
+                    hcLight: '#895503'
                 }, description: 'Status bar warning items background color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.'
             },
             {
                 id: 'statusBarItem.warningForeground', defaults: {
                     dark: Color.white,
                     light: Color.white,
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: Color.white
                 }, description: 'Status bar warning items foreground color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.'
             },
 
@@ -1632,67 +1692,71 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'quickInput.background', defaults: {
                     dark: 'editorWidget.background',
                     light: 'editorWidget.background',
-                    hc: 'editorWidget.background'
+                    hcDark: 'editorWidget.background',
+                    hcLight: 'editorWidget.background'
                 }, description: 'Quick Input background color. The Quick Input widget is the container for views like the color theme picker.'
             },
             {
                 id: 'quickInput.foreground', defaults: {
                     dark: 'editorWidget.foreground',
                     light: 'editorWidget.foreground',
-                    hc: 'editorWidget.foreground'
+                    hcDark: 'editorWidget.foreground',
+                    hcLight: 'editorWidget.foreground'
                 }, description: 'Quick Input foreground color. The Quick Input widget is the container for views like the color theme picker.'
             },
             {
                 id: 'quickInput.list.focusBackground', defaults: {
                     dark: undefined,
                     light: undefined,
-                    hc: undefined
+                    hcDark: undefined,
+                    hcLight: undefined
                 }, description: 'quickInput.list.focusBackground deprecation. Please use quickInputList.focusBackground instead'
             },
             {
                 id: 'quickInputList.focusForeground', defaults: {
                     dark: 'list.activeSelectionForeground',
                     light: 'list.activeSelectionForeground',
-                    hc: 'list.activeSelectionForeground'
+                    hcDark: 'list.activeSelectionForeground',
+                    hcLight: 'list.activeSelectionForeground'
                 }, description: 'Quick picker foreground color for the focused item'
             },
             {
                 id: 'quickInputList.focusBackground', defaults: {
                     dark: 'list.activeSelectionBackground',
                     light: 'list.activeSelectionBackground',
-                    hc: undefined
+                    hcDark: undefined
                 }, description: 'Quick picker background color for the focused item.'
             },
 
             // Panel colors should be aligned with https://code.visualstudio.com/api/references/theme-color#panel-colors
             {
                 id: 'panel.background', defaults: {
-                    dark: 'editor.background', light: 'editor.background', hc: 'editor.background'
+                    dark: 'editor.background', light: 'editor.background', hcDark: 'editor.background', hcLight: 'editor.background'
                 }, description: 'Panel background color. Panels are shown below the editor area and contain views like output and integrated terminal.'
             },
             {
                 id: 'panel.border', defaults: {
-                    dark: Color.transparent('#808080', 0.35), light: Color.transparent('#808080', 0.35), hc: 'contrastBorder'
+                    dark: Color.transparent('#808080', 0.35), light: Color.transparent('#808080', 0.35), hcDark: 'contrastBorder', hcLight: 'contrastBorder'
                 }, description: 'Panel border color to separate the panel from the editor. Panels are shown below the editor area and contain views like output and integrated terminal.'
             },
             {
                 id: 'panel.dropBackground', defaults: {
-                    dark: Color.rgba(255, 255, 255, 0.12), light: Color.transparent('#2677CB', 0.18), hc: Color.rgba(255, 255, 255, 0.12)
+                    dark: Color.rgba(255, 255, 255, 0.12), light: Color.transparent('#2677CB', 0.18), hcDark: Color.rgba(255, 255, 255, 0.12)
                 }, description: 'Drag and drop feedback color for the panel title items. The color should have transparency so that the panel entries can still shine through. Panels are shown below the editor area and contain views like output and integrated terminal.'
             },
             {
                 id: 'panelTitle.activeForeground', defaults: {
-                    dark: '#E7E7E7', light: '#424242', hc: Color.white
+                    dark: '#E7E7E7', light: '#424242', hcDark: Color.white, hcLight: 'editor.foreground'
                 }, description: 'Title color for the active panel. Panels are shown below the editor area and contain views like output and integrated terminal.'
             },
             {
                 id: 'panelTitle.inactiveForeground', defaults: {
-                    dark: Color.transparent('panelTitle.activeForeground', 0.6), light: Color.transparent('panelTitle.activeForeground', 0.75), hc: Color.white
+                    dark: Color.transparent('panelTitle.activeForeground', 0.6), light: Color.transparent('panelTitle.activeForeground', 0.75), hcDark: Color.white, hcLight: 'editor.foreground'
                 }, description: 'Title color for the inactive panel. Panels are shown below the editor area and contain views like output and integrated terminal.'
             },
             {
                 id: 'panelTitle.activeBorder', defaults: {
-                    dark: 'panelTitle.activeForeground', light: 'panelTitle.activeForeground', hc: 'contrastBorder'
+                    dark: 'panelTitle.activeForeground', light: 'panelTitle.activeForeground', hcDark: 'contrastBorder', hcLight: '#B5200D'
                 }, description: 'Border color for the active panel title. Panels are shown below the editor area and contain views like output and integrated terminal.'
             },
             {
@@ -1701,7 +1765,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 id: 'imagePreview.border', defaults: {
-                    dark: Color.transparent('#808080', 0.35), light: Color.transparent('#808080', 0.35), hc: 'contrastBorder'
+                    dark: Color.transparent('#808080', 0.35), light: Color.transparent('#808080', 0.35), hcDark: 'contrastBorder', hcLight: 'contrastBorder'
                 }, description: 'Border color for image in image preview.'
             },
 
@@ -1710,20 +1774,23 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'titleBar.activeForeground', defaults: {
                     dark: '#CCCCCC',
                     light: '#333333',
-                    hc: '#FFFFFF'
+                    hcDark: '#FFFFFF',
+                    hcLight: '#292929'
                 }, description: 'Title bar foreground when the window is active. Note that this color is currently only supported on macOS.'
             },
             {
                 id: 'titleBar.inactiveForeground', defaults: {
                     dark: Color.transparent('titleBar.activeForeground', 0.6),
-                    light: Color.transparent('titleBar.activeForeground', 0.6)
+                    light: Color.transparent('titleBar.activeForeground', 0.6),
+                    hcLight: '#292929'
                 }, description: 'Title bar foreground when the window is inactive. Note that this color is currently only supported on macOS.'
             },
             {
                 id: 'titleBar.activeBackground', defaults: {
                     dark: '#3C3C3C',
                     light: '#DDDDDD',
-                    hc: '#000000'
+                    hcDark: '#000000',
+                    hcLight: '#FFFFFF'
                 }, description: 'Title bar background when the window is active. Note that this color is currently only supported on macOS.'
             },
             {
@@ -1734,7 +1801,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 id: 'titleBar.border', defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 }, description: 'Title bar border color. Note that this color is currently only supported on macOS.'
             },
 
@@ -1743,7 +1811,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'menubar.selectionForeground', defaults: {
                     dark: 'titleBar.activeForeground',
                     light: 'titleBar.activeForeground',
-                    hc: 'titleBar.activeForeground'
+                    hcDark: 'titleBar.activeForeground',
+                    hcLight: 'titleBar.activeForeground'
                 }, description: 'Foreground color of the selected menu item in the menubar.'
             },
             {
@@ -1754,50 +1823,51 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 id: 'menubar.selectionBorder', defaults: {
-                    hc: 'activeContrastBorder'
+                    hcDark: 'activeContrastBorder', hcLight: 'activeContrastBorder'
                 }, description: 'Border color of the selected menu item in the menubar.'
             },
             {
                 id: 'menu.border', defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder', hcLight: 'contrastBorder'
                 }, description: 'Border color of menus.'
             },
             {
                 id: 'menu.foreground', defaults: {
-                    dark: 'dropdown.foreground', light: 'foreground', hc: 'dropdown.foreground'
+                    dark: 'dropdown.foreground', light: 'foreground', hcDark: 'dropdown.foreground', hcLight: 'dropdown.foreground'
                 },
                 description: 'Foreground color of menu items.'
             },
             {
                 id: 'menu.background', defaults: {
-                    dark: 'dropdown.background', light: 'dropdown.background', hc: 'dropdown.background'
+                    dark: 'dropdown.background', light: 'dropdown.background', hcDark: 'dropdown.background', hcLight: 'dropdown.background'
                 }, description: 'Background color of menu items.'
             },
             {
                 id: 'menu.selectionForeground', defaults: {
-                    dark: 'list.activeSelectionForeground', light: 'list.activeSelectionForeground', hc: 'list.activeSelectionForeground'
+                    dark: 'list.activeSelectionForeground', light: 'list.activeSelectionForeground', hcDark: 'list.activeSelectionForeground', hcLight: 'list.activeSelectionForeground'
                 }, description: 'Foreground color of the selected menu item in menus.'
             },
             {
-                id: 'menu.selectionBackground', defaults:
-                    { dark: 'list.activeSelectionBackground', light: 'list.activeSelectionBackground', hc: 'list.activeSelectionBackground' },
+                id: 'menu.selectionBackground', defaults: {
+                    dark: 'list.activeSelectionBackground', light: 'list.activeSelectionBackground', hcDark: 'list.activeSelectionBackground', hcLight: 'list.activeSelectionBackground'
+                },
                 description: 'Background color of the selected menu item in menus.'
             },
             {
                 id: 'menu.selectionBorder', defaults: {
-                    hc: 'activeContrastBorder'
+                    hcDark: 'activeContrastBorder', hcLight: 'activeContrastBorder'
                 }, description: 'Border color of the selected menu item in menus.'
             },
             {
                 id: 'menu.separatorBackground', defaults: {
-                    dark: '#BBBBBB', light: '#888888', hc: 'contrastBorder'
+                    dark: '#BBBBBB', light: '#888888', hcDark: 'contrastBorder', hcLight: 'contrastBorder'
                 },
                 description: 'Color of a separator menu item in menus.'
             },
 
             // Welcome Page colors should be aligned with https://code.visualstudio.com/api/references/theme-color#welcome-page
             { id: 'welcomePage.background', description: 'Background color for the Welcome page.' },
-            { id: 'welcomePage.buttonBackground', defaults: { dark: Color.rgba(0, 0, 0, .2), light: Color.rgba(0, 0, 0, .04), hc: Color.black }, description: 'Background color for the buttons on the Welcome page.' },
+            { id: 'welcomePage.buttonBackground', defaults: { dark: Color.rgba(0, 0, 0, .2), light: Color.rgba(0, 0, 0, .04), hcDark: Color.black, hcLight: Color.white }, description: 'Background color for the buttons on the Welcome page.' },
             { id: 'welcomePage.buttonHoverBackground', defaults: { dark: Color.rgba(200, 235, 255, .072), light: Color.rgba(0, 0, 0, .10) }, description: 'Hover background color for the buttons on the Welcome page.' },
             { id: 'walkThrough.embeddedEditorBackground', defaults: { dark: Color.rgba(0, 0, 0, .4), light: '#f4f4f4' }, description: 'Background color for the embedded editors on the Interactive Playground.' },
 
@@ -1807,132 +1877,140 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'dropdown.background', defaults: {
                     light: Color.white,
                     dark: '#3C3C3C',
-                    hc: Color.black
+                    hcDark: Color.black,
+                    hcLight: Color.white
                 }, description: 'Dropdown background.'
             },
             {
                 id: 'dropdown.listBackground', defaults: {
-                    hc: Color.black
+                    hcDark: Color.black,
+                    hcLight: Color.white
                 }, description: 'Dropdown list background.'
             },
             {
                 id: 'dropdown.foreground', defaults: {
                     dark: '#F0F0F0',
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: 'foreground'
                 }, description: 'Dropdown foreground.'
             },
             {
                 id: 'dropdown.border', defaults: {
                     light: '#CECECE',
                     dark: 'dropdown.background',
-                    hc: '#6FC3DF'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 }, description: 'Dropdown border.'
             },
 
             // Settings Editor colors should be aligned with https://code.visualstudio.com/api/references/theme-color#settings-editor-colors
             {
                 id: 'settings.headerForeground', defaults: {
-                    light: '#444444', dark: '#e7e7e7', hc: '#ffffff'
+                    light: '#444444', dark: '#e7e7e7', hcDark: '#ffffff', hcLight: '#292929'
                 }, description: 'The foreground color for a section header or active title.'
             },
             {
                 id: 'settings.modifiedItemIndicator', defaults: {
                     light: Color.rgba(102, 175, 224),
                     dark: Color.rgba(12, 125, 157),
-                    hc: Color.rgba(0, 73, 122)
+                    hcDark: Color.rgba(0, 73, 122),
+                    hcLight: Color.rgba(102, 175, 224)
                 }, description: 'The color of the modified setting indicator.'
             },
             {
-                id: 'settings.dropdownBackground', defaults:
-                    { dark: 'dropdown.background', light: 'dropdown.background', hc: 'dropdown.background' },
+                id: 'settings.dropdownBackground', defaults: {
+                    dark: 'dropdown.background', light: 'dropdown.background', hcDark: 'dropdown.background', hcLight: 'dropdown.background'
+                },
                 description: 'Settings editor dropdown background.'
             },
             {
                 id: 'settings.dropdownForeground', defaults: {
-                    dark: 'dropdown.foreground', light: 'dropdown.foreground', hc: 'dropdown.foreground'
+                    dark: 'dropdown.foreground', light: 'dropdown.foreground', hcDark: 'dropdown.foreground', hcLight: 'dropdown.foreground'
                 }, description: 'Settings editor dropdown foreground.'
             },
             {
                 id: 'settings.dropdownBorder', defaults: {
-                    dark: 'dropdown.border', light: 'dropdown.border', hc: 'dropdown.border'
+                    dark: 'dropdown.border', light: 'dropdown.border', hcDark: 'dropdown.border', hcLight: 'dropdown.border'
                 }, description: 'Settings editor dropdown border.'
             },
             {
                 id: 'settings.dropdownListBorder', defaults: {
-                    dark: 'editorWidget.border', light: 'editorWidget.border', hc: 'editorWidget.border'
+                    dark: 'editorWidget.border', light: 'editorWidget.border', hcDark: 'editorWidget.border', hcLight: 'editorWidget.border'
                 }, description: 'Settings editor dropdown list border. This surrounds the options and separates the options from the description.'
             },
             {
                 id: 'settings.checkboxBackground', defaults: {
-                    dark: 'checkbox.background', light: 'checkbox.background', hc: 'checkbox.background'
+                    dark: 'checkbox.background', light: 'checkbox.background', hcDark: 'checkbox.background', hcLight: 'checkbox.background'
                 }, description: 'Settings editor checkbox background.'
             },
             {
                 id: 'settings.checkboxForeground', defaults: {
-                    dark: 'checkbox.foreground', light: 'checkbox.foreground', hc: 'checkbox.foreground'
+                    dark: 'checkbox.foreground', light: 'checkbox.foreground', hcDark: 'checkbox.foreground', hcLight: 'checkbox.foreground'
                 }, description: 'Settings editor checkbox foreground.'
             },
             {
-                id: 'settings.checkboxBorder', defaults:
-                {
-                    dark: 'checkbox.border', light: 'checkbox.border', hc: 'checkbox.border'
+                id: 'settings.checkboxBorder', defaults: {
+                    dark: 'checkbox.border', light: 'checkbox.border', hcDark: 'checkbox.border', hcLight: 'checkbox.border'
                 }, description: 'Settings editor checkbox border.'
             },
             {
                 id: 'settings.textInputBackground', defaults: {
-                    dark: 'input.background', light: 'input.background', hc: 'input.background'
+                    dark: 'input.background', light: 'input.background', hcDark: 'input.background', hcLight: 'input.background'
                 }, description: 'Settings editor text input box background.'
             },
             {
                 id: 'settings.textInputForeground', defaults: {
-                    dark: 'input.foreground', light: 'input.foreground', hc: 'input.foreground'
+                    dark: 'input.foreground', light: 'input.foreground', hcDark: 'input.foreground', hcLight: 'input.foreground'
                 }, description: 'Settings editor text input box foreground.'
             },
             {
                 id: 'settings.textInputBorder', defaults: {
-                    dark: 'input.border', light: 'input.border', hc: 'input.border'
+                    dark: 'input.border', light: 'input.border', hcDark: 'input.border', hcLight: 'input.background'
                 }, description: 'Settings editor text input box border.'
             },
             {
                 id: 'settings.numberInputBackground', defaults: {
-                    dark: 'input.background', light: 'input.background', hc: 'input.background'
+                    dark: 'input.background', light: 'input.background', hcDark: 'input.background', hcLight: 'input.background'
                 }, description: 'Settings editor number input box background.'
             },
             {
                 id: 'settings.numberInputForeground', defaults: {
-                    dark: 'input.foreground', light: 'input.foreground', hc: 'input.foreground'
+                    dark: 'input.foreground', light: 'input.foreground', hcDark: 'input.foreground', hcLight: 'input.foreground'
                 }, description: 'Settings editor number input box foreground.'
             },
             {
                 id: 'settings.numberInputBorder', defaults: {
-                    dark: 'input.border', light: 'input.border', hc: 'input.border'
+                    dark: 'input.border', light: 'input.border', hcDark: 'input.border', hcLight: 'input.border'
                 }, description: 'Settings editor number input box border.'
             },
             {
                 id: 'settings.focusedRowBackground', defaults: {
                     dark: Color.transparent('#808080', 0.14),
                     light: Color.transparent('#808080', 0.03),
-                    hc: undefined
+                    hcDark: undefined,
+                    hcLight: undefined
                 }, description: 'The background color of a settings row when focused.'
             },
             {
                 id: 'settings.rowHoverBackground', defaults: {
                     dark: Color.transparent('#808080', 0.07),
                     light: Color.transparent('#808080', 0.05),
-                    hc: undefined
+                    hcDark: undefined,
+                    hcLight: undefined
                 }, description: 'The background color of a settings row when hovered.'
             },
             {
                 id: 'settings.focusedRowBorder', defaults: {
                     dark: Color.rgba(255, 255, 255, 0.12),
                     light: Color.rgba(0, 0, 0, 0.12),
-                    hc: 'focusBorder'
+                    hcDark: 'focusBorder',
+                    hcLight: 'focusBorder'
                 }, description: "The color of the row's top and bottom border when the row is focused."
             },
             // Toolbar Action colors should be aligned with https://code.visualstudio.com/api/references/theme-color#action-colors
             {
                 id: 'toolbar.hoverBackground', defaults: {
-                    dark: '#5a5d5e50', light: '#b8b8b850', hc: undefined
+                    dark: '#5a5d5e50', light: '#b8b8b850', hcDark: undefined, hcLight: undefined
                 }, description: 'Toolbar background when hovering over actions using the mouse.'
             },
 
@@ -1941,7 +2019,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'variable.name.color', defaults: {
                     dark: '#C586C0',
                     light: '#9B46B0',
-                    hc: '#C586C0'
+                    hcDark: '#C586C0'
                 },
                 description: 'Color of a variable name.'
             },
@@ -1949,7 +2027,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'variable.value.color', defaults: {
                     dark: Color.rgba(204, 204, 204, 0.6),
                     light: Color.rgba(108, 108, 108, 0.8),
-                    hc: Color.rgba(204, 204, 204, 0.6)
+                    hcDark: Color.rgba(204, 204, 204, 0.6)
                 },
                 description: 'Color of a variable value.'
             },
@@ -1957,7 +2035,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'variable.number.variable.color', defaults: {
                     dark: '#B5CEA8',
                     light: '#09885A',
-                    hc: '#B5CEA8'
+                    hcDark: '#B5CEA8'
                 },
                 description: 'Value color of a number variable'
             },
@@ -1965,7 +2043,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'variable.boolean.variable.color', defaults: {
                     dark: '#4E94CE',
                     light: '#0000FF',
-                    hc: '#4E94CE'
+                    hcDark: '#4E94CE'
                 },
                 description: 'Value color of a boolean variable'
             },
@@ -1973,7 +2051,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'variable.string.variable.color', defaults: {
                     dark: '#CE9178',
                     light: '#A31515',
-                    hc: '#CE9178'
+                    hcDark: '#CE9178'
                 },
                 description: 'Value color of a string variable'
             },
@@ -1983,7 +2061,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'ansi.black.color', defaults: {
                     dark: '#A0A0A0',
                     light: Color.rgba(128, 128, 128),
-                    hc: '#A0A0A0'
+                    hcDark: '#A0A0A0'
                 },
                 description: 'ANSI black color'
             },
@@ -1991,7 +2069,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'ansi.red.color', defaults: {
                     dark: '#A74747',
                     light: '#BE1717',
-                    hc: '#A74747'
+                    hcDark: '#A74747'
                 },
                 description: 'ANSI red color'
             },
@@ -1999,7 +2077,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'ansi.green.color', defaults: {
                     dark: '#348F34',
                     light: '#338A2F',
-                    hc: '#348F34'
+                    hcDark: '#348F34'
                 },
                 description: 'ANSI green color'
             },
@@ -2007,7 +2085,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'ansi.yellow.color', defaults: {
                     dark: '#5F4C29',
                     light: '#BEB817',
-                    hc: '#5F4C29'
+                    hcDark: '#5F4C29'
                 },
                 description: 'ANSI yellow color'
             },
@@ -2015,7 +2093,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'ansi.blue.color', defaults: {
                     dark: '#6286BB',
                     light: Color.rgba(0, 0, 139),
-                    hc: '#6286BB'
+                    hcDark: '#6286BB'
                 },
                 description: 'ANSI blue color'
             },
@@ -2023,7 +2101,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'ansi.magenta.color', defaults: {
                     dark: '#914191',
                     light: Color.rgba(139, 0, 139),
-                    hc: '#914191'
+                    hcDark: '#914191'
                 },
                 description: 'ANSI magenta color'
             },
@@ -2031,7 +2109,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'ansi.cyan.color', defaults: {
                     dark: '#218D8D',
                     light: Color.rgba(0, 139, 139),
-                    hc: '#218D8D'
+                    hcDark: '#218D8D'
                 },
                 description: 'ANSI cyan color'
             },
@@ -2039,7 +2117,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'ansi.white.color', defaults: {
                     dark: '#707070',
                     light: '#BDBDBD',
-                    hc: '#707070'
+                    hcDark: '#707070'
                 },
                 description: 'ANSI white color'
             },
@@ -2051,7 +2129,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'inputValidation.errorBackground',
                     light: 'inputValidation.errorBackground',
-                    hc: 'inputValidation.errorBackground'
+                    hcDark: 'inputValidation.errorBackground'
                 }, description: 'Background color of error widgets (like alerts or notifications).'
             },
             {
@@ -2059,7 +2137,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'editorGutter.addedBackground',
                     light: 'editorGutter.addedBackground',
-                    hc: 'editorGutter.addedBackground'
+                    hcDark: 'editorGutter.addedBackground'
                 }, description: 'Background color of success widgets (like alerts or notifications).'
             },
             {
@@ -2067,7 +2145,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'editorWarning.foreground',
                     light: 'editorWarning.foreground',
-                    hc: 'editorWarning.border'
+                    hcDark: 'editorWarning.border'
                 }, description: 'Background color of warning widgets (like alerts or notifications).'
             },
             {
@@ -2075,7 +2153,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'inputValidation.warningBackground',
                     light: 'inputValidation.warningBackground',
-                    hc: 'inputValidation.warningBackground'
+                    hcDark: 'inputValidation.warningBackground'
                 }, description: 'Foreground color of warning widgets (like alerts or notifications).'
             },
             // Statusbar
@@ -2084,7 +2162,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'editorWarning.foreground',
                     light: 'editorWarning.foreground',
-                    hc: 'editorWarning.foreground'
+                    hcDark: 'editorWarning.foreground',
+                    hcLight: 'editorWarning.foreground'
                 }, description: 'Background of hovered statusbar item in case the theia server is offline.'
             },
             {
@@ -2092,7 +2171,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'editor.background',
                     light: 'editor.background',
-                    hc: 'editor.background'
+                    hcDark: 'editor.background',
+                    hcLight: 'editor.background'
                 }, description: 'Background of hovered statusbar item in case the theia server is offline.'
             },
             {
@@ -2100,7 +2180,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.lighten('statusBar.offlineBackground', 0.4),
                     light: Color.lighten('statusBar.offlineBackground', 0.4),
-                    hc: Color.lighten('statusBar.offlineBackground', 0.4)
+                    hcDark: Color.lighten('statusBar.offlineBackground', 0.4),
+                    hcLight: Color.lighten('statusBar.offlineBackground', 0.4)
                 }, description: 'Background of hovered statusbar item in case the theia server is offline.'
             },
             {
@@ -2108,7 +2189,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.lighten('statusBar.offlineBackground', 0.6),
                     light: Color.lighten('statusBar.offlineBackground', 0.6),
-                    hc: Color.lighten('statusBar.offlineBackground', 0.6)
+                    hcDark: Color.lighten('statusBar.offlineBackground', 0.6),
+                    hcLight: Color.lighten('statusBar.offlineBackground', 0.6)
                 }, description: 'Background of active statusbar item in case the theia server is offline.'
             },
             // Buttons
@@ -2117,7 +2199,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'dropdown.foreground',
                     light: 'dropdown.foreground',
-                    hc: 'dropdown.foreground'
+                    hcDark: 'dropdown.foreground',
+                    hcLight: 'dropdown.foreground'
                 }, description: 'Foreground color of secondary buttons.'
             },
             {
@@ -2125,7 +2208,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.transparent('secondaryButton.foreground', 0.5),
                     light: Color.transparent('secondaryButton.foreground', 0.5),
-                    hc: Color.transparent('secondaryButton.foreground', 0.5),
+                    hcDark: Color.transparent('secondaryButton.foreground', 0.5),
+                    hcLight: Color.transparent('secondaryButton.foreground', 0.5),
                 }, description: 'Foreground color of secondary buttons.'
             },
             {
@@ -2154,7 +2238,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.transparent('button.foreground', 0.5),
                     light: Color.transparent('button.foreground', 0.5),
-                    hc: Color.transparent('button.foreground', 0.5)
+                    hcDark: Color.transparent('button.foreground', 0.5)
                 }, description: 'Foreground color of secondary buttons.'
             },
             {
@@ -2169,7 +2253,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: '#c5c5c5',
                     light: '#c5c5c5',
-                    hc: '#c5c5c5'
+                    hcDark: Color.white,
+                    hcLight: Color.white
                 }, description: 'Editor gutter decoration color for commenting ranges.'
             },
             {
@@ -2177,7 +2262,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.transparent('foreground', 0.8),
                     light: Color.transparent('foreground', 0.8),
-                    hc: Color.transparent('foreground', 0.8),
+                    hcDark: Color.transparent('foreground', 0.8),
+                    hcLight: Color.transparent('foreground', 0.8)
                 },
                 description: 'Color of breadcrumb item text'
             },
@@ -2186,7 +2272,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'editor.background',
                     light: 'editor.background',
-                    hc: 'editor.background',
+                    hcDark: 'editor.background',
+                    hcLight: 'editor.background'
                 },
                 description: 'Color of breadcrumb item background'
             },
@@ -2195,7 +2282,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.lighten('foreground', 0.1),
                     light: Color.darken('foreground', 0.2),
-                    hc: Color.lighten('foreground', 0.1),
+                    hcDark: Color.lighten('foreground', 0.1),
+                    hcLight: Color.lighten('foreground', 0.1)
                 },
                 description: 'Color of breadcrumb item text when focused'
             },
@@ -2204,7 +2292,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.lighten('foreground', 0.1),
                     light: Color.darken('foreground', 0.2),
-                    hc: Color.lighten('foreground', 0.1),
+                    hcDark: Color.lighten('foreground', 0.1),
+                    hcLight: Color.lighten('foreground', 0.1)
                 },
                 description: 'Color of selected breadcrumb item'
             },
@@ -2213,7 +2302,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: 'editorWidget.background',
                     light: 'editorWidget.background',
-                    hc: 'editorWidget.background',
+                    hcDark: 'editorWidget.background',
+                    hcLight: 'editorWidget.background'
                 },
                 description: 'Background color of breadcrumb item picker'
             },
@@ -2222,7 +2312,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.lighten('activityBar.background', 0.1),
                     light: Color.darken('activityBar.background', 0.1),
-                    hc: Color.lighten('activityBar.background', 0.1),
+                    hcDark: Color.lighten('activityBar.background', 0.1),
+                    hcLight: Color.lighten('activityBar.background', 0.1)
                 },
                 description: 'Background color of shell\'s global toolbar'
             },
@@ -2230,7 +2321,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'mainToolbar.foreground', defaults: {
                     dark: Color.darken('activityBar.foreground', 0.1),
                     light: Color.lighten('activityBar.foreground', 0.1),
-                    hc: Color.lighten('activityBar.foreground', 0.1),
+                    hcDark: Color.lighten('activityBar.foreground', 0.1),
+                    hcLight: Color.lighten('activityBar.foreground', 0.1),
                 }, description: 'Foreground color of active toolbar item',
             },
             {
@@ -2238,7 +2330,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 defaults: {
                     dark: Color.transparent('editorHoverWidget.border', 0.5),
                     light: Color.transparent('editorHoverWidget.border', 0.5),
-                    hc: Color.transparent('editorHoverWidget.border', 0.5),
+                    hcDark: Color.transparent('editorHoverWidget.border', 0.5),
+                    hcLight: Color.transparent('editorHoverWidget.border', 0.5)
                 },
                 description: 'The border between subelements of a hover widget'
             }

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -188,9 +188,17 @@ export class BuiltinThemeProvider {
         editorTheme: 'hc-theia' // loaded in /packages/monaco/src/browser/textmate/monaco-theme-registry.ts
     };
 
+    static readonly hcLightTheme: Theme = {
+        id: 'hc-theia-light',
+        type: 'hcLight',
+        label: 'High Contrast Light (Theia)',
+        editorTheme: 'hc-theia-light' // loaded in /packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+    };
+
     static readonly themes = [
         BuiltinThemeProvider.darkTheme,
         BuiltinThemeProvider.lightTheme,
-        BuiltinThemeProvider.hcTheme
+        BuiltinThemeProvider.hcTheme,
+        BuiltinThemeProvider.hcLightTheme
     ];
 }

--- a/packages/core/src/common/theme.ts
+++ b/packages/core/src/common/theme.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-export type ThemeType = 'light' | 'dark' | 'hc';
+export type ThemeType = 'light' | 'dark' | 'hc' | 'hcLight';
 
 export interface Theme {
     readonly id: string;
@@ -27,7 +27,7 @@ export interface Theme {
 }
 
 export function isHighContrast(scheme: ThemeType): boolean {
-    return scheme === 'hc';
+    return scheme === 'hc' || scheme === 'hcLight';
 }
 
 export interface ThemeChangeEvent {

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -1251,7 +1251,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 defaults: {
                     dark: '#ffff0033',
                     light: '#ffff6673',
-                    hc: '#fff600'
+                    hcDark: '#fff600',
+                    hcLight: '#ffff6673'
                 }, description: 'Background color for the highlight of line at the top stack frame position.'
             },
             {
@@ -1259,7 +1260,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 defaults: {
                     dark: '#7abd7a4d',
                     light: '#cee7ce73',
-                    hc: '#cee7ce'
+                    hcDark: '#cee7ce',
+                    hcLight: '#cee7ce73'
                 }, description: 'Background color for the highlight of line at focused stack frame position.'
             },
             // Status bar colors should be aligned with debugging colors from https://code.visualstudio.com/api/references/theme-color#status-bar-colors
@@ -1267,21 +1269,24 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'statusBar.debuggingBackground', defaults: {
                     dark: '#CC6633',
                     light: '#CC6633',
-                    hc: '#CC6633'
+                    hcDark: '#CC6633',
+                    hcLight: '#B5200D'
                 }, description: 'Status bar background color when a program is being debugged. The status bar is shown in the bottom of the window'
             },
             {
                 id: 'statusBar.debuggingForeground', defaults: {
                     dark: 'statusBar.foreground',
                     light: 'statusBar.foreground',
-                    hc: 'statusBar.foreground'
+                    hcDark: 'statusBar.foreground',
+                    hcLight: 'statusBar.foreground'
                 }, description: 'Status bar foreground color when a program is being debugged. The status bar is shown in the bottom of the window'
             },
             {
                 id: 'statusBar.debuggingBorder', defaults: {
                     dark: 'statusBar.border',
                     light: 'statusBar.border',
-                    hc: 'statusBar.border'
+                    hcDark: 'statusBar.border',
+                    hcLight: 'statusBar.border'
                 }, description: 'Status bar border color separating to the sidebar and editor when a program is being debugged. The status bar is shown in the bottom of the window'
             },
             // Debug Exception Widget colors should be aligned with
@@ -1290,14 +1295,16 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugExceptionWidget.border', defaults: {
                     dark: '#a31515',
                     light: '#a31515',
-                    hc: '#a31515'
+                    hcDark: '#a31515',
+                    hcLight: '#a31515'
                 }, description: 'Exception widget border color.',
             },
             {
                 id: 'debugExceptionWidget.background', defaults: {
                     dark: '#420b0d',
                     light: '#f1dfde',
-                    hc: '#420b0d'
+                    hcDark: '#420b0d',
+                    hcLight: '#f1dfde'
                 }, description: 'Exception widget background color.'
             },
             // Debug Icon colors should be aligned with
@@ -1306,7 +1313,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugIcon.breakpointForeground', defaults: {
                     dark: '#E51400',
                     light: '#E51400',
-                    hc: '#E51400'
+                    hcDark: '#E51400',
+                    hcLight: '#E51400'
                 },
                 description: 'Icon color for breakpoints.'
             },
@@ -1314,7 +1322,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugIcon.breakpointDisabledForeground', defaults: {
                     dark: '#848484',
                     light: '#848484',
-                    hc: '#848484'
+                    hcDark: '#848484',
+                    hcLight: '#848484'
                 },
                 description: 'Icon color for disabled breakpoints.'
             },
@@ -1322,15 +1331,17 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugIcon.breakpointUnverifiedForeground', defaults: {
                     dark: '#848484',
                     light: '#848484',
-                    hc: '#848484'
+                    hcDark: '#848484',
+                    hcLight: '#848484'
                 },
                 description: 'Icon color for unverified breakpoints.'
             },
             {
                 id: 'debugIcon.breakpointCurrentStackframeForeground', defaults: {
                     dark: '#FFCC00',
-                    light: '#FFCC00',
-                    hc: '#FFCC00'
+                    light: '#BE8700',
+                    hcDark: '#FFCC00',
+                    hcLight: '#BE8700'
                 },
                 description: 'Icon color for the current breakpoint stack frame.'
             },
@@ -1338,7 +1349,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugIcon.breakpointStackframeForeground', defaults: {
                     dark: '#89D185',
                     light: '#89D185',
-                    hc: '#89D185'
+                    hcDark: '#89D185',
+                    hcLight: '#89D185'
                 },
                 description: 'Icon color for all breakpoint stack frames.'
             },
@@ -1346,84 +1358,96 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugIcon.startForeground', defaults: {
                     dark: '#89D185',
                     light: '#388A34',
-                    hc: '#89D185'
+                    hcDark: '#89D185',
+                    hcLight: '#388A34'
                 }, description: 'Debug toolbar icon for start debugging.'
             },
             {
                 id: 'debugIcon.pauseForeground', defaults: {
                     dark: '#75BEFF',
                     light: '#007ACC',
-                    hc: '#75BEFF'
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC'
                 }, description: 'Debug toolbar icon for pause.'
             },
             {
                 id: 'debugIcon.stopForeground', defaults: {
                     dark: '#F48771',
                     light: '#A1260D',
-                    hc: '#F48771'
+                    hcDark: '#F48771',
+                    hcLight: '#A1260D'
                 }, description: 'Debug toolbar icon for stop.'
             },
             {
                 id: 'debugIcon.disconnectForeground', defaults: {
                     dark: '#F48771',
                     light: '#A1260D',
-                    hc: '#F48771'
+                    hcDark: '#F48771',
+                    hcLight: '#A1260D'
                 }, description: 'Debug toolbar icon for disconnect.'
             },
             {
                 id: 'debugIcon.restartForeground', defaults: {
                     dark: '#89D185',
                     light: '#388A34',
-                    hc: '#89D185'
+                    hcDark: '#89D185',
+                    hcLight: '#388A34'
                 }, description: 'Debug toolbar icon for restart.'
             },
             {
                 id: 'debugIcon.stepOverForeground', defaults: {
                     dark: '#75BEFF',
                     light: '#007ACC',
-                    hc: '#75BEFF'
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC',
                 }, description: 'Debug toolbar icon for step over.'
             },
             {
                 id: 'debugIcon.stepIntoForeground', defaults: {
                     dark: '#75BEFF',
                     light: '#007ACC',
-                    hc: '#75BEFF'
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC'
                 }, description: 'Debug toolbar icon for step into.'
             },
             {
                 id: 'debugIcon.stepOutForeground', defaults: {
                     dark: '#75BEFF',
                     light: '#007ACC',
-                    hc: '#75BEFF'
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC',
                 }, description: 'Debug toolbar icon for step over.'
             },
             {
                 id: 'debugIcon.continueForeground', defaults: {
                     dark: '#75BEFF',
                     light: '#007ACC',
-                    hc: '#75BEFF'
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC'
                 }, description: 'Debug toolbar icon for continue.'
             },
             {
                 id: 'debugIcon.stepBackForeground', defaults: {
                     dark: '#75BEFF',
                     light: '#007ACC',
-                    hc: '#75BEFF'
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC'
                 }, description: 'Debug toolbar icon for step back.'
             },
             {
                 id: 'debugConsole.infoForeground', defaults: {
                     dark: 'editorInfo.foreground',
                     light: 'editorInfo.foreground',
-                    hc: 'foreground'
+                    hcDark: 'foreground',
+                    hcLight: 'foreground'
                 }, description: 'Foreground color for info messages in debug REPL console.'
             },
             {
                 id: 'debugConsole.warningForeground', defaults: {
                     dark: 'editorWarning.foreground',
                     light: 'editorWarning.foreground',
-                    hc: '#008000'
+                    hcDark: '#008000',
+                    hcLight: 'editorWarning.foreground'
                 },
                 description: 'Foreground color for warning messages in debug REPL console.'
             },
@@ -1431,7 +1455,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugConsole.errorForeground', defaults: {
                     dark: 'errorForeground',
                     light: 'errorForeground',
-                    hc: 'errorForeground'
+                    hcDark: 'errorForeground',
+                    hcLight: 'errorForeground'
                 },
                 description: 'Foreground color for error messages in debug REPL console.',
             },
@@ -1439,7 +1464,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugConsole.sourceForeground', defaults: {
                     dark: 'foreground',
                     light: 'foreground',
-                    hc: 'foreground'
+                    hcDark: 'foreground',
+                    hcLight: 'foreground'
                 },
                 description: 'Foreground color for source filenames in debug REPL console.',
             },
@@ -1447,7 +1473,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                 id: 'debugConsoleInputIcon.foreground', defaults: {
                     dark: 'foreground',
                     light: 'foreground',
-                    hc: 'foreground'
+                    hcDark: 'foreground',
+                    hcLight: 'foreground'
                 },
                 description: 'Foreground color for debug console input marker icon.'
             }

--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -927,68 +927,73 @@ export class GitContribution implements CommandContribution, MenuContribution, T
      */
     registerColors(colors: ColorRegistry): void {
         colors.register({
-            'id': 'gitDecoration.addedResourceForeground',
-            'description': 'Color for added resources.',
-            'defaults': {
-                'light': '#587c0c',
-                'dark': '#81b88b',
-                'hc': '#1b5225'
+            id: 'gitDecoration.addedResourceForeground',
+            description: 'Color for added resources.',
+            defaults: {
+                light: '#587c0c',
+                dark: '#81b88b',
+                hcDark: '#a1e3ad',
+                hcLight: '#374e06'
             }
         }, {
-            'id': 'gitDecoration.modifiedResourceForeground',
-            'description': 'Color for modified resources.',
-            'defaults': {
-                'light': '#895503',
-                'dark': '#E2C08D',
-                'hc': '#E2C08D'
+            id: 'gitDecoration.modifiedResourceForeground',
+            description: 'Color for modified resources.',
+            defaults: {
+                light: '#895503',
+                dark: '#E2C08D',
+                hcDark: '#E2C08D',
+                hcLight: '#895503'
             }
         }, {
-            'id': 'gitDecoration.deletedResourceForeground',
-            'description': 'Color for deleted resources.',
-            'defaults': {
-                'light': '#ad0707',
-                'dark': '#c74e39',
-                'hc': '#c74e39'
+            id: 'gitDecoration.deletedResourceForeground',
+            description: 'Color for deleted resources.',
+            defaults: {
+                light: '#ad0707',
+                dark: '#c74e39',
+                hcDark: '#c74e39',
+                hcLight: '#ad0707'
             }
         }, {
-            'id': 'gitDecoration.untrackedResourceForeground',
-            'description': 'Color for untracked resources.',
-            'defaults': {
-                'light': '#007100',
-                'dark': '#73C991',
-                'hc': '#73C991'
+            id: 'gitDecoration.untrackedResourceForeground',
+            description: 'Color for untracked resources.',
+            defaults: {
+                light: '#007100',
+                dark: '#73C991',
+                hcDark: '#73C991',
+                hcLight: '#007100'
             }
         }, {
-            'id': 'gitDecoration.conflictingResourceForeground',
-            'description': 'Color for resources with conflicts.',
-            'defaults': {
-                'light': '#6c6cc4',
-                'dark': '#6c6cc4',
-                'hc': '#6c6cc4'
+            id: 'gitDecoration.conflictingResourceForeground',
+            description: 'Color for resources with conflicts.',
+            defaults: {
+                light: '#6c6cc4',
+                dark: '#6c6cc4',
+                hcDark: '#c74e39',
+                hcLight: '#ad0707'
             }
         }, {
-            'id': 'gitlens.gutterBackgroundColor',
-            'description': 'Specifies the background color of the gutter blame annotations',
-            'defaults': {
-                'dark': '#FFFFFF13',
-                'light': '#0000000C',
-                'hc': '#FFFFFF13'
+            id: 'gitlens.gutterBackgroundColor',
+            description: 'Specifies the background color of the gutter blame annotations',
+            defaults: {
+                dark: '#FFFFFF13',
+                light: '#0000000C',
+                hcDark: '#FFFFFF13'
             }
         }, {
-            'id': 'gitlens.gutterForegroundColor',
-            'description': 'Specifies the foreground color of the gutter blame annotations',
-            'defaults': {
-                'dark': '#BEBEBE',
-                'light': '#747474',
-                'hc': '#BEBEBE'
+            id: 'gitlens.gutterForegroundColor',
+            description: 'Specifies the foreground color of the gutter blame annotations',
+            defaults: {
+                dark: '#BEBEBE',
+                light: '#747474',
+                hcDark: '#BEBEBE'
             }
         }, {
-            'id': 'gitlens.lineHighlightBackgroundColor',
-            'description': 'Specifies the background color of the associated line highlights in blame annotations',
-            'defaults': {
-                'dark': '#00BCF233',
-                'light': '#00BCF233',
-                'hc': '#00BCF233'
+            id: 'gitlens.lineHighlightBackgroundColor',
+            description: 'Specifies the background color of the associated line highlights in blame annotations',
+            defaults: {
+                dark: '#00BCF233',
+                light: '#00BCF233',
+                hcDark: '#00BCF233'
             }
         });
     }

--- a/packages/messages/src/browser/notifications-contribution.ts
+++ b/packages/messages/src/browser/notifications-contribution.ts
@@ -107,33 +107,38 @@ export class NotificationsContribution implements FrontendApplicationContributio
         colors.register(
             {
                 id: 'notificationCenter.border', defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 }, description: 'Notifications center border color. Notifications slide in from the bottom right of the window.'
             },
             {
                 id: 'notificationToast.border', defaults: {
-                    hc: 'contrastBorder'
+                    hcDark: 'contrastBorder',
+                    hcLight: 'contrastBorder'
                 }, description: 'Notification toast border color. Notifications slide in from the bottom right of the window.'
             },
             {
                 id: 'notifications.foreground', defaults: {
                     dark: 'editorWidget.foreground',
                     light: 'editorWidget.foreground',
-                    hc: 'editorWidget.foreground'
+                    hcDark: 'editorWidget.foreground',
+                    hcLight: 'editorWidget.foreground'
                 }, description: 'Notifications foreground color. Notifications slide in from the bottom right of the window.'
             },
             {
                 id: 'notifications.background', defaults: {
                     dark: 'editorWidget.background',
                     light: 'editorWidget.background',
-                    hc: 'editorWidget.background'
+                    hcDark: 'editorWidget.background',
+                    hcLight: 'editorWidget.background'
                 }, description: 'Notifications background color. Notifications slide in from the bottom right of the window.'
             },
             {
                 id: 'notificationLink.foreground', defaults: {
                     dark: 'textLink.foreground',
                     light: 'textLink.foreground',
-                    hc: 'textLink.foreground'
+                    hcDark: 'textLink.foreground',
+                    hcLight: 'textLink.foreground'
                 }, description: 'Notification links foreground color. Notifications slide in from the bottom right of the window.'
             },
             {
@@ -144,14 +149,16 @@ export class NotificationsContribution implements FrontendApplicationContributio
                 id: 'notificationCenterHeader.background', defaults: {
                     dark: Color.lighten('notifications.background', 0.3),
                     light: Color.darken('notifications.background', 0.05),
-                    hc: 'notifications.background'
+                    hcDark: 'notifications.background',
+                    hcLight: 'notifications.background'
                 }, description: 'Notifications center header background color. Notifications slide in from the bottom right of the window.'
             },
             {
                 id: 'notifications.border', defaults: {
                     dark: 'notificationCenterHeader.background',
                     light: 'notificationCenterHeader.background',
-                    hc: 'notificationCenterHeader.background'
+                    hcDark: 'notificationCenterHeader.background',
+                    hcLight: 'notificationCenterHeader.background'
                     // eslint-disable-next-line max-len
                 }, description: 'Notifications border color separating from other notifications in the notifications center. Notifications slide in from the bottom right of the window.'
             },
@@ -159,21 +166,24 @@ export class NotificationsContribution implements FrontendApplicationContributio
                 id: 'notificationsErrorIcon.foreground', defaults: {
                     dark: 'editorError.foreground',
                     light: 'editorError.foreground',
-                    hc: 'editorError.foreground'
+                    hcDark: 'editorError.foreground',
+                    hcLight: 'editorError.foreground'
                 }, description: 'The color used for the icon of error notifications. Notifications slide in from the bottom right of the window.'
             },
             {
                 id: 'notificationsWarningIcon.foreground', defaults: {
                     dark: 'editorWarning.foreground',
                     light: 'editorWarning.foreground',
-                    hc: 'editorWarning.foreground'
+                    hcDark: 'editorWarning.foreground',
+                    hcLight: 'editorWarning.foreground'
                 }, description: 'The color used for the icon of warning notifications. Notifications slide in from the bottom right of the window.'
             },
             {
                 id: 'notificationsInfoIcon.foreground', defaults: {
                     dark: 'editorInfo.foreground',
                     light: 'editorInfo.foreground',
-                    hc: 'editorInfo.foreground'
+                    hcDark: 'editorInfo.foreground',
+                    hcLight: 'editorInfo.foreground'
                 }, description: 'The color used for the icon of info notifications. Notifications slide in from the bottom right of the window.'
             }
         );

--- a/packages/monaco/data/monaco-themes/vscode/hc_light.json
+++ b/packages/monaco/data/monaco-themes/vscode/hc_light.json
@@ -1,0 +1,590 @@
+{
+  "$schema": "vscode://schemas/color-theme",
+  "name": "Light High Contrast",
+  "tokenColors": [
+    {
+      "scope": [
+        "meta.embedded",
+        "source.groovy.embedded"
+      ],
+      "settings": {
+        "foreground": "#292929"
+      }
+    },
+    {
+      "scope": "emphasis",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "strong",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "meta.diff.header",
+      "settings": {
+        "foreground": "#062F4A"
+      }
+    },
+    {
+      "scope": "comment",
+      "settings": {
+        "foreground": "#515151"
+      }
+    },
+    {
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": [
+        "constant.numeric",
+        "variable.other.enummember",
+        "keyword.operator.plus.exponent",
+        "keyword.operator.minus.exponent"
+      ],
+      "settings": {
+        "foreground": "#096d48"
+      }
+    },
+    {
+      "scope": "constant.regexp",
+      "settings": {
+        "foreground": "#811F3F"
+      }
+    },
+    {
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "entity.name.selector",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#264F78"
+      }
+    },
+    {
+      "scope": [
+        "entity.other.attribute-name.class.css",
+        "entity.other.attribute-name.class.mixin.css",
+        "entity.other.attribute-name.id.css",
+        "entity.other.attribute-name.parent-selector.css",
+        "entity.other.attribute-name.pseudo-class.css",
+        "entity.other.attribute-name.pseudo-element.css",
+        "source.css.less entity.other.attribute-name.id",
+        "entity.other.attribute-name.scss"
+      ],
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "invalid",
+      "settings": {
+        "foreground": "#B5200D"
+      }
+    },
+    {
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "foreground": "#000080",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#0F4A85",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#096d48"
+      }
+    },
+    {
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#5A5A5A"
+      }
+    },
+    {
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#0451A5"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.quote.begin.markdown",
+        "punctuation.definition.list.begin.markdown"
+      ],
+      "settings": {
+        "foreground": "#0451A5"
+      }
+    },
+    {
+      "scope": "markup.inline.raw",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "punctuation.definition.tag",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": [
+        "meta.preprocessor",
+        "entity.name.function.preprocessor"
+      ],
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.string",
+      "settings": {
+        "foreground": "#b5200d"
+      }
+    },
+    {
+      "scope": "meta.preprocessor.numeric",
+      "settings": {
+        "foreground": "#096d48"
+      }
+    },
+    {
+      "scope": "meta.structure.dictionary.key.python",
+      "settings": {
+        "foreground": "#0451A5"
+      }
+    },
+    {
+      "scope": "storage",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "storage.type",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": [
+        "storage.modifier",
+        "keyword.operator.noexcept"
+      ],
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "meta.embedded.assembly"
+      ],
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": [
+        "string.comment.buffered.block.pug",
+        "string.quoted.pug",
+        "string.interpolated.pug",
+        "string.unquoted.plain.in.yaml",
+        "string.unquoted.plain.out.yaml",
+        "string.unquoted.block.yaml",
+        "string.quoted.single.yaml",
+        "string.quoted.double.xml",
+        "string.quoted.single.xml",
+        "string.unquoted.cdata.xml",
+        "string.quoted.double.html",
+        "string.quoted.single.html",
+        "string.unquoted.html",
+        "string.quoted.single.handlebars",
+        "string.quoted.double.handlebars"
+      ],
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#811F3F"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": [
+        "meta.template.expression"
+      ],
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "scope": [
+        "support.constant.property-value",
+        "support.constant.font-name",
+        "support.constant.media-type",
+        "support.constant.media",
+        "constant.other.color.rgb-value",
+        "constant.other.rgb-value",
+        "support.constant.color"
+      ],
+      "settings": {
+        "foreground": "#0451A5"
+      }
+    },
+    {
+      "scope": [
+        "support.type.vendored.property-name",
+        "support.type.property-name",
+        "variable.css",
+        "variable.scss",
+        "variable.other.less",
+        "source.coffee.embedded"
+      ],
+      "settings": {
+        "foreground": "#264F78"
+      }
+    },
+    {
+      "scope": [
+        "support.type.property-name.json"
+      ],
+      "settings": {
+        "foreground": "#0451A5"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator.new",
+        "keyword.operator.expression",
+        "keyword.operator.cast",
+        "keyword.operator.sizeof",
+        "keyword.operator.alignof",
+        "keyword.operator.typeid",
+        "keyword.operator.alignas",
+        "keyword.operator.instanceof",
+        "keyword.operator.logical.python",
+        "keyword.operator.wordlike"
+      ],
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#096d48"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.section.embedded.begin.php",
+        "punctuation.section.embedded.end.php"
+      ],
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "support.function.git-rebase",
+      "settings": {
+        "foreground": "#0451A5"
+      }
+    },
+    {
+      "scope": "constant.sha.git-rebase",
+      "settings": {
+        "foreground": "#096d48"
+      }
+    },
+    {
+      "scope": [
+        "storage.modifier.import.java",
+        "variable.language.wildcard.java",
+        "storage.modifier.package.java"
+      ],
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.function",
+        "support.function",
+        "support.constant.handlebars",
+        "source.powershell variable.other.member",
+        "entity.name.operator.custom-literal"
+      ],
+      "settings": {
+        "foreground": "#5e2cbc"
+      }
+    },
+    {
+      "scope": [
+        "support.class",
+        "support.type",
+        "entity.name.type",
+        "entity.name.namespace",
+        "entity.other.attribute",
+        "entity.name.scope-resolution",
+        "entity.name.class",
+        "storage.type.numeric.go",
+        "storage.type.byte.go",
+        "storage.type.boolean.go",
+        "storage.type.string.go",
+        "storage.type.uintptr.go",
+        "storage.type.error.go",
+        "storage.type.rune.go",
+        "storage.type.cs",
+        "storage.type.generic.cs",
+        "storage.type.modifier.cs",
+        "storage.type.variable.cs",
+        "storage.type.annotation.java",
+        "storage.type.generic.java",
+        "storage.type.java",
+        "storage.type.object.array.java",
+        "storage.type.primitive.array.java",
+        "storage.type.primitive.java",
+        "storage.type.token.java",
+        "storage.type.groovy",
+        "storage.type.annotation.groovy",
+        "storage.type.parameters.groovy",
+        "storage.type.generic.groovy",
+        "storage.type.object.array.groovy",
+        "storage.type.primitive.array.groovy",
+        "storage.type.primitive.groovy"
+      ],
+      "settings": {
+        "foreground": "#185E73"
+      }
+    },
+    {
+      "scope": [
+        "meta.type.cast.expr",
+        "meta.type.new.expr",
+        "support.constant.math",
+        "support.constant.dom",
+        "support.constant.json",
+        "entity.other.inherited-class"
+      ],
+      "settings": {
+        "foreground": "#185E73"
+      }
+    },
+    {
+      "scope": [
+        "keyword.control",
+        "source.cpp keyword.operator.new",
+        "source.cpp keyword.operator.delete",
+        "keyword.other.using",
+        "keyword.other.operator",
+        "entity.name.operator"
+      ],
+      "settings": {
+        "foreground": "#b5200d"
+      }
+    },
+    {
+      "scope": [
+        "variable",
+        "meta.definition.variable.name",
+        "support.variable",
+        "entity.name.variable",
+        "constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "#001080"
+      }
+    },
+    {
+      "scope": [
+        "variable.other.constant",
+        "variable.other.enummember"
+      ],
+      "settings": {
+        "foreground": "#02715D"
+      }
+    },
+    {
+      "scope": [
+        "meta.object-literal.key"
+      ],
+      "settings": {
+        "foreground": "#001080"
+      }
+    },
+    {
+      "scope": [
+        "support.constant.property-value",
+        "support.constant.font-name",
+        "support.constant.media-type",
+        "support.constant.media",
+        "constant.other.color.rgb-value",
+        "constant.other.rgb-value",
+        "support.constant.color"
+      ],
+      "settings": {
+        "foreground": "#0451A5"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.definition.group.regexp",
+        "punctuation.definition.group.assertion.regexp",
+        "punctuation.definition.character-class.regexp",
+        "punctuation.character.set.begin.regexp",
+        "punctuation.character.set.end.regexp",
+        "keyword.operator.negation.regexp",
+        "support.other.parenthesis.regexp"
+      ],
+      "settings": {
+        "foreground": "#D16969"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.character-class.regexp",
+        "constant.other.character-class.set.regexp",
+        "constant.other.character-class.regexp",
+        "constant.character.set.regexp"
+      ],
+      "settings": {
+        "foreground": "#811F3F"
+      }
+    },
+    {
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "scope": [
+        "keyword.operator.or.regexp",
+        "keyword.control.anchor.regexp"
+      ],
+      "settings": {
+        "foreground": "#EE0000"
+      }
+    },
+    {
+      "scope": "constant.character",
+      "settings": {
+        "foreground": "#0F4A85"
+      }
+    },
+    {
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#EE0000"
+      }
+    },
+    {
+      "scope": "entity.name.label",
+      "settings": {
+        "foreground": "#000000"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#316BCD"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#CD9731"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#CD3131"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#800080"
+      }
+    }
+  ]
+}

--- a/packages/monaco/data/monaco-themes/vscode/hc_theia_light.json
+++ b/packages/monaco/data/monaco-themes/vscode/hc_theia_light.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "vscode://schemas/color-theme",
+  "name": "Light High Contrast (Theia)",
+  "include": "./hc_light.json"
+}

--- a/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
@@ -43,6 +43,9 @@ export class MonacoThemeRegistry {
         this.register(require('../../../data/monaco-themes/vscode/hc_theia.json'), {
             './hc_black.json': require('../../../data/monaco-themes/vscode/hc_black.json')
         }, 'hc-theia', 'hc-black');
+        this.register(require('../../../data/monaco-themes/vscode/hc_theia_light.json'), {
+            './hc_light.json': require('../../../data/monaco-themes/vscode/hc_light.json')
+        }, 'hc-theia-light', 'hc-light');
     }
 
     getThemeData(): ThemeMix;
@@ -169,4 +172,5 @@ export namespace MonacoThemeRegistry {
     export const DARK_DEFAULT_THEME = 'dark-theia';
     export const LIGHT_DEFAULT_THEME = 'light-theia';
     export const HC_DEFAULT_THEME = 'hc-theia';
+    export const HC_LIGHT_THEME = 'hc-theia-light';
 }

--- a/packages/plugin-ext/src/plugin/theming.ts
+++ b/packages/plugin-ext/src/plugin/theming.ts
@@ -59,6 +59,9 @@ export class ThemingExtImpl implements ThemingExt {
             case 'hc':
                 kind = ColorThemeKind.HighContrast;
                 break;
+            case 'hcLight':
+                kind = ColorThemeKind.HighContrastLight;
+                break;
         }
         return kind;
     }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -176,7 +176,8 @@ export enum ViewColumn {
 export enum ColorThemeKind {
     Light = 1,
     Dark = 2,
-    HighContrast = 3
+    HighContrast = 3,
+    HighContrastLight = 4
 }
 
 export enum ExtensionMode {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5184,7 +5184,8 @@ export module '@theia/plugin' {
     export enum ColorThemeKind {
         Light = 1,
         Dark = 2,
-        HighContrast = 3
+        HighContrast = 3,
+        HighContrastLight = 4
     }
 
     /**
@@ -5192,7 +5193,7 @@ export module '@theia/plugin' {
      */
     export interface ColorTheme {
         /**
-         * The kind of this color theme: light, dark or high contrast.
+         * The kind of this color theme: light, dark, high contrast dark and high contrast light.
          */
         readonly kind: ColorThemeKind;
     }

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -274,66 +274,74 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
         colors.register(
             {
                 id: ScmColors.editorGutterModifiedBackground, defaults: {
-                    dark: Color.rgba(12, 125, 157),
-                    light: Color.rgba(102, 175, 224),
-                    hc: Color.rgba(0, 155, 249)
+                    dark: '#1B81A8',
+                    light: '#2090D3',
+                    hcDark: '#1B81A8',
+                    hcLight: '#2090D3'
                 }, description: 'Editor gutter background color for lines that are modified.'
             },
             {
                 id: ScmColors.editorGutterAddedBackground, defaults: {
-                    dark: Color.rgba(88, 124, 12),
-                    light: Color.rgba(129, 184, 139),
-                    hc: Color.rgba(51, 171, 78)
+                    dark: '#487E02',
+                    light: '#48985D',
+                    hcDark: '#487E02',
+                    hcLight: '#48985D'
                 }, description: 'Editor gutter background color for lines that are added.'
             },
             {
                 id: ScmColors.editorGutterDeletedBackground, defaults: {
-                    dark: Color.rgba(148, 21, 27),
-                    light: Color.rgba(202, 75, 81),
-                    hc: Color.rgba(252, 93, 109)
+                    dark: 'editorError.foreground',
+                    light: 'editorError.foreground',
+                    hcDark: 'editorError.foreground',
+                    hcLight: 'editorError.foreground'
                 }, description: 'Editor gutter background color for lines that are deleted.'
             },
             {
                 id: 'minimapGutter.modifiedBackground', defaults: {
-                    dark: Color.rgba(12, 125, 157),
-                    light: Color.rgba(102, 175, 224),
-                    hc: Color.rgba(0, 155, 249)
+                    dark: 'editorGutter.modifiedBackground',
+                    light: 'editorGutter.modifiedBackground',
+                    hcDark: 'editorGutter.modifiedBackground',
+                    hcLight: 'editorGutter.modifiedBackground'
                 }, description: 'Minimap gutter background color for lines that are modified.'
             },
             {
-                id: 'minimapGutter.addedBackground',
-                defaults: {
-                    dark: Color.rgba(88, 124, 12),
-                    light: Color.rgba(129, 184, 139),
-                    hc: Color.rgba(51, 171, 78)
+                id: 'minimapGutter.addedBackground', defaults: {
+                    dark: 'editorGutter.addedBackground',
+                    light: 'editorGutter.addedBackground',
+                    hcDark: 'editorGutter.modifiedBackground',
+                    hcLight: 'editorGutter.modifiedBackground'
                 }, description: 'Minimap gutter background color for lines that are added.'
             },
             {
                 id: 'minimapGutter.deletedBackground', defaults: {
-                    dark: Color.rgba(148, 21, 27),
-                    light: Color.rgba(202, 75, 81),
-                    hc: Color.rgba(252, 93, 109)
+                    dark: 'editorGutter.deletedBackground',
+                    light: 'editorGutter.deletedBackground',
+                    hcDark: 'editorGutter.deletedBackground',
+                    hcLight: 'editorGutter.deletedBackground'
                 }, description: 'Minimap gutter background color for lines that are deleted.'
             },
             {
                 id: 'editorOverviewRuler.modifiedForeground', defaults: {
                     dark: Color.transparent(ScmColors.editorGutterModifiedBackground, 0.6),
                     light: Color.transparent(ScmColors.editorGutterModifiedBackground, 0.6),
-                    hc: Color.transparent(ScmColors.editorGutterModifiedBackground, 0.6)
+                    hcDark: Color.transparent(ScmColors.editorGutterModifiedBackground, 0.6),
+                    hcLight: Color.transparent(ScmColors.editorGutterModifiedBackground, 0.6)
                 }, description: 'Overview ruler marker color for modified content.'
             },
             {
                 id: 'editorOverviewRuler.addedForeground', defaults: {
                     dark: Color.transparent(ScmColors.editorGutterAddedBackground, 0.6),
                     light: Color.transparent(ScmColors.editorGutterAddedBackground, 0.6),
-                    hc: Color.transparent(ScmColors.editorGutterAddedBackground, 0.6)
+                    hcDark: Color.transparent(ScmColors.editorGutterAddedBackground, 0.6),
+                    hcLight: Color.transparent(ScmColors.editorGutterAddedBackground, 0.6)
                 }, description: 'Overview ruler marker color for added content.'
             },
             {
                 id: 'editorOverviewRuler.deletedForeground', defaults: {
                     dark: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6),
                     light: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6),
-                    hc: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6)
+                    hcDark: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6),
+                    hcLight: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6)
                 }, description: 'Overview ruler marker color for deleted content.'
             }
         );

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -717,7 +717,8 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             defaults: {
                 dark: 'panel.background',
                 light: 'panel.background',
-                hc: 'panel.background'
+                hcDark: 'panel.background',
+                hcLight: 'panel.background'
             },
             description: 'The background color of the terminal, this allows coloring the terminal differently to the panel.'
         });
@@ -726,7 +727,8 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             defaults: {
                 light: '#333333',
                 dark: '#CCCCCC',
-                hc: '#FFFFFF'
+                hcDark: '#FFFFFF',
+                hcLight: '#292929'
             },
             description: 'The foreground color of the terminal.'
         });
@@ -741,9 +743,10 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
         colors.register({
             id: 'terminal.selectionBackground',
             defaults: {
-                light: '#00000040',
-                dark: '#FFFFFF40',
-                hc: '#FFFFFF80'
+                light: 'editor.selectionBackground',
+                dark: 'editor.selectionBackground',
+                hcDark: 'editor.selectionBackground',
+                hcLight: 'editor.selectionBackground'
             },
             description: 'The selection background color of the terminal.'
         });
@@ -752,7 +755,8 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             defaults: {
                 light: 'panel.border',
                 dark: 'panel.border',
-                hc: 'panel.border'
+                hcDark: 'panel.border',
+                hcLight: 'panel.border'
             },
             description: 'The color of the border that separates split panes within the terminal. This defaults to panel.border.'
         });

--- a/packages/terminal/src/browser/terminal-theme-service.ts
+++ b/packages/terminal/src/browser/terminal-theme-service.ts
@@ -31,7 +31,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#000000',
             dark: '#000000',
-            hc: '#000000'
+            hcDark: '#000000',
+            hcLight: '#292929'
         }
     },
     'terminal.ansiRed': {
@@ -39,7 +40,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#cd3131',
             dark: '#cd3131',
-            hc: '#cd0000'
+            hcDark: '#cd0000',
+            hcLight: '#cd3131'
         }
     },
     'terminal.ansiGreen': {
@@ -47,7 +49,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#00BC00',
             dark: '#0DBC79',
-            hc: '#00cd00'
+            hcDark: '#00cd00',
+            hcLight: '#00bc00'
         }
     },
     'terminal.ansiYellow': {
@@ -55,7 +58,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#949800',
             dark: '#e5e510',
-            hc: '#cdcd00'
+            hcDark: '#cdcd00',
+            hcLight: '#949800'
         }
     },
     'terminal.ansiBlue': {
@@ -63,7 +67,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#0451a5',
             dark: '#2472c8',
-            hc: '#0000ee'
+            hcDark: '#0000ee',
+            hcLight: '#0451a5'
         }
     },
     'terminal.ansiMagenta': {
@@ -71,7 +76,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#bc05bc',
             dark: '#bc3fbc',
-            hc: '#cd00cd'
+            hcDark: '#cd00cd',
+            hcLight: '#bc05bc'
         }
     },
     'terminal.ansiCyan': {
@@ -79,7 +85,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#0598bc',
             dark: '#11a8cd',
-            hc: '#00cdcd'
+            hcDark: '#00cdcd',
+            hcLight: '#0598b'
         }
     },
     'terminal.ansiWhite': {
@@ -87,7 +94,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#555555',
             dark: '#e5e5e5',
-            hc: '#e5e5e5'
+            hcDark: '#e5e5e5',
+            hcLight: '#555555'
         }
     },
     'terminal.ansiBrightBlack': {
@@ -95,7 +103,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#666666',
             dark: '#666666',
-            hc: '#7f7f7f'
+            hcDark: '#7f7f7f',
+            hcLight: '#666666'
         }
     },
     'terminal.ansiBrightRed': {
@@ -103,7 +112,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#cd3131',
             dark: '#f14c4c',
-            hc: '#ff0000'
+            hcDark: '#ff0000',
+            hcLight: '#cd3131'
         }
     },
     'terminal.ansiBrightGreen': {
@@ -111,7 +121,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#14CE14',
             dark: '#23d18b',
-            hc: '#00ff00'
+            hcDark: '#00ff00',
+            hcLight: '#00bc00'
         }
     },
     'terminal.ansiBrightYellow': {
@@ -119,7 +130,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#b5ba00',
             dark: '#f5f543',
-            hc: '#ffff00'
+            hcDark: '#ffff00',
+            hcLight: '#b5ba00'
         }
     },
     'terminal.ansiBrightBlue': {
@@ -127,7 +139,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#0451a5',
             dark: '#3b8eea',
-            hc: '#5c5cff'
+            hcDark: '#5c5cff',
+            hcLight: '#0451a5'
         }
     },
     'terminal.ansiBrightMagenta': {
@@ -135,7 +148,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#bc05bc',
             dark: '#d670d6',
-            hc: '#ff00ff'
+            hcDark: '#ff00ff',
+            hcLight: '#bc05bc'
         }
     },
     'terminal.ansiBrightCyan': {
@@ -143,7 +157,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#0598bc',
             dark: '#29b8db',
-            hc: '#00ffff'
+            hcDark: '#00ffff',
+            hcLight: '#0598bc'
         }
     },
     'terminal.ansiBrightWhite': {
@@ -151,7 +166,8 @@ export const terminalAnsiColorMap: { [key: string]: { index: number, defaults: C
         defaults: {
             light: '#a5a5a5',
             dark: '#e5e5e5',
-            hc: '#ffffff'
+            hcDark: '#ffffff',
+            hcLight: '#a5a5a5'
         }
     }
 };

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -158,14 +158,16 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
                 id: 'extensionEditor.tableHeadBorder', defaults: {
                     dark: Color.transparent('#ffffff', 0.7),
                     light: Color.transparent('#000000', 0.7),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: Color.black
                 }, description: 'Border color for the table head row of the extension editor view'
             },
             {
                 id: 'extensionEditor.tableCellBorder', defaults: {
                     dark: Color.transparent('#ffffff', 0.2),
                     light: Color.transparent('#000000', 0.2),
-                    hc: Color.white
+                    hcDark: Color.white,
+                    hcLight: Color.black
                 }, description: 'Border color for a table row of the extension editor view'
             },
         );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11314.
The pull-request adds support for **high contrast light themes** and includes the following updates:
- adds support for `hcLight` themes
- updates our color registrations to include `hcLight` based on values present in vscode
- updates our `change color theme` command to support `hcLight` and adds localizations

![Screen Shot 2022-08-19 at 9 17 35 AM](https://user-images.githubusercontent.com/40359487/185626980-64086b0c-3ff2-437e-a8bf-467cdac3f7d0.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test theme [theia-hclight-0.0.2.zip](https://github.com/eclipse-theia/theia/files/9992348/theia-hclight-0.0.2.zip)
2. start the application
3. execute the command `Preferences: Color Theme` - the high contrast light themes should be under `high contrast`, selecting `Test High Contrast Light Theme` should work
4. the new `High Contrast Light (Theme)` should also work

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers


- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>