### PR TITLE
core: Fix DescriptionWidget and BadgeWidget APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [core] updated `react` and `react-dom` dependencies to version 18, which introduce new root API for rendering (replaces ReactDOM.render). Since React no longer supports render callbacks, the `onRender` field from `ReactDialog` and `ReactWidget` was removed. [#11455](https://github.com/eclipse-theia/theia/pull/11455) - Contributed on behalf of STMicroelectronics
 - [core] removed `WidgetManager.widgetPromises`; use `WidgetManager.widgets` instead. [#11555](https://github.com/eclipse-theia/theia/pull/11555)
 - [core] Replaced `react-virtualized` with `react-virtuoso` for tree rendering. Removed the `TreeWidget#forceUpdate`, `TreeWidget#handleScroll` and `TreeWidget.View#renderTreeRow` methods in the process. [#11553](https://github.com/eclipse-theia/theia/pull/11553)
+- [core] Replaced `Emitter` fields by `Event` fields in both `DescriptionWidget` and `BadgeWidget`.
 
 ## v1.28.0 - 7/28/2022
 

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -54,12 +54,12 @@ export class ViewContainerIdentifier {
 
 export interface DescriptionWidget {
     description: string;
-    onDidChangeDescription: Emitter<void>;
+    onDidChangeDescription: CommonEvent<void>;
 }
 
 export interface BadgeWidget {
-    badge: number | undefined;
-    onDidChangeBadge: Emitter<void>;
+    badge?: number;
+    onDidChangeBadge: CommonEvent<void>;
 }
 
 export namespace DescriptionWidget {
@@ -956,13 +956,11 @@ export class ViewContainerPart extends BaseWidget {
         this.toDispose.push(Disposable.create(() => this.wrapped.title.changed.disconnect(fireTitleChanged)));
 
         if (DescriptionWidget.is(this.wrapped)) {
-            const fireDescriptionChanged = () => this.onDidChangeDescriptionEmitter.fire(undefined);
-            this.toDispose.push(this.wrapped?.onDidChangeDescription.event(fireDescriptionChanged));
+            this.wrapped?.onDidChangeDescription(() => this.onDidChangeDescriptionEmitter.fire(), undefined, this.toDispose);
         }
 
         if (BadgeWidget.is(this.wrapped)) {
-            const fireBadgeChanged = () => this.onDidChangeBadgeEmitter.fire(undefined);
-            this.toDispose.push(this.wrapped?.onDidChangeBadge.event(fireBadgeChanged));
+            this.wrapped?.onDidChangeBadge(() => this.onDidChangeBadgeEmitter.fire(), undefined, this.toDispose);
         }
 
         const { header, body, disposable } = this.createContent();

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
@@ -20,7 +20,7 @@ import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
 import { nls } from '@theia/core/lib/common/nls';
 import { BadgeWidget } from '@theia/core/lib/browser/view-container';
-import { Emitter } from '@theia/core/lib/common';
+import { Emitter, Event } from '@theia/core/lib/common';
 import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 import * as React from '@theia/core/shared/react';
 
@@ -49,6 +49,9 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
         return child.get(VSXExtensionsWidget);
     }
 
+    protected _badge?: number;
+    protected onDidChangeBadgeEmitter = new Emitter<void>();
+
     @inject(VSXExtensionsWidgetOptions)
     protected readonly options: VSXExtensionsWidgetOptions;
 
@@ -74,17 +77,18 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
         }));
     }
 
-    private _badge: number | undefined = undefined;
+    get onDidChangeBadge(): Event<void> {
+        return this.onDidChangeBadgeEmitter.event;
+    }
+
     get badge(): number | undefined {
         return this._badge;
     }
 
     set badge(count: number | undefined) {
         this._badge = count;
-        this.onDidChangeBadge.fire();
+        this.onDidChangeBadgeEmitter.fire();
     }
-
-    public onDidChangeBadge: Emitter<void> = new Emitter<void>();
 
     protected computeTitle(): string {
         switch (this.options.id) {


### PR DESCRIPTION
The `DescriptionWidget` interface and `BadgeWidget` interface both
exposed their event emitter instance instead of just an event.

Replace `Emitter<T>` fields by `Event<T>` fields.

Cleanup related code.

Closes https://github.com/eclipse-theia/theia/issues/11598

#### How to test

Play with the OpenVSX Registry view: The count badges should work as before.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
