### PR TITLE
Register VSCode items directly with corresponding internal menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [core] the generated webpack configuration (`gen-webpack.config.js`) now exports an array of two webpack configs instead of a single one: the first contains the config for 
 generating the main code bundle (as before), the second serves to generate a *.css file for inclusion into `secondaryWindow.html` [#11707](https://github.com/eclipse-theia/theia/pull/11707)
+- [plugin-ext] `when` clauses removed from `codeToTheiaMappings` [#11741](https://github.com/eclipse-theia/theia/pull/#11741)
 
 ## v1.30.0 - 9/29/2022
 

--- a/packages/core/src/common/menu/composite-menu-node.ts
+++ b/packages/core/src/common/menu/composite-menu-node.ts
@@ -75,12 +75,9 @@ export class CompositeMenuNode implements MenuNode, CompoundMenuNode, CompoundMe
      * @param id node id.
      */
     public removeNode(id: string): void {
-        const node = this._children.find(n => n.id === id);
-        if (node) {
-            const idx = this._children.indexOf(node);
-            if (idx >= 0) {
-                this._children.splice(idx, 1);
-            }
+        const idx = this._children.findIndex(n => n.id === id);
+        if (idx >= 0) {
+            this._children.splice(idx, 1);
         }
     }
 

--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -105,7 +105,7 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
             if (adapter) {
                 const paths = codeToTheiaMappings.get(contributionPoint);
                 if (paths) {
-                    paths.forEach(([path]) => this.addArgumentAdapter(path, adapter));
+                    paths.forEach(path => this.addArgumentAdapter(path, adapter));
                 }
             }
         });

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -54,22 +54,22 @@ export const implementedVSCodeContributionPoints = [
 export type ContributionPoint = (typeof implementedVSCodeContributionPoints)[number];
 
 /** The values are combinations of MenuPath and `when` clause, if any */
-export const codeToTheiaMappings = new Map<ContributionPoint, Array<[MenuPath] | [MenuPath, string]>>([
-    ['comments/comment/context', [[COMMENT_CONTEXT]]],
-    ['comments/comment/title', [[COMMENT_TITLE]]],
-    ['comments/commentThread/context', [[COMMENT_THREAD_CONTEXT]]],
-    ['debug/callstack/context', [[DebugStackFramesWidget.CONTEXT_MENU], [DebugThreadsWidget.CONTEXT_MENU]]],
-    ['editor/context', [[EDITOR_CONTEXT_MENU]]],
-    ['editor/title', [[PLUGIN_EDITOR_TITLE_MENU]]],
-    ['editor/title/context', [[SHELL_TABBAR_CONTEXT_MENU, 'resourceSet']]],
-    ['explorer/context', [[NAVIGATOR_CONTEXT_MENU]]],
-    ['scm/resourceFolder/context', [[ScmTreeWidget.RESOURCE_FOLDER_CONTEXT_MENU]]],
-    ['scm/resourceGroup/context', [[ScmTreeWidget.RESOURCE_GROUP_CONTEXT_MENU]]],
-    ['scm/resourceState/context', [[ScmTreeWidget.RESOURCE_CONTEXT_MENU]]],
-    ['scm/title', [[PLUGIN_SCM_TITLE_MENU]]],
-    ['timeline/item/context', [[TIMELINE_ITEM_CONTEXT_MENU]]],
-    ['view/item/context', [[VIEW_ITEM_CONTEXT_MENU]]],
-    ['view/title', [[PLUGIN_VIEW_TITLE_MENU]]],
+export const codeToTheiaMappings = new Map<ContributionPoint, MenuPath[]>([
+    ['comments/comment/context', [COMMENT_CONTEXT]],
+    ['comments/comment/title', [COMMENT_TITLE]],
+    ['comments/commentThread/context', [COMMENT_THREAD_CONTEXT]],
+    ['debug/callstack/context', [DebugStackFramesWidget.CONTEXT_MENU, DebugThreadsWidget.CONTEXT_MENU]],
+    ['editor/context', [EDITOR_CONTEXT_MENU]],
+    ['editor/title', [PLUGIN_EDITOR_TITLE_MENU]],
+    ['editor/title/context', [SHELL_TABBAR_CONTEXT_MENU]],
+    ['explorer/context', [NAVIGATOR_CONTEXT_MENU]],
+    ['scm/resourceFolder/context', [ScmTreeWidget.RESOURCE_FOLDER_CONTEXT_MENU]],
+    ['scm/resourceGroup/context', [ScmTreeWidget.RESOURCE_GROUP_CONTEXT_MENU]],
+    ['scm/resourceState/context', [ScmTreeWidget.RESOURCE_CONTEXT_MENU]],
+    ['scm/title', [PLUGIN_SCM_TITLE_MENU]],
+    ['timeline/item/context', [TIMELINE_ITEM_CONTEXT_MENU]],
+    ['view/item/context', [VIEW_ITEM_CONTEXT_MENU]],
+    ['view/title', [PLUGIN_VIEW_TITLE_MENU]],
 ]);
 
 type CodeEditorWidget = EditorWidget | WebviewWidget;

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -53,7 +53,7 @@ export const implementedVSCodeContributionPoints = [
 
 export type ContributionPoint = (typeof implementedVSCodeContributionPoints)[number];
 
-/** The values are combinations of MenuPath and `when` clause, if any */
+/** The values are menu paths to which the VSCode contribution points correspond */
 export const codeToTheiaMappings = new Map<ContributionPoint, MenuPath[]>([
     ['comments/comment/context', [COMMENT_CONTEXT]],
     ['comments/comment/title', [COMMENT_TITLE]],

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -288,6 +288,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         this.model.onDidChangeWelcomeState(this.update, this);
         this.toDispose.push(this.model.onDidChangeWelcomeState(this.update, this));
         this.toDispose.push(this.onDidChangeVisibilityEmitter);
+        this.toDispose.push(this.contextKeyService.onDidChange(() => this.update()));
     }
 
     protected markdownItPlugin(): void {

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -52,7 +52,7 @@ import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
 
 export const TREE_NODE_HYPERLINK = 'theia-TreeNodeHyperlink';
 export const VIEW_ITEM_CONTEXT_MENU: MenuPath = ['view-item-context-menu'];
-export const VIEW_ITEM_INLINE_MENU: MenuPath = ['view-item-inline-menu'];
+export const VIEW_ITEM_INLINE_MENU: MenuPath = ['view-item-context-menu', 'inline'];
 
 export interface SelectionEventHandler {
     readonly node: SelectableTreeNode;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11735

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Install [this plugin](https://github.com/eclipse-theia/theia/files/9728688/menu-contribution-test-0.0.1.zip). ([Source](https://github.com/colin-grant-work/demo-extensions/tree/main/menu-contribution-test))
1. Open a plugin tree view, e.g. the built-in NPM view.
1. Observe that a thumbs-up or thumbs-down icon is rendered on each item (in addition to run and debug options, for most).
1. Click it.
1. Observe that it changes immediately to the other direction.
---
1. Observe that other menu items appear in the correct locations, according to #11290.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
