### PR TITLE
add missing deprecated show overload

### DIFF
--- a/packages/plugin-ext/src/plugin/output-channel/output-channel-item.ts
+++ b/packages/plugin-ext/src/plugin/output-channel/output-channel-item.ts
@@ -52,8 +52,11 @@ export class OutputChannelImpl implements theia.OutputChannel {
         this.proxy.$clear(this.name);
     }
 
-    show(preserveFocus: boolean | undefined): void {
+    show(preserveFocusOrColumn?: boolean | theia.ViewColumn, preserveFocus?: boolean): void {
         this.validate();
+        if (typeof preserveFocusOrColumn === 'boolean') {
+            preserveFocus = preserveFocusOrColumn;
+        }
         this.proxy.$reveal(this.name, !!preserveFocus);
     }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2785,6 +2785,16 @@ export module '@theia/plugin' {
         /**
          * Reveal this channel in the UI.
          *
+         * @deprecated Use the overload with just one parameter (`show(preserveFocus?: boolean): void`).
+         *
+         * @param column This argument is **deprecated** and will be ignored.
+         * @param preserveFocus When `true` the channel will not take focus.
+         */
+        show(column?: ViewColumn, preserveFocus?: boolean): void;
+
+        /**
+         * Reveal this channel in the UI.
+         *
          * @param preserveFocus When `true` the channel will not take focus.
          */
         show(preserveFocus?: boolean): void;


### PR DESCRIPTION
#### What it does

Add an old deprecated overload signature for OutputChannel.show in theia.d.ts and update the implementation accordingly.

Closes https://github.com/eclipse-theia/theia/issues/11627

#### How to test

1. include the following extension in your app ([outputshow-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/9529836/outputshow-0.0.1.vsix.zip))
2. run the command "Output - Show Deprecated"
3. confirm that the channel is shown

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
