### PR TITLE
Stub vscode 'Tests' API

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -154,7 +154,11 @@ import {
     TerminalLink,
     InlayHint,
     InlayHintKind,
-    InlayHintLabelPart
+    InlayHintLabelPart,
+    TestRunProfileKind,
+    TestTag,
+    TestRunRequest,
+    TestMessage
 } from './types-impl';
 import { AuthenticationExtImpl } from './authentication-ext';
 import { SymbolKind } from '../common/plugin-api-rpc-model';
@@ -184,6 +188,12 @@ import { ClipboardExt } from './clipboard-ext';
 import { WebviewsExtImpl } from './webviews';
 import { ExtHostFileSystemEventService } from './file-system-event-service-ext-impl';
 import { LabelServiceExtImpl } from '../plugin/label-service';
+import {
+    createRunProfile,
+    createTestRun,
+    testItemCollection,
+    createTestItem
+} from './stubs/tests-api';
 import { TimelineExtImpl } from './timeline';
 import { ThemingExtImpl } from './theming';
 import { CommentsExtImpl } from './comments';
@@ -792,6 +802,30 @@ export function createAPIFactory(
             }
         };
 
+        // Tests API (@stubbed)
+        // The following implementation is temporarily `@stubbed` and marked as such under `theia.d.ts`
+        const tests: typeof theia.tests = {
+            createTestController(
+                provider,
+                controllerLabel: string,
+                refreshHandler?: (
+                    token: theia.CancellationToken
+                ) => Thenable<void> | void
+            ) {
+                return {
+                    id: provider,
+                    label: controllerLabel,
+                    items: testItemCollection,
+                    refreshHandler,
+                    createRunProfile,
+                    createTestRun,
+                    createTestItem,
+                    dispose: () => undefined,
+                };
+            },
+        };
+        /* End of Tests API */
+
         const plugins: typeof theia.plugins = {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             get all(): theia.Plugin<any>[] {
@@ -938,6 +972,7 @@ export function createAPIFactory(
             debug,
             tasks,
             scm,
+            tests,
             // Types
             StatusBarAlignment: StatusBarAlignment,
             Disposable: Disposable,
@@ -1061,7 +1096,11 @@ export function createAPIFactory(
             InputBoxValidationSeverity,
             InlayHint,
             InlayHintKind,
-            InlayHintLabelPart
+            InlayHintLabelPart,
+            TestRunProfileKind,
+            TestTag,
+            TestRunRequest,
+            TestMessage
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/stubs/tests-api.ts
+++ b/packages/plugin-ext/src/plugin/stubs/tests-api.ts
@@ -1,0 +1,96 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* tslint:disable:typedef */
+
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
+import type * as theia from '@theia/plugin';
+
+export const createRunProfile = (
+    label: string,
+    kind: theia.TestRunProfileKind,
+    runHandler: (
+        request: theia.TestRunRequest,
+        token: CancellationToken
+    ) => Thenable<void> | void,
+    isDefault?: boolean,
+    tag?: theia.TestTag
+) => ({
+    label,
+    kind,
+    isDefault: isDefault ?? false,
+    tag,
+    runHandler,
+    configureHandler: undefined,
+    dispose: () => undefined,
+});
+
+export const createTestRun = (
+    request: theia.TestRunRequest,
+    name?: string,
+    persist?: boolean
+): theia.TestRun => ({
+    name,
+    token: CancellationToken.None,
+    isPersisted: false,
+    enqueued: (test: theia.TestItem) => undefined,
+    started: (test: theia.TestItem) => undefined,
+    skipped: (test: theia.TestItem) => undefined,
+    failed: (
+        test: theia.TestItem,
+        message: theia.TestMessage | readonly theia.TestMessage[],
+        duration?: number
+    ) => undefined,
+    errored: (
+        test: theia.TestItem,
+        message: theia.TestMessage | readonly theia.TestMessage[],
+        duration?: number
+    ) => undefined,
+    passed: (test: theia.TestItem, duration?: number) => undefined,
+    appendOutput: (
+        output: string,
+        location?: theia.Location,
+        test?: theia.TestItem
+    ) => undefined,
+    end: () => undefined,
+});
+
+export const testItemCollection = {
+    add: () => { },
+    delete: () => { },
+    forEach: () => { },
+    *[Symbol.iterator]() { },
+    get: () => undefined,
+    replace: () => { },
+    size: 0,
+};
+
+export const createTestItem = (
+    id: string,
+    label: string,
+    uri?: theia.Uri
+): theia.TestItem => ({
+    id,
+    label,
+    uri,
+    children: testItemCollection,
+    parent: undefined,
+    tags: [],
+    canResolveChildren: false,
+    busy: false,
+    range: undefined,
+    error: undefined,
+});

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2706,6 +2706,42 @@ export class LinkedEditingRanges {
     }
 }
 
+export enum TestRunProfileKind {
+    Run = 1,
+    Debug = 2,
+    Coverage = 3,
+}
+
+@es5ClassCompat
+export class TestTag implements theia.TestTag {
+    constructor(public readonly id: string) { }
+}
+
+@es5ClassCompat
+export class TestRunRequest implements theia.TestRunRequest {
+    constructor(
+        public readonly include: theia.TestItem[] | undefined = undefined,
+        public readonly exclude: theia.TestItem[] | undefined = undefined,
+        public readonly profile: theia.TestRunProfile | undefined = undefined,
+    ) { }
+}
+
+@es5ClassCompat
+export class TestMessage implements theia.TestMessage {
+    public expectedOutput?: string;
+    public actualOutput?: string;
+    public location?: theia.Location;
+
+    public static diff(message: string | theia.MarkdownString, expected: string, actual: string): theia.TestMessage {
+        const msg = new TestMessage(message);
+        msg.expectedOutput = expected;
+        msg.actualOutput = actual;
+        return msg;
+    }
+
+    constructor(public message: string | theia.MarkdownString) { }
+}
+
 @es5ClassCompat
 export class TimelineItem {
     timestamp: number;


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This enables the possibility to load and start plugins which depend on the 'Tests' API.
  The 'Tests' functionality will not be operational but the rest of
the functionality offered by the plugin will be.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Update the supported `vscode` API version in `theia` to `1.68.0`, at: 
 > dev-packages/application-package/src/api.ts 
2. Reproduce the problem in the `theia` instance before switching to this PR, by installing the following `vscode` sample: https://github.com/alvsan09/vscode-extension-samples/releases/download/test-provider-prel-0.0.1/test-provider-sample-0.0.1.vsix
 - Open a workspace folder containing `markdown` files (extension `.md`)
 - you shall see the following failure message:
![image](https://user-images.githubusercontent.com/76971376/193070204-458ec873-bd3a-4088-9eb4-e02bd9e48fe4.png)

2. Update your `theia` repository to use this PR
  - Open the same workspace and make sure the message above is no longer displayed and the '.md' files open fine.

A more realistic test can be achieved using the latest `ms-python.python` extension, version `2022.14.0.`,
however additional API support is needed in addition to this change.
A test branch is provided for this purpose: 

1. Update your `theia` repository to load this PR on top of the branch offering additional missing API as follows:
> git fetch
> git checkout asl/tests_api_python_test
> git cherry-pick asl/test_api_stub
build it and start it.

2. Download the latest python extension via `openVSX` registry: 
https://open-vsx.org/api/ms-python/python/2022.14.0/file/ms-python.python-2022.14.0.vsix

3. Using the extensions view install the `vsix` above
4. The extension will attempt to install 4 python related extensions, the ones related to `jupyter` notes will not be successful however the core `python` extension will install and be functional, see the following video clip.

https://user-images.githubusercontent.com/76971376/193086561-863cf633-3af3-4342-904a-988e071cee6d.mp4

The stubbed API has been marked in`theia.d.ts` with the special tag `@stubbed` in order to reflect it is as such in the report generated by the `eclipse-theia/vscode-theia-comparator`

See a portion of the generated report when running it locally: 
![image](https://user-images.githubusercontent.com/76971376/193091892-71c98c46-78b7-4fb3-ba9c-05a9aa920458.png)


#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
