### PR TITLE
markers: update problem decorations

### DIFF
--- a/packages/markers/src/browser/problem/problem-utils.ts
+++ b/packages/markers/src/browser/problem/problem-utils.ts
@@ -78,14 +78,13 @@ export namespace ProblemUtils {
         switch (severity) {
             case DiagnosticSeverity.Error: return 'list.errorForeground';
             case DiagnosticSeverity.Warning: return 'list.warningForeground';
-            default: return 'successBackground';
+            default: return ''; // other severities should not be decorated.
         }
     }
 
     export function filterMarker(marker: Marker<Diagnostic>): boolean {
         const { severity } = marker.data;
         return severity === DiagnosticSeverity.Error
-            || severity === DiagnosticSeverity.Warning
-            || severity === DiagnosticSeverity.Information;
+            || severity === DiagnosticSeverity.Warning;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates our marker decorations for trees (most notably the navigator) to only render decorations for diagnostics with `error` or `warning` severity.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test plugin: [code-actions-sample-0.0.2.vsix.zip](https://github.com/eclipse-theia/theia/files/9579283/code-actions-sample-0.0.2.vsix.zip).
2. create a workspace folder that is not under version control (so we do not get git decorations).
3. create a file in that folder
4. use the created folder as the workspace
5. in the file, type:

    ```
    1
    2
    3
    4
    ```
6. each line in the file should produce a different severity diagnostic in the `problems` view:

![Screen Shot 2022-09-15 at 6 00 16 PM](https://user-images.githubusercontent.com/40359487/190516375-4fc57a97-6d30-49ac-b214-6671606b86f9.png)
7. confirm the navigator has an `error` decoration for the file.
8. delete line `1` - confirm the navigator has a `warning` decoration for the file.
9. delete line `2` - confirm the navigator has no decorations for the file since there is none left that have a high enough severity.

![Screen Shot 2022-09-15 at 6 02 28 PM](https://user-images.githubusercontent.com/40359487/190516657-bc82ba9b-bf43-47e4-8163-f8864b0e243b.png)



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>