### PR TITLE
Improve editor preference dendrification

### DIFF
--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -134,6 +134,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
             lightbulb: { enabled: true },
             fixedOverflowWidgets: true,
             scrollbar: {
+                ...options?.scrollbar,
                 useShadows: false,
                 verticalHasArrows: false,
                 horizontalHasArrows: false,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11709 by improving the dendrification of preferences - the old code would clobber e.g. `editor.scrollbar.scrollByPage` when it encountered `editor.scrollbar.horizontal` - and passing user values for `editor.scrollbar.*` preferences, along with defaults for internal (not user-accessible) values.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Set the preference `editor.scrollbar.scrollByPage` to `true`. (and set `editor.find.addExtraSpaceOnTop` to `false` and `editor.hover.delay` to something long)
2. Open a big file (I like `common-frontend-contribution.ts`).
3. Click on the scrollbar some distance from its current position.
4. Observe that your preference is respected.
5. Check the other two preference as well.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
