### PR TITLE
Support cancellation on plugin file events

### DIFF
--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -336,8 +336,7 @@ export namespace WaitUntilEvent {
         token = CancellationToken.None
     ): Promise<void> {
         const waitables: Promise<void>[] = [];
-        const asyncEvent = {
-            ...event,
+        const asyncEvent = Object.assign(event, {
             token,
             waitUntil: (thenable: Promise<any>) => {
                 if (Object.isFrozen(waitables)) {
@@ -345,7 +344,7 @@ export namespace WaitUntilEvent {
                 }
                 waitables.push(thenable);
             }
-        } as T;
+        }) as T;
         try {
             emitter.fire(asyncEvent);
             // Asynchronous calls to `waitUntil` should fail.
@@ -393,8 +392,7 @@ export class AsyncEmitter<T extends WaitUntilEvent> extends Emitter<T> {
                 return;
             }
             const waitables: Promise<void>[] = [];
-            const asyncEvent = {
-                ...event,
+            const asyncEvent = Object.assign(event, {
                 token,
                 waitUntil: (thenable: Promise<any>) => {
                     if (Object.isFrozen(waitables)) {
@@ -405,9 +403,9 @@ export class AsyncEmitter<T extends WaitUntilEvent> extends Emitter<T> {
                     }
                     waitables.push(thenable);
                 }
-            } as T;
+            }) as T;
             try {
-                listener(asyncEvent);
+                listener(event);
                 // Asynchronous calls to `waitUntil` should fail.
                 Object.freeze(waitables);
             } catch (e) {

--- a/packages/core/src/common/progress-service.ts
+++ b/packages/core/src/common/progress-service.ts
@@ -71,8 +71,8 @@ export class ProgressService {
         return `${this.progressIdPrefix}-${++this.counter}`;
     }
 
-    async withProgress<T>(text: string, locationId: string, task: () => Promise<T>): Promise<T> {
-        const progress = await this.showProgress({ text, options: { cancelable: true, location: locationId } });
+    async withProgress<T>(text: string, locationId: string, task: () => Promise<T>, onDidCancel?: () => void): Promise<T> {
+        const progress = await this.showProgress({ text, options: { cancelable: true, location: locationId } }, onDidCancel);
         try {
             return await task();
         } finally {

--- a/packages/plugin-ext/src/plugin/file-system-event-service-ext-impl.ts
+++ b/packages/plugin-ext/src/plugin/file-system-event-service-ext-impl.ts
@@ -28,7 +28,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/tslint/config */
 
-import { Emitter, WaitUntilEvent, AsyncEmitter } from '@theia/core/lib/common/event';
+import { Emitter, WaitUntilEvent, AsyncEmitter, WaitUntilData } from '@theia/core/lib/common/event';
 import { IRelativePattern, parse } from '@theia/core/lib/common/glob';
 import { UriComponents } from '@theia/core/shared/vscode-uri';
 import { Disposable, URI, WorkspaceEdit } from './types-impl';
@@ -222,7 +222,7 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
         }
     }
 
-    private async _fireWillEvent<E extends IWaitUntil>(emitter: AsyncEmitter<E>, data: Omit<E, 'waitUntil'>, timeout: number, token: CancellationToken): Promise<any> {
+    private async _fireWillEvent<E extends IWaitUntil>(emitter: AsyncEmitter<E>, data: WaitUntilData<E>, timeout: number, token: CancellationToken): Promise<any> {
 
         const edits: WorkspaceEdit[] = [];
         await emitter.fire(data, token, async (thenable, listener) => {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1713,6 +1713,11 @@ export module '@theia/plugin' {
     export interface FileWillCreateEvent {
 
         /**
+         * A cancellation token.
+         */
+        readonly token: CancellationToken;
+
+        /**
          * The files that are going to be created.
          */
         readonly files: ReadonlyArray<Uri>;
@@ -1768,6 +1773,11 @@ export module '@theia/plugin' {
     export interface FileWillDeleteEvent {
 
         /**
+         * A cancellation token.
+         */
+        readonly token: CancellationToken;
+
+        /**
          * The files that are going to be deleted.
          */
         readonly files: ReadonlyArray<Uri>;
@@ -1821,6 +1831,11 @@ export module '@theia/plugin' {
      * thenable that resolves to a {@link WorkspaceEdit workspace edit}.
      */
     export interface FileWillRenameEvent {
+
+        /**
+         * A cancellation token.
+         */
+        readonly token: CancellationToken;
 
         /**
          * The files that are going to be renamed.


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11508
Closes https://github.com/eclipse-theia/theia/pull/11563

Supersedes the PR above by adapting the approach taken by vscode. vscode [always passes the token into the async event](https://github.com/microsoft/vscode/blob/da34e253ca55a22c0272708dcfe622a6f8fb33fc/src/vs/base/common/event.ts#L880-L883), so we don't have to do that ourselves for each event.

Additionally enables to actually cancel the file events using a notification similar to vscode.

Also updates a few missing localizable strings in the `file-service.ts` file.

#### How to test
1. Install the test extension [cancellation-token-0.0.1.vsix](https://github.com/eclipse-theia/theia/files/9548623/cancellation-token-0.0.1.vsix.zip).
2. Create a new file in the explorer.
3. A notification should appear that a file is in progress of being created (both from Theia and from the extension)
4. Cancelling the operation explicitly or by waiting (5 seconds by default) will cancel the token and another notification will appear that the operation has been cancelled. The file will then be successfully created.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
