### PR TITLE
vscode: add support for `MarkdownString` tooltips

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5479,7 +5479,7 @@ export module '@theia/plugin' {
         /**
          * The tooltip text when you hover over this item.
          */
-        tooltip?: string | undefined;
+        tooltip?: string | MarkdownString | undefined;
 
         /**
          * The {@link Command command} which should be run when the tree item is selected.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates our `theia.d.ts` to reflect that `MarkdownString` is supported for `TreeItem.tooltip`.
The change is possible thanks to https://github.com/eclipse-theia/theia/pull/10899 which already implements support for markdown tooltips in our tree-views.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following plugin [custom-view-samples-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/9551297/custom-view-samples-0.0.1.vsix.zip).
2. start the application using `theia` as a workspace.
3. open a `package.json` - we want to test with the `json outline view`.
4. in the explorer, expand the `json outline view`.
5. hover over items - a markdown tooltip should display with the icon rendered

![Screen Shot 2022-09-12 at 3 47 37 PM](https://user-images.githubusercontent.com/40359487/189742468-7fb8d495-a1c5-4d48-bd8d-d0f827c4d073.png)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>