### PR TITLE
Support RelativePattern.baseUri

### DIFF
--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -967,7 +967,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
                 pattern = filter.pattern;
             } else if (filter.pattern) {
                 pattern = {
-                    base: MonacoPath.normalize(filter.pattern.base),
+                    base: MonacoPath.normalize(filter.pattern.baseUri.toString()),
                     pattern: filter.pattern.pattern,
                     pathToRelative: relative
                 };

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -233,7 +233,7 @@ export function fromGlobPattern(pattern: theia.GlobPattern): string | RelativePa
     }
 
     if (isRelativePattern(pattern)) {
-        return new types.RelativePattern(pattern.base, pattern.pattern);
+        return new types.RelativePattern(pattern.baseUri, pattern.pattern);
     }
 
     return pattern;
@@ -241,7 +241,7 @@ export function fromGlobPattern(pattern: theia.GlobPattern): string | RelativePa
 
 function isRelativePattern(obj: {}): obj is theia.RelativePattern {
     const rp = obj as theia.RelativePattern;
-    return rp && typeof rp.base === 'string' && typeof rp.pattern === 'string';
+    return rp && typeof rp.baseUri === 'string' && typeof rp.pattern === 'string';
 }
 
 export function fromCompletionItemKind(kind?: types.CompletionItemKind): model.CompletionItemKind {

--- a/packages/plugin-ext/src/plugin/types-impl.spec.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.spec.ts
@@ -66,4 +66,20 @@ describe('API Type Implementations:', () => {
                 'myScheme://authority/path/file.js?query#fragment');
         });
     });
+
+    describe('RelativePattern:', () => {
+        it('should update .base when setting .baseUri', () => {
+            const testUri = types.URI.file('/expected/file/path');
+            const rPattern = new types.RelativePattern('/initial/unrelated/path', 'not relevant');
+            rPattern.baseUri = testUri;
+            assert.strictEqual(rPattern.base, testUri.fsPath);
+        });
+
+        it('should update .baseUri when setting .base', () => {
+            const testUri = types.URI.file('/expected/file/path');
+            const rPattern = new types.RelativePattern('/initial/unrelated/path', 'not relevant');
+            rPattern.base = testUri.fsPath;
+            assert.strictEqual(rPattern.baseUri.toString(), testUri.toString());
+        });
+    });
 });

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -792,9 +792,18 @@ export class RelativePattern {
 
     base: string;
 
-    constructor(base: theia.WorkspaceFolder | string, public pattern: string) {
+    private _baseUri!: URI;
+    get baseUri(): URI {
+        return this._baseUri;
+    }
+    set baseUri(baseUri: URI) {
+        this._baseUri = baseUri;
+        this.base = baseUri.fsPath;
+    }
+
+    constructor(base: theia.WorkspaceFolder | URI | string, public pattern: string) {
         if (typeof base !== 'string') {
-            if (!base || !URI.isUri(base.uri)) {
+            if (!base || !URI.isUri(base) && !URI.isUri(base.uri)) {
                 throw illegalArgument('base');
             }
         }
@@ -803,7 +812,15 @@ export class RelativePattern {
             throw illegalArgument('pattern');
         }
 
-        this.base = typeof base === 'string' ? base : base.uri.fsPath;
+        if (typeof base === 'string') {
+            this.baseUri = URI.file(base);
+        } else if (URI.isUri(base)) {
+            this.baseUri = base;
+        } else {
+            this.baseUri = base.uri;
+        }
+
+        this.base = typeof base === 'string' ? base : this.baseUri.fsPath;
     }
 
     pathToRelative(from: string, to: string): string {

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -790,7 +790,14 @@ export enum ConfigurationTarget {
 @es5ClassCompat
 export class RelativePattern {
 
-    base: string;
+    private _base!: string;
+    get base(): string {
+        return this._base;
+    }
+    set base(base: string) {
+        this._base = base;
+        this._baseUri = URI.file(base);
+    }
 
     private _baseUri!: URI;
     get baseUri(): URI {
@@ -819,8 +826,6 @@ export class RelativePattern {
         } else {
             this.baseUri = base.uri;
         }
-
-        this.base = typeof base === 'string' ? base : this.baseUri.fsPath;
     }
 
     pathToRelative(from: string, to: string): string {

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -180,7 +180,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
                 includePattern = include;
             } else {
                 includePattern = include.pattern;
-                includeFolderUri = URI.file(include.base).toString();
+                includeFolderUri = include.baseUri.toString();
             }
         } else {
             includePattern = '';

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6705,6 +6705,18 @@ export module '@theia/plugin' {
         /**
          * A base file path to which this pattern will be matched against relatively.
          */
+        baseUri: Uri;
+
+        /**
+         * A base file path to which this pattern will be matched against relatively.
+         *
+         * This matches the `fsPath` value of {@link RelativePattern.baseUri}.
+         *
+         * *Note:* updating this value will update {@link RelativePattern.baseUri} to
+         * be a uri with `file` scheme.
+         *
+         * @deprecated This property is deprecated, please use {@link RelativePattern.baseUri} instead.
+         */
         base: string;
 
         /**
@@ -6724,7 +6736,7 @@ export module '@theia/plugin' {
          * @param pattern A file glob pattern like `*.{ts,js}` that will be matched on file paths
          * relative to the base path.
          */
-        constructor(base: WorkspaceFolder | string, pattern: string)
+        constructor(base: WorkspaceFolder | Uri | string, pattern: string)
     }
 
     /**


### PR DESCRIPTION

#### What it does

This commit updates the signature of RelativePattern and adds the baseUri field while keeping its value in sync with the deprecated base field (as well as the other way around), see the newly added tests.

Closes #11518

#### How to test
1. Include the following extension ([relative-pattern-0.0.2.vsix.zip](https://github.com/eclipse-theia/theia/files/9576804/relative-pattern-0.0.2.vsix.zip) ) in your application.
2. Execute the commands "RelativePattern: Base Uri", "RelativePattern: Base", "RelativePattern: Workspace Uri" and "RelativePattern: Workspace Folder".
3. The extension will spawn a notification message with and the number of found files matching.

Nb. To validate that Base and Base Uri are of same value, a unit test was added.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
