### PR TITLE
Tab bar - Add suffix to hidden tab bar 'li' elements

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -143,9 +143,9 @@ export class TabBarRenderer extends TabBar.Renderer {
      * @param {boolean} isInSidePanel An optional check which determines if the tab is in the side-panel.
      * @returns {VirtualElement} The virtual element of the rendered tab.
      */
-    override renderTab(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
+    override renderTab(data: SideBarRenderData, isInSidePanel?: boolean, isPartOfHiddenTabBar?: boolean): VirtualElement {
         const title = data.title;
-        const id = this.createTabId(data.title);
+        const id = this.createTabId(data.title, isPartOfHiddenTabBar);
         const key = this.createTabKey(data);
         const style = this.createTabStyle(data);
         const className = this.createTabClass(data);
@@ -177,8 +177,11 @@ export class TabBarRenderer extends TabBar.Renderer {
         );
     }
 
-    createTabId(title: Title<Widget>): string {
-        return 'shell-tab-' + title.owner.id;
+    /**
+     * If tab is part of hidden horz tab bar, add a suffix to keep the id unique across the DOM
+     */
+    createTabId(title: Title<Widget>, isPartOfHiddenTabBar = false): string {
+        return 'shell-tab-' + title.owner.id + (isPartOfHiddenTabBar ? '-hidden' : '');
     }
 
     /**
@@ -904,7 +907,9 @@ export class SideTabBar extends ScrollableTabBar {
             } else {
                 rd = { title, current, zIndex };
             }
-            content[i] = renderer.renderTab(rd, true);
+            // Based on how renderTabs() is called, assuming renderData will be undefined when
+            // invoked for this.hiddenContentNode
+            content[i] = renderer.renderTab(rd, true, renderData === undefined);
         }
         VirtualDOM.render(content, host);
     }

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -141,7 +141,7 @@ export class TabBarRenderer extends TabBar.Renderer {
      * Render tabs with the default DOM structure, but additionally register a context menu listener.
      * @param {SideBarRenderData} data Data used to render the tab.
      * @param {boolean} isInSidePanel An optional check which determines if the tab is in the side-panel.
-     * @param {boolean} isPartOfHiddenTabBar Optional - Tells us if this entry is part of the hidden horizontal tab bar.
+     * @param {boolean} isPartOfHiddenTabBar An optional check which determines if the tab is in the hidden horizontal tab bar.
      * @returns {VirtualElement} The virtual element of the rendered tab.
      */
     override renderTab(data: SideBarRenderData, isInSidePanel?: boolean, isPartOfHiddenTabBar?: boolean): VirtualElement {
@@ -912,8 +912,7 @@ export class SideTabBar extends ScrollableTabBar {
             } else {
                 rd = { title, current, zIndex };
             }
-            // Based on how renderTabs() is called, assume renderData will be undefined when
-            // invoked for this.hiddenContentNode
+            // Based on how renderTabs() is called, assume renderData will be undefined when invoked for this.hiddenContentNode
             content[i] = renderer.renderTab(rd, true, renderData === undefined);
         }
         VirtualDOM.render(content, host);

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -141,6 +141,7 @@ export class TabBarRenderer extends TabBar.Renderer {
      * Render tabs with the default DOM structure, but additionally register a context menu listener.
      * @param {SideBarRenderData} data Data used to render the tab.
      * @param {boolean} isInSidePanel An optional check which determines if the tab is in the side-panel.
+     * @param {boolean} isPartOfHiddenTabBar Optional - Tells us if this entry is part of the hidden horizontal tab bar.
      * @returns {VirtualElement} The virtual element of the rendered tab.
      */
     override renderTab(data: SideBarRenderData, isInSidePanel?: boolean, isPartOfHiddenTabBar?: boolean): VirtualElement {
@@ -178,7 +179,11 @@ export class TabBarRenderer extends TabBar.Renderer {
     }
 
     /**
-     * If tab is part of hidden horz tab bar, add a suffix to keep the id unique across the DOM
+     * Generate ID for an entry in the tab bar
+     * @param {Title<Widget>} title Title of the widget controlled by this tab bar
+     * @param {boolean} isPartOfHiddenTabBar Tells us if this entry is part of the hidden horizontal tab bar.
+     *      If yes, add a suffix to differentiate it's ID from the entry in the visible tab bar
+     * @returns {string} DOM element ID
      */
     createTabId(title: Title<Widget>, isPartOfHiddenTabBar = false): string {
         return 'shell-tab-' + title.owner.id + (isPartOfHiddenTabBar ? '-hidden' : '');
@@ -907,7 +912,7 @@ export class SideTabBar extends ScrollableTabBar {
             } else {
                 rd = { title, current, zIndex };
             }
-            // Based on how renderTabs() is called, assuming renderData will be undefined when
+            // Based on how renderTabs() is called, assume renderData will be undefined when
             // invoked for this.hiddenContentNode
             content[i] = renderer.renderTab(rd, true, renderData === undefined);
         }


### PR DESCRIPTION
Signed-off-by: Akhilesh Raju <rajuakhilesh@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### Issue
Non unique ID values for `<li>` elements in the hidden and visible tab bar's on the left and right side.
Without this, when I try writing a playwright page model to click the tab bar button using the Playwright `Locator`, I get a "strict mode" error from Playwright which signifies that it got more than one element for given ID.
AFAIK, element ID's must be unique across the DOM.

https://community.theia-ide.org/t/dom-element-id-field-not-unique-for-tab-bar-entries/2563

#### What it does
Code changes to add a suffix `-hidden` to the `<li>` elements to ensure there is no ID clash.


**Before the fix**

<img src="https://user-images.githubusercontent.com/17533956/187587852-bcfea85f-d0d3-459e-80ee-5b833a948fa0.jpeg" width="500">

**After the fix**

<img src="https://user-images.githubusercontent.com/17533956/187587933-89710861-8546-4660-ad3d-1e64df0e2c38.jpeg" width="500">


#### How to test

- Launch browser/electron app and inspect the elements in the hidden tab bar using the browser DevTools and notice the new `-hidden` suffix

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
