### PR TITLE
output: fix the selected channel name

### DIFF
--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -98,6 +98,7 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
         }
         return <div id='outputChannelList'>
             <SelectComponent
+                key={this.outputChannelManager.selectedChannel?.name}
                 options={channelOptionElements}
                 defaultValue={this.outputChannelManager.selectedChannel?.name}
                 onChange={option => this.changeChannel(option)}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fix the channel selector of the output view toolbar. Let the selector automatically switch to the selected channel name based on the current channel name.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Create a class at the frontend and inject the `OutputChannelManager`
2. Get a channel using `this.outputChannelManager.getChannel('Test Channel')
3. Show the channel and push some message into it using `channel.show()` and `channel.appendLine('test message',  OutputChannelSeverity.Info)`
4. The output view will show the message but the channel selector does not switch to the `Test Channel`.
5. This pull request fixes the channel selector and lets it automatically switch to the selected channel name based on the current channel name.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
