### PR TITLE
vscode: Support TerminalOptions.hideFromUser

### DIFF
--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -123,12 +123,13 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, Disposable 
                 title: options.name,
                 shellPath: options.shellPath,
                 shellArgs: options.shellArgs,
-                cwd: new URI(options.cwd),
+                cwd: options.cwd ? new URI(options.cwd) : undefined,
                 env: options.env,
                 strictEnv: options.strictEnv,
                 destroyTermOnClose: true,
                 useServerTitle: false,
                 attributes: options.attributes,
+                hideFromUser: options.hideFromUser,
                 isPseudoTerminal
             });
             if (options.message) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3007,6 +3007,15 @@ export module '@theia/plugin' {
         strictEnv?: boolean;
 
         /**
+         * When enabled the terminal will run the process as normal but not be surfaced to the user
+         * until `Terminal.show` is called. The typical usage for this is when you need to run
+         * something that may need interactivity but only want to tell the user about it when
+         * interaction is needed. Note that the terminals will still be exposed to all extensions
+         * as normal.
+         */
+        hideFromUser?: boolean;
+
+        /**
          * A message to write to the terminal on first launch. Note that this is not sent to the
          * process, but rather written directly to the terminal. This supports escape sequences such
          * as setting text style.

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -51,6 +51,9 @@ export abstract class TerminalWidget extends BaseWidget {
 
     abstract readonly exitStatus: TerminalExitStatus | undefined;
 
+    /** Terminal widget can be hidden from users until explicitly shown once. */
+    abstract readonly hiddenFromUser: boolean;
+
     /** The last CWD assigned to the terminal, useful when attempting getCwdURI on a task terminal fails */
     lastCwd: URI;
 
@@ -202,4 +205,9 @@ export interface TerminalWidgetOptions {
      * Terminal kind that indicates whether a terminal is created by a user or by some extension for a user
      */
     readonly kind?: 'user' | string;
+
+    /**
+     * When enabled the terminal will run the process as normal but not be surfaced to the user until `Terminal.show` is called.
+     */
+    readonly hideFromUser?: boolean;
 }

--- a/packages/terminal/src/browser/terminal-quick-open-service.ts
+++ b/packages/terminal/src/browser/terminal-quick-open-service.ts
@@ -51,8 +51,8 @@ export class TerminalQuickOpenService implements QuickAccessProvider {
     async getPicks(filter: string, token: CancellationToken): Promise<QuickPicks> {
         const items: QuickPickItem[] = [];
 
-        // Get the sorted list of currently opened terminal widgets
-        const widgets: TerminalWidget[] = this.terminalService.all
+        // Get the sorted list of currently opened terminal widgets that aren't hidden from users
+        const widgets: TerminalWidget[] = this.terminalService.all.filter(widget => !widget.hiddenFromUser)
             .sort((a: TerminalWidget, b: TerminalWidget) => this.compareItems(a, b));
 
         for (const widget of widgets) {

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -64,6 +64,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     protected hoverMessage: HTMLDivElement;
     protected lastTouchEnd: TouchEvent | undefined;
     protected isAttachedCloseListener: boolean = false;
+    protected shown = false;
     override lastCwd = new URI();
 
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
@@ -349,6 +350,13 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         return this.lastTouchEnd;
     }
 
+    get hiddenFromUser(): boolean {
+        if (this.shown) {
+            return false;
+        }
+        return this.options.hideFromUser ?? false;
+    }
+
     onDispose(onDispose: () => void): void {
         this.toDispose.push(Disposable.create(onDispose));
     }
@@ -461,6 +469,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.update();
+        this.shown = true;
     }
     protected override onAfterAttach(msg: Message): void {
         Widget.attach(this.searchBox, this.node);


### PR DESCRIPTION
#### What it does

Adds support for VS Code's `TerminalOptions.hideFromUser`. From the [VS Code API doc](https://code.visualstudio.com/api/references/vscode-api#TerminalOptions):

> When enabled the terminal will run the process as normal but not be surfaced to the user until `Terminal.show` is called. The typical usage for this is when you need to run something that may need interactivity but only want to tell the user about it when interaction is needed. Note that the terminals will still be exposed to all extensions as normal.

In particular, this change does:

* Add TerminalOptions.hideFromUser in `theia.d.ts` and pass it on from ext to main
* Add TerminalWidget.hiddenFromUser and respect it when showing terminals in the UI
* Fix `cwd` for created terminals with undefined `cwd` (default: workspace)<br>Strictly speaking, this change is unrelated but makes the terminal's `cwd` consistent with VS Code, when no `cwd` is explicitly specified

If `TerminalOptions.hideFromUser` is set to `true`, the `TerminalWidget` will be hidden from any user-facing terminal lists until it is first explicitly shown to the user (see `TerminalWidget.hidden`).

As we don't open terminal widgets by default on `TerminalService.newTerminal` anyway and as we don't have a global terminal view (in contrast to VS Code), we only need to hide hidden terminals in the `TerminalQuickOpenService` really. Or am I missing something?

Contributed on behalf of STMicroelectronics.

Change-Id: Ic1fdf2d5515d5b2fa8feb58b72218b93eeabda4d
Fixes https://github.com/eclipse-theia/theia/issues/11144

#### How to test

* Install test VS Code extension [terminal-creation-options-0.0.6.vsix](https://github.com/planger/vscode-playground/raw/planger/issues/11144/terminal-creation-options/terminal-creation-options-0.0.6.vsix) (code is pushed to https://github.com/planger/vscode-playground/tree/planger/issues/11144/terminal-creation-options)
* Execute task "Create default terminal"
* Run Quick Palette `term` and observe how it is listed
* Execute task "Create hidden terminal"
* Run Quick Palette `term` and observe how the default terminal is listed, but not the hidden terminal
* Execute task "Show hidden terminal"
* Observe how the hidden terminal is shown to the user
* Run Quick Palette `term` and observe how the default AND the hidden terminals are both listed now

Here is how this extension behaves in VS Code:

https://user-images.githubusercontent.com/588090/188132106-f557f035-671d-4b0e-93f1-d6db65dcffa9.mp4

Here is how this extension behaves in Theia (with this PR):

https://user-images.githubusercontent.com/588090/188132359-4a72421c-f905-4671-8d61-fc6e2756201a.mp4

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
