### PR TITLE
vscode: add `buttons` support for `QuickPickItem`

### DIFF
--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -57,7 +57,7 @@ export interface QuickPickItem {
     iconClasses?: string[];
     alwaysShow?: boolean;
     highlights?: QuickPickItemHighlights;
-    buttons?: QuickInputButton[];
+    buttons?: readonly QuickInputButton[];
     execute?: () => void;
 }
 
@@ -93,7 +93,7 @@ export interface QuickPickValue<V> extends QuickPickItem {
 }
 
 export interface QuickInputButton {
-    iconPath?: URI | { light?: URI | Uri; dark: URI | Uri } | { id: string };
+    iconPath?: URI | Uri | { light?: URI | Uri; dark: URI | Uri } | { id: string };
     iconClass?: string;
     tooltip?: string;
     /**

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -167,6 +167,10 @@
   color: var(--theia-list-focusHighlightForeground) !important;
 }
 
+.quick-input-titlebar .action-item .action-label {
+    color: var(--theia-foreground) !important;
+}
+
 .monaco-list-rows
   .monaco-list-row:not(:first-child)
   .quick-input-list-entry.quick-input-list-separator-border {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -100,7 +100,7 @@ import type {
 import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
 import { ThemeType } from '@theia/core/lib/common/theme';
 import { Disposable } from '@theia/core/lib/common/disposable';
-import { PickOptions, QuickInputButtonHandle, QuickPickItem } from '@theia/core/lib/common';
+import { PickOptions, QuickInputButtonHandle } from '@theia/core/lib/common';
 import { Severity } from '@theia/core/lib/common/severity';
 
 export interface PreferenceData {
@@ -431,12 +431,13 @@ export interface QuickOpenExt {
     $acceptDidChangeValue(sessionId: number, changedValue: string): Promise<void>;
     $acceptOnDidHide(sessionId: number): Promise<void>;
     $acceptOnDidTriggerButton(sessionId: number, btn: QuickInputButtonHandle): Promise<void>;
+    $onDidTriggerItemButton(sessionId: number, itemHandle: number, buttonHandle: number): void;
     $onDidChangeActive(sessionId: number, handles: number[]): void;
     $onDidChangeSelection(sessionId: number, handles: number[]): void;
 
     /* eslint-disable max-len */
     showQuickPick(itemsOrItemsPromise: Array<theia.QuickPickItem> | Promise<Array<theia.QuickPickItem>>, options: theia.QuickPickOptions & { canPickMany: true; },
-        token?: theia.CancellationToken): Promise<Array<QuickPickItem> | undefined>;
+        token?: theia.CancellationToken): Promise<Array<theia.QuickPickItem> | undefined>;
     showQuickPick(itemsOrItemsPromise: string[] | Promise<string[]>, options?: theia.QuickPickOptions, token?: theia.CancellationToken): Promise<string | undefined>;
     showQuickPick(itemsOrItemsPromise: Array<theia.QuickPickItem> | Promise<Array<theia.QuickPickItem>>, options?: theia.QuickPickOptions, token?: theia.CancellationToken): Promise<theia.QuickPickItem | undefined>;
     showQuickPick(itemsOrItemsPromise: Item[] | Promise<Item[]>, options?: theia.QuickPickOptions, token?: theia.CancellationToken): Promise<Item | Item[] | undefined>;
@@ -572,7 +573,8 @@ export interface TransferQuickPickSeparator extends theia.QuickPickItem {
 }
 
 export interface TransferQuickInputButton extends theia.QuickInputButton {
-    iconPath: theia.Uri | { light: theia.Uri, dark: theia.Uri } | ThemeIcon
+    iconPath: theia.Uri | { light: theia.Uri, dark: theia.Uri } | ThemeIcon;
+    iconClass?: string;
     handle?: number;
 }
 

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -39,7 +39,7 @@ import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposa
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { MonacoQuickInputService } from '@theia/monaco/lib/browser/monaco-quick-input-service';
 import { QuickInputButtons } from '../../plugin/types-impl';
-import { getIconUris } from '../../plugin/quick-open';
+import { getIconPathOrClass } from '../../plugin/quick-open';
 import * as monaco from '@theia/monaco-editor-core';
 import { IQuickPickItem, IQuickInput } from '@theia/monaco-editor-core/esm/vs/base/parts/quickinput/common/quickInput';
 import { ThemeIcon } from '@theia/monaco-editor-core/esm/vs/platform/theme/common/themeService';
