### PR TITLE
vscode: Support `Terminal.state`

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -265,6 +265,7 @@ export interface TerminalServiceExt {
     $terminalOnInput(id: string, data: string): void;
     $terminalSizeChanged(id: string, cols: number, rows: number): void;
     $currentTerminalChanged(id: string | undefined): void;
+    $terminalStateChanged(id: string): void;
     $initEnvironmentVariableCollections(collections: [string, SerializableEnvironmentVariableCollection][]): void;
     getEnvironmentVariableCollection(extensionIdentifier: string): theia.EnvironmentVariableCollection;
 }

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -97,6 +97,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, Disposable 
         }));
         this.toDispose.push(terminal.onData(data => {
             this.extProxy.$terminalOnInput(terminal.id, data);
+            this.extProxy.$terminalStateChanged(terminal.id);
         }));
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -289,7 +289,7 @@ export function createAPIFactory(
             }
         };
 
-        const { onDidChangeActiveTerminal, onDidCloseTerminal, onDidOpenTerminal } = terminalExt;
+        const { onDidChangeActiveTerminal, onDidChangeTerminalState, onDidCloseTerminal, onDidOpenTerminal } = terminalExt;
         const showInformationMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Info);
         const showWarningMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Warning);
         const showErrorMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Error);
@@ -439,6 +439,7 @@ export function createAPIFactory(
                 shellArgs?: string[]): theia.Terminal {
                 return terminalExt.createTerminal(nameOrOptions, shellPath, shellArgs);
             },
+            onDidChangeTerminalState,
             onDidCloseTerminal,
             onDidOpenTerminal,
             createTextEditorDecorationType(options: theia.DecorationRenderOptions): theia.TextEditorDecorationType {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3010,6 +3010,11 @@ export module '@theia/plugin' {
         readonly creationOptions: Readonly<TerminalOptions | ExtensionTerminalOptions>
 
         /**
+         * The current state of the terminal.
+         */
+        readonly state: TerminalState;
+
+        /**
          * Send text to the terminal.
          * @param text - text content.
          * @param addNewLine - in case true - apply new line after the text, otherwise don't apply new line. This defaults to `true`.
@@ -3031,6 +3036,13 @@ export module '@theia/plugin' {
          * Destroy terminal.
          */
         dispose(): void;
+    }
+
+    export interface TerminalState {
+        /**
+         * Whether the terminal has been interacted with.
+         */
+        readonly isInteractedWith: boolean;
     }
 
     /**
@@ -4994,6 +5006,11 @@ export module '@theia/plugin' {
          * either through the createTerminal API or commands.
          */
         export const onDidOpenTerminal: Event<Terminal>;
+
+        /**
+         * An {@link Event event} which fires when a terminal's state has changed.
+         */
+        export const onDidChangeTerminalState: Event<Terminal>;
 
         /**
          * Create new terminal with predefined options.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3010,7 +3010,7 @@ export module '@theia/plugin' {
         readonly creationOptions: Readonly<TerminalOptions | ExtensionTerminalOptions>
 
         /**
-         * The current state of the terminal.
+         * The current state of the {@link Terminal}.
          */
         readonly state: TerminalState;
 
@@ -3040,7 +3040,18 @@ export module '@theia/plugin' {
 
     export interface TerminalState {
         /**
-         * Whether the terminal has been interacted with.
+         * Whether the {@link Terminal} has been interacted with. Interaction means that the
+         * terminal has sent data to the process which depending on the terminal's _mode_. By
+         * default input is sent when a key is pressed or when a command or extension sends text,
+         * but based on the terminal's mode it can also happen on:
+         *
+         * - a pointer click event
+         * - a pointer scroll event
+         * - a pointer move event
+         * - terminal focus in/out
+         *
+         * For more information on events that can send data see "DEC Private Mode Set (DECSET)" on
+         * https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
          */
         readonly isInteractedWith: boolean;
     }
@@ -5008,7 +5019,7 @@ export module '@theia/plugin' {
         export const onDidOpenTerminal: Event<Terminal>;
 
         /**
-         * An {@link Event event} which fires when a terminal's state has changed.
+         * An {@link Event} which fires when a {@link Terminal.state terminal's state} has changed.
          */
         export const onDidChangeTerminalState: Event<Terminal>;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add support for indicating and notifying changes on `Terminal.state`.

Fixes #11515
Contributed on behalf of STMicroelectronics.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Download test extension [terminal-state-11515-0.0.1.zip](https://github.com/eclipse-theia/theia/files/9700842/terminal-state-11515-0.0.1.zip) and copy it to the `plugins` folder
- Start Theia and run the command `Show terminal state` that is provided by the test extension
- Verify that a terminal opens and a notification message with the text `Terminal state: { "isInteractedWith": false }` is shown
- Type something into the terminal
- Verify that a notification message with the text `Terminal state has changed: { "isInteractedWith": true }` is shown

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
