### PR TITLE
plugin-ext: cleanup `theia.d.ts` for `extensions`

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -180,7 +180,7 @@ import { ConnectionImpl } from '../common/connection';
 import { TasksExtImpl } from './tasks/tasks';
 import { DebugExtImpl } from './debug/debug-ext';
 import { FileSystemExtImpl } from './file-system-ext-impl';
-import { QuickPick, QuickPickItem, ResourceLabelFormatter, LineChange } from '@theia/plugin';
+import { QuickPick, QuickPickItem, ResourceLabelFormatter, LineChange, ExtensionKind } from '@theia/plugin';
 import { ScmExtImpl } from './scm';
 import { DecorationsExtImpl } from './decorations';
 import { TextEditorExt } from './text-editor';
@@ -1100,14 +1100,10 @@ export function createAPIFactory(
             TestRunProfileKind,
             TestTag,
             TestRunRequest,
-            TestMessage
+            TestMessage,
+            ExtensionKind
         };
     };
-}
-
-export enum ExtensionKind {
-    UI = 1,
-    Workspace = 2
 }
 
 /**

--- a/packages/plugin/src/theia-extra.d.ts
+++ b/packages/plugin/src/theia-extra.d.ts
@@ -14,6 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * This is the place for extra APIs Theia supports compared to VS Code.
  */
@@ -33,4 +35,263 @@ export module '@theia/plugin' {
         reveal(area?: WebviewPanelTargetArea, viewColumn?: ViewColumn, preserveFocus?: boolean): void;
     }
 
