### PR TITLE
Add opaque wrapper for notification items

### DIFF
--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -73,53 +73,55 @@ export class NotificationComponent extends React.Component<NotificationComponent
         const { messageId, message, type, progress, collapsed, expandable, source, actions } = this.props.notification;
         const isProgress = type === 'progress' || typeof progress === 'number';
         const icon = type === 'progress' ? 'info' : type;
-        return (<div key={messageId} className='theia-notification-list-item' tabIndex={0}>
-            <div className={`theia-notification-list-item-content ${collapsed ? 'collapsed' : ''}`}>
-                <div className='theia-notification-list-item-content-main'>
-                    <div className={`theia-notification-icon ${codicon(icon)} ${icon}`} />
-                    <div className='theia-notification-message'>
-                        <span
-                            // eslint-disable-next-line react/no-danger
-                            dangerouslySetInnerHTML={{
-                                __html: DOMPurify.sanitize(message, {
-                                    ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
-                                })
-                            }}
-                            onClick={this.onMessageClick}
-                        />
+        return (<div key={messageId} className='theia-notification-list-item-container'>
+            <div className='theia-notification-list-item' tabIndex={0}>
+                <div className={`theia-notification-list-item-content ${collapsed ? 'collapsed' : ''}`}>
+                    <div className='theia-notification-list-item-content-main'>
+                        <div className={`theia-notification-icon ${codicon(icon)} ${icon}`} />
+                        <div className='theia-notification-message'>
+                            <span
+                                // eslint-disable-next-line react/no-danger
+                                dangerouslySetInnerHTML={{
+                                    __html: DOMPurify.sanitize(message, {
+                                        ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
+                                    })
+                                }}
+                                onClick={this.onMessageClick}
+                            />
+                        </div>
+                        <ul className='theia-notification-actions'>
+                            {expandable && (
+                                <li className={codicon('chevron-down', true) + (collapsed ? ' expand' : ' collapse')} title={collapsed ? 'Expand' : 'Collapse'}
+                                    data-message-id={messageId} onClick={this.onToggleExpansion} />
+                            )}
+                            {!isProgress && (<li className={codicon('close', true)} title={nls.localizeByDefault('Clear')} data-message-id={messageId}
+                                onClick={this.onClear} />)}
+                        </ul>
                     </div>
-                    <ul className='theia-notification-actions'>
-                        {expandable && (
-                            <li className={codicon('chevron-down', true) + (collapsed ? ' expand' : ' collapse')} title={collapsed ? 'Expand' : 'Collapse'}
-                                data-message-id={messageId} onClick={this.onToggleExpansion} />
-                        )}
-                        {!isProgress && (<li className={codicon('close', true)} title={nls.localizeByDefault('Clear')} data-message-id={messageId}
-                            onClick={this.onClear} />)}
-                    </ul>
+                    {(source || !!actions.length) && (
+                        <div className='theia-notification-list-item-content-bottom'>
+                            <div className='theia-notification-source'>
+                                {source && (<span>{source}</span>)}
+                            </div>
+                            <div className='theia-notification-buttons'>
+                                {actions && actions.map((action, index) => (
+                                    <button key={messageId + `-action-${index}`} className='theia-button'
+                                        data-message-id={messageId} data-action={action}
+                                        onClick={this.onAction}>
+                                        {action}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    )}
                 </div>
-                {(source || !!actions.length) && (
-                    <div className='theia-notification-list-item-content-bottom'>
-                        <div className='theia-notification-source'>
-                            {source && (<span>{source}</span>)}
-                        </div>
-                        <div className='theia-notification-buttons'>
-                            {actions && actions.map((action, index) => (
-                                <button key={messageId + `-action-${index}`} className='theia-button'
-                                    data-message-id={messageId} data-action={action}
-                                    onClick={this.onAction}>
-                                    {action}
-                                </button>
-                            ))}
-                        </div>
+                {isProgress && (
+                    <div className='theia-notification-item-progress'>
+                        <div className={`theia-notification-item-progressbar ${progress ? 'determinate' : 'indeterminate'}`}
+                            style={{ width: `${progress ?? '100'}%` }} />
                     </div>
                 )}
             </div>
-            {isProgress && (
-                <div className='theia-notification-item-progress'>
-                    <div className={`theia-notification-item-progressbar ${progress ? 'determinate' : 'indeterminate'}`}
-                        style={{ width: `${progress ?? '100'}%` }} />
-                </div>
-            )}
         </div>);
     }
 

--- a/packages/messages/src/browser/notifications-contribution.ts
+++ b/packages/messages/src/browser/notifications-contribution.ts
@@ -180,6 +180,14 @@ export class NotificationsContribution implements FrontendApplicationContributio
     }
 
     registerThemeStyle(theme: ColorTheme, collector: CssStyleCollector): void {
+        const notificationsBackground = theme.getColor('notifications.background');
+        if (notificationsBackground) {
+            collector.addRule(`
+                .theia-notification-list-item-container {
+                    background-color: ${notificationsBackground};
+                }
+            `);
+        }
         const notificationHover = theme.getColor('list.hoverBackground');
         if (notificationHover) {
             collector.addRule(`

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -37,10 +37,13 @@
 
 /* Toasts */
 
+.theia-notifications-container.theia-notification-toasts .theia-notification-list-item-container {
+    margin-top: 6px;
+}
+
 .theia-notifications-container.theia-notification-toasts .theia-notification-list-item {
     box-shadow: 0px 0px 4px 0px var(--theia-widget-shadow);
     border: 1px solid var(--theia-notificationToast-border);
-    margin-top: 6px;
 }
 
 /* Center */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11710 by adding a wrapper div around toasts and applying the correct styling.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Set theme to `Solarized Light`
2. Get a toast (e.g. add an extension to `extensions.json` and restart)
3. Hover over the toast.
4. Observe that the toast does _not_ become transparent, with content behind the toast showing through.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
