### PR TITLE
vscode: fix partial support in `theia.d.ts`

### DIFF
--- a/packages/plugin-ext/src/plugin/webview-views.ts
+++ b/packages/plugin-ext/src/plugin/webview-views.ts
@@ -94,7 +94,7 @@ export class WebviewViewsExtImpl implements WebviewViewsExt {
     ): Promise<void> {
         const webviewView = this.getWebviewView(handle);
         webviewView.setVisible(visible);
-        webviewView.onDidChangeVisibilityEmitter.fire(visible);
+        webviewView.onDidChangeVisibilityEmitter.fire();
     }
 
     async $disposeWebviewView(handle: string): Promise<void> {
@@ -117,7 +117,7 @@ export class WebviewViewsExtImpl implements WebviewViewsExt {
 
 export class WebviewViewExtImpl implements theia.WebviewView {
 
-    readonly onDidChangeVisibilityEmitter = new Emitter<boolean>();
+    readonly onDidChangeVisibilityEmitter = new Emitter<void>();
     readonly onDidChangeVisibility = this.onDidChangeVisibilityEmitter.event;
 
     readonly onDidDisposeEmitter = new Emitter<void>();
@@ -196,7 +196,7 @@ export class WebviewViewExtImpl implements theia.WebviewView {
         }
 
         this._isVisible = visible;
-        this.onDidChangeVisibilityEmitter.fire(this._isVisible);
+        this.onDidChangeVisibilityEmitter.fire();
     }
 
     show(preserveFocus?: boolean): void {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -227,7 +227,12 @@ export module '@theia/plugin' {
     }
 
     /**
-     * Represents a line and character position.
+     * Represents a line and character position, such as
+     * the position of the cursor.
+     *
+     * Position objects are __immutable__. Use the {@link Position.with with} or
+     * {@link Position.translate translate} methods to derive new positions
+     * from an existing position.
      */
     export class Position {
 
@@ -241,6 +246,10 @@ export module '@theia/plugin' {
          */
         readonly character: number;
 
+        /**
+         * @param line A zero-based line value.
+         * @param character A zero-based character value.
+         */
         constructor(line: number, character: number);
 
         /**
@@ -410,15 +419,21 @@ export module '@theia/plugin' {
         /**
          * Derived a new range from this range.
          *
-         * @param start
-         * @param end
+         * @param start A position that should be used as start. The default value is the {@link Range.start current start}.
+         * @param end A position that should be used as end. The default value is the {@link Range.end current end}.
+         * @return A range derived from this range with the given start and end position.
+         * If start and end are not different `this` range will be returned.
          */
         with(start?: Position, end?: Position): Range;
 
         /**
          * Derived a new range from this range.
+         *
+         * @param change An object that describes a change to this range.
+         * @return A range that reflects the given change. Will return `this` range if the change
+         * is not changing anything.
          */
-        with(change: { start?: Position, end?: Position }): Range;
+        with(change: { start?: Position; end?: Position }): Range;
     }
 
     /**
@@ -4367,7 +4382,7 @@ export module '@theia/plugin' {
          *
          * Note that hiding a view using the context menu instead disposes of the view and fires `onDidDispose`.
          */
-        readonly onDidChangeVisibility: Event<boolean>;
+        readonly onDidChangeVisibility: Event<void>;
 
         /**
          * Reveal the view in the UI.
@@ -4605,7 +4620,7 @@ export module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showInformationMessage(message: string, ...items: string[]): Thenable<string | undefined>;
+        export function showInformationMessage<T extends string>(message: string, ...items: T[]): Thenable<T | undefined>;
 
         /**
          * Show an information message.
@@ -4615,7 +4630,7 @@ export module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showInformationMessage(message: string, options: MessageOptions, ...items: string[]): Thenable<string | undefined>;
+        export function showInformationMessage<T extends string>(message: string, options: MessageOptions, ...items: T[]): Thenable<T | undefined>;
 
         /**
          * Show an information message.
@@ -4643,7 +4658,7 @@ export module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showWarningMessage(message: string, ...items: string[]): Thenable<string | undefined>;
+        export function showWarningMessage<T extends string>(message: string, ...items: T[]): Thenable<T | undefined>;
 
         /**
          * Show a warning message.
@@ -4653,7 +4668,7 @@ export module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showWarningMessage(message: string, options: MessageOptions, ...items: string[]): Thenable<string | undefined>;
+        export function showWarningMessage<T extends string>(message: string, options: MessageOptions, ...items: T[]): Thenable<T | undefined>;
 
         /**
          * Show a warning message.
@@ -4681,7 +4696,7 @@ export module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showErrorMessage(message: string, ...items: string[]): Thenable<string | undefined>;
+        export function showErrorMessage<T extends string>(message: string, ...items: T[]): Thenable<T | undefined>;
 
         /**
          * Show an error message.
@@ -4691,7 +4706,7 @@ export module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showErrorMessage(message: string, options: MessageOptions, ...items: string[]): Thenable<string | undefined>;
+        export function showErrorMessage<T extends string>(message: string, options: MessageOptions, ...items: T[]): Thenable<T | undefined>;
 
         /**
          * Show an error message.
@@ -8354,7 +8369,7 @@ export module '@theia/plugin' {
          * @return An array of commands, quick fixes, or refactorings or a thenable of such. The lack of a result can be
          * signaled by returning `undefined`, `null`, or an empty array.
          */
-        provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken | undefined): ProviderResult<(Command | T)[]>;
+        provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken): ProviderResult<(Command | T)[]>;
 
         /**
          * Given a code action fill in its `edit`-property. Changes to
@@ -8370,7 +8385,7 @@ export module '@theia/plugin' {
          * @return The resolved code action or a thenable that resolves to such. It is OK to return the given
          * `item`. When no result is returned, the given `item` will be used.
          */
-        resolveCodeAction?(codeAction: T, token: CancellationToken | undefined): ProviderResult<T>;
+        resolveCodeAction?(codeAction: T, token: CancellationToken): ProviderResult<T>;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request fixes some incompatibilities with `theia.d.ts` compared to it's vscode counterpart. The commit mainly fixes some `partial` support for APIs.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

There should be no change in functionality, you can confirm the comparator reports `supported` for the updated APIs.

1. clone https://github.com/eclipse-theia/vscode-theia-comparator
2. `yarn`
3. `yarn run generate theia-path={path to your theia}`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>