### PR TITLE
Improve localization of `vsx-registry` package

### DIFF
--- a/packages/memory-inspector/src/browser/wrapper-widgets/memory-layout-widget.tsx
+++ b/packages/memory-inspector/src/browser/wrapper-widgets/memory-layout-widget.tsx
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Disposable, DisposableCollection, Emitter } from '@theia/core';
+import { Disposable, DisposableCollection, Emitter, nls } from '@theia/core';
 import { ApplicationShell, Message, Panel, Widget, WidgetManager } from '@theia/core/lib/browser';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { MemoryDiffSelectWidget } from '../diff-widget/memory-diff-select-widget';
@@ -26,7 +26,7 @@ import { MemoryDockpanelPlaceholder } from './memory-dockpanel-placeholder-widge
 @injectable()
 export class MemoryLayoutWidget extends Panel implements Disposable, ApplicationShell.TrackableWidgetProvider {
     static readonly ID = 'memory-layout-widget';
-    static readonly LABEL = 'Memory Inspector';
+    static readonly LABEL = nls.localize('theia/memory-inspector/memoryInspector', 'Memory Inspector');
 
     // Necessary to inherit theia's tabbar styling
     static readonly DOCK_PANEL_ID = 'theia-main-content-panel';

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -18,7 +18,7 @@ import '../../src/browser/style/terminal.css';
 import 'xterm/css/xterm.css';
 
 import { ContainerModule, Container } from '@theia/core/shared/inversify';
-import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
+import { CommandContribution, MenuContribution, nls } from '@theia/core/lib/common';
 import { bindContributionProvider } from '@theia/core';
 import { KeybindingContribution, WebSocketConnectionProvider, WidgetFactory, KeybindingContext, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
@@ -61,7 +61,7 @@ export default new ContainerModule(bind => {
             const counter = terminalNum++;
             const domId = options.id || 'terminal-' + counter;
             const widgetOptions: TerminalWidgetOptions = {
-                title: 'Terminal ' + counter,
+                title: `${nls.localizeByDefault('Terminal')} ${counter}`,
                 useServerTitle: true,
                 destroyTermOnClose: true,
                 ...options

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -177,7 +177,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
     protected async installFromVSIX(): Promise<void> {
         const props: OpenFileDialogProps = {
             title: VSXExtensionsCommands.INSTALL_FROM_VSIX.dialogLabel,
-            openLabel: 'Install',
+            openLabel: nls.localizeByDefault('Install from VSIX'),
             filters: { 'VSIX Extensions (*.vsix)': ['vsix'] },
             canSelectMany: false
         };
@@ -187,13 +187,13 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
                 const extensionName = this.labelProvider.getName(extensionUri);
                 try {
                     await this.commandRegistry.executeCommand(VscodeCommands.INSTALL_FROM_VSIX.id, extensionUri);
-                    this.messageService.info(`Completed installing ${extensionName} from VSIX.`);
+                    this.messageService.info(nls.localizeByDefault('Completed installing {0} extension from VSIX.', extensionName));
                 } catch (e) {
-                    this.messageService.error(`Failed to install ${extensionName} from VSIX.`);
+                    this.messageService.error(nls.localize('theia/vsx-registry/failedInstallingVSIX', 'Failed to install {0} from VSIX.', extensionName));
                     console.warn(e);
                 }
             } else {
-                this.messageService.error('The selected file is not a valid "*.vsix" plugin.');
+                this.messageService.error(nls.localize('theia/vsx-registry/invalidVSIX', 'The selected file is not a valid "*.vsix" plugin.'));
             }
         }
     }
@@ -278,12 +278,18 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
                 recommended.delete(installed);
             }
             if (recommended.size) {
-                const userResponse = await this.messageService.info('Would you like to install the recommended extensions?', 'Install', 'Show Recommended');
-                if (userResponse === 'Install') {
+                const install = nls.localizeByDefault('Install');
+                const showRecommendations = nls.localizeByDefault('Show Recommendations');
+                const userResponse = await this.messageService.info(
+                    nls.localizeByDefault('Do you want to install the recommended extensions for this repository?'),
+                    install,
+                    showRecommendations
+                );
+                if (userResponse === install) {
                     for (const recommendation of recommended) {
                         this.model.getExtension(recommendation)?.install();
                     }
-                } else if (userResponse === 'Show Recommended') {
+                } else if (userResponse === showRecommendations) {
                     await this.showRecommendedExtensions();
                 }
             }


### PR DESCRIPTION
#### What it does

Enables the localization of a few missing strings from the `vsx-registry` package, as well as a few other, minor improvements.

#### How to test

Assert that the values are correctly localized

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
