### PR TITLE
Use webcontents ID in `isSender` check

### DIFF
--- a/packages/core/src/electron-main/theia-electron-window.ts
+++ b/packages/core/src/electron-main/theia-electron-window.ts
@@ -181,7 +181,7 @@ export class TheiaElectronWindow {
     }
 
     protected isSender(e: IpcMainEvent): boolean {
-        return BrowserWindow.fromId(e.sender.id) === this._window;
+        return e.sender.id === this._window.webContents.id;
     }
 
     dispose(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11600 according to @kittaakos suggestion.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Run the electron example: (We can see the window 1)
1. Reload the window: (Reload the window 1)
1. Click the New Window in the menu, and it _does_ work.
---
1. Open a file and make it dirty.
1. Click to exit the application.
1. See a dialog prompting you for whether you want to exit.
1. Click no
1. The window should remain open.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
