### PR TITLE
vscode: add support for `onDidChangeFoldingRanges`

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1578,7 +1578,8 @@ export interface LanguagesMain {
     $emitCodeLensEvent(eventHandle: number, event?: any): void;
     $registerOutlineSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], displayName?: string): void;
     $registerWorkspaceSymbolProvider(handle: number, pluginInfo: PluginInfo): void;
-    $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], eventHandle?: number): void;
+    $emitFoldingRangeEvent(handle: number, event?: any): void;
     $registerSelectionRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveInitialValues: boolean): void;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -678,9 +678,16 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$provideOnTypeFormattingEdits(handle, model.uri, position, ch, options, token);
     }
 
-    $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], eventHandle: number | undefined): void {
         const languageSelector = this.toLanguageSelector(selector);
         const provider = this.createFoldingRangeProvider(handle);
+
+        if (typeof eventHandle === 'number') {
+            const emitter = new Emitter<monaco.languages.FoldingRangeProvider>();
+            this.services.set(eventHandle, emitter);
+            provider.onDidChange = emitter.event;
+        }
+
         this.register(handle, (monaco.languages.registerFoldingRangeProvider as RegistrationFunction<monaco.languages.FoldingRangeProvider>)(languageSelector, provider));
     }
 
@@ -688,6 +695,13 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return {
             provideFoldingRanges: (model, context, token) => this.provideFoldingRanges(handle, model, context, token)
         };
+    }
+
+    $emitFoldingRangeEvent(eventHandle: number, event?: unknown): void {
+        const obj = this.services.get(eventHandle);
+        if (obj instanceof Emitter) {
+            obj.fire(event);
+        }
     }
 
     protected provideFoldingRanges(handle: number, model: monaco.editor.ITextModel,

--- a/packages/plugin-metrics/src/browser/plugin-metrics-languages-main.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-languages-main.ts
@@ -294,9 +294,9 @@ export class LanguagesMainPluginMetrics extends LanguagesMainImpl {
         super.$registerOnTypeFormattingProvider(handle, pluginInfo, selector, autoFormatTriggerCharacters);
     }
 
-    override $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], eventHandle: number): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
-        super.$registerFoldingRangeProvider(handle, pluginInfo, selector);
+        super.$registerFoldingRangeProvider(handle, pluginInfo, selector, eventHandle);
     }
 
     override $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7640,6 +7640,12 @@ export module '@theia/plugin' {
      * [Folding](https://code.visualstudio.com/docs/editor/codebasics#_folding) in the editor.
      */
     export interface FoldingRangeProvider {
+
+        /**
+         * An optional event to signal that the folding ranges from this provider have changed.
+         */
+        onDidChangeFoldingRanges?: Event<void>;
+
         /**
          * Returns a list of folding ranges or null and undefined if the provider
          * does not want to participate or was cancelled.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: https://github.com/eclipse-theia/theia/issues/11127.
Closes: https://github.com/eclipse-theia/theia/pull/11320.

The pull-request adds support for the `FoldingRangeProvider. onDidChangeFoldingRanges` VS Code API.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test plugin ([folding-range-provider-0.0.2.vsix](https://github.com/eclipse-theia/theia/files/9633400/folding-range-provider-0.0.2.vsix.zip))
2. start the application
3. create a file `folding.test` and add multiple lines
4. confirm that no folding ranges are present:
![Screen Shot 2022-09-23 at 8 06 26 AM](https://user-images.githubusercontent.com/40359487/191956640-13ad7dcf-b1ea-4495-b80d-762593f874ad.png)
5. execute the command `Custom Folding Range: Update` - the command triggers the `onDidChangeFoldingRanges` event from the provider signalling that `provideFoldingRanges` should be re-calculated (each call should create a new range)
6. confirm that folding ranges are present:
![Screen Shot 2022-09-23 at 8 08 00 AM](https://user-images.githubusercontent.com/40359487/191956830-9863e1ef-1586-4543-8609-2eaaca127918.png)




#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>