+    export type PluginType = 'frontend' | 'backend';
+
+    /**
+     * Namespace for dealing with installed plug-ins. Plug-ins are represented
+     * by an [plug-in](#Plugin)-interface which enables reflection on them.
+     *
+     * Plug-in writers can provide APIs to other plug-ins by returning their API public
+     * surface from the `start`-call.
+     *
+     * ```javascript
+     * export function start() {
+     *     let api = {
+     *         sum(a, b) {
+     *             return a + b;
+     *         },
+     *         mul(a, b) {
+     *             return a * b;
+     *         }
+     *     };
+     *     // 'export' public api-surface
+     *     return api;
+     * }
+     * ```
+     * ```javascript
+     * let mathExt = plugins.getPlugin('genius.math');
+     * let importedApi = mathExt.exports;
+     *
+     * console.log(importedApi.mul(42, 1));
+     * ```
+     */
+    export namespace plugins {
+        /**
+         * Get an plug-in by its full identifier in the form of: `publisher.name`.
+         *
+         * @param pluginId An plug-in identifier.
+         * @return An plug-in or `undefined`.
+         */
+        export function getPlugin(pluginId: string): Plugin<any> | undefined;
+
+        /**
+         * Get an plug-in its full identifier in the form of: `publisher.name`.
+         *
+         * @param pluginId An plug-in identifier.
+         * @return An plug-in or `undefined`.
+         */
+        export function getPlugin<T>(pluginId: string): Plugin<T> | undefined;
+
+        /**
+         * All plug-ins currently known to the system.
+         */
+        export let all: Plugin<any>[];
+
+        /**
+         * An event which fires when `plugins.all` changes. This can happen when extensions are
+         * installed, uninstalled, enabled or disabled.
+         */
+        export let onDidChange: Event<void>;
+    }
+
+    /**
+     * Represents an plugin.
+     *
+     * To get an instance of an `Plugin` use {@link plugins.getPlugin getPlugin}.
+     */
+    export interface Plugin<T> {
+
+        /**
+         * The canonical plug-in identifier in the form of: `publisher.name`.
+         */
+        readonly id: string;
+
+        /**
+         * The absolute file path of the directory containing this plug-in.
+         */
+        readonly pluginPath: string;
+
+        /**
+         * The uri of the directory containing this plug-in.
+         */
+        readonly pluginUri: Uri;
+
+        /**
+         * `true` if the plug-in has been activated.
+         */
+        readonly isActive: boolean;
+
+        /**
+         * The parsed contents of the plug-in's package.json.
+         */
+        readonly packageJSON: any;
+
+        /**
+         *
+         */
+        readonly pluginType: PluginType;
+
+        /**
+         * The public API exported by this plug-in. It is an invalid action
+         * to access this field before this plug-in has been activated.
+         */
+        readonly exports: T;
+
+        /**
+         * Activates this plug-in and returns its public API.
+         *
+         * @return A promise that will resolve when this plug-in has been activated.
+         */
+        activate(): Thenable<T>;
+    }
+
+    /**
+     * A plug-in context is a collection of utilities private to a
+     * plug-in.
+     *
+     * An instance of a `PluginContext` is provided as the first
+     * parameter to the `start` of a plug-in.
+     */
+    export interface PluginContext {
+
+        /**
+         * An array to which disposables can be added. When this
+         * extension is deactivated the disposables will be disposed.
+         */
+        subscriptions: { dispose(): any }[];
+
+        /**
+         * A memento object that stores state in the context
+         * of the currently opened {@link workspace.workspaceFolders workspace}.
+         */
+        workspaceState: Memento;
+
+        /**
+         * A memento object that stores state independent
+         * of the current opened {@link workspace.workspaceFolders workspace}.
+         */
+        globalState: Memento & {
+            /**
+             * Set the keys whose values should be synchronized across devices when synchronizing user-data
+             * like configuration, extensions, and mementos.
+             *
+             * Note that this function defines the whole set of keys whose values are synchronized:
+             *  - calling it with an empty array stops synchronization for this memento
+             *  - calling it with a non-empty array replaces all keys whose values are synchronized
+             *
+             * For any given set of keys this function needs to be called only once but there is no harm in
+             * repeatedly calling it.
+             *
+             * @param keys The set of keys whose values are synced.
+             */
+            setKeysForSync(keys: readonly string[]): void;
+        };
+
+        /**
+         * A storage utility for secrets.
+         */
+        readonly secrets: SecretStorage;
+
+        /**
+         * The absolute file path of the directory containing the extension.
+         */
+        extensionPath: string;
+
+        /**
+         * The uri of the directory containing the extension.
+         */
+        readonly extensionUri: Uri;
+
+        /**
+         * Gets the extension's environment variable collection for this workspace, enabling changes
+         * to be applied to terminal environment variables.
+         */
+        readonly environmentVariableCollection: EnvironmentVariableCollection;
+
+        /**
+         * Get the absolute path of a resource contained in the extension.
+         *
+         * @param relativePath A relative path to a resource contained in the extension.
+         * @return The absolute path of the resource.
+         */
+        asAbsolutePath(relativePath: string): string;
+
+        /**
+         * An absolute file path of a workspace specific directory in which the extension
+         * can store private state. The directory might not exist on disk and creation is
+         * up to the extension. However, the parent directory is guaranteed to be existent.
+         *
+         * Use [`workspaceState`](#PluginContext.workspaceState) or
+         * [`globalState`](#PluginContext.globalState) to store key value data.
+         *
+         * @deprecated Use {@link PluginContext.storageUri storageUri} instead.
+         */
+        storagePath: string | undefined;
+
+        /**
+         * The uri of a workspace specific directory in which the extension
+         * can store private state. The directory might not exist and creation is
+         * up to the extension. However, the parent directory is guaranteed to be existent.
+         * The value is `undefined` when no workspace nor folder has been opened.
+         *
+         * Use [`workspaceState`](#PluginContext.workspaceState) or
+         * [`globalState`](#PluginContext.globalState) to store key value data.
+         *
+         * @see [`workspace.fs`](#FileSystem) for how to read and write files and folders from
+         *  an uri.
+         */
+        readonly storageUri: Uri | undefined;
+
+        /**
+         * An absolute file path in which the extension can store global state.
+         * The directory might not exist on disk and creation is
+         * up to the extension. However, the parent directory is guaranteed to be existent.
+         *
+         * Use [`globalState`](#PluginContext.globalState) to store key value data.
+         *
+         * @deprecated Use {@link PluginContext.globalStorageUri globalStorageUri} instead.
+         */
+        readonly globalStoragePath: string;
+
+        /**
+         * The uri of a directory in which the extension can store global state.
+         * The directory might not exist on disk and creation is
+         * up to the extension. However, the parent directory is guaranteed to be existent.
+         *
+         * Use [`globalState`](#PluginContext.globalState) to store key value data.
+         *
+         * @see [`workspace.fs`](#FileSystem) for how to read and write files and folders from
+         *  an uri.
+         */
+        readonly globalStorageUri: Uri;
+
+        /**
+         * An absolute file path of a directory in which the extension can create log files.
+         * The directory might not exist on disk and creation is up to the extension. However,
+         * the parent directory is guaranteed to be existent.
+         */
+        readonly logPath: string;
+
+        /**
+         * The mode the extension is running in. This is specific to the current
+         * extension. One extension may be in `ExtensionMode.Development` while
+         * other extensions in the host run in `ExtensionMode.Release`.
+         */
+        readonly extensionMode: ExtensionMode;
+
+        /**
+         * The current extension instance.
+         */
+        readonly extension: Plugin<any> | undefined;
+
+        /**
+         * The uri of a directory in which the extension can create log files. The directory might
+         * not exist on disk and creation is up to the extension. However, the parent directory is
+         * guaranteed to be existent.
+         * see - workspace.fs for how to read and write files and folders from an uri.
+         */
+        readonly logUri: Uri;
+    }
+
 }
