### PR TITLE
[electron]: Listen on keyboard layout changes in electron app

### DIFF
--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -27,6 +27,7 @@ import { ElectronMessagingService } from './messaging/electron-messaging-service
 import { ElectronConnectionHandler } from '../electron-common/messaging/electron-connection-handler';
 import { ElectronSecurityTokenService } from './electron-security-token-service';
 import { TheiaBrowserWindowOptions, TheiaElectronWindow, TheiaElectronWindowFactory, WindowApplicationConfig } from './theia-electron-window';
+import { ElectronNativeKeymap } from './electron-native-keymap';
 
 const electronSecurityToken: ElectronSecurityToken = { value: v4() };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,4 +60,7 @@ export default new ContainerModule(bind => {
         child.bind(WindowApplicationConfig).toConstantValue(config);
         return child.get(TheiaElectronWindow);
     });
+
+    bind(ElectronNativeKeymap).toSelf().inSingletonScope();
+    bind(ElectronMainApplicationContribution).toService(ElectronNativeKeymap);
 });


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

From now on, the electron main sends an event to the frontend via IPC (`'keyboardLayoutChanged'`) if the OS layout changes.

Closes #11688

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

I did the following (on macOS):
 - build and start the electron example in debug mode,
 - add a breakpoint to [here](https://github.com/eclipse-theia/theia/blob/f4a536f445b550e5ca7b803c3a73bd6eebffb335/packages/core/src/electron-main/electron-native-keymap.ts#L30) and [here](https://github.com/eclipse-theia/theia/blob/f4a536f445b550e5ca7b803c3a73bd6eebffb335/packages/core/src/browser/keyboard/keyboard-layout-service.ts#L54) and change your OS layout,
 - you will hit both breakpoints.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
