### PR TITLE
plugin-ext: remove conflicting shortcut ctrlcmd+shift+l

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [core] Added constructor injection to `ApplicationShell`: `SecondaryWindowHandler`. [#11048](https://github.com/eclipse-theia/theia/pull/11048) - Contributed on behalf of ST Microelectronics and Ericsson and by ARM and EclipseSource
 - [core] Changed type of `FrontendApplicationConfig#defaultTheme` from `string` to `DefaultTheme`. From now on, the default theme can be dispatched based on the OS theme. Use `DefaultTheme#defaultForOSTheme` to derive the `string` theme ID.
+- [plugin-ext] removed `ctrlcmd+shift+l` keybinding for `pluginsView:toggle` [#11608](https://github.com/eclipse-theia/theia/pull/11608)
 
 ## v1.29.0 - 8/25/2022
 

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-view-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-view-contribution.ts
@@ -31,8 +31,7 @@ export class PluginFrontendViewContribution extends AbstractViewContribution<Plu
                 area: 'left',
                 rank: 400
             },
-            toggleCommandId: 'pluginsView:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+l'
+            toggleCommandId: 'pluginsView:toggle'
         });
     }
 


### PR DESCRIPTION
"Toggle plugin view" from theia's plugin-ext conflicts with "Select All
Occurrences of Find Match" from monaco.

"Toggle plugin view" is not a common action, so it does not need a
keybinding by default

Signed-off-by: Jérome Perrin <jerome@nexedi.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11403

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a file containing:
```
foo
bar
foo
```
2. place the cursor on the first occurrence of `foo`
3. press <kbd>CtrlCmd</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd> to select all matches
4. all occurrences should be selected:

![image](https://user-images.githubusercontent.com/521510/186634042-ebc25aae-d076-49cc-8a6a-5027ad12685f.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