+

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -63,116 +63,6 @@ export module '@theia/plugin' {
 
     }
 
-    export type PluginType = 'frontend' | 'backend';
-
-    /**
-     * Represents an plugin.
-     *
-     * To get an instance of an `Plugin` use {@link plugins.getPlugin getPlugin}.
-     */
-    export interface Plugin<T> {
-
-        /**
-         * The canonical plug-in identifier in the form of: `publisher.name`.
-         */
-        readonly id: string;
-
-        /**
-         * The absolute file path of the directory containing this plug-in.
-         */
-        readonly pluginPath: string;
-
-        /**
-         * The uri of the directory containing this plug-in.
-         */
-        readonly pluginUri: Uri;
-
-        /**
-         * `true` if the plug-in has been activated.
-         */
-        readonly isActive: boolean;
-
-        /**
-         * The parsed contents of the plug-in's package.json.
-         */
-        readonly packageJSON: any;
-
-        /**
-         *
-         */
-        readonly pluginType: PluginType;
-
-        /**
-         * The public API exported by this plug-in. It is an invalid action
-         * to access this field before this plug-in has been activated.
-         */
-        readonly exports: T;
-
-        /**
-         * Activates this plug-in and returns its public API.
-         *
-         * @return A promise that will resolve when this plug-in has been activated.
-         */
-        activate(): Thenable<T>;
-    }
-
-    /**
-     * Namespace for dealing with installed plug-ins. Plug-ins are represented
-     * by an [plug-in](#Plugin)-interface which enables reflection on them.
-     *
-     * Plug-in writers can provide APIs to other plug-ins by returning their API public
-     * surface from the `start`-call.
-     *
-     * ```javascript
-     * export function start() {
-     *     let api = {
-     *         sum(a, b) {
-     *             return a + b;
-     *         },
-     *         mul(a, b) {
-     *             return a * b;
-     *         }
-     *     };
-     *     // 'export' public api-surface
-     *     return api;
-     * }
-     * ```
-     * ```javascript
-     * let mathExt = plugins.getPlugin('genius.math');
-     * let importedApi = mathExt.exports;
-     *
-     * console.log(importedApi.mul(42, 1));
-     * ```
-     */
-    export namespace plugins {
-        /**
-         * Get an plug-in by its full identifier in the form of: `publisher.name`.
-         *
-         * @param pluginId An plug-in identifier.
-         * @return An plug-in or `undefined`.
-         */
-        export function getPlugin(pluginId: string): Plugin<any> | undefined;
-
-        /**
-         * Get an plug-in its full identifier in the form of: `publisher.name`.
-         *
-         * @param pluginId An plug-in identifier.
-         * @return An plug-in or `undefined`.
-         */
-        export function getPlugin<T>(pluginId: string): Plugin<T> | undefined;
-
-        /**
-         * All plug-ins currently known to the system.
-         */
-        export let all: Plugin<any>[];
-
-        /**
-         * An event which fires when `plugins.all` changes. This can happen when extensions are
-         * installed, uninstalled, enabled or disabled.
-         */
-        export let onDidChange: Event<void>;
-    }
-
     /**
      * A command is a unique identifier of a function
      * which can be executed by a user via a keyboard shortcut,
@@ -2530,7 +2420,7 @@ export module '@theia/plugin' {
      * Registration can be split in two step: first register command without handler,
      * second register handler by command id.
      *
-     * Any contributed command are available to any plugin, command can be invoked
+     * Any contributed command are available to any extension, command can be invoked
      * by {@link commands.executeCommand executeCommand} function.
      *
      * Simple example that register command:
@@ -3514,31 +3404,130 @@ export module '@theia/plugin' {
     }
 
     /**
-     * A plug-in context is a collection of utilities private to a
-     * plug-in.
-     *
-     * An instance of a `PluginContext` is provided as the first
-     * parameter to the `start` of a plug-in.
+     * In a remote window the extension kind describes if an extension
+     * runs where the UI (window) runs or if an extension runs remotely.
      */
