### PR TITLE
Upgrade vscode-textmate to ^7.0.3

### DIFF
--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -13,7 +13,7 @@
     "idb": "^4.0.5",
     "jsonc-parser": "^2.2.0",
     "vscode-oniguruma": "1.6.1",
-    "vscode-textmate": "7.0.1"
+    "vscode-textmate": "^7.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/monaco/src/browser/textmate/monaco-textmate-frontend-bindings.ts
+++ b/packages/monaco/src/browser/textmate/monaco-textmate-frontend-bindings.ts
@@ -22,7 +22,8 @@ import { LanguageGrammarDefinitionContribution } from './textmate-contribution';
 import { MonacoTextmateService } from './monaco-textmate-service';
 import { MonacoThemeRegistry } from './monaco-theme-registry';
 import { loadWASM, createOnigScanner, OnigScanner, createOnigString, OnigString } from 'vscode-oniguruma';
-import { IOnigLib, IRawGrammar, parseRawGrammar, Registry } from 'vscode-textmate';
+import { IOnigLib, parseRawGrammar, Registry } from 'vscode-textmate';
+import { IRawGrammar } from 'vscode-textmate/release/rawGrammar';
 import { OnigasmPromise, TextmateRegistryFactory, ThemeMix } from './monaco-theme-types';
 
 export class OnigasmLib implements IOnigLib {

--- a/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
@@ -18,7 +18,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { IRawThemeSetting } from 'vscode-textmate';
+import { IRawThemeSetting } from 'vscode-textmate/release/theme';
 import * as monaco from '@theia/monaco-editor-core';
 import { IStandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';

--- a/packages/monaco/src/browser/textmate/monaco-theme-types.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-types.ts
@@ -16,7 +16,8 @@
 
 import * as monaco from '@theia/monaco-editor-core';
 import { IStandaloneTheme } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
-import { IOnigLib, IRawTheme, Registry } from 'vscode-textmate';
+import { IOnigLib, Registry } from 'vscode-textmate';
+import { IRawTheme } from 'vscode-textmate/release/theme';
 
 export interface ThemeMix extends IRawTheme, monaco.editor.IStandaloneThemeData { }
 export interface MixStandaloneTheme extends IStandaloneTheme {

--- a/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
+++ b/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
@@ -14,13 +14,13 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { INITIAL, StackElement, IGrammar } from 'vscode-textmate';
+import { INITIAL, StateStack, IGrammar } from 'vscode-textmate';
 import * as monaco from '@theia/monaco-editor-core';
 
 export class TokenizerState implements monaco.languages.IState {
 
     constructor(
-        public readonly ruleStack: StackElement
+        public readonly ruleStack: StateStack
     ) { }
 
     clone(): monaco.languages.IState {

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -45,7 +45,7 @@
     "uuid": "^8.0.0",
     "vhost": "^3.0.2",
     "vscode-proxy-agent": "^0.11.0",
-    "vscode-textmate": "7.0.1"
+    "vscode-textmate": "^7.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -15,7 +15,8 @@
 // *****************************************************************************
 
 import { injectable, inject, named } from '@theia/core/shared/inversify';
-import { ITokenTypeMap, IEmbeddedLanguagesMap, StandardTokenType } from 'vscode-textmate';
+import { ITokenTypeMap, IEmbeddedLanguagesMap } from 'vscode-textmate';
+import { StandardTokenType } from 'vscode-textmate/release/encodedTokenAttributes';
 import { TextmateRegistry, getEncodedLanguageId, MonacoTextmateService, GrammarDefinition } from '@theia/monaco/lib/browser/textmate';
 import { MenusContributionPointHandler } from './menus/menus-contribution-handler';
 import { PluginViewRegistry } from './view/plugin-view-registry';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11660,10 +11660,10 @@ vscode-textmate@5.2.0:
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
   integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
-vscode-textmate@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-7.0.1.tgz#8118a32b02735dccd14f893b495fa5389ad7de79"
-  integrity sha512-zQ5U/nuXAAMsh691FtV0wPz89nSkHbs+IQV8FDk+wew9BlSDhf4UmWGlWJfTR2Ti6xZv87Tj5fENzKf6Qk7aLw==
+vscode-textmate@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-7.0.3.tgz#71e29c3de01b878ab50927791e335d0e035b5240"
+  integrity sha512-OkE/mYm1h5ZX9IEKeKR/2zKDt2SzYyIfTEOVFX4QhA+B3BPROvNEmDDXvBThz3qknKO3Cy/VVb8/sx1UlqP/Xw==
 
 vscode-uri@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
Breaking changes in vscode-textmate between 7.0.1 and 7.0.3

Replacing pin to version 7.0.1 in https://github.com/eclipse-theia/theia/commit/bd3db5ec16ab58a93ad90dbcce17e82120523d2d

Contributed by STMicroelectronics

Signed-off-by: Niklas DAHLQUIST <niklas.dahlquist@st.com>
Co-written-by: Samuel HULTGREN <samuel.hultgren@st.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
