### PR TITLE
core: fix `about` dialog

### DIFF
--- a/packages/core/src/browser/dialogs/react-dialog.tsx
+++ b/packages/core/src/browser/dialogs/react-dialog.tsx
@@ -24,18 +24,26 @@ import { createRoot, Root } from 'react-dom/client';
 @injectable()
 export abstract class ReactDialog<T> extends AbstractDialog<T> {
     protected contentNodeRoot: Root;
+    protected isMounted: boolean;
 
     constructor(
         @inject(DialogProps) props: DialogProps
     ) {
         super(props);
         this.contentNodeRoot = createRoot(this.contentNode);
-        this.toDispose.push(Disposable.create(() => this.contentNodeRoot.unmount()));
+        this.isMounted = true;
+        this.toDispose.push(Disposable.create(() => {
+            this.contentNodeRoot.unmount();
+            this.isMounted = false;
+        }));
     }
 
     protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
-        this.contentNodeRoot.render(<>{this.render()}</>);
+        if (!this.isMounted) {
+            this.contentNodeRoot = createRoot(this.contentNode);
+        }
+        this.contentNodeRoot?.render(<>{this.render()}</>);
     }
 
     /**

--- a/packages/core/src/browser/style/about.css
+++ b/packages/core/src/browser/style/about.css
@@ -14,14 +14,23 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
- ul.theia-aboutDialog {
+.theia-aboutDialog .about-details {
+    padding-left: 10px;
+}
+
+.theia-aboutDialog .about-details a {
+    cursor: pointer;
+}
+
+ul.theia-aboutDialog {
     flex: 1 100%;
     padding-bottom: calc(var(--theia-ui-padding) * 3);
- }
- ul.theia-aboutExtensions {
+}
+
+ul.theia-aboutExtensions {
     height: 200px;
     overflow: hidden;
     overflow-y: scroll;
     list-style-type: none;
     padding: 0;
- }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11669.

The pull-request fixes an issue where singleton react-dialogs cannot be updated after they have been closed since they are unmounted. The dialogs are mounted (constructor) and unmounted when closed but this poses a problem for singletons, where even if closed can be re-opened. The change ensures that if a react-dialog receives an update request we confirm that the dialog is first mounted, and if not, we mount it.

I included a secondary commit which enhances the `about` dialog and includes some additional information:

![Screen Shot 2022-09-22 at 9 17 31 AM](https://user-images.githubusercontent.com/40359487/191759133-c88b263b-1351-44ba-ac9d-3b4060411bf2.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open the about dialog - `help` > `about`
3. close the dialog with <kbd>esc</kbd> or clicking the `x`
4. re-open the about dialog - `help` > `about`
5. confirm the dialog is re-opened and the content is correct

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>