### PR TITLE
make `@theia/ffmpeg` lazy

### DIFF
--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -18,7 +18,6 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as cp from 'child_process';
 import * as semver from 'semver';
-import * as ffmpeg from '@theia/ffmpeg';
 import { ApplicationPackage, ApplicationPackageOptions } from '@theia/application-package';
 import { WebpackGenerator, FrontendGenerator, BackendGenerator } from './generator';
 import { ApplicationProcess } from './application-process';
@@ -181,6 +180,7 @@ export class ApplicationPackageManager {
         if (!theiaElectron.electronVersion || !semver.satisfies(theiaElectron.electronVersion, currentRange)) {
             throw new AbortError('Dependencies are out of sync, please run "install" again');
         }
+        const ffmpeg = await import('@theia/ffmpeg');
         await ffmpeg.replaceFfmpeg();
         await ffmpeg.checkFfmpeg();
     }

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -21,7 +21,6 @@ import * as yargs from 'yargs';
 import yargsFactory = require('yargs/yargs');
 import { ApplicationPackageManager, rebuild } from '@theia/application-manager';
 import { ApplicationProps, DEFAULT_SUPPORTED_API_VERSION } from '@theia/application-package';
-import * as ffmpeg from '@theia/ffmpeg';
 import checkDependencies from './check-dependencies';
 import downloadPlugins from './download-plugins';
 import runTest from './run-test';
@@ -559,6 +558,7 @@ async function theiaCli(): Promise<void> {
                 },
             },
             handler: async options => {
+                const ffmpeg = await import('@theia/ffmpeg');
                 await ffmpeg.replaceFfmpeg(options);
             },
         })
@@ -586,8 +586,9 @@ async function theiaCli(): Promise<void> {
                     choices: ['darwin', 'linux', 'win32'] as NodeJS.Platform[],
                 },
             },
-            handler: options => {
-                ffmpeg.checkFfmpeg(options);
+            handler: async options => {
+                const ffmpeg = await import('@theia/ffmpeg');
+                await ffmpeg.checkFfmpeg(options);
             },
         })
         .parserConfiguration({

--- a/dev-packages/ffmpeg/src/ffmpeg.ts
+++ b/dev-packages/ffmpeg/src/ffmpeg.ts
@@ -26,18 +26,6 @@ export interface FfmpegNativeAddon {
     codecs(ffmpegPath: string): Codec[]
 }
 
-let _FFMPEG: FfmpegNativeAddon;
-try {
-    _FFMPEG = require('../build/Release/ffmpeg.node');
-} catch (error) {
-    if (error.code === 'MODULE_NOT_FOUND') {
-        _FFMPEG = require('../build/Debug/ffmpeg.node');
-    } else {
-        throw error;
-    }
-}
-export { _FFMPEG };
-
 export interface FfmpegNameAndLocation {
     /**
      * Name with extension of the shared library.
@@ -54,6 +42,21 @@ export interface FfmpegOptions {
     electronDist?: string
     ffmpegPath?: string
     platform?: NodeJS.Platform
+}
+
+/**
+ * @internal
+ */
+export function _loadFfmpegNativeAddon(): FfmpegNativeAddon {
+    try {
+        return require('../build/Release/ffmpeg.node');
+    } catch (error) {
+        if (error.code === 'MODULE_NOT_FOUND') {
+            return require('../build/Debug/ffmpeg.node');
+        } else {
+            throw error;
+        }
+    }
 }
 
 /**
@@ -107,5 +110,5 @@ export function ffmpegAbsolutePath(options: FfmpegOptions = {}): string {
  * @returns list of codecs for the given ffmpeg shared library.
  */
 export function getFfmpegCodecs(ffmpegPath: string): Codec[] {
-    return _FFMPEG.codecs(ffmpegPath);
+    return _loadFfmpegNativeAddon().codecs(ffmpegPath);
 }


### PR DESCRIPTION
`@theia/ffmpeg` is loaded eagerly and tries to load its native addon eagerly as well.

Make imports of `@theia/ffmpeg` lazy both internally and externally.

This will fix the issue when dependents pull our packages while ignoring install scripts: In such a case the native addon won't be built and won't be found at runtime when `@theia/ffmpeg` was loaded.

Closes https://github.com/eclipse-theia/theia/issues/11698

#### How to test

The following commands should work:

```
yarn
yarn build:examples
mv dev-packages/ffmpeg/build/Release/ffmpeg.node dev-packages/ffmpeg/build/Release/ffmpeg2.node
yarn browser build
```

Following the previous commands, these should fail:

```
yarn electron build
```

Then this should work:

```
mv dev-packages/ffmpeg/build/Release/ffmpeg2.node dev-packages/ffmpeg/build/Release/ffmpeg.node
yarn electron build
```

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)