### PR TITLE
support Pseudoterminal.onDidChangeName

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -334,6 +334,13 @@ export interface TerminalServiceMain {
     $dispose(id: string): void;
 
     /**
+     * Set the terminal widget name
+     * @param id  terminal widget id.
+     * @param name  new terminal widget name.
+     */
+    $setName(id: string, name: string): void;
+
+    /**
      * Send text to the terminal by id.
      * @param id - terminal id.
      * @param text - text content.
@@ -377,6 +384,13 @@ export interface TerminalServiceMain {
     $disposeByTerminalId(id: number, waitOnExit?: boolean | string): void;
 
     $setEnvironmentVariableCollection(extensionIdentifier: string, persistent: boolean, collection: SerializableEnvironmentVariableCollection | undefined): void;
+
+    /**
+     * Set the terminal widget name
+     * @param id  terminal id.
+     * @param name  new terminal widget name.
+     */
+    $setNameByTerminalId(id: number, name: string): void;
 }
 
 export interface AutoFocus {

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -179,6 +179,13 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, Disposable 
         }
     }
 
+    $setName(id: string, name: string): void {
+        const terminal = this.terminals.getById(id);
+        if (terminal) {
+            terminal.setTitle(name);
+        }
+    }
+
     $sendTextByTerminalId(id: number, text: string, addNewLine?: boolean): void {
         const terminal = this.terminals.getByTerminalId(id);
         if (terminal) {
@@ -231,5 +238,9 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, Disposable 
             }
             terminal.dispose();
         }
+    }
+
+    $setNameByTerminalId(id: number, name: string): void {
+        this.terminals.getByTerminalId(id)?.setTitle(name);
     }
 }

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -343,6 +343,15 @@ export class PseudoTerminal {
                 }
             });
         }
+        if (pseudoTerminal.onDidChangeName) {
+            pseudoTerminal.onDidChangeName(name => {
+                if (typeof id === 'string') {
+                    this.proxy.$setName(id, name);
+                } else {
+                    this.proxy.$setNameByTerminalId(id, name);
+                }
+            });
+        }
     }
 
     emitOnClose(): void {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3082,6 +3082,26 @@ export module '@theia/plugin' {
         onDidClose?: Event<void | number>;
 
         /**
+         * An event that when fired allows changing the name of the terminal.
+         *
+         * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
+         *
+         * **Example:** Change the terminal name to "My new terminal".
+         * ```typescript
+         * const writeEmitter = new vscode.EventEmitter<string>();
+         * const changeNameEmitter = new vscode.EventEmitter<string>();
+         * const pty: vscode.Pseudoterminal = {
+         *   onDidWrite: writeEmitter.event,
+         *   onDidChangeName: changeNameEmitter.event,
+         *   open: () => changeNameEmitter.fire('My new terminal'),
+         *   close: () => {}
+         * };
+         * vscode.window.createTerminal({ name: 'My terminal', pty });
+         * ```
+         */
+        onDidChangeName?: Event<string>;
+
+        /**
          * Implement to handle when the pty is opened.
          *
          * @param dimensions The dimensions of the terminal.


### PR DESCRIPTION
#### What it does
Closes #11513
Adds support for the Pseudoterminal.onDidChangeName VS Code API.

#### How to test

1. include the following extension ([pseudoterminal-name-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/9538139/pseudoterminal-name-0.0.1.vsix.zip)) in your application.
2. Execute the command "Pseudoterminal: Test Name".
3. The extension will spawn a pseudoterminal with a name of "Initial Name" and will update to "Updated Name" using 'onDidChangeName'.
 
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