-    export interface PluginContext {
+    export enum ExtensionKind {
+
+        /**
+         * Extension runs where the UI runs.
+         */
+        UI = 1,
+
+        /**
+         * Extension runs where the remote extension host runs.
+         */
+        Workspace = 2
+    }
+
+    /**
+     * Represents an extension.
+     *
+     * To get an instance of an `Extension` use {@link extensions.getExtension getExtension}.
+     */
+    export interface Extension<T> {
+
+        /**
+         * The canonical extension identifier in the form of: `publisher.name`.
+         */
+        readonly id: string;
+
+        /**
+         * The uri of the directory containing the extension.
+         */
+        readonly extensionUri: Uri;
+
+        /**
+         * The absolute file path of the directory containing this extension. Shorthand
+         * notation for {@link Extension.extensionUri Extension.extensionUri.fsPath} (independent of the uri scheme).
+         */
+        readonly extensionPath: string;
+
+        /**
+         * `true` if the extension has been activated.
+         */
+        readonly isActive: boolean;
+
+        /**
+         * The parsed contents of the extension's package.json.
+         */
+        readonly packageJSON: any;
+
+        /**
+         * The extension kind describes if an extension runs where the UI runs
+         * or if an extension runs where the remote extension host runs. The extension kind
+         * is defined in the `package.json`-file of extensions but can also be refined
+         * via the `remote.extensionKind`-setting. When no remote extension host exists,
+         * the value is {@linkcode ExtensionKind.UI}.
+         */
+        extensionKind: ExtensionKind;
+
+        /**
+         * The public API exported by this extension (return value of `activate`).
+         * It is an invalid action to access this field before this extension has been activated.
+         */
+        readonly exports: T;
+
+        /**
+         * Activates this extension and returns its public API.
+         *
+         * @return A promise that will resolve when this extension has been activated.
+         */
+        activate(): Thenable<T>;
+    }
+
+    /**
+     * The ExtensionMode is provided on the `ExtensionContext` and indicates the
+     * mode the specific extension is running in.
+     */
+    export enum ExtensionMode {
+        /**
+         * The extension is installed normally (for example, from the marketplace
+         * or VSIX) in the editor.
+         */
+        Production = 1,
+
+        /**
+         * The extension is running from an `--extensionDevelopmentPath` provided
+         * when launching the editor.
+         */
+        Development = 2,
+
+        /**
+         * The extension is running from an `--extensionTestsPath` and
+         * the extension host is running unit tests.
+         */
+        Test = 3,
+    }
+
+    /**
+     * An extension context is a collection of utilities private to an
+     * extension.
+     *
+     * An instance of an `ExtensionContext` is provided as the first
+     * parameter to the `activate`-call of an extension.
+     */
+    export interface ExtensionContext {
 
         /**
          * An array to which disposables can be added. When this
          * extension is deactivated the disposables will be disposed.
+         *
+         * *Note* that asynchronous dispose-functions aren't awaited.
          */
-        subscriptions: { dispose(): any }[];
+        readonly subscriptions: { dispose(): any }[];
 
         /**
          * A memento object that stores state in the context
          * of the currently opened {@link workspace.workspaceFolders workspace}.
          */
-        workspaceState: Memento;
+        readonly workspaceState: Memento;
 
         /**
          * A memento object that stores state independent
          * of the current opened {@link workspace.workspaceFolders workspace}.
          */
-        globalState: Memento & {
+        readonly globalState: Memento & {
             /**
              * Set the keys whose values should be synchronized across devices when synchronizing user-data
              * like configuration, extensions, and mementos.
@@ -3556,19 +3545,21 @@ export module '@theia/plugin' {
         };
 
         /**
-         * A storage utility for secrets.
+         * A storage utility for secrets. Secrets are persisted across reloads and are independent of the
+         * current opened {@link workspace.workspaceFolders workspace}.
          */
         readonly secrets: SecretStorage;
-
-        /**
-         * The absolute file path of the directory containing the extension.
-         */
-        extensionPath: string;
 
         /**
          * The uri of the directory containing the extension.
          */
         readonly extensionUri: Uri;
+
+        /**
+         * The absolute file path of the directory containing the extension. Shorthand
+         * notation for {@link TextDocument.uri ExtensionContext.extensionUri.fsPath} (independent of the uri scheme).
+         */
+        readonly extensionPath: string;
 
         /**
          * Gets the extension's environment variable collection for this workspace, enabling changes
@@ -3579,22 +3570,13 @@ export module '@theia/plugin' {
         /**
          * Get the absolute path of a resource contained in the extension.
          *
+         * *Note* that an absolute uri can be constructed via {@linkcode Uri.joinPath} and
+         * {@linkcode ExtensionContext.extensionUri extensionUri}, e.g. `vscode.Uri.joinPath(context.extensionUri, relativePath);`
+         *
          * @param relativePath A relative path to a resource contained in the extension.
          * @return The absolute path of the resource.
          */
         asAbsolutePath(relativePath: string): string;
-
-        /**
-         * An absolute file path of a workspace specific directory in which the extension
-         * can store private state. The directory might not exist on disk and creation is
-         * up to the extension. However, the parent directory is guaranteed to be existent.
-         *
-         * Use [`workspaceState`](#PluginContext.workspaceState) or
-         * [`globalState`](#PluginContext.globalState) to store key value data.
-         *
-         * @deprecated Use {@link PluginContext.storageUri storageUri} instead.
-         */
-        storagePath: string | undefined;
 
         /**
          * The uri of a workspace specific directory in which the extension
@@ -3602,41 +3584,65 @@ export module '@theia/plugin' {
          * up to the extension. However, the parent directory is guaranteed to be existent.
          * The value is `undefined` when no workspace nor folder has been opened.
          *
-         * Use [`workspaceState`](#PluginContext.workspaceState) or
-         * [`globalState`](#PluginContext.globalState) to store key value data.
+         * Use {@linkcode ExtensionContext.workspaceState workspaceState} or
+         * {@linkcode ExtensionContext.globalState globalState} to store key value data.
          *
-         * @see [`workspace.fs`](#FileSystem) for how to read and write files and folders from
+         * @see {@linkcode FileSystem workspace.fs} for how to read and write files and folders from
          *  an uri.
          */
         readonly storageUri: Uri | undefined;
 
         /**
-         * An absolute file path in which the extension can store global state.
-         * The directory might not exist on disk and creation is
+         * An absolute file path of a workspace specific directory in which the extension
+         * can store private state. The directory might not exist on disk and creation is
          * up to the extension. However, the parent directory is guaranteed to be existent.
          *
-         * Use [`globalState`](#PluginContext.globalState) to store key value data.
+         * Use {@linkcode ExtensionContext.workspaceState workspaceState} or
+         * {@linkcode ExtensionContext.globalState globalState} to store key value data.
          *
-         * @deprecated Use {@link PluginContext.globalStorageUri globalStorageUri} instead.
+         * @deprecated Use {@link ExtensionContext.storageUri storageUri} instead.
          */
-        readonly globalStoragePath: string;
+        readonly storagePath: string | undefined;
 
         /**
          * The uri of a directory in which the extension can store global state.
          * The directory might not exist on disk and creation is
          * up to the extension. However, the parent directory is guaranteed to be existent.
          *
-         * Use [`globalState`](#PluginContext.globalState) to store key value data.
+         * Use {@linkcode ExtensionContext.globalState globalState} to store key value data.
          *
-         * @see [`workspace.fs`](#FileSystem) for how to read and write files and folders from
+         * @see {@linkcode FileSystem workspace.fs} for how to read and write files and folders from
          *  an uri.
          */
         readonly globalStorageUri: Uri;
 
         /**
+         * An absolute file path in which the extension can store global state.
+         * The directory might not exist on disk and creation is
+         * up to the extension. However, the parent directory is guaranteed to be existent.
+         *
+         * Use {@linkcode ExtensionContext.globalState globalState} to store key value data.
+         *
+         * @deprecated Use {@link ExtensionContext.globalStorageUri globalStorageUri} instead.
+         */
+        readonly globalStoragePath: string;
+
+        /**
+         * The uri of a directory in which the extension can create log files.
+         * The directory might not exist on disk and creation is up to the extension. However,
+         * the parent directory is guaranteed to be existent.
+         *
+         * @see {@linkcode FileSystem workspace.fs} for how to read and write files and folders from
+         *  an uri.
+         */
+        readonly logUri: Uri;
+
+        /**
          * An absolute file path of a directory in which the extension can create log files.
          * The directory might not exist on disk and creation is up to the extension. However,
          * the parent directory is guaranteed to be existent.
+         *
+         * @deprecated Use {@link ExtensionContext.logUri logUri} instead.
          */
         readonly logPath: string;
 
@@ -3648,17 +3654,9 @@ export module '@theia/plugin' {
         readonly extensionMode: ExtensionMode;
 
         /**
-         * The current extension instance.
+         * The current `Extension` instance.
          */
-        readonly extension: Plugin<any> | undefined;
-
-        /**
-         * The uri of a directory in which the extension can create log files. The directory might
-         * not exist on disk and creation is up to the extension. However, the parent directory is
-         * guaranteed to be existent.
-         * see - workspace.fs for how to read and write files and folders from an uri.
-         */
-        readonly logUri: Uri;
+        readonly extension: Extension<any>;
     }
 
     /**
@@ -4874,7 +4872,7 @@ export module '@theia/plugin' {
         /**
          * Registers a webview panel serializer.
          *
-         * Plugins that support reviving should have an `"onWebviewPanel:viewType"` activation event and
+         * Extensions that support reviving should have an `"onWebviewPanel:viewType"` activation event and
          * make sure that {@link registerWebviewPanelSerializer registerWebviewPanelSerializer} is called during activation.
          *
          * Only a single serializer may be registered at a time for a given `viewType`.
@@ -8238,7 +8236,7 @@ export module '@theia/plugin' {
     }
 
     /**
-     * The completion item provider interface defines the contract between plugin and IntelliSense
+     * The completion item provider interface defines the contract between extensions and IntelliSense
      *
      * Providers can delay the computation of the [`detail`](#CompletionItem.detail)
      * and [`documentation`](#CompletionItem.documentation) properties by implementing the
@@ -11748,7 +11746,7 @@ export module '@theia/plugin' {
         /**
          * Fetches all tasks available in the systems. This includes tasks
          * from `tasks.json` files as well as tasks from task providers
-         * contributed through extensions and plugins.
+         * contributed through extensions.
          *
          * @param filter a filter to filter the return tasks.
          */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Related: #11815 

The commit cleans up the `theia.d.ts` with the following changes:
- moves `plugin` namespace to `theia-extra.d.ts` since it is different than `vscode.d.ts`.
- adds `extension` namespace to `theia.d.ts` for our compatibility report.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The changes should work like before, since `extensions` was already supported but the code now organizes it in the proper location, and the report now passes for the API:

<details>

<summary>Compatibility Report</summary>

<br />

![image](https://user-images.githubusercontent.com/40359487/198708283-76eca16f-5b06-4e60-aecc-d03a5ed64017.png)

</details>

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>