### PR TITLE
vscode: fix partial errors with `Position`

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -315,7 +315,7 @@ export module '@theia/plugin' {
          * @return A position that reflects the given delta. Will return `this` position if the change
          * is not changing anything.
          */
-        translate(change: { lineDelta?: number; characterDelta?: number; }): Position;
+        translate(change: { lineDelta?: number; characterDelta?: number }): Position;
 
         /**
          * Create a new position derived from this position.
@@ -333,7 +333,7 @@ export module '@theia/plugin' {
          * @return A position that reflects the given change. Will return `this` position if the change
          * is not changing anything.
          */
-        with(change: { line?: number; character?: number; }): Position;
+        with(change: { line?: number; character?: number }): Position;
     }
 
     /**
@@ -8938,7 +8938,7 @@ export module '@theia/plugin' {
          * @param tokenType The token type.
          * @param tokenModifiers The token modifiers.
          */
-        push(range: Range, tokenType: string, tokenModifiers?: string[]): void;
+        push(range: Range, tokenType: string, tokenModifiers?: readonly string[]): void;
 
         /**
          * Finish and create a `SemanticTokens` instance.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates the reported **partial** support in the comparator for:
- `Position.with` and `Position.translate`.
- `SemanticTokensBuilder.push`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

There is no change in functionality but you can generate the compatibility report with this branch by comparing locally:


1. clone https://github.com/eclipse-theia/vscode-theia-comparator
2. `yarn`
3. `yarn run generate theia-path={path to your theia}`

![Screen Shot 2022-09-12 at 12 33 02 PM](https://user-images.githubusercontent.com/40359487/189707877-6e93722d-1ed9-453c-aa77-44c5c0c8055f.png)

![Screen Shot 2022-09-12 at 12 33 36 PM](https://user-images.githubusercontent.com/40359487/189707986-399dc21f-69a4-4e5f-8a84-f7aafa2eaad1.png)



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>