### PR TITLE
vscode: add deprecated `withScmProgress`

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -476,6 +476,10 @@ export function createAPIFactory(
             createTreeView<T>(viewId: string, options: { treeDataProvider: theia.TreeDataProvider<T> }): theia.TreeView<T> {
                 return treeViewsExt.createTreeView(plugin, viewId, options);
             },
+            withScmProgress<R>(task: (progress: theia.Progress<number>) => Thenable<R>) {
+                const options: ProgressOptions = { location: ProgressLocation.SourceControl };
+                return notificationExt.withProgress(options, () => task({ report() { /* noop */ } }));
+            },
             withProgress<R>(
                 options: ProgressOptions,
                 task: (progress: Progress<{ message?: string; increment?: number }>, token: theia.CancellationToken) => PromiseLike<R>

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5109,6 +5109,18 @@ export module '@theia/plugin' {
         export function registerUriHandler(handler: UriHandler): Disposable;
 
         /**
+         * Show progress in the Source Control viewlet while running the given callback and while
+         * its returned promise isn't resolve or rejected.
+         *
+         * @deprecated Use `withProgress` instead.
+         *
+         * @param task A callback returning a promise. Progress increments can be reported with
+         * the provided {@link Progress}-object.
+         * @return The thenable the task did return.
+         */
+        export function withScmProgress<R>(task: (progress: Progress<number>) => Thenable<R>): Thenable<R>;
+
+        /**
          * Show progress in the editor. Progress is shown while running the given callback
          * and while the promise it returned isn't resolved nor rejected. The location at which
          * progress should show (and other details) is defined via the passed [`ProgressOptions`](#ProgressOptions).


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds the **deprecated** `withScmProgress` API to satisfy our compatibility report. Similarly to [VS Code](https://github.com/microsoft/vscode/blob/3807cdebcb7548f14f8c8055fc01da16f858d8ec/src/vs/workbench/api/common/extHost.api.impl.ts#L707-L712) the API implementation is a `no-op` for progress in the source control location. The deprecated API is mainly implemented for backwards compatibility.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- [x] confirm that the API is marked as supported with the comparator report

![image](https://user-images.githubusercontent.com/40359487/197832798-b4c565fa-bb38-4b0e-adcb-052e8be18a21.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>