### PR TITLE
[CI] Fix license check for non-committers

### DIFF
--- a/scripts/check_3pp_licenses.js
+++ b/scripts/check_3pp_licenses.js
@@ -22,7 +22,7 @@ const readline = require('readline');
 const kSECRET = Symbol('secret');
 
 // Submit any suspicious dependencies for review by the Eclipse Foundation, using dash-license "review" mode?
-const autoReviewMode = process.argv.includes('--review');
+var autoReviewMode = process.argv.includes('--review');
 const project = process.argv.find(arg => /--project=(\S+)/.exec(arg)?.[1]) ?? 'ecd.theia';
 
 const NO_COLOR = Boolean(process.env['NO_COLOR']);
@@ -45,9 +45,10 @@ main().catch(error => {
 
 async function main() {
     if (autoReviewMode && !personalAccessToken) {
-        error('Please setup an Eclipse Foundation Gitlab Personal Access Token to run the license check in "review" mode');
-        error('It should be set in an environment variable named "DASH_LICENSES_PAT"');
-        process.exit(1);
+        warn('Please setup an Eclipse Foundation Gitlab Personal Access Token to run the license check in "review" mode');
+        warn('It should be set in an environment variable named "DASH_LICENSES_PAT"');
+        warn('Proceeding in normal mode since the PAT is not currently set');
+        autoReviewMode = false;
     }
     if (!fs.existsSync(dashLicensesJar)) {
         info('Fetching dash-licenses...');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Be more flexible in the absence of the EF Gitlab Private Access Token, to accommodate the case where non-committers (contributors without write access to the repo) submit PRs and do not have access to GitHub secrets (for security reasons).

Instead of immediately failing the license check, warn and proceed in "normal mode" - i.e. like we did before introducing the "review mode".

Fixes #11769

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run locally without setting PAT in environment variable `DASH_LICENSES_PAT` and confirm that the license check proceeds with only a warning: 
`$> yarn license:check:review`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
