### PR TITLE
Organize `edt` quickpick entries by areas and groups

### DIFF
--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -69,7 +69,7 @@ export interface LabelProviderContribution {
     getLongName?(element: object): string | undefined;
 
     /**
-     * A compromise between getName and getLongName. Can be used to supplement getName in contexts that allow both a primary display field and extra detail.
+     * A compromise between {@link getName} and {@link getLongName}. Can be used to supplement getName in contexts that allow both a primary display field and extra detail.
      */
     getDetails?(element: object): string | undefined;
 
@@ -360,7 +360,7 @@ export class LabelProvider implements FrontendApplicationContribution {
     /**
      * Get details from the list of available {@link LabelProviderContribution} for the given element.
      * @return the details
-     * Can be used to supplement getName in contexts that allow both a primary display field and extra detail.
+     * Can be used to supplement {@link getName} in contexts that allow both a primary display field and extra detail.
      */
     getDetails(element: object): string {
         return this.handleRequest(element, 'getDetails') ?? '';

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -69,6 +69,11 @@ export interface LabelProviderContribution {
     getLongName?(element: object): string | undefined;
 
     /**
+     * A compromise between getName and getLongName. Can be used to supplement getName in contexts that allow both a primary display field and extra detail.
+     */
+    getDetails?(element: object): string | undefined;
+
+    /**
      * Emit when something has changed that may result in this label provider returning a different
      * value for one or more properties (name, icon etc).
      */
@@ -166,6 +171,14 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
             }
         }
         return uri && uri.path.fsPath();
+    }
+
+    getDetails(element: URI | URIIconReference): string | undefined {
+        const uri = this.getUri(element);
+        if (uri) {
+            return this.getLongName(uri.parent);
+        }
+        return this.getLongName(element);
     }
 
     protected getUri(element: URI | URIIconReference): URI | undefined {
@@ -325,15 +338,7 @@ export class LabelProvider implements FrontendApplicationContribution {
      * @return the icon class
      */
     getIcon(element: object): string {
-        const contributions = this.findContribution(element);
-        for (const contribution of contributions) {
-            const value = contribution.getIcon && contribution.getIcon(element);
-            if (value === undefined) {
-                continue;
-            }
-            return value;
-        }
-        return '';
+        return this.handleRequest(element, 'getIcon') ?? '';
     }
 
     /**
@@ -341,15 +346,7 @@ export class LabelProvider implements FrontendApplicationContribution {
      * @return the short name
      */
     getName(element: object): string {
-        const contributions = this.findContribution(element);
-        for (const contribution of contributions) {
-            const value = contribution.getName && contribution.getName(element);
-            if (value === undefined) {
-                continue;
-            }
-            return value;
-        }
-        return '<unknown>';
+        return this.handleRequest(element, 'getName') ?? '<unknown>';
     }
 
     /**
@@ -357,21 +354,33 @@ export class LabelProvider implements FrontendApplicationContribution {
      * @return the long name
      */
     getLongName(element: object): string {
-        const contributions = this.findContribution(element);
-        for (const contribution of contributions) {
-            const value = contribution.getLongName && contribution.getLongName(element);
-            if (value === undefined) {
-                continue;
-            }
-            return value;
-        }
-        return '';
+        return this.handleRequest(element, 'getLongName') ?? '';
     }
 
-    protected findContribution(element: object): LabelProviderContribution[] {
-        const prioritized = Prioritizeable.prioritizeAllSync(this.contributionProvider.getContributions(), contrib =>
+    /**
+     * Get details from the list of available {@link LabelProviderContribution} for the given element.
+     * @return the details
+     * Can be used to supplement getName in contexts that allow both a primary display field and extra detail.
+     */
+    getDetails(element: object): string {
+        return this.handleRequest(element, 'getDetails') ?? '';
+    }
+
+    protected handleRequest(element: object, method: keyof Omit<LabelProviderContribution, 'canHandle' | 'onDidChange' | 'affects'>): string | undefined {
+        for (const contribution of this.findContribution(element, method)) {
+            const value = contribution[method]?.(element);
+            if (value !== undefined) {
+                return value;
+            }
+        }
+    }
+
+    protected findContribution(element: object, method?: keyof Omit<LabelProviderContribution, 'canHandle' | 'onDidChange' | 'affects'>): LabelProviderContribution[] {
+        const candidates = method
+            ? this.contributionProvider.getContributions().filter(candidate => candidate[method])
+            : this.contributionProvider.getContributions();
+        return Prioritizeable.prioritizeAllSync(candidates, contrib =>
             contrib.canHandle(element)
-        );
-        return prioritized.map(c => c.value);
+        ).map(entry => entry.value);
     }
 }

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1963,6 +1963,7 @@ export namespace ApplicationShell {
         left: nls.localize('theia/shell-area/left', 'Left'),
         right: nls.localize('theia/shell-area/right', 'Right'),
         bottom: nls.localize('theia/shell-area/bottom', 'Bottom'),
+        secondaryWindow: nls.localize('theia/shell-area/secondary', 'Secondary Window'),
     };
 
     /**

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1957,6 +1957,14 @@ export namespace ApplicationShell {
      */
     export type Area = 'main' | 'top' | 'left' | 'right' | 'bottom' | 'secondaryWindow';
 
+    export const areaLabels: Record<Area, string> = {
+        main: nls.localizeByDefault('Main'),
+        top: nls.localize('theia/shell-area/top', 'Top'),
+        left: nls.localize('theia/shell-area/left', 'Left'),
+        right: nls.localize('theia/shell-area/right', 'Right'),
+        bottom: nls.localize('theia/shell-area/bottom', 'Bottom'),
+    };
+
     /**
      * The _side areas_ are those shell areas that can be collapsed and expanded,
      * i.e. `left`, `right`, and `bottom`.

--- a/packages/editor/src/browser/quick-editor-service.ts
+++ b/packages/editor/src/browser/quick-editor-service.ts
@@ -84,7 +84,7 @@ export class QuickEditorService implements QuickAccessContribution, QuickAccessP
 
         return {
             label: this.labelProvider.getName(uri),
-            description: this.labelProvider.getLongName(uri.parent),
+            description: this.labelProvider.getDetails(uri),
             iconClasses,
             ariaLabel: uri.path.fsPath(),
             alwaysShow: true,

--- a/packages/editor/src/browser/quick-editor-service.ts
+++ b/packages/editor/src/browser/quick-editor-service.ts
@@ -15,30 +15,21 @@
 // *****************************************************************************
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { CancellationToken } from '@theia/core/lib/common';
-import URI from '@theia/core/lib/common/uri';
+import { CancellationToken, nls, QuickPickItemOrSeparator } from '@theia/core/lib/common';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
-import { OpenerService } from '@theia/core/lib/browser/opener-service';
 import { QuickAccessProvider, QuickAccessRegistry, QuickAccessContribution } from '@theia/core/lib/browser/quick-input/quick-access';
 import { filterItems, QuickPickItem, QuickPickSeparator } from '@theia/core/lib/browser/quick-input/quick-input-service';
-import { EditorManager } from './editor-manager';
-import { EditorWidget } from './editor-widget';
+import { ApplicationShell, NavigatableWidget, Widget } from '@theia/core/lib/browser';
 
 @injectable()
 export class QuickEditorService implements QuickAccessContribution, QuickAccessProvider {
     static PREFIX = 'edt ';
 
-    @inject(OpenerService)
-    protected readonly openerService: OpenerService;
+    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+    @inject(QuickAccessRegistry) protected readonly quickAccessRegistry: QuickAccessRegistry;
+    @inject(ApplicationShell) protected readonly shell: ApplicationShell;
 
-    @inject(LabelProvider)
-    protected readonly labelProvider: LabelProvider;
-
-    @inject(QuickAccessRegistry)
-    protected readonly quickAccessRegistry: QuickAccessRegistry;
-
-    @inject(EditorManager)
-    protected readonly editorManager: EditorManager;
+    protected groupLocalizations: string[] = [];
 
     registerQuickAccessProvider(): void {
         this.quickAccessRegistry.registerQuickAccessProvider({
@@ -50,44 +41,49 @@ export class QuickEditorService implements QuickAccessContribution, QuickAccessP
     }
 
     getPicks(filter: string, token: CancellationToken): (QuickPickItem | QuickPickSeparator)[] {
-        const editorItems: QuickPickItem[] = [];
-
-        // Get the alphabetically sorted list of URIs of all currently opened editor widgets.
-        const widgets: URI[] = this.editorManager.all
-            .map((w: EditorWidget) => w.editor.uri)
-            .sort();
-
-        if (widgets.length === 0) {
-            editorItems.push(({
-                label: 'List of opened editors is currently empty'
-            }));
-        } else {
-            for (const uri of widgets) {
-                const item = this.toItem(uri);
-                editorItems.push(item);
+        const editorItems: QuickPickItemOrSeparator[] = [];
+        const hasUri = (widget: Widget): widget is NavigatableWidget => Boolean(NavigatableWidget.getUri(widget));
+        const handleWidgets = (widgets: NavigatableWidget[], label: string) => {
+            if (widgets.length) {
+                editorItems.push({ type: 'separator', label });
             }
+            editorItems.push(...widgets.map(widget => this.toItem(widget)));
+        };
+
+        this.shell.mainAreaTabBars.forEach((tabbar, index) => {
+            const editorsOnTabbar = tabbar.titles.reduce<NavigatableWidget[]>((widgets, title) => {
+                if (hasUri(title.owner)) {
+                    widgets.push(title.owner);
+                }
+                return widgets;
+            }, []);
+            handleWidgets(editorsOnTabbar, this.getGroupLocalization(index));
+        });
+
+        for (const area of ['left', 'bottom', 'right'] as ApplicationShell.Area[]) {
+            const editorsInArea = this.shell.getWidgets(area).filter(hasUri);
+            handleWidgets(editorsInArea, ApplicationShell.areaLabels[area]);
         }
 
         return filterItems(editorItems.slice(), filter);
     }
 
-    protected toItem(uri: URI): QuickPickItem {
-        const description = this.labelProvider.getLongName(uri.parent);
+    protected getGroupLocalization(index: number): string {
+        return this.groupLocalizations[index] || nls.localizeByDefault('Group {0}', index + 1);
+    }
+
+    protected toItem(widget: NavigatableWidget): QuickPickItem {
+        const uri = NavigatableWidget.getUri(widget)!;
         const icon = this.labelProvider.getIcon(uri);
         const iconClasses = icon === '' ? undefined : [icon + ' file-icon'];
 
         return {
             label: this.labelProvider.getName(uri),
-            description: description,
+            description: this.labelProvider.getLongName(uri.parent),
             iconClasses,
             ariaLabel: uri.path.fsPath(),
             alwaysShow: true,
-            execute: () => this.openFile(uri)
+            execute: () => this.shell.activateWidget(widget.id),
         };
-    }
-
-    protected openFile(uri: URI): void {
-        this.openerService.getOpener(uri)
-            .then(opener => opener.open(uri));
     }
 }

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -310,21 +310,7 @@ export class QuickFileOpenService implements QuickAccessProvider {
     }
 
     private getItemDescription(uri: URI): string {
-        const resourcePathLabel = this.labelProvider.getLongName(uri.parent);
-        const rootUri = this.workspaceService.getWorkspaceRootUri(uri);
-
-        // Display the path normally if outside any workspace root.
-        if (!rootUri) {
-            return resourcePathLabel;
-        }
-
-        // Compute the multi-root label for the resource.
-        if (this.workspaceService.isMultiRootWorkspaceOpened) {
-            const rootLabel = this.labelProvider.getName(rootUri);
-            return rootUri.path.toString() === uri.parent.path.toString() ? `${rootLabel}` : `${rootLabel} • ${resourcePathLabel}`;
-        } else {
-            return rootUri.toString() === uri.parent.toString() ? '' : resourcePathLabel;
-        }
+        return this.labelProvider.getDetails(uri);
     }
 
     private getPlaceHolder(): string {

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-tree-model.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-tree-model.ts
@@ -192,7 +192,7 @@ export class OpenEditorsModel extends FileTreeModel {
             const areaNode: CompositeTreeNode & ExpandableTreeNode = {
                 id: `${OpenEditorsModel.AREA_NODE_ID_PREFIX}:${area}`,
                 parent: rootNode,
-                name: area === 'secondaryWindow' ? 'in secondary window' : area,
+                name: ApplicationShell.areaLabels[area],
                 expanded: true,
                 children: []
             };

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -136,23 +136,9 @@ export class OpenEditorsWidget extends FileTreeWidget {
 
     protected getWorkspaceDecoration(node: OpenEditorNode): TreeDecoration.CaptionAffix[] {
         const color = this.getDecorationData(node, 'fontData').find(data => data.color)?.color;
-        const workspaceRoots = this.workspaceService.tryGetRoots();
-        const parentWorkspace = this.workspaceService.getWorkspaceRootUri(node.fileStat.resource);
-        let workspacePrefixString = '';
-        let separator = '';
-        let filePathString = '';
-        const nodeURIDir = node.fileStat.resource.parent;
-        if (parentWorkspace) {
-            const relativeDirFromWorkspace = parentWorkspace.relative(nodeURIDir);
-            workspacePrefixString = workspaceRoots.length > 1 ? this.labelProvider.getName(parentWorkspace) : '';
-            filePathString = relativeDirFromWorkspace?.fsPath() ?? '';
-            separator = filePathString && workspacePrefixString ? ' \u2022 ' : ''; // add a bullet point between workspace and path
-        } else {
-            workspacePrefixString = nodeURIDir.path.fsPath();
-        }
         return [{
             fontData: { color },
-            data: `${workspacePrefixString}${separator}${filePathString}`,
+            data: this.labelProvider.getDetails(node.fileStat),
         }];
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Improves the open editors (`edt `) quickpick by organizing the entries by area and tabbar rather than alphabetically by URI.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the application and open a number of editors.
2. Scatter the editors around the UI: different areas, different tabbars in main and bottom areas.
3. Open the `edt` quick pick (`ctrl+k ctrl+p`)
4. Observe that the editors are grouped by area and tabbar rather than alphabetically.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
