### PR TITLE
plugin: update default api version to `1.55.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [plugin] added `Task#runOptions` field and `RunOptions` interface [#11759](https://github.com/eclipse-theia/theia/pull/11759) - Contributed on behalf of STMicroelectronics
 - [tasks] added support for `reevaluateOnRerun` run option [#11759](https://github.com/eclipse-theia/theia/pull/11759) - Contributed on behalf of STMicroelectronics
+- [plugin] updated the default VS Code API version from `1.53.2` to `1.55.2` [#11823](https://github.com/eclipse-theia/theia/pull/11823)
 
 <a name="breaking_changes_1.32.0">[Breaking Changes:](#breaking_changes_1.32.0)</a>
 

--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.53.2';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.55.2';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: https://github.com/eclipse-theia/theia/issues/9863.

The pull-request bumps the framework's default supported vscode api version from `1.53.2` to `1.55.2` given that the appropriate apis have been implemented.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- CI should successfully pass.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>