### PR TITLE
Add support explorer.decorations.colors preference

### DIFF
--- a/packages/navigator/src/browser/abstract-navigator-tree-widget.ts
+++ b/packages/navigator/src/browser/abstract-navigator-tree-widget.ts
@@ -1,0 +1,59 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { FileNavigatorPreferences } from './navigator-preferences';
+import { PreferenceService } from '@theia/core/lib/browser/preferences/preference-service';
+import { FileTreeWidget } from '@theia/filesystem/lib/browser';
+import { Attributes, HTMLAttributes } from '@theia/core/shared/react';
+import { TreeNode } from '@theia/core/lib/browser';
+
+@injectable()
+export class AbstractNavigatorTreeWidget extends FileTreeWidget {
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(FileNavigatorPreferences)
+    protected readonly navigatorPreferences: FileNavigatorPreferences;
+
+    @postConstruct()
+    protected override init(): void {
+        super.init();
+        this.toDispose.push(
+            this.preferenceService.onPreferenceChanged(preference => {
+                if (preference.preferenceName === 'explorer.decorations.colors') {
+                    this.update();
+                }
+            })
+        );
+    }
+
+    protected override decorateCaption(node: TreeNode, attrs: HTMLAttributes<HTMLElement>): Attributes & HTMLAttributes<HTMLElement> {
+        const attributes = super.decorateCaption(node, attrs);
+        if (this.navigatorPreferences.get('explorer.decorations.colors')) {
+            return attributes;
+        } else {
+            return {
+                ...attributes,
+                style: {
+                    ...attributes.style,
+                    color: undefined,
+                }
+            };
+        }
+    }
+}

--- a/packages/navigator/src/browser/navigator-preferences.ts
+++ b/packages/navigator/src/browser/navigator-preferences.ts
@@ -28,6 +28,11 @@ export const FileNavigatorConfigSchema: PreferenceSchema = {
             description: nls.localizeByDefault('Controls whether the explorer should automatically reveal and select files when opening them.'),
             default: true
         },
+        'explorer.decorations.colors': {
+            type: 'boolean',
+            description: nls.localizeByDefault('Controls whether file decorations should use colors.'),
+            default: true
+        },
         [EXPLORER_COMPACT_FOLDERS]: {
             type: 'boolean',
             // eslint-disable-next-line max-len
@@ -39,6 +44,7 @@ export const FileNavigatorConfigSchema: PreferenceSchema = {
 
 export interface FileNavigatorConfiguration {
     'explorer.autoReveal': boolean;
+    'explorer.decorations.colors': boolean;
     [EXPLORER_COMPACT_FOLDERS]: boolean;
 }
 

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -19,7 +19,7 @@ import { Message } from '@theia/core/shared/@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { CommandService } from '@theia/core/lib/common';
 import { Key, TreeModel, SelectableTreeNode, OpenerService, ContextMenuRenderer, ExpandableTreeNode, TreeProps, TreeNode } from '@theia/core/lib/browser';
-import { FileTreeWidget, FileNode, DirNode } from '@theia/filesystem/lib/browser';
+import { FileNode, DirNode } from '@theia/filesystem/lib/browser';
 import { WorkspaceService, WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 import { WorkspaceNode, WorkspaceRootNode } from './navigator-tree';
@@ -29,13 +29,14 @@ import * as React from '@theia/core/shared/react';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
 import { FileNavigatorCommands } from './navigator-contribution';
 import { nls } from '@theia/core/lib/common/nls';
+import { AbstractNavigatorTreeWidget } from './abstract-navigator-tree-widget';
 
 export const FILE_NAVIGATOR_ID = 'files';
 export const LABEL = nls.localizeByDefault('No Folder Opened');
 export const CLASS = 'theia-Files';
 
 @injectable()
-export class FileNavigatorWidget extends FileTreeWidget {
+export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
 
     @inject(ApplicationShell) protected readonly shell: ApplicationShell;
     @inject(CommandService) protected readonly commandService: CommandService;

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -42,6 +42,7 @@ import { CommandService } from '@theia/core/lib/common';
 import { OpenEditorsCommands } from './navigator-open-editors-commands';
 import { nls } from '@theia/core/lib/common/nls';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { AbstractNavigatorTreeWidget } from '../abstract-navigator-tree-widget';
 
 export const OPEN_EDITORS_PROPS: TreeProps = {
     ...defaultTreeProps,
@@ -54,7 +55,7 @@ export interface OpenEditorsNodeRow extends TreeWidget.NodeRow {
     node: OpenEditorNode;
 }
 @injectable()
-export class OpenEditorsWidget extends FileTreeWidget {
+export class OpenEditorsWidget extends AbstractNavigatorTreeWidget {
     static ID = 'theia-open-editors-widget';
     static LABEL = nls.localizeByDefault('Open Editors');
 


### PR DESCRIPTION
#### What it does

Closes #6864.

The pull-request adds support for the `explorer.decorations.colors` preference which is used to toggle decorations for files in the navigator/explorer. In order to support the preference a new `AbstractNavigatorTreeWidget` class was created which is common to both `FileNavigatorWidget` and `OpenEditorsWidget`, so we can affect how they decorate their nodes based on different contributions.

#### How to test

1. start the application using `theia` itself as a workspace
2. enable the preference `explorer.decorations.enabled` and confirm that decorations in the explorer and open-editors are present (ex: problem markers, git status)
3. disable the preference `explorer.decorations.enabled` and confirm that decorations are still present (ex: tail decorations) but the node's file color is not
4. confirm that toggling the preference is supported
5. confirm that starting the application with both preference values is respected

_`explorer.decorations.colors` = `true`_

![image](https://user-images.githubusercontent.com/40359487/198113040-76359bdc-6598-4f9c-9b86-64624f2fcbfd.png)

_`explorer.decorations.colors` = `false`_

![image](https://user-images.githubusercontent.com/40359487/198112948-cf608f2f-de20-42ee-aa31-351390fab1eb.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
