### PR TITLE
Theia 3PP license check workflow improvement: retry upon failure, after a delay

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -48,6 +48,6 @@ jobs:
         if: matrix.tests != 'skip'
         shell: bash
         run: |
-          yarn license:check:review
+          yarn license:check:review || ( sleep 15m && yarn license:check:review )
         env:
           DASH_LICENSES_PAT: ${{ secrets.DASH_LICENSES_PAT }}


### PR DESCRIPTION
#### What it does
Currently, if our 3PP license check workflow fails to validate the license of all our dependencies, the workflow is marked as failed and the offending dependencies are automatically submitted to the Eclipse Foundation's Gitlab for analysis and (hopefully) approval.  This approval  can often happen in a totally automated way, within a few minutes.  Re-running the workflow at that point would end with success, but this  needs to be triggered manually.  

This commit improves the workflow, to have it fail less often.  We do this by taking advantage of the usually quick approval of 3PP dependencies that failed the check, by modifying the bash command used to run the license check:  upon failure, it waits for 15 minutes and then another attempt is made. Any dependency that was approved in the meantime will now pass the check.

Before:
$> yarn license:check:review
After:
$> yarn license:check:review || (sleep 15m && yarn license:check:review)
Note that if the workflow works on the first try, no second attempt will
 happen.

#### How to test

Can be test locally by adding a dependency that is likely not to pass on first try in package.json.
_(note: this requires an Eclipse Foundation GitLab token, set in an environment variable named DASH_LICENSES_PAT. See [here](https://github.com/eclipse/dash-licenses#automatic-ip-team-review-requests) and [here](https://github.com/eclipse-theia/theia/blob/master/scripts/check_3pp_licenses.js#L39) for more details)_

**Then run the following command (which is in licence-check.yml file) in the terminal:** 
yarn license:check:review || ( sleep 15m && yarn license:check:review )
or
**on window terminal:**
 yarn license:check:review || ( timeout 15m && yarn && yarn license:check:review )



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
