### PR TITLE
Support for declaring extensions as peer dependencies

### DIFF
--- a/dev-packages/application-package/src/extension-package-collector.ts
+++ b/dev-packages/application-package/src/extension-package-collector.ts
@@ -36,13 +36,11 @@ export class ExtensionPackageCollector {
     }
 
     protected collectPackages(pck: NodePackage): void {
-        if (!pck.dependencies) {
-            return;
-        }
-        // eslint-disable-next-line guard-for-in
-        for (const dependency in pck.dependencies) {
-            const versionRange = pck.dependencies[dependency]!;
-            this.collectPackage(dependency, versionRange);
+        for (const [dependency, versionRange] of [
+            ...Object.entries(pck.dependencies ?? {}),
+            ...Object.entries(pck.peerDependencies ?? {})
+        ]) {
+            this.collectPackage(dependency, versionRange!);
         }
     }
 

--- a/dev-packages/application-package/src/npm-registry.ts
+++ b/dev-packages/application-package/src/npm-registry.ts
@@ -47,6 +47,7 @@ export interface NodePackage {
     maintainers?: Maintainer[];
     keywords?: string[];
     dependencies?: Dependencies;
+    peerDependencies?: Dependencies;
     [property: string]: any;
 }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Ensures that the ExtensionPackageCollector also correctly picks up packages that are declared as peer dependencies.

This change allows extension providers to declare their dependencies to Theia core extensions as peer dependencies. This can simplify version management and eliminates the need for yarn resolutions (or a similar feature) to ensure that only one version of Theia extensions is resolved. 

This topics has already been discussed multiple times:
-  https://github.com/eclipse-theia/theia/discussions/10791
- https://github.com/eclipse-theia/theia/issues/10194
- https://github.com/eclipse-theia/theia/pull/5939

The question whether we actually want to change inter dependencies between Theia core packages to peer dependencies is still up for discussion. 
Nevertheless, ensuring the the application builder also supports and correctly loads Theia extensions that are declared as peer dependencies is a good idea.

This is an opt-in feature that does not break any existing applications and gives third party extension providers the opportunity to use peer dependencies if they want to.

Contributed on behalf of STMicroelectronics
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Can for instance be tested with the "@theia/api-samples" package by simply switching all dependencies to peerDependencies:
```diff
- "dependencies": {
+ "peerDependencies": {
    "@theia/core": "1.30.0",
    "@theia/file-search": "1.30.0",
    "@theia/filesystem": "1.30.0",
    "@theia/monaco": "1.30.0",
    "@theia/monaco-editor-core": "1.67.2",
    "@theia/output": "1.30.0",
    "@theia/search-in-workspace": "1.30.0",
    "@theia/toolbar": "1.30.0",
    "@theia/vsx-registry": "1.30.0",
    "@theia/workspace": "1.30.0"
  },
```

1. Building this change on master results in a corrupt application. I.e. the browser application no longer loads and the following error is logged:
![Screenshot from 2022-10-27 18-15-20](https://user-images.githubusercontent.com/2311075/198344022-2c93e262-e36d-48fe-964b-f858955dad0a.png)
In the generated frontend index.js file you can see that the api-samples frontend module gets loaded before the required core modules which causes the error.

2. Building this change on the PR branch causes no errors. The browser application loads as expected and the module loading is in correct order.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
