### PR TITLE
Update typing TreeDataProvider.onDidChangeTreeData

### DIFF
--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -192,7 +192,7 @@ class TreeViewExtImpl<T> implements Disposable {
         this.toDispose.push(Disposable.create(() => this.proxy.$unregisterTreeDataProvider(treeViewId)));
 
         if (treeDataProvider.onDidChangeTreeData) {
-            treeDataProvider.onDidChangeTreeData((e: T) => {
+            treeDataProvider.onDidChangeTreeData(() => {
                 this.pendingRefresh = proxy.$refresh(treeViewId);
             });
         }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5441,7 +5441,7 @@ export module '@theia/plugin' {
          * This will trigger the view to update the changed element/root and its children recursively (if shown).
          * To signal that root has changed, do not pass any argument or pass `undefined` or `null`.
          */
-        onDidChangeTreeData?: Event<T | undefined | null>;
+        onDidChangeTreeData?: Event<T | T[] | undefined | null | void>;
 
         /**
          * Get {@link TreeItem TreeItem} representation of the `element`


### PR DESCRIPTION
#### What it does
Aligned the typing of TreeDataProvider.onDidChangeTreeData with the VScode API.
closes #11664

#### How to test

CI should pass.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
