### PR TITLE
git: re-add support for git decoration preferences

### DIFF
--- a/packages/git/src/browser/git-decoration-provider.ts
+++ b/packages/git/src/browser/git-decoration-provider.ts
@@ -14,46 +14,66 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { GitFileChange, GitFileStatus, GitStatusChangeEvent } from '../common';
 import { CancellationToken, Emitter, Event } from '@theia/core/lib/common';
 import { Decoration, DecorationsProvider } from '@theia/core/lib/browser/decorations-service';
 import { GitRepositoryTracker } from './git-repository-tracker';
 import URI from '@theia/core/lib/common/uri';
+import { GitConfiguration, GitPreferences } from './git-preferences';
+import { PreferenceChangeEvent } from '@theia/core/lib/browser';
 
 @injectable()
 export class GitDecorationProvider implements DecorationsProvider {
 
+    @inject(GitPreferences) protected readonly preferences: GitPreferences;
+    @inject(GitRepositoryTracker) protected readonly gitRepositoryTracker: GitRepositoryTracker;
+
+    protected decorationsEnabled: boolean;
+    protected colorsEnabled: boolean;
+
+    protected decorations = new Map<string, Decoration>();
+    protected uris: Set<string> = new Set<string>();
+
+    /**
+     * Cached change event for re-rendering decorations.
+     */
+    protected changeEvent: GitStatusChangeEvent | undefined;
+
     private readonly onDidChangeDecorationsEmitter = new Emitter<URI[]>();
     readonly onDidChange: Event<URI[]> = this.onDidChangeDecorationsEmitter.event;
 
-    private decorations = new Map<string, Decoration>();
-
-    constructor(@inject(GitRepositoryTracker) protected readonly gitRepositoryTracker: GitRepositoryTracker) {
-        this.gitRepositoryTracker.onGitEvent((event: GitStatusChangeEvent | undefined) => {
-            this.onGitEvent(event);
-        });
+    @postConstruct()
+    protected init(): void {
+        this.decorationsEnabled = this.preferences['git.decorations.enabled'];
+        this.colorsEnabled = this.preferences['git.decorations.colors'];
+        this.gitRepositoryTracker.onGitEvent((event: GitStatusChangeEvent | undefined) => this.handleGitEvent(event));
+        this.preferences.onPreferenceChanged(event => this.handlePreferenceChange(event));
     }
 
-    private async onGitEvent(event: GitStatusChangeEvent | undefined): Promise<void> {
-        if (!event) {
+    protected async handleGitEvent(event: GitStatusChangeEvent | undefined): Promise<void> {
+        this.changeEvent = event;
+        this.updateDecorations();
+    }
+
+    protected updateDecorations(): void {
+        if (!this.changeEvent) {
             return;
         }
-
         const newDecorations = new Map<string, Decoration>();
-        this.collectDecorationData(event.status.changes, newDecorations);
+        this.collectDecorationData(this.changeEvent.status.changes, newDecorations);
 
-        const uris = new Set([...this.decorations.keys()].concat([...newDecorations.keys()]));
+        this.uris = new Set([...this.decorations.keys()].concat([...newDecorations.keys()]));
         this.decorations = newDecorations;
-        this.onDidChangeDecorationsEmitter.fire(Array.from(uris, value => new URI(value)));
+        this.triggerDecorationChange();
     }
 
-    private collectDecorationData(changes: GitFileChange[], bucket: Map<string, Decoration>): void {
+    protected collectDecorationData(changes: GitFileChange[], bucket: Map<string, Decoration>): void {
         changes.forEach(change => {
             const color = GitFileStatus.getColor(change.status, change.staged);
             bucket.set(change.uri, {
                 bubble: true,
-                colorId: color.substring(12, color.length - 1).replace(/-/g, '.'),
+                colorId: this.colorsEnabled ? color.substring(12, color.length - 1).replace(/-/g, '.') : undefined,
                 tooltip: GitFileStatus.toString(change.status),
                 letter: GitFileStatus.toAbbreviation(change.status, change.staged)
             });
@@ -61,7 +81,36 @@ export class GitDecorationProvider implements DecorationsProvider {
     }
 
     provideDecorations(uri: URI, token: CancellationToken): Decoration | Promise<Decoration | undefined> | undefined {
-        return this.decorations.get(uri.toString());
+        if (this.decorationsEnabled) {
+            return this.decorations.get(uri.toString());
+        }
     }
+
+    protected handlePreferenceChange(event: PreferenceChangeEvent<GitConfiguration>): void {
+        const { preferenceName, newValue } = event;
+        if (preferenceName === 'git.decorations.enabled' || preferenceName === 'git.decorations.colors') {
+            if (preferenceName === 'git.decorations.enabled') {
+                const decorationsEnabled = !!newValue;
+                if (this.decorationsEnabled !== decorationsEnabled) {
+                    this.decorationsEnabled = decorationsEnabled;
+                }
+            }
+            if (preferenceName === 'git.decorations.colors') {
+                const colorsEnabled = !!newValue;
+                if (this.colorsEnabled !== colorsEnabled) {
+                    this.colorsEnabled = colorsEnabled;
+                }
+            }
+            this.updateDecorations();
+        }
+    }
+
+    /**
+     * Notify that the provider has been updated to trigger a re-render of decorations.
+     */
+    protected triggerDecorationChange(): void {
+        this.onDidChangeDecorationsEmitter.fire(Array.from(this.uris, value => new URI(value)));
+    }
+
 }
 

--- a/packages/git/src/browser/git-preferences.ts
+++ b/packages/git/src/browser/git-preferences.ts
@@ -31,7 +31,7 @@ export const GitConfigSchema: PreferenceSchema = {
         'git.decorations.colors': {
             'type': 'boolean',
             'description': nls.localize('theia/git/gitDecorationsColors', 'Use color decoration in the navigator.'),
-            'default': false
+            'default': true
         },
         'git.editor.decorations.enabled': {
             'type': 'boolean',


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request re-adds support for `git.decorations.enabled` and `git.decorations.colors` which were previously not referenced and supported after a change in https://github.com/eclipse-theia/theia/pull/8911 (v1.14.0).

https://user-images.githubusercontent.com/40359487/190656031-c124f559-ca5d-4e43-b052-32005dc0a11f.mov

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with a workspace that is under version control
2. perform some changes in the workspace, (create new files, modifications, deletions)
3. open the preferences-view
4. search for `git decorations`
5. confirm that toggling `git.decorations.enabled` hides/shows decorations in the navigator for the resources
6. confirm that toggling `git.decorations.colors` hides/displays colors for the decorations in the navigator for the resources
7. confirm the preferences are respected on startup

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>