### PR TITLE
[CI] Reduce repo size by auto-trimming `gh-pages` branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -146,6 +146,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages
+          force_orphan: true    # will only keep latest commit on branch gh-pages
 
       - name: Publish NPM
         uses: nick-invision/retry@v2


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Use "force_orphan" option of GH action peaceiris/actions-gh-pages@v3

With this change, the API documentation that we generate as part of our CI will overwrite the `gh-pages` branch, only keeping the latest generated documentation. This will reduce the repository size (when cloned, from close to 3GB to ~150M.

As a consequence, we will lose the history of API documentation. It will still be possible to manually generate it locally (yarn docs).

Fixes #11625

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I pushed the change on my fork of this repo. See resulting `gh-pages` branch: https://github.com/marcdumais-work/theia/tree/gh-pages. 

You can also try cloning my fork, and confirm that about 150M is transferred, instead of ~2.8G: 
`$ git clone git@github.com:marcdumais-work/theia.git`

update: it took a little while, but my repo size, as reported by GitHub, has shrunk to the expected, much smaller size, without further action on my part: 
![image](https://user-images.githubusercontent.com/25749063/189389902-2829068b-c8d6-42b8-8372-e40e77469b51.png)

Generated doc (my fork): https://marcdumais-work.github.io/theia/docs/next/index.html

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
