### PR TITLE
vscode: add support for inlay hints

### DIFF
--- a/packages/plugin-ext/src/common/cache.ts
+++ b/packages/plugin-ext/src/common/cache.ts
@@ -1,0 +1,51 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// copied from https://github.com/microsoft/vscode/blob/53eac52308c4611000a171cc7bf1214293473c78/src/vs/workbench/api/common/cache.ts
+export class Cache<T> {
+
+    private static readonly enableDebugLogging = false;
+
+    private readonly _data = new Map<number, readonly T[]>();
+    private _idPool = 1;
+
+    constructor(
+        private readonly id: string
+    ) { }
+
+    add(item: readonly T[]): number {
+        const id = this._idPool++;
+        this._data.set(id, item);
+        this.logDebugInfo();
+        return id;
+    }
+
+    get(pid: number, id: number): T | undefined {
+        return this._data.has(pid) ? this._data.get(pid)![id] : undefined;
+    }
+
+    delete(id: number): void {
+        this._data.delete(id);
+        this.logDebugInfo();
+    }
+
+    private logDebugInfo(): void {
+        if (!Cache.enableDebugLogging) {
+            return;
+        }
+        console.log(`${this.id} cache size — ${this._data.size}`);
+    }
+}

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -360,6 +360,9 @@ export interface ReferenceContext {
 export type CacheId = number;
 export type ChainedCacheId = [CacheId, CacheId];
 
+export type CachedSessionItem<T> = T & { cacheId?: ChainedCacheId };
+export type CachedSession<T> = T & { cacheId?: CacheId };
+
 export interface DocumentLink {
     cacheId?: ChainedCacheId,
     range: Range;
@@ -727,3 +730,32 @@ export interface CommentInfo {
 export interface ProvidedTerminalLink extends theia.TerminalLink {
     providerId: string
 }
+
+export interface InlayHintLabelPart {
+    label: string;
+    tooltip?: string | MarkdownStringDTO;
+    location?: Location;
+    command?: Command;
+}
+
+export interface InlayHint {
+    position: { lineNumber: number, column: number };
+    label: string | InlayHintLabelPart[];
+    tooltip?: string | MarkdownStringDTO | undefined;
+    kind?: InlayHintKind;
+    textEdits?: TextEdit[];
+    paddingLeft?: boolean;
+    paddingRight?: boolean;
+}
+
+export enum InlayHintKind {
+    Type = 1,
+    Parameter = 2,
+}
+
+export interface InlayHintsProvider {
+    onDidChangeInlayHints?: TheiaEvent<void> | undefined;
+    provideInlayHints(model: monaco.editor.ITextModel, range: Range, token: monaco.CancellationToken): InlayHint[] | undefined | Thenable<InlayHint[] | undefined>;
+    resolveInlayHint?(hint: InlayHint, token: monaco.CancellationToken): InlayHint[] | undefined | Thenable<InlayHint[] | undefined>;
+}
+

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -77,7 +77,10 @@ import {
     CommentThreadChangedEvent,
     CodeActionProviderDocumentation,
     LinkedEditingRanges,
-    ProvidedTerminalLink
+    ProvidedTerminalLink,
+    InlayHint,
+    CachedSession,
+    CachedSessionItem
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -1548,6 +1551,9 @@ export interface LanguagesExt {
     $provideSelectionRanges(handle: number, resource: UriComponents, positions: Position[], token: CancellationToken): PromiseLike<SelectionRange[][]>;
     $provideDocumentColors(handle: number, resource: UriComponents, token: CancellationToken): PromiseLike<RawColorInfo[]>;
     $provideColorPresentations(handle: number, resource: UriComponents, colorInfo: RawColorInfo, token: CancellationToken): PromiseLike<ColorPresentation[]>;
+    $provideInlayHints(handle: number, resource: UriComponents, range: Range, token: CancellationToken): Promise<InlayHintsDto | undefined>;
+    $resolveInlayHint(handle: number, id: ChainedCacheId, token: CancellationToken): Promise<InlayHintDto | undefined>;
+    $releaseInlayHints(handle: number, id: number): void;
     $provideRenameEdits(handle: number, resource: UriComponents, position: Position, newName: string, token: CancellationToken): PromiseLike<WorkspaceEditDto | undefined>;
     $resolveRenameLocation(handle: number, resource: UriComponents, position: Position, token: CancellationToken): PromiseLike<RenameLocation | undefined>;
     $provideDocumentSemanticTokens(handle: number, resource: UriComponents, previousResultId: number, token: CancellationToken): Promise<BinaryBuffer | null>;
@@ -1603,6 +1609,8 @@ export interface LanguagesMain {
     $emitFoldingRangeEvent(handle: number, event?: any): void;
     $registerSelectionRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerInlayHintsProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], displayName?: string, eventHandle?: number): void;
+    $emitInlayHintsEvent(eventHandle: number, event?: any): void;
     $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveInitialValues: boolean): void;
     $registerDocumentSemanticTokensProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[],
         legend: theia.SemanticTokensLegend, eventHandle: number | undefined): void;
@@ -2016,3 +2024,6 @@ export interface SecretsMain {
     $setPassword(extensionId: string, key: string, value: string): Promise<void>;
     $deletePassword(extensionId: string, key: string): Promise<void>;
 }
+
+export type InlayHintDto = CachedSessionItem<InlayHint>;
+export type InlayHintsDto = CachedSession<{ hints: InlayHint[] }>;

--- a/packages/plugin-ext/src/plugin/custom-editors.ts
+++ b/packages/plugin-ext/src/plugin/custom-editors.ts
@@ -29,6 +29,7 @@ import { WebviewImpl, WebviewsExtImpl } from './webviews';
 import { CancellationToken, CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { WorkspaceExtImpl } from './workspace';
+import { Cache } from '../common/cache';
 
 export class CustomEditorsExtImpl implements CustomEditorsExt {
     private readonly proxy: CustomEditorsMain;
@@ -333,36 +334,3 @@ class CustomDocumentStore {
     }
 }
 
-// copied from https://github.com/microsoft/vscode/blob/53eac52308c4611000a171cc7bf1214293473c78/src/vs/workbench/api/common/cache.ts
-class Cache<T> {
-    private static readonly enableDebugLogging = false;
-    private readonly _data = new Map<number, readonly T[]>();
-    private _idPool = 1;
-
-    constructor(
-        private readonly id: string
-    ) { }
-
-    add(item: readonly T[]): number {
-        const id = this._idPool++;
-        this._data.set(id, item);
-        this.logDebugInfo();
-        return id;
-    }
-
-    get(pid: number, id: number): T | undefined {
-        return this._data.has(pid) ? this._data.get(pid)![id] : undefined;
-    }
-
-    delete(id: number): void {
-        this._data.delete(id);
-        this.logDebugInfo();
-    }
-
-    private logDebugInfo(): void {
-        if (!Cache.enableDebugLogging) {
-            return;
-        }
-        console.log(`${this.id} cache size — ${this._data.size}`);
-    }
-}

--- a/packages/plugin-ext/src/plugin/languages/inlay-hints.ts
+++ b/packages/plugin-ext/src/plugin/languages/inlay-hints.ts
@@ -1,0 +1,149 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// copied and modified from https://github.com/microsoft/vscode/blob/1.65.0/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L1178-L1288
+
+import * as theia from '@theia/plugin';
+import * as Converter from '../type-converters';
+import { Cache } from '../../common/cache';
+import { ChainedCacheId, InlayHint, InlayHintLabelPart, Range } from '../../common/plugin-api-rpc-model';
+import { CommandRegistryImpl } from '../command-registry';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { DocumentsExtImpl } from '../documents';
+import { InlayHintDto, InlayHintsDto } from '../../common';
+import { URI } from '@theia/core/shared/vscode-uri';
+import { isLocationArray } from './util';
+
+export class InlayHintsAdapter {
+
+    private cache = new Cache<theia.InlayHint>('InlayHints');
+    private readonly disposables = new Map<number, DisposableCollection>();
+
+    constructor(
+        private readonly provider: theia.InlayHintsProvider,
+        private readonly documents: DocumentsExtImpl,
+        private readonly commands: CommandRegistryImpl
+    ) { }
+
+    async provideInlayHints(resource: URI, range: Range, token: theia.CancellationToken): Promise<InlayHintsDto | undefined> {
+        const documentData = this.documents.getDocumentData(resource);
+        if (!documentData) {
+            return Promise.reject(new Error(`There are no documents for ${resource}`));
+        }
+
+        const doc = documentData.document;
+        const ran = Converter.toRange(range);
+        const hints = await this.provider.provideInlayHints(doc, ran, token);
+
+        if (!Array.isArray(hints) || hints.length === 0) {
+            return undefined;
+        }
+
+        if (token.isCancellationRequested) {
+            return undefined;
+        }
+
+        const pid = this.cache.add(hints);
+        this.disposables.set(pid, new DisposableCollection());
+        const result: InlayHintsDto = { hints: [], cacheId: pid };
+
+        for (let i = 0; i < hints.length; i++) {
+            if (this.isValidInlayHint(hints[i], ran)) {
+                result.hints.push(this.convertInlayHint(hints[i], [pid, i]));
+            }
+        }
+
+        return result;
+    }
+
+    async resolveInlayHint(id: ChainedCacheId, token: theia.CancellationToken): Promise<InlayHint | undefined> {
+        if (typeof this.provider.resolveInlayHint !== 'function') {
+            return undefined;
+        }
+        const item = this.cache.get(...id);
+        if (!item) {
+            return undefined;
+        }
+        const hint = await this.provider.resolveInlayHint!(item, token);
+        if (!hint) {
+            return undefined;
+        }
+        if (!this.isValidInlayHint(hint)) {
+            return undefined;
+        }
+        return this.convertInlayHint(hint, id);
+    }
+
+    private isValidInlayHint(hint: theia.InlayHint, range?: theia.Range): boolean {
+        if (hint.label.length === 0 || Array.isArray(hint.label) && hint.label.every(part => part.value.length === 0)) {
+            return false;
+        }
+        if (range && !range.contains(hint.position)) {
+            return false;
+        }
+        return true;
+    }
+
+    private convertInlayHint(hint: theia.InlayHint, id: ChainedCacheId): InlayHintDto {
+
+        const disposables = this.disposables.get(id[0]);
+        if (!disposables) {
+            throw Error('DisposableCollection is missing...');
+        }
+
+        const result: InlayHintDto = {
+            label: '', // fill-in below.
+            cacheId: id,
+            tooltip: hint.tooltip,
+            position: Converter.fromPosition(hint.position),
+            textEdits: hint.textEdits && hint.textEdits.map(Converter.fromTextEdit),
+            kind: hint.kind && Converter.InlayHintKind.from(hint.kind),
+            paddingLeft: hint.paddingLeft,
+            paddingRight: hint.paddingRight,
+        };
+
+        if (typeof hint.label === 'string') {
+            result.label = hint.label;
+        } else {
+            result.label = hint.label.map(part => {
+                const partResult: InlayHintLabelPart = { label: part.value };
+                if (part.tooltip) {
+                    partResult.tooltip = typeof partResult === 'string' ? part.tooltip : Converter.fromMarkdown(part.tooltip);
+                }
+                if (isLocationArray(part.location)) {
+                    partResult.location = Converter.fromLocation(part.location);
+                }
+                if (part.command) {
+                    partResult.command = this.commands.converter.toSafeCommand(part.command, disposables);
+                }
+                return partResult;
+            });
+        }
+
+        return result;
+    }
+
+    async releaseHints(id: number): Promise<void> {
+        this.disposables.get(id)?.dispose();
+        this.disposables.delete(id);
+        this.cache.delete(id);
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -150,7 +150,10 @@ import {
     LanguageStatusSeverity,
     TextDocumentChangeReason,
     InputBoxValidationSeverity,
-    TerminalLink
+    TerminalLink,
+    InlayHint,
+    InlayHintKind,
+    InlayHintLabelPart
 } from './types-impl';
 import { AuthenticationExtImpl } from './authentication-ext';
 import { SymbolKind } from '../common/plugin-api-rpc-model';
@@ -748,6 +751,9 @@ export function createAPIFactory(
             registerColorProvider(selector: theia.DocumentSelector, provider: theia.DocumentColorProvider): theia.Disposable {
                 return languagesExt.registerColorProvider(selector, provider, pluginToPluginInfo(plugin));
             },
+            registerInlayHintsProvider(selector: theia.DocumentSelector, provider: theia.InlayHintsProvider): theia.Disposable {
+                return languagesExt.registerInlayHintsProvider(selector, provider, pluginToPluginInfo(plugin));
+            },
             registerFoldingRangeProvider(selector: theia.DocumentSelector, provider: theia.FoldingRangeProvider): theia.Disposable {
                 return languagesExt.registerFoldingRangeProvider(selector, provider, pluginToPluginInfo(plugin));
             },
@@ -1041,7 +1047,10 @@ export function createAPIFactory(
             CancellationError,
             ExtensionMode,
             LinkedEditingRanges,
-            InputBoxValidationSeverity
+            InputBoxValidationSeverity,
+            InlayHint,
+            InlayHintKind,
+            InlayHintLabelPart
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -129,7 +129,7 @@ export function fromRange(range: theia.Range | undefined): model.Range | undefin
     };
 }
 
-export function fromPosition(position: types.Position): Position {
+export function fromPosition(position: types.Position | theia.Position): Position {
     return { lineNumber: position.line + 1, column: position.character + 1 };
 }
 
@@ -1271,3 +1271,11 @@ export function pluginToPluginInfo(plugin: Plugin): rpc.PluginInfo {
     };
 }
 
+export namespace InlayHintKind {
+    export function from(kind: theia.InlayHintKind): model.InlayHintKind {
+        return kind;
+    }
+    export function to(kind: model.InlayHintKind): theia.InlayHintKind {
+        return kind;
+    }
+}

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2489,6 +2489,40 @@ export enum ColorFormat {
 }
 
 @es5ClassCompat
+export class InlayHintLabelPart implements theia.InlayHintLabelPart {
+    value: string;
+    tooltip?: string | theia.MarkdownString | undefined;
+    location?: Location | undefined;
+    command?: theia.Command | undefined;
+
+    constructor(value: string) {
+        this.value = value;
+    }
+}
+
+@es5ClassCompat
+export class InlayHint implements theia.InlayHint {
+    position: theia.Position;
+    label: string | InlayHintLabelPart[];
+    tooltip?: string | theia.MarkdownString | undefined;
+    kind?: InlayHintKind;
+    textEdits?: TextEdit[];
+    paddingLeft?: boolean;
+    paddingRight?: boolean;
+
+    constructor(position: theia.Position, label: string | InlayHintLabelPart[], kind?: InlayHintKind) {
+        this.position = position;
+        this.label = label;
+        this.kind = kind;
+    }
+}
+
+export enum InlayHintKind {
+    Type = 1,
+    Parameter = 2,
+}
+
+@es5ClassCompat
 export class FoldingRange {
     start: number;
     end: number;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7613,6 +7613,176 @@ export module '@theia/plugin' {
     }
 
     /**
+     * Inlay hint kinds.
+     *
+     * The kind of an inline hint defines its appearance, e.g the corresponding foreground and background colors are being
+     * used.
+     */
+    export enum InlayHintKind {
+        /**
+         * An inlay hint that for a type annotation.
+         */
+        Type = 1,
+        /**
+         * An inlay hint that is for a parameter.
+         */
+        Parameter = 2,
+    }
+
+    /**
+     * An inlay hint label part allows for interactive and composite labels of inlay hints.
+     */
+    export class InlayHintLabelPart {
+
+        /**
+         * The value of this label part.
+         */
+        value: string;
+
+        /**
+         * The tooltip text when you hover over this label part.
+         *
+         * *Note* that this property can be set late during
+         * {@link InlayHintsProvider.resolveInlayHint resolving} of inlay hints.
+         */
+        tooltip?: string | MarkdownString | undefined;
+
+        /**
+         * An optional {@link Location source code location} that represents this label
+         * part.
+         *
+         * The editor will use this location for the hover and for code navigation features: This
+         * part will become a clickable link that resolves to the definition of the symbol at the
+         * given location (not necessarily the location itself), it shows the hover that shows at
+         * the given location, and it shows a context menu with further code navigation commands.
+         *
+         * *Note* that this property can be set late during
+         * {@link InlayHintsProvider.resolveInlayHint resolving} of inlay hints.
+         */
+        location?: Location | undefined;
+
+        /**
+         * An optional command for this label part.
+         *
+         * The editor renders parts with commands as clickable links. The command is added to the context menu
+         * when a label part defines {@link InlayHintLabelPart.location location} and {@link InlayHintLabelPart.command command} .
+         *
+         * *Note* that this property can be set late during
+         * {@link InlayHintsProvider.resolveInlayHint resolving} of inlay hints.
+         */
+        command?: Command | undefined;
+
+        /**
+         * Creates a new inlay hint label part.
+         *
+         * @param value The value of the part.
+         */
+        constructor(value: string);
+    }
+
+    /**
+     * Inlay hint information.
+     */
+    export class InlayHint {
+
+        /**
+         * The position of this hint.
+         */
+        position: Position;
+
+        /**
+         * The label of this hint. A human readable string or an array of {@link InlayHintLabelPart label parts}.
+         *
+         * *Note* that neither the string nor the label part can be empty.
+         */
+        label: string | InlayHintLabelPart[];
+
+        /**
+         * The tooltip text when you hover over this item.
+         *
+         * *Note* that this property can be set late during
+         * {@link InlayHintsProvider.resolveInlayHint resolving} of inlay hints.
+         */
+        tooltip?: string | MarkdownString | undefined;
+
+        /**
+         * The kind of this hint. The inlay hint kind defines the appearance of this inlay hint.
+         */
+        kind?: InlayHintKind;
+
+        /**
+         * Optional {@link TextEdit text edits} that are performed when accepting this inlay hint. The default
+         * gesture for accepting an inlay hint is the double click.
+         *
+         * *Note* that edits are expected to change the document so that the inlay hint (or its nearest variant) is
+         * now part of the document and the inlay hint itself is now obsolete.
+         *
+         * *Note* that this property can be set late during
+         * {@link InlayHintsProvider.resolveInlayHint resolving} of inlay hints.
+         */
+        textEdits?: TextEdit[];
+
+        /**
+         * Render padding before the hint. Padding will use the editor's background color,
+         * not the background color of the hint itself. That means padding can be used to visually
+         * align/separate an inlay hint.
+         */
+        paddingLeft?: boolean;
+
+        /**
+         * Render padding after the hint. Padding will use the editor's background color,
+         * not the background color of the hint itself. That means padding can be used to visually
+         * align/separate an inlay hint.
+         */
+        paddingRight?: boolean;
+
+        /**
+         * Creates a new inlay hint.
+         *
+         * @param position The position of the hint.
+         * @param label The label of the hint.
+         * @param kind The {@link InlayHintKind kind} of the hint.
+         */
+        constructor(position: Position, label: string | InlayHintLabelPart[], kind?: InlayHintKind);
+    }
+
+    /**
+     * The inlay hints provider interface defines the contract between extensions and
+     * the inlay hints feature.
+     */
+    export interface InlayHintsProvider<T extends InlayHint = InlayHint> {
+
+        /**
+         * An optional event to signal that inlay hints from this provider have changed.
+         */
+        onDidChangeInlayHints?: Event<void>;
+
+        /**
+         * Provide inlay hints for the given range and document.
+         *
+         * *Note* that inlay hints that are not {@link Range.contains contained} by the given range are ignored.
+         *
+         * @param document The document in which the command was invoked.
+         * @param range The range for which inlay hints should be computed.
+         * @param token A cancellation token.
+         * @return An array of inlay hints or a thenable that resolves to such.
+         */
+        provideInlayHints(document: TextDocument, range: Range, token: CancellationToken): ProviderResult<T[]>;
+
+        /**
+         * Given an inlay hint fill in {@link InlayHint.tooltip tooltip}, {@link InlayHint.textEdits text edits},
+         * or complete label {@link InlayHintLabelPart parts}.
+         *
+         * *Note* that the editor will resolve an inlay hint at most once.
+         *
+         * @param hint An inlay hint.
+         * @param token A cancellation token.
+         * @return The resolved inlay hint or a thenable that resolves to such. It is OK to return the given `item`. When no result is returned, the given `item` will be used.
+         */
+        resolveInlayHint?(hint: T, token: CancellationToken): ProviderResult<T>;
+    }
+
+    /**
      * A line based folding range. To be valid, start and end line must a zero or larger and smaller than the number of lines in the document.
      * Invalid ranges will be ignored.
      */
@@ -9688,6 +9858,19 @@ export module '@theia/plugin' {
          * @return A {@link Disposable disposable} that unregisters this provider when being disposed.
          */
         export function registerColorProvider(selector: DocumentSelector, provider: DocumentColorProvider): Disposable;
+
+        /**
+         * Register a inlay hints provider.
+         *
+         * Multiple providers can be registered for a language. In that case providers are asked in
+         * parallel and the results are merged. A failing provider (rejected promise or exception) will
+         * not cause a failure of the whole operation.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider An inlay hints provider.
+         * @return A {@link Disposable} that unregisters this provider when being disposed.
+         */
+        export function registerInlayHintsProvider(selector: DocumentSelector, provider: InlayHintsProvider): Disposable;
 
         /**
          * Register a folding range provider.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: https://github.com/eclipse-theia/theia/issues/10978.

The pull-request adds support for [inlay hints](https://code.visualstudio.com/docs/typescript/typescript-editing#_inlay-hints) in the editor:

![Screen Shot 2022-10-05 at 10 39 52 AM](https://user-images.githubusercontent.com/40359487/194089077-e3f4fd6a-3e3e-4f0f-8109-7859b87c9bb8.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

In order to verify inlay hints, I build a newer version of the typescript builtins (v1.65.0) which included the feature.

1. checkout the branch, and build the changes
2. remove the `plugins` folder, and instead add the following extensions ([typescript-builtins-1.65.0.zip](https://github.com/eclipse-theia/theia/files/9716584/typescript-builtins-1.65.0.zip))
3. start the application using `theia` itself as a workspace
4. ensure that the following preferences are turned on:
    ```json
    "editor.inlayHints.enabled": "on"
    "typescript.inlayHints.enumMemberValues.enabled": true,
    "typescript.inlayHints.functionLikeReturnTypes.enabled": true,
    "typescript.inlayHints.parameterNames.enabled": "all",
    "typescript.inlayHints.parameterTypes.enabled": true,
    "typescript.inlayHints.propertyDeclarationTypes.enabled": true,
    "typescript.inlayHints.variableTypes.enabled": true,
    ```
5. ensure that the workspace is using at least `typescript@4.4.0` as a version which includes support for [inlay hints](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#inlay-hints)
6. open a typescript file and confirm that inlay hints are in fact present


#### Additional Information

- [x] [CQ](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/3754)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>