### PR TITLE
Show `window.menuBarVisibility` on OSX (browser)

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { interfaces } from 'inversify';
+import { environment } from '@theia/application-package/lib/environment';
 import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from './preferences';
 import { SUPPORTED_ENCODINGS } from './supported-encodings';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
@@ -73,7 +74,7 @@ export const corePreferenceSchema: PreferenceSchema = {
             scope: 'application',
             // eslint-disable-next-line max-len
             markdownDescription: nls.localizeByDefault("Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen."),
-            included: !isOSX
+            included: !(isOSX && environment.electron.is())
         },
         'http.proxy': {
             type: 'string',


### PR DESCRIPTION
#### What it does

Fixes a regression from https://github.com/eclipse-theia/theia/pull/11588 where the `window.menuBarVisibility` preference was removed on OSX (browser)

#### How to test

1. Open Theia in browser mode on Mac
2. Assert that the menu bar is visible

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
