### PR TITLE
Disable `bundleStrings` RPC extension

### DIFF
--- a/packages/core/src/common/message-rpc/rpc-message-encoder.ts
+++ b/packages/core/src/common/message-rpc/rpc-message-encoder.ts
@@ -120,7 +120,7 @@ export interface RpcMessageEncoder {
 
 }
 
-export const defaultMsgPack = new MsgPack({ moreTypes: true, encodeUndefinedAsNil: false, bundleStrings: true });
+export const defaultMsgPack = new MsgPack({ moreTypes: true, encodeUndefinedAsNil: false, bundleStrings: false });
 // Add custom msgpackR extension for ResponseErrors.
 addExtension({
     Class: ResponseError,


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11624
Closes https://github.com/eclipse-theia/theia/issues/11631

Disables the `bundleStrings` encoding/decoding extension for `msgpackr`. Although it aims to [improve performance](https://github.com/kriszyp/msgpackr#options), it leads to decoding errors on large objects (> a few mb).

#### How to test

1. Open Theia and run the `Configure Display Language` command.
2. Change to any other language and reload the window
3. Plugin support should continue to work as expected (see https://github.com/eclipse-theia/theia/issues/11631)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