@@ -210,6 +210,9 @@ export class QuickOpenMainImpl implements QuickOpenMain, Disposable {
                 quickPick.onDidTriggerButton((button: QuickInputButtonHandle) => {
                     this.proxy.$acceptOnDidTriggerButton(sessionId, button);
                 });
+                quickPick.onDidTriggerItemButton(e => {
+                    this.proxy.$onDidTriggerItemButton(sessionId, (e.item as TransferQuickPickItems).handle, (e.button as TransferQuickPickItems).handle);
+                });
                 quickPick.onDidChangeValue((value: string) => {
                     this.proxy.$acceptDidChangeValue(sessionId, value);
                 });
@@ -313,7 +316,7 @@ export class QuickOpenMainImpl implements QuickOpenMain, Disposable {
 
     private convertToQuickInputButtons(buttons: Array<TransferQuickInputButton>): Array<QuickInputButton> {
         return buttons.map((button, i) => ({
-            iconPath: getIconUris(button.iconPath),
+            ...getIconPathOrClass(button),
             tooltip: button.tooltip,
             handle: button === QuickInputButtons.Back ? -1 : i,
         } as QuickInputButton));

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -1085,7 +1085,7 @@ export function convertToTransferQuickPickItems(items: rpc.Item[]): rpc.Transfer
         } else if (item.kind === QuickPickItemKind.Separator) {
             return { type: 'separator', label: item.label, handle: index };
         } else {
-            const { label, description, detail, picked, alwaysShow } = item;
+            const { label, description, detail, picked, alwaysShow, buttons } = item;
             return {
                 type: 'item',
                 label,
@@ -1093,6 +1093,7 @@ export function convertToTransferQuickPickItems(items: rpc.Item[]): rpc.Transfer
                 detail,
                 picked,
                 alwaysShow,
+                buttons,
                 handle: index,
             };
         }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2186,35 +2186,63 @@ export module '@theia/plugin' {
      * Represents an item that can be selected from a list of items.
      */
     export interface QuickPickItem {
+
+        /**
+         * A human-readable string which is rendered prominent. Supports rendering of {@link ThemeIcon theme icons} via
+         * the `$(<name>)`-syntax.
+         */
+        label: string;
+
         /**
          * Defaults to {@link QuickPickItemKind.Default}. If set to {@link QUickPickItemKind.Separator}, the item will not be displayed as a row but only as a separator,
          * and all fields other than {@link QuickPickItem.label label} will be ignored.
          */
         kind?: QuickPickItemKind;
-        /**
-         * The item label
-         */
-        label: string;
 
         /**
-         * The item description
+         * A human-readable string which is rendered less prominent in the same line. Supports rendering of
+         * {@link ThemeIcon theme icons} via the `$(<name>)`-syntax.
+         *
+         * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
          */
         description?: string;
 
         /**
-         * The item detail
+         * A human-readable string which is rendered less prominent in a separate line. Supports rendering of
+         * {@link ThemeIcon theme icons} via the `$(<name>)`-syntax.
+         *
+         * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
          */
         detail?: string;
 
         /**
-         * Used for [QuickPickOptions.canPickMany](#QuickPickOptions.canPickMany)
-         * not implemented yet
+         * Optional flag indicating if this item is picked initially. This is only honored when using
+         * the {@link window.showQuickPick()} API. To do the same thing with the {@link window.createQuickPick()} API,
+         * simply set the {@link QuickPick.selectedItems} to the items you want picked initially.
+         * (*Note:* This is only honored when the picker allows multiple selections.)
+         *
+         * @see {@link QuickPickOptions.canPickMany}
+         *
+         * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
          */
         picked?: boolean;
+
         /**
          * Always show this item.
+         *
+         * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
          */
         alwaysShow?: boolean;
+
+        /**
+         * Optional buttons that will be rendered on this particular item. These buttons will trigger
+         * an {@link QuickPickItemButtonEvent} when clicked. Buttons are only rendered when using a quickpick
+         * created by the {@link window.createQuickPick()} API. Buttons are not rendered when using
+         * the {@link window.showQuickPick()} API.
+         *
+         * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
+         */
+        buttons?: readonly QuickInputButton[];
     }
 
     /**
@@ -2266,6 +2294,12 @@ export module '@theia/plugin' {
          * An event signaling when a button was triggered.
          */
         readonly onDidTriggerButton: Event<QuickInputButton>;
+
+        /**
+         * An event signaling when a button in a particular {@link QuickPickItem} was triggered.
+         * This event does not fire for buttons in the title bar.
+         */
+        readonly onDidTriggerItemButton: Event<QuickPickItemButtonEvent<T>>;
 
         /**
          * Items to pick from.
@@ -5056,6 +5090,21 @@ export module '@theia/plugin' {
          * @hidden
          */
         private constructor();
+    }
+
+    /**
+     * An event signaling when a button in a particular {@link QuickPickItem} was triggered.
+     * This event does not fire for buttons in the title bar.
+     */
+    export interface QuickPickItemButtonEvent<T extends QuickPickItem> {
+        /**
+         * The button that was clicked.
+         */
+        readonly button: QuickInputButton;
+        /**
+         * The item that the button belongs to.
+         */
+        readonly item: T;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: https://github.com/eclipse-theia/theia/issues/11514.
The pull-request adds support for `buttons` in the `QuickPickItem` VS Code API.

The changes include:
- adding support for `buttons` in `QuickPickItem`.
- adding support for the missing handling of `iconClass` (used to handle the `ThemeIcon` that can be used).
- adding the proper styling for icons present in input boxes (previously styled as standard `<a>` tags). 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test extension ([vscode-quickpick-buttons-0.0.7.vsix.zip](https://github.com/eclipse-theia/theia/files/9536127/vscode-quickpick-buttons-0.0.7.vsix.zip))  in the application
2. execute the command `QuickPick: Show with Buttons` - the individual rows should display the icons properly

![Screen Shot 2022-09-08 at 1 09 20 PM](https://user-images.githubusercontent.com/40359487/189183666-9f2e97c6-c2b5-40d7-9da0-7d349d8a8ce7.png)

3. click either `file` or `folder` item and confirm `onDidTriggerItemButton` works (the even is listened to and produces an information message).
4. execute the command `InputBox: Show with Buttons` - the toolbar should include icons, and they should be styled properly

![Screen Shot 2022-09-08 at 1 09 29 PM](https://user-images.githubusercontent.com/40359487/189183740-266af586-ed1f-4aa8-a9c1-d4e4cb907613.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>