### PR TITLE
fix: make  on first tab cycle back to last tab

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1849,6 +1849,13 @@ export class ApplicationShell extends Widget {
                     }
                     return true;
                 } else if (ci === 0) {
+                    if (current && current.titles.length > 0) {
+                        current.currentIndex = current.titles.length - 1;
+                        if (current.currentTitle) {
+                            this.activateWidget(current.currentTitle.owner.id);
+                        }
+                        return true;
+                    }
                     return this.activatePreviousTabBar(current);
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11746

Before this commit, trying to cycle back to the previous tab, when you were on the first tab had no action. The expected behaviour was to have the last tab in focus. This was because trying to move back from the first tab was thought to be an action of moving to the previous tab group. This commit fixes that issue by treating it as a same tab group action, and redirecting the user to the last tab in the same group.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- confirm that #11746 is fixed
- confirm there are no regressions with https://github.com/eclipse-theia/theia/pull/10685 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
