### PR TITLE
Add full support for TerminalOptions.shellArgs

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -461,7 +461,7 @@ export function createAPIFactory(
             },
             createTerminal(nameOrOptions: theia.TerminalOptions | theia.PseudoTerminalOptions | theia.ExtensionTerminalOptions | (string | undefined),
                 shellPath?: string,
-                shellArgs?: string[]): theia.Terminal {
+                shellArgs?: string[] | string): theia.Terminal {
                 return terminalExt.createTerminal(nameOrOptions, shellPath, shellArgs);
             },
             onDidChangeTerminalState,

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -61,7 +61,10 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         return [...this._terminals.values()];
     }
 
-    createTerminal(nameOrOptions: TerminalOptions | PseudoTerminalOptions | ExtensionTerminalOptions | (string | undefined), shellPath?: string, shellArgs?: string[]): Terminal {
+    createTerminal(
+        nameOrOptions: TerminalOptions | PseudoTerminalOptions | ExtensionTerminalOptions | (string | undefined),
+        shellPath?: string, shellArgs?: string[] | string
+    ): Terminal {
         let options: TerminalOptions;
         let pseudoTerminal: theia.Pseudoterminal | undefined = undefined;
         const id = `plugin-terminal-${UUID.uuid4()}`;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3071,9 +3071,10 @@ export module '@theia/plugin' {
         shellPath?: string;
 
         /**
-         * Arguments to configure executable shell. For example ["-l"] - run shell without login.
+         * Args for the custom shell executable. A string can be used on Windows only which allows
+         * specifying shell args in [command-line format](https://msdn.microsoft.com/en-au/08dfcab2-eb6e-49a4-80eb-87d4076c98c6).
          */
-        shellArgs?: string[];
+        shellArgs?: string[] | string;
 
         /**
          * Current working directory.
@@ -5026,7 +5027,7 @@ export module '@theia/plugin' {
          * @param shellPath - path to the executable shell. For example "/bin/bash", "bash", "sh".
          * @param shellArgs - arguments to configure executable shell. For example ["-l"] - run shell without login.
          */
-        export function createTerminal(name?: string, shellPath?: string, shellArgs?: string[]): Terminal;
+        export function createTerminal(name?: string, shellPath?: string, shellArgs?: string[] | string): Terminal;
 
         /**
          * Event which fires when terminal did closed. Event value contains closed terminal definition.

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -155,9 +155,10 @@ export interface TerminalWidgetOptions {
     readonly shellPath?: string;
 
     /**
-     * Shell arguments to executable shell, for example: [`-l`] - without login.
+     * Args for the custom shell executable. A string can be used on Windows only which allows
+     * specifying shell args in [command-line format](https://msdn.microsoft.com/en-au/08dfcab2-eb6e-49a4-80eb-87d4076c98c6).
      */
-    readonly shellArgs?: string[];
+    readonly shellArgs?: string[] | string;
 
     /**
      * Current working directory.

--- a/packages/terminal/src/common/shell-terminal-protocol.ts
+++ b/packages/terminal/src/common/shell-terminal-protocol.ts
@@ -38,7 +38,7 @@ export interface IShellTerminalPreferences {
 export interface IShellTerminalServerOptions extends IBaseTerminalServerOptions {
     shellPreferences?: IShellTerminalPreferences,
     shell?: string,
-    args?: string[],
+    args?: string[] | string,
     rootURI?: string,
     cols?: number,
     rows?: number,

--- a/packages/terminal/src/node/shell-process.ts
+++ b/packages/terminal/src/node/shell-process.ts
@@ -32,7 +32,7 @@ export const ShellProcessOptions = Symbol('ShellProcessOptions');
 export interface ShellProcessOptions {
     shellPreferences?: IShellTerminalPreferences,
     shell?: string,
-    args?: string[],
+    args?: string[] | string,
     rootURI?: string,
     cols?: number,
     rows?: number,


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11683
Fully support `TerminalOptions.shellArgs` on **Windows**.

#### How to test
1. Test using a **windows** machine
2. Include the folllowing extension in your app ([terminaloptions-shellargs-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/9779551/terminaloptions-shellargs-0.0.1.vsix.zip))
3. Run the command "TerminalOptions ShellArgs"
5. The extension will open a new terminal and a confirmation message will appear.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
