### PR TITLE
[debug] Wait for debugger capabilities initialization before breakpoint update

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -40,7 +40,7 @@ import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/brows
 import { DebugFunctionBreakpoint } from './model/debug-function-breakpoint';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { DebugContribution } from './debug-contribution';
-import { waitForEvent } from '@theia/core/lib/common/promise-util';
+import { Deferred, waitForEvent } from '@theia/core/lib/common/promise-util';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { DebugInstructionBreakpoint } from './model/debug-instruction-breakpoint';
 
@@ -53,8 +53,7 @@ export enum DebugState {
 
 // FIXME: make injectable to allow easily inject services
 export class DebugSession implements CompositeTreeElement {
-    private onCapabilitiesConfiguredEmitter = new Emitter<void>();
-    private readonly onCapabilitiesConfigured = this.onCapabilitiesConfiguredEmitter.event;
+    protected readonly deferredOnDidConfigureCapabilities = new Deferred<void>();
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
@@ -510,18 +509,7 @@ export class DebugSession implements CompositeTreeElement {
 
     protected updateCapabilities(capabilities: DebugProtocol.Capabilities): void {
         Object.assign(this._capabilities, capabilities);
-        this.onCapabilitiesConfiguredEmitter.fire(undefined);
-    }
-
-    private waitUntilCapabilitiesConfigured(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            if (Object.keys(this._capabilities).length !== 0) {
-                resolve();
-            }
-
-            this.onCapabilitiesConfigured(resolve);
-            setTimeout(reject, 300);
-        });
+        this.deferredOnDidConfigureCapabilities.resolve();
     }
 
     protected readonly _breakpoints = new Map<string, DebugBreakpoint[]>();
@@ -649,7 +637,7 @@ export class DebugSession implements CompositeTreeElement {
             return;
         }
         const { uri, sourceModified } = options;
-        await this.waitUntilCapabilitiesConfigured();
+        await this.deferredOnDidConfigureCapabilities.promise;
         for (const affectedUri of this.getAffectedUris(uri)) {
             if (affectedUri.toString() === BreakpointManager.EXCEPTION_URI.toString()) {
                 await this.sendExceptionBreakpoints();


### PR DESCRIPTION
#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/11606
Fix an issue where debugger doesn't send breakpoints on first run.

#### How to test
1. Open any project in Theia.
2. Switch to the debugger tab.
3. Add function breakpoint by clicking on "Add Function Breakpoint" button.
4. Run debugger.
5. Make sure that debugger wait for capability initialization and catches breakpoints correctly.

#### Review checklist
- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers
- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)