### PR TITLE
[workspace] Exported `RecentWorkspacePathsData` type, fixed typo in field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [core] removed `WidgetManager.widgetPromises`; use `WidgetManager.widgets` instead. [#11555](https://github.com/eclipse-theia/theia/pull/11555)
 - [core] Replaced `react-virtualized` with `react-virtuoso` for tree rendering. Removed the `TreeWidget#forceUpdate`, `TreeWidget#handleScroll` and `TreeWidget.View#renderTreeRow` methods in the process. [#11553](https://github.com/eclipse-theia/theia/pull/11553)
 - [core] Replaced `Emitter` fields by `Event` fields in both `DescriptionWidget` and `BadgeWidget`.
+- [workspace] Removed `DefaultWorkspaceServer#untitledWorkspaceStaleThreshhold`. Use `DefaultWorkspaceServer#untitledWorkspaceStaleThreshold` instead.
 
 ## v1.28.0 - 7/28/2022
 

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -89,7 +89,7 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
      * Untitled workspaces that are not among the most recent N workspaces will be deleted on start. Increase this number to keep older files,
      * lower it to delete stale untitled workspaces more aggressively.
      */
-    protected untitledWorkspaceStaleThreshhold = 10;
+    protected untitledWorkspaceStaleThreshold = 10;
 
     @inject(WorkspaceCliContribution)
     protected readonly cliParams: WorkspaceCliContribution;
@@ -209,11 +209,11 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
 
     /**
      * Removes untitled workspaces that are not among the most recently used workspaces.
-     * Use the `untitledWorkspaceStaleThreshhold` to configure when to delete workspaces.
+     * Use the `untitledWorkspaceStaleThreshold` to configure when to delete workspaces.
      */
     protected async removeOldUntitledWorkspaces(): Promise<void> {
         const recents = (await this.getRecentWorkspaces()).map(FileUri.fsPath);
-        const olderUntitledWorkspaces = recents.slice(this.untitledWorkspaceStaleThreshhold).filter(workspace => this.utils.isUntitledWorkspace(FileUri.create(workspace)));
+        const olderUntitledWorkspaces = recents.slice(this.untitledWorkspaceStaleThreshold).filter(workspace => this.utils.isUntitledWorkspace(FileUri.create(workspace)));
         await Promise.all(olderUntitledWorkspaces.map(workspace => fs.promises.unlink(FileUri.fsPath(workspace)).catch(() => { })));
         if (olderUntitledWorkspaces.length > 0) {
             await this.writeToUserHome({ recentRoots: await this.getRecentWorkspaces() });

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -221,11 +221,11 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
     }
 }
 
-interface RecentWorkspacePathsData {
+export interface RecentWorkspacePathsData {
     recentRoots: string[];
 }
 
-namespace RecentWorkspacePathsData {
+export namespace RecentWorkspacePathsData {
     /**
      * Parses `data` as `RecentWorkspacePathsData` but removes any non-string array entry.
      *


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 - Exports the `RecentWorkspacePathsData` type so that extenders can subclass the `protected` methods of the `DefaultWorkspaceServer` class with proper typing.
 - Fixes the typo in the field name.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

No behavioral changes are expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
