### PR TITLE
vscode: Support `TerminalOptions.strictEnv`

### DIFF
--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -125,6 +125,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, Disposable 
                 shellArgs: options.shellArgs,
                 cwd: new URI(options.cwd),
                 env: options.env,
+                strictEnv: options.strictEnv,
                 destroyTermOnClose: true,
                 useServerTitle: false,
                 attributes: options.attributes,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2988,6 +2988,15 @@ export module '@theia/plugin' {
         env?: { [key: string]: string | null };
 
         /**
+         * Whether the terminal process environment should be exactly as provided in
+         * `TerminalOptions.env`. When this is false (default), the environment will be based on the
+         * window's environment and also apply configured platform settings like
+         * `terminal.integrated.windows.env` on top. When this is true, the complete environment
+         * must be provided as nothing will be inherited from the process or any configuration.
+         */
+        strictEnv?: boolean;
+
+        /**
          * A message to write to the terminal on first launch. Note that this is not sent to the
          * process, but rather written directly to the terminal. This supports escape sequences such
          * as setting text style.

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -167,6 +167,11 @@ export interface TerminalWidgetOptions {
     readonly env?: { [key: string]: string | null };
 
     /**
+     * Whether the terminal process environment should be exactly as provided in `env`.
+     */
+    readonly strictEnv?: boolean;
+
+    /**
      * In case `destroyTermOnClose` is true - terminal process will be destroyed on close terminal widget, otherwise will be kept
      * alive.
      */

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -428,6 +428,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             shell: this.options.shellPath,
             args: this.options.shellArgs,
             env: this.options.env,
+            strictEnv: this.options.strictEnv,
             isPseudo: this.options.isPseudoTerminal,
             rootURI,
             cols,

--- a/packages/terminal/src/common/shell-terminal-protocol.ts
+++ b/packages/terminal/src/common/shell-terminal-protocol.ts
@@ -42,7 +42,8 @@ export interface IShellTerminalServerOptions extends IBaseTerminalServerOptions 
     rootURI?: string,
     cols?: number,
     rows?: number,
-    env?: { [key: string]: string | null };
+    env?: { [key: string]: string | null },
+    strictEnv?: boolean,
     isPseudo?: boolean,
 }
 

--- a/packages/terminal/src/node/shell-process.ts
+++ b/packages/terminal/src/node/shell-process.ts
@@ -37,6 +37,7 @@ export interface ShellProcessOptions {
     cols?: number,
     rows?: number,
     env?: { [key: string]: string | null },
+    strictEnv?: boolean,
     isPseudo?: boolean,
 }
 
@@ -70,7 +71,7 @@ export class ShellProcess extends TerminalProcess {
                 cols: options.cols || ShellProcess.defaultCols,
                 rows: options.rows || ShellProcess.defaultRows,
                 cwd: getRootPath(options.rootURI),
-                env: environmentUtils.mergeProcessEnv(options.env),
+                env: options.strictEnv !== true ? environmentUtils.mergeProcessEnv(options.env) : options.env,
             },
             isPseudo: options.isPseudo,
         }, processManager, ringBuffer, logger);

--- a/packages/terminal/src/node/shell-terminal-server.ts
+++ b/packages/terminal/src/node/shell-terminal-server.ts
@@ -38,8 +38,10 @@ export class ShellTerminalServer extends BaseTerminalServer {
 
     async create(options: IShellTerminalServerOptions): Promise<number> {
         try {
-            options.env = this.environmentUtils.mergeProcessEnv(options.env);
-            this.mergedCollection.applyToProcessEnvironment(options.env);
+            if (options.strictEnv !== true) {
+                options.env = this.environmentUtils.mergeProcessEnv(options.env);
+                this.mergedCollection.applyToProcessEnvironment(options.env);
+            }
             const term = this.shellFactory(options);
             this.postCreate(term);
             return term.id;


### PR DESCRIPTION
#### What it does

Support optional property `vscode.TerminalOptions.strictEnv` when used in `createTerminal(options: TerminalOptions)` in Theia. In particular, the doc defines the property `strictEnv` of [`TerminalOptions`](https://code.visualstudio.com/api/references/vscode-api#TerminalOptions) as follows:

> Whether the terminal process environment should be exactly as provided in `TerminalOptions.env`. When this is false (default), the environment will be based on the window's environment and also apply configured platform settings like `terminal.integrated.windows.env` on top. When this is true, the complete environment must be provided as nothing will be inherited from the process or any configuration.

Fixes #11143 
Contributed on behalf of STMicroelectronics.

PS: This change might cause conflicts with https://github.com/eclipse-theia/theia/pull/11630, which are however very easy to fix in `theia.d.ts` once either of those PRs are merged. I didn't combine them to ensure a more focused and simple test scenario.

#### How to test

* Download test extension [terminal-creation-options-0.0.7.vsix](https://github.com/planger/vscode-playground/raw/planger/issues/11143/terminal-creation-options/terminal-creation-options-0.0.7.vsix) and copy it to the `plugins` folder
* Start Theia with an environment variable: e.g. `TESTVAR=TESTVALUE yarn browser start`
* This test extension registers two commands (see [code of this extension](https://github.com/planger/vscode-playground/tree/planger/issues/11143/terminal-creation-options))
  * *Create default terminal*:<br>Creates a terminal without using `strictEnv` but defining an environment variable `hello: world`.
  * *Create strict env terminal*:<br>Creates a terminal with `strictEnv` and an environment variable `hello: world`.
* Run both of these commands in Theia
* Show both terminals: e.g., by running the command "View: Show all opened terminals" in the command palette and select one terminal and run command again and select the other terminal
* Run `printenv` in both of the terminals
* Compare the printed environment and check that the one with strict environment shows no environment variables of the Theia process (e.g. `TESTVAR*` added above but also others, etc.).

I also compared the resulting environments in Ubuntu between VS Code and Theia and the environments are equivalent for the `strictEnv` case.
We should also verify with Windows that no transformations are applied to the specified environment variables, as indicated by the documentation in VS Code.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
