### PR TITLE
Check whether editor commands are declared in package.json

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -239,14 +239,17 @@ export function createAPIFactory(
                 return authenticationExt.onDidChangeSessions;
             }
         };
+        function commandIsDeclaredInPackage(id: string, model: PluginPackage): boolean {
+            const rawCommands = model.contributes?.commands;
+            if (!rawCommands) { return false; }
+            return Array.isArray(rawCommands) ? rawCommands.some(candidate => candidate.command === id) : rawCommands.command === id;
+        }
         const commands: typeof theia.commands = {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             registerCommand(command: theia.CommandDescription | string, handler?: <T>(...args: any[]) => T | Thenable<T | undefined>, thisArg?: any): Disposable {
                 // use of the ID when registering commands
                 if (typeof command === 'string') {
-                    const rawCommands = plugin.rawModel.contributes && plugin.rawModel.contributes.commands;
-                    const contributedCommands = rawCommands ? Array.isArray(rawCommands) ? rawCommands : [rawCommands] : undefined;
-                    if (handler && contributedCommands && contributedCommands.some(item => item.command === command)) {
+                    if (handler && commandIsDeclaredInPackage(command, plugin.rawModel)) {
                         return commandRegistry.registerHandler(command, handler, thisArg);
                     }
                     return commandRegistry.registerCommand({ id: command }, handler, thisArg);
@@ -258,7 +261,7 @@ export function createAPIFactory(
                 return commandRegistry.executeCommand<T>(commandId, ...args);
             },
             registerTextEditorCommand(command: string, handler: (textEditor: theia.TextEditor, edit: theia.TextEditorEdit, ...arg: any[]) => void, thisArg?: any): Disposable {
-                return commandRegistry.registerCommand({ id: command }, (...args: any[]): any => {
+                const internalHandler = (...args: any[]): any => {
                     const activeTextEditor = editors.getActiveEditor();
                     if (!activeTextEditor) {
                         console.warn('Cannot execute ' + command + ' because there is no active text editor.');
@@ -275,7 +278,10 @@ export function createAPIFactory(
                     }, err => {
                         console.warn('An error occurred while running command ' + command, err);
                     });
-                });
+                };
+                return commandIsDeclaredInPackage(command, plugin.rawModel)
+                    ? commandRegistry.registerHandler(command, internalHandler)
+                    : commandRegistry.registerCommand({ id: command }, internalHandler);
             },
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             registerHandler(commandId: string, handler: (...args: any[]) => any, thisArg?: any): Disposable {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11763 by checking whether commands registered via `registerTextEditorCommand` are declared in `package.json` and registering only a handler, if so.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Install and activate CLangD.
2. Observe that no warnings about redundant registration of `clangd.typeHierarchy` or `clangd.ast` are logged.
3. Observe that the `clangd.ast` command still works as expected: right clicking in a C(++) editor should show a `Show Ast` menu item, and clicking it should add a view container part to the Navigator that shows the AST at that place in the file.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
