### PR TITLE
[vscode] Support Terminal#creationOptions #11138

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2929,6 +2929,12 @@ export module '@theia/plugin' {
         readonly exitStatus: TerminalExitStatus | undefined;
 
         /**
+         * The object used to initialize the terminal, this is useful for example to detecting the shell type of when the terminal was not launched by this extension or for
+         * detecting what folder the shell was launched in.
+         */
+        readonly creationOptions: Readonly<TerminalOptions | ExtensionTerminalOptions>
+
+        /**
          * Send text to the terminal.
          * @param text - text content.
          * @param addNewLine - in case true - apply new line after the text, otherwise don't apply new line. This defaults to `true`.


### PR DESCRIPTION
#### What it does
Saves the passed terminal creation options and exposes them via Terminal#creationOptions

Fixes #11138

Contributed on behalf of STMicroelectronics

#### How to test
I have prepares a small sample extension using the API. 
This is available here: https://github.com/jfaltermeier/vscode-playground/releases/download/terminal-creation-options.0.0.5/terminal-creation-options-0.0.5.vsix
Source code: https://github.com/jfaltermeier/vscode-playground/blob/main/terminal-creation-options/src/extension.ts

This extension adds commands to create terminals using the different available `vscode.window.createTerminal`-methods. 
Also the `creationOptions` of all open terminals may get logged:

![ksnip_20220831-104140](https://user-images.githubusercontent.com/5889696/187648041-0983d161-1a8b-4a39-b77f-c1b356c66f7a.png)

For regular terminals the `creationOptions` will be written into the newly created terminal.
For the pseudo terminal you have to check the logs.  

Output of "Print all terminal options" with the three terminals from the extension:
```
2022-08-31T09:26:38.193Z root INFO [hosted-plugin: 147603] {"name":"Terminal 2","isTransient":true,"pty":{}}
2022-08-31T09:38:33.696Z root INFO [hosted-plugin: 147603] {"name":"Terminal 0"}
2022-08-31T09:38:33.696Z root INFO [hosted-plugin: 147603] {"name":"Terminal 1","isTransient":true,"env":{"ENV1":"env one"}}
```

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
