### PR TITLE
Fix Debug hover might not appear (#11500)

### DIFF
--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -250,14 +250,15 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
             return undefined!;
         }
         const position = this.options && this.options.selection.getStartPosition();
-        const word = position && this.editor.getControl().getModel()!.getWordAtPosition(position);
-        return position && word ? {
-            position: new monaco.Position(position.lineNumber, word.startColumn),
-            preference: [
-                monaco.editor.ContentWidgetPositionPreference.ABOVE,
-                monaco.editor.ContentWidgetPositionPreference.BELOW
-            ]
-        } : undefined!;
+        return position
+            ? {
+                position: new monaco.Position(position.lineNumber, position.column),
+                preference: [
+                    monaco.editor.ContentWidgetPositionPreference.ABOVE,
+                    monaco.editor.ContentWidgetPositionPreference.BELOW,
+                ],
+            }
+            : undefined!;
     }
 
     protected override onUpdateRequest(msg: Message): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: #11500.

As per the issue title:
`Debug Hover Widget might not appear for evaluated expressions`

Resolving the position of a selection did not resolve if a
`word` was not found within the specific language model.
This caused specific variables provided by the extension to fail,
e.g. `${name}` on a markdown document.

The required matching on the language model was removed,
this is aligned with the solution in `vscode`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The related issue was found while attempting to use the `vscode-mock-debug` extension, 
a branch that works with `theia` was created for this purpose: 

1) Clone the following plugin under your `theia/plugins` directory
repository: https://github.com/alvsan09/vscode-mock-debug
BRANCH to CHECKOUT:  **theia-evaluatable-expressions**
> git checkout theia-evaluatable-expressions

A .vsix is not provided as the execution requires a debug adapter which does not seem to be packaged

2) Build the extension
> yarn install
> yarn compile 
> yarn vscode:prepublish

3) Start `theia` and create a `markdown` file e.g. `test.md` with the following content:

```
## Variables

Words starting with `$` are treated as variables. Letter casing doesn't matter.

- Integer: $i=123
- String: $s="abc"
- Boolean: $b1=true $b2=false
- Float: $f=3.14
- Object: $o={abc}

## Test
```
4) From the debug view, you can select a dynamic debug configuration type: `mock` provided by the plugin above,
5) Select `Dynamic Launch` configuration and then start it, pressing the green arrow button, the debug session
will stop at the first line.
6) Add a `breakpoint` on the last line and let it continue, so it stops at the new `breakpoint`
7) when at the `breakpoint`, hover over the variable names and verify the values are displayed.

https://user-images.githubusercontent.com/76971376/186022782-3f505669-ba9a-4ee8-ae4e-0c5fab6627f4.mp4

#### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
