### PR TITLE
Improve theme preference selection

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -152,11 +152,15 @@ export const corePreferenceSchema: PreferenceSchema = {
         },
         'workbench.colorTheme': {
             type: 'string',
+            enum: ['dark', 'light', 'hc-theia'],
+            enumItemLabels: ['Dark (Theia)', 'Light (Theia)', 'High Contrast (Theia)'],
             default: DefaultTheme.defaultForOSTheme(FrontendApplicationConfigProvider.get().defaultTheme),
             description: nls.localizeByDefault('Specifies the color theme used in the workbench.')
         },
         'workbench.iconTheme': {
-            type: ['string', 'null'],
+            type: ['string'],
+            enum: ['none', 'theia-file-icons'],
+            enumItemLabels: [nls.localizeByDefault('None'), 'File Icons (Theia)'],
             default: FrontendApplicationConfigProvider.get().defaultIconTheme,
             description: nls.localizeByDefault("Specifies the file icon theme used in the workbench or 'null' to not show any file icons.")
         },
@@ -220,7 +224,7 @@ export interface CoreConfiguration {
     'workbench.editor.mouseBackForwardToNavigate': boolean;
     'workbench.editor.closeOnFileDelete': boolean;
     'workbench.colorTheme': string;
-    'workbench.iconTheme': string | null;
+    'workbench.iconTheme': string;
     'workbench.silentNotifications': boolean;
     'workbench.statusBar.visible': boolean;
     'workbench.tree.renderIndentGuides': 'onHover' | 'none' | 'always';

--- a/packages/core/src/browser/icon-theme-service.ts
+++ b/packages/core/src/browser/icon-theme-service.ts
@@ -19,7 +19,8 @@ import { Emitter } from '../common/event';
 import { Disposable, DisposableCollection } from '../common/disposable';
 import { LabelProviderContribution, DidChangeLabelEvent } from './label-provider';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
-import { PreferenceService } from './preferences';
+import { PreferenceService, PreferenceSchemaProvider } from './preferences';
+import debounce = require('lodash.debounce');
 
 const ICON_THEME_PREFERENCE_KEY = 'workbench.iconTheme';
 
@@ -95,6 +96,7 @@ export class IconThemeService {
 
     @inject(NoneIconTheme) protected readonly noneIconTheme: NoneIconTheme;
     @inject(PreferenceService) protected readonly preferences: PreferenceService;
+    @inject(PreferenceSchemaProvider) protected readonly schemaProvider: PreferenceSchemaProvider;
 
     protected readonly onDidChangeCurrentEmitter = new Emitter<string>();
     readonly onDidChangeCurrent = this.onDidChangeCurrentEmitter.event;
@@ -109,6 +111,7 @@ export class IconThemeService {
         this.setCurrent(this.fallback, false);
         this.preferences.ready.then(() => {
             this.validateActiveTheme();
+            this.updateIconThemePreference();
             this.preferences.onPreferencesChanged(changes => {
                 if (ICON_THEME_PREFERENCE_KEY in changes) {
                     this.validateActiveTheme();
@@ -125,7 +128,11 @@ export class IconThemeService {
         this._iconThemes.set(iconTheme.id, iconTheme);
         this.onDidChangeEmitter.fire(undefined);
         this.validateActiveTheme();
-        return Disposable.create(() => this.unregister(iconTheme.id));
+        this.updateIconThemePreference();
+        return Disposable.create(() => {
+            this.unregister(iconTheme.id);
+            this.updateIconThemePreference();
+        });
     }
 
     unregister(id: string): IconTheme | undefined {
@@ -183,6 +190,17 @@ export class IconThemeService {
                 this.setCurrent(configured, false);
             }
         }
+    }
+
+    protected updateIconThemePreference = debounce(() => this.doUpdateIconThemePreference(), 500);
+
+    protected doUpdateIconThemePreference(): void {
+        const existingSchema = this.schemaProvider.getCombinedSchema();
+        const preference = existingSchema.properties[ICON_THEME_PREFERENCE_KEY];
+        const sortedThemes = Array.from(this.definitions).sort((a, b) => a.label.localeCompare(b.label));
+        preference.enum = sortedThemes.map(e => e.id);
+        preference.enumItemLabels = sortedThemes.map(e => e.label);
+        this.schemaProvider.updateSchemaProperty(ICON_THEME_PREFERENCE_KEY, preference);
     }
 
     get default(): IconTheme {

--- a/packages/core/src/browser/icon-theme-service.ts
+++ b/packages/core/src/browser/icon-theme-service.ts
@@ -195,12 +195,13 @@ export class IconThemeService {
     protected updateIconThemePreference = debounce(() => this.doUpdateIconThemePreference(), 500);
 
     protected doUpdateIconThemePreference(): void {
-        const existingSchema = this.schemaProvider.getCombinedSchema();
-        const preference = existingSchema.properties[ICON_THEME_PREFERENCE_KEY];
-        const sortedThemes = Array.from(this.definitions).sort((a, b) => a.label.localeCompare(b.label));
-        preference.enum = sortedThemes.map(e => e.id);
-        preference.enumItemLabels = sortedThemes.map(e => e.label);
-        this.schemaProvider.updateSchemaProperty(ICON_THEME_PREFERENCE_KEY, preference);
+        const preference = this.schemaProvider.getSchemaProperty(ICON_THEME_PREFERENCE_KEY);
+        if (preference) {
+            const sortedThemes = Array.from(this.definitions).sort((a, b) => a.label.localeCompare(b.label));
+            preference.enum = sortedThemes.map(e => e.id);
+            preference.enumItemLabels = sortedThemes.map(e => e.label);
+            this.schemaProvider.updateSchemaProperty(ICON_THEME_PREFERENCE_KEY, preference);
+        }
     }
 
     get default(): IconTheme {

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -356,6 +356,15 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
         return [][Symbol.iterator]();
     }
 
+    getSchemaProperty(key: string): PreferenceDataProperty | undefined {
+        return this.combinedSchema.properties[key];
+    }
+
+    updateSchemaProperty(key: string, property: PreferenceDataProperty): void {
+        this.updateSchemaProps(key, property);
+        this.fireDidPreferenceSchemaChanged();
+    }
+
     protected updateSchemaProps(key: string, property: PreferenceDataProperty): void {
         this.combinedSchema.properties[key] = property;
 

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -21,7 +21,8 @@ import { ApplicationProps, DefaultTheme } from '@theia/application-package/lib/a
 import { Theme, ThemeChangeEvent } from '../common/theme';
 import { inject, injectable, postConstruct } from 'inversify';
 import { Deferred } from '../common/promise-util';
-import { PreferenceService } from './preferences';
+import { PreferenceSchemaProvider, PreferenceService } from './preferences';
+import debounce = require('lodash.debounce');
 
 const COLOR_THEME_PREFERENCE_KEY = 'workbench.colorTheme';
 const NO_THEME = { id: 'no-theme', label: 'Not a real theme.', type: 'dark' } as const;
@@ -31,6 +32,7 @@ export class ThemeService {
     static readonly STORAGE_KEY = 'theme';
 
     @inject(PreferenceService) protected readonly preferences: PreferenceService;
+    @inject(PreferenceSchemaProvider) protected readonly schemaProvider: PreferenceSchemaProvider;
 
     protected themes: { [id: string]: Theme } = {};
     protected activeTheme: Theme = NO_THEME;
@@ -48,6 +50,7 @@ export class ThemeService {
         this.loadUserTheme();
         this.preferences.ready.then(() => {
             this.validateActiveTheme();
+            this.updateColorThemePreference();
             this.preferences.onPreferencesChanged(changes => {
                 if (COLOR_THEME_PREFERENCE_KEY in changes) {
                     this.validateActiveTheme();
@@ -61,6 +64,7 @@ export class ThemeService {
             this.themes[theme.id] = theme;
         }
         this.validateActiveTheme();
+        this.updateColorThemePreference();
         return Disposable.create(() => {
             for (const theme of themes) {
                 delete this.themes[theme.id];
@@ -68,6 +72,7 @@ export class ThemeService {
                     this.setCurrentTheme(this.defaultTheme.id, false);
                 }
             }
+            this.updateColorThemePreference();
         });
     }
 
@@ -78,6 +83,17 @@ export class ThemeService {
                 this.setCurrentTheme(configuredTheme.id, false);
             }
         }
+    }
+
+    protected updateColorThemePreference = debounce(() => this.doUpdateColorThemePreference(), 500);
+
+    protected doUpdateColorThemePreference(): void {
+        const existingSchema = this.schemaProvider.getCombinedSchema();
+        const preference = existingSchema.properties[COLOR_THEME_PREFERENCE_KEY];
+        const sortedThemes = this.getThemes().sort((a, b) => a.label.localeCompare(b.label));
+        preference.enum = sortedThemes.map(e => e.id);
+        preference.enumItemLabels = sortedThemes.map(e => e.label);
+        this.schemaProvider.updateSchemaProperty(COLOR_THEME_PREFERENCE_KEY, preference);
     }
 
     getThemes(): Theme[] {

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -88,12 +88,13 @@ export class ThemeService {
     protected updateColorThemePreference = debounce(() => this.doUpdateColorThemePreference(), 500);
 
     protected doUpdateColorThemePreference(): void {
-        const existingSchema = this.schemaProvider.getCombinedSchema();
-        const preference = existingSchema.properties[COLOR_THEME_PREFERENCE_KEY];
-        const sortedThemes = this.getThemes().sort((a, b) => a.label.localeCompare(b.label));
-        preference.enum = sortedThemes.map(e => e.id);
-        preference.enumItemLabels = sortedThemes.map(e => e.label);
-        this.schemaProvider.updateSchemaProperty(COLOR_THEME_PREFERENCE_KEY, preference);
+        const preference = this.schemaProvider.getSchemaProperty(COLOR_THEME_PREFERENCE_KEY);
+        if (preference) {
+            const sortedThemes = this.getThemes().sort((a, b) => a.label.localeCompare(b.label));
+            preference.enum = sortedThemes.map(e => e.id);
+            preference.enumItemLabels = sortedThemes.map(e => e.label);
+            this.schemaProvider.updateSchemaProperty(COLOR_THEME_PREFERENCE_KEY, preference);
+        }
     }
 
     getThemes(): Theme[] {

--- a/packages/core/src/common/json-schema.ts
+++ b/packages/core/src/common/json-schema.ts
@@ -85,6 +85,7 @@ export interface IJSONSchema {
     errorMessage?: string; // VSCode extension
     patternErrorMessage?: string; // VSCode extension
     deprecationMessage?: string; // VSCode extension
+    enumItemLabels?: string[]; // VSCode extension
     enumDescriptions?: string[]; // VSCode extension
     markdownEnumDescriptions?: string[]; // VSCode extension
     markdownDescription?: string; // VSCode extension

--- a/packages/preferences/src/browser/views/components/preference-select-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-select-input.ts
@@ -37,15 +37,16 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
     protected get selectOptions(): SelectOption[] {
         const items: SelectOption[] = [];
         const values = this.enumValues;
-        const defaultValue = this.preferenceNode.preference.data.default;
+        const preferenceData = this.preferenceNode.preference.data;
+        const defaultValue = preferenceData.default;
         for (let i = 0; i < values.length; i++) {
             const value = values[i];
             const stringValue = `${value}`;
-            const label = escapeInvisibleChars(stringValue);
+            const label = escapeInvisibleChars(preferenceData.enumItemLabels?.[i] ?? stringValue);
             const detail = PreferenceProvider.deepEqual(defaultValue, value) ? 'default' : undefined;
-            let enumDescription = this.preferenceNode.preference.data.enumDescriptions?.[i];
+            let enumDescription = preferenceData.enumDescriptions?.[i];
             let markdown = false;
-            const markdownEnumDescription = this.preferenceNode.preference.data.markdownEnumDescriptions?.[i];
+            const markdownEnumDescription = preferenceData.markdownEnumDescriptions?.[i];
             if (markdownEnumDescription) {
                 enumDescription = this.markdownRenderer.renderInline(markdownEnumDescription);
                 markdown = true;


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11672

Changes the preferences for color theme and icon theme to use an enum. In order to facilitate label displaying and changing the associated preference schemas during runtime some more changes had to be performed:

1. Support for `enumItemLabels` in `PreferenceSelectInput`
2. Add `updateSchemaProperty` method to `PreferenceSchemaProvider` that triggers the associated change event.
3. Creating and storing keys for each preference while rendering. Allows us to identify which preferences have changed. The previous method only could tell whether a preference was removed/added.

#### How to test

1. Open the preferences and search for the file/color theme preference
2. It should be a select component and display all currently displayed themes
3. Changing to another file/color theme applies the change as expected
4. Installing a new file/color theme using plugins updates the preference widget and allows to select the newly installed theme

Note that uninstalling color themes doesn't work correctly due to https://github.com/eclipse-theia/theia/issues/11676.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
