### PR TITLE
[custom-editor] fix restore layout issue when using the vscode registerWebviewPanelSerializer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.30.0
+
+- [custom-editor] fix the restore editor as part of layout when using the vscode registerWebviewPanelSerializer API [#10787](https://github.com/eclipse-theia/theia/issues/10787)
+
+
 ## v1.29.0 - 8/25/2022
 
 - [application-manager] added the `applicationName` in the frontend generator [#11575](https://github.com/eclipse-theia/theia/pull/11575)

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
@@ -45,7 +45,7 @@ export class CustomEditorWidget extends WebviewWidget implements SaveableSource,
         );
     }
     get saveable(): Saveable {
-        return this._modelRef.object;
+        return this._modelRef?.object;
     }
 
     @inject(UndoRedoService)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fix this issue: https://github.com/eclipse-theia/theia/issues/10787


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. use the attached updated vscode custom editor cats sample
2. open the example.cscratch file - will open the cutom editor
3. reload the page (F5)
4. the custom editor should be restored

[cat-customs-0.0.2.vsix.zip](https://github.com/eclipse-theia/theia/files/9454709/cat-customs-0.0.2.vsix.zip)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
