### PR TITLE
Add `task#runOptions` to API.

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1433,8 +1433,13 @@ export interface TaskDto {
     group?: string;
     detail?: string;
     presentation?: TaskPresentationOptionsDTO;
+    runOptions?: RunOptionsDTO;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
+}
+
+export interface RunOptionsDTO {
+    reevaluateOnRerun?: boolean;
 }
 
 export interface TaskPresentationOptionsDTO {

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -202,7 +202,7 @@ export class TasksMainImpl implements TasksMain, Disposable {
     }
 
     protected toTaskConfiguration(taskDto: TaskDto): TaskConfiguration {
-        const { group, presentation, scope, source, ...common } = taskDto ?? {};
+        const { group, presentation, scope, source, runOptions, ...common } = taskDto ?? {};
         const partialConfig: Partial<TaskConfiguration> = {};
         if (presentation) {
             partialConfig.presentation = this.convertTaskPresentation(presentation);
@@ -213,6 +213,7 @@ export class TasksMainImpl implements TasksMain, Disposable {
         return {
             ...common,
             ...partialConfig,
+            runOptions,
             _scope: scope,
             _source: source,
         };

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -235,6 +235,9 @@ describe('Type converters:', () => {
                 options: {
                     cwd
                 }
+            },
+            runOptions: {
+                reevaluateOnRerun: false
             }
         };
 
@@ -264,6 +267,9 @@ describe('Type converters:', () => {
                 options: {
                     cwd
                 }
+            },
+            runOptions: {
+                reevaluateOnRerun: false
             }
         };
 
@@ -291,6 +297,9 @@ describe('Type converters:', () => {
                 options: {
                     cwd
                 }
+            },
+            runOptions: {
+                reevaluateOnRerun: false
             }
         };
 

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -750,6 +750,8 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
     taskDto.label = task.name;
     taskDto.source = task.source;
 
+    taskDto.runOptions = task.runOptions;
+
     if ((task as types.Task).hasProblemMatchers) {
         taskDto.problemMatcher = task.problemMatchers;
     }
@@ -811,10 +813,11 @@ export function toTask(taskDto: TaskDto): theia.Task {
         throw new Error('Task should be provided for converting');
     }
 
-    const { type, taskType, label, source, scope, problemMatcher, detail, command, args, options, group, presentation, ...properties } = taskDto;
+    const { type, taskType, label, source, scope, problemMatcher, detail, command, args, options, group, presentation, runOptions, ...properties } = taskDto;
     const result = {} as theia.Task;
     result.name = label;
     result.source = source;
+    result.runOptions = runOptions ?? {};
     if (detail) {
         result.detail = detail;
     }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1965,6 +1965,7 @@ export class Task {
     private taskSource: string;
     private taskGroup: TaskGroup | undefined;
     private taskPresentationOptions: theia.TaskPresentationOptions;
+    private _runOptions: theia.RunOptions;
     constructor(
         taskDefinition: theia.TaskDefinition,
         scope: theia.WorkspaceFolder | theia.TaskScope.Global | theia.TaskScope.Workspace,
@@ -2136,6 +2137,17 @@ export class Task {
             value = Object.create(null);
         }
         this.taskPresentationOptions = value;
+    }
+
+    get runOptions(): theia.RunOptions {
+        return this._runOptions;
+    }
+
+    set runOptions(value: theia.RunOptions) {
+        if (value === null || value === undefined) {
+            value = Object.create(null);
+        }
+        this._runOptions = value;
     }
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -11153,6 +11153,16 @@ export module '@theia/plugin' {
         clear?: boolean;
     }
 
+    /**
+     * Run options for a task.
+     */
+    export interface RunOptions {
+        /**
+         * Controls whether task variables are re-evaluated on rerun.
+         */
+        reevaluateOnRerun?: boolean;
+    }
+
     export class Task {
 
         /**
@@ -11239,6 +11249,11 @@ export module '@theia/plugin' {
          * array.
          */
         problemMatchers?: string[];
+
+        /**
+         * Run options for the task
+         */
+        runOptions: RunOptions;
     }
 
     /**

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -328,7 +328,7 @@ export class TaskConfigurations implements Disposable {
             console.error('Detected / Contributed tasks should have a task definition.');
             return;
         }
-        const customization: TaskCustomization = { type: task.type };
+        const customization: TaskCustomization = { type: task.type, runOptions: task.runOptions };
         definition.properties.all.forEach(p => {
             if (task[p] !== undefined) {
                 customization[p] = task[p];

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -87,13 +87,18 @@ export interface TaskEndedInfo {
     value: number | boolean | undefined
 }
 
+export interface LastRunTaskInfo {
+    resolvedTask?: TaskConfiguration;
+    option?: RunTaskOption
+}
+
 @injectable()
 export class TaskService implements TaskConfigurationClient {
 
     /**
      * The last executed task.
      */
-    protected lastTask: { source: string, taskLabel: string, scope: TaskConfigurationScope } | undefined = undefined;
+    protected lastTask: LastRunTaskInfo = {resolvedTask: undefined, option: undefined};
     protected cachedRecentTasks: TaskConfiguration[] = [];
     protected runningTasks = new Map<number, {
         exitCode: Deferred<number | undefined>,
@@ -470,7 +475,7 @@ export class TaskService implements TaskConfigurationClient {
      *
      * @returns the last executed task or `undefined`.
      */
-    getLastTask(): { source: string, taskLabel: string, scope: TaskConfigurationScope } | undefined {
+    getLastTask(): LastRunTaskInfo {
         return this.lastTask;
     }
 
@@ -496,11 +501,14 @@ export class TaskService implements TaskConfigurationClient {
      * @param token  The cache token for the user interaction in progress
      */
     async runLastTask(token: number): Promise<TaskInfo | undefined> {
-        if (!this.lastTask) {
+        if (!this.lastTask || !this.lastTask.resolvedTask) {
             return;
         }
-        const { source, taskLabel, scope } = this.lastTask;
-        return this.run(token, source, taskLabel, scope);
+        if (!this.lastTask.resolvedTask.runOptions?.reevaluateOnRerun) {
+            return this.runResolvedTask(this.lastTask.resolvedTask, this.lastTask.option);
+        }
+        const { _source, label, _scope } = this.lastTask.resolvedTask;
+        return this.run(token, _source, label, _scope);
     }
 
     /**
@@ -737,7 +745,7 @@ export class TaskService implements TaskConfigurationClient {
         try {
             // resolve problemMatchers
             if (!option && task.problemMatcher) {
-                const customizationObject: TaskCustomization = { type: task.taskType, problemMatcher: task.problemMatcher };
+                const customizationObject: TaskCustomization = { type: task.taskType, problemMatcher: task.problemMatcher, runOptions: task.runOptions };
                 const resolvedMatchers = await this.resolveProblemMatchers(task, customizationObject);
                 option = {
                     customization: { ...customizationObject, ...{ problemMatcher: resolvedMatchers } }
@@ -949,7 +957,7 @@ export class TaskService implements TaskConfigurationClient {
     }
 
     protected async getTaskCustomization(task: TaskConfiguration): Promise<TaskCustomization> {
-        const customizationObject: TaskCustomization = { type: '', _scope: task._scope };
+        const customizationObject: TaskCustomization = { type: '', _scope: task._scope, runOptions: task.runOptions };
         const customizationFound = this.taskConfigurations.getCustomizationForTask(task);
         if (customizationFound) {
             Object.assign(customizationObject, customizationFound);
@@ -982,12 +990,11 @@ export class TaskService implements TaskConfigurationClient {
      * @param option options to run the resolved task
      */
     protected async runResolvedTask(resolvedTask: TaskConfiguration, option?: RunTaskOption): Promise<TaskInfo | undefined> {
-        const source = resolvedTask._source;
         const taskLabel = resolvedTask.label;
         let taskInfo: TaskInfo | undefined;
         try {
             taskInfo = await this.taskServer.run(resolvedTask, this.getContext(), option);
-            this.lastTask = { source, taskLabel, scope: resolvedTask._scope };
+            this.lastTask = {resolvedTask, option };
             this.logger.debug(`Task created. Task id: ${taskInfo.taskId}`);
 
             /**

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -127,6 +127,8 @@ export interface TaskCustomization {
     /** The order the dependsOn tasks should be executed in. */
     dependsOrder?: DependsOrder;
 
+    runOptions?: RunOptions;
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [name: string]: any;
 }
@@ -226,6 +228,10 @@ export interface TaskCustomizationData {
 
 export interface RunTaskOption {
     customization?: TaskCustomizationData;
+}
+
+export interface RunOptions {
+    reevaluateOnRerun?: boolean;
 }
 
 /** Event sent when a task has concluded its execution */


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Additionally added functionality to support `reevaluateOnRerun`. If this flag is set to false no variables will be resolved again. Therefore lastTask can now be re-triggered without resolving all variables. For this the lastTask object was updated to contain all resolved information.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
To test you can use the follwing `tasks.json`:
```
{
  "version": "2.0.0",
  "tasks": [
    {
      "label": "Node Command",
      "type": "shell",
      "command": "node",
      "args": [
        "${input:node command}"
      ],
      "isBackground": true,
      "runOptions": {
        "reevaluateOnRerun": false
      }
    },
  ],
  "inputs": [
    {
      "id": "node command",
      "description": "node ${input:node command}",
      "default": "--version",
      "type": "promptString"
    },
  ]
}
```

When you run the node command you will be asked, which command you want to run. If you enter `--version` for example and then rerun the last task. You will not be asked and `node --version` is automatically executed.
When you change `reevaluateOnRerun` to true, run and rerun the task, you will need to reenter the command every time.

To test the API you can use this [extension](https://github.com/eclipse-theia/theia/files/9764231/task-provider-samples-0.0.1.zip). It provides a task (custombuildscript: 32) with `reevaluateOnRerun: true`. When you run this task and debug, for example at `task-service.ts#808` the `task` object should have the correct `runOptions` set.
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

