### PR TITLE
custom-editors: Fix the issue: Auto Save on Binary Custom Editor does not work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [vsx-registry] improved styling of the `Extensions` view [#11494](https://github.com/eclipse-theia/theia/pull/11494)
 - [vsx-registry] removed localization for `Open VSX Registry` [#11523](https://github.com/eclipse-theia/theia/pull/11523)
 - [vsx-registry] updated extension editor rendering [#11605](https://github.com/eclipse-theia/theia/pull/11605)
+- [custom-editor] Auto Save on Binary Custom Editor does not work correctly [#11460](https://github.com/eclipse-theia/theia/issues/11460)
 
 <a name="breaking_changes_1.29.0">[Breaking Changes:](#breaking_changes_1.29.0)</a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@
 - [vsx-registry] improved styling of the `Extensions` view [#11494](https://github.com/eclipse-theia/theia/pull/11494)
 - [vsx-registry] removed localization for `Open VSX Registry` [#11523](https://github.com/eclipse-theia/theia/pull/11523)
 - [vsx-registry] updated extension editor rendering [#11605](https://github.com/eclipse-theia/theia/pull/11605)
-- [custom-editor] Auto Save on Binary Custom Editor does not work correctly [#11460](https://github.com/eclipse-theia/theia/issues/11460)
 
 <a name="breaking_changes_1.29.0">[Breaking Changes:](#breaking_changes_1.29.0)</a>
 

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
@@ -25,7 +25,7 @@ import { RPCProtocol } from '../../../common/rpc-protocol';
 import { HostedPluginSupport } from '../../../hosted/browser/hosted-plugin';
 import { PluginCustomEditorRegistry } from './plugin-custom-editor-registry';
 import { CustomEditorWidget } from './custom-editor-widget';
-import { Emitter } from '@theia/core';
+import { Emitter, UNTITLED_SCHEME } from '@theia/core';
 import { UriComponents } from '../../../common/uri-components';
 import { URI } from '@theia/core/shared/vscode-uri';
 import TheiaURI from '@theia/core/lib/common/uri';
@@ -505,7 +505,7 @@ export class MainCustomEditorModel implements CustomEditorModel {
             this.onDirtyChangedEmitter.fire();
         }
 
-        if (this.autoSave !== 'off') {
+        if (this.autoSave !== 'off' && this.dirty && this.resource.scheme !== UNTITLED_SCHEME) {
             const handle = window.setTimeout(() => {
                 this.save();
                 window.clearTimeout(handle);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11460.
Fix an issue where auto save on custom editor does not work correctly.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. enable the auto-save
2. Use the vscode cats example and open the binary file example.pawDraw
3. do a change, and make sure that the file was saved
4. make sure that the save is not called recursively, you can see it by adding a breakpoint in the custom-editors-main.ts file using dev-tools, on the method change of the MainCustomEditorModel class.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Safi Seid-Ahmad <safi@k2view.com>