### PR TITLE
core: fix `about` dialog `nls`

### DIFF
--- a/packages/core/src/browser/about-dialog.tsx
+++ b/packages/core/src/browser/about-dialog.tsx
@@ -67,8 +67,8 @@ export class AboutDialog extends ReactDialog<void> {
 
         const detailsLabel = nls.localizeByDefault('Details');
         const versionLabel = nls.localizeByDefault('Version');
-        const defaultApiLabel = nls.localize('theia/core/about/defaultApi', 'Default VS Code API');
-        const compatibilityLabel = nls.localize('theia/core/about/compatibility', 'VS Code Compatibility');
+        const defaultApiLabel = nls.localize('theia/core/about/defaultApi', 'Default {0} API', 'VS Code');
+        const compatibilityLabel = nls.localize('theia/core/about/compatibility', '{0} Compatibility', 'VS Code');
 
         return <>
             <h3>{detailsLabel}</h3>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request fixes the translation label for the `about` dialog to not localize `VS Code`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Confirm the changes are correct.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>