### PR TITLE
open-editors: fix toolbar enablement and updates

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -39,8 +39,6 @@ import {
     Command,
     CommandRegistry,
     DisposableCollection,
-    Emitter,
-    Event,
     isOSX,
     MenuModelRegistry,
     MenuPath,
@@ -179,9 +177,6 @@ export const FILE_NAVIGATOR_TOGGLE_COMMAND_ID = 'fileNavigator:toggle';
 @injectable()
 export class FileNavigatorContribution extends AbstractViewContribution<FileNavigatorWidget> implements FrontendApplicationContribution, TabBarToolbarContribution {
 
-    protected readonly onDidUpdateOpenEditorsEmitter = new Emitter<void>();
-    protected readonly onDidUpdateOpenEditors: Event<void> = this.onDidUpdateOpenEditorsEmitter.event;
-
     @inject(ClipboardService)
     protected readonly clipboardService: ClipboardService;
 
@@ -243,8 +238,6 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         this.shell.onDidChangeActiveWidget(updateFocusContextKeys);
         this.workspaceCommandContribution.onDidCreateNewFile(async event => this.onDidCreateNewResource(event));
         this.workspaceCommandContribution.onDidCreateNewFolder(async event => this.onDidCreateNewResource(event));
-        this.shell.onDidAddWidget(() => this.onDidUpdateOpenEditorsEmitter.fire());
-        this.shell.onDidRemoveWidget(() => this.onDidUpdateOpenEditorsEmitter.fire());
     }
 
     private async onDidCreateNewResource(event: DidCreateNewResourceEvent): Promise<void> {
@@ -365,12 +358,12 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         });
         registry.registerCommand(OpenEditorsCommands.CLOSE_ALL_TABS_FROM_TOOLBAR, {
             execute: widget => this.withOpenEditorsWidget(widget, () => this.shell.closeMany(this.editorWidgets)),
-            isEnabled: widget => this.withOpenEditorsWidget(widget, () => !!this.editorWidgets.length),
+            isEnabled: widget => this.withOpenEditorsWidget(widget, () => true),
             isVisible: widget => this.withOpenEditorsWidget(widget, () => true)
         });
         registry.registerCommand(OpenEditorsCommands.SAVE_ALL_TABS_FROM_TOOLBAR, {
             execute: widget => this.withOpenEditorsWidget(widget, () => registry.executeCommand(CommonCommands.SAVE_ALL.id)),
-            isEnabled: widget => this.withOpenEditorsWidget(widget, () => !!this.editorWidgets.length),
+            isEnabled: widget => this.withOpenEditorsWidget(widget, () => true),
             isVisible: widget => this.withOpenEditorsWidget(widget, () => true)
         });
 
@@ -630,14 +623,12 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             command: OpenEditorsCommands.SAVE_ALL_TABS_FROM_TOOLBAR.id,
             tooltip: OpenEditorsCommands.SAVE_ALL_TABS_FROM_TOOLBAR.label,
             priority: 0,
-            onDidChange: this.onDidUpdateOpenEditors
         });
         toolbarRegistry.registerItem({
             id: OpenEditorsCommands.CLOSE_ALL_TABS_FROM_TOOLBAR.id,
             command: OpenEditorsCommands.CLOSE_ALL_TABS_FROM_TOOLBAR.id,
             tooltip: OpenEditorsCommands.CLOSE_ALL_TABS_FROM_TOOLBAR.label,
             priority: 1,
-            onDidChange: this.onDidUpdateOpenEditors
         });
     }
 


### PR DESCRIPTION


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11632.

The pull-request fixes the toolbar for the `open editors` tree-view to update properly:
- [x] the toolbar items are now always visible for the widget
- [x] the toolbar items are updated when there are changes with opened editors

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open the `open editors` tree-view in the `explorer`
3. open editors - confirm the toolbar updates (becomes enabled)
4. perform `close all editors` - confirm the toolbar updates (becomes disabled)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
