### PR TITLE
Added CodeActionTriggerKind

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -356,8 +356,14 @@ export interface CodeAction {
     isPreferred?: boolean;
 }
 
+export enum CodeActionTriggerKind {
+    Invoke = 1,
+    Automatic = 2,
+}
+
 export interface CodeActionContext {
     only?: string;
+    trigger: CodeActionTriggerKind
 }
 
 export type CodeActionProviderDocumentation = ReadonlyArray<{ command: Command, kind: string }>;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -784,6 +784,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         token: monaco.CancellationToken): Promise<monaco.languages.CodeActionList | monaco.languages.CodeActionList> {
         const actions = await this.proxy.$provideCodeActions(handle, model.uri, rangeOrSelection, {
             ...context,
+            // @monaco-uplift
             // the current version of monaco.languages.CodeActionContext has no CodeActionTriggerKind
             trigger: CodeActionTriggerKind.Automatic
         }, token);

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -69,6 +69,7 @@ import { LanguageSelector, RelativePattern } from '@theia/editor/lib/common/lang
 import { ILanguageFeaturesService } from '@theia/monaco-editor-core/esm/vs/editor/common/services/languageFeatures';
 import { EvaluatableExpression, EvaluatableExpressionProvider } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
 import { ITextModel } from '@theia/monaco-editor-core/esm/vs/editor/common/model';
+import { CodeActionTriggerKind } from '../../plugin/types-impl';
 
 /**
  * @monaco-uplift The public API declares these functions as (languageId: string, service).
@@ -782,7 +783,9 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         rangeOrSelection: Range, context: monaco.languages.CodeActionContext,
         token: monaco.CancellationToken): Promise<monaco.languages.CodeActionList | monaco.languages.CodeActionList> {
         const actions = await this.proxy.$provideCodeActions(handle, model.uri, rangeOrSelection, {
-            ...context
+            ...context,
+            // the current version of monaco.languages.CodeActionContext has no CodeActionTriggerKind
+            trigger: CodeActionTriggerKind.Automatic
         }, token);
         if (!actions) {
             return undefined!;

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -61,7 +61,8 @@ export class CodeActionAdapter {
 
         const codeActionContext: theia.CodeActionContext = {
             diagnostics: allDiagnostics,
-            only: context.only ? new CodeActionKind(context.only) : undefined
+            only: context.only ? new CodeActionKind(context.only) : undefined,
+            triggerKind: Converter.toCodeActionTriggerKind(context.trigger)
         };
 
         const commandsOrActions = await this.provider.provideCodeActions(doc, ran, codeActionContext, token);

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -584,6 +584,16 @@ export namespace SymbolKind {
     }
 }
 
+export function toCodeActionTriggerKind(triggerKind: model.CodeActionTriggerKind): types.CodeActionTriggerKind  {
+    switch (triggerKind) {
+        case model.CodeActionTriggerKind.Invoke:
+            return types.CodeActionTriggerKind.Invoke;
+
+        case model.CodeActionTriggerKind.Automatic:
+            return types.CodeActionTriggerKind.Automatic;
+    }
+}
+
 export function fromDocumentSymbol(info: theia.DocumentSymbol): model.DocumentSymbol {
     const result: model.DocumentSymbol = {
         name: info.name,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -8606,10 +8606,33 @@ export module '@theia/plugin' {
     }
 
     /**
+     * The reason why code actions were requested.
+     */
+    export enum CodeActionTriggerKind {
+        /**
+         * Code actions were explicitly requested by the user or by an extension.
+         */
+        Invoke = 1,
+
+        /**
+         * Code actions were requested automatically.
+         *
+         * This typically happens when current selection in a file changes, but can
+         * also be triggered when file content changes.
+         */
+        Automatic = 2,
+    }
+
+    /**
      * Contains additional diagnostic information about the context in which
      * a {@link CodeActionProvider.provideCodeActions code action} is run.
      */
     export interface CodeActionContext {
+        /**
+         * The reason why code actions were requested.
+         */
+        readonly triggerKind: CodeActionTriggerKind;
+
         /**
          * An array of diagnostics.
          */


### PR DESCRIPTION
#### What it does
This fixes https://github.com/eclipse-theia/theia/issues/11502
The CodeActiontriggerKind is now present in the CodeActionProvider.

#### How to test
1. Download this little test extension 
[code-action-test-ext-0.0.1.zip](https://github.com/eclipse-theia/theia/files/9632416/code-action-test-ext-0.0.1.zip)
or create it [here](https://github.com/jbicker/code-action-test-extension) 
2. install it in theia and open a Markdown file
3. open CodeActions anywhere

<img width="331" alt="Bildschirmfoto 2022-09-23 um 10 46 52" src="https://user-images.githubusercontent.com/28291421/191931643-f50c11c8-b949-47a6-8858-78866db872d4.png">

The title contains the type of the CodeActionTrigger.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
