### PR TITLE
Remove manual height manipulation in Extension Editor

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -153,15 +153,12 @@
     padding: calc(var(--theia-ui-padding) * 3) calc(var(--theia-ui-padding) * 3) calc(var(--theia-ui-padding) * 3);
     flex-shrink: 0;
     border-bottom: 1px solid hsla(0, 0% ,50% ,.5);
-    position: sticky;
-    top: 0;
     width: 100%;
     background: var(--theia-editor-background);
 }
 
 .theia-vsx-extension-editor .scroll-container {
-    position: absolute;
-    bottom: 0;
+    position: relative;
     padding-top: 0;
     max-width: 100%;
     width: 100%;

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -497,11 +497,10 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
             averageRating, downloadCount, repository, license, readme
         } = this.props.extension;
 
-        const { baseStyle, scrollStyle } = this.getSubcomponentStyles();
         const sanitizedReadme = !!readme ? DOMPurify.sanitize(readme) : undefined;
 
         return <React.Fragment>
-            <div className='header' style={baseStyle} ref={ref => this.header = (ref || undefined)}>
+            <div className='header' ref={ref => this.header = (ref || undefined)}>
                 {iconUrl ?
                     <img className='icon-container' src={iconUrl} /> :
                     <div className='icon-container placeholder' />}
@@ -534,12 +533,10 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
             {
                 sanitizedReadme &&
                 <div className='scroll-container'
-                    style={scrollStyle}
                     ref={ref => this._scrollContainer = (ref || undefined)}>
                     <div className='body'
                         ref={ref => this.body = (ref || undefined)}
                         onClick={this.openLink}
-                        style={baseStyle}
                         // eslint-disable-next-line react/no-danger
                         dangerouslySetInnerHTML={{ __html: sanitizedReadme }}
                     />
@@ -576,14 +573,6 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
         return <React.Fragment>
             {renderStarAt(1)}{renderStarAt(2)}{renderStarAt(3)}{renderStarAt(4)}{renderStarAt(5)}
         </React.Fragment>;
-    }
-
-    protected getSubcomponentStyles(): { baseStyle: React.CSSProperties, scrollStyle: React.CSSProperties; } {
-        const visibility: 'unset' | 'hidden' = this.header ? 'unset' : 'hidden';
-        const baseStyle = { visibility };
-        const scrollStyle = this.header?.clientHeight ? { visibility, height: `calc(100% - (${this.header.clientHeight}px + 1px))` } : baseStyle;
-
-        return { baseStyle, scrollStyle };
     }
 
     // TODO replace with webview


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11604 by removing code that expected at least two render cycles to be triggered before showing content.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the Extensions View and search for something.
1. Click on several of the search results and observe that each of the ExtensionEditor views that opens displays its content - none are blank.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
