### PR TITLE
docs: update `1.31.0` changelog for `unstage all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.31.0 - 10/27/2022
 
 - [debug] added confirmation message for debug exit [#11546](https://github.com/eclipse-theia/theia/pull/11546)
+- [git] fixed the implementation of the `unstage all` command [#11805](https://github.com/eclipse-theia/theia/pull/11805)
 - [messages] fixed transparent notifications issue [#11714](https://github.com/eclipse-theia/theia/pull/11714)
 - [monaco] fixed issue with `editor-*` preferences not being applied properly [#11711](https://github.com/eclipse-theia/theia/pull/11711)
 - [output] fixed issue with channel selector [#11727](https://github.com/eclipse-theia/theia/pull/11727)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds an entry note to the `1.31.0` changelog for https://github.com/eclipse-theia/theia/pull/11805 (`unstage all` fix).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- confirm the entry is correct.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>