### PR TITLE
process: fix `env` when building commands

### DIFF
--- a/packages/process/src/common/shell-command-builder.ts
+++ b/packages/process/src/common/shell-command-builder.ts
@@ -19,8 +19,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* eslint-disable no-null/no-null */
+
 import { injectable } from '@theia/core/shared/inversify';
-import { createShellCommandLine, BashQuotingFunctions, PowershellQuotingFunctions, CmdQuotingFunctions, ShellQuoting, ShellQuotedString } from '../common/shell-quoting';
+import {
+    createShellCommandLine, BashQuotingFunctions, PowershellQuotingFunctions, CmdQuotingFunctions, ShellQuoting, ShellQuotedString, escapeForShell, ShellQuotingFunctions
+} from '../common/shell-quoting';
 
 export interface ProcessInfo {
     executable: string
@@ -88,7 +92,6 @@ export class ShellCommandBuilder {
         if (env?.length) {
             command += 'env';
             for (const [key, value] of env) {
-                // eslint-disable-next-line no-null/no-null
                 if (value === null) {
                     command += ` -u ${BashQuotingFunctions.strong(key)}`;
                 } else {
@@ -97,7 +100,7 @@ export class ShellCommandBuilder {
             }
             command += ' ';
         }
-        command += createShellCommandLine(args, BashQuotingFunctions);
+        command += this.createShellCommandLine(args, BashQuotingFunctions);
         return command;
     }
 
@@ -113,7 +116,6 @@ export class ShellCommandBuilder {
                 const quotedKey = key
                     .replace(/`/g, '````')
                     .replace(/\?/g, '``?');
-                // eslint-disable-next-line no-null/no-null
                 if (value === null) {
                     command += `Remove-Item \${env:${quotedKey}}; `;
                 } else {
@@ -121,7 +123,7 @@ export class ShellCommandBuilder {
                 }
             }
         }
-        command += '& ' + createShellCommandLine(args, PowershellQuotingFunctions);
+        command += '& ' + this.createShellCommandLine(args, PowershellQuotingFunctions);
         return command;
     }
 
@@ -130,10 +132,10 @@ export class ShellCommandBuilder {
         if (cwd) {
             command += `cd ${CmdQuotingFunctions.strong(cwd)} && `;
         }
+        // Current quoting mechanism only works within a nested `cmd` call:
+        command += 'cmd /C "';
         if (env?.length) {
-            command += 'cmd /C "';
             for (const [key, value] of env) {
-                // eslint-disable-next-line no-null/no-null
                 if (value === null) {
                     command += `set ${CmdQuotingFunctions.strong(key)}="" && `;
                 } else {
@@ -141,10 +143,8 @@ export class ShellCommandBuilder {
                 }
             }
         }
-        command += createShellCommandLine(args, CmdQuotingFunctions);
-        if (env?.length) {
-            command += '"';
-        }
+        command += this.createShellCommandLine(args, CmdQuotingFunctions);
+        command += '"';
         return command;
     }
 
@@ -152,4 +152,36 @@ export class ShellCommandBuilder {
         return this.buildForBash(args, cwd, env);
     }
 
+    /**
+     * This method will try to leave `arg[0]` unescaped if possible. The reason
+     * is that shells like `cmd` expect their own commands like `dir` to be
+     * unescaped.
+     *
+     * @returns empty string if `args` is empty, otherwise an escaped command.
+     */
+    protected createShellCommandLine(args: (string | ShellQuotedString)[], quotingFunctions: ShellQuotingFunctions): string {
+        let command = '';
+        if (args.length > 0) {
+            const [exec, ...execArgs] = args;
+            // Some commands like `dir` should not be quoted for `cmd` to understand:
+            command += this.quoteExecutableIfNecessary(exec, quotingFunctions);
+            if (execArgs.length > 0) {
+                command += ' ' + createShellCommandLine(execArgs, quotingFunctions);
+            }
+        }
+        return command;
+    }
+
+    protected quoteExecutableIfNecessary(exec: string | ShellQuotedString, quotingFunctions: ShellQuotingFunctions): string {
+        return typeof exec === 'string' && !this.needsQuoting(exec) ? exec : escapeForShell(exec, quotingFunctions);
+    }
+
+    /**
+     * If this method returns `false` then we definitely need quoting.
+     *
+     * May return false positives.
+     */
+    protected needsQuoting(arg: string): boolean {
+        return /\W/.test(arg);
+    }
 }

--- a/packages/process/src/common/shell-command-builder.ts
+++ b/packages/process/src/common/shell-command-builder.ts
@@ -85,7 +85,7 @@ export class ShellCommandBuilder {
         if (cwd) {
             command += `cd ${BashQuotingFunctions.strong(cwd)} && `;
         }
-        if (env) {
+        if (env?.length) {
             command += 'env';
             for (const [key, value] of env) {
                 // eslint-disable-next-line no-null/no-null
@@ -106,7 +106,7 @@ export class ShellCommandBuilder {
         if (cwd) {
             command += `cd ${PowershellQuotingFunctions.strong(cwd)}; `;
         }
-        if (env) {
+        if (env?.length) {
             for (const [key, value] of env) {
                 // Powershell requires special quoting when dealing with
                 // environment variable names.
@@ -130,7 +130,7 @@ export class ShellCommandBuilder {
         if (cwd) {
             command += `cd ${CmdQuotingFunctions.strong(cwd)} && `;
         }
-        if (env) {
+        if (env?.length) {
             command += 'cmd /C "';
             for (const [key, value] of env) {
                 // eslint-disable-next-line no-null/no-null
@@ -142,7 +142,7 @@ export class ShellCommandBuilder {
             }
         }
         command += createShellCommandLine(args, CmdQuotingFunctions);
-        if (env) {
+        if (env?.length) {
             command += '"';
         }
         return command;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request fixes `env` handling when building commands. The issue is that `[]` is truthy to TypeScript and means that `if (env)` will always pass causing commands with unnecessary options.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the test commit 51025b75635450dd5c9430918dde4921901a5fe2
2. open a terminal
3. execute the command `Terminal: Execute`

_master_:

```bash
cd './' && env 'dir'
```

_pull-request_:

```bash
cd './' && 'dir'
```

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>