### PR TITLE
Update nls metadata for vscode 1.55.2

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -84,15 +84,15 @@ export const corePreferenceSchema: PreferenceSchema = {
             type: 'string',
             enum: ['classic', 'visible', 'hidden', 'compact'],
             markdownEnumDescriptions: [
-                nls.localizeByDefault('Menu is only hidden in full screen mode.'),
-                nls.localizeByDefault('Menu is always visible even in full screen mode.'),
+                nls.localizeByDefault('Menu is displayed at the top of the window and only hidden in full screen mode.'),
+                nls.localizeByDefault('Menu is always visible at the top of the window even in full screen mode.'),
                 nls.localizeByDefault('Menu is always hidden.'),
                 nls.localizeByDefault('Menu is displayed as a compact button in the sidebar. This value is ignored when `#window.titleBarStyle#` is `native`.')
             ],
             default: 'classic',
             scope: 'application',
             // eslint-disable-next-line max-len
-            markdownDescription: nls.localizeByDefault("Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen."),
+            markdownDescription: nls.localizeByDefault('Control the visibility of the menu bar. A setting of \'toggle\' means that the menu bar is hidden and a single press of the Alt key will show it. A setting of \'compact\' will move the menu into the sidebar.'),
             included: !(isOSX && environment.electron.is())
         },
         'window.title': {
@@ -144,7 +144,7 @@ export const corePreferenceSchema: PreferenceSchema = {
             type: 'boolean',
             default: true,
             // eslint-disable-next-line max-len
-            description: nls.localizeByDefault('Controls whether CA certificates should be loaded from the OS. (On Windows and macOS a reload of the window is required after turning this off.)'),
+            description: nls.localizeByDefault('Controls whether CA certificates should be loaded from the OS. (On Windows and macOS, a reload of the window is required after turning this off.)'),
             scope: 'application'
         },
         'workbench.list.openMode': {
@@ -155,7 +155,7 @@ export const corePreferenceSchema: PreferenceSchema = {
             ],
             default: 'singleClick',
             // eslint-disable-next-line max-len
-            description: nls.localizeByDefault('Controls how to open items in trees and lists using the mouse (if supported). For parents with children in trees, this setting will control if a single click expands the parent or a double click. Note that some trees and lists might choose to ignore this setting if it is not applicable. ')
+            description: nls.localizeByDefault('Controls how to open items in trees and lists using the mouse (if supported). Note that some trees and lists might choose to ignore this setting if it is not applicable.')
         },
         'workbench.editor.highlightModifiedTabs': {
             'type': 'boolean',
@@ -222,19 +222,15 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: 300,
             minimum: 0,
             maximum: 2000,
-            // nls-todo: Will be available with VSCode API 1.55
-            description: nls.localize('theia/core/sashDelay', 'Controls the hover feedback delay in milliseconds of the dragging area in between views/editors.')
+            description: nls.localizeByDefault('Controls the hover feedback delay in milliseconds of the dragging area in between views/editors.')
         },
         'workbench.sash.size': {
             type: 'number',
             default: 4,
             minimum: 1,
             maximum: 20,
-            // nls-todo: Will be available with VSCode API 1.55
-            description: nls.localize(
-                'theia/core/sashSize',
-                'Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if needed.'
-            )
+            // eslint-disable-next-line max-len
+            description: nls.localizeByDefault('Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it\'s hard to resize views using the mouse.')
         },
         'workbench.tab.maximize': {
             type: 'boolean',

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -175,7 +175,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
             }),
             menuRegistry.registerMenuAction([...this.contextMenuPath, '0_global'], {
                 commandId: this.globalHideCommandId,
-                label: nls.localize('theia/core/hideViewContainer', 'Hide')
+                label: nls.localizeByDefault('Hide')
             }),
             this.onDidChangeTrackableWidgetsEmitter,
             this.onDidChangeTrackableWidgets(() => this.decoratorService.fireDidChangeDecorations())

--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -33,9 +33,7 @@
 			"selectSource",
 			"vscode",
 			"extension",
-			"selectSource",
-			"vscode",
-			"extension",
+			"marketplace",
 			"unknown",
 			"stepsToReproduce",
 			"bugDescription",
@@ -57,18 +55,6 @@
 			"copy",
 			"copyAll",
 			"debug"
-		],
-		"vs/workbench/services/integrity/node/integrityService": [
-			"integrity.prompt",
-			"integrity.moreInformation",
-			"integrity.dontShowAgain"
-		],
-		"vs/workbench/services/textfile/electron-browser/nativeTextFileService": [
-			"fileReadOnlyError"
-		],
-		"vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService": [
-			"local",
-			"remote"
 		],
 		"vs/workbench/services/extensions/electron-browser/extensionService": [
 			"extensionService.versionMismatchCrash",
@@ -133,115 +119,10 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/userDataSync/electron-browser/userDataSync.contribution": [
-			"operationId",
-			{
-				"key": "too many requests",
-				"comment": [
-					"Settings Sync is the name of the feature"
-				]
-			},
-			"settings sync",
-			"show sync logs",
-			"report issue",
-			"Open Backup folder",
-			"no backups"
-		],
 		"vs/platform/environment/node/argvHelper": [
 			"unknownOption",
 			"multipleValues",
 			"gotoValidation"
-		],
-		"vs/platform/request/common/request": [
-			"httpConfigurationTitle",
-			"proxy",
-			"strictSSL",
-			"proxyAuthorization",
-			"proxySupportOff",
-			"proxySupportOn",
-			"proxySupportOverride",
-			"proxySupport",
-			"systemCertificates"
-		],
-		"vs/code/electron-main/app": [
-			"trace.message",
-			"trace.detail",
-			"trace.ok",
-			{
-				"key": "open",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "cancel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"confirmOpenMessage",
-			"confirmOpenDetail"
-		],
-		"vs/platform/files/node/diskFileSystemProvider": [
-			"fileExists",
-			"fileNotExists",
-			"moveError",
-			"copyError",
-			"fileCopyErrorPathCase",
-			"fileCopyErrorExists"
-		],
-		"vs/platform/files/common/fileService": [
-			"invalidPath",
-			"noProviderFound",
-			"fileNotFoundError",
-			"fileExists",
-			"err.write",
-			"fileIsDirectoryWriteError",
-			"fileModifiedError",
-			"err.read",
-			"err.read",
-			"err.read",
-			"fileIsDirectoryReadError",
-			"fileNotModifiedError",
-			"fileTooLargeError",
-			"unableToMoveCopyError1",
-			"unableToMoveCopyError2",
-			"unableToMoveCopyError3",
-			"unableToMoveCopyError4",
-			"mkdirExistsError",
-			"deleteFailedTrashUnsupported",
-			"deleteFailedNotFound",
-			"deleteFailedNonEmptyFolder",
-			"err.readonly"
-		],
-		"vs/platform/files/common/files": [
-			"unknownError",
-			"sizeB",
-			"sizeKB",
-			"sizeMB",
-			"sizeGB",
-			"sizeTB"
-		],
-		"vs/base/common/errorMessage": [
-			"stackTrace.format",
-			"nodeExceptionMessage",
-			"error.defaultMessage",
-			"error.defaultMessage",
-			"error.moreErrors",
-			"error.defaultMessage"
-		],
-		"vs/platform/update/common/update.config.contribution": [
-			"updateConfigurationTitle",
-			"updateMode",
-			"none",
-			"manual",
-			"start",
-			"default",
-			"updateMode",
-			"deprecated",
-			"enableWindowsBackgroundUpdatesTitle",
-			"enableWindowsBackgroundUpdates",
-			"showReleaseNotes"
 		],
 		"vs/platform/environment/node/argv": [
 			"optionsUpperCase",
@@ -284,9 +165,97 @@
 			"unknownVersion",
 			"unknownCommit"
 		],
-		"vs/platform/extensionManagement/common/extensionManagement": [
-			"extensions",
-			"preferences"
+		"vs/code/electron-main/app": [
+			{
+				"key": "open",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "cancel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"confirmOpenMessage",
+			"confirmOpenDetail",
+			"trace.message",
+			"trace.detail",
+			"trace.ok"
+		],
+		"vs/platform/request/common/request": [
+			"httpConfigurationTitle",
+			"proxy",
+			"strictSSL",
+			"proxyAuthorization",
+			"proxySupportOff",
+			"proxySupportOn",
+			"proxySupportOverride",
+			"proxySupport",
+			"systemCertificates"
+		],
+		"vs/platform/files/common/fileService": [
+			"invalidPath",
+			"noProviderFound",
+			"fileNotFoundError",
+			"fileExists",
+			"err.write",
+			"writeFailedUnlockUnsupported",
+			"fileIsDirectoryWriteError",
+			"fileModifiedError",
+			"err.read",
+			"err.read",
+			"err.read",
+			"fileIsDirectoryReadError",
+			"fileNotModifiedError",
+			"fileTooLargeError",
+			"unableToMoveCopyError1",
+			"unableToMoveCopyError2",
+			"unableToMoveCopyError3",
+			"unableToMoveCopyError4",
+			"mkdirExistsError",
+			"deleteFailedTrashUnsupported",
+			"deleteFailedNotFound",
+			"deleteFailedNonEmptyFolder",
+			"err.readonly"
+		],
+		"vs/platform/files/node/diskFileSystemProvider": [
+			"fileExists",
+			"fileNotExists",
+			"moveError",
+			"copyError",
+			"fileCopyErrorPathCase",
+			"fileCopyErrorExists"
+		],
+		"vs/platform/files/common/files": [
+			"unknownError",
+			"sizeB",
+			"sizeKB",
+			"sizeMB",
+			"sizeGB",
+			"sizeTB"
+		],
+		"vs/base/common/errorMessage": [
+			"stackTrace.format",
+			"nodeExceptionMessage",
+			"error.defaultMessage",
+			"error.defaultMessage",
+			"error.moreErrors",
+			"error.defaultMessage"
+		],
+		"vs/platform/update/common/update.config.contribution": [
+			"updateConfigurationTitle",
+			"updateMode",
+			"none",
+			"manual",
+			"start",
+			"default",
+			"updateMode",
+			"deprecated",
+			"enableWindowsBackgroundUpdatesTitle",
+			"enableWindowsBackgroundUpdates",
+			"showReleaseNotes"
 		],
 		"vs/platform/extensionManagement/node/extensionManagementService": [
 			"incompatible",
@@ -308,6 +277,10 @@
 			"twoIndirectDependentsError",
 			"multipleIndirectDependentsError",
 			"notExists"
+		],
+		"vs/platform/extensionManagement/common/extensionManagement": [
+			"extensions",
+			"preferences"
 		],
 		"vs/platform/telemetry/common/telemetryService": [
 			"telemetryConfigurationTitle",
@@ -399,9 +372,6 @@
 			"app.extension.identifier.errorMessage",
 			"settingsSync.ignoredSettings"
 		],
-		"vs/platform/userDataSync/common/userDataSyncMachines": [
-			"error incompatible"
-		],
 		"vs/platform/extensionManagement/electron-sandbox/extensionTipsService": [
 			{
 				"key": "exeRecommended",
@@ -409,6 +379,9 @@
 					"Placeholder string is the name of the software that is installed."
 				]
 			}
+		],
+		"vs/platform/userDataSync/common/userDataSyncMachines": [
+			"error incompatible"
 		],
 		"vs/platform/userDataSync/common/userDataAutoSyncService": [
 			"default service changed",
@@ -434,6 +407,15 @@
 			"workspaceOpenedMessage",
 			"ok",
 			"workspaceOpenedDetail"
+		],
+		"vs/workbench/services/extensionManagement/electron-sandbox/extensionManagementServerService": [
+			"local",
+			"remote"
+		],
+		"vs/workbench/services/integrity/electron-sandbox/integrityService": [
+			"integrity.prompt",
+			"integrity.moreInformation",
+			"integrity.dontShowAgain"
 		],
 		"vs/workbench/contrib/localizations/browser/localizations.contribution": [
 			"updateLocale",
@@ -537,6 +519,7 @@
 			"argv.enableCrashReporter",
 			"argv.crashReporterId",
 			"argv.enebleProposedApi",
+			"argv.logLevel",
 			"argv.force-renderer-accessibility"
 		],
 		"vs/workbench/contrib/files/electron-sandbox/files.contribution": [
@@ -560,61 +543,23 @@
 			"remote",
 			"remote.downloadExtensionsLocally"
 		],
-		"vs/workbench/browser/workbench": [
-			"loaderErrorNative"
-		],
-		"vs/workbench/electron-sandbox/window": [
-			"learnMore",
-			"shellEnvSlowWarning",
-			"shellEnvTimeoutError",
-			"proxyAuthRequired",
+		"vs/workbench/contrib/userDataSync/electron-sandbox/userDataSync.contribution": [
+			"operationId",
 			{
-				"key": "loginButton",
+				"key": "too many requests",
 				"comment": [
-					"&& denotes a mnemonic"
+					"Settings Sync is the name of the feature"
 				]
 			},
-			{
-				"key": "cancelButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"username",
-			"password",
-			"proxyDetail",
-			"rememberCredentials",
-			"runningAsRoot",
-			"loaderCycle",
-			"ok"
-		],
-		"vs/platform/workspaces/common/workspaces": [
-			"codeWorkspace"
-		],
-		"vs/workbench/services/remote/electron-sandbox/remoteAgentServiceImpl": [
-			"connectionError"
+			"settings sync",
+			"show sync logs",
+			"report issue",
+			"Open Backup folder",
+			"no backups"
 		],
 		"vs/platform/files/electron-browser/diskFileSystemProvider": [
 			"binFailed",
 			"trashFailed"
-		],
-		"vs/workbench/services/textfile/browser/textFileService": [
-			"fileBinaryError",
-			"confirmOverwrite",
-			"irreversible",
-			{
-				"key": "replaceButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/platform/dialogs/common/dialogs": [
-			"moreFile",
-			"moreFiles"
-		],
-		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
-			"incompatible"
 		],
 		"vs/workbench/services/extensions/electron-browser/localProcessExtensionHost": [
 			"extensionHost.startupFailDebug",
@@ -631,7 +576,8 @@
 			"reloadWindow"
 		],
 		"vs/workbench/services/extensions/common/abstractExtensionService": [
-			"looping"
+			"looping",
+			"extensionTestError"
 		],
 		"vs/workbench/services/extensions/common/remoteExtensionHost": [
 			"remote extension host Log"
@@ -650,37 +596,60 @@
 				]
 			}
 		],
-		"vs/base/common/date": [
-			"date.fromNow.in",
-			"date.fromNow.now",
-			"date.fromNow.seconds.singular.ago",
-			"date.fromNow.seconds.plural.ago",
-			"date.fromNow.seconds.singular",
-			"date.fromNow.seconds.plural",
-			"date.fromNow.minutes.singular.ago",
-			"date.fromNow.minutes.plural.ago",
-			"date.fromNow.minutes.singular",
-			"date.fromNow.minutes.plural",
-			"date.fromNow.hours.singular.ago",
-			"date.fromNow.hours.plural.ago",
-			"date.fromNow.hours.singular",
-			"date.fromNow.hours.plural",
-			"date.fromNow.days.singular.ago",
-			"date.fromNow.days.plural.ago",
-			"date.fromNow.days.singular",
-			"date.fromNow.days.plural",
-			"date.fromNow.weeks.singular.ago",
-			"date.fromNow.weeks.plural.ago",
-			"date.fromNow.weeks.singular",
-			"date.fromNow.weeks.plural",
-			"date.fromNow.months.singular.ago",
-			"date.fromNow.months.plural.ago",
-			"date.fromNow.months.singular",
-			"date.fromNow.months.plural",
-			"date.fromNow.years.singular.ago",
-			"date.fromNow.years.plural.ago",
-			"date.fromNow.years.singular",
-			"date.fromNow.years.plural"
+		"vs/workbench/contrib/webview/electron-browser/webviewCommands": [
+			"openToolsLabel"
+		],
+		"vs/editor/contrib/clipboard/clipboard": [
+			{
+				"key": "miCut",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.clipboard.cutLabel",
+			"actions.clipboard.cutLabel",
+			{
+				"key": "miCopy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.clipboard.copyLabel",
+			"actions.clipboard.copyLabel",
+			"copy as",
+			"copy as",
+			{
+				"key": "miPaste",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.clipboard.pasteLabel",
+			"actions.clipboard.pasteLabel",
+			"actions.clipboard.copyWithSyntaxHighlightingLabel"
+		],
+		"vs/editor/browser/editorExtensions": [
+			{
+				"key": "miUndo",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"undo",
+			{
+				"key": "miRedo",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"redo",
+			{
+				"key": "miSelectAll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"selectAll"
 		],
 		"vs/platform/theme/common/colorRegistry": [
 			"foreground",
@@ -789,11 +758,13 @@
 			"diffDiagonalFill",
 			"listFocusBackground",
 			"listFocusForeground",
+			"listFocusOutline",
 			"listActiveSelectionBackground",
 			"listActiveSelectionForeground",
 			"listInactiveSelectionBackground",
 			"listInactiveSelectionForeground",
 			"listInactiveFocusBackground",
+			"listInactiveFocusOutline",
 			"listHoverBackground",
 			"listHoverForeground",
 			"listDropBackground",
@@ -807,7 +778,10 @@
 			"listFilterMatchHighlight",
 			"listFilterMatchHighlightBorder",
 			"treeIndentGuidesStroke",
+			"treeIndentGuidesStroke",
 			"listDeemphasizedForeground",
+			"quickInput.list.focusBackground deprecation",
+			"quickInput.listFocusBackground",
 			"menuBorder",
 			"menuForeground",
 			"menuBackground",
@@ -962,130 +936,13 @@
 			"windowActiveBorder",
 			"windowInactiveBorder"
 		],
-		"vs/workbench/contrib/debug/common/debug": [
-			"internalConsoleOptions"
-		],
-		"vs/workbench/contrib/webview/electron-browser/webviewCommands": [
-			"openToolsLabel"
-		],
-		"vs/editor/contrib/clipboard/clipboard": [
-			{
-				"key": "miCut",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"actions.clipboard.cutLabel",
-			"actions.clipboard.cutLabel",
-			{
-				"key": "miCopy",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"actions.clipboard.copyLabel",
-			"actions.clipboard.copyLabel",
-			{
-				"key": "miPaste",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"actions.clipboard.pasteLabel",
-			"actions.clipboard.pasteLabel",
-			"actions.clipboard.copyWithSyntaxHighlightingLabel"
-		],
-		"vs/editor/browser/editorExtensions": [
-			{
-				"key": "miUndo",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"undo",
-			{
-				"key": "miRedo",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"redo",
-			{
-				"key": "miSelectAll",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"selectAll"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/coreActions": [
-			"notebookActions.category",
-			"notebookActions.execute",
-			"notebookActions.execute",
-			"notebookActions.cancel",
-			"notebookActions.cancel",
-			"notebookActions.executeCell",
-			"notebookActions.CancelCell",
-			"notebookActions.deleteCell",
-			"notebookActions.executeAndSelectBelow",
-			"notebookActions.executeAndInsertBelow",
-			"notebookActions.renderMarkdown",
-			"notebookActions.executeNotebook",
-			"notebookActions.executeNotebook",
-			"notebookActions.cancelNotebook",
-			"notebookActions.cancelNotebook",
-			"notebookMenu.insertCell",
-			"notebookMenu.cellTitle",
-			"notebookActions.menu.executeNotebook",
-			"notebookActions.menu.cancelNotebook",
-			"notebookActions.changeCellToCode",
-			"notebookActions.changeCellToMarkdown",
-			"notebookActions.insertCodeCellAbove",
-			"notebookActions.insertCodeCellBelow",
-			"notebookActions.insertCodeCellAtTop",
-			"notebookActions.insertMarkdownCellAtTop",
-			"notebookActions.menu.insertCode",
-			"notebookActions.menu.insertCode.tooltip",
-			"notebookActions.menu.insertCode",
-			"notebookActions.menu.insertCode.tooltip",
-			"notebookActions.insertMarkdownCellAbove",
-			"notebookActions.insertMarkdownCellBelow",
-			"notebookActions.menu.insertMarkdown",
-			"notebookActions.menu.insertMarkdown.tooltip",
-			"notebookActions.menu.insertMarkdown",
-			"notebookActions.menu.insertMarkdown.tooltip",
-			"notebookActions.editCell",
-			"notebookActions.quitEdit",
-			"notebookActions.deleteCell",
-			"notebookActions.moveCellUp",
-			"notebookActions.moveCellDown",
-			"notebookActions.copy",
-			"notebookActions.cut",
-			"notebookActions.paste",
-			"notebookActions.pasteAbove",
-			"notebookActions.copyCellUp",
-			"notebookActions.copyCellDown",
-			"cursorMoveDown",
-			"cursorMoveUp",
-			"focusOutput",
-			"focusOutputOut",
-			"focusFirstCell",
-			"focusLastCell",
-			"clearCellOutputs",
-			"changeLanguage",
-			"languageDescription",
-			"languageDescriptionConfigured",
-			"pickLanguageToConfigure",
-			"clearAllCellsOutputs",
-			"notebookActions.splitCell",
-			"notebookActions.joinCellAbove",
-			"notebookActions.joinCellBelow",
-			"notebookActions.centerActiveCell",
-			"notebookActions.collapseCellInput",
-			"notebookActions.expandCellContent",
-			"notebookActions.collapseCellOutput",
-			"notebookActions.expandCellOutput",
-			"notebookActions.inspectLayout"
+		"vs/workbench/browser/editor": [
+			"promptOpenWith.defaultEditor.displayName",
+			"builtinProviderDisplayName",
+			"editor.editorAssociations",
+			"editor.editorAssociations.viewType",
+			"editor.editorAssociations.filenamePattern",
+			"editorAssociations.viewType.sourceDescription"
 		],
 		"vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor": [
 			"extensionHostProfileStart",
@@ -1101,6 +958,24 @@
 			"debugExtensionHost.launch.name"
 		],
 		"vs/workbench/common/editor": [
+			"activeEditorIsDirty",
+			"activeEditorIsNotPreview",
+			"activeEditorIsPinned",
+			"activeEditorIsReadonly",
+			"activeEditor",
+			"activeEditorAvailableEditorIds",
+			"textCompareEditorVisible",
+			"textCompareEditorActive",
+			"groupEditorsCount",
+			"activeEditorGroupEmpty",
+			"activeEditorGroupIndex",
+			"activeEditorGroupLast",
+			"multipleEditorGroups",
+			"editorIsOpen",
+			"inZenMode",
+			"isCenteredLayout",
+			"splitEditorsVertically",
+			"editorAreaVisible",
 			"sideBySideLabels",
 			"preview",
 			"pinned"
@@ -1136,6 +1011,9 @@
 			"config.property.duplicate"
 		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
+			"terminalProfile.path",
+			"terminalProfile.args",
+			"terminalProfile.overrideName",
 			"terminalIntegratedConfigurationTitle",
 			"terminal.integrated.sendKeybindingsToShell",
 			{
@@ -1161,6 +1039,27 @@
 			"terminal.integrated.shellArgs.windows",
 			"terminal.integrated.shellArgs.windows",
 			"terminal.integrated.shellArgs.windows.string",
+			{
+				"key": "terminal.integrated.profiles.windows",
+				"comment": [
+					"{0}, {1}, and {2} are the `source`, `path` and optional `args` settings keys"
+				]
+			},
+			"terminalProfile.windowsSource",
+			"terminalProfile.overrideName",
+			{
+				"key": "terminal.integrated.profile.osx",
+				"comment": [
+					"{0} and {1} are the `path` and optional `args` settings keys"
+				]
+			},
+			{
+				"key": "terminal.integrated.profile.linux",
+				"comment": [
+					"{0} and {1} are the `path` and optional `args` settings keys"
+				]
+			},
+			"terminal.integrated.useWslProfiles",
 			"terminal.integrated.macOptionIsMeta",
 			"terminal.integrated.macOptionClickForcesSelection",
 			"terminal.integrated.altClickMovesCursor",
@@ -1209,6 +1108,7 @@
 			"terminal.integrated.environmentChangesIndicator.off",
 			"terminal.integrated.environmentChangesIndicator.on",
 			"terminal.integrated.environmentChangesIndicator.warnonly",
+			"terminal.integrated.environmentChangesRelaunch",
 			"terminal.integrated.showExitAlert",
 			"terminal.integrated.splitCwd",
 			"terminal.integrated.splitCwd.workspaceRoot",
@@ -1225,9 +1125,7 @@
 			"terminal.integrated.localEchoLatencyThreshold",
 			"terminal.integrated.localEchoExcludePrograms",
 			"terminal.integrated.localEchoStyle",
-			"terminal.integrated.serverSpawn",
 			"terminal.integrated.enablePersistentSessions",
-			"terminal.integrated.flowControl",
 			"terminalIntegratedConfigurationTitle",
 			"terminal.integrated.shell.linux.noDefault",
 			"terminal.integrated.shell.osx.noDefault",
@@ -1236,10 +1134,11 @@
 			"terminal.integrated.shell.osx",
 			"terminal.integrated.shell.windows"
 		],
-		"vs/workbench/contrib/codeEditor/electron-browser/startDebugTextMate": [
-			"startDebugTextMate"
-		],
 		"vs/workbench/contrib/terminal/common/terminal": [
+			"terminalFocusContextKey",
+			"terminalShellTypeContextKey",
+			"terminalTextSelectedContextKey",
+			"terminalProcessSupportedContextKey",
 			"terminalCategory",
 			"vscode.extension.contributes.terminal",
 			"vscode.extension.contributes.terminal.types",
@@ -1254,16 +1153,20 @@
 			"linux.term.failed",
 			"ext.term.app.not.found"
 		],
-		"vs/workbench/contrib/performance/electron-browser/startupProfiler": [
-			"prof.message",
-			"prof.detail",
-			"prof.restartAndFileIssue",
-			"prof.restart",
-			"prof.thanks",
-			"prof.detail.restart",
-			"prof.restart.button"
+		"vs/platform/dialogs/common/dialogs": [
+			"moreFile",
+			"moreFiles"
+		],
+		"vs/platform/contextkey/common/contextkeys": [
+			"isMac",
+			"isLinux",
+			"isWindows",
+			"isWeb",
+			"isMacNative",
+			"inputFocus"
 		],
 		"vs/workbench/contrib/tasks/common/tasks": [
+			"tasks.taskRunningContext",
 			"tasksCategory",
 			"TaskDefinition.missingRequiredProperty"
 		],
@@ -1290,14 +1193,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/tasks/node/processTaskSystem": [
-			"version1_0",
-			"TaskRunnerSystem.unknownError",
-			"TaskRunnerSystem.watchingBuildTaskFinished",
-			"TaskRunnerSystem.childProcessError",
-			"TaskRunnerSystem.cancelRequested",
-			"unknownProblemMatcher"
-		],
 		"vs/workbench/contrib/tasks/node/processRunnerDetector": [
 			"TaskSystemDetector.noGulpTasks",
 			"TaskSystemDetector.noJakeTasks",
@@ -1308,24 +1203,12 @@
 			"TaskSystemDetector.buildTaskDetected",
 			"TaskSystemDetector.testTaskDetected"
 		],
-		"vs/platform/markers/common/markers": [
-			"sev.error",
-			"sev.warning",
-			"sev.info"
-		],
-		"vs/workbench/common/views": [
-			"defaultViewIcon",
-			"duplicateId"
-		],
-		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
-			"TerminalTaskSystem.unknownError",
-			"dependencyCycle",
-			"dependencyFailed",
-			"TerminalTaskSystem.nonWatchingMatcher",
-			"TerminalTaskSystem.terminalName",
-			"closeTerminal",
-			"reuseTerminal",
-			"TerminalTaskSystem",
+		"vs/workbench/contrib/tasks/node/processTaskSystem": [
+			"version1_0",
+			"TaskRunnerSystem.unknownError",
+			"TaskRunnerSystem.watchingBuildTaskFinished",
+			"TaskRunnerSystem.childProcessError",
+			"TaskRunnerSystem.cancelRequested",
 			"unknownProblemMatcher"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
@@ -1414,23 +1297,43 @@
 			"TaskService.pickShowTask",
 			"TaskService.noTaskIsRunning"
 		],
+		"vs/workbench/contrib/tasks/common/taskService": [
+			"tasks.customExecutionSupported",
+			"tasks.shellExecutionSupported",
+			"tasks.processExecutionSupported"
+		],
+		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+			"TerminalTaskSystem.unknownError",
+			"dependencyCycle",
+			"dependencyFailed",
+			"TerminalTaskSystem.nonWatchingMatcher",
+			"TerminalTaskSystem.terminalName",
+			"closeTerminal",
+			"reuseTerminal",
+			"TerminalTaskSystem",
+			"unknownProblemMatcher"
+		],
+		"vs/platform/markers/common/markers": [
+			"sev.error",
+			"sev.warning",
+			"sev.info"
+		],
+		"vs/workbench/common/views": [
+			"defaultViewIcon",
+			"duplicateId",
+			"focusedView"
+		],
 		"vs/workbench/services/preferences/common/preferences": [
 			"userSettingsTarget",
 			"workspaceSettingsTarget"
 		],
-		"vs/base/common/actions": [
-			"submenu.empty"
-		],
-		"vs/workbench/services/userDataSync/common/userDataSync": [
-			"settings",
-			"keybindings",
-			"snippets",
-			"extensions",
-			"ui state label",
-			"sync category",
-			"syncViewIcon"
+		"vs/platform/workspace/common/workspaceTrust": [
+			"trusted",
+			"untrusted",
+			"unknown"
 		],
 		"vs/workbench/api/common/extHostExtensionService": [
+			"extensionTestError1",
 			"extensionTestError"
 		],
 		"vs/workbench/api/common/extHostTerminalService": [
@@ -1442,12 +1345,21 @@
 		"vs/base/node/processes": [
 			"TaskRunner.UNC"
 		],
+		"vs/platform/terminal/node/terminalProcess": [
+			"launchFail.cwdNotDirectory",
+			"launchFail.cwdDoesNotExist",
+			"launchFail.executableIsNotFileOrSymlink",
+			"launchFail.executableDoesNotExist"
+		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			"ok",
 			"pathNotExistTitle",
 			"uriInvalidTitle",
 			"pathNotExistDetail",
 			"uriInvalidDetail"
+		],
+		"vs/platform/workspaces/common/workspaces": [
+			"codeWorkspace"
 		],
 		"vs/platform/issue/electron-main/issueMainService": [
 			"local",
@@ -1463,8 +1375,6 @@
 		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
 			"newWindow",
 			"newWindowDesc",
-			"folderDesc",
-			"workspaceDesc",
 			"recentFoldersAndWorkspaces",
 			"recentFolders",
 			"untitledWorkspace",
@@ -1508,8 +1418,12 @@
 		"vs/platform/extensionManagement/node/extensionsScanner": [
 			"errorDeleting",
 			"cannot read",
+			"cannot read",
 			"renameError",
 			"invalidManifest"
+		],
+		"vs/base/common/actions": [
+			"submenu.empty"
 		],
 		"vs/platform/userDataSync/common/keybindingsSync": [
 			"errorInvalidSettings",
@@ -1518,36 +1432,44 @@
 		"vs/platform/userDataSync/common/settingsSync": [
 			"errorInvalidSettings"
 		],
+		"vs/base/common/date": [
+			"date.fromNow.in",
+			"date.fromNow.now",
+			"date.fromNow.seconds.singular.ago",
+			"date.fromNow.seconds.plural.ago",
+			"date.fromNow.seconds.singular",
+			"date.fromNow.seconds.plural",
+			"date.fromNow.minutes.singular.ago",
+			"date.fromNow.minutes.plural.ago",
+			"date.fromNow.minutes.singular",
+			"date.fromNow.minutes.plural",
+			"date.fromNow.hours.singular.ago",
+			"date.fromNow.hours.plural.ago",
+			"date.fromNow.hours.singular",
+			"date.fromNow.hours.plural",
+			"date.fromNow.days.singular.ago",
+			"date.fromNow.days.plural.ago",
+			"date.fromNow.days.singular",
+			"date.fromNow.days.plural",
+			"date.fromNow.weeks.singular.ago",
+			"date.fromNow.weeks.plural.ago",
+			"date.fromNow.weeks.singular",
+			"date.fromNow.weeks.plural",
+			"date.fromNow.months.singular.ago",
+			"date.fromNow.months.plural.ago",
+			"date.fromNow.months.singular",
+			"date.fromNow.months.plural",
+			"date.fromNow.years.singular.ago",
+			"date.fromNow.years.plural.ago",
+			"date.fromNow.years.singular",
+			"date.fromNow.years.plural"
+		],
 		"vs/base/browser/ui/tree/abstractTree": [
 			"clear",
 			"disable filter on type",
 			"enable filter on type",
 			"empty",
 			"found"
-		],
-		"vs/workbench/services/authentication/browser/authenticationService": [
-			"authentication.id",
-			"authentication.label",
-			{
-				"key": "authenticationExtensionPoint",
-				"comment": [
-					"'Contributes' means adds here"
-				]
-			},
-			"loading",
-			"authentication.missingId",
-			"authentication.missingLabel",
-			"authentication.idConflict",
-			"noAccounts",
-			"loading",
-			"sign in",
-			{
-				"key": "signInRequest",
-				"comment": [
-					"The placeholder {0} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count."
-				]
-			},
-			"sign in"
 		],
 		"vs/platform/list/browser/listService": [
 			"workbenchConfigurationTitle",
@@ -1576,6 +1498,9 @@
 			"keyboardNavigationSettingKey",
 			"automatic keyboard navigation setting",
 			"expand mode"
+		],
+		"vs/platform/contextkey/browser/contextKeyService": [
+			"getContextKeyInfo"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"workbench.editor.titleScrollbarSizing.default",
@@ -1609,6 +1534,12 @@
 					"This is the description for a setting. Values surrounded by parenthesis are not to be translated."
 				],
 				"key": "untitledLabelFormat"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "untitledHint"
 			},
 			{
 				"comment": [
@@ -1690,6 +1621,7 @@
 			"settings.editor.ui",
 			"settings.editor.json",
 			"settings.editor.desc",
+			"workbench.hover.delay",
 			"windowTitle",
 			"activeEditorShort",
 			"activeEditorMedium",
@@ -1707,11 +1639,13 @@
 			"separator",
 			"windowConfigurationTitle",
 			"window.titleSeparator",
-			"window.menuBarVisibility.default",
+			"window.menuBarVisibility.classic",
 			"window.menuBarVisibility.visible",
+			"window.menuBarVisibility.toggle.mac",
 			"window.menuBarVisibility.toggle",
 			"window.menuBarVisibility.hidden",
 			"window.menuBarVisibility.compact",
+			"menuBarVisibility.mac",
 			"menuBarVisibility",
 			"enableMenuBarMnemonics",
 			"customMenuBarAltFocus",
@@ -1739,14 +1673,6 @@
 			"zenMode.restore",
 			"zenMode.silentNotifications"
 		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"undo",
-			"redo",
-			"cut",
-			"copy",
-			"paste",
-			"selectAll"
-		],
 		"vs/workbench/browser/actions/developerActions": [
 			"inspect context keys",
 			"toggle screencast mode",
@@ -1770,64 +1696,13 @@
 			"screencastMode.mouseIndicatorColor",
 			"screencastMode.mouseIndicatorSize"
 		],
-		"vs/workbench/browser/actions/helpActions": [
-			"keybindingsReference",
-			"openDocumentationUrl",
-			"openIntroductoryVideosUrl",
-			"openTipsAndTricksUrl",
-			"newsletterSignup",
-			"openTwitterUrl",
-			"openUserVoiceUrl",
-			"openLicenseUrl",
-			"openPrivacyStatement",
-			{
-				"key": "miDocumentation",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miKeyboardShortcuts",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miIntroductoryVideos",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miTipsAndTricks",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miTwitter",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miUserVoice",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miLicense",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miPrivacyStatement",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
+		"vs/workbench/browser/actions/textInputActions": [
+			"undo",
+			"redo",
+			"cut",
+			"copy",
+			"paste",
+			"selectAll"
 		],
 		"vs/workbench/browser/actions/layoutActions": [
 			"closeSidebar",
@@ -1937,6 +1812,65 @@
 			"decreaseEditorWidth",
 			"decreaseEditorHeight"
 		],
+		"vs/workbench/browser/actions/helpActions": [
+			"keybindingsReference",
+			"openDocumentationUrl",
+			"openIntroductoryVideosUrl",
+			"openTipsAndTricksUrl",
+			"newsletterSignup",
+			"openTwitterUrl",
+			"openUserVoiceUrl",
+			"openLicenseUrl",
+			"openPrivacyStatement",
+			{
+				"key": "miDocumentation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miKeyboardShortcuts",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miIntroductoryVideos",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTipsAndTricks",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTwitter",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miUserVoice",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miLicense",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miPrivacyStatement",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/workbench/browser/actions/navigationActions": [
 			"navigateLeft",
 			"navigateRight",
@@ -2002,6 +1936,17 @@
 				]
 			}
 		],
+		"vs/workbench/browser/actions/workspaceCommands": [
+			"addFolderToWorkspace",
+			{
+				"key": "add",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"addFolderToWorkspaceTitle",
+			"workspaceFolderPickerPlaceholder"
+		],
 		"vs/workbench/browser/actions/workspaceActions": [
 			"openFile",
 			"openFolder",
@@ -2013,6 +1958,8 @@
 			"globalRemoveFolderFromWorkspace",
 			"saveWorkspaceAsAction",
 			"duplicateWorkspaceInNewWindow",
+			"manageTrustAction",
+			"workspacesCategory",
 			"workspaces",
 			{
 				"key": "miAddFolderToWorkspace",
@@ -2034,17 +1981,6 @@
 				]
 			}
 		],
-		"vs/workbench/browser/actions/workspaceCommands": [
-			"addFolderToWorkspace",
-			{
-				"key": "add",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"addFolderToWorkspaceTitle",
-			"workspaceFolderPickerPlaceholder"
-		],
 		"vs/workbench/browser/actions/quickAccessActions": [
 			"quickOpen",
 			"quickNavigateNext",
@@ -2056,7 +1992,9 @@
 			"menus.commandPalette",
 			"menus.touchBar",
 			"menus.editorTitle",
+			"menus.editorTitleRun",
 			"menus.editorContext",
+			"menus.editorContextCopyAs",
 			"menus.explorerContext",
 			"menus.editorTabContext",
 			"menus.debugCallstackContext",
@@ -2064,11 +2002,12 @@
 			"menus.debugToolBar",
 			"menus.file",
 			"menus.home",
+			"menus.opy",
 			"menus.scmTitle",
 			"menus.scmSourceControl",
-			"menus.resourceGroupContext",
 			"menus.resourceStateContext",
 			"menus.resourceFolderContext",
+			"menus.resourceGroupContext",
 			"menus.changeTitle",
 			"menus.statusBarWindowIndicator",
 			"view.viewTitle",
@@ -2077,10 +2016,14 @@
 			"commentThread.actions",
 			"comment.title",
 			"comment.actions",
+			"notebook.toolbar",
 			"notebook.cell.title",
+			"testing.item.title",
 			"menus.extensionContext",
 			"view.timelineTitle",
 			"view.timelineContext",
+			"view.tunnelContext",
+			"view.tunnelOriginInline",
 			"requirestring",
 			"optstring",
 			"optstring",
@@ -2101,7 +2044,12 @@
 			"vscode.extension.contributes.menuItem.group",
 			"vscode.extension.contributes.submenu.id",
 			"vscode.extension.contributes.submenu.label",
-			"vscode.extension.contributes.submenu.icon",
+			{
+				"key": "vscode.extension.contributes.submenu.icon",
+				"comment": [
+					"do not translate or change `\\$(zap)`, \\ in front of $ is important."
+				]
+			},
 			"vscode.extension.contributes.submenu.icon.light",
 			"vscode.extension.contributes.submenu.icon.dark",
 			"vscode.extension.contributes.menus",
@@ -2118,7 +2066,12 @@
 			"vscode.extension.contributes.commandType.title",
 			"vscode.extension.contributes.commandType.category",
 			"vscode.extension.contributes.commandType.precondition",
-			"vscode.extension.contributes.commandType.icon",
+			{
+				"key": "vscode.extension.contributes.commandType.icon",
+				"comment": [
+					"do not translate or change `\\$(zap)`, \\ in front of $ is important."
+				]
+			},
 			"vscode.extension.contributes.commandType.icon.light",
 			"vscode.extension.contributes.commandType.icon.dark",
 			"vscode.extension.contributes.commands",
@@ -2171,3810 +2124,6 @@
 			"workspaceConfig.remoteAuthority",
 			"unknownWorkspaceProperty"
 		],
-		"vs/workbench/api/browser/viewsExtensionPoint": [
-			{
-				"key": "vscode.extension.contributes.views.containers.id",
-				"comment": [
-					"Contribution refers to those that an extension contributes to VS Code through an extension/contribution point. "
-				]
-			},
-			"vscode.extension.contributes.views.containers.title",
-			"vscode.extension.contributes.views.containers.icon",
-			"vscode.extension.contributes.viewsContainers",
-			"views.container.activitybar",
-			"views.container.panel",
-			"vscode.extension.contributes.view.type",
-			"vscode.extension.contributes.view.tree",
-			"vscode.extension.contributes.view.webview",
-			"vscode.extension.contributes.view.id",
-			"vscode.extension.contributes.view.name",
-			"vscode.extension.contributes.view.when",
-			"vscode.extension.contributes.view.icon",
-			"vscode.extension.contributes.view.contextualTitle",
-			"vscode.extension.contributes.view.initialState",
-			"vscode.extension.contributes.view.initialState.visible",
-			"vscode.extension.contributes.view.initialState.hidden",
-			"vscode.extension.contributes.view.initialState.collapsed",
-			"vscode.extension.contributes.view.id",
-			"vscode.extension.contributes.view.name",
-			"vscode.extension.contributes.view.when",
-			"vscode.extension.contributes.view.group",
-			"vscode.extension.contributes.view.remoteName",
-			"vscode.extension.contributes.views",
-			"views.explorer",
-			"views.debug",
-			"views.scm",
-			"views.test",
-			"views.remote",
-			"views.contributed",
-			"viewcontainer requirearray",
-			"requireidstring",
-			"requireidstring",
-			"requirestring",
-			"requirestring",
-			"showViewlet",
-			"ViewContainerRequiresProposedAPI",
-			"ViewContainerDoesnotExist",
-			"duplicateView1",
-			"duplicateView2",
-			"unknownViewType",
-			"requirearray",
-			"requirestring",
-			"requirestring",
-			"optstring",
-			"optstring",
-			"optstring",
-			"optenum"
-		],
-		"vs/workbench/browser/parts/activitybar/activitybarPart": [
-			"settingsViewBarIcon",
-			"accountsViewBarIcon",
-			"homeButton",
-			"homeButton",
-			"menu",
-			"menu",
-			"accounts",
-			"accounts",
-			"hideActivitBar",
-			"resetLocation",
-			"resetLocation",
-			"homeIndicator",
-			"home",
-			"home",
-			"manage",
-			"manage",
-			"accounts",
-			"accounts",
-			"focusActivityBar"
-		],
-		"vs/workbench/browser/parts/panel/panelPart": [
-			"hidePanel",
-			"resetLocation",
-			"resetLocation",
-			"panel.emptyMessage"
-		],
-		"vs/workbench/browser/parts/sidebar/sidebarPart": [
-			"focusSideBar"
-		],
-		"vs/workbench/browser/parts/views/viewsService": [
-			{
-				"key": "focus view",
-				"comment": [
-					"{0} indicates the name of the view to be focused."
-				]
-			},
-			"resetViewLocation"
-		],
-		"vs/workbench/browser/parts/statusbar/statusbarPart": [
-			"hide",
-			"hideStatusBar"
-		],
-		"vs/platform/undoRedo/common/undoRedoService": [
-			{
-				"key": "externalRemoval",
-				"comment": [
-					"{0} is a list of filenames"
-				]
-			},
-			{
-				"key": "noParallelUniverses",
-				"comment": [
-					"{0} is a list of filenames"
-				]
-			},
-			{
-				"key": "cannotWorkspaceUndo",
-				"comment": [
-					"{0} is a label for an operation. {1} is another message."
-				]
-			},
-			{
-				"key": "cannotWorkspaceUndo",
-				"comment": [
-					"{0} is a label for an operation. {1} is another message."
-				]
-			},
-			{
-				"key": "cannotWorkspaceUndoDueToChanges",
-				"comment": [
-					"{0} is a label for an operation. {1} is a list of filenames."
-				]
-			},
-			{
-				"key": "cannotWorkspaceUndoDueToInProgressUndoRedo",
-				"comment": [
-					"{0} is a label for an operation. {1} is a list of filenames."
-				]
-			},
-			{
-				"key": "cannotWorkspaceUndoDueToInMeantimeUndoRedo",
-				"comment": [
-					"{0} is a label for an operation. {1} is a list of filenames."
-				]
-			},
-			"confirmWorkspace",
-			{
-				"key": "ok",
-				"comment": [
-					"{0} denotes a number that is > 1"
-				]
-			},
-			"nok",
-			"cancel",
-			{
-				"key": "cannotResourceUndoDueToInProgressUndoRedo",
-				"comment": [
-					"{0} is a label for an operation."
-				]
-			},
-			"confirmDifferentSource",
-			"confirmDifferentSource.ok",
-			"cancel",
-			{
-				"key": "cannotWorkspaceRedo",
-				"comment": [
-					"{0} is a label for an operation. {1} is another message."
-				]
-			},
-			{
-				"key": "cannotWorkspaceRedo",
-				"comment": [
-					"{0} is a label for an operation. {1} is another message."
-				]
-			},
-			{
-				"key": "cannotWorkspaceRedoDueToChanges",
-				"comment": [
-					"{0} is a label for an operation. {1} is a list of filenames."
-				]
-			},
-			{
-				"key": "cannotWorkspaceRedoDueToInProgressUndoRedo",
-				"comment": [
-					"{0} is a label for an operation. {1} is a list of filenames."
-				]
-			},
-			{
-				"key": "cannotWorkspaceRedoDueToInMeantimeUndoRedo",
-				"comment": [
-					"{0} is a label for an operation. {1} is a list of filenames."
-				]
-			},
-			{
-				"key": "cannotResourceRedoDueToInProgressUndoRedo",
-				"comment": [
-					"{0} is a label for an operation."
-				]
-			}
-		],
-		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
-			"confirmUrl",
-			"rememberConfirmUrl",
-			"open",
-			"reloadAndHandle",
-			"reloadAndOpen",
-			"enableAndHandle",
-			"enableAndReload",
-			"installAndHandle",
-			"install",
-			"Installing",
-			"reload",
-			"Reload",
-			"manage",
-			"extensions",
-			"no"
-		],
-		"vs/workbench/services/keybinding/common/keybindingEditing": [
-			"errorKeybindingsFileDirty",
-			"parseErrors",
-			"errorInvalidConfiguration",
-			"emptyKeybindingsHeader"
-		],
-		"vs/workbench/services/decorations/browser/decorationsService": [
-			"bubbleTitle"
-		],
-		"vs/workbench/services/progress/browser/progressService": [
-			"progress.text2",
-			"progress.title3",
-			"progress.title2",
-			"progress.title2",
-			"status.progress",
-			"cancel",
-			"cancel",
-			"dismiss"
-		],
-		"vs/workbench/services/preferences/browser/preferencesService": [
-			"openFolderFirst",
-			"emptyKeybindingsHeader",
-			"defaultKeybindings",
-			"defaultKeybindings",
-			"defaultSettings",
-			"folderSettingsName",
-			"fail.createSettings"
-		],
-		"vs/workbench/services/configuration/common/jsonEditingService": [
-			"errorInvalidFile",
-			"errorFileDirty"
-		],
-		"vs/workbench/services/editor/browser/editorService": [
-			"editorAssociations.viewType.sourceDescription"
-		],
-		"vs/workbench/services/keybinding/browser/keybindingService": [
-			"nonempty",
-			"requirestring",
-			"optstring",
-			"optstring",
-			"optstring",
-			"optstring",
-			"optstring",
-			"vscode.extension.contributes.keybindings.command",
-			"vscode.extension.contributes.keybindings.args",
-			"vscode.extension.contributes.keybindings.key",
-			"vscode.extension.contributes.keybindings.mac",
-			"vscode.extension.contributes.keybindings.linux",
-			"vscode.extension.contributes.keybindings.win",
-			"vscode.extension.contributes.keybindings.when",
-			"vscode.extension.contributes.keybindings",
-			"invalid.keybindings",
-			"unboundCommands",
-			"keybindings.json.title",
-			"keybindings.json.key",
-			"keybindings.json.command",
-			"keybindings.json.when",
-			"keybindings.json.args",
-			"keyboardConfigurationTitle",
-			"dispatch"
-		],
-		"vs/workbench/services/mode/common/workbenchModeService": [
-			"vscode.extension.contributes.languages",
-			"vscode.extension.contributes.languages.id",
-			"vscode.extension.contributes.languages.aliases",
-			"vscode.extension.contributes.languages.extensions",
-			"vscode.extension.contributes.languages.filenames",
-			"vscode.extension.contributes.languages.filenamePatterns",
-			"vscode.extension.contributes.languages.mimetypes",
-			"vscode.extension.contributes.languages.firstLine",
-			"vscode.extension.contributes.languages.configuration",
-			"invalid",
-			"invalid.empty",
-			"require.id",
-			"opt.extensions",
-			"opt.filenames",
-			"opt.firstLine",
-			"opt.configuration",
-			"opt.aliases",
-			"opt.mimetypes"
-		],
-		"vs/workbench/services/themes/browser/workbenchThemeService": [
-			"error.cannotloadtheme"
-		],
-		"vs/workbench/services/label/common/labelService": [
-			"vscode.extension.contributes.resourceLabelFormatters",
-			"vscode.extension.contributes.resourceLabelFormatters.scheme",
-			"vscode.extension.contributes.resourceLabelFormatters.authority",
-			"vscode.extension.contributes.resourceLabelFormatters.formatting",
-			"vscode.extension.contributes.resourceLabelFormatters.label",
-			"vscode.extension.contributes.resourceLabelFormatters.separator",
-			"vscode.extension.contributes.resourceLabelFormatters.stripPathStartingSeparator",
-			"vscode.extension.contributes.resourceLabelFormatters.tildify",
-			"vscode.extension.contributes.resourceLabelFormatters.formatting.workspaceSuffix",
-			"untitledWorkspace",
-			"workspaceNameVerbose",
-			"workspaceName"
-		],
-		"vs/workbench/services/extensionManagement/common/webExtensionsScannerService": [
-			"cannot be installed"
-		],
-		"vs/workbench/services/extensionManagement/browser/extensionEnablementService": [
-			"extensionsDisabled",
-			"Reload",
-			"cannot disable language pack extension",
-			"cannot disable auth extension",
-			"noWorkspace",
-			"cannot disable auth extension in workspace"
-		],
-		"vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig": [
-			"select for remove",
-			"select for add",
-			"select for remove",
-			"select for add",
-			"workspace folder",
-			"workspace"
-		],
-		"vs/workbench/services/notification/common/notificationService": [
-			"neverShowAgain",
-			"neverShowAgain"
-		],
-		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
-			"no authentication providers",
-			"no account",
-			"show log",
-			"sync turned on",
-			"sync in progress",
-			"settings sync",
-			{
-				"key": "yes",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "no",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"turning on",
-			"syncing resource",
-			"conflicts detected",
-			"merge Manually",
-			"resolve",
-			"merge or replace",
-			"merge",
-			"replace local",
-			"merge Manually",
-			"cancel",
-			"first time sync detail",
-			"reset",
-			"reset title",
-			{
-				"key": "resetButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"choose account placeholder",
-			"signed in",
-			"last used",
-			"others",
-			"sign in using account",
-			"successive auth failures",
-			"sign in"
-		],
-		"vs/workbench/services/views/browser/viewDescriptorService": [
-			"hideView",
-			"resetViewLocation"
-		],
-		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
-			"defaultPreferencesEditor",
-			"settingsEditor2",
-			"keybindingsEditor",
-			"openSettings2",
-			"preferences",
-			"settings",
-			{
-				"key": "miOpenSettings",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"openSettings2",
-			"openSettingsJson",
-			"openGlobalSettings",
-			"openRawDefaultSettings",
-			"openSettingsJson",
-			"openWorkspaceSettings",
-			"openWorkspaceSettingsFile",
-			"openFolderSettings",
-			"openFolderSettingsFile",
-			"openFolderSettings",
-			"filterModifiedLabel",
-			"filterOnlineServicesLabel",
-			{
-				"key": "miOpenOnlineSettings",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"onlineServices",
-			"openRemoteSettings",
-			"settings.focusSearch",
-			"settings.clearResults",
-			"settings.focusFile",
-			"settings.focusFile",
-			"settings.focusNextSetting",
-			"settings.focusPreviousSetting",
-			"settings.editFocusedSetting",
-			"settings.focusSettingsList",
-			"settings.focusSettingsTOC",
-			"settings.focusSettingControl",
-			"settings.showContextMenu",
-			"settings.focusLevelUp",
-			"preferences",
-			"openGlobalKeybindings",
-			"Keyboard Shortcuts",
-			"Keyboard Shortcuts",
-			"openDefaultKeybindingsFile",
-			"openGlobalKeybindingsFile",
-			"showDefaultKeybindings",
-			"showExtensionKeybindings",
-			"showUserKeybindings",
-			"clear",
-			{
-				"key": "miPreferences",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"defineKeybinding.start",
-			"defineKeybinding.kbLayoutErrorMessage",
-			{
-				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
-					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			},
-			{
-				"key": "defineKeybinding.kbLayoutLocalMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
-					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			}
-		],
-		"vs/workbench/contrib/performance/browser/performance.contribution": [
-			"show.label"
-		],
-		"vs/workbench/contrib/testing/browser/testing.contribution": [
-			"test",
-			"noTestProvidersRegistered",
-			{
-				"key": "searchMarketplaceForTestExtensions",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			},
-			"testExplorer"
-		],
-		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
-			"diffLeftRightLabel",
-			"notebookConfigurationTitle",
-			"notebook.displayOrder.description",
-			"notebook.cellToolbarLocation.description",
-			"notebook.showCellStatusbar.description",
-			"notebook.diff.enablePreview.description"
-		],
-		"vs/workbench/contrib/logs/common/logs.contribution": [
-			"userDataSyncLog",
-			"rendererLog",
-			"telemetryLog",
-			"show window log",
-			"mainLog",
-			"sharedLog"
-		],
-		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
-			"helpQuickAccessPlaceholder",
-			"helpQuickAccess",
-			"viewQuickAccessPlaceholder",
-			"viewQuickAccess",
-			"commandsQuickAccessPlaceholder",
-			"commandsQuickAccess",
-			{
-				"key": "miCommandPalette",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miOpenView",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miGotoSymbolInEditor",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miGotoLine",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"commandPalette",
-			"commandPalette"
-		],
-		"vs/workbench/contrib/files/browser/explorerViewlet": [
-			"explorerViewIcon",
-			"openEditorsIcon",
-			"folders",
-			"explore",
-			{
-				"key": "noWorkspaceHelp",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			},
-			{
-				"key": "remoteNoFolderHelp",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			},
-			{
-				"key": "noFolderHelp",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			}
-		],
-		"vs/workbench/contrib/files/browser/fileActions.contribution": [
-			"filesCategory",
-			"workspaces",
-			"file",
-			"copyPath",
-			"copyRelativePath",
-			"revealInSideBar",
-			"acceptLocalChanges",
-			"revertLocalChanges",
-			"copyPathOfActive",
-			"copyRelativePathOfActive",
-			"saveAllInGroup",
-			"saveFiles",
-			"revert",
-			"compareActiveWithSaved",
-			"openToSide",
-			"revert",
-			"saveAll",
-			"compareWithSaved",
-			"compareWithSelected",
-			"compareSource",
-			"compareSelected",
-			"close",
-			"closeOthers",
-			"closeSaved",
-			"closeAll",
-			"explorerOpenWith",
-			"cut",
-			"deleteFile",
-			"deleteFile",
-			"newFile",
-			"openFile",
-			{
-				"key": "miNewFile",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miSave",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miSaveAs",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miSaveAll",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miOpen",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miOpenFile",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miOpenFolder",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miOpenWorkspace",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miAutoSave",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miRevert",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miCloseEditor",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miGotoFile",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/files/browser/files.contribution": [
-			"showExplorerViewlet",
-			"binaryFileEditor",
-			"hotExit.off",
-			"hotExit.onExit",
-			"hotExit.onExitAndWindowClose",
-			"hotExit",
-			"hotExit.off",
-			"hotExit.onExitAndWindowCloseBrowser",
-			"hotExit",
-			"filesConfigurationTitle",
-			"exclude",
-			"files.exclude.boolean",
-			"files.exclude.when",
-			"associations",
-			"encoding",
-			"autoGuessEncoding",
-			"eol.LF",
-			"eol.CRLF",
-			"eol.auto",
-			"eol",
-			"useTrash",
-			"trimTrailingWhitespace",
-			"insertFinalNewline",
-			"trimFinalNewlines",
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "files.autoSave.off"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "files.autoSave.afterDelay"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "files.autoSave.onFocusChange"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "files.autoSave.onWindowChange"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "autoSave"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "autoSaveDelay"
-			},
-			"watcherExclude",
-			"defaultLanguage",
-			"maxMemoryForLargeFilesMB",
-			"files.restoreUndoStack",
-			"askUser",
-			"overwriteFileOnDisk",
-			"files.saveConflictResolution",
-			"files.simpleDialog.enable",
-			"formatOnSave",
-			{
-				"key": "everything",
-				"comment": [
-					"This is the description of an option"
-				]
-			},
-			{
-				"key": "modification",
-				"comment": [
-					"This is the description of an option"
-				]
-			},
-			"formatOnSaveMode",
-			"explorerConfigurationTitle",
-			{
-				"key": "openEditorsVisible",
-				"comment": [
-					"Open is an adjective"
-				]
-			},
-			{
-				"key": "openEditorsSortOrder",
-				"comment": [
-					"Open is an adjective"
-				]
-			},
-			"sortOrder.editorOrder",
-			"sortOrder.alphabetical",
-			"autoReveal.on",
-			"autoReveal.off",
-			"autoReveal.focusNoScroll",
-			"autoReveal",
-			"enableDragAndDrop",
-			"confirmDragAndDrop",
-			"confirmDelete",
-			"sortOrder.default",
-			"sortOrder.mixed",
-			"sortOrder.filesFirst",
-			"sortOrder.type",
-			"sortOrder.modified",
-			"sortOrder",
-			"explorer.decorations.colors",
-			"explorer.decorations.badges",
-			"simple",
-			"smart",
-			"explorer.incrementalNaming",
-			"compressSingleChildFolders",
-			{
-				"key": "miViewExplorer",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
-			"summary.0",
-			"summary.nm",
-			"summary.n0",
-			"workspaceEdit",
-			"workspaceEdit",
-			"nothing",
-			"fileOperation",
-			"areYouSureQuiteBulkEdit",
-			"quit"
-		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
-			"overlap",
-			"cancel",
-			"continue",
-			"detail",
-			"apply",
-			"cat",
-			"Discard",
-			"cat",
-			"toogleSelection",
-			"cat",
-			"groupByFile",
-			"cat",
-			"groupByType",
-			"cat",
-			"groupByType",
-			"cat",
-			"refactorPreviewViewIcon",
-			"panel",
-			"panel"
-		],
-		"vs/workbench/contrib/search/browser/search.contribution": [
-			"search",
-			"copyMatchLabel",
-			"copyPathLabel",
-			"copyAllLabel",
-			"CancelSearchAction.label",
-			"RefreshAction.label",
-			"CollapseDeepestExpandedLevelAction.label",
-			"ExpandAllAction.label",
-			"ClearSearchResultsAction.label",
-			"revealInSideBar",
-			"clearSearchHistoryLabel",
-			"focusSearchListCommandLabel",
-			"findInFolder",
-			"findInWorkspace",
-			"showTriggerActions",
-			"name",
-			"search",
-			"findInFiles.description",
-			"findInFiles.args",
-			"findInFiles",
-			{
-				"key": "miFindInFiles",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miReplaceInFiles",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"anythingQuickAccessPlaceholder",
-			"anythingQuickAccess",
-			"symbolsQuickAccessPlaceholder",
-			"symbolsQuickAccess",
-			"searchConfigurationTitle",
-			"exclude",
-			"exclude.boolean",
-			"exclude.when",
-			"search.mode",
-			"search.mode.view",
-			"search.mode.reuseEditor",
-			"search.mode.newEditor",
-			"useRipgrep",
-			"useRipgrepDeprecated",
-			"search.maintainFileSearchCache",
-			"useIgnoreFiles",
-			"useGlobalIgnoreFiles",
-			"search.quickOpen.includeSymbols",
-			"search.quickOpen.includeHistory",
-			"filterSortOrder.default",
-			"filterSortOrder.recency",
-			"filterSortOrder",
-			"search.followSymlinks",
-			"search.smartCase",
-			"search.globalFindClipboard",
-			"search.location",
-			"search.location.deprecationMessage",
-			"search.collapseResults.auto",
-			"search.collapseAllResults",
-			"search.useReplacePreview",
-			"search.showLineNumbers",
-			"search.usePCRE2",
-			"usePCRE2Deprecated",
-			"search.actionsPositionAuto",
-			"search.actionsPositionRight",
-			"search.actionsPosition",
-			"search.searchOnType",
-			"search.seedWithNearestWord",
-			"search.seedOnFocus",
-			"search.searchOnTypeDebouncePeriod",
-			"search.searchEditor.doubleClickBehaviour.selectWord",
-			"search.searchEditor.doubleClickBehaviour.goToLocation",
-			"search.searchEditor.doubleClickBehaviour.openLocationToSide",
-			"search.searchEditor.doubleClickBehaviour",
-			{
-				"key": "search.searchEditor.reusePriorSearchConfiguration",
-				"comment": [
-					"\"Search Editor\" is a type of editor that can display search results. \"includes, excludes, and flags\" refers to the \"files to include\" and \"files to exclude\" input boxes, and the flags that control whether a query is case-sensitive or a regex."
-				]
-			},
-			"search.searchEditor.defaultNumberOfContextLines",
-			"searchSortOrder.default",
-			"searchSortOrder.filesOnly",
-			"searchSortOrder.type",
-			"searchSortOrder.modified",
-			"searchSortOrder.countDescending",
-			"searchSortOrder.countAscending",
-			"search.sortOrder",
-			"search.experimental.searchInOpenEditors",
-			{
-				"key": "miViewSearch",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miGotoSymbolInWorkspace",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/search/browser/searchView": [
-			"searchCanceled",
-			"moreSearch",
-			"searchScope.includes",
-			"label.includes",
-			"searchScope.excludes",
-			"label.excludes",
-			"replaceAll.confirmation.title",
-			"replaceAll.confirm.button",
-			"replaceAll.occurrence.file.message",
-			"removeAll.occurrence.file.message",
-			"replaceAll.occurrence.files.message",
-			"removeAll.occurrence.files.message",
-			"replaceAll.occurrences.file.message",
-			"removeAll.occurrences.file.message",
-			"replaceAll.occurrences.files.message",
-			"removeAll.occurrences.files.message",
-			"removeAll.occurrence.file.confirmation.message",
-			"replaceAll.occurrence.file.confirmation.message",
-			"removeAll.occurrence.files.confirmation.message",
-			"replaceAll.occurrence.files.confirmation.message",
-			"removeAll.occurrences.file.confirmation.message",
-			"replaceAll.occurrences.file.confirmation.message",
-			"removeAll.occurrences.files.confirmation.message",
-			"replaceAll.occurrences.files.confirmation.message",
-			"emptySearch",
-			"ariaSearchResultsClearStatus",
-			"searchPathNotFoundError",
-			"searchMaxResultsWarning",
-			"noOpenEditorResultsIncludesExcludes",
-			"noOpenEditorResultsIncludes",
-			"noOpenEditorResultsExcludes",
-			"noOpenEditorResultsFound",
-			"noResultsIncludesExcludes",
-			"noResultsIncludes",
-			"noResultsExcludes",
-			"noResultsFound",
-			"rerunSearch.message",
-			"rerunSearchInAll.message",
-			"openSettings.message",
-			"openSettings.learnMore",
-			"ariaSearchResultsStatus",
-			"forTerm",
-			"useIgnoresAndExcludesDisabled",
-			"openInEditor.message",
-			"openInEditor.tooltip",
-			"search.file.result",
-			"search.files.result",
-			"search.file.results",
-			"search.files.results",
-			"searchWithoutFolder",
-			"openFolder"
-		],
-		"vs/workbench/contrib/sash/browser/sash.contribution": [
-			"sashSize"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
-			"searchEditor",
-			"search",
-			"searchEditor.deleteResultBlock",
-			"search.openNewSearchEditor",
-			"search.openSearchEditor",
-			"search.openNewEditorToSide",
-			"search.openResultsInEditor",
-			"search.rerunSearchInEditor",
-			"search.action.focusQueryEditorWidget",
-			"searchEditor.action.toggleSearchEditorCaseSensitive",
-			"searchEditor.action.toggleSearchEditorWholeWord",
-			"searchEditor.action.toggleSearchEditorRegex",
-			"searchEditor.action.toggleSearchEditorContextLines",
-			"searchEditor.action.increaseSearchEditorContextLines",
-			"searchEditor.action.decreaseSearchEditorContextLines",
-			"searchEditor.action.selectAllSearchEditorMatches",
-			"search.openNewEditor"
-		],
-		"vs/workbench/contrib/scm/browser/scm.contribution": [
-			"sourceControlViewIcon",
-			"source control",
-			"no open repo",
-			"source control",
-			"source control repositories",
-			"toggleSCMViewlet",
-			"scmConfigurationTitle",
-			"scm.diffDecorations.all",
-			"scm.diffDecorations.gutter",
-			"scm.diffDecorations.overviewRuler",
-			"scm.diffDecorations.minimap",
-			"scm.diffDecorations.none",
-			"diffDecorations",
-			"diffGutterWidth",
-			"scm.diffDecorationsGutterVisibility.always",
-			"scm.diffDecorationsGutterVisibility.hover",
-			"scm.diffDecorationsGutterVisibility",
-			"scm.diffDecorationsGutterAction.diff",
-			"scm.diffDecorationsGutterAction.none",
-			"scm.diffDecorationsGutterAction",
-			"alwaysShowActions",
-			"scm.countBadge.all",
-			"scm.countBadge.focused",
-			"scm.countBadge.off",
-			"scm.countBadge",
-			"scm.providerCountBadge.hidden",
-			"scm.providerCountBadge.auto",
-			"scm.providerCountBadge.visible",
-			"scm.providerCountBadge",
-			"scm.defaultViewMode.tree",
-			"scm.defaultViewMode.list",
-			"scm.defaultViewMode",
-			"autoReveal",
-			"inputFontFamily",
-			"alwaysShowRepository",
-			"providersVisible",
-			{
-				"key": "miViewSCM",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"scm accept",
-			"scm view next commit",
-			"scm view previous commit",
-			"open in terminal"
-		],
-		"vs/workbench/contrib/debug/browser/debug.contribution": [
-			"debugCategory",
-			"startDebugPlaceholder",
-			"startDebuggingHelp",
-			"terminateThread",
-			{
-				"comment": [
-					"Debug is a noun in this context, not a verb."
-				],
-				"key": "debugFocusConsole"
-			},
-			"jumpToCursor",
-			"SetNextStatement",
-			"inlineBreakpoint",
-			"terminateThread",
-			"restartFrame",
-			"copyStackTrace",
-			"setValue",
-			"copyValue",
-			"copyAsExpression",
-			"addToWatchExpressions",
-			"breakWhenValueChanges",
-			"editWatchExpression",
-			"copyValue",
-			"removeWatchExpression",
-			{
-				"key": "miViewRun",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miStartDebugging",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miRun",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miStopDebugging",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miRestart Debugging",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miAddConfiguration",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miStepOver",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miStepInto",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miStepOut",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miContinue",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miInlineBreakpoint",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miNewBreakpoint",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miInstallAdditionalDebuggers",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"comment": [
-					"Debug is a noun in this context, not a verb."
-				],
-				"key": "debugPanel"
-			},
-			{
-				"comment": [
-					"Debug is a noun in this context, not a verb."
-				],
-				"key": "debugPanel"
-			},
-			"run",
-			"variables",
-			"watch",
-			"callStack",
-			"breakpoints",
-			"loadedScripts",
-			"debugConfigurationTitle",
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "allowBreakpointsEverywhere"
-			},
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "openExplorerOnEnd"
-			},
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "inlineValues"
-			},
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "toolBarLocation"
-			},
-			"never",
-			"always",
-			"onFirstSessionStart",
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "showInStatusBar"
-			},
-			"debug.console.closeOnEnd",
-			"openDebug",
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "showSubSessionsInToolBar"
-			},
-			"debug.console.fontSize",
-			"debug.console.fontFamily",
-			"debug.console.lineHeight",
-			"debug.console.wordWrap",
-			"debug.console.historySuggestions",
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "launch"
-			},
-			"debug.focusWindowOnBreak",
-			"debugAnyway",
-			"showErrors",
-			"prompt",
-			"cancel",
-			"debug.onTaskErrors",
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "showBreakpointsInOverviewRuler"
-			},
-			{
-				"comment": [
-					"This is the description for a setting"
-				],
-				"key": "showInlineBreakpointCandidates"
-			}
-		],
-		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
-			"addConfiguration"
-		],
-		"vs/workbench/contrib/debug/browser/breakpointEditorContribution": [
-			"logPoint",
-			"breakpoint",
-			"breakpointHasConditionDisabled",
-			"message",
-			"condition",
-			"breakpointHasConditionEnabled",
-			"message",
-			"condition",
-			"removeLogPoint",
-			"disableLogPoint",
-			"disable",
-			"enable",
-			"cancel",
-			"logPoint",
-			"breakpoint",
-			"removeBreakpoint",
-			"editBreakpoint",
-			"disableBreakpoint",
-			"enableBreakpoint",
-			"removeBreakpoints",
-			"removeInlineBreakpointOnColumn",
-			"removeLineBreakpoint",
-			"editBreakpoints",
-			"editInlineBreakpointOnColumn",
-			"editLineBrekapoint",
-			"enableDisableBreakpoints",
-			"disableInlineColumnBreakpoint",
-			"disableBreakpointOnLine",
-			"enableBreakpoints",
-			"enableBreakpointOnLine",
-			"addBreakpoint",
-			"addConditionalBreakpoint",
-			"addLogPoint",
-			"debugIcon.breakpointForeground",
-			"debugIcon.breakpointDisabledForeground",
-			"debugIcon.breakpointUnverifiedForeground",
-			"debugIcon.breakpointCurrentStackframeForeground",
-			"debugIcon.breakpointStackframeForeground"
-		],
-		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
-			"topStackFrameLineHighlight",
-			"focusedStackFrameLineHighlight"
-		],
-		"vs/workbench/contrib/debug/browser/debugViewlet": [
-			"toggleDebugViewlet",
-			{
-				"key": "miOpenConfigurations",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "selectWorkspaceFolder",
-				"comment": [
-					"User picks a workspace folder or a workspace configuration file here. Workspace configuration files can contain settings and thus a launch.json configuration can be written into one."
-				]
-			},
-			"debugPanel",
-			{
-				"key": "miToggleDebugConsole",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"debugPanel",
-			"startAdditionalSession"
-		],
-		"vs/workbench/contrib/debug/browser/repl": [
-			{
-				"key": "workbench.debug.filter.placeholder",
-				"comment": [
-					"Text in the brackets after e.g. is not localizable"
-				]
-			},
-			"debugConsole",
-			"startDebugFirst",
-			{
-				"key": "actions.repl.acceptInput",
-				"comment": [
-					"Apply input from the debug console input box"
-				]
-			},
-			"repl.action.filter",
-			"actions.repl.copyAll",
-			"filter",
-			"selectRepl",
-			"clearRepl",
-			"debugConsoleCleared",
-			"collapse",
-			"paste",
-			"copyAll",
-			"copy"
-		],
-		"vs/workbench/contrib/markers/browser/markers.contribution": [
-			"markersViewIcon",
-			{
-				"key": "miMarker",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"copyMarker",
-			"copyMessage",
-			"copyMessage",
-			"focusProblemsList",
-			"focusProblemsFilter",
-			"show multiline",
-			"problems",
-			"show singleline",
-			"problems",
-			"clearFiltersText",
-			"problems",
-			"collapseAll",
-			"filter",
-			"status.problems",
-			"totalErrors",
-			"totalWarnings",
-			"totalInfos",
-			"noProblems",
-			"manyProblems"
-		],
-		"vs/workbench/contrib/comments/browser/comments.contribution": [
-			"commentsConfigurationTitle",
-			"openComments"
-		],
-		"vs/workbench/contrib/url/browser/url.contribution": [
-			"openUrl",
-			"urlToOpen"
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
-			"webview.editor.label"
-		],
-		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
-			"manageExtensionsQuickAccessPlaceholder",
-			"manageExtensionsHelp",
-			"extension",
-			"extensions",
-			"extensionsConfigurationTitle",
-			"extensionsAutoUpdate",
-			"extensionsCheckUpdates",
-			"extensionsIgnoreRecommendations",
-			"extensionsShowRecommendationsOnlyOnDemand_Deprecated",
-			"extensionsCloseExtensionDetailsOnViewChange",
-			"handleUriConfirmedExtensions",
-			"extensionsWebWorker",
-			"workbench.extensions.installExtension.description",
-			"workbench.extensions.installExtension.arg.name",
-			"notFound",
-			"workbench.extensions.uninstallExtension.description",
-			"workbench.extensions.uninstallExtension.arg.name",
-			"id required",
-			"notInstalled",
-			"builtin",
-			"workbench.extensions.search.description",
-			"workbench.extensions.search.arg.name",
-			"installExtensionQuickAccessPlaceholder",
-			"installExtensionQuickAccessHelp",
-			"toggleExtensionsViewlet",
-			{
-				"key": "miPreferencesExtensions",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miViewExtensions",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"showExtensions",
-			"installExtensions",
-			"showRecommendedKeymapExtensionsShort",
-			{
-				"key": "miOpenKeymapExtensions",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"miOpenKeymapExtensions2",
-			"showLanguageExtensionsShort",
-			"checkForUpdates",
-			"noUpdatesAvailable",
-			"singleUpdateAvailable",
-			"updatesAvailable",
-			"singleDisabledUpdateAvailable",
-			"updatesAvailableOneDisabled",
-			"updatesAvailableAllDisabled",
-			"updatesAvailableIncludingDisabled",
-			"disableAutoUpdate",
-			"updateAll",
-			"enableAutoUpdate",
-			"enableAll",
-			"enableAllWorkspace",
-			"disableAll",
-			"disableAllWorkspace",
-			"InstallFromVSIX",
-			"installFromVSIX",
-			{
-				"key": "installButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"installVSIX",
-			"InstallVSIXAction.successReload",
-			"InstallVSIXAction.success",
-			"InstallVSIXAction.reloadNow",
-			"filterExtensions",
-			"showFeaturedExtensions",
-			"featured filter",
-			"showPopularExtensions",
-			"most popular filter",
-			"showRecommendedExtensions",
-			"most popular recommended",
-			"recentlyPublishedExtensions",
-			"recently published filter",
-			"filter by category",
-			"showBuiltInExtensions",
-			"builtin filter",
-			"showInstalledExtensions",
-			"installed filter",
-			"showEnabledExtensions",
-			"enabled filter",
-			"showDisabledExtensions",
-			"disabled filter",
-			"showOutdatedExtensions",
-			"outdated filter",
-			"sorty by",
-			"sort by installs",
-			"sort by rating",
-			"sort by name",
-			"sort by date",
-			"clearExtensionsSearchResults",
-			"refreshExtension",
-			"installWorkspaceRecommendedExtensions",
-			"workbench.extensions.action.copyExtension",
-			"extensionInfoName",
-			"extensionInfoId",
-			"extensionInfoDescription",
-			"extensionInfoVersion",
-			"extensionInfoPublisher",
-			"extensionInfoVSMarketplaceLink",
-			"workbench.extensions.action.copyExtensionId",
-			"workbench.extensions.action.configure",
-			"workbench.extensions.action.toggleIgnoreExtension",
-			"workbench.extensions.action.ignoreRecommendation",
-			"workbench.extensions.action.undoIgnoredRecommendation",
-			"workbench.extensions.action.addExtensionToWorkspaceRecommendations",
-			"workbench.extensions.action.removeExtensionFromWorkspaceRecommendations",
-			"workbench.extensions.action.addToWorkspaceRecommendations",
-			"extensions",
-			"workbench.extensions.action.addToWorkspaceFolderRecommendations",
-			"extensions",
-			"workbench.extensions.action.addToWorkspaceIgnoredRecommendations",
-			"extensions",
-			"workbench.extensions.action.addToWorkspaceFolderIgnoredRecommendations",
-			"extensions",
-			"extensions"
-		],
-		"vs/workbench/contrib/output/browser/output.contribution": [
-			"outputViewIcon",
-			"output",
-			"output",
-			"logViewer",
-			"switchToOutput.label",
-			"clearOutput.label",
-			"outputCleared",
-			"toggleAutoScroll",
-			"outputScrollOff",
-			"outputScrollOn",
-			"openActiveLogOutputFile",
-			"toggleOutput",
-			"showLogs",
-			"selectlog",
-			"openLogFile",
-			"selectlogFile",
-			{
-				"key": "miToggleOutput",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"output",
-			"output.smartScroll.enabled"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			"installed",
-			"select and install local extensions",
-			{
-				"key": "remote",
-				"comment": [
-					"Remote as in remote machine"
-				]
-			},
-			"install remote in local",
-			{
-				"key": "remote",
-				"comment": [
-					"Remote as in remote machine"
-				]
-			},
-			"popularExtensions",
-			"recommendedExtensions",
-			"enabledExtensions",
-			"disabledExtensions",
-			"marketPlace",
-			"installed",
-			"enabled",
-			"disabled",
-			"outdated",
-			"builtin",
-			"workspaceRecommendedExtensions",
-			"otherRecommendedExtensions",
-			"builtinFeatureExtensions",
-			"builtInThemesExtensions",
-			"builtinProgrammingLanguageExtensions",
-			"searchExtensions",
-			"extensionFoundInSection",
-			"extensionFound",
-			"extensionsFoundInSection",
-			"extensionsFound",
-			"suggestProxyError",
-			"open user settings",
-			"outdatedExtensions",
-			"malicious warning",
-			"reloadNow"
-		],
-		"vs/workbench/contrib/output/browser/outputView": [
-			"output model title",
-			"channel",
-			"output",
-			"outputViewWithInputAriaLabel",
-			"outputViewAriaLabel",
-			"outputChannels",
-			"logChannel"
-		],
-		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
-			"tasksQuickAccessPlaceholder",
-			"tasksQuickAccessHelp",
-			"terminal",
-			"terminal"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalView": [
-			"terminal.useMonospace",
-			"terminal.monospaceOnly"
-		],
-		"vs/workbench/contrib/terminal/browser/remoteTerminalService": [
-			"terminal.integrated.starting"
-		],
-		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
-			"relaunchSettingMessage",
-			"relaunchSettingMessageWeb",
-			"relaunchSettingDetail",
-			"relaunchSettingDetailWeb",
-			"restart",
-			"restartWeb"
-		],
-		"vs/workbench/contrib/tasks/browser/task.contribution": [
-			"building",
-			"numberOfRunningTasks",
-			"runningTasks",
-			"status.runningTasks",
-			{
-				"key": "miRunTask",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miBuildTask",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miRunningTask",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miRestartTask",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miTerminateTask",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miConfigureTask",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miConfigureBuildTask",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"workbench.action.tasks.openWorkspaceFileTasks",
-			"ShowLogAction.label",
-			"RunTaskAction.label",
-			"ReRunTaskAction.label",
-			"RestartTaskAction.label",
-			"ShowTasksAction.label",
-			"TerminateAction.label",
-			"BuildAction.label",
-			"TestAction.label",
-			"ConfigureDefaultBuildTask.label",
-			"ConfigureDefaultTestTask.label",
-			"workbench.action.tasks.openUserTasks",
-			"tasksQuickAccessPlaceholder",
-			"tasksQuickAccessHelp",
-			"tasksConfigurationTitle",
-			"task.problemMatchers.neverPrompt",
-			"task.problemMatchers.neverPrompt.boolean",
-			"task.problemMatchers.neverPrompt.array",
-			"task.autoDetect",
-			"task.slowProviderWarning",
-			"task.slowProviderWarning.boolean",
-			"task.slowProviderWarning.array",
-			"task.quickOpen.history",
-			"task.quickOpen.detail",
-			"task.quickOpen.skip",
-			"task.quickOpen.showAll",
-			"task.saveBeforeRun",
-			"task.saveBeforeRun.always",
-			"task.saveBeforeRun.never",
-			"task.SaveBeforeRun.prompt"
-		],
-		"vs/workbench/contrib/remote/common/remote.contribution": [
-			"remoteExtensionLog",
-			"ui",
-			"workspace",
-			"web",
-			"remote",
-			"remote.extensionKind",
-			"remote.restoreForwardedPorts",
-			"remote.autoForwardPorts",
-			"remote.portsAttributes.port",
-			"remote.portsAttributes.notify",
-			"remote.portsAttributes.openBrowser",
-			"remote.portsAttributes.silent",
-			"remote.portsAttributes.ignore",
-			"remote.portsAttributes.onForward",
-			"remote.portsAttributes.elevateIfNeeded",
-			"remote.portsAttributes.label",
-			"remote.portsAttributes.labelDefault",
-			"remote.portsAttributes.labelDefault",
-			"remote.portsAttributes"
-		],
-		"vs/workbench/contrib/remote/browser/remote": [
-			"RemoteHelpInformationExtPoint",
-			"RemoteHelpInformationExtPoint.getStarted",
-			"RemoteHelpInformationExtPoint.documentation",
-			"RemoteHelpInformationExtPoint.feedback",
-			"RemoteHelpInformationExtPoint.issues",
-			"remote.help.getStarted",
-			"remote.help.documentation",
-			"remote.help.feedback",
-			"remote.help.issues",
-			"remote.help.report",
-			"pickRemoteExtension",
-			"remote.help",
-			"remotehelp",
-			"remote.explorer",
-			"remote.explorer",
-			"toggleRemoteViewlet",
-			"reconnectionWaitOne",
-			"reconnectionWaitMany",
-			"reconnectNow",
-			"reloadWindow",
-			"connectionLost",
-			"reconnectionRunning",
-			"reconnectionPermanentFailure",
-			"reloadWindow",
-			"cancel"
-		],
-		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
-			"toggleKeybindingsLog"
-		],
-		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
-			"scopedConsoleAction",
-			"scopedConsoleAction.integrated",
-			"scopedConsoleAction.integrated",
-			"scopedConsoleAction.wt",
-			"scopedConsoleAction.external"
-		],
-		"vs/workbench/contrib/snippets/browser/snippets.contribution": [
-			"snippetSchema.json.prefix",
-			"snippetSchema.json.body",
-			"snippetSchema.json.description",
-			"snippetSchema.json.default",
-			"snippetSchema.json",
-			"snippetSchema.json.default",
-			"snippetSchema.json",
-			"snippetSchema.json.scope"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"invalid.path.0",
-			"invalid.language.0",
-			"invalid.language",
-			"invalid.path.1",
-			"vscode.extension.contributes.snippets",
-			"vscode.extension.contributes.snippets-language",
-			"vscode.extension.contributes.snippets-path",
-			"badVariableUse",
-			"badFile"
-		],
-		"vs/workbench/contrib/snippets/browser/insertSnippet": [
-			"snippet.suggestions.label",
-			"sep.userSnippet",
-			"sep.extSnippet",
-			"sep.workspaceSnippet",
-			"disableSnippet",
-			"isDisabled",
-			"enable.snippet",
-			"pick.placeholder"
-		],
-		"vs/workbench/contrib/snippets/browser/configureSnippets": [
-			"global.scope",
-			"global.1",
-			"name",
-			"bad_name1",
-			"bad_name2",
-			"bad_name3",
-			"new.global_scope",
-			"new.global",
-			"new.workspace_scope",
-			"new.folder",
-			"group.global",
-			"new.global.sep",
-			"new.global.sep",
-			"openSnippet.pickLanguage",
-			"openSnippet.label",
-			"preferences",
-			{
-				"key": "miOpenSnippets",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"userSnippets"
-		],
-		"vs/workbench/contrib/themes/browser/themes.contribution": [
-			"selectTheme.label",
-			"themes.category.light",
-			"themes.category.dark",
-			"themes.category.hc",
-			"installColorThemes",
-			"themes.selectTheme",
-			"selectIconTheme.label",
-			"noIconThemeLabel",
-			"noIconThemeDesc",
-			"installIconThemes",
-			"themes.selectIconTheme",
-			"selectProductIconTheme.label",
-			"defaultProductIconThemeLabel",
-			"installProductIconThemes",
-			"themes.selectProductIconTheme",
-			"generateColorTheme.label",
-			"preferences",
-			{
-				"key": "miSelectColorTheme",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miSelectIconTheme",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miSelectProductIconTheme",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"selectTheme.label",
-			"themes.selectIconTheme.label",
-			"themes.selectProductIconTheme.label"
-		],
-		"vs/workbench/contrib/update/browser/update.contribution": [
-			{
-				"key": "miReleaseNotes",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/watermark/browser/watermark": [
-			"watermark.showCommands",
-			"watermark.quickAccess",
-			"watermark.openFile",
-			"watermark.openFolder",
-			"watermark.openFileFolder",
-			"watermark.openRecent",
-			"watermark.newUntitledFile",
-			{
-				"key": "watermark.toggleTerminal",
-				"comment": [
-					"toggle is a verb here"
-				]
-			},
-			"watermark.findInFiles",
-			"watermark.startDebugging",
-			"tips.enabled"
-		],
-		"vs/workbench/contrib/surveys/browser/nps.contribution": [
-			"surveyQuestion",
-			"takeSurvey",
-			"remindLater",
-			"neverAgain"
-		],
-		"vs/workbench/contrib/surveys/browser/languageSurveys.contribution": [
-			"helpUs",
-			"takeShortSurvey",
-			"remindLater",
-			"neverAgain"
-		],
-		"vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay": [
-			"welcomeOverlay.explorer",
-			"welcomeOverlay.search",
-			"welcomeOverlay.git",
-			"welcomeOverlay.debug",
-			"welcomeOverlay.extensions",
-			"welcomeOverlay.problems",
-			"welcomeOverlay.terminal",
-			"welcomeOverlay.commandPalette",
-			"welcomeOverlay.notifications",
-			"welcomeOverlay",
-			"hideWelcomeOverlay"
-		],
-		"vs/workbench/contrib/welcome/page/browser/welcomePage.contribution": [
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "workbench.startupEditor.none"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "workbench.startupEditor.welcomePage"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "workbench.startupEditor.readme"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "workbench.startupEditor.newUntitledFile"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "workbench.startupEditor.welcomePageInEmptyWorkbench"
-			},
-			{
-				"comment": [
-					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
-				],
-				"key": "workbench.startupEditor.gettingStarted"
-			},
-			"workbench.startupEditor",
-			{
-				"key": "miWelcome",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution": [
-			"Getting Started",
-			"help",
-			"gettingStartedDescription"
-		],
-		"vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution": [
-			"walkThrough.editor.label",
-			{
-				"key": "miInteractivePlayground",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
-			"no.item",
-			"error",
-			"title",
-			"title.incoming",
-			"showIncomingCallsIcons",
-			"title.outgoing",
-			"showOutgoingCallsIcon",
-			"title.refocus",
-			"close"
-		],
-		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
-			"document"
-		],
-		"vs/workbench/contrib/outline/browser/outline.contribution": [
-			"outlineViewIcon",
-			"name",
-			"outlineConfigurationTitle",
-			"outline.showIcons",
-			"outline.showProblem",
-			"outline.problem.colors",
-			"outline.problems.badges",
-			"filteredTypes.file",
-			"filteredTypes.module",
-			"filteredTypes.namespace",
-			"filteredTypes.package",
-			"filteredTypes.class",
-			"filteredTypes.method",
-			"filteredTypes.property",
-			"filteredTypes.field",
-			"filteredTypes.constructor",
-			"filteredTypes.enum",
-			"filteredTypes.interface",
-			"filteredTypes.function",
-			"filteredTypes.variable",
-			"filteredTypes.constant",
-			"filteredTypes.string",
-			"filteredTypes.number",
-			"filteredTypes.boolean",
-			"filteredTypes.array",
-			"filteredTypes.object",
-			"filteredTypes.key",
-			"filteredTypes.null",
-			"filteredTypes.enumMember",
-			"filteredTypes.struct",
-			"filteredTypes.event",
-			"filteredTypes.operator",
-			"filteredTypes.typeParameter"
-		],
-		"vs/workbench/contrib/experiments/browser/experiments.contribution": [
-			"workbench.enableExperiments"
-		],
-		"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution": [
-			"operationId",
-			"too many requests"
-		],
-		"vs/workbench/contrib/timeline/browser/timeline.contribution": [
-			"timelineViewIcon",
-			"timelineOpenIcon",
-			"timelineConfigurationTitle",
-			"timeline.excludeSources",
-			"timeline.pageSize",
-			"timeline.pageOnScroll",
-			"files.openTimeline"
-		],
-		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
-			"workspaceFound",
-			"openWorkspace",
-			"workspacesFound",
-			"selectWorkspace",
-			"selectToOpen"
-		],
-		"vs/workbench/browser/parts/dialogs/dialogHandler": [
-			{
-				"key": "yesButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"cancelButton",
-			"aboutDetail",
-			"copy",
-			"ok"
-		],
-		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
-			{
-				"key": "yesButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"cancelButton",
-			{
-				"key": "aboutDetail",
-				"comment": [
-					"Electron, Chrome, Node.js and V8 are product names that need no translation"
-				]
-			},
-			"okButton",
-			{
-				"key": "copy",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
-			"saveChangesDetail",
-			"saveChangesMessage",
-			"saveChangesMessages",
-			{
-				"key": "saveAll",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "save",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "dontSave",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"cancel",
-			"openFileOrFolder.title",
-			"openFile.title",
-			"openFolder.title",
-			"openWorkspace.title",
-			"filterName.workspace",
-			"saveFileAs.title",
-			"saveAsTitle",
-			"allFiles",
-			"noExt"
-		],
-		"vs/workbench/services/textMate/browser/abstractTextMateService": [
-			"alreadyDebugging",
-			"stop",
-			"progress1",
-			"progress2",
-			"invalid.language",
-			"invalid.scopeName",
-			"invalid.path.0",
-			"invalid.injectTo",
-			"invalid.embeddedLanguages",
-			"invalid.tokenTypes",
-			"invalid.path.1",
-			"too many characters",
-			"neverAgain"
-		],
-		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
-			"save",
-			"saveWorkspace",
-			"errorInvalidTaskConfiguration",
-			"errorWorkspaceConfigurationFileDirty",
-			"openWorkspaceConfigurationFile"
-		],
-		"vs/workbench/services/configurationResolver/browser/configurationResolverService": [
-			"commandVariable.noStringType",
-			"inputVariable.noInputSection",
-			"inputVariable.missingAttribute",
-			"inputVariable.defaultInputValue",
-			"inputVariable.command.noStringType",
-			"inputVariable.unknownType",
-			"inputVariable.undefinedVariable"
-		],
-		"vs/workbench/services/extensionManagement/common/extensionManagementService": [
-			"singleDependentError",
-			"twoDependentsError",
-			"multipleDependentsError",
-			"Manifest is not found",
-			"cannot be installed",
-			"cannot be installed on web",
-			"install extension",
-			"install extensions",
-			"install",
-			"install and do no sync",
-			"cancel",
-			"install single extension",
-			"install multiple extensions"
-		],
-		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
-			"openLogsFolder",
-			"openExtensionLogsFolder"
-		],
-		"vs/workbench/contrib/localizations/browser/localizationsActions": [
-			"configureLocale",
-			"installAdditionalLanguages",
-			"chooseDisplayLanguage",
-			"relaunchDisplayLanguageMessage",
-			"relaunchDisplayLanguageDetail",
-			"restart"
-		],
-		"vs/workbench/services/extensions/common/extensionsRegistry": [
-			"ui",
-			"workspace",
-			"web",
-			"vscode.extension.engines",
-			"vscode.extension.engines.vscode",
-			"vscode.extension.publisher",
-			"vscode.extension.displayName",
-			"vscode.extension.categories",
-			"vscode.extension.category.languages.deprecated",
-			"vscode.extension.galleryBanner",
-			"vscode.extension.galleryBanner.color",
-			"vscode.extension.galleryBanner.theme",
-			"vscode.extension.contributes",
-			"vscode.extension.preview",
-			"vscode.extension.activationEvents",
-			"vscode.extension.activationEvents.onLanguage",
-			"vscode.extension.activationEvents.onCommand",
-			"vscode.extension.activationEvents.onDebug",
-			"vscode.extension.activationEvents.onDebugInitialConfigurations",
-			"vscode.extension.activationEvents.onDebugDynamicConfigurations",
-			"vscode.extension.activationEvents.onDebugResolve",
-			"vscode.extension.activationEvents.onDebugAdapterProtocolTracker",
-			"vscode.extension.activationEvents.workspaceContains",
-			"vscode.extension.activationEvents.onStartupFinished",
-			"vscode.extension.activationEvents.onFileSystem",
-			"vscode.extension.activationEvents.onSearch",
-			"vscode.extension.activationEvents.onView",
-			"vscode.extension.activationEvents.onIdentity",
-			"vscode.extension.activationEvents.onUri",
-			"vscode.extension.activationEvents.onCustomEditor",
-			"vscode.extension.activationEvents.onNotebook",
-			"vscode.extension.activationEvents.star",
-			"vscode.extension.badges",
-			"vscode.extension.badges.url",
-			"vscode.extension.badges.href",
-			"vscode.extension.badges.description",
-			"vscode.extension.markdown",
-			"vscode.extension.qna",
-			"vscode.extension.extensionDependencies",
-			"vscode.extension.contributes.extensionPack",
-			"extensionKind",
-			"extensionKind.ui",
-			"extensionKind.workspace",
-			"extensionKind.ui-workspace",
-			"extensionKind.workspace-ui",
-			"extensionKind.empty",
-			"vscode.extension.scripts.prepublish",
-			"vscode.extension.scripts.uninstall",
-			"vscode.extension.icon"
-		],
-		"vs/workbench/contrib/localizations/browser/minimalTranslations": [
-			"showLanguagePackExtensions",
-			"searchMarketplace",
-			"installAndRestartMessage",
-			"installAndRestart"
-		],
-		"vs/workbench/electron-sandbox/actions/developerActions": [
-			"toggleDevTools",
-			"configureRuntimeArguments",
-			"toggleSharedProcess",
-			"reloadWindowWithExtensionsDisabled"
-		],
-		"vs/workbench/electron-sandbox/actions/windowActions": [
-			"closeWindow",
-			"zoomIn",
-			"zoomOut",
-			"zoomReset",
-			"close",
-			"close",
-			"switchWindowPlaceHolder",
-			"windowDirtyAriaLabel",
-			"current",
-			"switchWindow",
-			"quickSwitchWindow"
-		],
-		"vs/workbench/contrib/files/common/editors/fileEditorInput": [
-			"orphanedReadonlyFile",
-			"orphanedFile",
-			"readonlyFile"
-		],
-		"vs/workbench/contrib/files/electron-sandbox/textFileEditor": [
-			"fileTooLargeForHeapError",
-			"relaunchWithIncreasedMemoryLimit",
-			"configureMemoryLimit"
-		],
-		"vs/workbench/contrib/backup/electron-sandbox/backupTracker": [
-			"backupTrackerBackupFailed",
-			"backupTrackerConfirmFailed",
-			"backupErrorDetails",
-			"ok",
-			"saveBeforeShutdown"
-		],
-		"vs/workbench/contrib/files/electron-sandbox/fileCommands": [
-			"openFileToReveal"
-		],
-		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
-			"actions.pasteSelectionClipboard"
-		],
-		"vs/workbench/contrib/issue/electron-sandbox/issueActions": [
-			"openProcessExplorer",
-			{
-				"key": "reportPerformanceIssue",
-				"comment": [
-					"Here, 'issue' means problem or bug"
-				]
-			}
-		],
-		"vs/workbench/services/dialogs/browser/simpleFileDialog": [
-			"openLocalFile",
-			"saveLocalFile",
-			"openLocalFolder",
-			"openLocalFileFolder",
-			"remoteFileDialog.notConnectedToRemote",
-			"remoteFileDialog.local",
-			"remoteFileDialog.badPath",
-			"remoteFileDialog.cancel",
-			"remoteFileDialog.invalidPath",
-			"remoteFileDialog.validateFolder",
-			"remoteFileDialog.validateExisting",
-			"remoteFileDialog.validateBadFilename",
-			"remoteFileDialog.validateNonexistentDir",
-			"remoteFileDialog.validateNonexistentDir",
-			"remoteFileDialog.windowsDriveLetter",
-			"remoteFileDialog.validateFileOnly",
-			"remoteFileDialog.validateFolderOnly"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"notificationsEmpty",
-			"notifications",
-			"notificationsToolbar"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
-			"alertErrorMessage",
-			"alertWarningMessage",
-			"alertInfoMessage"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsStatus": [
-			"status.notifications",
-			"status.notifications",
-			"hideNotifications",
-			"zeroNotifications",
-			"noNotifications",
-			"oneNotification",
-			{
-				"key": "notifications",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "noNotificationsWithProgress",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "oneNotificationWithProgress",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "notificationsWithProgress",
-				"comment": [
-					"{0} and {1} will be replaced by a number"
-				]
-			},
-			"status.message"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCommands": [
-			"notifications",
-			"showNotifications",
-			"hideNotifications",
-			"clearAllNotifications",
-			"focusNotificationToasts"
-		],
-		"vs/platform/actions/browser/menuEntryActionViewItem": [
-			"titleAndKb"
-		],
-		"vs/workbench/services/configuration/common/configurationEditingService": [
-			"openTasksConfiguration",
-			"openLaunchConfiguration",
-			"open",
-			"openTasksConfiguration",
-			"openLaunchConfiguration",
-			"saveAndRetry",
-			"saveAndRetry",
-			"open",
-			"errorUnknownKey",
-			"errorInvalidWorkspaceConfigurationApplication",
-			"errorInvalidWorkspaceConfigurationMachine",
-			"errorInvalidFolderConfiguration",
-			"errorInvalidUserTarget",
-			"errorInvalidWorkspaceTarget",
-			"errorInvalidFolderTarget",
-			"errorInvalidResourceLanguageConfiguraiton",
-			"errorNoWorkspaceOpened",
-			"errorInvalidTaskConfiguration",
-			"errorInvalidLaunchConfiguration",
-			"errorInvalidConfiguration",
-			"errorInvalidRemoteConfiguration",
-			"errorInvalidConfigurationWorkspace",
-			"errorInvalidConfigurationFolder",
-			"errorTasksConfigurationFileDirty",
-			"errorLaunchConfigurationFileDirty",
-			"errorConfigurationFileDirty",
-			"errorRemoteConfigurationFileDirty",
-			"errorConfigurationFileDirtyWorkspace",
-			"errorConfigurationFileDirtyFolder",
-			"errorTasksConfigurationFileModifiedSince",
-			"errorLaunchConfigurationFileModifiedSince",
-			"errorConfigurationFileModifiedSince",
-			"errorRemoteConfigurationFileModifiedSince",
-			"errorConfigurationFileModifiedSinceWorkspace",
-			"errorConfigurationFileModifiedSinceFolder",
-			"userTarget",
-			"remoteUserTarget",
-			"workspaceTarget",
-			"folderTarget"
-		],
-		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
-			{
-				"key": "genericSaveError",
-				"comment": [
-					"{0} is the resource that failed to save and {1} the error message"
-				]
-			}
-		],
-		"vs/editor/common/modes/modesRegistry": [
-			"plainText.alias"
-		],
-		"vs/workbench/services/extensions/node/extensionPoints": [
-			"jsonParseInvalidType",
-			"jsonParseFail",
-			"fileReadFail",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat",
-			"missingNLSKey",
-			"notSemver",
-			"extensionDescription.empty",
-			"extensionDescription.publisher",
-			"extensionDescription.name",
-			"extensionDescription.version",
-			"extensionDescription.engines",
-			"extensionDescription.engines.vscode",
-			"extensionDescription.extensionDependencies",
-			"extensionDescription.activationEvents1",
-			"extensionDescription.activationEvents2",
-			"extensionDescription.main1",
-			"extensionDescription.main2",
-			"extensionDescription.main3",
-			"extensionDescription.browser1",
-			"extensionDescription.browser2",
-			"extensionDescription.browser3"
-		],
-		"vs/workbench/services/extensions/common/extensionHostManager": [
-			"measureExtHostLatency"
-		],
-		"vs/workbench/contrib/webview/browser/baseWebviewElement": [
-			"fatalErrorMessage"
-		],
-		"vs/workbench/contrib/notebook/browser/notebookIcons": [
-			"configureKernel",
-			"selectKernelIcon",
-			"executeIcon",
-			"stopIcon",
-			"deleteCellIcon",
-			"executeAllIcon",
-			"editIcon",
-			"stopEditIcon",
-			"moveUpIcon",
-			"moveDownIcon",
-			"clearIcon",
-			"splitCellIcon",
-			"unfoldIcon",
-			"successStateIcon",
-			"errorStateIcon",
-			"collapsedIcon",
-			"expandedIcon",
-			"openAsTextIcon",
-			"revertIcon",
-			"renderOutputIcon",
-			"mimetypeIcon"
-		],
-		"vs/workbench/contrib/extensions/electron-browser/extensionsSlowActions": [
-			"cmd.reportOrShow",
-			"cmd.report",
-			"attach.title",
-			"ok",
-			"attach.msg",
-			"cmd.show",
-			"attach.title",
-			"ok",
-			"attach.msg2"
-		],
-		"vs/workbench/contrib/extensions/electron-browser/reportExtensionIssueAction": [
-			"reportExtensionIssue"
-		],
-		"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor": [
-			{
-				"key": "starActivation",
-				"comment": [
-					"{0} will be an extension identifier"
-				]
-			},
-			{
-				"key": "workspaceContainsGlobActivation",
-				"comment": [
-					"{0} will be a glob pattern",
-					"{1} will be an extension identifier"
-				]
-			},
-			{
-				"key": "workspaceContainsFileActivation",
-				"comment": [
-					"{0} will be a file name",
-					"{1} will be an extension identifier"
-				]
-			},
-			{
-				"key": "workspaceContainsTimeout",
-				"comment": [
-					"{0} will be a glob pattern",
-					"{1} will be an extension identifier"
-				]
-			},
-			{
-				"key": "startupFinishedActivation",
-				"comment": [
-					"This refers to an extension. {0} will be an activation event."
-				]
-			},
-			"languageActivation",
-			{
-				"key": "workspaceGenericActivation",
-				"comment": [
-					"{0} will be an activation event, like e.g. 'language:typescript', 'debug', etc.",
-					"{1} will be an extension identifier"
-				]
-			},
-			"unresponsive.title",
-			"errors",
-			"runtimeExtensions",
-			"disable workspace",
-			"disable",
-			"showRuntimeExtensions"
-		],
-		"vs/workbench/contrib/terminal/node/terminalProcess": [
-			"launchFail.cwdNotDirectory",
-			"launchFail.cwdDoesNotExist",
-			"launchFail.executableIsNotFileOrSymlink",
-			"launchFail.executableDoesNotExist"
-		],
-		"vs/workbench/contrib/terminal/electron-browser/terminalRemote": [
-			"workbench.action.terminal.newLocal"
-		],
-		"vs/editor/common/config/editorOptions": [
-			"accessibilitySupport.auto",
-			"accessibilitySupport.on",
-			"accessibilitySupport.off",
-			"accessibilitySupport",
-			"comments.insertSpace",
-			"comments.ignoreEmptyLines",
-			"emptySelectionClipboard",
-			"find.cursorMoveOnType",
-			"find.seedSearchStringFromSelection",
-			"editor.find.autoFindInSelection.never",
-			"editor.find.autoFindInSelection.always",
-			"editor.find.autoFindInSelection.multiline",
-			"find.autoFindInSelection",
-			"find.globalFindClipboard",
-			"find.addExtraSpaceOnTop",
-			"find.loop",
-			"fontLigatures",
-			"fontFeatureSettings",
-			"fontLigaturesGeneral",
-			"fontSize",
-			"fontWeightErrorMessage",
-			"fontWeight",
-			"editor.gotoLocation.multiple.peek",
-			"editor.gotoLocation.multiple.gotoAndPeek",
-			"editor.gotoLocation.multiple.goto",
-			"editor.gotoLocation.multiple.deprecated",
-			"editor.editor.gotoLocation.multipleDefinitions",
-			"editor.editor.gotoLocation.multipleTypeDefinitions",
-			"editor.editor.gotoLocation.multipleDeclarations",
-			"editor.editor.gotoLocation.multipleImplemenattions",
-			"editor.editor.gotoLocation.multipleReferences",
-			"alternativeDefinitionCommand",
-			"alternativeTypeDefinitionCommand",
-			"alternativeDeclarationCommand",
-			"alternativeImplementationCommand",
-			"alternativeReferenceCommand",
-			"hover.enabled",
-			"hover.delay",
-			"hover.sticky",
-			"codeActions",
-			"inlineHints.enable",
-			"inlineHints.fontSize",
-			"inlineHints.fontFamily",
-			"lineHeight",
-			"minimap.enabled",
-			"minimap.size.proportional",
-			"minimap.size.fill",
-			"minimap.size.fit",
-			"minimap.size",
-			"minimap.side",
-			"minimap.showSlider",
-			"minimap.scale",
-			"minimap.renderCharacters",
-			"minimap.maxColumn",
-			"padding.top",
-			"padding.bottom",
-			"parameterHints.enabled",
-			"parameterHints.cycle",
-			"quickSuggestions.strings",
-			"quickSuggestions.comments",
-			"quickSuggestions.other",
-			"quickSuggestions",
-			"lineNumbers.off",
-			"lineNumbers.on",
-			"lineNumbers.relative",
-			"lineNumbers.interval",
-			"lineNumbers",
-			"rulers.size",
-			"rulers.color",
-			"rulers",
-			"suggest.insertMode.insert",
-			"suggest.insertMode.replace",
-			"suggest.insertMode",
-			"suggest.filterGraceful",
-			"suggest.localityBonus",
-			"suggest.shareSuggestSelections",
-			"suggest.snippetsPreventQuickSuggestions",
-			"suggest.showIcons",
-			"suggest.showStatusBar",
-			"suggest.showInlineDetails",
-			"suggest.maxVisibleSuggestions.dep",
-			"deprecated",
-			"editor.suggest.showMethods",
-			"editor.suggest.showFunctions",
-			"editor.suggest.showConstructors",
-			"editor.suggest.showFields",
-			"editor.suggest.showVariables",
-			"editor.suggest.showClasss",
-			"editor.suggest.showStructs",
-			"editor.suggest.showInterfaces",
-			"editor.suggest.showModules",
-			"editor.suggest.showPropertys",
-			"editor.suggest.showEvents",
-			"editor.suggest.showOperators",
-			"editor.suggest.showUnits",
-			"editor.suggest.showValues",
-			"editor.suggest.showConstants",
-			"editor.suggest.showEnums",
-			"editor.suggest.showEnumMembers",
-			"editor.suggest.showKeywords",
-			"editor.suggest.showTexts",
-			"editor.suggest.showColors",
-			"editor.suggest.showFiles",
-			"editor.suggest.showReferences",
-			"editor.suggest.showCustomcolors",
-			"editor.suggest.showFolders",
-			"editor.suggest.showTypeParameters",
-			"editor.suggest.showSnippets",
-			"editor.suggest.showUsers",
-			"editor.suggest.showIssues",
-			"selectLeadingAndTrailingWhitespace",
-			"acceptSuggestionOnCommitCharacter",
-			"acceptSuggestionOnEnterSmart",
-			"acceptSuggestionOnEnter",
-			"accessibilityPageSize",
-			"editorViewAccessibleLabel",
-			"editor.autoClosingBrackets.languageDefined",
-			"editor.autoClosingBrackets.beforeWhitespace",
-			"autoClosingBrackets",
-			"editor.autoClosingOvertype.auto",
-			"autoClosingOvertype",
-			"editor.autoClosingQuotes.languageDefined",
-			"editor.autoClosingQuotes.beforeWhitespace",
-			"autoClosingQuotes",
-			"editor.autoIndent.none",
-			"editor.autoIndent.keep",
-			"editor.autoIndent.brackets",
-			"editor.autoIndent.advanced",
-			"editor.autoIndent.full",
-			"autoIndent",
-			"editor.autoSurround.languageDefined",
-			"editor.autoSurround.quotes",
-			"editor.autoSurround.brackets",
-			"autoSurround",
-			"stickyTabStops",
-			"codeLens",
-			"codeLensFontFamily",
-			"codeLensFontSize",
-			"colorDecorators",
-			"columnSelection",
-			"copyWithSyntaxHighlighting",
-			"cursorBlinking",
-			"cursorSmoothCaretAnimation",
-			"cursorStyle",
-			"cursorSurroundingLines",
-			"cursorSurroundingLinesStyle.default",
-			"cursorSurroundingLinesStyle.all",
-			"cursorSurroundingLinesStyle",
-			"cursorWidth",
-			"dragAndDrop",
-			"fastScrollSensitivity",
-			"folding",
-			"foldingStrategy.auto",
-			"foldingStrategy.indentation",
-			"foldingStrategy",
-			"foldingHighlight",
-			"unfoldOnClickAfterEndOfLine",
-			"fontFamily",
-			"formatOnPaste",
-			"formatOnType",
-			"glyphMargin",
-			"hideCursorInOverviewRuler",
-			"highlightActiveIndentGuide",
-			"letterSpacing",
-			"linkedEditing",
-			"links",
-			"matchBrackets",
-			"mouseWheelScrollSensitivity",
-			"mouseWheelZoom",
-			"multiCursorMergeOverlapping",
-			"multiCursorModifier.ctrlCmd",
-			"multiCursorModifier.alt",
-			{
-				"key": "multiCursorModifier",
-				"comment": [
-					"- `ctrlCmd` refers to a value the setting can take and should not be localized.",
-					"- `Control` and `Command` refer to the modifier keys Ctrl or Cmd on the keyboard and can be localized."
-				]
-			},
-			"multiCursorPaste.spread",
-			"multiCursorPaste.full",
-			"multiCursorPaste",
-			"occurrencesHighlight",
-			"overviewRulerBorder",
-			"peekWidgetDefaultFocus.tree",
-			"peekWidgetDefaultFocus.editor",
-			"peekWidgetDefaultFocus",
-			"definitionLinkOpensInPeek",
-			"quickSuggestionsDelay",
-			"renameOnType",
-			"renameOnTypeDeprecate",
-			"renderControlCharacters",
-			"renderIndentGuides",
-			"renderFinalNewline",
-			"renderLineHighlight.all",
-			"renderLineHighlight",
-			"renderLineHighlightOnlyWhenFocus",
-			"renderWhitespace.boundary",
-			"renderWhitespace.selection",
-			"renderWhitespace.trailing",
-			"renderWhitespace",
-			"roundedSelection",
-			"scrollBeyondLastColumn",
-			"scrollBeyondLastLine",
-			"scrollPredominantAxis",
-			"selectionClipboard",
-			"selectionHighlight",
-			"showFoldingControls.always",
-			"showFoldingControls.mouseover",
-			"showFoldingControls",
-			"showUnused",
-			"showDeprecated",
-			"snippetSuggestions.top",
-			"snippetSuggestions.bottom",
-			"snippetSuggestions.inline",
-			"snippetSuggestions.none",
-			"snippetSuggestions",
-			"smoothScrolling",
-			"suggestFontSize",
-			"suggestLineHeight",
-			"suggestOnTriggerCharacters",
-			"suggestSelection.first",
-			"suggestSelection.recentlyUsed",
-			"suggestSelection.recentlyUsedByPrefix",
-			"suggestSelection",
-			"tabCompletion.on",
-			"tabCompletion.off",
-			"tabCompletion.onlySnippets",
-			"tabCompletion",
-			"unusualLineTerminators.auto",
-			"unusualLineTerminators.off",
-			"unusualLineTerminators.prompt",
-			"unusualLineTerminators",
-			"useTabStops",
-			"wordSeparators",
-			"wordWrap.off",
-			"wordWrap.on",
-			{
-				"key": "wordWrap.wordWrapColumn",
-				"comment": [
-					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
-				]
-			},
-			{
-				"key": "wordWrap.bounded",
-				"comment": [
-					"- viewport means the edge of the visible window size.",
-					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
-				]
-			},
-			{
-				"key": "wordWrap",
-				"comment": [
-					"- 'off', 'on', 'wordWrapColumn' and 'bounded' refer to values the setting can take and should not be localized.",
-					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
-				]
-			},
-			{
-				"key": "wordWrapColumn",
-				"comment": [
-					"- `editor.wordWrap` refers to a different setting and should not be localized.",
-					"- 'wordWrapColumn' and 'bounded' refer to values the different setting can take and should not be localized."
-				]
-			},
-			"wrappingIndent.none",
-			"wrappingIndent.same",
-			"wrappingIndent.indent",
-			"wrappingIndent.deepIndent",
-			"wrappingIndent",
-			"wrappingStrategy.simple",
-			"wrappingStrategy.advanced",
-			"wrappingStrategy"
-		],
-		"vs/workbench/contrib/performance/browser/perfviewEditor": [
-			"name"
-		],
-		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
-			"TaskDefinition.description",
-			"TaskDefinition.properties",
-			"TaskDefinition.when",
-			"TaskTypeConfiguration.noType",
-			"TaskDefinitionExtPoint"
-		],
-		"vs/workbench/contrib/tasks/common/problemMatcher": [
-			"ProblemPatternParser.problemPattern.missingRegExp",
-			"ProblemPatternParser.loopProperty.notLast",
-			"ProblemPatternParser.problemPattern.kindProperty.notFirst",
-			"ProblemPatternParser.problemPattern.missingProperty",
-			"ProblemPatternParser.problemPattern.missingLocation",
-			"ProblemPatternParser.invalidRegexp",
-			"ProblemPatternSchema.regexp",
-			"ProblemPatternSchema.kind",
-			"ProblemPatternSchema.file",
-			"ProblemPatternSchema.location",
-			"ProblemPatternSchema.line",
-			"ProblemPatternSchema.column",
-			"ProblemPatternSchema.endLine",
-			"ProblemPatternSchema.endColumn",
-			"ProblemPatternSchema.severity",
-			"ProblemPatternSchema.code",
-			"ProblemPatternSchema.message",
-			"ProblemPatternSchema.loop",
-			"NamedProblemPatternSchema.name",
-			"NamedMultiLineProblemPatternSchema.name",
-			"NamedMultiLineProblemPatternSchema.patterns",
-			"ProblemPatternExtPoint",
-			"ProblemPatternRegistry.error",
-			"ProblemPatternRegistry.error",
-			"ProblemMatcherParser.noProblemMatcher",
-			"ProblemMatcherParser.noProblemPattern",
-			"ProblemMatcherParser.noOwner",
-			"ProblemMatcherParser.noFileLocation",
-			"ProblemMatcherParser.unknownSeverity",
-			"ProblemMatcherParser.noDefinedPatter",
-			"ProblemMatcherParser.noIdentifier",
-			"ProblemMatcherParser.noValidIdentifier",
-			"ProblemMatcherParser.problemPattern.watchingMatcher",
-			"ProblemMatcherParser.invalidRegexp",
-			"WatchingPatternSchema.regexp",
-			"WatchingPatternSchema.file",
-			"PatternTypeSchema.name",
-			"PatternTypeSchema.description",
-			"ProblemMatcherSchema.base",
-			"ProblemMatcherSchema.owner",
-			"ProblemMatcherSchema.source",
-			"ProblemMatcherSchema.severity",
-			"ProblemMatcherSchema.applyTo",
-			"ProblemMatcherSchema.fileLocation",
-			"ProblemMatcherSchema.background",
-			"ProblemMatcherSchema.background.activeOnStart",
-			"ProblemMatcherSchema.background.beginsPattern",
-			"ProblemMatcherSchema.background.endsPattern",
-			"ProblemMatcherSchema.watching.deprecated",
-			"ProblemMatcherSchema.watching",
-			"ProblemMatcherSchema.watching.activeOnStart",
-			"ProblemMatcherSchema.watching.beginsPattern",
-			"ProblemMatcherSchema.watching.endsPattern",
-			"LegacyProblemMatcherSchema.watchedBegin.deprecated",
-			"LegacyProblemMatcherSchema.watchedBegin",
-			"LegacyProblemMatcherSchema.watchedEnd.deprecated",
-			"LegacyProblemMatcherSchema.watchedEnd",
-			"NamedProblemMatcherSchema.name",
-			"NamedProblemMatcherSchema.label",
-			"ProblemMatcherExtPoint",
-			"msCompile",
-			"lessCompile",
-			"gulp-tsc",
-			"jshint",
-			"jshint-stylish",
-			"eslint-compact",
-			"eslint-stylish",
-			"go"
-		],
-		"vs/platform/theme/common/iconRegistry": [
-			"iconDefintion.fontId",
-			"iconDefintion.fontCharacter",
-			"widgetClose",
-			"previousChangeIcon",
-			"nextChangeIcon"
-		],
-		"vs/workbench/contrib/tasks/common/taskTemplates": [
-			"dotnetCore",
-			"msbuild",
-			"externalCommand",
-			"Maven"
-		],
-		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
-			"tasks.run.allowAutomatic",
-			"allow",
-			"disallow",
-			"openTasks",
-			"workbench.action.tasks.manageAutomaticRunning",
-			"workbench.action.tasks.allowAutomaticTasks",
-			"workbench.action.tasks.disallowAutomaticTasks"
-		],
-		"vs/workbench/contrib/tasks/browser/taskQuickPick": [
-			"taskQuickPick.showAll",
-			"configureTaskIcon",
-			"removeTaskIcon",
-			"configureTask",
-			"contributedTasks",
-			"taskType",
-			"removeRecent",
-			"recentlyUsed",
-			"configured",
-			"configured",
-			"TaskQuickPick.goBack",
-			"TaskQuickPick.noTasksForType",
-			"noProviderForTask"
-		],
-		"vs/workbench/api/common/extHostExtensionActivator": [
-			"failedDep1",
-			"activationError"
-		],
-		"vs/workbench/contrib/debug/common/abstractDebugAdapter": [
-			"timeout"
-		],
-		"vs/workbench/services/configurationResolver/common/variableResolver": [
-			"canNotResolveFile",
-			"canNotResolveFolderForFile",
-			"canNotFindFolder",
-			"canNotResolveWorkspaceFolderMultiRoot",
-			"canNotResolveWorkspaceFolder",
-			"missingEnvVarName",
-			"configNotFound",
-			"configNoString",
-			"missingConfigName",
-			"canNotResolveLineNumber",
-			"canNotResolveSelectedText",
-			"noValueForCommand"
-		],
-		"vs/workbench/api/common/extHost.api.impl": [
-			"extensionLabel"
-		],
-		"vs/workbench/api/node/extHostDebugService": [
-			"debug.terminal.title"
-		],
-		"vs/code/electron-main/window": [
-			{
-				"key": "reopen",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "wait",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "close",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"appStalled",
-			"appStalledDetail",
-			"appCrashedDetails",
-			"appCrashed",
-			{
-				"key": "reopen",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "close",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"appCrashedDetail",
-			"hiddenMenuBar"
-		],
-		"vs/platform/menubar/electron-main/menubar": [
-			{
-				"key": "miNewWindow",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "mFile",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "mEdit",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "mSelection",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "mView",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "mGoto",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "mRun",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "mTerminal",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"mWindow",
-			{
-				"key": "mHelp",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"mAbout",
-			{
-				"key": "miPreferences",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"mServices",
-			"mHide",
-			"mHideOthers",
-			"mShowAll",
-			"miQuit",
-			"mMinimize",
-			"mZoom",
-			"mBringToFront",
-			{
-				"key": "miSwitchWindow",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"mNewTab",
-			"mShowPreviousTab",
-			"mShowNextTab",
-			"mMoveTabToNewWindow",
-			"mMergeAllWindows",
-			"miCheckForUpdates",
-			"miCheckingForUpdates",
-			"miDownloadUpdate",
-			"miDownloadingUpdate",
-			"miInstallUpdate",
-			"miInstallingUpdate",
-			"miRestartToUpdate"
-		],
-		"vs/platform/userDataSync/common/abstractSynchronizer": [
-			{
-				"key": "incompatible",
-				"comment": [
-					"This is an error while syncing a resource that its local version is not compatible with its remote version."
-				]
-			},
-			"incompatible sync data"
-		],
-		"vs/editor/common/view/editorColorRegistry": [
-			"lineHighlight",
-			"lineHighlightBorderBox",
-			"rangeHighlight",
-			"rangeHighlightBorder",
-			"symbolHighlight",
-			"symbolHighlightBorder",
-			"caret",
-			"editorCursorBackground",
-			"editorWhitespaces",
-			"editorIndentGuides",
-			"editorActiveIndentGuide",
-			"editorLineNumbers",
-			"editorActiveLineNumber",
-			"deprecatedEditorActiveLineNumber",
-			"editorActiveLineNumber",
-			"editorRuler",
-			"editorCodeLensForeground",
-			"editorBracketMatchBackground",
-			"editorBracketMatchBorder",
-			"editorOverviewRulerBorder",
-			"editorOverviewRulerBackground",
-			"editorGutter",
-			"unnecessaryCodeBorder",
-			"unnecessaryCodeOpacity",
-			"overviewRulerRangeHighlight",
-			"overviewRuleError",
-			"overviewRuleWarning",
-			"overviewRuleInfo"
-		],
-		"vs/editor/common/model/editStack": [
-			"edit"
-		],
-		"vs/editor/browser/controller/coreCommands": [
-			"stickydesc",
-			"stickydesc"
-		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"cursors.maximum"
-		],
-		"vs/editor/contrib/anchorSelect/anchorSelect": [
-			"selectionAnchor",
-			"anchorSet",
-			"setSelectionAnchor",
-			"goToSelectionAnchor",
-			"selectFromAnchorToCursor",
-			"cancelSelectionAnchor"
-		],
-		"vs/editor/browser/widget/diffEditorWidget": [
-			"diffInsertIcon",
-			"diffRemoveIcon",
-			"diff.tooLarge"
-		],
-		"vs/editor/contrib/caretOperations/caretOperations": [
-			"caret.moveLeft",
-			"caret.moveRight"
-		],
-		"vs/editor/contrib/caretOperations/transpose": [
-			"transposeLetters.label"
-		],
-		"vs/editor/contrib/bracketMatching/bracketMatching": [
-			"overviewRulerBracketMatchForeground",
-			"smartSelect.jumpBracket",
-			"smartSelect.selectToBracket",
-			{
-				"key": "miGoToBracket",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/editor/contrib/codelens/codelensController": [
-			"showLensOnLine"
-		],
-		"vs/editor/contrib/comment/comment": [
-			"comment.line",
-			{
-				"key": "miToggleLineComment",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"comment.line.add",
-			"comment.line.remove",
-			"comment.block",
-			{
-				"key": "miToggleBlockComment",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/editor/contrib/contextmenu/contextmenu": [
-			"action.showContextMenu.label"
-		],
-		"vs/editor/contrib/cursorUndo/cursorUndo": [
-			"cursor.undo",
-			"cursor.redo"
-		],
-		"vs/editor/contrib/find/findController": [
-			"startFindAction",
-			{
-				"key": "miFind",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"startFindWithSelectionAction",
-			"findNextMatchAction",
-			"findNextMatchAction",
-			"findPreviousMatchAction",
-			"findPreviousMatchAction",
-			"nextSelectionMatchFindAction",
-			"previousSelectionMatchFindAction",
-			"startReplace",
-			{
-				"key": "miReplace",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/editor/contrib/fontZoom/fontZoom": [
-			"EditorFontZoomIn.label",
-			"EditorFontZoomOut.label",
-			"EditorFontZoomReset.label"
-		],
-		"vs/editor/contrib/folding/folding": [
-			"unfoldAction.label",
-			"unFoldRecursivelyAction.label",
-			"foldAction.label",
-			"toggleFoldAction.label",
-			"foldRecursivelyAction.label",
-			"foldAllBlockComments.label",
-			"foldAllMarkerRegions.label",
-			"unfoldAllMarkerRegions.label",
-			"foldAllAction.label",
-			"unfoldAllAction.label",
-			"foldLevelAction.label",
-			"foldBackgroundBackground",
-			"editorGutter.foldingControlForeground"
-		],
-		"vs/editor/contrib/format/formatActions": [
-			"formatDocument.label",
-			"formatSelection.label"
-		],
-		"vs/editor/contrib/gotoSymbol/goToCommands": [
-			"peek.submenu",
-			"def.title",
-			"noResultWord",
-			"generic.noResults",
-			"actions.goToDecl.label",
-			{
-				"key": "miGotoDefinition",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"actions.goToDeclToSide.label",
-			"actions.previewDecl.label",
-			"decl.title",
-			"decl.noResultWord",
-			"decl.generic.noResults",
-			"actions.goToDeclaration.label",
-			{
-				"key": "miGotoDeclaration",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"decl.noResultWord",
-			"decl.generic.noResults",
-			"actions.peekDecl.label",
-			"typedef.title",
-			"goToTypeDefinition.noResultWord",
-			"goToTypeDefinition.generic.noResults",
-			"actions.goToTypeDefinition.label",
-			{
-				"key": "miGotoTypeDefinition",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"actions.peekTypeDefinition.label",
-			"impl.title",
-			"goToImplementation.noResultWord",
-			"goToImplementation.generic.noResults",
-			"actions.goToImplementation.label",
-			{
-				"key": "miGotoImplementation",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"actions.peekImplementation.label",
-			"references.no",
-			"references.noGeneric",
-			"goToReferences.label",
-			{
-				"key": "miGotoReference",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"ref.title",
-			"references.action.label",
-			"ref.title",
-			"label.generic",
-			"generic.title",
-			"generic.noResult",
-			"ref.title"
-		],
-		"vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition": [
-			"multipleResults"
-		],
-		"vs/editor/contrib/gotoError/gotoError": [
-			"markerAction.next.label",
-			"nextMarkerIcon",
-			"markerAction.previous.label",
-			"previousMarkerIcon",
-			"markerAction.nextInFiles.label",
-			{
-				"key": "miGotoNextProblem",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"markerAction.previousInFiles.label",
-			{
-				"key": "miGotoPreviousProblem",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/editor/contrib/hover/hover": [
-			{
-				"key": "showHover",
-				"comment": [
-					"Label for action that will trigger the showing of a hover in the editor.",
-					"This allows for users to show the hover without using the mouse."
-				]
-			},
-			{
-				"key": "showDefinitionPreviewHover",
-				"comment": [
-					"Label for action that will trigger the showing of definition preview hover in the editor.",
-					"This allows for users to show the definition preview hover without using the mouse."
-				]
-			}
-		],
-		"vs/editor/contrib/indentation/indentation": [
-			"indentationToSpaces",
-			"indentationToTabs",
-			"configuredTabSize",
-			{
-				"key": "selectTabWidth",
-				"comment": [
-					"Tab corresponds to the tab key"
-				]
-			},
-			"indentUsingTabs",
-			"indentUsingSpaces",
-			"detectIndentation",
-			"editor.reindentlines",
-			"editor.reindentselectedlines"
-		],
-		"vs/editor/contrib/inPlaceReplace/inPlaceReplace": [
-			"InPlaceReplaceAction.previous.label",
-			"InPlaceReplaceAction.next.label"
-		],
-		"vs/editor/contrib/linesOperations/linesOperations": [
-			"lines.copyUp",
-			{
-				"key": "miCopyLinesUp",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"lines.copyDown",
-			{
-				"key": "miCopyLinesDown",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"duplicateSelection",
-			{
-				"key": "miDuplicateSelection",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"lines.moveUp",
-			{
-				"key": "miMoveLinesUp",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"lines.moveDown",
-			{
-				"key": "miMoveLinesDown",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"lines.sortAscending",
-			"lines.sortDescending",
-			"lines.trimTrailingWhitespace",
-			"lines.delete",
-			"lines.indent",
-			"lines.outdent",
-			"lines.insertBefore",
-			"lines.insertAfter",
-			"lines.deleteAllLeft",
-			"lines.deleteAllRight",
-			"lines.joinLines",
-			"editor.transpose",
-			"editor.transformToUppercase",
-			"editor.transformToLowercase",
-			"editor.transformToTitlecase",
-			"editor.transformToSnakecase"
-		],
-		"vs/editor/contrib/linkedEditing/linkedEditing": [
-			"linkedEditing.label",
-			"editorLinkedEditingBackground"
-		],
-		"vs/editor/contrib/links/links": [
-			"links.navigate.executeCmd",
-			"links.navigate.follow",
-			"links.navigate.kb.meta.mac",
-			"links.navigate.kb.meta",
-			"links.navigate.kb.alt.mac",
-			"links.navigate.kb.alt",
-			"tooltip.explanation",
-			"invalid.url",
-			"missing.url",
-			"label"
-		],
-		"vs/editor/contrib/parameterHints/parameterHints": [
-			"parameterHints.trigger.label"
-		],
-		"vs/editor/contrib/multicursor/multicursor": [
-			"mutlicursor.insertAbove",
-			{
-				"key": "miInsertCursorAbove",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"mutlicursor.insertBelow",
-			{
-				"key": "miInsertCursorBelow",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"mutlicursor.insertAtEndOfEachLineSelected",
-			{
-				"key": "miInsertCursorAtEndOfEachLineSelected",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"mutlicursor.addCursorsToBottom",
-			"mutlicursor.addCursorsToTop",
-			"addSelectionToNextFindMatch",
-			{
-				"key": "miAddSelectionToNextFindMatch",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"addSelectionToPreviousFindMatch",
-			{
-				"key": "miAddSelectionToPreviousFindMatch",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"moveSelectionToNextFindMatch",
-			"moveSelectionToPreviousFindMatch",
-			"selectAllOccurrencesOfFindMatch",
-			{
-				"key": "miSelectHighlights",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"changeAll.label"
-		],
-		"vs/editor/contrib/rename/rename": [
-			"no result",
-			"resolveRenameLocationFailed",
-			"label",
-			"quotableLabel",
-			"aria",
-			"rename.failedApply",
-			"rename.failed",
-			"rename.label",
-			"enablePreview"
-		],
-		"vs/editor/contrib/smartSelect/smartSelect": [
-			"smartSelect.expand",
-			{
-				"key": "miSmartSelectGrow",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"smartSelect.shrink",
-			{
-				"key": "miSmartSelectShrink",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/editor/contrib/suggest/suggestController": [
-			"aria.alert.snippet",
-			"suggest.trigger.label",
-			"accept.insert",
-			"accept.insert",
-			"accept.replace",
-			"accept.replace",
-			"accept.insert",
-			"detail.more",
-			"detail.less",
-			"suggest.reset.label"
-		],
-		"vs/editor/contrib/tokenization/tokenization": [
-			"forceRetokenize"
-		],
-		"vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode": [
-			{
-				"key": "toggle.tabMovesFocus",
-				"comment": [
-					"Turn on/off use of tab key for moving focus around VS Code"
-				]
-			},
-			"toggle.tabMovesFocus.on",
-			"toggle.tabMovesFocus.off"
-		],
-		"vs/editor/contrib/unusualLineTerminators/unusualLineTerminators": [
-			"unusualLineTerminators.title",
-			"unusualLineTerminators.message",
-			"unusualLineTerminators.detail",
-			"unusualLineTerminators.fix",
-			"unusualLineTerminators.ignore"
-		],
-		"vs/editor/contrib/wordHighlighter/wordHighlighter": [
-			"wordHighlight",
-			"wordHighlightStrong",
-			"wordHighlightBorder",
-			"wordHighlightStrongBorder",
-			"overviewRulerWordHighlightForeground",
-			"overviewRulerWordHighlightStrongForeground",
-			"wordHighlight.next.label",
-			"wordHighlight.previous.label",
-			"wordHighlight.trigger.label"
-		],
-		"vs/editor/contrib/wordOperations/wordOperations": [
-			"deleteInsideWord"
-		],
-		"vs/editor/common/standaloneStrings": [
-			"noSelection",
-			"singleSelectionRange",
-			"singleSelection",
-			"multiSelectionRange",
-			"multiSelection",
-			"emergencyConfOn",
-			"openingDocs",
-			"readonlyDiffEditor",
-			"editableDiffEditor",
-			"readonlyEditor",
-			"editableEditor",
-			"changeConfigToOnMac",
-			"changeConfigToOnWinLinux",
-			"auto_on",
-			"auto_off",
-			"tabFocusModeOnMsg",
-			"tabFocusModeOnMsgNoKb",
-			"tabFocusModeOffMsg",
-			"tabFocusModeOffMsgNoKb",
-			"openDocMac",
-			"openDocWinLinux",
-			"outroMsg",
-			"showAccessibilityHelpAction",
-			"inspectTokens",
-			"gotoLineActionLabel",
-			"helpQuickAccess",
-			"quickCommandActionLabel",
-			"quickCommandActionHelp",
-			"quickOutlineActionLabel",
-			"quickOutlineByCategoryActionLabel",
-			"editorViewAccessibleLabel",
-			"accessibilityHelpMessage",
-			"toggleHighContrast",
-			"bulkEditServiceSummary"
-		],
-		"vs/workbench/api/common/jsonValidationExtensionPoint": [
-			"contributes.jsonValidation",
-			"contributes.jsonValidation.fileMatch",
-			"contributes.jsonValidation.url",
-			"invalid.jsonValidation",
-			"invalid.fileMatch",
-			"invalid.url",
-			"invalid.path.1",
-			"invalid.url.fileschema",
-			"invalid.url.schema"
-		],
-		"vs/workbench/services/themes/common/colorExtensionPoint": [
-			"contributes.color",
-			"contributes.color.id",
-			"contributes.color.id.format",
-			"contributes.color.description",
-			"contributes.defaults.light",
-			"contributes.defaults.dark",
-			"contributes.defaults.highContrast",
-			"invalid.colorConfiguration",
-			"invalid.default.colorType",
-			"invalid.id",
-			"invalid.id.format",
-			"invalid.description",
-			"invalid.defaults"
-		],
-		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
-			"contributes.semanticTokenTypes",
-			"contributes.semanticTokenTypes.id",
-			"contributes.semanticTokenTypes.id.format",
-			"contributes.semanticTokenTypes.superType",
-			"contributes.semanticTokenTypes.superType.format",
-			"contributes.color.description",
-			"contributes.semanticTokenModifiers",
-			"contributes.semanticTokenModifiers.id",
-			"contributes.semanticTokenModifiers.id.format",
-			"contributes.semanticTokenModifiers.description",
-			"contributes.semanticTokenScopes",
-			"contributes.semanticTokenScopes.languages",
-			"contributes.semanticTokenScopes.scopes",
-			"invalid.id",
-			"invalid.id.format",
-			"invalid.superType.format",
-			"invalid.description",
-			"invalid.semanticTokenTypeConfiguration",
-			"invalid.semanticTokenModifierConfiguration",
-			"invalid.semanticTokenScopes.configuration",
-			"invalid.semanticTokenScopes.language",
-			"invalid.semanticTokenScopes.scopes",
-			"invalid.semanticTokenScopes.scopes.value",
-			"invalid.semanticTokenScopes.scopes.selector"
-		],
-		"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint": [
-			"parseErrors",
-			"formatError",
-			"schema.openBracket",
-			"schema.closeBracket",
-			"schema.comments",
-			"schema.blockComments",
-			"schema.blockComment.begin",
-			"schema.blockComment.end",
-			"schema.lineComment",
-			"schema.brackets",
-			"schema.autoClosingPairs",
-			"schema.autoClosingPairs.notIn",
-			"schema.autoCloseBefore",
-			"schema.surroundingPairs",
-			"schema.wordPattern",
-			"schema.wordPattern.pattern",
-			"schema.wordPattern.flags",
-			"schema.wordPattern.flags.errorMessage",
-			"schema.indentationRules",
-			"schema.indentationRules.increaseIndentPattern",
-			"schema.indentationRules.increaseIndentPattern.pattern",
-			"schema.indentationRules.increaseIndentPattern.flags",
-			"schema.indentationRules.increaseIndentPattern.errorMessage",
-			"schema.indentationRules.decreaseIndentPattern",
-			"schema.indentationRules.decreaseIndentPattern.pattern",
-			"schema.indentationRules.decreaseIndentPattern.flags",
-			"schema.indentationRules.decreaseIndentPattern.errorMessage",
-			"schema.indentationRules.indentNextLinePattern",
-			"schema.indentationRules.indentNextLinePattern.pattern",
-			"schema.indentationRules.indentNextLinePattern.flags",
-			"schema.indentationRules.indentNextLinePattern.errorMessage",
-			"schema.indentationRules.unIndentedLinePattern",
-			"schema.indentationRules.unIndentedLinePattern.pattern",
-			"schema.indentationRules.unIndentedLinePattern.flags",
-			"schema.indentationRules.unIndentedLinePattern.errorMessage",
-			"schema.folding",
-			"schema.folding.offSide",
-			"schema.folding.markers",
-			"schema.folding.markers.start",
-			"schema.folding.markers.end",
-			"schema.onEnterRules",
-			"schema.onEnterRules",
-			"schema.onEnterRules.beforeText",
-			"schema.onEnterRules.beforeText.pattern",
-			"schema.onEnterRules.beforeText.flags",
-			"schema.onEnterRules.beforeText.errorMessage",
-			"schema.onEnterRules.afterText",
-			"schema.onEnterRules.afterText.pattern",
-			"schema.onEnterRules.afterText.flags",
-			"schema.onEnterRules.afterText.errorMessage",
-			"schema.onEnterRules.previousLineText",
-			"schema.onEnterRules.previousLineText.pattern",
-			"schema.onEnterRules.previousLineText.flags",
-			"schema.onEnterRules.previousLineText.errorMessage",
-			"schema.onEnterRules.action",
-			"schema.onEnterRules.action.indent",
-			"schema.onEnterRules.action.indent.none",
-			"schema.onEnterRules.action.indent.indent",
-			"schema.onEnterRules.action.indent.indentOutdent",
-			"schema.onEnterRules.action.indent.outdent",
-			"schema.onEnterRules.action.appendText",
-			"schema.onEnterRules.action.removeText"
-		],
-		"vs/workbench/api/browser/mainThreadCLICommands": [
-			"cannot be installed"
-		],
-		"vs/workbench/api/browser/mainThreadExtensionService": [
-			"reload window",
-			"reload",
-			"disabledDep",
-			"enable dep",
-			"uninstalledDep",
-			"install missing dep",
-			"unknownDep"
-		],
-		"vs/workbench/api/browser/mainThreadFileSystemEventService": [
-			"ask.1.create",
-			"ask.1.copy",
-			"ask.1.move",
-			"ask.1.delete",
-			"ask.N.create",
-			"ask.N.copy",
-			"ask.N.move",
-			"ask.N.delete",
-			"preview",
-			"cancel",
-			"ok",
-			"preview",
-			"cancel",
-			"again",
-			"msg-create",
-			"msg-rename",
-			"msg-copy",
-			"msg-delete",
-			"label",
-			"files.participants.timeout"
-		],
-		"vs/workbench/api/browser/mainThreadMessageService": [
-			"extensionSource",
-			"defaultSource",
-			"manageExtension",
-			"cancel",
-			"ok"
-		],
-		"vs/workbench/api/browser/mainThreadProgress": [
-			"manageExtension"
-		],
-		"vs/workbench/api/browser/mainThreadSaveParticipant": [
-			"timeout.onWillSave"
-		],
-		"vs/workbench/api/browser/mainThreadUriOpeners": [
-			"openerFailedUseDefault",
-			"openerFailedMessage"
-		],
-		"vs/workbench/api/browser/mainThreadWorkspace": [
-			"folderStatusMessageAddSingleFolder",
-			"folderStatusMessageAddMultipleFolders",
-			"folderStatusMessageRemoveSingleFolder",
-			"folderStatusMessageRemoveMultipleFolders",
-			"folderStatusChangeFolder"
-		],
-		"vs/workbench/api/browser/mainThreadComments": [
-			"commentsViewIcon"
-		],
-		"vs/workbench/api/browser/mainThreadTask": [
-			"task.label"
-		],
-		"vs/workbench/api/browser/mainThreadTunnelService": [
-			"remote.tunnel.openTunnel",
-			"remote.tunnelsView.elevationButton"
-		],
-		"vs/workbench/api/browser/mainThreadAuthentication": [
-			"noTrustedExtensions",
-			{
-				"key": "accountLastUsedDate",
-				"comment": [
-					"The placeholder {0} is a string with time information, such as \"3 days ago\""
-				]
-			},
-			"notUsed",
-			"manageTrustedExtensions",
-			"manageExensions",
-			"signOutConfirm",
-			"signOutMessagve",
-			"signOutMessageSimple",
-			"signedOut",
-			"useOtherAccount",
-			{
-				"key": "selectAccount",
-				"comment": [
-					"The placeholder {0} is the name of an extension. {1} is the name of the type of account, such as Microsoft or GitHub."
-				]
-			},
-			"getSessionPlateholder",
-			"confirmAuthenticationAccess",
-			"allow",
-			"cancel",
-			"confirmLogin",
-			"allow",
-			"cancel"
-		],
-		"vs/workbench/common/configuration": [
-			"workbenchConfigurationTitle"
-		],
-		"vs/workbench/browser/parts/views/treeView": [
-			"no-dataprovider",
-			"refresh",
-			"collapseAll",
-			"command-error"
-		],
-		"vs/workbench/browser/parts/views/viewPaneContainer": [
-			"views",
-			"viewMoveUp",
-			"viewMoveLeft",
-			"viewMoveDown",
-			"viewMoveRight"
-		],
-		"vs/workbench/contrib/remote/browser/remoteExplorer": [
-			"ports",
-			"1forwardedPort",
-			"nForwardedPorts",
-			"status.forwardedPorts",
-			"remote.forwardedPorts.statusbarTextNone",
-			"remote.forwardedPorts.statusbarTooltip",
-			"remote.tunnelsView.automaticForward",
-			"remote.tunnelsView.notificationLink",
-			"remote.tunnelsView.elevationMessage",
-			"remote.tunnelsView.elevationButton"
-		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"ariaLabelGroupActions",
-			"closeGroupAction",
-			"emptyEditorGroup",
-			"groupLabel",
-			"groupAriaLabel",
-			"ok",
-			"cancel",
-			"editorOpenErrorDialog",
-			"editorOpenError"
-		],
-		"vs/workbench/browser/parts/editor/editorDropTarget": [
-			"fileTooLarge"
-		],
 		"vs/workbench/browser/parts/editor/editor.contribution": [
 			"textEditor",
 			"textDiffEditor",
@@ -6004,11 +2153,12 @@
 			"splitDown",
 			"splitLeft",
 			"splitRight",
-			"toggleInlineView",
+			"inlineView",
 			"showOpenedEditors",
 			"closeAll",
 			"closeAllSaved",
 			"toggleKeepEditors",
+			"run",
 			"splitEditorRight",
 			"splitEditorDown",
 			"splitEditorDown",
@@ -6273,12 +2423,4196 @@
 				]
 			}
 		],
+		"vs/workbench/browser/parts/activitybar/activitybarPart": [
+			"settingsViewBarIcon",
+			"accountsViewBarIcon",
+			"menu",
+			"menu",
+			"accounts",
+			"accounts",
+			"hideActivitBar",
+			"resetLocation",
+			"resetLocation",
+			"manage",
+			"manage",
+			"accounts",
+			"accounts",
+			"focusActivityBar"
+		],
+		"vs/workbench/api/browser/viewsExtensionPoint": [
+			{
+				"key": "vscode.extension.contributes.views.containers.id",
+				"comment": [
+					"Contribution refers to those that an extension contributes to VS Code through an extension/contribution point. "
+				]
+			},
+			"vscode.extension.contributes.views.containers.title",
+			"vscode.extension.contributes.views.containers.icon",
+			"vscode.extension.contributes.viewsContainers",
+			"views.container.activitybar",
+			"views.container.panel",
+			"vscode.extension.contributes.view.type",
+			"vscode.extension.contributes.view.tree",
+			"vscode.extension.contributes.view.webview",
+			"vscode.extension.contributes.view.id",
+			"vscode.extension.contributes.view.name",
+			"vscode.extension.contributes.view.when",
+			"vscode.extension.contributes.view.icon",
+			"vscode.extension.contributes.view.contextualTitle",
+			"vscode.extension.contributes.view.initialState",
+			"vscode.extension.contributes.view.initialState.visible",
+			"vscode.extension.contributes.view.initialState.hidden",
+			"vscode.extension.contributes.view.initialState.collapsed",
+			"vscode.extension.contributes.view.id",
+			"vscode.extension.contributes.view.name",
+			"vscode.extension.contributes.view.when",
+			"vscode.extension.contributes.view.group",
+			"vscode.extension.contributes.view.remoteName",
+			"vscode.extension.contributes.views",
+			"views.explorer",
+			"views.debug",
+			"views.scm",
+			"views.test",
+			"views.remote",
+			"views.contributed",
+			"viewcontainer requirearray",
+			"requireidstring",
+			"requireidstring",
+			"requirestring",
+			"requirestring",
+			"ViewContainerRequiresProposedAPI",
+			"ViewContainerDoesnotExist",
+			"duplicateView1",
+			"duplicateView2",
+			"unknownViewType",
+			"requirearray",
+			"requirestring",
+			"requirestring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"optenum"
+		],
+		"vs/workbench/browser/parts/panel/panelPart": [
+			"hidePanel",
+			"resetLocation",
+			"resetLocation",
+			"panel.emptyMessage"
+		],
+		"vs/workbench/browser/parts/sidebar/sidebarPart": [
+			"focusSideBar"
+		],
+		"vs/workbench/browser/parts/statusbar/statusbarPart": [
+			"statusBarFocused",
+			"hide",
+			"hideStatusBar"
+		],
+		"vs/workbench/browser/parts/views/viewsService": [
+			"show view",
+			"toggle view",
+			"show view",
+			"toggle view",
+			{
+				"key": "focus view",
+				"comment": [
+					"{0} indicates the name of the view to be focused."
+				]
+			},
+			"resetViewLocation"
+		],
+		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
+			"confirmUrl",
+			"rememberConfirmUrl",
+			"open",
+			"reloadAndHandle",
+			"reloadAndOpen",
+			"enableAndHandle",
+			"enableAndReload",
+			"installAndHandle",
+			"install",
+			"Installing",
+			"reload",
+			"Reload",
+			"manage",
+			"extensions",
+			"no"
+		],
+		"vs/platform/undoRedo/common/undoRedoService": [
+			{
+				"key": "externalRemoval",
+				"comment": [
+					"{0} is a list of filenames"
+				]
+			},
+			{
+				"key": "noParallelUniverses",
+				"comment": [
+					"{0} is a list of filenames"
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndo",
+				"comment": [
+					"{0} is a label for an operation. {1} is another message."
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndo",
+				"comment": [
+					"{0} is a label for an operation. {1} is another message."
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndoDueToChanges",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndoDueToInProgressUndoRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndoDueToInMeantimeUndoRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			"confirmWorkspace",
+			{
+				"key": "ok",
+				"comment": [
+					"{0} denotes a number that is > 1"
+				]
+			},
+			"nok",
+			"cancel",
+			{
+				"key": "cannotResourceUndoDueToInProgressUndoRedo",
+				"comment": [
+					"{0} is a label for an operation."
+				]
+			},
+			"confirmDifferentSource",
+			"confirmDifferentSource.ok",
+			"cancel",
+			{
+				"key": "cannotWorkspaceRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is another message."
+				]
+			},
+			{
+				"key": "cannotWorkspaceRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is another message."
+				]
+			},
+			{
+				"key": "cannotWorkspaceRedoDueToChanges",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotWorkspaceRedoDueToInProgressUndoRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotWorkspaceRedoDueToInMeantimeUndoRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotResourceRedoDueToInProgressUndoRedo",
+				"comment": [
+					"{0} is a label for an operation."
+				]
+			}
+		],
+		"vs/workbench/services/keybinding/common/keybindingEditing": [
+			"errorKeybindingsFileDirty",
+			"parseErrors",
+			"errorInvalidConfiguration",
+			"emptyKeybindingsHeader"
+		],
+		"vs/workbench/services/decorations/browser/decorationsService": [
+			"bubbleTitle"
+		],
+		"vs/workbench/services/progress/browser/progressService": [
+			"progress.text2",
+			"progress.title3",
+			"progress.title2",
+			"progress.title2",
+			"status.progress",
+			"cancel",
+			"cancel",
+			"dismiss"
+		],
+		"vs/workbench/services/preferences/browser/preferencesService": [
+			"openFolderFirst",
+			"emptyKeybindingsHeader",
+			"defaultKeybindings",
+			"defaultKeybindings",
+			"defaultSettings",
+			"folderSettingsName",
+			"fail.createSettings"
+		],
+		"vs/workbench/services/configuration/common/jsonEditingService": [
+			"errorInvalidFile",
+			"errorFileDirty"
+		],
+		"vs/workbench/services/editor/browser/editorService": [
+			"promptOpenWith.currentlyActive",
+			"promptOpenWith.setDefaultTooltip",
+			"promptOpenWith.placeHolder",
+			"promptOpenWith.placeHolderGeneric"
+		],
+		"vs/workbench/services/history/browser/history": [
+			"canNavigateBack",
+			"canNavigateForward",
+			"canNavigateToLastEditLocation",
+			"canReopenClosedEditor"
+		],
+		"vs/workbench/services/keybinding/browser/keybindingService": [
+			"nonempty",
+			"requirestring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"vscode.extension.contributes.keybindings.command",
+			"vscode.extension.contributes.keybindings.args",
+			"vscode.extension.contributes.keybindings.key",
+			"vscode.extension.contributes.keybindings.mac",
+			"vscode.extension.contributes.keybindings.linux",
+			"vscode.extension.contributes.keybindings.win",
+			"vscode.extension.contributes.keybindings.when",
+			"vscode.extension.contributes.keybindings",
+			"invalid.keybindings",
+			"unboundCommands",
+			"keybindings.json.title",
+			"keybindings.json.key",
+			"keybindings.json.command",
+			"keybindings.json.when",
+			"keybindings.json.args",
+			"keyboardConfigurationTitle",
+			"dispatch"
+		],
+		"vs/workbench/services/mode/common/workbenchModeService": [
+			"vscode.extension.contributes.languages",
+			"vscode.extension.contributes.languages.id",
+			"vscode.extension.contributes.languages.aliases",
+			"vscode.extension.contributes.languages.extensions",
+			"vscode.extension.contributes.languages.filenames",
+			"vscode.extension.contributes.languages.filenamePatterns",
+			"vscode.extension.contributes.languages.mimetypes",
+			"vscode.extension.contributes.languages.firstLine",
+			"vscode.extension.contributes.languages.configuration",
+			"invalid",
+			"invalid.empty",
+			"require.id",
+			"opt.extensions",
+			"opt.filenames",
+			"opt.firstLine",
+			"opt.configuration",
+			"opt.aliases",
+			"opt.mimetypes"
+		],
+		"vs/workbench/services/themes/browser/workbenchThemeService": [
+			"error.cannotloadtheme"
+		],
+		"vs/workbench/services/label/common/labelService": [
+			"vscode.extension.contributes.resourceLabelFormatters",
+			"vscode.extension.contributes.resourceLabelFormatters.scheme",
+			"vscode.extension.contributes.resourceLabelFormatters.authority",
+			"vscode.extension.contributes.resourceLabelFormatters.formatting",
+			"vscode.extension.contributes.resourceLabelFormatters.label",
+			"vscode.extension.contributes.resourceLabelFormatters.separator",
+			"vscode.extension.contributes.resourceLabelFormatters.stripPathStartingSeparator",
+			"vscode.extension.contributes.resourceLabelFormatters.tildify",
+			"vscode.extension.contributes.resourceLabelFormatters.formatting.workspaceSuffix",
+			"untitledWorkspace",
+			"workspaceNameVerbose",
+			"workspaceName"
+		],
+		"vs/workbench/services/extensionManagement/common/webExtensionsScannerService": [
+			"cannot be installed"
+		],
+		"vs/workbench/services/extensionManagement/browser/extensionEnablementService": [
+			"extensionsDisabled",
+			"Reload",
+			"cannot disable language pack extension",
+			"cannot disable auth extension",
+			"noWorkspace",
+			"cannot disable auth extension in workspace"
+		],
+		"vs/workbench/services/notification/common/notificationService": [
+			"neverShowAgain",
+			"neverShowAgain"
+		],
+		"vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig": [
+			"select for remove",
+			"select for add",
+			"select for remove",
+			"select for add",
+			"workspace folder",
+			"workspace"
+		],
+		"vs/workbench/services/views/browser/viewDescriptorService": [
+			"hideView",
+			"resetViewLocation"
+		],
+		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
+			"no authentication providers",
+			"no account",
+			"show log",
+			"sync turned on",
+			"sync in progress",
+			"settings sync",
+			{
+				"key": "yes",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "no",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"turning on",
+			"syncing resource",
+			"conflicts detected",
+			"merge Manually",
+			"resolve",
+			"merge or replace",
+			"merge",
+			"replace local",
+			"merge Manually",
+			"cancel",
+			"first time sync detail",
+			"reset",
+			"reset title",
+			{
+				"key": "resetButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"choose account placeholder",
+			"signed in",
+			"last used",
+			"others",
+			"sign in using account",
+			"successive auth failures",
+			"sign in"
+		],
+		"vs/workbench/services/authentication/browser/authenticationService": [
+			"authentication.id",
+			"authentication.label",
+			{
+				"key": "authenticationExtensionPoint",
+				"comment": [
+					"'Contributes' means adds here"
+				]
+			},
+			"loading",
+			"authentication.missingId",
+			"authentication.missingLabel",
+			"authentication.idConflict",
+			"loading",
+			"sign in",
+			"confirmAuthenticationAccess",
+			"allow",
+			"deny",
+			"cancel",
+			"useOtherAccount",
+			{
+				"key": "selectAccount",
+				"comment": [
+					"The placeholder {0} is the name of an extension. {1} is the name of the type of account, such as Microsoft or GitHub."
+				]
+			},
+			"getSessionPlateholder",
+			{
+				"key": "accessRequest",
+				"comment": [
+					"The placeholder {0} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count"
+				]
+			},
+			{
+				"key": "signInRequest",
+				"comment": [
+					"The placeholder {0} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count."
+				]
+			}
+		],
+		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
+			"defaultPreferencesEditor",
+			"settingsEditor2",
+			"keybindingsEditor",
+			"openSettings2",
+			"preferences",
+			"settings",
+			{
+				"key": "miOpenSettings",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"openSettings2",
+			"openSettingsJson",
+			"openGlobalSettings",
+			"openRawDefaultSettings",
+			"openSettingsJson",
+			"openWorkspaceSettings",
+			"openWorkspaceSettingsFile",
+			"openFolderSettings",
+			"openFolderSettingsFile",
+			"openFolderSettings",
+			"filterModifiedLabel",
+			"filterOnlineServicesLabel",
+			{
+				"key": "miOpenOnlineSettings",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"onlineServices",
+			"openRemoteSettings",
+			"settings.focusSearch",
+			"settings.clearResults",
+			"settings.focusFile",
+			"settings.focusFile",
+			"settings.focusNextSetting",
+			"settings.focusPreviousSetting",
+			"settings.editFocusedSetting",
+			"settings.focusSettingsList",
+			"settings.focusSettingsTOC",
+			"settings.focusSettingControl",
+			"settings.showContextMenu",
+			"settings.focusLevelUp",
+			"preferences",
+			"openGlobalKeybindings",
+			"Keyboard Shortcuts",
+			"Keyboard Shortcuts",
+			"openDefaultKeybindingsFile",
+			"openGlobalKeybindingsFile",
+			"showDefaultKeybindings",
+			"showExtensionKeybindings",
+			"showUserKeybindings",
+			"clear",
+			{
+				"key": "miPreferences",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"defineKeybinding.start",
+			"defineKeybinding.kbLayoutErrorMessage",
+			{
+				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
+					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			},
+			{
+				"key": "defineKeybinding.kbLayoutLocalMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
+					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			}
+		],
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"show.label"
+		],
+		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
+			"diffLeftRightLabel",
+			"notebookConfigurationTitle",
+			"notebook.displayOrder.description",
+			"notebook.cellToolbarLocation.description",
+			"notebook.showCellStatusbar.description",
+			"notebook.diff.enablePreview.description"
+		],
+		"vs/workbench/contrib/testing/browser/testing.contribution": [
+			"test",
+			"noTestProvidersRegistered",
+			{
+				"key": "searchMarketplaceForTestExtensions",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			"testExplorer"
+		],
+		"vs/workbench/contrib/logs/common/logs.contribution": [
+			"userDataSyncLog",
+			"rendererLog",
+			"telemetryLog",
+			"show window log",
+			"mainLog",
+			"sharedLog"
+		],
+		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
+			"helpQuickAccessPlaceholder",
+			"helpQuickAccess",
+			"viewQuickAccessPlaceholder",
+			"viewQuickAccess",
+			"commandsQuickAccessPlaceholder",
+			"commandsQuickAccess",
+			{
+				"key": "miCommandPalette",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenView",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoSymbolInEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoLine",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"commandPalette",
+			"commandPalette"
+		],
+		"vs/workbench/contrib/files/browser/explorerViewlet": [
+			"explorerViewIcon",
+			"openEditorsIcon",
+			"folders",
+			"explore",
+			"explore",
+			{
+				"key": "miViewExplorer",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "noWorkspaceHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "remoteNoFolderHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "noFolderHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			}
+		],
+		"vs/workbench/contrib/files/browser/fileActions.contribution": [
+			"filesCategory",
+			"workspaces",
+			"file",
+			"copyPath",
+			"copyRelativePath",
+			"revealInSideBar",
+			"acceptLocalChanges",
+			"revertLocalChanges",
+			"copyPathOfActive",
+			"copyRelativePathOfActive",
+			"saveAllInGroup",
+			"saveFiles",
+			"revert",
+			"compareActiveWithSaved",
+			"openToSide",
+			"revert",
+			"saveAll",
+			"compareWithSaved",
+			"compareWithSelected",
+			"compareSource",
+			"compareSelected",
+			"close",
+			"closeOthers",
+			"closeSaved",
+			"closeAll",
+			"explorerOpenWith",
+			"cut",
+			"deleteFile",
+			"deleteFile",
+			"newFile",
+			"openFile",
+			{
+				"key": "miNewFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSave",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSaveAs",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSaveAll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpen",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenFolder",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miAutoSave",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRevert",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miCloseEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/files/browser/files.contribution": [
+			"binaryFileEditor",
+			"hotExit.off",
+			"hotExit.onExit",
+			"hotExit.onExitAndWindowClose",
+			"hotExit",
+			"hotExit.off",
+			"hotExit.onExitAndWindowCloseBrowser",
+			"hotExit",
+			"filesConfigurationTitle",
+			"exclude",
+			"files.exclude.boolean",
+			"files.exclude.when",
+			"associations",
+			"encoding",
+			"autoGuessEncoding",
+			"eol.LF",
+			"eol.CRLF",
+			"eol.auto",
+			"eol",
+			"useTrash",
+			"trimTrailingWhitespace",
+			"insertFinalNewline",
+			"trimFinalNewlines",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "files.autoSave.off"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "files.autoSave.afterDelay"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "files.autoSave.onFocusChange"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "files.autoSave.onWindowChange"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "autoSave"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "autoSaveDelay"
+			},
+			"watcherExclude",
+			"defaultLanguage",
+			"maxMemoryForLargeFilesMB",
+			"files.restoreUndoStack",
+			"askUser",
+			"overwriteFileOnDisk",
+			"files.saveConflictResolution",
+			"files.simpleDialog.enable",
+			"formatOnSave",
+			{
+				"key": "everything",
+				"comment": [
+					"This is the description of an option"
+				]
+			},
+			{
+				"key": "modification",
+				"comment": [
+					"This is the description of an option"
+				]
+			},
+			"formatOnSaveMode",
+			"explorerConfigurationTitle",
+			{
+				"key": "openEditorsVisible",
+				"comment": [
+					"Open is an adjective"
+				]
+			},
+			{
+				"key": "openEditorsSortOrder",
+				"comment": [
+					"Open is an adjective"
+				]
+			},
+			"sortOrder.editorOrder",
+			"sortOrder.alphabetical",
+			"autoReveal.on",
+			"autoReveal.off",
+			"autoReveal.focusNoScroll",
+			"autoReveal",
+			"enableDragAndDrop",
+			"confirmDragAndDrop",
+			"confirmDelete",
+			"sortOrder.default",
+			"sortOrder.mixed",
+			"sortOrder.filesFirst",
+			"sortOrder.type",
+			"sortOrder.modified",
+			"sortOrder",
+			"explorer.decorations.colors",
+			"explorer.decorations.badges",
+			"simple",
+			"smart",
+			"explorer.incrementalNaming",
+			"compressSingleChildFolders"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
+			"summary.0",
+			"summary.nm",
+			"summary.n0",
+			"workspaceEdit",
+			"workspaceEdit",
+			"nothing",
+			"fileOperation",
+			"areYouSureQuiteBulkEdit",
+			"quit"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
+			"overlap",
+			"cancel",
+			"continue",
+			"detail",
+			"apply",
+			"cat",
+			"Discard",
+			"cat",
+			"toogleSelection",
+			"cat",
+			"groupByFile",
+			"cat",
+			"groupByType",
+			"cat",
+			"groupByType",
+			"cat",
+			"refactorPreviewViewIcon",
+			"panel",
+			"panel"
+		],
+		"vs/workbench/contrib/search/browser/search.contribution": [
+			"search",
+			"copyMatchLabel",
+			"copyPathLabel",
+			"copyAllLabel",
+			"CancelSearchAction.label",
+			"RefreshAction.label",
+			"CollapseDeepestExpandedLevelAction.label",
+			"ExpandAllAction.label",
+			"ClearSearchResultsAction.label",
+			"revealInSideBar",
+			"clearSearchHistoryLabel",
+			"focusSearchListCommandLabel",
+			"findInFolder",
+			"findInWorkspace",
+			"showTriggerActions",
+			"name",
+			"search",
+			{
+				"key": "miViewSearch",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"findInFiles.description",
+			"findInFiles.args",
+			"findInFiles",
+			{
+				"key": "miFindInFiles",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miReplaceInFiles",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"anythingQuickAccessPlaceholder",
+			"anythingQuickAccess",
+			"symbolsQuickAccessPlaceholder",
+			"symbolsQuickAccess",
+			"searchConfigurationTitle",
+			"exclude",
+			"exclude.boolean",
+			"exclude.when",
+			"search.mode",
+			"search.mode.view",
+			"search.mode.reuseEditor",
+			"search.mode.newEditor",
+			"useRipgrep",
+			"useRipgrepDeprecated",
+			"search.maintainFileSearchCache",
+			"useIgnoreFiles",
+			"useGlobalIgnoreFiles",
+			"search.quickOpen.includeSymbols",
+			"search.quickOpen.includeHistory",
+			"filterSortOrder.default",
+			"filterSortOrder.recency",
+			"filterSortOrder",
+			"search.followSymlinks",
+			"search.smartCase",
+			"search.globalFindClipboard",
+			"search.location",
+			"search.location.deprecationMessage",
+			"search.collapseResults.auto",
+			"search.collapseAllResults",
+			"search.useReplacePreview",
+			"search.showLineNumbers",
+			"search.usePCRE2",
+			"usePCRE2Deprecated",
+			"search.actionsPositionAuto",
+			"search.actionsPositionRight",
+			"search.actionsPosition",
+			"search.searchOnType",
+			"search.seedWithNearestWord",
+			"search.seedOnFocus",
+			"search.searchOnTypeDebouncePeriod",
+			"search.searchEditor.doubleClickBehaviour.selectWord",
+			"search.searchEditor.doubleClickBehaviour.goToLocation",
+			"search.searchEditor.doubleClickBehaviour.openLocationToSide",
+			"search.searchEditor.doubleClickBehaviour",
+			{
+				"key": "search.searchEditor.reusePriorSearchConfiguration",
+				"comment": [
+					"\"Search Editor\" is a type of editor that can display search results. \"includes, excludes, and flags\" refers to the \"files to include\" and \"files to exclude\" input boxes, and the flags that control whether a query is case-sensitive or a regex."
+				]
+			},
+			"search.searchEditor.defaultNumberOfContextLines",
+			"searchSortOrder.default",
+			"searchSortOrder.filesOnly",
+			"searchSortOrder.type",
+			"searchSortOrder.modified",
+			"searchSortOrder.countDescending",
+			"searchSortOrder.countAscending",
+			"search.sortOrder",
+			{
+				"key": "miGotoSymbolInWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/search/browser/searchView": [
+			"searchCanceled",
+			"moreSearch",
+			"searchScope.includes",
+			"label.includes",
+			"placeholder.includes",
+			"searchScope.excludes",
+			"label.excludes",
+			"placeholder.excludes",
+			"replaceAll.confirmation.title",
+			"replaceAll.confirm.button",
+			"replaceAll.occurrence.file.message",
+			"removeAll.occurrence.file.message",
+			"replaceAll.occurrence.files.message",
+			"removeAll.occurrence.files.message",
+			"replaceAll.occurrences.file.message",
+			"removeAll.occurrences.file.message",
+			"replaceAll.occurrences.files.message",
+			"removeAll.occurrences.files.message",
+			"removeAll.occurrence.file.confirmation.message",
+			"replaceAll.occurrence.file.confirmation.message",
+			"removeAll.occurrence.files.confirmation.message",
+			"replaceAll.occurrence.files.confirmation.message",
+			"removeAll.occurrences.file.confirmation.message",
+			"replaceAll.occurrences.file.confirmation.message",
+			"removeAll.occurrences.files.confirmation.message",
+			"replaceAll.occurrences.files.confirmation.message",
+			"emptySearch",
+			"ariaSearchResultsClearStatus",
+			"searchPathNotFoundError",
+			"searchMaxResultsWarning",
+			"noOpenEditorResultsIncludesExcludes",
+			"noOpenEditorResultsIncludes",
+			"noOpenEditorResultsExcludes",
+			"noOpenEditorResultsFound",
+			"noResultsIncludesExcludes",
+			"noResultsIncludes",
+			"noResultsExcludes",
+			"noResultsFound",
+			"rerunSearch.message",
+			"rerunSearchInAll.message",
+			"openSettings.message",
+			"openSettings.learnMore",
+			"ariaSearchResultsStatus",
+			"forTerm",
+			"useIgnoresAndExcludesDisabled",
+			"excludes.enable",
+			"useExcludesAndIgnoreFilesDescription",
+			"openInEditor.tooltip",
+			"openInEditor.message",
+			"search.file.result",
+			"search.files.result",
+			"search.file.results",
+			"search.files.results",
+			"searchWithoutFolder",
+			"openFolder"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
+			"searchEditor",
+			"search",
+			"searchEditor.deleteResultBlock",
+			"search.openNewSearchEditor",
+			"search.openSearchEditor",
+			"search.openNewEditorToSide",
+			"search.openResultsInEditor",
+			"search.rerunSearchInEditor",
+			"search.action.focusQueryEditorWidget",
+			"searchEditor.action.toggleSearchEditorCaseSensitive",
+			"searchEditor.action.toggleSearchEditorWholeWord",
+			"searchEditor.action.toggleSearchEditorRegex",
+			"searchEditor.action.toggleSearchEditorContextLines",
+			"searchEditor.action.increaseSearchEditorContextLines",
+			"searchEditor.action.decreaseSearchEditorContextLines",
+			"searchEditor.action.selectAllSearchEditorMatches",
+			"search.openNewEditor"
+		],
+		"vs/workbench/contrib/sash/browser/sash.contribution": [
+			"sashSize",
+			"sashHoverDelay"
+		],
+		"vs/workbench/contrib/scm/browser/scm.contribution": [
+			"sourceControlViewIcon",
+			"source control",
+			"no open repo",
+			"source control",
+			{
+				"key": "miViewSCM",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"source control repositories",
+			"scmConfigurationTitle",
+			"scm.diffDecorations.all",
+			"scm.diffDecorations.gutter",
+			"scm.diffDecorations.overviewRuler",
+			"scm.diffDecorations.minimap",
+			"scm.diffDecorations.none",
+			"diffDecorations",
+			"diffGutterWidth",
+			"scm.diffDecorationsGutterVisibility.always",
+			"scm.diffDecorationsGutterVisibility.hover",
+			"scm.diffDecorationsGutterVisibility",
+			"scm.diffDecorationsGutterAction.diff",
+			"scm.diffDecorationsGutterAction.none",
+			"scm.diffDecorationsGutterAction",
+			"alwaysShowActions",
+			"scm.countBadge.all",
+			"scm.countBadge.focused",
+			"scm.countBadge.off",
+			"scm.countBadge",
+			"scm.providerCountBadge.hidden",
+			"scm.providerCountBadge.auto",
+			"scm.providerCountBadge.visible",
+			"scm.providerCountBadge",
+			"scm.defaultViewMode.tree",
+			"scm.defaultViewMode.list",
+			"scm.defaultViewMode",
+			"autoReveal",
+			"inputFontFamily",
+			"inputFontSize",
+			"alwaysShowRepository",
+			"providersVisible",
+			"scm accept",
+			"scm view next commit",
+			"scm view previous commit",
+			"open in terminal"
+		],
+		"vs/workbench/contrib/debug/browser/debug.contribution": [
+			"debugCategory",
+			"startDebugPlaceholder",
+			"startDebuggingHelp",
+			"terminateThread",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "debugFocusConsole"
+			},
+			"jumpToCursor",
+			"SetNextStatement",
+			"inlineBreakpoint",
+			"terminateThread",
+			"restartFrame",
+			"copyStackTrace",
+			"setValue",
+			"copyValue",
+			"copyAsExpression",
+			"addToWatchExpressions",
+			"breakWhenValueIsRead",
+			"breakWhenValueChanges",
+			"breakWhenValueIsAccessed",
+			"editWatchExpression",
+			"copyValue",
+			"removeWatchExpression",
+			{
+				"key": "miStartDebugging",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRun",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStopDebugging",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRestart Debugging",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miAddConfiguration",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStepOver",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStepInto",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStepOut",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miContinue",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miInlineBreakpoint",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miNewBreakpoint",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miInstallAdditionalDebuggers",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "debugPanel"
+			},
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "debugPanel"
+			},
+			{
+				"key": "miToggleDebugConsole",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"run and debug",
+			{
+				"key": "miViewRun",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"variables",
+			"watch",
+			"callStack",
+			"breakpoints",
+			"loadedScripts",
+			"debugConfigurationTitle",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "allowBreakpointsEverywhere"
+			},
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "openExplorerOnEnd"
+			},
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "inlineValues"
+			},
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "toolBarLocation"
+			},
+			"never",
+			"always",
+			"onFirstSessionStart",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "showInStatusBar"
+			},
+			"debug.console.closeOnEnd",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "debug.terminal.clearBeforeReusing"
+			},
+			"openDebug",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "showSubSessionsInToolBar"
+			},
+			"debug.console.fontSize",
+			"debug.console.fontFamily",
+			"debug.console.lineHeight",
+			"debug.console.wordWrap",
+			"debug.console.historySuggestions",
+			"debug.console.collapseIdenticalLines",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "launch"
+			},
+			"debug.focusWindowOnBreak",
+			"debugAnyway",
+			"showErrors",
+			"prompt",
+			"cancel",
+			"debug.onTaskErrors",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "showBreakpointsInOverviewRuler"
+			},
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "showInlineBreakpointCandidates"
+			},
+			"debug.saveBeforeStart",
+			"debug.saveBeforeStart.allEditorsInActiveGroup",
+			"debug.saveBeforeStart.nonUntitledEditorsInActiveGroup",
+			"debug.saveBeforeStart.none"
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
+			"addConfiguration"
+		],
+		"vs/workbench/contrib/debug/browser/breakpointEditorContribution": [
+			"logPoint",
+			"breakpoint",
+			"breakpointHasConditionDisabled",
+			"message",
+			"condition",
+			"breakpointHasConditionEnabled",
+			"message",
+			"condition",
+			"removeLogPoint",
+			"disableLogPoint",
+			"disable",
+			"enable",
+			"cancel",
+			"logPoint",
+			"breakpoint",
+			"removeBreakpoint",
+			"editBreakpoint",
+			"disableBreakpoint",
+			"enableBreakpoint",
+			"removeBreakpoints",
+			"removeInlineBreakpointOnColumn",
+			"removeLineBreakpoint",
+			"editBreakpoints",
+			"editInlineBreakpointOnColumn",
+			"editLineBrekapoint",
+			"enableDisableBreakpoints",
+			"disableInlineColumnBreakpoint",
+			"disableBreakpointOnLine",
+			"enableBreakpoints",
+			"enableBreakpointOnLine",
+			"addBreakpoint",
+			"addConditionalBreakpoint",
+			"addLogPoint",
+			"debugIcon.breakpointForeground",
+			"debugIcon.breakpointDisabledForeground",
+			"debugIcon.breakpointUnverifiedForeground",
+			"debugIcon.breakpointCurrentStackframeForeground",
+			"debugIcon.breakpointStackframeForeground"
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"topStackFrameLineHighlight",
+			"focusedStackFrameLineHighlight"
+		],
+		"vs/workbench/contrib/debug/browser/repl": [
+			{
+				"key": "workbench.debug.filter.placeholder",
+				"comment": [
+					"Text in the brackets after e.g. is not localizable"
+				]
+			},
+			"debugConsole",
+			"startDebugFirst",
+			{
+				"key": "actions.repl.acceptInput",
+				"comment": [
+					"Apply input from the debug console input box"
+				]
+			},
+			"repl.action.filter",
+			"actions.repl.copyAll",
+			"filter",
+			"selectRepl",
+			"clearRepl",
+			"debugConsoleCleared",
+			"collapse",
+			"paste",
+			"copyAll",
+			"copy"
+		],
+		"vs/workbench/contrib/debug/browser/debugViewlet": [
+			{
+				"key": "miOpenConfigurations",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "selectWorkspaceFolder",
+				"comment": [
+					"User picks a workspace folder or a workspace configuration file here. Workspace configuration files can contain settings and thus a launch.json configuration can be written into one."
+				]
+			},
+			"debugPanel",
+			"startAdditionalSession"
+		],
+		"vs/workbench/contrib/markers/browser/markers.contribution": [
+			"markersViewIcon",
+			{
+				"key": "miMarker",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"copyMarker",
+			"copyMessage",
+			"copyMessage",
+			"focusProblemsList",
+			"focusProblemsFilter",
+			"show multiline",
+			"problems",
+			"show singleline",
+			"problems",
+			"clearFiltersText",
+			"problems",
+			"collapseAll",
+			"filter",
+			"status.problems",
+			"totalErrors",
+			"totalWarnings",
+			"totalInfos",
+			"noProblems",
+			"manyProblems"
+		],
+		"vs/workbench/contrib/comments/browser/comments.contribution": [
+			"commentsConfigurationTitle",
+			"openComments"
+		],
+		"vs/workbench/contrib/url/browser/url.contribution": [
+			"openUrl",
+			"urlToOpen"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
+			"webview.editor.label"
+		],
+		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
+			"manageExtensionsQuickAccessPlaceholder",
+			"manageExtensionsHelp",
+			"extension",
+			"extensions",
+			{
+				"key": "miViewExtensions",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"extensionsConfigurationTitle",
+			"extensionsAutoUpdate",
+			"extensionsCheckUpdates",
+			"extensionsIgnoreRecommendations",
+			"extensionsShowRecommendationsOnlyOnDemand_Deprecated",
+			"extensionsCloseExtensionDetailsOnViewChange",
+			"handleUriConfirmedExtensions",
+			"extensionsWebWorker",
+			"workbench.extensions.installExtension.description",
+			"workbench.extensions.installExtension.arg.name",
+			"notFound",
+			"workbench.extensions.uninstallExtension.description",
+			"workbench.extensions.uninstallExtension.arg.name",
+			"id required",
+			"notInstalled",
+			"builtin",
+			"workbench.extensions.search.description",
+			"workbench.extensions.search.arg.name",
+			"installExtensionQuickAccessPlaceholder",
+			"installExtensionQuickAccessHelp",
+			{
+				"key": "miPreferencesExtensions",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"showExtensions",
+			"installExtensions",
+			"showRecommendedKeymapExtensionsShort",
+			{
+				"key": "miOpenKeymapExtensions",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"miOpenKeymapExtensions2",
+			"showLanguageExtensionsShort",
+			"checkForUpdates",
+			"noUpdatesAvailable",
+			"disableAutoUpdate",
+			"updateAll",
+			"enableAutoUpdate",
+			"enableAll",
+			"enableAllWorkspace",
+			"disableAll",
+			"disableAllWorkspace",
+			"InstallFromVSIX",
+			"installFromVSIX",
+			{
+				"key": "installButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"installVSIX",
+			"InstallVSIXAction.successReload",
+			"InstallVSIXAction.success",
+			"InstallVSIXAction.reloadNow",
+			"filterExtensions",
+			"showFeaturedExtensions",
+			"featured filter",
+			"showPopularExtensions",
+			"most popular filter",
+			"showRecommendedExtensions",
+			"most popular recommended",
+			"recentlyPublishedExtensions",
+			"recently published filter",
+			"filter by category",
+			"showBuiltInExtensions",
+			"builtin filter",
+			"showInstalledExtensions",
+			"installed filter",
+			"showEnabledExtensions",
+			"enabled filter",
+			"showDisabledExtensions",
+			"disabled filter",
+			"showOutdatedExtensions",
+			"outdated filter",
+			"sorty by",
+			"sort by installs",
+			"sort by rating",
+			"sort by name",
+			"sort by date",
+			"clearExtensionsSearchResults",
+			"refreshExtension",
+			"installWorkspaceRecommendedExtensions",
+			"workbench.extensions.action.copyExtension",
+			"extensionInfoName",
+			"extensionInfoId",
+			"extensionInfoDescription",
+			"extensionInfoVersion",
+			"extensionInfoPublisher",
+			"extensionInfoVSMarketplaceLink",
+			"workbench.extensions.action.copyExtensionId",
+			"workbench.extensions.action.configure",
+			"workbench.extensions.action.toggleIgnoreExtension",
+			"workbench.extensions.action.ignoreRecommendation",
+			"workbench.extensions.action.undoIgnoredRecommendation",
+			"workbench.extensions.action.addExtensionToWorkspaceRecommendations",
+			"workbench.extensions.action.removeExtensionFromWorkspaceRecommendations",
+			"workbench.extensions.action.addToWorkspaceRecommendations",
+			"extensions",
+			"workbench.extensions.action.addToWorkspaceFolderRecommendations",
+			"extensions",
+			"workbench.extensions.action.addToWorkspaceIgnoredRecommendations",
+			"extensions",
+			"workbench.extensions.action.addToWorkspaceFolderIgnoredRecommendations",
+			"extensions",
+			"extensions"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			"installed",
+			"select and install local extensions",
+			{
+				"key": "remote",
+				"comment": [
+					"Remote as in remote machine"
+				]
+			},
+			"install remote in local",
+			{
+				"key": "remote",
+				"comment": [
+					"Remote as in remote machine"
+				]
+			},
+			"popularExtensions",
+			"recommendedExtensions",
+			"enabledExtensions",
+			"disabledExtensions",
+			"marketPlace",
+			"installed",
+			"enabled",
+			"disabled",
+			"outdated",
+			"builtin",
+			"workspaceRecommendedExtensions",
+			"otherRecommendedExtensions",
+			"builtinFeatureExtensions",
+			"builtInThemesExtensions",
+			"builtinProgrammingLanguageExtensions",
+			"searchExtensions",
+			"extensionFoundInSection",
+			"extensionFound",
+			"extensionsFoundInSection",
+			"extensionsFound",
+			"suggestProxyError",
+			"open user settings",
+			"outdatedExtensions",
+			"malicious warning",
+			"reloadNow"
+		],
+		"vs/workbench/contrib/output/browser/output.contribution": [
+			"outputViewIcon",
+			"output",
+			"output",
+			{
+				"key": "miToggleOutput",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"logViewer",
+			"switchToOutput.label",
+			"clearOutput.label",
+			"outputCleared",
+			"toggleAutoScroll",
+			"outputScrollOff",
+			"outputScrollOn",
+			"openActiveLogOutputFile",
+			"showLogs",
+			"selectlog",
+			"openLogFile",
+			"selectlogFile",
+			"output",
+			"output.smartScroll.enabled"
+		],
+		"vs/workbench/contrib/output/browser/outputView": [
+			"output model title",
+			"channel",
+			"output",
+			"outputViewWithInputAriaLabel",
+			"outputViewAriaLabel",
+			"outputChannels",
+			"logChannel"
+		],
+		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
+			"tasksQuickAccessPlaceholder",
+			"tasksQuickAccessHelp",
+			"terminal",
+			"terminal",
+			{
+				"key": "miToggleIntegratedTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"terminal.useMonospace",
+			"terminal.monospaceOnly",
+			"terminals",
+			"terminalConnectingLabel"
+		],
+		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
+			"relaunchSettingMessage",
+			"relaunchSettingMessageWeb",
+			"relaunchSettingDetail",
+			"relaunchSettingDetailWeb",
+			"restart",
+			"restartWeb"
+		],
+		"vs/workbench/contrib/tasks/browser/task.contribution": [
+			"building",
+			"numberOfRunningTasks",
+			"runningTasks",
+			"status.runningTasks",
+			{
+				"key": "miRunTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miBuildTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRunningTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRestartTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTerminateTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miConfigureTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miConfigureBuildTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"workbench.action.tasks.openWorkspaceFileTasks",
+			"ShowLogAction.label",
+			"RunTaskAction.label",
+			"ReRunTaskAction.label",
+			"RestartTaskAction.label",
+			"ShowTasksAction.label",
+			"TerminateAction.label",
+			"BuildAction.label",
+			"TestAction.label",
+			"ConfigureDefaultBuildTask.label",
+			"ConfigureDefaultTestTask.label",
+			"workbench.action.tasks.openUserTasks",
+			"tasksQuickAccessPlaceholder",
+			"tasksQuickAccessHelp",
+			"tasksConfigurationTitle",
+			"task.problemMatchers.neverPrompt",
+			"task.problemMatchers.neverPrompt.boolean",
+			"task.problemMatchers.neverPrompt.array",
+			"task.autoDetect",
+			"task.slowProviderWarning",
+			"task.slowProviderWarning.boolean",
+			"task.slowProviderWarning.array",
+			"task.quickOpen.history",
+			"task.quickOpen.detail",
+			"task.quickOpen.skip",
+			"task.quickOpen.showAll",
+			"task.saveBeforeRun",
+			"task.saveBeforeRun.always",
+			"task.saveBeforeRun.never",
+			"task.SaveBeforeRun.prompt"
+		],
+		"vs/workbench/contrib/remote/common/remote.contribution": [
+			"remoteExtensionLog",
+			"ui",
+			"workspace",
+			"web",
+			"remote",
+			"remote.extensionKind",
+			"remote.restoreForwardedPorts",
+			"remote.autoForwardPorts",
+			"remote.autoForwardPortsSource",
+			"remote.autoForwardPortsSource.process",
+			"remote.autoForwardPortsSource.output",
+			"remote.portsAttributes.port",
+			"remote.portsAttributes.notify",
+			"remote.portsAttributes.openBrowser",
+			"remote.portsAttributes.openPreview",
+			"remote.portsAttributes.silent",
+			"remote.portsAttributes.ignore",
+			"remote.portsAttributes.onForward",
+			"remote.portsAttributes.elevateIfNeeded",
+			"remote.portsAttributes.label",
+			"remote.portsAttributes.labelDefault",
+			"remote.portsAttributes.labelDefault",
+			"remote.portsAttributes",
+			"remote.portsAttributes.patternError",
+			"remote.portsAttributes.notify",
+			"remote.portsAttributes.openBrowser",
+			"remote.portsAttributes.openPreview",
+			"remote.portsAttributes.silent",
+			"remote.portsAttributes.ignore",
+			"remote.portsAttributes.onForward",
+			"remote.portsAttributes.elevateIfNeeded",
+			"remote.portsAttributes.label",
+			"remote.portsAttributes.labelDefault",
+			"remote.portsAttributes.defaults"
+		],
+		"vs/workbench/contrib/remote/browser/remote": [
+			"RemoteHelpInformationExtPoint",
+			"RemoteHelpInformationExtPoint.getStarted",
+			"RemoteHelpInformationExtPoint.documentation",
+			"RemoteHelpInformationExtPoint.feedback",
+			"RemoteHelpInformationExtPoint.issues",
+			"remote.help.getStarted",
+			"remote.help.documentation",
+			"remote.help.feedback",
+			"remote.help.issues",
+			"remote.help.report",
+			"pickRemoteExtension",
+			"remote.help",
+			"remotehelp",
+			"remote.explorer",
+			"remote.explorer",
+			"reconnectionWaitOne",
+			"reconnectionWaitMany",
+			"reconnectNow",
+			"reloadWindow",
+			"connectionLost",
+			"reconnectionRunning",
+			"reconnectionPermanentFailure",
+			"reloadWindow",
+			"cancel"
+		],
+		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
+			"toggleKeybindingsLog"
+		],
+		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
+			"scopedConsoleAction",
+			"scopedConsoleAction.integrated",
+			"scopedConsoleAction.integrated",
+			"scopedConsoleAction.wt",
+			"scopedConsoleAction.external"
+		],
+		"vs/workbench/contrib/snippets/browser/snippets.contribution": [
+			"snippetSchema.json.prefix",
+			"snippetSchema.json.body",
+			"snippetSchema.json.description",
+			"snippetSchema.json.default",
+			"snippetSchema.json",
+			"snippetSchema.json.default",
+			"snippetSchema.json",
+			"snippetSchema.json.scope"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"invalid.path.0",
+			"invalid.language.0",
+			"invalid.language",
+			"invalid.path.1",
+			"vscode.extension.contributes.snippets",
+			"vscode.extension.contributes.snippets-language",
+			"vscode.extension.contributes.snippets-path",
+			"badVariableUse",
+			"badFile"
+		],
+		"vs/workbench/contrib/snippets/browser/insertSnippet": [
+			"snippet.suggestions.label",
+			"sep.userSnippet",
+			"sep.extSnippet",
+			"sep.workspaceSnippet",
+			"disableSnippet",
+			"isDisabled",
+			"enable.snippet",
+			"pick.placeholder"
+		],
+		"vs/workbench/contrib/snippets/browser/configureSnippets": [
+			"global.scope",
+			"global.1",
+			"name",
+			"bad_name1",
+			"bad_name2",
+			"bad_name3",
+			"new.global_scope",
+			"new.global",
+			"new.workspace_scope",
+			"new.folder",
+			"group.global",
+			"new.global.sep",
+			"new.global.sep",
+			"openSnippet.pickLanguage",
+			"openSnippet.label",
+			"preferences",
+			{
+				"key": "miOpenSnippets",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"userSnippets"
+		],
+		"vs/workbench/contrib/update/browser/update.contribution": [
+			{
+				"key": "miReleaseNotes",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/watermark/browser/watermark": [
+			"watermark.showCommands",
+			"watermark.quickAccess",
+			"watermark.openFile",
+			"watermark.openFolder",
+			"watermark.openFileFolder",
+			"watermark.openRecent",
+			"watermark.newUntitledFile",
+			{
+				"key": "watermark.toggleTerminal",
+				"comment": [
+					"toggle is a verb here"
+				]
+			},
+			"watermark.findInFiles",
+			"watermark.startDebugging",
+			"tips.enabled"
+		],
+		"vs/workbench/contrib/themes/browser/themes.contribution": [
+			"selectTheme.label",
+			"themes.category.light",
+			"themes.category.dark",
+			"themes.category.hc",
+			"installColorThemes",
+			"themes.selectTheme",
+			"selectIconTheme.label",
+			"noIconThemeLabel",
+			"noIconThemeDesc",
+			"installIconThemes",
+			"themes.selectIconTheme",
+			"selectProductIconTheme.label",
+			"defaultProductIconThemeLabel",
+			"installProductIconThemes",
+			"themes.selectProductIconTheme",
+			"generateColorTheme.label",
+			"preferences",
+			{
+				"key": "miSelectColorTheme",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSelectIconTheme",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSelectProductIconTheme",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"selectTheme.label",
+			"themes.selectIconTheme.label",
+			"themes.selectProductIconTheme.label"
+		],
+		"vs/workbench/contrib/surveys/browser/nps.contribution": [
+			"surveyQuestion",
+			"takeSurvey",
+			"remindLater",
+			"neverAgain"
+		],
+		"vs/workbench/contrib/surveys/browser/ces.contribution": [
+			"cesSurveyQuestion",
+			"giveFeedback",
+			"remindLater"
+		],
+		"vs/workbench/contrib/surveys/browser/languageSurveys.contribution": [
+			"helpUs",
+			"takeShortSurvey",
+			"remindLater",
+			"neverAgain"
+		],
+		"vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay": [
+			"welcomeOverlay.explorer",
+			"welcomeOverlay.search",
+			"welcomeOverlay.git",
+			"welcomeOverlay.debug",
+			"welcomeOverlay.extensions",
+			"welcomeOverlay.problems",
+			"welcomeOverlay.terminal",
+			"welcomeOverlay.commandPalette",
+			"welcomeOverlay.notifications",
+			"welcomeOverlay",
+			"hideWelcomeOverlay"
+		],
+		"vs/workbench/contrib/welcome/page/browser/welcomePage.contribution": [
+			{
+				"key": "miWelcome",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution": [
+			"Getting Started",
+			"help",
+			"gettingStarted",
+			"gettingStarted",
+			"gettingStarted.goBack",
+			"gettingStarted.goNext",
+			"gettingStarted.goPrev",
+			"gettingStarted.markTaskComplete",
+			"gettingStarted.markTaskInomplete",
+			"welcomePage.hiddenCategories",
+			"walkthroughs",
+			"walkthroughs.id",
+			"walkthroughs.title",
+			"walkthroughs.description",
+			"walkthroughs.primary",
+			"walkthroughs.when",
+			"walkthroughs.tasks",
+			"walkthroughs.tasks.id",
+			"walkthroughs.tasks.title",
+			"walkthroughs.tasks.description",
+			"walkthroughs.tasks.button",
+			"walkthroughs.tasks.button.title",
+			"walkthroughs.tasks.button.command",
+			"walkthroughs.tasks.button.title",
+			"walkthroughs.tasks.button.link",
+			"walkthroughs.tasks.media",
+			"walkthroughs.tasks.media.path",
+			"walkthroughs.tasks.media.altText",
+			"walkthroughs.tasks.doneOn",
+			"walkthroughs.tasks.oneOn.command",
+			"walkthroughs.tasks.when"
+		],
+		"vs/workbench/contrib/welcome/walkthroughs/browser/walkthroughs.contribution": [
+			"Walkthroughs",
+			"help",
+			"walkthroughs",
+			"walkthroughs",
+			"walkthroughs.goBack",
+			"walkthroughs.goNext",
+			"walkthroughs.goPrev"
+		],
+		"vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution": [
+			"walkThrough.editor.label",
+			{
+				"key": "miInteractivePlayground",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
+			"editorHasCallHierarchyProvider",
+			"callHierarchyVisible",
+			"callHierarchyDirection",
+			"no.item",
+			"error",
+			"title",
+			"title.incoming",
+			"showIncomingCallsIcons",
+			"title.outgoing",
+			"showOutgoingCallsIcon",
+			"title.refocus",
+			"close"
+		],
+		"vs/workbench/contrib/outline/browser/outline.contribution": [
+			"outlineViewIcon",
+			"name",
+			"outlineConfigurationTitle",
+			"outline.showIcons",
+			"outline.showProblem",
+			"outline.problem.colors",
+			"outline.problems.badges",
+			"filteredTypes.file",
+			"filteredTypes.module",
+			"filteredTypes.namespace",
+			"filteredTypes.package",
+			"filteredTypes.class",
+			"filteredTypes.method",
+			"filteredTypes.property",
+			"filteredTypes.field",
+			"filteredTypes.constructor",
+			"filteredTypes.enum",
+			"filteredTypes.interface",
+			"filteredTypes.function",
+			"filteredTypes.variable",
+			"filteredTypes.constant",
+			"filteredTypes.string",
+			"filteredTypes.number",
+			"filteredTypes.boolean",
+			"filteredTypes.array",
+			"filteredTypes.object",
+			"filteredTypes.key",
+			"filteredTypes.null",
+			"filteredTypes.enumMember",
+			"filteredTypes.struct",
+			"filteredTypes.event",
+			"filteredTypes.operator",
+			"filteredTypes.typeParameter"
+		],
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
+			"document"
+		],
+		"vs/workbench/contrib/experiments/browser/experiments.contribution": [
+			"workbench.enableExperiments"
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution": [
+			"operationId",
+			"too many requests"
+		],
+		"vs/workbench/contrib/timeline/browser/timeline.contribution": [
+			"timelineViewIcon",
+			"timelineOpenIcon",
+			"timelineConfigurationTitle",
+			"timeline.excludeSources",
+			"timeline.pageSize",
+			"timeline.pageOnScroll",
+			"files.openTimeline"
+		],
+		"vs/workbench/contrib/workspace/browser/workspace.contribution": [
+			"workspaceTrustIcon",
+			"requestTrustIconText",
+			"immediateTrustRequestMessage",
+			"grantWorkspaceTrustButton",
+			"manageWorkspaceTrustButton",
+			"cancelWorkspaceTrustButton",
+			"immediateTrustRequestTitle",
+			"immediateTrustRequestDetail",
+			"trustConfigurationChangeMessage",
+			"status.WorkspaceTrust",
+			"status.WorkspaceTrust",
+			"status.WorkspaceTrust",
+			"workspaceTrustEditor",
+			"grantWorkspaceTrust",
+			"workspacesCategory",
+			"grantWorkspaceTrust",
+			"confirmGrantWorkspaceTrust",
+			"yes",
+			"no",
+			"denyWorkspaceTrust",
+			"workspacesCategory",
+			"denyWorkspaceTrust",
+			"confirmDenyWorkspaceTrust",
+			"yes",
+			"no",
+			"manageWorkspaceTrust",
+			"workspacesCategory",
+			"manageWorkspaceTrustPending"
+		],
+		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
+			"workspaceFound",
+			"openWorkspace",
+			"workspacesFound",
+			"selectWorkspace",
+			"selectToOpen"
+		],
+		"vs/workbench/browser/parts/dialogs/dialogHandler": [
+			{
+				"key": "yesButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cancelButton",
+			"aboutDetail",
+			"copy",
+			"ok"
+		],
+		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
+			{
+				"key": "yesButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cancelButton",
+			{
+				"key": "aboutDetail",
+				"comment": [
+					"Electron, Chrome, Node.js and V8 are product names that need no translation"
+				]
+			},
+			"okButton",
+			{
+				"key": "copy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/services/textfile/browser/textFileService": [
+			"fileBinaryError",
+			"confirmOverwrite",
+			"irreversible",
+			{
+				"key": "replaceButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
+			"saveChangesDetail",
+			"saveChangesMessage",
+			"saveChangesMessages",
+			{
+				"key": "saveAll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "save",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "dontSave",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cancel",
+			"openFileOrFolder.title",
+			"openFile.title",
+			"openFolder.title",
+			"openWorkspace.title",
+			"filterName.workspace",
+			"saveFileAs.title",
+			"saveAsTitle",
+			"allFiles",
+			"noExt"
+		],
+		"vs/workbench/services/userDataSync/common/userDataSync": [
+			"settings",
+			"keybindings",
+			"snippets",
+			"extensions",
+			"ui state label",
+			"sync category",
+			"syncViewIcon"
+		],
+		"vs/workbench/services/textMate/browser/abstractTextMateService": [
+			"alreadyDebugging",
+			"stop",
+			"progress1",
+			"progress2",
+			"invalid.language",
+			"invalid.scopeName",
+			"invalid.path.0",
+			"invalid.injectTo",
+			"invalid.embeddedLanguages",
+			"invalid.tokenTypes",
+			"invalid.path.1",
+			"too many characters",
+			"neverAgain"
+		],
+		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
+			"save",
+			"saveWorkspace",
+			"errorInvalidTaskConfiguration",
+			"errorWorkspaceConfigurationFileDirty",
+			"openWorkspaceConfigurationFile"
+		],
+		"vs/workbench/services/configurationResolver/browser/configurationResolverService": [
+			"commandVariable.noStringType",
+			"inputVariable.noInputSection",
+			"inputVariable.missingAttribute",
+			"inputVariable.defaultInputValue",
+			"inputVariable.command.noStringType",
+			"inputVariable.unknownType",
+			"inputVariable.undefinedVariable"
+		],
+		"vs/workbench/services/extensionManagement/common/extensionManagementService": [
+			"singleDependentError",
+			"twoDependentsError",
+			"multipleDependentsError",
+			"Manifest is not found",
+			"cannot be installed",
+			"install extension",
+			"install extensions",
+			"install",
+			"install and do no sync",
+			"cancel",
+			"install single extension",
+			"install multiple extensions"
+		],
+		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
+			"incompatible"
+		],
+		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
+			"openLogsFolder",
+			"openExtensionLogsFolder"
+		],
+		"vs/workbench/contrib/localizations/browser/localizationsActions": [
+			"configureLocale",
+			"installAdditionalLanguages",
+			"chooseDisplayLanguage",
+			"relaunchDisplayLanguageMessage",
+			"relaunchDisplayLanguageDetail",
+			"restart"
+		],
+		"vs/workbench/services/extensions/common/extensionsRegistry": [
+			"ui",
+			"workspace",
+			"web",
+			"vscode.extension.engines",
+			"vscode.extension.engines.vscode",
+			"vscode.extension.publisher",
+			"vscode.extension.displayName",
+			"vscode.extension.categories",
+			"vscode.extension.category.languages.deprecated",
+			"vscode.extension.galleryBanner",
+			"vscode.extension.galleryBanner.color",
+			"vscode.extension.galleryBanner.theme",
+			"vscode.extension.contributes",
+			"vscode.extension.preview",
+			"vscode.extension.activationEvents",
+			"vscode.extension.activationEvents.onLanguage",
+			"vscode.extension.activationEvents.onCommand",
+			"vscode.extension.activationEvents.onDebug",
+			"vscode.extension.activationEvents.onDebugInitialConfigurations",
+			"vscode.extension.activationEvents.onDebugDynamicConfigurations",
+			"vscode.extension.activationEvents.onDebugResolve",
+			"vscode.extension.activationEvents.onDebugAdapterProtocolTracker",
+			"vscode.extension.activationEvents.workspaceContains",
+			"vscode.extension.activationEvents.onStartupFinished",
+			"vscode.extension.activationEvents.onFileSystem",
+			"vscode.extension.activationEvents.onSearch",
+			"vscode.extension.activationEvents.onView",
+			"vscode.extension.activationEvents.onIdentity",
+			"vscode.extension.activationEvents.onUri",
+			"vscode.extension.activationEvents.onOpenExternalUri",
+			"vscode.extension.activationEvents.onCustomEditor",
+			"vscode.extension.activationEvents.onNotebook",
+			"vscode.extension.activationEvents.onAuthenticationRequest",
+			"vscode.extension.activationEvents.star",
+			"vscode.extension.badges",
+			"vscode.extension.badges.url",
+			"vscode.extension.badges.href",
+			"vscode.extension.badges.description",
+			"vscode.extension.markdown",
+			"vscode.extension.qna",
+			"vscode.extension.extensionDependencies",
+			"vscode.extension.contributes.extensionPack",
+			"extensionKind",
+			"extensionKind.ui",
+			"extensionKind.workspace",
+			"extensionKind.ui-workspace",
+			"extensionKind.workspace-ui",
+			"extensionKind.empty",
+			"vscode.extension.scripts.prepublish",
+			"vscode.extension.scripts.uninstall",
+			"vscode.extension.icon"
+		],
+		"vs/workbench/contrib/localizations/browser/minimalTranslations": [
+			"showLanguagePackExtensions",
+			"searchMarketplace",
+			"installAndRestartMessage",
+			"installAndRestart"
+		],
+		"vs/workbench/electron-sandbox/actions/developerActions": [
+			"toggleDevTools",
+			"configureRuntimeArguments",
+			"toggleSharedProcess",
+			"reloadWindowWithExtensionsDisabled"
+		],
+		"vs/workbench/electron-sandbox/actions/windowActions": [
+			"closeWindow",
+			"zoomIn",
+			"zoomOut",
+			"zoomReset",
+			"close",
+			"close",
+			"switchWindowPlaceHolder",
+			"windowDirtyAriaLabel",
+			"current",
+			"switchWindow",
+			"quickSwitchWindow"
+		],
+		"vs/workbench/contrib/files/common/editors/fileEditorInput": [
+			"orphanedReadonlyFile",
+			"orphanedFile",
+			"readonlyFile"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/textFileEditor": [
+			"fileTooLargeForHeapError",
+			"relaunchWithIncreasedMemoryLimit",
+			"configureMemoryLimit"
+		],
+		"vs/editor/common/editorContextKeys": [
+			"editorTextFocus",
+			"editorFocus",
+			"textInputFocus",
+			"editorReadonly",
+			"inDiffEditor",
+			"editorColumnSelection",
+			"editorHasSelection",
+			"editorHasMultipleSelections",
+			"editorTabMovesFocus",
+			"editorHoverVisible",
+			"inCompositeEditor",
+			"editorLangId",
+			"editorHasCompletionItemProvider",
+			"editorHasCodeActionsProvider",
+			"editorHasCodeLensProvider",
+			"editorHasDefinitionProvider",
+			"editorHasDeclarationProvider",
+			"editorHasImplementationProvider",
+			"editorHasTypeDefinitionProvider",
+			"editorHasHoverProvider",
+			"editorHasDocumentHighlightProvider",
+			"editorHasDocumentSymbolProvider",
+			"editorHasReferenceProvider",
+			"editorHasRenameProvider",
+			"editorHasSignatureHelpProvider",
+			"editorHasInlineHintsProvider",
+			"editorHasDocumentFormattingProvider",
+			"editorHasDocumentSelectionFormattingProvider",
+			"editorHasMultipleDocumentFormattingProvider",
+			"editorHasMultipleDocumentSelectionFormattingProvider"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileCommands": [
+			"openFileToReveal"
+		],
+		"vs/workbench/common/resources": [
+			"resourceScheme",
+			"resourceFilename",
+			"resourceDirname",
+			"resourcePath",
+			"resourceLangId",
+			"resource",
+			"resourceExtname",
+			"resourceSet",
+			"isFileSystemResource"
+		],
+		"vs/workbench/contrib/backup/electron-sandbox/backupTracker": [
+			"backupTrackerBackupFailed",
+			"backupTrackerConfirmFailed",
+			"backupErrorDetails",
+			"ok",
+			"backupBeforeShutdown",
+			"saveBeforeShutdown",
+			"revertBeforeShutdown"
+		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
+			"actions.pasteSelectionClipboard"
+		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate": [
+			"startDebugTextMate"
+		],
+		"vs/workbench/contrib/issue/electron-sandbox/issueActions": [
+			"openProcessExplorer",
+			{
+				"key": "reportPerformanceIssue",
+				"comment": [
+					"Here, 'issue' means problem or bug"
+				]
+			}
+		],
+		"vs/workbench/services/dialogs/browser/simpleFileDialog": [
+			"openLocalFile",
+			"saveLocalFile",
+			"openLocalFolder",
+			"openLocalFileFolder",
+			"remoteFileDialog.notConnectedToRemote",
+			"remoteFileDialog.local",
+			"remoteFileDialog.badPath",
+			"remoteFileDialog.cancel",
+			"remoteFileDialog.invalidPath",
+			"remoteFileDialog.validateFolder",
+			"remoteFileDialog.validateExisting",
+			"remoteFileDialog.validateBadFilename",
+			"remoteFileDialog.validateNonexistentDir",
+			"remoteFileDialog.validateNonexistentDir",
+			"remoteFileDialog.windowsDriveLetter",
+			"remoteFileDialog.validateFileOnly",
+			"remoteFileDialog.validateFolderOnly"
+		],
+		"vs/workbench/contrib/terminal/electron-sandbox/localTerminalService": [
+			"restartPtyHost",
+			"nonResponsivePtyHost"
+		],
+		"vs/workbench/contrib/performance/electron-sandbox/startupProfiler": [
+			"prof.message",
+			"prof.detail",
+			"prof.restartAndFileIssue",
+			"prof.restart",
+			"prof.thanks",
+			"prof.detail.restart",
+			"prof.restart.button"
+		],
+		"vs/workbench/browser/workbench": [
+			"loaderErrorNative"
+		],
+		"vs/workbench/electron-sandbox/window": [
+			"learnMore",
+			"shellEnvSlowWarning",
+			"shellEnvTimeoutError",
+			"proxyAuthRequired",
+			{
+				"key": "loginButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "cancelButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"username",
+			"password",
+			"proxyDetail",
+			"rememberCredentials",
+			"runningAsRoot",
+			"loaderCycle",
+			"ok"
+		],
+		"vs/workbench/services/remote/electron-sandbox/remoteAgentServiceImpl": [
+			"connectionError"
+		],
+		"vs/workbench/services/extensions/node/extensionPoints": [
+			"jsonParseInvalidType",
+			"jsonParseFail",
+			"fileReadFail",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat",
+			"missingNLSKey",
+			"notSemver",
+			"extensionDescription.empty",
+			"extensionDescription.publisher",
+			"extensionDescription.name",
+			"extensionDescription.version",
+			"extensionDescription.engines",
+			"extensionDescription.engines.vscode",
+			"extensionDescription.extensionDependencies",
+			"extensionDescription.activationEvents1",
+			"extensionDescription.activationEvents2",
+			"extensionDescription.main1",
+			"extensionDescription.main2",
+			"extensionDescription.main3",
+			"extensionDescription.browser1",
+			"extensionDescription.browser2",
+			"extensionDescription.browser3"
+		],
+		"vs/workbench/services/extensions/common/extensionHostManager": [
+			"measureExtHostLatency"
+		],
+		"vs/workbench/contrib/webview/browser/baseWebviewElement": [
+			"fatalErrorMessage"
+		],
+		"vs/workbench/common/configuration": [
+			"workbenchConfigurationTitle"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/reportExtensionIssueAction": [
+			"reportExtensionIssue"
+		],
+		"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor": [
+			{
+				"key": "starActivation",
+				"comment": [
+					"{0} will be an extension identifier"
+				]
+			},
+			{
+				"key": "workspaceContainsGlobActivation",
+				"comment": [
+					"{0} will be a glob pattern",
+					"{1} will be an extension identifier"
+				]
+			},
+			{
+				"key": "workspaceContainsFileActivation",
+				"comment": [
+					"{0} will be a file name",
+					"{1} will be an extension identifier"
+				]
+			},
+			{
+				"key": "workspaceContainsTimeout",
+				"comment": [
+					"{0} will be a glob pattern",
+					"{1} will be an extension identifier"
+				]
+			},
+			{
+				"key": "startupFinishedActivation",
+				"comment": [
+					"This refers to an extension. {0} will be an activation event."
+				]
+			},
+			"languageActivation",
+			{
+				"key": "workspaceGenericActivation",
+				"comment": [
+					"{0} will be an activation event, like e.g. 'language:typescript', 'debug', etc.",
+					"{1} will be an extension identifier"
+				]
+			},
+			"unresponsive.title",
+			"errors",
+			"runtimeExtensions",
+			"disable workspace",
+			"disable",
+			"showRuntimeExtensions"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensionsSlowActions": [
+			"cmd.reportOrShow",
+			"cmd.report",
+			"attach.title",
+			"ok",
+			"attach.msg",
+			"cmd.show",
+			"attach.title",
+			"ok",
+			"attach.msg2"
+		],
+		"vs/workbench/contrib/debug/common/debug": [
+			"debugType",
+			"debugConfigurationType",
+			"debugState",
+			"debugUX",
+			"inDebugMode",
+			"inDebugRepl",
+			"breakpointWidgetVisibile",
+			"inBreakpointWidget",
+			"breakpointsFocused",
+			"watchExpressionsFocused",
+			"watchExpressionsExist",
+			"variablesFocused",
+			"expressionSelected",
+			"breakpointInputFocused",
+			"callStackItemType",
+			"callStackSessionIsAttach",
+			"callStackItemStopped",
+			"callStackSessionHasOneThread",
+			"watchItemType",
+			"breakpointItemType",
+			"breakpointAccessType",
+			"breakpointSupportsCondition",
+			"loadedScriptsSupported",
+			"loadedScriptsItemType",
+			"focusedSessionIsAttach",
+			"stepBackSupported",
+			"restartFrameSupported",
+			"stackFrameSupportsRestart",
+			"jumpToCursorSupported",
+			"stepIntoTargetsSupported",
+			"breakpointsExist",
+			"debuggersAvailable",
+			"debugProtocolVariableMenuContext",
+			"debugSetVariableSupported",
+			"breakWhenValueChangesSupported",
+			"breakWhenValueIsAccessedSupported",
+			"breakWhenValueIsReadSupported",
+			"variableEvaluateNamePresent",
+			"exceptionWidgetVisible",
+			"multiSessionRepl",
+			"multiSessionDebug",
+			"internalConsoleOptions"
+		],
+		"vs/workbench/contrib/terminal/electron-browser/terminalRemote": [
+			"workbench.action.terminal.newLocal"
+		],
+		"vs/editor/common/config/editorOptions": [
+			"accessibilitySupport.auto",
+			"accessibilitySupport.on",
+			"accessibilitySupport.off",
+			"accessibilitySupport",
+			"comments.insertSpace",
+			"comments.ignoreEmptyLines",
+			"emptySelectionClipboard",
+			"find.cursorMoveOnType",
+			"find.seedSearchStringFromSelection",
+			"editor.find.autoFindInSelection.never",
+			"editor.find.autoFindInSelection.always",
+			"editor.find.autoFindInSelection.multiline",
+			"find.autoFindInSelection",
+			"find.globalFindClipboard",
+			"find.addExtraSpaceOnTop",
+			"find.loop",
+			"fontLigatures",
+			"fontFeatureSettings",
+			"fontLigaturesGeneral",
+			"fontSize",
+			"fontWeightErrorMessage",
+			"fontWeight",
+			"editor.gotoLocation.multiple.peek",
+			"editor.gotoLocation.multiple.gotoAndPeek",
+			"editor.gotoLocation.multiple.goto",
+			"editor.gotoLocation.multiple.deprecated",
+			"editor.editor.gotoLocation.multipleDefinitions",
+			"editor.editor.gotoLocation.multipleTypeDefinitions",
+			"editor.editor.gotoLocation.multipleDeclarations",
+			"editor.editor.gotoLocation.multipleImplemenattions",
+			"editor.editor.gotoLocation.multipleReferences",
+			"alternativeDefinitionCommand",
+			"alternativeTypeDefinitionCommand",
+			"alternativeDeclarationCommand",
+			"alternativeImplementationCommand",
+			"alternativeReferenceCommand",
+			"hover.enabled",
+			"hover.delay",
+			"hover.sticky",
+			"codeActions",
+			"inlineHints.enable",
+			"inlineHints.fontSize",
+			"inlineHints.fontFamily",
+			"lineHeight",
+			"minimap.enabled",
+			"minimap.size.proportional",
+			"minimap.size.fill",
+			"minimap.size.fit",
+			"minimap.size",
+			"minimap.side",
+			"minimap.showSlider",
+			"minimap.scale",
+			"minimap.renderCharacters",
+			"minimap.maxColumn",
+			"padding.top",
+			"padding.bottom",
+			"parameterHints.enabled",
+			"parameterHints.cycle",
+			"quickSuggestions.strings",
+			"quickSuggestions.comments",
+			"quickSuggestions.other",
+			"quickSuggestions",
+			"lineNumbers.off",
+			"lineNumbers.on",
+			"lineNumbers.relative",
+			"lineNumbers.interval",
+			"lineNumbers",
+			"rulers.size",
+			"rulers.color",
+			"rulers",
+			"suggest.insertMode.insert",
+			"suggest.insertMode.replace",
+			"suggest.insertMode",
+			"suggest.filterGraceful",
+			"suggest.localityBonus",
+			"suggest.shareSuggestSelections",
+			"suggest.snippetsPreventQuickSuggestions",
+			"suggest.showIcons",
+			"suggest.showStatusBar",
+			"suggest.showInlineDetails",
+			"suggest.maxVisibleSuggestions.dep",
+			"deprecated",
+			"editor.suggest.showMethods",
+			"editor.suggest.showFunctions",
+			"editor.suggest.showConstructors",
+			"editor.suggest.showFields",
+			"editor.suggest.showVariables",
+			"editor.suggest.showClasss",
+			"editor.suggest.showStructs",
+			"editor.suggest.showInterfaces",
+			"editor.suggest.showModules",
+			"editor.suggest.showPropertys",
+			"editor.suggest.showEvents",
+			"editor.suggest.showOperators",
+			"editor.suggest.showUnits",
+			"editor.suggest.showValues",
+			"editor.suggest.showConstants",
+			"editor.suggest.showEnums",
+			"editor.suggest.showEnumMembers",
+			"editor.suggest.showKeywords",
+			"editor.suggest.showTexts",
+			"editor.suggest.showColors",
+			"editor.suggest.showFiles",
+			"editor.suggest.showReferences",
+			"editor.suggest.showCustomcolors",
+			"editor.suggest.showFolders",
+			"editor.suggest.showTypeParameters",
+			"editor.suggest.showSnippets",
+			"editor.suggest.showUsers",
+			"editor.suggest.showIssues",
+			"selectLeadingAndTrailingWhitespace",
+			"acceptSuggestionOnCommitCharacter",
+			"acceptSuggestionOnEnterSmart",
+			"acceptSuggestionOnEnter",
+			"accessibilityPageSize",
+			"accessibilityPageSize.deprecated",
+			"editorViewAccessibleLabel",
+			"editor.autoClosingBrackets.languageDefined",
+			"editor.autoClosingBrackets.beforeWhitespace",
+			"autoClosingBrackets",
+			"editor.autoClosingDelete.auto",
+			"autoClosingDelete",
+			"editor.autoClosingOvertype.auto",
+			"autoClosingOvertype",
+			"editor.autoClosingQuotes.languageDefined",
+			"editor.autoClosingQuotes.beforeWhitespace",
+			"autoClosingQuotes",
+			"editor.autoIndent.none",
+			"editor.autoIndent.keep",
+			"editor.autoIndent.brackets",
+			"editor.autoIndent.advanced",
+			"editor.autoIndent.full",
+			"autoIndent",
+			"editor.autoSurround.languageDefined",
+			"editor.autoSurround.quotes",
+			"editor.autoSurround.brackets",
+			"autoSurround",
+			"stickyTabStops",
+			"codeLens",
+			"codeLensFontFamily",
+			"codeLensFontSize",
+			"colorDecorators",
+			"columnSelection",
+			"copyWithSyntaxHighlighting",
+			"cursorBlinking",
+			"cursorSmoothCaretAnimation",
+			"cursorStyle",
+			"cursorSurroundingLines",
+			"cursorSurroundingLinesStyle.default",
+			"cursorSurroundingLinesStyle.all",
+			"cursorSurroundingLinesStyle",
+			"cursorWidth",
+			"dragAndDrop",
+			"fastScrollSensitivity",
+			"folding",
+			"foldingStrategy.auto",
+			"foldingStrategy.indentation",
+			"foldingStrategy",
+			"foldingHighlight",
+			"unfoldOnClickAfterEndOfLine",
+			"fontFamily",
+			"formatOnPaste",
+			"formatOnType",
+			"glyphMargin",
+			"hideCursorInOverviewRuler",
+			"highlightActiveIndentGuide",
+			"letterSpacing",
+			"linkedEditing",
+			"links",
+			"matchBrackets",
+			"mouseWheelScrollSensitivity",
+			"mouseWheelZoom",
+			"multiCursorMergeOverlapping",
+			"multiCursorModifier.ctrlCmd",
+			"multiCursorModifier.alt",
+			{
+				"key": "multiCursorModifier",
+				"comment": [
+					"- `ctrlCmd` refers to a value the setting can take and should not be localized.",
+					"- `Control` and `Command` refer to the modifier keys Ctrl or Cmd on the keyboard and can be localized."
+				]
+			},
+			"multiCursorPaste.spread",
+			"multiCursorPaste.full",
+			"multiCursorPaste",
+			"occurrencesHighlight",
+			"overviewRulerBorder",
+			"peekWidgetDefaultFocus.tree",
+			"peekWidgetDefaultFocus.editor",
+			"peekWidgetDefaultFocus",
+			"definitionLinkOpensInPeek",
+			"quickSuggestionsDelay",
+			"renameOnType",
+			"renameOnTypeDeprecate",
+			"renderControlCharacters",
+			"renderIndentGuides",
+			"renderFinalNewline",
+			"renderLineHighlight.all",
+			"renderLineHighlight",
+			"renderLineHighlightOnlyWhenFocus",
+			"renderWhitespace.boundary",
+			"renderWhitespace.selection",
+			"renderWhitespace.trailing",
+			"renderWhitespace",
+			"roundedSelection",
+			"scrollBeyondLastColumn",
+			"scrollBeyondLastLine",
+			"scrollPredominantAxis",
+			"selectionClipboard",
+			"selectionHighlight",
+			"showFoldingControls.always",
+			"showFoldingControls.mouseover",
+			"showFoldingControls",
+			"showUnused",
+			"showDeprecated",
+			"snippetSuggestions.top",
+			"snippetSuggestions.bottom",
+			"snippetSuggestions.inline",
+			"snippetSuggestions.none",
+			"snippetSuggestions",
+			"smoothScrolling",
+			"suggestFontSize",
+			"suggestLineHeight",
+			"suggestOnTriggerCharacters",
+			"suggestSelection.first",
+			"suggestSelection.recentlyUsed",
+			"suggestSelection.recentlyUsedByPrefix",
+			"suggestSelection",
+			"tabCompletion.on",
+			"tabCompletion.off",
+			"tabCompletion.onlySnippets",
+			"tabCompletion",
+			"unusualLineTerminators.auto",
+			"unusualLineTerminators.off",
+			"unusualLineTerminators.prompt",
+			"unusualLineTerminators",
+			"useTabStops",
+			"wordSeparators",
+			"wordWrap.off",
+			"wordWrap.on",
+			{
+				"key": "wordWrap.wordWrapColumn",
+				"comment": [
+					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
+				]
+			},
+			{
+				"key": "wordWrap.bounded",
+				"comment": [
+					"- viewport means the edge of the visible window size.",
+					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
+				]
+			},
+			{
+				"key": "wordWrap",
+				"comment": [
+					"- 'off', 'on', 'wordWrapColumn' and 'bounded' refer to values the setting can take and should not be localized.",
+					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
+				]
+			},
+			{
+				"key": "wordWrapColumn",
+				"comment": [
+					"- `editor.wordWrap` refers to a different setting and should not be localized.",
+					"- 'wordWrapColumn' and 'bounded' refer to values the different setting can take and should not be localized."
+				]
+			},
+			"wrappingIndent.none",
+			"wrappingIndent.same",
+			"wrappingIndent.indent",
+			"wrappingIndent.deepIndent",
+			"wrappingIndent",
+			"wrappingStrategy.simple",
+			"wrappingStrategy.advanced",
+			"wrappingStrategy"
+		],
+		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
+			"TaskDefinition.description",
+			"TaskDefinition.properties",
+			"TaskDefinition.when",
+			"TaskTypeConfiguration.noType",
+			"TaskDefinitionExtPoint"
+		],
+		"vs/workbench/contrib/tasks/common/problemMatcher": [
+			"ProblemPatternParser.problemPattern.missingRegExp",
+			"ProblemPatternParser.loopProperty.notLast",
+			"ProblemPatternParser.problemPattern.kindProperty.notFirst",
+			"ProblemPatternParser.problemPattern.missingProperty",
+			"ProblemPatternParser.problemPattern.missingLocation",
+			"ProblemPatternParser.invalidRegexp",
+			"ProblemPatternSchema.regexp",
+			"ProblemPatternSchema.kind",
+			"ProblemPatternSchema.file",
+			"ProblemPatternSchema.location",
+			"ProblemPatternSchema.line",
+			"ProblemPatternSchema.column",
+			"ProblemPatternSchema.endLine",
+			"ProblemPatternSchema.endColumn",
+			"ProblemPatternSchema.severity",
+			"ProblemPatternSchema.code",
+			"ProblemPatternSchema.message",
+			"ProblemPatternSchema.loop",
+			"NamedProblemPatternSchema.name",
+			"NamedMultiLineProblemPatternSchema.name",
+			"NamedMultiLineProblemPatternSchema.patterns",
+			"ProblemPatternExtPoint",
+			"ProblemPatternRegistry.error",
+			"ProblemPatternRegistry.error",
+			"ProblemMatcherParser.noProblemMatcher",
+			"ProblemMatcherParser.noProblemPattern",
+			"ProblemMatcherParser.noOwner",
+			"ProblemMatcherParser.noFileLocation",
+			"ProblemMatcherParser.unknownSeverity",
+			"ProblemMatcherParser.noDefinedPatter",
+			"ProblemMatcherParser.noIdentifier",
+			"ProblemMatcherParser.noValidIdentifier",
+			"ProblemMatcherParser.problemPattern.watchingMatcher",
+			"ProblemMatcherParser.invalidRegexp",
+			"WatchingPatternSchema.regexp",
+			"WatchingPatternSchema.file",
+			"PatternTypeSchema.name",
+			"PatternTypeSchema.description",
+			"ProblemMatcherSchema.base",
+			"ProblemMatcherSchema.owner",
+			"ProblemMatcherSchema.source",
+			"ProblemMatcherSchema.severity",
+			"ProblemMatcherSchema.applyTo",
+			"ProblemMatcherSchema.fileLocation",
+			"ProblemMatcherSchema.background",
+			"ProblemMatcherSchema.background.activeOnStart",
+			"ProblemMatcherSchema.background.beginsPattern",
+			"ProblemMatcherSchema.background.endsPattern",
+			"ProblemMatcherSchema.watching.deprecated",
+			"ProblemMatcherSchema.watching",
+			"ProblemMatcherSchema.watching.activeOnStart",
+			"ProblemMatcherSchema.watching.beginsPattern",
+			"ProblemMatcherSchema.watching.endsPattern",
+			"LegacyProblemMatcherSchema.watchedBegin.deprecated",
+			"LegacyProblemMatcherSchema.watchedBegin",
+			"LegacyProblemMatcherSchema.watchedEnd.deprecated",
+			"LegacyProblemMatcherSchema.watchedEnd",
+			"NamedProblemMatcherSchema.name",
+			"NamedProblemMatcherSchema.label",
+			"ProblemMatcherExtPoint",
+			"msCompile",
+			"lessCompile",
+			"gulp-tsc",
+			"jshint",
+			"jshint-stylish",
+			"eslint-compact",
+			"eslint-stylish",
+			"go"
+		],
+		"vs/workbench/contrib/tasks/common/taskTemplates": [
+			"dotnetCore",
+			"msbuild",
+			"externalCommand",
+			"Maven"
+		],
+		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
+			"tasks.run.allowAutomatic",
+			"allow",
+			"disallow",
+			"openTask",
+			"openTasks",
+			"workbench.action.tasks.manageAutomaticRunning",
+			"workbench.action.tasks.allowAutomaticTasks",
+			"workbench.action.tasks.disallowAutomaticTasks"
+		],
+		"vs/workbench/contrib/tasks/browser/taskQuickPick": [
+			"taskQuickPick.showAll",
+			"configureTaskIcon",
+			"removeTaskIcon",
+			"configureTask",
+			"contributedTasks",
+			"taskType",
+			"removeRecent",
+			"recentlyUsed",
+			"configured",
+			"configured",
+			"TaskQuickPick.goBack",
+			"TaskQuickPick.noTasksForType",
+			"noProviderForTask"
+		],
+		"vs/platform/theme/common/iconRegistry": [
+			"iconDefintion.fontId",
+			"iconDefintion.fontCharacter",
+			"widgetClose",
+			"previousChangeIcon",
+			"nextChangeIcon"
+		],
+		"vs/workbench/api/common/extHostExtensionActivator": [
+			"failedDep1",
+			"activationError"
+		],
+		"vs/workbench/contrib/debug/common/abstractDebugAdapter": [
+			"timeout"
+		],
+		"vs/workbench/services/configurationResolver/common/variableResolver": [
+			"canNotResolveFile",
+			"canNotResolveFolderForFile",
+			"canNotFindFolder",
+			"canNotResolveWorkspaceFolderMultiRoot",
+			"canNotResolveWorkspaceFolder",
+			"missingEnvVarName",
+			"configNotFound",
+			"configNoString",
+			"missingConfigName",
+			"canNotResolveLineNumber",
+			"canNotResolveSelectedText",
+			"noValueForCommand"
+		],
+		"vs/workbench/api/common/extHost.api.impl": [
+			"extensionLabel"
+		],
+		"vs/workbench/api/node/extHostDebugService": [
+			"debug.terminal.title"
+		],
+		"vs/platform/windows/electron-main/window": [
+			{
+				"key": "reopen",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "wait",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "close",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"appStalled",
+			"appStalledDetail",
+			"appCrashed",
+			"appCrashedDetails",
+			{
+				"key": "reopen",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "close",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"appCrashedDetail",
+			"hiddenMenuBar"
+		],
+		"vs/platform/menubar/electron-main/menubar": [
+			{
+				"key": "miNewWindow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mEdit",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mSelection",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mView",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mGoto",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mRun",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mWindow",
+			{
+				"key": "mHelp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mAbout",
+			{
+				"key": "miPreferences",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mServices",
+			"mHide",
+			"mHideOthers",
+			"mShowAll",
+			"miQuit",
+			"mMinimize",
+			"mZoom",
+			"mBringToFront",
+			{
+				"key": "miSwitchWindow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mNewTab",
+			"mShowPreviousTab",
+			"mShowNextTab",
+			"mMoveTabToNewWindow",
+			"mMergeAllWindows",
+			"miCheckForUpdates",
+			"miCheckingForUpdates",
+			"miDownloadUpdate",
+			"miDownloadingUpdate",
+			"miInstallUpdate",
+			"miInstallingUpdate",
+			"miRestartToUpdate"
+		],
+		"vs/platform/userDataSync/common/abstractSynchronizer": [
+			{
+				"key": "incompatible",
+				"comment": [
+					"This is an error while syncing a resource that its local version is not compatible with its remote version."
+				]
+			},
+			"incompatible sync data"
+		],
+		"vs/editor/common/view/editorColorRegistry": [
+			"lineHighlight",
+			"lineHighlightBorderBox",
+			"rangeHighlight",
+			"rangeHighlightBorder",
+			"symbolHighlight",
+			"symbolHighlightBorder",
+			"caret",
+			"editorCursorBackground",
+			"editorWhitespaces",
+			"editorIndentGuides",
+			"editorActiveIndentGuide",
+			"editorLineNumbers",
+			"editorActiveLineNumber",
+			"deprecatedEditorActiveLineNumber",
+			"editorActiveLineNumber",
+			"editorRuler",
+			"editorCodeLensForeground",
+			"editorBracketMatchBackground",
+			"editorBracketMatchBorder",
+			"editorOverviewRulerBorder",
+			"editorOverviewRulerBackground",
+			"editorGutter",
+			"unnecessaryCodeBorder",
+			"unnecessaryCodeOpacity",
+			"overviewRulerRangeHighlight",
+			"overviewRuleError",
+			"overviewRuleWarning",
+			"overviewRuleInfo"
+		],
+		"vs/editor/common/modes/modesRegistry": [
+			"plainText.alias"
+		],
+		"vs/editor/common/model/editStack": [
+			"edit"
+		],
+		"vs/editor/browser/controller/coreCommands": [
+			"stickydesc",
+			"stickydesc",
+			"removedCursor"
+		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"cursors.maximum"
+		],
+		"vs/editor/contrib/anchorSelect/anchorSelect": [
+			"selectionAnchor",
+			"anchorSet",
+			"setSelectionAnchor",
+			"goToSelectionAnchor",
+			"selectFromAnchorToCursor",
+			"cancelSelectionAnchor"
+		],
+		"vs/editor/browser/widget/diffEditorWidget": [
+			"diffInsertIcon",
+			"diffRemoveIcon",
+			"diff.tooLarge"
+		],
+		"vs/editor/contrib/bracketMatching/bracketMatching": [
+			"overviewRulerBracketMatchForeground",
+			"smartSelect.jumpBracket",
+			"smartSelect.selectToBracket",
+			{
+				"key": "miGoToBracket",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/caretOperations/caretOperations": [
+			"caret.moveLeft",
+			"caret.moveRight"
+		],
+		"vs/editor/contrib/caretOperations/transpose": [
+			"transposeLetters.label"
+		],
+		"vs/editor/contrib/codelens/codelensController": [
+			"showLensOnLine"
+		],
+		"vs/editor/contrib/comment/comment": [
+			"comment.line",
+			{
+				"key": "miToggleLineComment",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"comment.line.add",
+			"comment.line.remove",
+			"comment.block",
+			{
+				"key": "miToggleBlockComment",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/contextmenu/contextmenu": [
+			"action.showContextMenu.label"
+		],
+		"vs/editor/contrib/cursorUndo/cursorUndo": [
+			"cursor.undo",
+			"cursor.redo"
+		],
+		"vs/editor/contrib/find/findController": [
+			"startFindAction",
+			{
+				"key": "miFind",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"startFindWithSelectionAction",
+			"findNextMatchAction",
+			"findNextMatchAction",
+			"findPreviousMatchAction",
+			"findPreviousMatchAction",
+			"nextSelectionMatchFindAction",
+			"previousSelectionMatchFindAction",
+			"startReplace",
+			{
+				"key": "miReplace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/fontZoom/fontZoom": [
+			"EditorFontZoomIn.label",
+			"EditorFontZoomOut.label",
+			"EditorFontZoomReset.label"
+		],
+		"vs/editor/contrib/folding/folding": [
+			"unfoldAction.label",
+			"unFoldRecursivelyAction.label",
+			"foldAction.label",
+			"toggleFoldAction.label",
+			"foldRecursivelyAction.label",
+			"foldAllBlockComments.label",
+			"foldAllMarkerRegions.label",
+			"unfoldAllMarkerRegions.label",
+			"foldAllExcept.label",
+			"unfoldAllExcept.label",
+			"foldAllAction.label",
+			"unfoldAllAction.label",
+			"foldLevelAction.label",
+			"foldBackgroundBackground",
+			"editorGutter.foldingControlForeground"
+		],
+		"vs/editor/contrib/format/formatActions": [
+			"formatDocument.label",
+			"formatSelection.label"
+		],
+		"vs/editor/contrib/gotoSymbol/goToCommands": [
+			"peek.submenu",
+			"def.title",
+			"noResultWord",
+			"generic.noResults",
+			"actions.goToDecl.label",
+			{
+				"key": "miGotoDefinition",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.goToDeclToSide.label",
+			"actions.previewDecl.label",
+			"decl.title",
+			"decl.noResultWord",
+			"decl.generic.noResults",
+			"actions.goToDeclaration.label",
+			{
+				"key": "miGotoDeclaration",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"decl.noResultWord",
+			"decl.generic.noResults",
+			"actions.peekDecl.label",
+			"typedef.title",
+			"goToTypeDefinition.noResultWord",
+			"goToTypeDefinition.generic.noResults",
+			"actions.goToTypeDefinition.label",
+			{
+				"key": "miGotoTypeDefinition",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.peekTypeDefinition.label",
+			"impl.title",
+			"goToImplementation.noResultWord",
+			"goToImplementation.generic.noResults",
+			"actions.goToImplementation.label",
+			{
+				"key": "miGotoImplementation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.peekImplementation.label",
+			"references.no",
+			"references.noGeneric",
+			"goToReferences.label",
+			{
+				"key": "miGotoReference",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"ref.title",
+			"references.action.label",
+			"ref.title",
+			"label.generic",
+			"generic.title",
+			"generic.noResult",
+			"ref.title"
+		],
+		"vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition": [
+			"multipleResults"
+		],
+		"vs/editor/contrib/gotoError/gotoError": [
+			"markerAction.next.label",
+			"nextMarkerIcon",
+			"markerAction.previous.label",
+			"previousMarkerIcon",
+			"markerAction.nextInFiles.label",
+			{
+				"key": "miGotoNextProblem",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"markerAction.previousInFiles.label",
+			{
+				"key": "miGotoPreviousProblem",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/hover/hover": [
+			{
+				"key": "showHover",
+				"comment": [
+					"Label for action that will trigger the showing of a hover in the editor.",
+					"This allows for users to show the hover without using the mouse."
+				]
+			},
+			{
+				"key": "showDefinitionPreviewHover",
+				"comment": [
+					"Label for action that will trigger the showing of definition preview hover in the editor.",
+					"This allows for users to show the definition preview hover without using the mouse."
+				]
+			}
+		],
+		"vs/editor/contrib/indentation/indentation": [
+			"indentationToSpaces",
+			"indentationToTabs",
+			"configuredTabSize",
+			{
+				"key": "selectTabWidth",
+				"comment": [
+					"Tab corresponds to the tab key"
+				]
+			},
+			"indentUsingTabs",
+			"indentUsingSpaces",
+			"detectIndentation",
+			"editor.reindentlines",
+			"editor.reindentselectedlines"
+		],
+		"vs/editor/contrib/inPlaceReplace/inPlaceReplace": [
+			"InPlaceReplaceAction.previous.label",
+			"InPlaceReplaceAction.next.label"
+		],
+		"vs/editor/contrib/linesOperations/linesOperations": [
+			"lines.copyUp",
+			{
+				"key": "miCopyLinesUp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"lines.copyDown",
+			{
+				"key": "miCopyLinesDown",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"duplicateSelection",
+			{
+				"key": "miDuplicateSelection",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"lines.moveUp",
+			{
+				"key": "miMoveLinesUp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"lines.moveDown",
+			{
+				"key": "miMoveLinesDown",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"lines.sortAscending",
+			"lines.sortDescending",
+			"lines.trimTrailingWhitespace",
+			"lines.delete",
+			"lines.indent",
+			"lines.outdent",
+			"lines.insertBefore",
+			"lines.insertAfter",
+			"lines.deleteAllLeft",
+			"lines.deleteAllRight",
+			"lines.joinLines",
+			"editor.transpose",
+			"editor.transformToUppercase",
+			"editor.transformToLowercase",
+			"editor.transformToTitlecase",
+			"editor.transformToSnakecase"
+		],
+		"vs/editor/contrib/linkedEditing/linkedEditing": [
+			"linkedEditing.label",
+			"editorLinkedEditingBackground"
+		],
+		"vs/editor/contrib/links/links": [
+			"links.navigate.executeCmd",
+			"links.navigate.follow",
+			"links.navigate.kb.meta.mac",
+			"links.navigate.kb.meta",
+			"links.navigate.kb.alt.mac",
+			"links.navigate.kb.alt",
+			"tooltip.explanation",
+			"invalid.url",
+			"missing.url",
+			"label"
+		],
+		"vs/editor/contrib/parameterHints/parameterHints": [
+			"parameterHints.trigger.label"
+		],
+		"vs/editor/contrib/multicursor/multicursor": [
+			"cursorAdded",
+			"cursorsAdded",
+			"mutlicursor.insertAbove",
+			{
+				"key": "miInsertCursorAbove",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mutlicursor.insertBelow",
+			{
+				"key": "miInsertCursorBelow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mutlicursor.insertAtEndOfEachLineSelected",
+			{
+				"key": "miInsertCursorAtEndOfEachLineSelected",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mutlicursor.addCursorsToBottom",
+			"mutlicursor.addCursorsToTop",
+			"addSelectionToNextFindMatch",
+			{
+				"key": "miAddSelectionToNextFindMatch",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"addSelectionToPreviousFindMatch",
+			{
+				"key": "miAddSelectionToPreviousFindMatch",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"moveSelectionToNextFindMatch",
+			"moveSelectionToPreviousFindMatch",
+			"selectAllOccurrencesOfFindMatch",
+			{
+				"key": "miSelectHighlights",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"changeAll.label"
+		],
+		"vs/editor/contrib/smartSelect/smartSelect": [
+			"smartSelect.expand",
+			{
+				"key": "miSmartSelectGrow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"smartSelect.shrink",
+			{
+				"key": "miSmartSelectShrink",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/rename/rename": [
+			"no result",
+			"resolveRenameLocationFailed",
+			"label",
+			"quotableLabel",
+			"aria",
+			"rename.failedApply",
+			"rename.failed",
+			"rename.label",
+			"enablePreview"
+		],
+		"vs/editor/contrib/snippet/snippetController2": [
+			"inSnippetMode",
+			"hasNextTabstop",
+			"hasPrevTabstop"
+		],
+		"vs/editor/contrib/suggest/suggestController": [
+			"aria.alert.snippet",
+			"suggest.trigger.label",
+			"accept.insert",
+			"accept.insert",
+			"accept.replace",
+			"accept.replace",
+			"accept.insert",
+			"detail.more",
+			"detail.less",
+			"suggest.reset.label"
+		],
+		"vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode": [
+			{
+				"key": "toggle.tabMovesFocus",
+				"comment": [
+					"Turn on/off use of tab key for moving focus around VS Code"
+				]
+			},
+			"toggle.tabMovesFocus.on",
+			"toggle.tabMovesFocus.off"
+		],
+		"vs/editor/contrib/tokenization/tokenization": [
+			"forceRetokenize"
+		],
+		"vs/editor/contrib/unusualLineTerminators/unusualLineTerminators": [
+			"unusualLineTerminators.title",
+			"unusualLineTerminators.message",
+			"unusualLineTerminators.detail",
+			"unusualLineTerminators.fix",
+			"unusualLineTerminators.ignore"
+		],
+		"vs/editor/contrib/wordHighlighter/wordHighlighter": [
+			"wordHighlight",
+			"wordHighlightStrong",
+			"wordHighlightBorder",
+			"wordHighlightStrongBorder",
+			"overviewRulerWordHighlightForeground",
+			"overviewRulerWordHighlightStrongForeground",
+			"wordHighlight.next.label",
+			"wordHighlight.previous.label",
+			"wordHighlight.trigger.label"
+		],
+		"vs/editor/contrib/wordOperations/wordOperations": [
+			"deleteInsideWord"
+		],
+		"vs/editor/common/standaloneStrings": [
+			"noSelection",
+			"singleSelectionRange",
+			"singleSelection",
+			"multiSelectionRange",
+			"multiSelection",
+			"emergencyConfOn",
+			"openingDocs",
+			"readonlyDiffEditor",
+			"editableDiffEditor",
+			"readonlyEditor",
+			"editableEditor",
+			"changeConfigToOnMac",
+			"changeConfigToOnWinLinux",
+			"auto_on",
+			"auto_off",
+			"tabFocusModeOnMsg",
+			"tabFocusModeOnMsgNoKb",
+			"tabFocusModeOffMsg",
+			"tabFocusModeOffMsgNoKb",
+			"openDocMac",
+			"openDocWinLinux",
+			"outroMsg",
+			"showAccessibilityHelpAction",
+			"inspectTokens",
+			"gotoLineActionLabel",
+			"helpQuickAccess",
+			"quickCommandActionLabel",
+			"quickCommandActionHelp",
+			"quickOutlineActionLabel",
+			"quickOutlineByCategoryActionLabel",
+			"editorViewAccessibleLabel",
+			"accessibilityHelpMessage",
+			"toggleHighContrast",
+			"bulkEditServiceSummary"
+		],
+		"vs/workbench/api/common/jsonValidationExtensionPoint": [
+			"contributes.jsonValidation",
+			"contributes.jsonValidation.fileMatch",
+			"contributes.jsonValidation.url",
+			"invalid.jsonValidation",
+			"invalid.fileMatch",
+			"invalid.url",
+			"invalid.path.1",
+			"invalid.url.fileschema",
+			"invalid.url.schema"
+		],
+		"vs/workbench/services/themes/common/colorExtensionPoint": [
+			"contributes.color",
+			"contributes.color.id",
+			"contributes.color.id.format",
+			"contributes.color.description",
+			"contributes.defaults.light",
+			"contributes.defaults.dark",
+			"contributes.defaults.highContrast",
+			"invalid.colorConfiguration",
+			"invalid.default.colorType",
+			"invalid.id",
+			"invalid.id.format",
+			"invalid.description",
+			"invalid.defaults"
+		],
+		"vs/workbench/services/themes/common/iconExtensionPoint": [
+			"contributes.icons",
+			"contributes.icon.id",
+			"contributes.icon.id.format",
+			"contributes.icon.description",
+			"contributes.icon.default.fontId",
+			"contributes.icon.default.fontCharacter",
+			"contributes.icon.default",
+			"contributes.iconFonts",
+			"contributes.iconFonts.id",
+			"contributes.iconFonts.id.formatError",
+			"contributes.iconFonts.src",
+			"contributes.iconFonts.src.path",
+			"contributes.iconFonts.src.format",
+			"invalid.icons.proposedAPI",
+			"invalid.icons.configuration",
+			"invalid.icons.id",
+			"invalid.icons.id.format",
+			"invalid.icons.description",
+			"invalid.icons.default",
+			"invalid.iconFonts.proposedAPI",
+			"invalid.iconFonts.configuration",
+			"invalid.iconFonts.id",
+			"invalid.iconFonts.id.format",
+			"invalid.iconFonts.src",
+			"invalid.iconFonts.src.path",
+			"invalid.iconFonts.src.item"
+		],
+		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
+			"contributes.semanticTokenTypes",
+			"contributes.semanticTokenTypes.id",
+			"contributes.semanticTokenTypes.id.format",
+			"contributes.semanticTokenTypes.superType",
+			"contributes.semanticTokenTypes.superType.format",
+			"contributes.color.description",
+			"contributes.semanticTokenModifiers",
+			"contributes.semanticTokenModifiers.id",
+			"contributes.semanticTokenModifiers.id.format",
+			"contributes.semanticTokenModifiers.description",
+			"contributes.semanticTokenScopes",
+			"contributes.semanticTokenScopes.languages",
+			"contributes.semanticTokenScopes.scopes",
+			"invalid.id",
+			"invalid.id.format",
+			"invalid.superType.format",
+			"invalid.description",
+			"invalid.semanticTokenTypeConfiguration",
+			"invalid.semanticTokenModifierConfiguration",
+			"invalid.semanticTokenScopes.configuration",
+			"invalid.semanticTokenScopes.language",
+			"invalid.semanticTokenScopes.scopes",
+			"invalid.semanticTokenScopes.scopes.value",
+			"invalid.semanticTokenScopes.scopes.selector"
+		],
+		"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint": [
+			"parseErrors",
+			"formatError",
+			"schema.openBracket",
+			"schema.closeBracket",
+			"schema.comments",
+			"schema.blockComments",
+			"schema.blockComment.begin",
+			"schema.blockComment.end",
+			"schema.lineComment",
+			"schema.brackets",
+			"schema.autoClosingPairs",
+			"schema.autoClosingPairs.notIn",
+			"schema.autoCloseBefore",
+			"schema.surroundingPairs",
+			"schema.wordPattern",
+			"schema.wordPattern.pattern",
+			"schema.wordPattern.flags",
+			"schema.wordPattern.flags.errorMessage",
+			"schema.indentationRules",
+			"schema.indentationRules.increaseIndentPattern",
+			"schema.indentationRules.increaseIndentPattern.pattern",
+			"schema.indentationRules.increaseIndentPattern.flags",
+			"schema.indentationRules.increaseIndentPattern.errorMessage",
+			"schema.indentationRules.decreaseIndentPattern",
+			"schema.indentationRules.decreaseIndentPattern.pattern",
+			"schema.indentationRules.decreaseIndentPattern.flags",
+			"schema.indentationRules.decreaseIndentPattern.errorMessage",
+			"schema.indentationRules.indentNextLinePattern",
+			"schema.indentationRules.indentNextLinePattern.pattern",
+			"schema.indentationRules.indentNextLinePattern.flags",
+			"schema.indentationRules.indentNextLinePattern.errorMessage",
+			"schema.indentationRules.unIndentedLinePattern",
+			"schema.indentationRules.unIndentedLinePattern.pattern",
+			"schema.indentationRules.unIndentedLinePattern.flags",
+			"schema.indentationRules.unIndentedLinePattern.errorMessage",
+			"schema.folding",
+			"schema.folding.offSide",
+			"schema.folding.markers",
+			"schema.folding.markers.start",
+			"schema.folding.markers.end",
+			"schema.onEnterRules",
+			"schema.onEnterRules",
+			"schema.onEnterRules.beforeText",
+			"schema.onEnterRules.beforeText.pattern",
+			"schema.onEnterRules.beforeText.flags",
+			"schema.onEnterRules.beforeText.errorMessage",
+			"schema.onEnterRules.afterText",
+			"schema.onEnterRules.afterText.pattern",
+			"schema.onEnterRules.afterText.flags",
+			"schema.onEnterRules.afterText.errorMessage",
+			"schema.onEnterRules.previousLineText",
+			"schema.onEnterRules.previousLineText.pattern",
+			"schema.onEnterRules.previousLineText.flags",
+			"schema.onEnterRules.previousLineText.errorMessage",
+			"schema.onEnterRules.action",
+			"schema.onEnterRules.action.indent",
+			"schema.onEnterRules.action.indent.none",
+			"schema.onEnterRules.action.indent.indent",
+			"schema.onEnterRules.action.indent.indentOutdent",
+			"schema.onEnterRules.action.indent.outdent",
+			"schema.onEnterRules.action.appendText",
+			"schema.onEnterRules.action.removeText"
+		],
+		"vs/workbench/api/browser/mainThreadCLICommands": [
+			"cannot be installed"
+		],
+		"vs/workbench/api/browser/mainThreadExtensionService": [
+			"reload window",
+			"reload",
+			"disabledDep",
+			"enable dep",
+			"uninstalledDep",
+			"install missing dep",
+			"unknownDep"
+		],
+		"vs/workbench/api/browser/mainThreadFileSystemEventService": [
+			"ask.1.create",
+			"ask.1.copy",
+			"ask.1.move",
+			"ask.1.delete",
+			{
+				"key": "ask.N.create",
+				"comment": [
+					"{0} is a number, e.g \"3 extensions want...\""
+				]
+			},
+			{
+				"key": "ask.N.copy",
+				"comment": [
+					"{0} is a number, e.g \"3 extensions want...\""
+				]
+			},
+			{
+				"key": "ask.N.move",
+				"comment": [
+					"{0} is a number, e.g \"3 extensions want...\""
+				]
+			},
+			{
+				"key": "ask.N.delete",
+				"comment": [
+					"{0} is a number, e.g \"3 extensions want...\""
+				]
+			},
+			"preview",
+			"cancel",
+			"ok",
+			"preview",
+			"cancel",
+			"again",
+			"msg-create",
+			"msg-rename",
+			"msg-copy",
+			"msg-delete",
+			"label",
+			"files.participants.timeout"
+		],
+		"vs/workbench/api/browser/mainThreadMessageService": [
+			"extensionSource",
+			"defaultSource",
+			"manageExtension",
+			"cancel",
+			"ok"
+		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"manageExtension"
+		],
+		"vs/workbench/api/browser/mainThreadSaveParticipant": [
+			"timeout.onWillSave"
+		],
+		"vs/workbench/api/browser/mainThreadUriOpeners": [
+			"openerFailedUseDefault",
+			{
+				"key": "openerFailedMessage",
+				"comment": [
+					"{0} is the id of the opener. {1} is the url being opened."
+				]
+			}
+		],
+		"vs/workbench/api/browser/mainThreadWorkspace": [
+			"folderStatusMessageAddSingleFolder",
+			"folderStatusMessageAddMultipleFolders",
+			"folderStatusMessageRemoveSingleFolder",
+			"folderStatusMessageRemoveMultipleFolders",
+			"folderStatusChangeFolder"
+		],
+		"vs/workbench/api/browser/mainThreadComments": [
+			"commentsViewIcon"
+		],
+		"vs/workbench/api/browser/mainThreadTask": [
+			"task.label"
+		],
+		"vs/workbench/api/browser/mainThreadTunnelService": [
+			"remote.tunnel.openTunnel",
+			"remote.tunnelsView.elevationButton"
+		],
+		"vs/workbench/api/browser/mainThreadAuthentication": [
+			"noTrustedExtensions",
+			{
+				"key": "accountLastUsedDate",
+				"comment": [
+					"The placeholder {0} is a string with time information, such as \"3 days ago\""
+				]
+			},
+			"notUsed",
+			"manageTrustedExtensions",
+			"manageExensions",
+			"signOutMessagve",
+			"signOutMessageSimple",
+			"signOut",
+			"cancel",
+			"signedOut",
+			"confirmLogin",
+			"allow",
+			"cancel"
+		],
+		"vs/workbench/common/viewlet": [
+			"sideBarVisible",
+			"sideBarFocus",
+			"activeViewlet"
+		],
+		"vs/workbench/browser/contextkeys": [
+			"workbenchState",
+			"workspaceFolderCount",
+			"dirtyWorkingCopies",
+			"remoteName",
+			"isFullscreen"
+		],
+		"vs/workbench/browser/quickaccess": [
+			"inQuickOpen"
+		],
+		"vs/workbench/browser/parts/editor/textResourceEditor": [
+			"textEditor"
+		],
+		"vs/workbench/common/editor/diffEditorInput": [
+			"sideBySideLabels"
+		],
+		"vs/workbench/browser/parts/editor/textDiffEditor": [
+			"textDiffEditor"
+		],
+		"vs/workbench/browser/parts/editor/untitledHint": [
+			"selectALanguage",
+			"selectAlanguage",
+			"toGetStarted",
+			"dontshow",
+			"thisAgain"
+		],
+		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
+			"metadataDiff"
+		],
+		"vs/workbench/browser/parts/editor/editorStatus": [
+			"singleSelectionRange",
+			"singleSelection",
+			"multiSelectionRange",
+			"multiSelection",
+			"endOfLineLineFeed",
+			"endOfLineCarriageReturnLineFeed",
+			"screenReaderDetectedExplanation.question",
+			"screenReaderDetectedExplanation.answerYes",
+			"screenReaderDetectedExplanation.answerNo",
+			"noEditor",
+			"noWritableCodeEditor",
+			"indentConvert",
+			"indentView",
+			"pickAction",
+			"tabFocusModeEnabled",
+			"disableTabMode",
+			"status.editor.tabFocusMode",
+			"columnSelectionModeEnabled",
+			"disableColumnSelectionMode",
+			"status.editor.columnSelectionMode",
+			"screenReaderDetected",
+			"status.editor.screenReaderMode",
+			"gotoLine",
+			"status.editor.selection",
+			"selectIndentation",
+			"status.editor.indentation",
+			"selectEncoding",
+			"status.editor.encoding",
+			"selectEOL",
+			"status.editor.eol",
+			"selectLanguageMode",
+			"status.editor.mode",
+			"fileInfo",
+			"status.editor.info",
+			"spacesSize",
+			{
+				"key": "tabSize",
+				"comment": [
+					"Tab corresponds to the tab key"
+				]
+			},
+			"currentProblem",
+			"showLanguageExtensions",
+			"changeMode",
+			"noEditor",
+			"languageDescription",
+			"languageDescriptionConfigured",
+			"languagesPicks",
+			"configureModeSettings",
+			"configureAssociationsExt",
+			"autoDetect",
+			"pickLanguage",
+			"currentAssociation",
+			"pickLanguageToConfigure",
+			"changeEndOfLine",
+			"noEditor",
+			"noWritableCodeEditor",
+			"pickEndOfLine",
+			"changeEncoding",
+			"noEditor",
+			"noEditor",
+			"noFileEditor",
+			"saveWithEncoding",
+			"reopenWithEncoding",
+			"pickAction",
+			"guessedEncoding",
+			"pickEncodingForReopen",
+			"pickEncodingForSave"
+		],
+		"vs/workbench/browser/parts/editor/editorActions": [
+			"splitEditor",
+			"splitEditorOrthogonal",
+			"splitEditorGroupLeft",
+			"splitEditorGroupRight",
+			"splitEditorGroupUp",
+			"splitEditorGroupDown",
+			"joinTwoGroups",
+			"joinAllGroups",
+			"navigateEditorGroups",
+			"focusActiveEditorGroup",
+			"focusFirstEditorGroup",
+			"focusLastEditorGroup",
+			"focusNextGroup",
+			"focusPreviousGroup",
+			"focusLeftGroup",
+			"focusRightGroup",
+			"focusAboveGroup",
+			"focusBelowGroup",
+			"closeEditor",
+			"unpinEditor",
+			"closeOneEditor",
+			"revertAndCloseActiveEditor",
+			"closeEditorsToTheLeft",
+			"closeAllEditors",
+			"closeAllGroups",
+			"closeEditorsInOtherGroups",
+			"closeEditorInAllGroups",
+			"moveActiveGroupLeft",
+			"moveActiveGroupRight",
+			"moveActiveGroupUp",
+			"moveActiveGroupDown",
+			"duplicateActiveGroupLeft",
+			"duplicateActiveGroupRight",
+			"duplicateActiveGroupUp",
+			"duplicateActiveGroupDown",
+			"minimizeOtherEditorGroups",
+			"evenEditorGroups",
+			"toggleEditorWidths",
+			"maximizeEditor",
+			"openNextEditor",
+			"openPreviousEditor",
+			"nextEditorInGroup",
+			"openPreviousEditorInGroup",
+			"firstEditorInGroup",
+			"lastEditorInGroup",
+			"navigateNext",
+			"navigatePrevious",
+			"navigateToLastEditLocation",
+			"navigateLast",
+			"reopenClosedEditor",
+			"clearRecentFiles",
+			"showEditorsInActiveGroup",
+			"showAllEditors",
+			"showAllEditorsByMostRecentlyUsed",
+			"quickOpenPreviousRecentlyUsedEditor",
+			"quickOpenLeastRecentlyUsedEditor",
+			"quickOpenPreviousRecentlyUsedEditorInGroup",
+			"quickOpenLeastRecentlyUsedEditorInGroup",
+			"navigateEditorHistoryByInput",
+			"openNextRecentlyUsedEditor",
+			"openPreviousRecentlyUsedEditor",
+			"openNextRecentlyUsedEditorInGroup",
+			"openPreviousRecentlyUsedEditorInGroup",
+			"clearEditorHistory",
+			"moveEditorLeft",
+			"moveEditorRight",
+			"moveEditorToPreviousGroup",
+			"moveEditorToNextGroup",
+			"moveEditorToAboveGroup",
+			"moveEditorToBelowGroup",
+			"moveEditorToLeftGroup",
+			"moveEditorToRightGroup",
+			"moveEditorToFirstGroup",
+			"moveEditorToLastGroup",
+			"editorLayoutSingle",
+			"editorLayoutTwoColumns",
+			"editorLayoutThreeColumns",
+			"editorLayoutTwoRows",
+			"editorLayoutThreeRows",
+			"editorLayoutTwoByTwoGrid",
+			"editorLayoutTwoColumnsBottom",
+			"editorLayoutTwoRowsRight",
+			"newEditorLeft",
+			"newEditorRight",
+			"newEditorAbove",
+			"newEditorBelow",
+			"workbench.action.reopenWithEditor",
+			"workbench.action.toggleEditorType"
+		],
+		"vs/workbench/browser/codeeditor": [
+			"openWorkspace"
+		],
+		"vs/workbench/browser/parts/editor/editorCommands": [
+			"editorCommand.activeEditorMove.description",
+			"editorCommand.activeEditorMove.arg.name",
+			"editorCommand.activeEditorMove.arg.description",
+			"toggleInlineView",
+			"compare"
+		],
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"noViewResults",
+			"entryAriaLabelWithGroupDirty",
+			"entryAriaLabelWithGroup",
+			"entryAriaLabelDirty",
+			"closeEditor"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"ariaLabelGroupActions",
+			"closeGroupAction",
+			"emptyEditorGroup",
+			"groupLabel",
+			"groupAriaLabel",
+			"ok",
+			"cancel",
+			"editorOpenErrorDialog",
+			"editorOpenError"
+		],
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"fileTooLarge"
+		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
-			"goHome",
-			"hideHomeButton",
 			"manageTrustedExtensions",
 			"signOut",
 			"authProviderUnavailable",
+			"noAccounts",
 			"hideAccounts",
 			"previousSideBarView",
 			"nextSideBarView"
@@ -6374,8 +6708,57 @@
 				"comment": [
 					"&& denotes a mnemonic"
 				]
-			},
-			"goHome"
+			}
+		],
+		"vs/workbench/browser/parts/views/treeView": [
+			"no-dataprovider",
+			"treeView.enableCollapseAll",
+			"treeView.toggleCollapseAll",
+			"treeView.enableRefresh",
+			"refresh",
+			"collapseAll",
+			"command-error"
+		],
+		"vs/workbench/browser/parts/views/viewPaneContainer": [
+			"views",
+			"viewMoveUp",
+			"viewMoveLeft",
+			"viewMoveDown",
+			"viewMoveRight"
+		],
+		"vs/workbench/contrib/files/common/files": [
+			"explorerViewletVisible",
+			"explorerResourceIsFolder",
+			"explorerResourceReadonly",
+			"explorerResourceIsRoot",
+			"explorerResourceCut",
+			"explorerResourceMoveableToTrash",
+			"filesExplorerFocus",
+			"openEditorsVisible",
+			"openEditorsFocus",
+			"explorerViewletFocus",
+			"explorerViewletCompressedFocus",
+			"explorerViewletCompressedFirstFocus",
+			"explorerViewletCompressedLastFocus"
+		],
+		"vs/workbench/contrib/remote/browser/remoteExplorer": [
+			"ports",
+			"1forwardedPort",
+			"nForwardedPorts",
+			"status.forwardedPorts",
+			"remote.forwardedPorts.statusbarTextNone",
+			"remote.forwardedPorts.statusbarTooltip",
+			"remote.tunnelsView.automaticForward",
+			"remote.tunnelsView.notificationLink",
+			"remote.tunnelsView.elevationMessage",
+			"remote.tunnelsView.elevationButton"
+		],
+		"vs/workbench/common/panel": [
+			"activePanel",
+			"panelFocus",
+			"panelPosition",
+			"panelVisible",
+			"panelMaximized"
 		],
 		"vs/workbench/browser/parts/compositePart": [
 			"ariaCompositeToolbarLabel",
@@ -6425,23 +6808,34 @@
 		"vs/workbench/services/textfile/common/textFileEditorModel": [
 			"saveFileFirst"
 		],
-		"vs/workbench/common/editor/diffEditorInput": [
-			"sideBySideLabels"
-		],
-		"vs/workbench/services/editor/common/editorOpenWith": [
-			"promptOpenWith.currentlyActive",
-			"promptOpenWith.setDefaultTooltip",
-			"promptOpenWith.placeHolder",
-			"builtinProviderDisplayName",
-			"promptOpenWith.defaultEditor.displayName",
-			"editor.editorAssociations",
-			"editor.editorAssociations.viewType",
-			"editor.editorAssociations.filenamePattern",
-			"promptOpenWith.defaultEditor.displayName"
-		],
 		"vs/platform/keybinding/common/abstractKeybindingService": [
 			"first.chord",
 			"missing.chord"
+		],
+		"vs/workbench/services/themes/common/colorThemeData": [
+			"error.cannotparsejson",
+			"error.invalidformat",
+			{
+				"key": "error.invalidformat.colors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			{
+				"key": "error.invalidformat.tokenColors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			{
+				"key": "error.invalidformat.semanticTokenColors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			"error.plist.invalidformat",
+			"error.cannotparse",
+			"error.cannotload"
 		],
 		"vs/workbench/services/themes/common/fileIconThemeSchema": [
 			"schema.folderExpanded",
@@ -6476,31 +6870,6 @@
 			"schema.light",
 			"schema.highContrast",
 			"schema.hidesExplorerArrows"
-		],
-		"vs/workbench/services/themes/common/colorThemeData": [
-			"error.cannotparsejson",
-			"error.invalidformat",
-			{
-				"key": "error.invalidformat.colors",
-				"comment": [
-					"{0} will be replaced by a path. Values in quotes should not be translated."
-				]
-			},
-			{
-				"key": "error.invalidformat.tokenColors",
-				"comment": [
-					"{0} will be replaced by a path. Values in quotes should not be translated."
-				]
-			},
-			{
-				"key": "error.invalidformat.semanticTokenColors",
-				"comment": [
-					"{0} will be replaced by a path. Values in quotes should not be translated."
-				]
-			},
-			"error.plist.invalidformat",
-			"error.cannotparse",
-			"error.cannotload"
 		],
 		"vs/workbench/services/themes/browser/fileIconThemeData": [
 			"error.cannotparseicontheme",
@@ -6605,6 +6974,16 @@
 			"error.icon.fontId",
 			"error.icon.fontCharacter"
 		],
+		"vs/workbench/services/themes/common/productIconThemeSchema": [
+			"schema.id",
+			"schema.id.formatError",
+			"schema.src",
+			"schema.font-path",
+			"schema.font-format",
+			"schema.font-weight",
+			"schema.font-style",
+			"schema.iconDefinitions"
+		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
 			"bisect",
 			"title.start",
@@ -6630,20 +7009,15 @@
 			"title.stop",
 			"help"
 		],
-		"vs/workbench/services/themes/common/productIconThemeSchema": [
-			"schema.id",
-			"schema.id.formatError",
-			"schema.src",
-			"schema.font-path",
-			"schema.font-format",
-			"schema.font-weight",
-			"schema.font-style",
-			"schema.iconDefinitions"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"configureLanguageBasedSettings",
-			"languageDescriptionConfigured",
-			"pickLanguage"
+		"vs/editor/contrib/suggest/suggest": [
+			"suggestWidgetVisible",
+			"suggestWidgetDetailsVisible",
+			"suggestWidgetMultipleSuggestions",
+			"suggestionMakesTextEdit",
+			"acceptSuggestionOnEnter",
+			"suggestionHasInsertAndReplaceRange",
+			"suggestionInsertMode",
+			"suggestionCanResolve"
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"recordKeysLabel",
@@ -6679,6 +7053,11 @@
 			"keybindingsLabel",
 			"noKeybinding",
 			"noWhen"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"configureLanguageBasedSettings",
+			"languageDescriptionConfigured",
+			"pickLanguage"
 		],
 		"vs/workbench/contrib/preferences/browser/preferencesEditor": [
 			"SearchSettingsWidget.AriaLabel",
@@ -6737,76 +7116,8 @@
 			"defineKeybinding.existing",
 			"defineKeybinding.chordsTo"
 		],
-		"vs/workbench/browser/codeeditor": [
-			"openWorkspace"
-		],
-		"vs/workbench/contrib/testing/browser/icons": [
-			"testViewIcon",
-			"testingRunIcon",
-			"testingRunAllIcon",
-			"testingDebugIcon",
-			"testingCancelIcon",
-			"testingShowAsList",
-			"testingShowAsTree",
-			"testingErrorIcon",
-			"testingFailedIcon",
-			"testingPassedIcon",
-			"testingQueuedIcon",
-			"testingSkippedIcon",
-			"testingUnsetIcon"
-		],
-		"vs/workbench/contrib/testing/browser/testingDecorations": [
-			"testing.clickToRun",
-			"run test",
-			"debug test",
-			"reveal test"
-		],
-		"vs/workbench/contrib/testing/browser/testingExplorerFilter": [
-			"testExplorerFilter",
-			"filter"
-		],
-		"vs/workbench/contrib/testing/browser/testingExplorerView": [
-			"testExplorer",
-			{
-				"key": "testing.treeElementLabel",
-				"comment": [
-					"label then the unit tests state, for example \"Addition Tests (Running)\""
-				]
-			},
-			"testProgress",
-			"testProgressWithSkip",
-			"testResultStarting",
-			"testBadgeRunning",
-			"testBadgeFailures"
-		],
-		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
-			"close"
-		],
-		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
-			"testing"
-		],
-		"vs/workbench/contrib/testing/common/testServiceImpl": [
-			"testError"
-		],
-		"vs/workbench/contrib/testing/browser/testExplorerActions": [
-			"testing.category",
-			"debug test",
-			"run test",
-			"runSelectedTests",
-			"debugSelectedTests",
-			"runAllTests",
-			"noTestProvider",
-			"debugAllTests",
-			"noDebugTestProvider",
-			"testing.cancelRun",
-			"testing.viewAsList",
-			"testing.viewAsTree",
-			"testing.groupByLocation",
-			"testing.groupByStatus",
-			"testing.collapseAll",
-			"testing.refresh",
-			"showTestViewley",
-			"testing.editFocusedTest"
+		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+			"name"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookEditor": [
 			"fail.noEditor",
@@ -6815,8 +7126,74 @@
 		"vs/workbench/contrib/notebook/browser/notebookServiceImpl": [
 			"builtinProviderDisplayName"
 		],
+		"vs/workbench/contrib/customEditor/common/customEditor": [
+			"context.customEditor"
+		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor": [
 			"notebookTreeAriaLabel"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
+			"notebookActions.copy",
+			"notebookActions.cut",
+			"notebookActions.paste",
+			"notebookActions.pasteAbove"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/coreActions": [
+			"notebookActions.category",
+			"notebookActions.execute",
+			"notebookActions.execute",
+			"notebookActions.cancel",
+			"notebookActions.cancel",
+			"notebookActions.deleteCell",
+			"notebookActions.executeAndSelectBelow",
+			"notebookActions.executeAndInsertBelow",
+			"notebookActions.renderMarkdown",
+			"notebookActions.executeNotebook",
+			"notebookActions.executeNotebook",
+			"notebookActions.cancelNotebook",
+			"notebookActions.cancelNotebook",
+			"notebookMenu.insertCell",
+			"notebookMenu.cellTitle",
+			"notebookActions.menu.executeNotebook",
+			"notebookActions.menu.cancelNotebook",
+			"notebookActions.changeCellToCode",
+			"notebookActions.changeCellToMarkdown",
+			"notebookActions.insertCodeCellAbove",
+			"notebookActions.insertCodeCellBelow",
+			"notebookActions.insertCodeCellAtTop",
+			"notebookActions.insertMarkdownCellAtTop",
+			"notebookActions.menu.insertCode",
+			"notebookActions.menu.insertCode.tooltip",
+			"notebookActions.menu.insertCode",
+			"notebookActions.menu.insertCode.tooltip",
+			"notebookActions.insertMarkdownCellAbove",
+			"notebookActions.insertMarkdownCellBelow",
+			"notebookActions.menu.insertMarkdown",
+			"notebookActions.menu.insertMarkdown.tooltip",
+			"notebookActions.menu.insertMarkdown",
+			"notebookActions.menu.insertMarkdown.tooltip",
+			"notebookActions.editCell",
+			"notebookActions.quitEdit",
+			"notebookActions.deleteCell",
+			"cursorMoveDown",
+			"cursorMoveUp",
+			"focusOutput",
+			"focusOutputOut",
+			"focusFirstCell",
+			"focusLastCell",
+			"clearCellOutputs",
+			"changeLanguage",
+			"changeLanguage",
+			"languageDescription",
+			"languageDescriptionConfigured",
+			"pickLanguageToConfigure",
+			"clearAllCellsOutputs",
+			"notebookActions.centerActiveCell",
+			"notebookActions.collapseCellInput",
+			"notebookActions.expandCellInput",
+			"notebookActions.collapseCellOutput",
+			"notebookActions.expandCellOutput",
+			"notebookActions.inspectLayout"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/find/findController": [
 			"notebookActions.hideFind",
@@ -6846,12 +7223,144 @@
 			"chooseActiveKernel",
 			"notebook.selectKernel"
 		],
+		"vs/workbench/contrib/notebook/browser/contrib/cellOperations/cellOperations": [
+			"notebookActions.moveCellUp",
+			"notebookActions.moveCellDown",
+			"notebookActions.copyCellUp",
+			"notebookActions.copyCellDown",
+			"notebookActions.splitCell",
+			"notebookActions.joinCellAbove",
+			"notebookActions.joinCellBelow"
+		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions": [
 			"notebook.diff.switchToText",
 			"notebook.diff.cell.revertMetadata",
 			"notebook.diff.cell.switchOutputRenderingStyleToText",
 			"notebook.diff.cell.revertOutputs",
-			"notebook.diff.cell.revertInput"
+			"notebook.diff.cell.revertInput",
+			"notebook.diff.showOutputs",
+			"notebook.diff.showMetadata",
+			"notebook.diff.ignoreMetadata",
+			"notebook.diff.ignoreOutputs"
+		],
+		"vs/workbench/contrib/testing/browser/icons": [
+			"testViewIcon",
+			"testingRunIcon",
+			"testingRunAllIcon",
+			"testingDebugIcon",
+			"testingCancelIcon",
+			"filterIcon",
+			"autoRunIcon",
+			"hiddenIcon",
+			"testingShowAsList",
+			"testingShowAsTree",
+			"testingErrorIcon",
+			"testingFailedIcon",
+			"testingPassedIcon",
+			"testingQueuedIcon",
+			"testingSkippedIcon",
+			"testingUnsetIcon"
+		],
+		"vs/workbench/contrib/testing/browser/testingDecorations": [
+			"failedHoverMessage",
+			"failedPeekAction",
+			"testing.clickToRun",
+			"run test",
+			"debug test",
+			"reveal test"
+		],
+		"vs/workbench/contrib/testing/browser/testingExplorerFilter": [
+			"testing.filters.menu",
+			"testExplorerFilter",
+			"testing.filters.showOnlyFailed",
+			"testing.filters.showOnlyExecuted",
+			"testing.filters.showAll",
+			"testing.filters.showExcludedTests",
+			"testing.filters.removeTestExclusions",
+			"testing.filters.currentFile",
+			"filter"
+		],
+		"vs/workbench/contrib/testing/browser/testingExplorerView": [
+			"testingNoTest",
+			"testingFindExtension",
+			"testExplorer",
+			{
+				"key": "testing.treeElementLabel",
+				"comment": [
+					"label then the unit tests state, for example \"Addition Tests (Running)\""
+				]
+			},
+			{
+				"key": "testing.treeElementLabelOutdated",
+				"comment": [
+					"{0} is the original label in testing.treeElementLabel"
+				]
+			}
+		],
+		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
+			"testingOutputExpected",
+			"testingOutputActual",
+			"close"
+		],
+		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
+			"testProgress.running",
+			"testProgressWithSkip.running",
+			"testProgress.completed",
+			"testProgressWithSkip.completed"
+		],
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"testing"
+		],
+		"vs/workbench/contrib/testing/common/configuration": [
+			"testConfigurationTitle",
+			"testing.autoRun.mode",
+			"testing.autoRun.mode.allInWorkspace",
+			"testing.autoRun.mode.onlyPreviouslyRun",
+			"testing.autoRun.delay",
+			"testing.automaticallyOpenPeekView",
+			"testing.automaticallyOpenPeekView.failureAnywhere",
+			"testing.automaticallyOpenPeekView.failureInVisibleDocument",
+			"testing.automaticallyOpenPeekViewDuringAutoRun"
+		],
+		"vs/workbench/contrib/testing/common/testingContextKeys": [
+			"testing.testId"
+		],
+		"vs/workbench/contrib/testing/common/testServiceImpl": [
+			"testError"
+		],
+		"vs/workbench/contrib/testing/browser/testExplorerActions": [
+			"testing.category",
+			"unhideTest",
+			"hideTest",
+			"debug test",
+			"run test",
+			"runSelectedTests",
+			"debugSelectedTests",
+			"discoveringTests",
+			"runAllTests",
+			"noTestProvider",
+			"debugAllTests",
+			"noDebugTestProvider",
+			"testing.cancelRun",
+			"testing.viewAsList",
+			"testing.viewAsTree",
+			"testing.sortByName",
+			"testing.sortByLocation",
+			"testing.collapseAll",
+			"testing.refresh",
+			"testing.clearResults",
+			"testing.editFocusedTest",
+			"testing.turnOnAutoRun",
+			"testing.turnOffAutoRun",
+			"testing.runAtCursor",
+			"testing.debugAtCursor",
+			"testing.runCurrentFile",
+			"testing.debugCurrentFile",
+			"testing.reRunFailTests",
+			"testing.debugFailTests",
+			"testing.reRunLastRun",
+			"testing.debugLastRun",
+			"testing.searchForTestExtension"
 		],
 		"vs/workbench/contrib/logs/common/logsActions": [
 			"setLogLevel",
@@ -6871,6 +7380,11 @@
 			"sessions placeholder",
 			"log placeholder"
 		],
+		"vs/platform/quickinput/browser/helpQuickAccess": [
+			"globalCommands",
+			"editorCommands",
+			"helpPickAriaLabel"
+		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"noViewResults",
 			"views",
@@ -6889,20 +7403,12 @@
 			"showTriggerActions",
 			"clearCommandHistory"
 		],
-		"vs/platform/quickinput/browser/helpQuickAccess": [
-			"globalCommands",
-			"editorCommands",
-			"helpPickAriaLabel"
-		],
 		"vs/workbench/contrib/files/browser/views/explorerView": [
 			"explorerSection",
 			"createNewFile",
 			"createNewFolder",
 			"refreshExplorer",
 			"collapseExplorerFolders"
-		],
-		"vs/workbench/contrib/files/browser/views/emptyView": [
-			"noWorkspace"
 		],
 		"vs/workbench/contrib/files/browser/views/openEditorsView": [
 			{
@@ -6919,7 +7425,11 @@
 				"comment": [
 					"&& denotes a mnemonic"
 				]
-			}
+			},
+			"newUntitledFile"
+		],
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"noWorkspace"
 		],
 		"vs/workbench/contrib/files/browser/fileActions": [
 			"newFile",
@@ -7085,11 +7595,28 @@
 			},
 			"fileDeleted"
 		],
+		"vs/workbench/contrib/files/browser/fileCommands": [
+			"saveAs",
+			"save",
+			"saveWithoutFormatting",
+			"saveAll",
+			"removeFolderFromWorkspace",
+			"newUntitledFile",
+			"modifiedLabel",
+			"openFileToCopy",
+			{
+				"key": "genericSaveError",
+				"comment": [
+					"{0} is the resource that failed to save and {1} the error message"
+				]
+			},
+			"retry",
+			"discard",
+			"genericRevertError"
+		],
 		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
 			"userGuide",
 			"staleSaveError",
-			"retry",
-			"discard",
 			"readonlySaveErrorAdmin",
 			"readonlySaveErrorSudo",
 			"readonlySaveError",
@@ -7109,33 +7636,11 @@
 			"overwriteElevatedSudo",
 			"saveElevated",
 			"saveElevatedSudo",
+			"retry",
+			"discard",
 			"overwrite",
 			"overwrite",
 			"configure"
-		],
-		"vs/workbench/contrib/files/browser/fileCommands": [
-			"saveAs",
-			"save",
-			"saveWithoutFormatting",
-			"saveAll",
-			"removeFolderFromWorkspace",
-			"newUntitledFile",
-			"modifiedLabel",
-			"openFileToCopy",
-			{
-				"key": "genericSaveError",
-				"comment": [
-					"{0} is the resource that failed to save and {1} the error message"
-				]
-			},
-			"genericRevertError"
-		],
-		"vs/workbench/browser/parts/editor/editorCommands": [
-			"editorCommand.activeEditorMove.description",
-			"editorCommand.activeEditorMove.arg.name",
-			"editorCommand.activeEditorMove.arg.description",
-			"toggleInlineView",
-			"compare"
 		],
 		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
 			"binaryFileEditor"
@@ -7225,7 +7730,6 @@
 			"closeEditor"
 		],
 		"vs/workbench/contrib/search/browser/searchActions": [
-			"showSearch",
 			"replaceInFiles",
 			"toggleTabs",
 			"FocusNextSearchResult.label",
@@ -7268,6 +7772,10 @@
 		],
 		"vs/workbench/contrib/search/common/queryBuilder": [
 			"search.noWorkspaceWithName"
+		],
+		"vs/platform/actions/browser/menuEntryActionViewItem": [
+			"titleAndKb",
+			"titleAndKb"
 		],
 		"vs/workbench/browser/parts/views/viewPane": [
 			"viewPaneContainerExpandedIcon",
@@ -7326,6 +7834,7 @@
 		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
 			"changes",
 			"change",
+			"label.close",
 			"show previous change",
 			"show next change",
 			{
@@ -7355,23 +7864,22 @@
 		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
 			"source control"
 		],
-		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
-			"scm"
-		],
 		"vs/workbench/contrib/scm/browser/scmViewPane": [
 			"scm",
 			"input",
-			"repositories",
 			"sortAction",
-			"toggleViewMode",
-			"viewModeList",
-			"viewModeTree",
+			"repositories",
+			"setListViewMode",
+			"setTreeViewMode",
 			"sortByName",
 			"sortByPath",
 			"sortByStatus",
-			"expand all",
 			"collapse all",
+			"expand all",
 			"scm.providerBorder"
+		],
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"scm"
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"expressionCondition",
@@ -7384,8 +7892,8 @@
 			"functionBreakPointExpresionAriaLabel",
 			"functionBreakpointHitCountPlaceholder",
 			"functionBreakPointHitCountAriaLabel",
-			"exceptionBreakpointPlaceholder",
 			"exceptionBreakpointAriaLabel",
+			"exceptionBreakpointPlaceholder",
 			"breakpoints",
 			"disabledLogpoint",
 			"disabledBreakpoint",
@@ -7434,6 +7942,8 @@
 			},
 			"reapplyAllBreakpoints",
 			"editCondition",
+			"editCondition",
+			"editHitCount",
 			"editBreakpoint",
 			"editHitCount"
 		],
@@ -7785,6 +8295,25 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/debug/common/debugModel": [
+			"invalidVariableAttributes",
+			"startDebugFirst",
+			"notAvailable",
+			{
+				"key": "pausedOn",
+				"comment": [
+					"indicates reason for program being paused"
+				]
+			},
+			"paused",
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"breakpointDirtydHover"
+		],
 		"vs/workbench/contrib/debug/browser/breakpointWidget": [
 			"breakpointWidgetLogMessagePlaceholder",
 			"breakpointWidgetHitCountPlaceholder",
@@ -7800,6 +8329,12 @@
 			"addConfigTo",
 			"addConfiguration",
 			"debugSession"
+		],
+		"vs/workbench/contrib/debug/browser/linkDetector": [
+			"followForwardedLink",
+			"followLink",
+			"fileLinkMac",
+			"fileLink"
 		],
 		"vs/workbench/contrib/debug/browser/replViewer": [
 			"debugConsole",
@@ -7819,6 +8354,11 @@
 		],
 		"vs/workbench/contrib/debug/browser/replFilter": [
 			"showing filtered repl lines"
+		],
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"No problems filtered",
+			"problems filtered",
+			"clearFilter"
 		],
 		"vs/workbench/contrib/markers/browser/messages": [
 			"problems.view.toggle.label",
@@ -7865,19 +8405,14 @@
 			"problems.tree.aria.label.relatedinfo.message",
 			"errors.warnings.show.label"
 		],
-		"vs/workbench/contrib/markers/browser/markersView": [
-			"No problems filtered",
-			"problems filtered",
-			"clearFilter"
-		],
-		"vs/workbench/contrib/markers/browser/markers": [
-			"totalProblems"
-		],
 		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
 			"label",
 			"tooltip.1",
 			"tooltip.N",
 			"markers.showOnFile"
+		],
+		"vs/workbench/contrib/markers/browser/markers": [
+			"totalProblems"
 		],
 		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
 			"pickCommentService",
@@ -7906,11 +8441,6 @@
 			"editor.action.webvieweditor.findPrevious",
 			"refreshWebviewLabel"
 		],
-		"vs/workbench/contrib/customEditor/browser/customEditors": [
-			"openWithCurrentlyActive",
-			"promptOpenWith.setDefaultTooltip",
-			"promptOpenWith.placeHolder"
-		],
 		"vs/workbench/contrib/externalUriOpener/common/configuration": [
 			"externalUriOpeners",
 			"externalUriOpeners.uri",
@@ -7926,120 +8456,6 @@
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"extensionsInputName"
 		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"disableOtherKeymapsConfirmation",
-			"yes",
-			"no"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionEditor": [
-			"name",
-			"extension id",
-			"preview",
-			"preview",
-			"builtin",
-			"publisher",
-			"install count",
-			"rating",
-			"repository",
-			"license",
-			"version",
-			"details",
-			"detailstooltip",
-			"contributions",
-			"contributionstooltip",
-			"changelog",
-			"changelogtooltip",
-			"dependencies",
-			"dependenciestooltip",
-			"recommendationHasBeenIgnored",
-			"noReadme",
-			"extension pack",
-			"noReadme",
-			"noChangelog",
-			"noContributions",
-			"noContributions",
-			"noDependencies",
-			"settings",
-			"setting name",
-			"description",
-			"default",
-			"debuggers",
-			"debugger name",
-			"debugger type",
-			"viewContainers",
-			"view container id",
-			"view container title",
-			"view container location",
-			"views",
-			"view id",
-			"view name",
-			"view location",
-			"localizations",
-			"localizations language id",
-			"localizations language name",
-			"localizations localized language name",
-			"customEditors",
-			"customEditors view type",
-			"customEditors priority",
-			"customEditors filenamePattern",
-			"codeActions",
-			"codeActions.title",
-			"codeActions.kind",
-			"codeActions.description",
-			"codeActions.languages",
-			"authentication",
-			"authentication.label",
-			"authentication.id",
-			"colorThemes",
-			"iconThemes",
-			"colors",
-			"colorId",
-			"description",
-			"defaultDark",
-			"defaultLight",
-			"defaultHC",
-			"JSON Validation",
-			"fileMatch",
-			"schema",
-			"commands",
-			"command name",
-			"description",
-			"keyboard shortcuts",
-			"menuContexts",
-			"languages",
-			"language id",
-			"language name",
-			"file extensions",
-			"grammar",
-			"snippets",
-			"activation events",
-			"find",
-			"find next",
-			"find previous"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
-			"app.extensions.json.title",
-			"app.extensions.json.recommendations",
-			"app.extension.identifier.errorMessage",
-			"app.extensions.json.unwantedRecommendations",
-			"app.extension.identifier.errorMessage"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
-			"activation"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"extensions",
-			"auto install missing deps",
-			"finished installing missing deps",
-			"reload",
-			"no missing deps"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"type",
-			"searchFor",
-			"install",
-			"manage"
-		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"noOfYearsAgo",
 			"one year ago",
@@ -8050,11 +8466,20 @@
 			"noOfHoursAgo",
 			"one hour ago",
 			"just now",
-			"update operation",
-			"install operation",
+			{
+				"key": "vscode web",
+				"comment": [
+					"VS Code Web is the name of the product"
+				]
+			},
+			"cannot be installed",
+			"close",
+			"more information",
 			"download",
 			"install vsix",
 			"installVSIX",
+			"update operation",
+			"install operation",
 			"check logs",
 			"installExtensionStart",
 			"installExtensionComplete",
@@ -8182,6 +8607,7 @@
 			"disabled because of extension kind",
 			"disabled locally",
 			"disabled remotely",
+			"extension disabled because of trust requirement",
 			"reinstall",
 			"selectExtensionToReinstall",
 			"ReinstallAction.successReload",
@@ -8206,6 +8632,124 @@
 			"extensionButtonProminentForeground",
 			"extensionButtonProminentHoverBackground"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionEditor": [
+			"name",
+			"extension id",
+			"preview",
+			"preview",
+			"builtin",
+			"publisher",
+			"install count",
+			"rating",
+			"repository",
+			"license",
+			"version",
+			"details",
+			"detailstooltip",
+			"contributions",
+			"contributionstooltip",
+			"changelog",
+			"changelogtooltip",
+			"dependencies",
+			"dependenciestooltip",
+			"extensionpack",
+			"extensionpacktooltip",
+			"recommendationHasBeenIgnored",
+			"noReadme",
+			"extension pack",
+			"noReadme",
+			"noChangelog",
+			"noContributions",
+			"noContributions",
+			"noDependencies",
+			"noextensions",
+			"settings",
+			"setting name",
+			"description",
+			"default",
+			"debuggers",
+			"debugger name",
+			"debugger type",
+			"viewContainers",
+			"view container id",
+			"view container title",
+			"view container location",
+			"views",
+			"view id",
+			"view name",
+			"view location",
+			"localizations",
+			"localizations language id",
+			"localizations language name",
+			"localizations localized language name",
+			"customEditors",
+			"customEditors view type",
+			"customEditors priority",
+			"customEditors filenamePattern",
+			"codeActions",
+			"codeActions.title",
+			"codeActions.kind",
+			"codeActions.description",
+			"codeActions.languages",
+			"authentication",
+			"authentication.label",
+			"authentication.id",
+			"colorThemes",
+			"iconThemes",
+			"productThemes",
+			"colors",
+			"colorId",
+			"description",
+			"defaultDark",
+			"defaultLight",
+			"defaultHC",
+			"JSON Validation",
+			"fileMatch",
+			"schema",
+			"commands",
+			"command name",
+			"description",
+			"keyboard shortcuts",
+			"menuContexts",
+			"languages",
+			"language id",
+			"language name",
+			"file extensions",
+			"grammar",
+			"snippets",
+			"activation events",
+			"find",
+			"find next",
+			"find previous"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
+			"app.extensions.json.title",
+			"app.extensions.json.recommendations",
+			"app.extension.identifier.errorMessage",
+			"app.extensions.json.unwantedRecommendations",
+			"app.extension.identifier.errorMessage"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"disableOtherKeymapsConfirmation",
+			"yes",
+			"no"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"activation"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"extensions",
+			"auto install missing deps",
+			"finished installing missing deps",
+			"reload",
+			"no missing deps"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"type",
+			"searchFor",
+			"install",
+			"manage"
+		],
 		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
 			"Manifest is not found",
 			"malicious",
@@ -8217,6 +8761,16 @@
 			"singleDependentError",
 			"twoDependentsError",
 			"multipleDependentsError"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
+			"neverShowAgain",
+			"ignoreExtensionRecommendations",
+			"ignoreAll",
+			"no",
+			"workspaceRecommended",
+			"install",
+			"install and do no sync",
+			"show recommendations"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
 			"extensionsViewIcon",
@@ -8236,23 +8790,11 @@
 			"starHalfIcon",
 			"starEmptyIcon",
 			"warningIcon",
-			"infoIcon"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
-			"neverShowAgain",
-			"ignoreExtensionRecommendations",
-			"ignoreAll",
-			"no",
-			"workspaceRecommended",
-			"install",
-			"install and do no sync",
-			"show recommendations"
-		],
-		"vs/workbench/contrib/output/browser/logViewer": [
-			"logViewerAriaLabel"
+			"infoIcon",
+			"trustIcon"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsViews": [
-			"extension-arialabel",
+			"extension.arialabel",
 			"extensions",
 			"galleryError",
 			"error",
@@ -8261,8 +8803,8 @@
 			"open user settings",
 			"no local extensions"
 		],
-		"vs/workbench/browser/parts/editor/textResourceEditor": [
-			"textEditor"
+		"vs/workbench/contrib/output/browser/logViewer": [
+			"logViewerAriaLabel"
 		],
 		"vs/base/browser/ui/actionbar/actionViewItems": [
 			{
@@ -8273,37 +8815,10 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
-			"terminal.background",
-			"terminal.foreground",
-			"terminalCursor.foreground",
-			"terminalCursor.background",
-			"terminal.selectionBackground",
-			"terminal.border",
-			"terminal.ansiColor"
-		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
-			"workbench.action.terminal.newWorkspacePlaceholder",
-			"workbench.action.terminal.toggleTerminal",
-			"workbench.action.terminal.kill",
-			"workbench.action.terminal.kill.short",
-			"workbench.action.terminal.copySelection",
-			"workbench.action.terminal.copySelection.short",
-			"workbench.action.terminal.selectAll",
-			"workbench.action.terminal.new",
-			"workbench.action.terminal.new.short",
-			"workbench.action.terminal.newWorkspacePlaceholder",
-			"workbench.action.terminal.split",
-			"workbench.action.terminal.split.short",
-			"workbench.action.terminal.splitInActiveWorkspace",
-			"workbench.action.terminal.paste",
-			"workbench.action.terminal.paste.short",
-			"workbench.action.terminal.selectDefaultShell",
+			"workbench.action.terminal.selectDefaultProfile",
 			"workbench.action.terminal.openSettings",
-			"workbench.action.terminal.switchTerminal",
-			"terminals",
-			"terminalConnectingLabel",
-			"workbench.action.terminal.clear",
+			"workbench.action.terminal.newWorkspacePlaceholder",
 			"terminalLaunchHelp",
 			"workbench.action.terminal.newInActiveWorkspace",
 			"workbench.action.terminal.focusPreviousPane",
@@ -8334,6 +8849,7 @@
 			"workbench.action.terminal.focusFind",
 			"workbench.action.terminal.hideFind",
 			"workbench.action.terminal.attachToRemote",
+			"noUnattachedTerminals",
 			"quickAccessTerminal",
 			"workbench.action.terminal.scrollToPreviousCommand",
 			"workbench.action.terminal.scrollToNextCommand",
@@ -8355,15 +8871,34 @@
 			"workbench.action.terminal.findPrevious",
 			"workbench.action.terminal.searchWorkspace",
 			"workbench.action.terminal.relaunch",
-			"workbench.action.terminal.showEnvironmentInformation"
+			"workbench.action.terminal.showEnvironmentInformation",
+			"workbench.action.terminal.split",
+			"workbench.action.terminal.split.short",
+			"workbench.action.terminal.splitInActiveWorkspace",
+			"workbench.action.terminal.selectAll",
+			"workbench.action.terminal.new",
+			"workbench.action.terminal.newWorkspacePlaceholder",
+			"workbench.action.terminal.new.short",
+			"workbench.action.terminal.kill",
+			"workbench.action.terminal.kill.short",
+			"workbench.action.terminal.clear",
+			"workbench.action.terminal.selectDefaultProfile",
+			"workbench.action.terminal.copySelection",
+			"workbench.action.terminal.copySelection.short",
+			"workbench.action.terminal.paste",
+			"workbench.action.terminal.paste.short",
+			"workbench.action.terminal.switchTerminal"
+		],
+		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
+			"terminal.background",
+			"terminal.foreground",
+			"terminalCursor.foreground",
+			"terminalCursor.background",
+			"terminal.selectionBackground",
+			"terminal.border",
+			"terminal.ansiColor"
 		],
 		"vs/workbench/contrib/terminal/common/terminalMenu": [
-			{
-				"key": "miToggleIntegratedTerminal",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
 			{
 				"key": "miNewTerminal",
 				"comment": [
@@ -8389,6 +8924,18 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"workbench.action.terminal.allowWorkspaceShell",
+			"workbench.action.terminal.disallowWorkspaceShell",
+			"terminalService.terminalCloseConfirmationSingular",
+			"terminalService.terminalCloseConfirmationPlural",
+			"terminal.integrated.chooseWindowsShell",
+			"enterTerminalProfileName",
+			"terminalProfileAlreadyExists",
+			"terminalProfiles",
+			"terminalProfiles.detected",
+			"createQuickLaunchProfile"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
 			"renameTerminal",
 			"killTerminal",
@@ -8398,14 +8945,12 @@
 			"terminalViewIcon",
 			"renameTerminalIcon",
 			"killTerminalIcon",
-			"newTerminalIcon"
+			"newTerminalIcon",
+			"configureTerminalProfileIcon"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalService": [
-			"workbench.action.terminal.allowWorkspaceShell",
-			"workbench.action.terminal.disallowWorkspaceShell",
-			"terminalService.terminalCloseConfirmationSingular",
-			"terminalService.terminalCloseConfirmationPlural",
-			"terminal.integrated.chooseWindowsShell"
+		"vs/workbench/contrib/terminal/browser/remoteTerminalService": [
+			"restartPtyHost",
+			"nonResponsivePtyHost"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
 			"JsonSchema.version.deprecated",
@@ -8500,15 +9045,6 @@
 			"noTaskResults",
 			"TaskService.pickRunTask"
 		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"expandAbbreviationAction",
-			{
-				"key": "miEmmetExpandAbbreviation",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/remote/browser/explorerViewItems": [
 			"remotes",
 			"remote.explorer.switch"
@@ -8530,6 +9066,7 @@
 			"disconnectedFrom",
 			"host.tooltipDisconnected",
 			"host.tooltip",
+			"workspace.tooltip",
 			"noHost.tooltip",
 			"remoteHost",
 			"cat.title",
@@ -8548,7 +9085,21 @@
 			"publicPortIcon",
 			"forwardPortIcon",
 			"stopForwardIcon",
-			"openBrowserIcon"
+			"openBrowserIcon",
+			"openPreviewIcon",
+			"copyAddressIcon",
+			"labelPortIcon",
+			"forwardedPortWithoutProcessIcon",
+			"forwardedPortWithProcessIcon"
+		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"expandAbbreviationAction",
+			{
+				"key": "miEmmetExpandAbbreviation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
 			"emergencyConfOn",
@@ -8599,6 +9150,15 @@
 			"gotoLineQuickAccess",
 			"gotoLine"
 		],
+		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
+			"toggleColumnSelection",
+			{
+				"key": "miColumnSelection",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
 			"formatting",
 			"codeaction",
@@ -8629,15 +9189,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
-			"toggleColumnSelection",
-			{
-				"key": "miColumnSelection",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
 			"toggleRenderWhitespace",
 			{
@@ -8648,6 +9199,7 @@
 			}
 		],
 		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
+			"editorWordWrap",
 			"toggle.wordwrap",
 			"unwrapMinified",
 			"wrapMinified",
@@ -8669,6 +9221,7 @@
 			"snippetSuggest.longLabel"
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
+			"null",
 			"nullFormatterDescription",
 			"miss",
 			"config.needed",
@@ -8727,18 +9280,97 @@
 			"installUpdate...",
 			"installingUpdate",
 			"restartToUpdate",
+			"switchToInsiders",
+			"switchToStable",
 			"relaunchMessage",
 			"relaunchDetailInsiders",
 			"relaunchDetailStable",
 			"reload",
-			"switchToInsiders",
-			"switchToStable",
+			"selectSyncService.message",
+			"use insiders",
+			"use stable",
+			"cancel",
+			"selectSyncService.detail",
 			"checkForUpdates"
 		],
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"unbound"
 		],
 		"vs/workbench/contrib/welcome/page/browser/welcomePage": [
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.none"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.welcomePage"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.readme"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.newUntitledFile"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.welcomePageInEmptyWorkbench"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.gettingStarted"
+			},
+			"workbench.startupEditor",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.none"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.welcomePage"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.readme"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.newUntitledFile"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.welcomePageInEmptyWorkbench"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.gettingStarted"
+			},
+			"workbench.startupEditor",
 			"welcomePage",
 			"welcomePage.javaScript",
 			"welcomePage.python",
@@ -8769,13 +9401,45 @@
 			"details"
 		],
 		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted": [
-			"editorGettingStarted.title",
-			"gettingStarted.skip",
-			"next"
+			"gettingStartedLabel",
+			"more",
+			"close",
+			"no categories",
+			"configure visiblity",
+			"gettingStarted.vscode",
+			{
+				"key": "gettingStarted.editingEvolved",
+				"comment": [
+					"Shown as subtitle on the Welcome page."
+				]
+			},
+			"gettingStarted",
+			"welcomePage.showOnStartup",
+			"welcomePage.openFolderWithPath",
+			"recent",
+			"start",
+			"next",
+			"nextPage",
+			"imageShowing"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedInput": [
+			"gettingStarted"
 		],
 		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedIcons": [
 			"gettingStartedUnchecked",
 			"gettingStartedChecked"
+		],
+		"vs/workbench/contrib/welcome/walkthroughs/browser/walkthroughs": [
+			"gettingStarted",
+			"more",
+			"gettingStartedLabel",
+			"pressEnterToSelect",
+			"pressEnterToSelect",
+			"gettingStarted.vscode",
+			"walkthroughs",
+			"imageShowing",
+			"next",
+			"nextPage"
 		],
 		"vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart": [
 			"walkThrough.unboundCommand",
@@ -8794,6 +9458,7 @@
 			"empt.callsTo"
 		],
 		"vs/editor/contrib/peekView/peekView": [
+			"inReferenceSearchEditor",
 			"label.close",
 			"peekViewTitleBackground",
 			"peekViewTitleForeground",
@@ -8809,6 +9474,17 @@
 			"peekViewResultsMatchHighlight",
 			"peekViewEditorMatchHighlight",
 			"peekViewEditorMatchHighlightBorder"
+		],
+		"vs/workbench/contrib/outline/browser/outlinePane": [
+			"no-editor",
+			"loading",
+			"no-symbols",
+			"collapse",
+			"followCur",
+			"filterOnType",
+			"sortByPosition",
+			"sortByName",
+			"sortByKind"
 		],
 		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree": [
 			"title.template",
@@ -8840,57 +9516,7 @@
 			"String",
 			"Struct",
 			"TypeParameter",
-			"Variable",
-			"symbolIcon.arrayForeground",
-			"symbolIcon.booleanForeground",
-			"symbolIcon.classForeground",
-			"symbolIcon.colorForeground",
-			"symbolIcon.constantForeground",
-			"symbolIcon.constructorForeground",
-			"symbolIcon.enumeratorForeground",
-			"symbolIcon.enumeratorMemberForeground",
-			"symbolIcon.eventForeground",
-			"symbolIcon.fieldForeground",
-			"symbolIcon.fileForeground",
-			"symbolIcon.folderForeground",
-			"symbolIcon.functionForeground",
-			"symbolIcon.interfaceForeground",
-			"symbolIcon.keyForeground",
-			"symbolIcon.keywordForeground",
-			"symbolIcon.methodForeground",
-			"symbolIcon.moduleForeground",
-			"symbolIcon.namespaceForeground",
-			"symbolIcon.nullForeground",
-			"symbolIcon.numberForeground",
-			"symbolIcon.objectForeground",
-			"symbolIcon.operatorForeground",
-			"symbolIcon.packageForeground",
-			"symbolIcon.propertyForeground",
-			"symbolIcon.referenceForeground",
-			"symbolIcon.snippetForeground",
-			"symbolIcon.stringForeground",
-			"symbolIcon.structForeground",
-			"symbolIcon.textForeground",
-			"symbolIcon.typeParameterForeground",
-			"symbolIcon.unitForeground",
-			"symbolIcon.variableForeground"
-		],
-		"vs/workbench/contrib/outline/browser/outlinePane": [
-			"no-editor",
-			"loading",
-			"no-symbols",
-			"collapse",
-			"followCur",
-			"filterOnType",
-			"sortByPosition",
-			"sortByName",
-			"sortByKind"
-		],
-		"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem": [
-			"status.feedback",
-			"status.feedback",
-			"status.feedback",
-			"status.feedback"
+			"Variable"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
 			"turn on sync with category",
@@ -8920,7 +9546,11 @@
 			"error reset required",
 			"reset",
 			"show synced data action",
-			"switched to insiders",
+			"service switched to insiders",
+			"service switched to stable",
+			"using separate service",
+			"service changed and turned off",
+			"turn on sync",
 			"operationId",
 			"open file",
 			"errorInvalidConfiguration",
@@ -8999,6 +9629,12 @@
 			"update conflicts",
 			"accept failed"
 		],
+		"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem": [
+			"status.feedback",
+			"status.feedback",
+			"status.feedback",
+			"status.feedback"
+		],
 		"vs/workbench/contrib/codeActions/common/codeActionsContribution": [
 			"codeActionsOnSave.fixAll",
 			"codeActionsOnSave",
@@ -9054,6 +9690,31 @@
 			"timeline.filterSource",
 			"timeline"
 		],
+		"vs/workbench/contrib/workspace/browser/workspaceTrustEditor": [
+			"trustedHeader",
+			"untrustedHeader",
+			"unknownHeader",
+			"unknownHeaderDescription",
+			"trustButton",
+			"doNotTrustButton",
+			"onStartExtensions",
+			"onStartExtensionsDescription",
+			"onDemandExtensions",
+			"onDemandExtensionsDescription",
+			"configurationSectionTitle",
+			"affectedFeaturesTitle"
+		],
+		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
+			"workspaceTrustEditorInputName"
+		],
+		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
+			{
+				"key": "genericSaveError",
+				"comment": [
+					"{0} is the resource that failed to save and {1} the error message"
+				]
+			}
+		],
 		"vs/workbench/services/textMate/common/TMGrammars": [
 			"vscode.extension.contributes.grammars",
 			"vscode.extension.contributes.grammars.language",
@@ -9089,150 +9750,99 @@
 			"telemetryOptOut.OptIn",
 			"telemetryOptOut.OptOut"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsList": [
-			"notificationAriaLabel",
-			"notificationWithSourceAriaLabel",
-			"notificationsList"
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"notificationsEmpty",
+			"notifications",
+			"notificationsToolbar"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsActions": [
-			"clearIcon",
-			"clearAllIcon",
-			"hideIcon",
-			"expandIcon",
-			"collapseIcon",
-			"configureIcon",
-			"clearNotification",
-			"clearNotifications",
-			"hideNotificationsCenter",
-			"expandNotification",
-			"collapseNotification",
-			"configureNotification",
-			"copyNotification"
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"alertErrorMessage",
+			"alertWarningMessage",
+			"alertInfoMessage"
 		],
-		"vs/base/common/keybindingLabels": [
+		"vs/workbench/browser/parts/notifications/notificationsStatus": [
+			"status.notifications",
+			"status.notifications",
+			"hideNotifications",
+			"zeroNotifications",
+			"noNotifications",
+			"oneNotification",
 			{
-				"key": "ctrlKey",
+				"key": "notifications",
 				"comment": [
-					"This is the short form for the Control key on the keyboard"
+					"{0} will be replaced by a number"
 				]
 			},
 			{
-				"key": "shiftKey",
+				"key": "noNotificationsWithProgress",
 				"comment": [
-					"This is the short form for the Shift key on the keyboard"
+					"{0} will be replaced by a number"
 				]
 			},
 			{
-				"key": "altKey",
+				"key": "oneNotificationWithProgress",
 				"comment": [
-					"This is the short form for the Alt key on the keyboard"
+					"{0} will be replaced by a number"
 				]
 			},
 			{
-				"key": "windowsKey",
+				"key": "notificationsWithProgress",
 				"comment": [
-					"This is the short form for the Windows key on the keyboard"
+					"{0} and {1} will be replaced by a number"
 				]
 			},
-			{
-				"key": "ctrlKey",
-				"comment": [
-					"This is the short form for the Control key on the keyboard"
-				]
-			},
-			{
-				"key": "shiftKey",
-				"comment": [
-					"This is the short form for the Shift key on the keyboard"
-				]
-			},
-			{
-				"key": "altKey",
-				"comment": [
-					"This is the short form for the Alt key on the keyboard"
-				]
-			},
-			{
-				"key": "superKey",
-				"comment": [
-					"This is the short form for the Super key on the keyboard"
-				]
-			},
-			{
-				"key": "ctrlKey.long",
-				"comment": [
-					"This is the long form for the Control key on the keyboard"
-				]
-			},
-			{
-				"key": "shiftKey.long",
-				"comment": [
-					"This is the long form for the Shift key on the keyboard"
-				]
-			},
-			{
-				"key": "altKey.long",
-				"comment": [
-					"This is the long form for the Alt key on the keyboard"
-				]
-			},
-			{
-				"key": "cmdKey.long",
-				"comment": [
-					"This is the long form for the Command key on the keyboard"
-				]
-			},
-			{
-				"key": "ctrlKey.long",
-				"comment": [
-					"This is the long form for the Control key on the keyboard"
-				]
-			},
-			{
-				"key": "shiftKey.long",
-				"comment": [
-					"This is the long form for the Shift key on the keyboard"
-				]
-			},
-			{
-				"key": "altKey.long",
-				"comment": [
-					"This is the long form for the Alt key on the keyboard"
-				]
-			},
-			{
-				"key": "windowsKey.long",
-				"comment": [
-					"This is the long form for the Windows key on the keyboard"
-				]
-			},
-			{
-				"key": "ctrlKey.long",
-				"comment": [
-					"This is the long form for the Control key on the keyboard"
-				]
-			},
-			{
-				"key": "shiftKey.long",
-				"comment": [
-					"This is the long form for the Shift key on the keyboard"
-				]
-			},
-			{
-				"key": "altKey.long",
-				"comment": [
-					"This is the long form for the Alt key on the keyboard"
-				]
-			},
-			{
-				"key": "superKey.long",
-				"comment": [
-					"This is the long form for the Super key on the keyboard"
-				]
-			}
+			"status.message"
 		],
-		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
-			"saveParticipants"
+		"vs/workbench/browser/parts/notifications/notificationsCommands": [
+			"notificationFocus",
+			"notificationCenterVisible",
+			"notificationToastsVisible",
+			"notifications",
+			"showNotifications",
+			"hideNotifications",
+			"clearAllNotifications",
+			"focusNotificationToasts"
+		],
+		"vs/workbench/services/configuration/common/configurationEditingService": [
+			"openTasksConfiguration",
+			"openLaunchConfiguration",
+			"open",
+			"openTasksConfiguration",
+			"openLaunchConfiguration",
+			"saveAndRetry",
+			"saveAndRetry",
+			"open",
+			"errorUnknownKey",
+			"errorInvalidWorkspaceConfigurationApplication",
+			"errorInvalidWorkspaceConfigurationMachine",
+			"errorInvalidFolderConfiguration",
+			"errorInvalidUserTarget",
+			"errorInvalidWorkspaceTarget",
+			"errorInvalidFolderTarget",
+			"errorInvalidResourceLanguageConfiguraiton",
+			"errorNoWorkspaceOpened",
+			"errorInvalidTaskConfiguration",
+			"errorInvalidLaunchConfiguration",
+			"errorInvalidConfiguration",
+			"errorInvalidRemoteConfiguration",
+			"errorInvalidConfigurationWorkspace",
+			"errorInvalidConfigurationFolder",
+			"errorTasksConfigurationFileDirty",
+			"errorLaunchConfigurationFileDirty",
+			"errorConfigurationFileDirty",
+			"errorRemoteConfigurationFileDirty",
+			"errorConfigurationFileDirtyWorkspace",
+			"errorConfigurationFileDirtyFolder",
+			"errorTasksConfigurationFileModifiedSince",
+			"errorLaunchConfigurationFileModifiedSince",
+			"errorConfigurationFileModifiedSince",
+			"errorRemoteConfigurationFileModifiedSince",
+			"errorConfigurationFileModifiedSinceWorkspace",
+			"errorConfigurationFileModifiedSinceFolder",
+			"userTarget",
+			"remoteUserTarget",
+			"workspaceTarget",
+			"folderTarget"
 		],
 		"vs/base/common/jsonErrorMessages": [
 			"error.invalidSymbol",
@@ -9356,6 +9966,10 @@
 			"autoFix.label",
 			"editor.action.autoFix.noneMessage"
 		],
+		"vs/editor/contrib/folding/foldingDecorations": [
+			"foldingExpandedIcon",
+			"foldingCollapsedIcon"
+		],
 		"vs/editor/contrib/find/findWidget": [
 			"findSelectionIcon",
 			"findCollapsedIcon",
@@ -9384,10 +9998,6 @@
 			"ariaSearchNoResultWithLineNumNoCurrentMatch",
 			"ctrlEnter.keybindingChanged"
 		],
-		"vs/editor/contrib/folding/foldingDecorations": [
-			"foldingExpandedIcon",
-			"foldingCollapsedIcon"
-		],
 		"vs/editor/contrib/format/format": [
 			"hint11",
 			"hintn1",
@@ -9395,11 +10005,31 @@
 			"hintnn"
 		],
 		"vs/editor/contrib/message/messageController": [
+			"messageVisible",
 			"editor.readonly"
 		],
 		"vs/editor/contrib/gotoSymbol/peek/referencesController": [
+			"referenceSearchVisible",
 			"labelLoading",
 			"metaTitle.N"
+		],
+		"vs/editor/contrib/gotoError/gotoErrorWidget": [
+			"Error",
+			"Warning",
+			"Info",
+			"Hint",
+			"marker aria",
+			"problems",
+			"change",
+			"editorMarkerNavigationError",
+			"editorMarkerNavigationWarning",
+			"editorMarkerNavigationInfo",
+			"editorMarkerNavigationBackground"
+		],
+		"vs/editor/contrib/gotoSymbol/symbolNavigation": [
+			"hasSymbols",
+			"location.kb",
+			"location"
 		],
 		"vs/editor/contrib/gotoSymbol/referencesModel": [
 			"aria.oneReference",
@@ -9416,24 +10046,13 @@
 			"aria.result.n1",
 			"aria.result.nm"
 		],
-		"vs/editor/contrib/gotoSymbol/symbolNavigation": [
-			"location.kb",
-			"location"
-		],
-		"vs/editor/contrib/gotoError/gotoErrorWidget": [
-			"Error",
-			"Warning",
-			"Info",
-			"Hint",
-			"marker aria",
-			"problems",
-			"change",
-			"editorMarkerNavigationError",
-			"editorMarkerNavigationWarning",
-			"editorMarkerNavigationInfo",
-			"editorMarkerNavigationBackground"
+		"vs/editor/contrib/parameterHints/parameterHintsWidget": [
+			"parameterHintsNextIcon",
+			"parameterHintsPreviousIcon",
+			"hint"
 		],
 		"vs/editor/contrib/rename/renameInputField": [
+			"renameInputVisible",
 			"renameAriaLabel",
 			{
 				"key": "label",
@@ -9441,11 +10060,6 @@
 					"placeholders are keybindings, e.g \"F2 to Rename, Shift+F2 to Preview\""
 				]
 			}
-		],
-		"vs/editor/contrib/parameterHints/parameterHintsWidget": [
-			"parameterHintsNextIcon",
-			"parameterHintsPreviousIcon",
-			"hint"
 		],
 		"vs/editor/contrib/suggest/suggestWidget": [
 			"editorSuggestWidgetBackground",
@@ -9500,14 +10114,14 @@
 			"async",
 			"readonly"
 		],
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"errorMessage"
+		],
 		"vs/workbench/browser/parts/editor/textEditor": [
 			"editor"
 		],
 		"vs/workbench/api/browser/mainThreadCustomEditors": [
 			"defaultEditLabel"
-		],
-		"vs/workbench/api/browser/mainThreadWebviews": [
-			"errorMessage"
 		],
 		"vs/workbench/contrib/comments/browser/commentsView": [
 			"rootCommentsLabel",
@@ -9519,226 +10133,14 @@
 			"imageWithLabel",
 			"image"
 		],
-		"vs/workbench/contrib/remote/browser/tunnelView": [
-			"remote.tunnelsView.add",
-			"remote.tunnelsView.detected",
-			"remote.tunnelsView.candidates",
-			"remote.tunnelsView.input",
-			"remote.tunnelsView.forwardedPortLabel0",
-			"remote.tunnelsView.forwardedPortLabel1",
-			"remote.tunnelsView.forwardedPortLabel2",
-			"remote.tunnelsView.forwardedPortDescription0",
-			"remote.tunnel",
-			"remote.tunnel.ariaLabelForwarded",
-			"remote.tunnel.ariaLabelCandidate",
-			"tunnelView",
-			"remote.tunnel.label",
-			"remote.tunnelsView.labelPlaceholder",
-			"remote.tunnelsView.portNumberValid",
-			"remote.tunnelsView.portNumberToHigh",
-			"remote.tunnelView.inlineElevationMessage",
-			"remote.tunnel.forward",
-			"remote.tunnel.forwardItem",
-			"remote.tunnel.forwardPrompt",
-			"remote.tunnel.forwardError",
-			"remote.tunnel.closeNoPorts",
-			"remote.tunnel.close",
-			"remote.tunnel.closePlaceholder",
-			"remote.tunnel.open",
-			"remote.tunnel.openCommandPalette",
-			"remote.tunnel.openCommandPaletteNone",
-			"remote.tunnel.openCommandPaletteView",
-			"remote.tunnel.openCommandPalettePick",
-			"remote.tunnel.copyAddressInline",
-			"remote.tunnel.copyAddressCommandPalette",
-			"remote.tunnel.copyAddressPlaceholdter",
-			"remote.tunnel.changeLocalPort",
-			"remote.tunnel.changeLocalPortNumber",
-			"remote.tunnelsView.changePort",
-			"remote.tunnel.makePublic",
-			"remote.tunnel.makePrivate"
-		],
-		"vs/base/browser/ui/tree/treeDefaults": [
-			"collapse all"
-		],
-		"vs/base/browser/ui/splitview/paneview": [
-			"viewSection"
+		"vs/workbench/browser/parts/editor/binaryEditor": [
+			"binaryEditor",
+			"nativeFileTooLargeError",
+			"nativeBinaryError",
+			"openAsText"
 		],
 		"vs/workbench/browser/parts/editor/tabsTitleControl": [
 			"ariaLabelTabActions"
-		],
-		"vs/workbench/browser/parts/editor/textDiffEditor": [
-			"textDiffEditor"
-		],
-		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
-			"metadataDiff"
-		],
-		"vs/workbench/browser/parts/editor/editorQuickAccess": [
-			"noViewResults",
-			"entryAriaLabelWithGroupDirty",
-			"entryAriaLabelWithGroup",
-			"entryAriaLabelDirty",
-			"closeEditor"
-		],
-		"vs/workbench/browser/parts/editor/editorStatus": [
-			"singleSelectionRange",
-			"singleSelection",
-			"multiSelectionRange",
-			"multiSelection",
-			"endOfLineLineFeed",
-			"endOfLineCarriageReturnLineFeed",
-			"screenReaderDetectedExplanation.question",
-			"screenReaderDetectedExplanation.answerYes",
-			"screenReaderDetectedExplanation.answerNo",
-			"noEditor",
-			"noWritableCodeEditor",
-			"indentConvert",
-			"indentView",
-			"pickAction",
-			"tabFocusModeEnabled",
-			"disableTabMode",
-			"status.editor.tabFocusMode",
-			"columnSelectionModeEnabled",
-			"disableColumnSelectionMode",
-			"status.editor.columnSelectionMode",
-			"screenReaderDetected",
-			"status.editor.screenReaderMode",
-			"gotoLine",
-			"status.editor.selection",
-			"selectIndentation",
-			"status.editor.indentation",
-			"selectEncoding",
-			"status.editor.encoding",
-			"selectEOL",
-			"status.editor.eol",
-			"selectLanguageMode",
-			"status.editor.mode",
-			"fileInfo",
-			"status.editor.info",
-			"spacesSize",
-			{
-				"key": "tabSize",
-				"comment": [
-					"Tab corresponds to the tab key"
-				]
-			},
-			"currentProblem",
-			"showLanguageExtensions",
-			"changeMode",
-			"noEditor",
-			"languageDescription",
-			"languageDescriptionConfigured",
-			"languagesPicks",
-			"configureModeSettings",
-			"configureAssociationsExt",
-			"autoDetect",
-			"pickLanguage",
-			"currentAssociation",
-			"pickLanguageToConfigure",
-			"changeEndOfLine",
-			"noEditor",
-			"noWritableCodeEditor",
-			"pickEndOfLine",
-			"changeEncoding",
-			"noEditor",
-			"noEditor",
-			"noFileEditor",
-			"saveWithEncoding",
-			"reopenWithEncoding",
-			"pickAction",
-			"guessedEncoding",
-			"pickEncodingForReopen",
-			"pickEncodingForSave"
-		],
-		"vs/workbench/browser/parts/editor/editorActions": [
-			"splitEditor",
-			"splitEditorOrthogonal",
-			"splitEditorGroupLeft",
-			"splitEditorGroupRight",
-			"splitEditorGroupUp",
-			"splitEditorGroupDown",
-			"joinTwoGroups",
-			"joinAllGroups",
-			"navigateEditorGroups",
-			"focusActiveEditorGroup",
-			"focusFirstEditorGroup",
-			"focusLastEditorGroup",
-			"focusNextGroup",
-			"focusPreviousGroup",
-			"focusLeftGroup",
-			"focusRightGroup",
-			"focusAboveGroup",
-			"focusBelowGroup",
-			"closeEditor",
-			"unpinEditor",
-			"closeOneEditor",
-			"revertAndCloseActiveEditor",
-			"closeEditorsToTheLeft",
-			"closeAllEditors",
-			"closeAllGroups",
-			"closeEditorsInOtherGroups",
-			"closeEditorInAllGroups",
-			"moveActiveGroupLeft",
-			"moveActiveGroupRight",
-			"moveActiveGroupUp",
-			"moveActiveGroupDown",
-			"duplicateActiveGroupLeft",
-			"duplicateActiveGroupRight",
-			"duplicateActiveGroupUp",
-			"duplicateActiveGroupDown",
-			"minimizeOtherEditorGroups",
-			"evenEditorGroups",
-			"toggleEditorWidths",
-			"maximizeEditor",
-			"openNextEditor",
-			"openPreviousEditor",
-			"nextEditorInGroup",
-			"openPreviousEditorInGroup",
-			"firstEditorInGroup",
-			"lastEditorInGroup",
-			"navigateNext",
-			"navigatePrevious",
-			"navigateToLastEditLocation",
-			"navigateLast",
-			"reopenClosedEditor",
-			"clearRecentFiles",
-			"showEditorsInActiveGroup",
-			"showAllEditors",
-			"showAllEditorsByMostRecentlyUsed",
-			"quickOpenPreviousRecentlyUsedEditor",
-			"quickOpenLeastRecentlyUsedEditor",
-			"quickOpenPreviousRecentlyUsedEditorInGroup",
-			"quickOpenLeastRecentlyUsedEditorInGroup",
-			"navigateEditorHistoryByInput",
-			"openNextRecentlyUsedEditor",
-			"openPreviousRecentlyUsedEditor",
-			"openNextRecentlyUsedEditorInGroup",
-			"openPreviousRecentlyUsedEditorInGroup",
-			"clearEditorHistory",
-			"moveEditorLeft",
-			"moveEditorRight",
-			"moveEditorToPreviousGroup",
-			"moveEditorToNextGroup",
-			"moveEditorToAboveGroup",
-			"moveEditorToBelowGroup",
-			"moveEditorToLeftGroup",
-			"moveEditorToRightGroup",
-			"moveEditorToFirstGroup",
-			"moveEditorToLastGroup",
-			"editorLayoutSingle",
-			"editorLayoutTwoColumns",
-			"editorLayoutThreeColumns",
-			"editorLayoutTwoRows",
-			"editorLayoutThreeRows",
-			"editorLayoutTwoByTwoGrid",
-			"editorLayoutTwoColumnsBottom",
-			"editorLayoutTwoRowsRight",
-			"newEditorLeft",
-			"newEditorRight",
-			"newEditorAbove",
-			"newEditorBelow",
-			"workbench.action.reopenWithEditor",
-			"workbench.action.toggleEditorType"
 		],
 		"vs/base/browser/ui/menu/menubar": [
 			"mAppMenu",
@@ -9752,6 +10154,70 @@
 					"action keybinding"
 				]
 			}
+		],
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"collapse all"
+		],
+		"vs/base/browser/ui/splitview/paneview": [
+			"viewSection"
+		],
+		"vs/workbench/contrib/remote/browser/tunnelView": [
+			"tunnel.forwardedPortsViewEnabled",
+			"remote.tunnelsView.addPort",
+			"tunnel.portColumn.label",
+			"tunnel.portColumn.tooltip",
+			"tunnel.addressColumn.label",
+			"tunnel.addressColumn.tooltip",
+			"tunnel.processColumn.label",
+			"tunnel.processColumn.tooltip",
+			"tunnel.originColumn.label",
+			"tunnel.originColumn.tooltip",
+			"tunnel.privacyColumn.label",
+			"tunnel.privacyColumn.tooltip",
+			"tunnel.privacyPublic",
+			"tunnel.privacyPrivate",
+			"remote.tunnelsView.input",
+			"tunnel.user",
+			"tunnel.staticallyForwarded",
+			"tunnel.automatic",
+			"tunnelView.runningProcess.inacessable",
+			"remote.tunnel.tooltipForwarded",
+			"remote.tunnel.tooltipCandidate",
+			"tunnel.iconColumn.running",
+			"tunnel.iconColumn.notRunning",
+			"remote.tunnel.tooltipName",
+			"remote.tunnel.tooltipPublic",
+			"remote.tunnel.tooltipPrivate",
+			"tunnel.focusContext",
+			"remote.tunnel",
+			"tunnelView",
+			"remote.tunnel.label",
+			"remote.tunnelsView.labelPlaceholder",
+			"remote.tunnelsView.portNumberValid",
+			"remote.tunnelsView.portNumberToHigh",
+			"remote.tunnelView.inlineElevationMessage",
+			"remote.tunnelView.alreadyForwarded",
+			"remote.tunnel.forward",
+			"remote.tunnel.forwardItem",
+			"remote.tunnel.forwardPrompt",
+			"remote.tunnel.forwardError",
+			"remote.tunnel.closeNoPorts",
+			"remote.tunnel.close",
+			"remote.tunnel.closePlaceholder",
+			"remote.tunnel.open",
+			"remote.tunnel.openPreview",
+			"remote.tunnel.openCommandPalette",
+			"remote.tunnel.openCommandPaletteNone",
+			"remote.tunnel.openCommandPaletteView",
+			"remote.tunnel.openCommandPalettePick",
+			"remote.tunnel.copyAddressInline",
+			"remote.tunnel.copyAddressCommandPalette",
+			"remote.tunnel.copyAddressPlaceholdter",
+			"remote.tunnel.changeLocalPort",
+			"remote.tunnel.changeLocalPortNumber",
+			"remote.tunnelsView.changePort",
+			"remote.tunnel.makePublic",
+			"remote.tunnel.makePrivate"
 		],
 		"vs/base/browser/ui/toolbar/toolbar": [
 			"moreActions"
@@ -9794,9 +10260,9 @@
 		],
 		"vs/base/parts/quickinput/browser/quickInput": [
 			"quickInput.back",
+			"inputModeEntry",
 			"quickInput.steps",
 			"quickInputBox.ariaLabel",
-			"inputModeEntry",
 			"inputModeEntryDescription",
 			{
 				"key": "quickInput.visibleCount",
@@ -9814,6 +10280,20 @@
 			"custom",
 			"quickInput.backWithKeybinding",
 			"quickInput.back"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
+			"emptyUserSettingsHeader",
+			"emptyWorkspaceSettingsHeader",
+			"emptyFolderSettingsHeader",
+			"editTtile",
+			"replaceDefaultValue",
+			"copyDefaultValue",
+			"unknown configuration setting",
+			"unsupportedRemoteMachineSetting",
+			"unsupportedWindowSetting",
+			"unsupportedApplicationSetting",
+			"unsupportedMachineSetting",
+			"unsupportedProperty"
 		],
 		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
 			"defaultSettings",
@@ -9850,6 +10330,7 @@
 			"fileExplorer",
 			"search",
 			"debug",
+			"testing",
 			"scm",
 			"extensions",
 			"terminal",
@@ -9867,33 +10348,32 @@
 			"telemetry",
 			"settingsSync"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
-			"emptyUserSettingsHeader",
-			"emptyWorkspaceSettingsHeader",
-			"emptyFolderSettingsHeader",
-			"editTtile",
-			"replaceDefaultValue",
-			"copyDefaultValue",
-			"unknown configuration setting",
-			"unsupportedRemoteMachineSetting",
-			"unsupportedWindowSetting",
-			"unsupportedApplicationSetting",
-			"unsupportedMachineSetting",
-			"unsupportedProperty"
+		"vs/workbench/contrib/preferences/browser/settingsTree": [
+			"extensions",
+			"extensionSyncIgnoredLabel",
+			"modified",
+			"settingsContextMenuTitle",
+			"alsoConfiguredIn",
+			"configuredIn",
+			"newExtensionsButtonLabel",
+			"editInSettingsJson",
+			"settings.Default",
+			"modified",
+			"resetSettingLabel",
+			"validationError",
+			"validationError",
+			"settings.Modified",
+			"alsoConfiguredIn",
+			"configuredIn",
+			"settings",
+			"copySettingIdLabel",
+			"copySettingAsJSONLabel",
+			"stopSyncingSetting"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsTreeModels": [
 			"workspace",
 			"remote",
 			"user"
-		],
-		"vs/workbench/contrib/preferences/browser/tocTree": [
-			{
-				"key": "settingsTOC",
-				"comment": [
-					"A label for the table of contents for the full settings list"
-				]
-			},
-			"groupRowAriaLabel"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsWidgets": [
 			"headerForeground",
@@ -9942,27 +10422,228 @@
 			"objectKeyHeader",
 			"objectValueHeader"
 		],
-		"vs/workbench/contrib/preferences/browser/settingsTree": [
-			"extensions",
-			"extensionSyncIgnoredLabel",
-			"modified",
-			"settingsContextMenuTitle",
-			"alsoConfiguredIn",
-			"configuredIn",
-			"newExtensionsButtonLabel",
-			"editInSettingsJson",
-			"settings.Default",
-			"modified",
-			"resetSettingLabel",
-			"validationError",
-			"validationError",
-			"settings.Modified",
-			"alsoConfiguredIn",
-			"configuredIn",
-			"settings",
-			"copySettingIdLabel",
-			"copySettingAsJSONLabel",
-			"stopSyncingSetting"
+		"vs/workbench/contrib/preferences/browser/tocTree": [
+			{
+				"key": "settingsTOC",
+				"comment": [
+					"A label for the table of contents for the full settings list"
+				]
+			},
+			"groupRowAriaLabel"
+		],
+		"vs/base/common/keybindingLabels": [
+			{
+				"key": "ctrlKey",
+				"comment": [
+					"This is the short form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey",
+				"comment": [
+					"This is the short form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey",
+				"comment": [
+					"This is the short form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "windowsKey",
+				"comment": [
+					"This is the short form for the Windows key on the keyboard"
+				]
+			},
+			{
+				"key": "ctrlKey",
+				"comment": [
+					"This is the short form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey",
+				"comment": [
+					"This is the short form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey",
+				"comment": [
+					"This is the short form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "superKey",
+				"comment": [
+					"This is the short form for the Super key on the keyboard"
+				]
+			},
+			{
+				"key": "ctrlKey.long",
+				"comment": [
+					"This is the long form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey.long",
+				"comment": [
+					"This is the long form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey.long",
+				"comment": [
+					"This is the long form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "cmdKey.long",
+				"comment": [
+					"This is the long form for the Command key on the keyboard"
+				]
+			},
+			{
+				"key": "ctrlKey.long",
+				"comment": [
+					"This is the long form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey.long",
+				"comment": [
+					"This is the long form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey.long",
+				"comment": [
+					"This is the long form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "windowsKey.long",
+				"comment": [
+					"This is the long form for the Windows key on the keyboard"
+				]
+			},
+			{
+				"key": "ctrlKey.long",
+				"comment": [
+					"This is the long form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey.long",
+				"comment": [
+					"This is the long form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey.long",
+				"comment": [
+					"This is the long form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "superKey.long",
+				"comment": [
+					"This is the long form for the Super key on the keyboard"
+				]
+			}
+		],
+		"vs/workbench/contrib/notebook/browser/notebookKernelAssociation": [
+			"notebook.kernelProviderAssociations"
+		],
+		"vs/workbench/contrib/notebook/browser/extensionPoint": [
+			"contributes.notebook.provider",
+			"contributes.notebook.provider.viewType",
+			"contributes.notebook.provider.displayName",
+			"contributes.notebook.provider.selector",
+			"contributes.notebook.provider.selector.filenamePattern",
+			"contributes.notebook.selector.provider.excludeFileNamePattern",
+			"contributes.priority",
+			"contributes.priority.default",
+			"contributes.priority.option",
+			"contributes.notebook.renderer",
+			"contributes.notebook.renderer.viewType",
+			"contributes.notebook.provider.viewType.deprecated",
+			"contributes.notebook.renderer.viewType",
+			"contributes.notebook.renderer.displayName",
+			"contributes.notebook.selector",
+			"contributes.notebook.renderer.entrypoint",
+			"contributes.notebook.markdownRenderer",
+			"contributes.notebook.markdownRenderer.id",
+			"contributes.notebook.markdownRenderer.displayName",
+			"contributes.notebook.markdownRenderer.entrypoint"
+		],
+		"vs/workbench/contrib/notebook/common/notebookEditorModel": [
+			"notebook.staleSaveError",
+			"notebook.staleSaveError.revert",
+			"notebook.staleSaveError.overwrite.",
+			"save"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookEditorWidget": [
+			"notebookTreeAriaLabel",
+			"notebook.cellBorderColor",
+			"notebook.focusedEditorBorder",
+			"notebookStatusSuccessIcon.foreground",
+			"notebookStatusErrorIcon.foreground",
+			"notebookStatusRunningIcon.foreground",
+			"notebook.outputContainerBackgroundColor",
+			"notebook.cellToolbarSeparator",
+			"focusedCellBackground",
+			"selectedCellBackground",
+			"notebook.cellHoverBackground",
+			"notebook.selectedCellBorder",
+			"notebook.inactiveSelectedCellBorder",
+			"notebook.focusedCellBorder",
+			"notebook.inactiveFocusedCellBorder",
+			"notebook.cellStatusBarItemHoverBackground",
+			"notebook.cellInsertionIndicator",
+			"notebookScrollbarSliderBackground",
+			"notebookScrollbarSliderHoverBackground",
+			"notebookScrollbarSliderActiveBackground",
+			"notebook.symbolHighlightBackground"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookIcons": [
+			"configureKernel",
+			"selectKernelIcon",
+			"executeIcon",
+			"stopIcon",
+			"deleteCellIcon",
+			"executeAllIcon",
+			"editIcon",
+			"stopEditIcon",
+			"moveUpIcon",
+			"moveDownIcon",
+			"clearIcon",
+			"splitCellIcon",
+			"unfoldIcon",
+			"successStateIcon",
+			"errorStateIcon",
+			"collapsedIcon",
+			"expandedIcon",
+			"openAsTextIcon",
+			"revertIcon",
+			"renderOutputIcon",
+			"mimetypeIcon"
+		],
+		"vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget": [
+			"label.find",
+			"placeholder.find",
+			"label.previousMatchButton",
+			"label.nextMatchButton",
+			"label.closeButton",
+			"label.toggleReplaceButton",
+			"label.replace",
+			"placeholder.replace",
+			"label.replaceButton",
+			"label.replaceAllButton"
+		],
+		"vs/base/browser/ui/iconLabel/iconLabel": [
+			"iconLabel.loading"
 		],
 		"vs/workbench/contrib/testing/browser/theme": [
 			"testing.iconFailed",
@@ -9990,73 +10671,6 @@
 			"testState.running",
 			"testState.skipped",
 			"testState.unset"
-		],
-		"vs/workbench/contrib/notebook/browser/extensionPoint": [
-			"contributes.notebook.provider",
-			"contributes.notebook.provider.viewType",
-			"contributes.notebook.provider.displayName",
-			"contributes.notebook.provider.selector",
-			"contributes.notebook.provider.selector.filenamePattern",
-			"contributes.notebook.selector.provider.excludeFileNamePattern",
-			"contributes.priority",
-			"contributes.priority.default",
-			"contributes.priority.option",
-			"contributes.notebook.renderer",
-			"contributes.notebook.renderer.viewType",
-			"contributes.notebook.provider.viewType.deprecated",
-			"contributes.notebook.renderer.viewType",
-			"contributes.notebook.renderer.displayName",
-			"contributes.notebook.selector",
-			"contributes.notebook.renderer.entrypoint"
-		],
-		"vs/workbench/contrib/notebook/browser/notebookKernelAssociation": [
-			"notebook.kernelProviderAssociations"
-		],
-		"vs/workbench/contrib/notebook/common/model/notebookTextModel": [
-			"defaultEditLabel"
-		],
-		"vs/workbench/contrib/notebook/common/notebookEditorModel": [
-			"notebook.staleSaveError",
-			"notebook.staleSaveError.revert",
-			"notebook.staleSaveError.overwrite."
-		],
-		"vs/workbench/contrib/notebook/browser/notebookEditorWidget": [
-			"notebookTreeAriaLabel",
-			"notebook.runCell.selectKernel",
-			"notebook.promptKernel.setDefaultTooltip",
-			"notebook.cellBorderColor",
-			"notebook.focusedEditorBorder",
-			"notebookStatusSuccessIcon.foreground",
-			"notebookStatusErrorIcon.foreground",
-			"notebookStatusRunningIcon.foreground",
-			"notebook.outputContainerBackgroundColor",
-			"notebook.cellToolbarSeparator",
-			"focusedCellBackground",
-			"notebook.cellHoverBackground",
-			"notebook.selectedCellBorder",
-			"notebook.focusedCellBorder",
-			"notebook.inactiveFocusedCellBorder",
-			"notebook.cellStatusBarItemHoverBackground",
-			"notebook.cellInsertionIndicator",
-			"notebookScrollbarSliderBackground",
-			"notebookScrollbarSliderHoverBackground",
-			"notebookScrollbarSliderActiveBackground",
-			"notebook.symbolHighlightBackground"
-		],
-		"vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget": [
-			"label.find",
-			"placeholder.find",
-			"label.previousMatchButton",
-			"label.nextMatchButton",
-			"label.closeButton",
-			"label.toggleReplaceButton",
-			"label.replace",
-			"placeholder.replace",
-			"label.replaceButton",
-			"label.replaceAllButton"
-		],
-		"vs/base/browser/ui/iconLabel/iconLabel": [
-			"iconLabel.loading"
 		],
 		"vs/platform/quickinput/browser/commandsQuickAccess": [
 			"commandPickAriaLabelWithKeybinding",
@@ -10123,12 +10737,6 @@
 			"move",
 			"moving"
 		],
-		"vs/workbench/browser/parts/editor/binaryEditor": [
-			"binaryEditor",
-			"nativeFileTooLargeError",
-			"nativeBinaryError",
-			"openAsText"
-		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
 			"bulkEdit",
 			"aria.renameAndEdit",
@@ -10185,46 +10793,12 @@
 		"vs/workbench/contrib/search/browser/replaceService": [
 			"fileReplaceChanges"
 		],
-		"vs/workbench/contrib/debug/common/debugModel": [
-			"invalidVariableAttributes",
-			"startDebugFirst",
-			"notAvailable",
-			{
-				"key": "pausedOn",
-				"comment": [
-					"indicates reason for program being paused"
-				]
-			},
-			"paused",
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"breakpointDirtydHover"
-		],
 		"vs/workbench/contrib/debug/browser/debugConfigurationManager": [
 			"selectConfiguration",
 			"editLaunchConfig",
 			"DebugConfig.failed",
 			"workspace",
 			"user settings"
-		],
-		"vs/workbench/contrib/debug/browser/debugTaskRunner": [
-			"preLaunchTaskErrors",
-			"preLaunchTaskError",
-			"preLaunchTaskExitCode",
-			"preLaunchTaskTerminated",
-			"debugAnyway",
-			"showErrors",
-			"abort",
-			"remember",
-			"invalidTaskReference",
-			"DebugTaskNotFoundWithTaskId",
-			"DebugTaskNotFound",
-			"taskNotTrackedWithTaskId",
-			"taskNotTracked"
 		],
 		"vs/workbench/contrib/debug/browser/debugSession": [
 			"noDebugAdapter",
@@ -10262,13 +10836,31 @@
 			"debuggingStarted",
 			"debuggingStopped"
 		],
+		"vs/workbench/contrib/debug/browser/debugTaskRunner": [
+			"preLaunchTaskErrors",
+			"preLaunchTaskError",
+			"preLaunchTaskExitCode",
+			"preLaunchTaskTerminated",
+			"debugAnyway",
+			"showErrors",
+			"abort",
+			"remember",
+			"debugAnyway",
+			"cancel",
+			"rememberTask",
+			"invalidTaskReference",
+			"DebugTaskNotFoundWithTaskId",
+			"DebugTaskNotFound",
+			"taskNotTrackedWithTaskId",
+			"taskNotTracked"
+		],
+		"vs/workbench/contrib/debug/common/debugSource": [
+			"unknownSource"
+		],
 		"vs/workbench/contrib/debug/browser/debugAdapterManager": [
 			"debugNoType",
 			"more",
 			"selectDebug"
-		],
-		"vs/workbench/contrib/debug/common/debugSource": [
-			"unknownSource"
 		],
 		"vs/base/browser/ui/findinput/findInput": [
 			"defaultLabel"
@@ -10307,20 +10899,22 @@
 			"newComment"
 		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
+			"promptOpenWith.defaultEditor.displayName",
 			"builtinProviderDisplayName",
-			"promptOpenWith.defaultEditor.displayName"
+			"builtinProviderDisplayName"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"ratedBySingleUser",
 			"ratedByUsers",
 			"noRating",
 			"remote extension title",
-			"syncingore.label"
+			"syncingore.label",
+			"extensionIconStarForeground"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
 			"error",
 			"Unknown Extension",
-			"extension-arialabel",
+			"extension.arialabel",
 			"extensions"
 		],
 		"vs/workbench/contrib/extensions/browser/dynamicWorkspaceRecommendations": [
@@ -10332,9 +10926,6 @@
 		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
 			"workspaceRecommendation"
 		],
-		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
-			"exeBasedRecommendation"
-		],
 		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
 			"searchMarketplace",
 			"fileBasedRecommendation",
@@ -10342,12 +10933,37 @@
 			"showLanguageExtensions",
 			"dontShowAgainExtension"
 		],
+		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
+			"exeBasedRecommendation"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
 			"terminal.integrated.allowWorkspaceShell",
 			"allow",
 			"disallow",
 			"useWslExtension.title",
 			"install"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalTab": [
+			"ptyDisconnected"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalInstance": [
+			"terminal.integrated.a11yPromptLabel",
+			"terminal.integrated.a11yTooMuchOutput",
+			"keybindingHandling",
+			"configureTerminalSettings",
+			"yes",
+			"no",
+			"dontShowAgain",
+			"terminal.slowRendering",
+			"terminal.integrated.copySelection.noSelection",
+			"launchFailed.exitCodeAndCommandLine",
+			"launchFailed.exitCodeOnly",
+			"terminated.exitCodeAndCommandLine",
+			"terminated.exitCodeOnly",
+			"launchFailed.errorMessage",
+			"terminalTextBoxAriaLabelNumberAndTitle",
+			"terminalTextBoxAriaLabel",
+			"terminalStaleTextBoxAriaLabel"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
 			"JsonSchema.options",
@@ -10391,25 +11007,6 @@
 			"JsonSchema.taskSelector",
 			"JsonSchema.matchers",
 			"JsonSchema.tasks"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalInstance": [
-			"terminal.integrated.a11yPromptLabel",
-			"terminal.integrated.a11yTooMuchOutput",
-			"configure terminal settings",
-			"configureTerminalSettings",
-			"yes",
-			"no",
-			"dontShowAgain",
-			"terminal.slowRendering",
-			"terminal.integrated.copySelection.noSelection",
-			"launchFailed.exitCodeAndCommandLine",
-			"launchFailed.exitCodeOnly",
-			"terminated.exitCodeAndCommandLine",
-			"terminated.exitCodeOnly",
-			"launchFailed.errorMessage",
-			"terminalTextBoxAriaLabelNumberAndTitle",
-			"terminalTextBoxAriaLabel",
-			"terminalStaleTextBoxAriaLabel"
 		],
 		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
 			"deprecatedVariables"
@@ -10472,6 +11069,9 @@
 			"NovemberShort",
 			"DecemberShort"
 		],
+		"vs/editor/browser/core/keybindingCancellation": [
+			"cancellableOperation"
+		],
 		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
 			"releaseNotesInputName",
 			"unassigned"
@@ -10480,6 +11080,9 @@
 			"welcomePage.buttonBackground",
 			"welcomePage.buttonHoverBackground",
 			"welcomePage.background",
+			"welcomePage.tileBackground",
+			"welcomePage.tileHoverBackground",
+			"welcomePage.tileShadow",
 			"welcomePage.progress.background",
 			"welcomePage.progress.foreground"
 		],
@@ -10528,19 +11131,138 @@
 			"welcomePage.interactivePlayground",
 			"welcomePage.interactivePlaygroundDescription"
 		],
-		"vs/workbench/contrib/welcome/gettingStarted/browser/vs_code_editor_getting_started": [
-			"gettingStarted.vscode",
-			{
-				"key": "gettingStarted.editingRedefined",
-				"comment": [
-					"Shown as subtitle on the Welcome page."
-				]
-			}
+		"vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent": [
+			"getting-started-setup-icon",
+			"getting-started-beginner-icon",
+			"getting-started-codespaces-icon",
+			"gettingStarted.newFile.title",
+			"gettingStarted.newFile.description",
+			"gettingStarted.openMac.title",
+			"gettingStarted.openMac.description",
+			"gettingStarted.openFile.title",
+			"gettingStarted.openFile.description",
+			"gettingStarted.openFolder.title",
+			"gettingStarted.openFolder.description",
+			"gettingStarted.cloneRepo.title",
+			"gettingStarted.cloneRepo.description",
+			"gettingStarted.topLevelCommandPalette.title",
+			"gettingStarted.topLevelCommandPalette.description",
+			"gettingStarted.codespaces.title",
+			"gettingStarted.codespaces.description",
+			"gettingStarted.runProject.title",
+			"gettingStarted.runProject.description",
+			"gettingStarted.runProject.button",
+			"gettingStarted.forwardPorts.title",
+			"gettingStarted.forwardPorts.description",
+			"gettingStarted.forwardPorts.button",
+			"gettingStarted.pullRequests.title",
+			"gettingStarted.pullRequests.description",
+			"gettingStarted.pullRequests.button",
+			"gettingStarted.remoteTerminal.title",
+			"gettingStarted.remoteTerminal.description",
+			"gettingStarted.remoteTerminal.button",
+			"gettingStarted.openVSC.title",
+			"gettingStarted.openVSC.description",
+			"gettingStarted.openVSC.button",
+			"gettingStarted.setup.title",
+			"gettingStarted.setup.description",
+			"gettingStarted.pickColor.title",
+			"gettingStarted.pickColor.description",
+			"gettingStarted.pickColor.button",
+			"gettingStarted.findLanguageExts.title",
+			"gettingStarted.findLanguageExts.description",
+			"gettingStarted.findLanguageExts.button",
+			"gettingStarted.keymaps.title",
+			"gettingStarted.keymaps.description",
+			"gettingStarted.keymaps.button",
+			"gettingStarted.settingsSync.title",
+			"gettingStarted.settingsSync.description",
+			"gettingStarted.settingsSync.button",
+			"gettingStarted.setup.OpenFolder.title",
+			"gettingStarted.setup.OpenFolder.description",
+			"gettingStarted.setup.OpenFolder.button",
+			"gettingStarted.setup.OpenFolder.title",
+			"gettingStarted.setup.OpenFolder.description2",
+			"gettingStarted.setup.OpenFolder.button",
+			"gettingStarted.beginner.title",
+			"gettingStarted.beginner.description",
+			"gettingStarted.commandPalette.title",
+			"gettingStarted.commandPalette.description",
+			"gettingStarted.commandPalette.button",
+			"gettingStarted.terminal.title",
+			"gettingStarted.terminal.description",
+			"gettingStarted.terminal.button",
+			"gettingStarted.extensions.title",
+			"gettingStarted.extensions.description",
+			"gettingStarted.extensions.button",
+			"gettingStarted.settings.title",
+			"gettingStarted.settings.description",
+			"gettingStarted.settings.button",
+			"gettingStarted.videoTutorial.title",
+			"gettingStarted.videoTutorial.description",
+			"gettingStarted.videoTutorial.button"
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
 			"tree.aria",
 			"from",
 			"to"
+		],
+		"vs/editor/contrib/symbolIcons/symbolIcons": [
+			"symbolIcon.arrayForeground",
+			"symbolIcon.booleanForeground",
+			"symbolIcon.classForeground",
+			"symbolIcon.colorForeground",
+			"symbolIcon.constantForeground",
+			"symbolIcon.constructorForeground",
+			"symbolIcon.enumeratorForeground",
+			"symbolIcon.enumeratorMemberForeground",
+			"symbolIcon.eventForeground",
+			"symbolIcon.fieldForeground",
+			"symbolIcon.fileForeground",
+			"symbolIcon.folderForeground",
+			"symbolIcon.functionForeground",
+			"symbolIcon.interfaceForeground",
+			"symbolIcon.keyForeground",
+			"symbolIcon.keywordForeground",
+			"symbolIcon.methodForeground",
+			"symbolIcon.moduleForeground",
+			"symbolIcon.namespaceForeground",
+			"symbolIcon.nullForeground",
+			"symbolIcon.numberForeground",
+			"symbolIcon.objectForeground",
+			"symbolIcon.operatorForeground",
+			"symbolIcon.packageForeground",
+			"symbolIcon.propertyForeground",
+			"symbolIcon.referenceForeground",
+			"symbolIcon.snippetForeground",
+			"symbolIcon.stringForeground",
+			"symbolIcon.structForeground",
+			"symbolIcon.textForeground",
+			"symbolIcon.typeParameterForeground",
+			"symbolIcon.unitForeground",
+			"symbolIcon.variableForeground"
+		],
+		"vs/workbench/contrib/feedback/browser/feedback": [
+			"sendFeedback",
+			"label.sendASmile",
+			"close",
+			"patchedVersion1",
+			"patchedVersion2",
+			"sentiment",
+			"smileCaption",
+			"smileCaption",
+			"frownCaption",
+			"frownCaption",
+			"other ways to contact us",
+			"submit a bug",
+			"request a missing feature",
+			"tell us why",
+			"feedbackTextInput",
+			"showFeedback",
+			"tweet",
+			"tweetFeedback",
+			"character left",
+			"characters left"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
 			"merges",
@@ -10557,12 +11279,7 @@
 					"A confirmation message to replace current user data (settings, extensions, keybindings, snippets) with selected version"
 				]
 			},
-			{
-				"key": "workbench.actions.sync.compareWithLocal",
-				"comment": [
-					"This is an action title to show the changes between local and remote version of resources"
-				]
-			},
+			"reset",
 			{
 				"key": "leftResourceName",
 				"comment": [
@@ -10576,8 +11293,6 @@
 				]
 			},
 			"sideBySideLabels",
-			"sideBySideDescription",
-			"reset",
 			{
 				"key": "current",
 				"comment": [
@@ -10603,32 +11318,40 @@
 			"not found",
 			"valid message"
 		],
-		"vs/workbench/contrib/feedback/browser/feedback": [
-			"sendFeedback",
-			"label.sendASmile",
-			"close",
-			"patchedVersion1",
-			"patchedVersion2",
-			"sentiment",
-			"smileCaption",
-			"smileCaption",
-			"frownCaption",
-			"frownCaption",
-			"other ways to contact us",
-			"submit a bug",
-			"request a missing feature",
-			"tell us why",
-			"feedbackTextInput",
-			"showFeedback",
-			"tweet",
-			"tweetFeedback",
-			"character left",
-			"characters left"
+		"vs/workbench/contrib/workspace/browser/workspaceTrustTree": [
+			"modified",
+			"trustedFolders",
+			"trustedFoldersDescription",
+			"untrustedFolders",
+			"untrustedFoldersDescription",
+			"settings"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsViewer": [
-			"executeCommand",
-			"notificationActions",
-			"notificationSource"
+		"vs/workbench/contrib/workspace/browser/workspaceTrustColors": [
+			"workspaceTrustTrustedColor",
+			"workspaceTrustUntrustedColor"
+		],
+		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
+			"saveParticipants"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"notificationAriaLabel",
+			"notificationWithSourceAriaLabel",
+			"notificationsList"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsActions": [
+			"clearIcon",
+			"clearAllIcon",
+			"hideIcon",
+			"expandIcon",
+			"collapseIcon",
+			"configureIcon",
+			"clearNotification",
+			"clearNotifications",
+			"hideNotificationsCenter",
+			"expandNotification",
+			"collapseNotification",
+			"configureNotification",
+			"copyNotification"
 		],
 		"vs/editor/browser/controller/textAreaHandler": [
 			"editor",
@@ -10645,7 +11368,7 @@
 			"peekView.alternateTitle"
 		],
 		"vs/editor/contrib/hover/markerHoverParticipant": [
-			"peek problem",
+			"view problem",
 			"noQuickFixes",
 			"checkingForQuickFixes",
 			"noQuickFixes",
@@ -10654,12 +11377,12 @@
 		"vs/editor/contrib/hover/markdownHoverParticipant": [
 			"modesContentHover.loading"
 		],
+		"vs/editor/contrib/suggest/suggestWidgetStatus": [
+			"ddd"
+		],
 		"vs/editor/contrib/suggest/suggestWidgetDetails": [
 			"details.close",
 			"loading"
-		],
-		"vs/editor/contrib/suggest/suggestWidgetStatus": [
-			"ddd"
 		],
 		"vs/editor/contrib/suggest/suggestWidgetRenderer": [
 			"suggestMoreInfoIcon",
@@ -10673,6 +11396,9 @@
 			"draggedEditorGroup"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
+			"breadcrumbsPossible",
+			"breadcrumbsVisible",
+			"breadcrumbsActive",
 			"cmd.toggle",
 			"miShowBreadcrumbs",
 			"cmd.focus"
@@ -10680,8 +11406,17 @@
 		"vs/base/parts/quickinput/browser/quickInputList": [
 			"quickInput"
 		],
+		"vs/workbench/contrib/notebook/browser/notebookEditorKernelManager": [
+			"notebook.runCell.selectKernel",
+			"notebook.promptKernel.setDefaultTooltip"
+		],
 		"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer": [
-			"cellExpandButtonLabel"
+			"cellExpandButtonLabel",
+			"runStateExecuting",
+			"runStatePending"
+		],
+		"vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel": [
+			"notebook.emptyMarkdownPlaceholder"
 		],
 		"vs/workbench/contrib/debug/common/debugSchemas": [
 			"vscode.extension.contributes.debuggers",
@@ -10720,6 +11455,11 @@
 			"app.launch.json.compound.stopAll",
 			"compoundPrelaunchTask"
 		],
+		"vs/workbench/contrib/debug/browser/rawDebugSession": [
+			"noDebugAdapterStart",
+			"noDebugAdapter",
+			"moreInfo"
+		],
 		"vs/workbench/contrib/debug/common/debugger": [
 			"cannot.find.da",
 			"launch.config.comment1",
@@ -10736,11 +11476,6 @@
 			"debugWindowsConfiguration",
 			"debugOSXConfiguration",
 			"debugLinuxConfiguration"
-		],
-		"vs/workbench/contrib/debug/browser/rawDebugSession": [
-			"noDebugAdapterStart",
-			"noDebugAdapter",
-			"moreInfo"
 		],
 		"vs/base/browser/ui/selectBox/selectBoxCustom": [
 			{
@@ -10778,61 +11513,8 @@
 			"followLink",
 			"followLinkUrl"
 		],
-		"vs/workbench/services/gettingStarted/common/gettingStartedContent": [
-			"getting-started-setup-icon",
-			"getting-started-beginner-icon",
-			"getting-started-codespaces-icon",
-			"gettingStarted.codespaces.title",
-			"gettingStarted.codespaces.description",
-			"gettingStarted.runProject.title",
-			"gettingStarted.runProject.description",
-			"gettingStarted.runProject.button",
-			"gettingStarted.forwardPorts.title",
-			"gettingStarted.forwardPorts.description",
-			"gettingStarted.forwardPorts.button",
-			"gettingStarted.pullRequests.title",
-			"gettingStarted.pullRequests.description",
-			"gettingStarted.pullRequests.button",
-			"gettingStarted.remoteTerminal.title",
-			"gettingStarted.remoteTerminal.description",
-			"gettingStarted.remoteTerminal.button",
-			"gettingStarted.openVSC.title",
-			"gettingStarted.openVSC.description",
-			"gettingStarted.openVSC.button",
-			"gettingStarted.setup.title",
-			"gettingStarted.setup.description",
-			"gettingStarted.pickColor.title",
-			"gettingStarted.pickColor.description",
-			"gettingStarted.pickColor.button",
-			"gettingStarted.findLanguageExts.title",
-			"gettingStarted.findLanguageExts.description",
-			"gettingStarted.findLanguageExts.button",
-			"gettingStarted.settingsSync.title",
-			"gettingStarted.settingsSync.description",
-			"gettingStarted.settingsSync.button",
-			"gettingStarted.setup.OpenFolder.title",
-			"gettingStarted.setup.OpenFolder.description",
-			"gettingStarted.setup.OpenFolder.button",
-			"gettingStarted.setup.OpenFolder.title",
-			"gettingStarted.setup.OpenFolder.description2",
-			"gettingStarted.setup.OpenFolder.button",
-			"gettingStarted.beginner.title",
-			"gettingStarted.beginner.description",
-			"gettingStarted.commandPalette.title",
-			"gettingStarted.commandPalette.description",
-			"gettingStarted.commandPalette.button",
-			"gettingStarted.terminal.title",
-			"gettingStarted.terminal.description",
-			"gettingStarted.terminal.button",
-			"gettingStarted.extensions.title",
-			"gettingStarted.extensions.description",
-			"gettingStarted.extensions.button",
-			"gettingStarted.settings.title",
-			"gettingStarted.settings.description",
-			"gettingStarted.settings.button",
-			"gettingStarted.videoTutorial.title",
-			"gettingStarted.videoTutorial.description",
-			"gettingStarted.videoTutorial.button"
+		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
+			"ptyHostRelaunch"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncMergesView": [
 			"explanation",
@@ -10873,6 +11555,11 @@
 			"accept remote",
 			"accept local",
 			"accept merges"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsViewer": [
+			"executeCommand",
+			"notificationActions",
+			"notificationSource"
 		],
 		"vs/editor/contrib/codeAction/lightBulbWidget": [
 			"prefferedQuickFixWithKb",
@@ -10930,6 +11617,9 @@
 		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
 			"breadcrumbs"
 		],
+		"vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets": [
+			"notebook.cell.status.language"
+		],
 		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
 			"mimeTypePicker",
 			"curruentActiveMimeType",
@@ -10938,20 +11628,11 @@
 			"builtinRenderInfo",
 			"builtinRenderInfo"
 		],
-		"vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel": [
-			"notebook.emptyMarkdownPlaceholder"
-		],
-		"vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets": [
-			"notebook.cell.status.language"
-		],
 		"vs/workbench/contrib/comments/browser/reactionsAction": [
 			"pickReactions"
 		],
 		"vs/workbench/contrib/terminal/browser/links/terminalWordLinkProvider": [
 			"searchWorkspace"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy": [
-			"terminal.integrated.starting"
 		],
 		"vs/workbench/contrib/terminal/browser/environmentVariableInfo": [
 			"extensionEnvironmentContributionChanges",
@@ -11002,10 +11683,8 @@
 			"Select source",
 			"Visual Studio Code",
 			"An extension",
-			"Select source",
-			"Visual Studio Code",
-			"An extension",
-			"Don't Know",
+			"Extensions marketplace",
+			"Don't know",
 			"Steps to Reproduce",
 			"Share the steps needed to reliably reproduce the problem. Please include actual and expected results. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
 			"Steps to Reproduce",
@@ -11026,18 +11705,6 @@
 			"Copy",
 			"Copy All",
 			"Debug"
-		],
-		"vs/workbench/services/integrity/node/integrityService": [
-			"Your {0} installation appears to be corrupt. Please reinstall.",
-			"More Information",
-			"Don't Show Again"
-		],
-		"vs/workbench/services/textfile/electron-browser/nativeTextFileService": [
-			"File is Read Only"
-		],
-		"vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService": [
-			"Local",
-			"Remote"
 		],
 		"vs/workbench/services/extensions/electron-browser/extensionService": [
 			"Extension host cannot start: version mismatch.",
@@ -11092,100 +11759,10 @@
 			"The launched task doesn't exist anymore. If the task spawned background processes exiting VS Code might result in orphaned processes. To avoid this start the last background process with a wait flag.",
 			"&&Exit Anyways"
 		],
-		"vs/workbench/contrib/userDataSync/electron-browser/userDataSync.contribution": [
-			"Operation Id: {0}",
-			"Settings sync is disabled because the current device is making too many requests. Please report an issue by providing the sync logs.",
-			"Settings Sync. Operation Id: {0}",
-			"Show Log",
-			"Report Issue",
-			"Open Local Backups Folder",
-			"Local backups folder does not exist"
-		],
 		"vs/platform/environment/node/argvHelper": [
 			"Warning: '{0}' is not in the list of known options, but still passed to Electron/Chromium.",
 			"Option '{0}' is defined more than once. Using value '{1}.'",
 			"Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`."
-		],
-		"vs/platform/request/common/request": [
-			"HTTP",
-			"The proxy setting to use. If not set, will be inherited from the `http_proxy` and `https_proxy` environment variables.",
-			"Controls whether the proxy server certificate should be verified against the list of supplied CAs.",
-			"The value to send as the `Proxy-Authorization` header for every network request.",
-			"Disable proxy support for extensions.",
-			"Enable proxy support for extensions.",
-			"Enable proxy support for extensions, override request options.",
-			"Use the proxy support for extensions.",
-			"Controls whether CA certificates should be loaded from the OS. (On Windows and macOS a reload of the window is required after turning this off.)"
-		],
-		"vs/code/electron-main/app": [
-			"Successfully created trace.",
-			"Please create an issue and manually attach the following file:\n{0}",
-			"OK",
-			"&&Yes",
-			"&&No",
-			"An external application wants to open '{0}' in {1}. Do you want to open this file or folder?",
-			"If you did not initiate this request, it may represent an attempted attack on your system. Unless you took an explicit action to initiate this request, you should press 'No'"
-		],
-		"vs/platform/files/node/diskFileSystemProvider": [
-			"File already exists",
-			"File does not exist",
-			"Unable to move '{0}' into '{1}' ({2}).",
-			"Unable to copy '{0}' into '{1}' ({2}).",
-			"'File cannot be copied to same path with different path case",
-			"File at target already exists"
-		],
-		"vs/platform/files/common/fileService": [
-			"Unable to resolve filesystem provider with relative file path '{0}'",
-			"No file system provider found for resource '{0}'",
-			"Unable to resolve non-existing file '{0}'",
-			"Unable to create file '{0}' that already exists when overwrite flag is not set",
-			"Unable to write file '{0}' ({1})",
-			"Unable to write file '{0}' that is actually a directory",
-			"File Modified Since",
-			"Unable to read file '{0}' ({1})",
-			"Unable to read file '{0}' ({1})",
-			"Unable to read file '{0}' ({1})",
-			"Unable to read file '{0}' that is actually a directory",
-			"File not modified since",
-			"Unable to read file '{0}' that is too large to open",
-			"Unable to copy when source '{0}' is same as target '{1}' with different path case on a case insensitive file system",
-			"Unable to move/copy when source '{0}' is parent of target '{1}'.",
-			"Unable to move/copy '{0}' because target '{1}' already exists at destination.",
-			"Unable to move/copy '{0}' into '{1}' since a file would replace the folder it is contained in.",
-			"Unable to create folder '{0}' that already exists but is not a directory",
-			"Unable to delete file '{0}' via trash because provider does not support it.",
-			"Unable to delete non-existing file '{0}'",
-			"Unable to delete non-empty folder '{0}'.",
-			"Unable to modify readonly file '{0}'"
-		],
-		"vs/platform/files/common/files": [
-			"Unknown Error",
-			"{0}B",
-			"{0}KB",
-			"{0}MB",
-			"{0}GB",
-			"{0}TB"
-		],
-		"vs/base/common/errorMessage": [
-			"{0}: {1}",
-			"A system error occurred ({0})",
-			"An unknown error occurred. Please consult the log for more details.",
-			"An unknown error occurred. Please consult the log for more details.",
-			"{0} ({1} errors in total)",
-			"An unknown error occurred. Please consult the log for more details."
-		],
-		"vs/platform/update/common/update.config.contribution": [
-			"Update",
-			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
-			"Disable updates.",
-			"Disable automatic background update checks. Updates will be available if you manually check for updates.",
-			"Check for updates only on startup. Disable automatic background update checks.",
-			"Enable automatic update checks. Code will check for updates automatically and periodically.",
-			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
-			"This setting is deprecated, please use '{0}' instead.",
-			"Enable Background Updates on Windows",
-			"Enable to download and install new VS Code Versions in the background on Windows",
-			"Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."
 		],
 		"vs/platform/environment/node/argv": [
 			"Options",
@@ -11228,9 +11805,87 @@
 			"Unknown version",
 			"Unknown commit"
 		],
-		"vs/platform/extensionManagement/common/extensionManagement": [
-			"Extensions",
-			"Preferences"
+		"vs/code/electron-main/app": [
+			"&&Yes",
+			"&&No",
+			"An external application wants to open '{0}' in {1}. Do you want to open this file or folder?",
+			"If you did not initiate this request, it may represent an attempted attack on your system. Unless you took an explicit action to initiate this request, you should press 'No'",
+			"Successfully created trace.",
+			"Please create an issue and manually attach the following file:\n{0}",
+			"OK"
+		],
+		"vs/platform/request/common/request": [
+			"HTTP",
+			"The proxy setting to use. If not set, will be inherited from the `http_proxy` and `https_proxy` environment variables.",
+			"Controls whether the proxy server certificate should be verified against the list of supplied CAs.",
+			"The value to send as the `Proxy-Authorization` header for every network request.",
+			"Disable proxy support for extensions.",
+			"Enable proxy support for extensions.",
+			"Enable proxy support for extensions, override request options.",
+			"Use the proxy support for extensions.",
+			"Controls whether CA certificates should be loaded from the OS. (On Windows and macOS, a reload of the window is required after turning this off.)"
+		],
+		"vs/platform/files/common/fileService": [
+			"Unable to resolve filesystem provider with relative file path '{0}'",
+			"No file system provider found for resource '{0}'",
+			"Unable to resolve non-existing file '{0}'",
+			"Unable to create file '{0}' that already exists when overwrite flag is not set",
+			"Unable to write file '{0}' ({1})",
+			"Unable to unlock file '{0}' because provider does not support it.",
+			"Unable to write file '{0}' that is actually a directory",
+			"File Modified Since",
+			"Unable to read file '{0}' ({1})",
+			"Unable to read file '{0}' ({1})",
+			"Unable to read file '{0}' ({1})",
+			"Unable to read file '{0}' that is actually a directory",
+			"File not modified since",
+			"Unable to read file '{0}' that is too large to open",
+			"Unable to copy when source '{0}' is same as target '{1}' with different path case on a case insensitive file system",
+			"Unable to move/copy when source '{0}' is parent of target '{1}'.",
+			"Unable to move/copy '{0}' because target '{1}' already exists at destination.",
+			"Unable to move/copy '{0}' into '{1}' since a file would replace the folder it is contained in.",
+			"Unable to create folder '{0}' that already exists but is not a directory",
+			"Unable to delete file '{0}' via trash because provider does not support it.",
+			"Unable to delete non-existing file '{0}'",
+			"Unable to delete non-empty folder '{0}'.",
+			"Unable to modify readonly file '{0}'"
+		],
+		"vs/platform/files/node/diskFileSystemProvider": [
+			"File already exists",
+			"File does not exist",
+			"Unable to move '{0}' into '{1}' ({2}).",
+			"Unable to copy '{0}' into '{1}' ({2}).",
+			"'File cannot be copied to same path with different path case",
+			"File at target already exists"
+		],
+		"vs/platform/files/common/files": [
+			"Unknown Error",
+			"{0}B",
+			"{0}KB",
+			"{0}MB",
+			"{0}GB",
+			"{0}TB"
+		],
+		"vs/base/common/errorMessage": [
+			"{0}: {1}",
+			"A system error occurred ({0})",
+			"An unknown error occurred. Please consult the log for more details.",
+			"An unknown error occurred. Please consult the log for more details.",
+			"{0} ({1} errors in total)",
+			"An unknown error occurred. Please consult the log for more details."
+		],
+		"vs/platform/update/common/update.config.contribution": [
+			"Update",
+			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
+			"Disable updates.",
+			"Disable automatic background update checks. Updates will be available if you manually check for updates.",
+			"Check for updates only on startup. Disable automatic background update checks.",
+			"Enable automatic update checks. Code will check for updates automatically and periodically.",
+			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
+			"This setting is deprecated, please use '{0}' instead.",
+			"Enable Background Updates on Windows",
+			"Enable to download and install new VS Code versions in the background on Windows.",
+			"Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."
 		],
 		"vs/platform/extensionManagement/node/extensionManagementService": [
 			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.",
@@ -11252,6 +11907,10 @@
 			"Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}' and '{3}' extensions depend on this.",
 			"Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}', '{3}' and other extensions depend on this.",
 			"Could not find extension"
+		],
+		"vs/platform/extensionManagement/common/extensionManagement": [
+			"Extensions",
+			"Preferences"
 		],
 		"vs/platform/telemetry/common/telemetryService": [
 			"Telemetry",
@@ -11318,11 +11977,11 @@
 			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
 			"Configure settings to be ignored while synchronizing."
 		],
-		"vs/platform/userDataSync/common/userDataSyncMachines": [
-			"Cannot read machines data as the current version is incompatible. Please update {0} and try again."
-		],
 		"vs/platform/extensionManagement/electron-sandbox/extensionTipsService": [
 			"You have {0} installed on your system. Do you want to install the recommended extensions for it?"
+		],
+		"vs/platform/userDataSync/common/userDataSyncMachines": [
+			"Cannot read machines data as the current version is incompatible. Please update {0} and try again."
 		],
 		"vs/platform/userDataSync/common/userDataAutoSyncService": [
 			"Cannot sync because default service has changed",
@@ -11348,6 +12007,15 @@
 			"Unable to save workspace '{0}'",
 			"OK",
 			"The workspace is already opened in another window. Please close that window first and then try again."
+		],
+		"vs/workbench/services/extensionManagement/electron-sandbox/extensionManagementServerService": [
+			"Local",
+			"Remote"
+		],
+		"vs/workbench/services/integrity/electron-sandbox/integrityService": [
+			"Your {0} installation appears to be corrupt. Please reinstall.",
+			"More Information",
+			"Don't Show Again"
 		],
 		"vs/workbench/contrib/localizations/browser/localizations.contribution": [
 			"Would you like to change VS Code's UI language to {0} and restart?",
@@ -11407,7 +12075,7 @@
 			"Enable crash reports to be sent to a Microsoft online service. \nThis option requires restart to take effect.",
 			"Keyboard",
 			"Enables the macOS touchbar buttons on the keyboard if available.",
-			"A set of identifiers for entries in the touchbar that should not show up (for example `workbench.action.navigateBack`.",
+			"A set of identifiers for entries in the touchbar that should not show up (for example `workbench.action.navigateBack`).",
 			"The display Language to use. Picking a different language requires the associated language pack to be installed.",
 			"Disables hardware acceleration. ONLY change this option if you encounter graphic issues.",
 			"Resolves issues around color profile selection. ONLY change this option if you encounter graphic issues.",
@@ -11415,6 +12083,7 @@
 			"Allows to disable crash reporting, should restart the app if the value is changed.",
 			"Unique id used for correlating crash reports sent from this app instance.",
 			"Enable proposed APIs for a list of extension ids (such as `vscode.git`). Proposed APIs are unstable and subject to breaking without warning at any time. This should only be set for extension development and testing purposes.",
+			"Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.",
 			"Forces the renderer to be accessible. ONLY change this if you are using a screen reader on Linux. On other platforms the renderer will automatically be accessible. This flag is automatically set if you have editor.accessibilitySupport: on."
 		],
 		"vs/workbench/contrib/files/electron-sandbox/files.contribution": [
@@ -11433,46 +12102,18 @@
 			"Remote",
 			"When enabled extensions are downloaded locally and installed on remote."
 		],
-		"vs/workbench/browser/workbench": [
-			"Failed to load a required file. Please restart the application to try again. Details: {0}"
-		],
-		"vs/workbench/electron-sandbox/window": [
-			"Learn More",
-			"Resolving your shell environment is taking very long. Please review your shell configuration.",
-			"Unable to resolve your shell environment in a reasonable time. Please review your shell configuration.",
-			"Proxy Authentication Required",
-			"&&Log In",
-			"&&Cancel",
-			"Username",
-			"Password",
-			"The proxy {0} requires a username and password.",
-			"Remember my credentials",
-			"It is not recommended to run {0} as root user.",
-			"There is a dependency cycle in the AMD modules that needs to be resolved!",
-			"OK"
-		],
-		"vs/platform/workspaces/common/workspaces": [
-			"Code Workspace"
-		],
-		"vs/workbench/services/remote/electron-sandbox/remoteAgentServiceImpl": [
-			"Failed to connect to the remote extension host server (Error: {0})"
+		"vs/workbench/contrib/userDataSync/electron-sandbox/userDataSync.contribution": [
+			"Operation Id: {0}",
+			"Settings sync is disabled because the current device is making too many requests. Please report an issue by providing the sync logs.",
+			"Settings Sync. Operation Id: {0}",
+			"Show Log",
+			"Report Issue",
+			"Open Local Backups Folder",
+			"Local backups folder does not exist"
 		],
 		"vs/platform/files/electron-browser/diskFileSystemProvider": [
 			"Failed to move '{0}' to the recycle bin",
 			"Failed to move '{0}' to the trash"
-		],
-		"vs/workbench/services/textfile/browser/textFileService": [
-			"File seems to be binary and cannot be opened as text",
-			"'{0}' already exists. Do you want to replace it?",
-			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
-			"&&Replace"
-		],
-		"vs/platform/dialogs/common/dialogs": [
-			"...1 additional file not shown",
-			"...{0} additional files not shown"
-		],
-		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
-			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'."
 		],
 		"vs/workbench/services/extensions/electron-browser/localProcessExtensionHost": [
 			"Extension host did not start in 10 seconds, it might be stopped on the first line and needs a debugger to continue.",
@@ -11489,7 +12130,8 @@
 			"Reload Window"
 		],
 		"vs/workbench/services/extensions/common/abstractExtensionService": [
-			"The following extensions contain dependency loops and have been disabled: {0}"
+			"The following extensions contain dependency loops and have been disabled: {0}",
+			"No extension host found that can launch the test runner at {0}."
 		],
 		"vs/workbench/services/extensions/common/remoteExtensionHost": [
 			"Remote Extension Host"
@@ -11503,37 +12145,30 @@
 			"Preferences",
 			"Developer"
 		],
-		"vs/base/common/date": [
-			"in {0}",
-			"now",
-			"{0} sec ago",
-			"{0} secs ago",
-			"{0} sec",
-			"{0} secs",
-			"{0} min ago",
-			"{0} mins ago",
-			"{0} min",
-			"{0} mins",
-			"{0} hr ago",
-			"{0} hrs ago",
-			"{0} hr",
-			"{0} hrs",
-			"{0} day ago",
-			"{0} days ago",
-			"{0} day",
-			"{0} days",
-			"{0} wk ago",
-			"{0} wks ago",
-			"{0} wk",
-			"{0} wks",
-			"{0} mo ago",
-			"{0} mos ago",
-			"{0} mo",
-			"{0} mos",
-			"{0} yr ago",
-			"{0} yrs ago",
-			"{0} yr",
-			"{0} yrs"
+		"vs/workbench/contrib/webview/electron-browser/webviewCommands": [
+			"Open Webview Developer Tools"
+		],
+		"vs/editor/contrib/clipboard/clipboard": [
+			"Cu&&t",
+			"Cut",
+			"Cut",
+			"&&Copy",
+			"Copy",
+			"Copy",
+			"Copy As",
+			"Copy As",
+			"&&Paste",
+			"Paste",
+			"Paste",
+			"Copy With Syntax Highlighting"
+		],
+		"vs/editor/browser/editorExtensions": [
+			"&&Undo",
+			"Undo",
+			"&&Redo",
+			"Redo",
+			"&&Select All",
+			"Select All"
 		],
 		"vs/platform/theme/common/colorRegistry": [
 			"Overall foreground color. This color is only used if not overridden by a component.",
@@ -11642,11 +12277,13 @@
 			"Color of the diff editor's diagonal fill. The diagonal fill is used in side-by-side diff views.",
 			"List/Tree background color for the focused item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree foreground color for the focused item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree outline color for the focused item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree background color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree foreground color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree background color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree foreground color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree background color for the focused item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree outline color for the focused item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree background when hovering over items using the mouse.",
 			"List/Tree foreground when hovering over items using the mouse.",
 			"List/Tree drag and drop background when moving items around using the mouse.",
@@ -11660,7 +12297,10 @@
 			"Background color of the filtered match.",
 			"Border color of the filtered match.",
 			"Tree stroke color for the indentation guides.",
+			"Tree stroke color for the indentation guides.",
 			"List/Tree foreground color for items that are deemphasized. ",
+			"Please use quickInputList.focusBackground instead",
+			"Quick picker background color for the focused item.",
 			"Border color of menus.",
 			"Foreground color of menu items.",
 			"Background color of menu items.",
@@ -11815,100 +12455,13 @@
 			"The color used for the border of the window when it is active. Only supported in the desktop client when using the custom title bar.",
 			"The color used for the border of the window when it is inactive. Only supported in the desktop client when using the custom title bar."
 		],
-		"vs/workbench/contrib/debug/common/debug": [
-			"Controls when the internal debug console should open."
-		],
-		"vs/workbench/contrib/webview/electron-browser/webviewCommands": [
-			"Open Webview Developer Tools"
-		],
-		"vs/editor/contrib/clipboard/clipboard": [
-			"Cu&&t",
-			"Cut",
-			"Cut",
-			"&&Copy",
-			"Copy",
-			"Copy",
-			"&&Paste",
-			"Paste",
-			"Paste",
-			"Copy With Syntax Highlighting"
-		],
-		"vs/editor/browser/editorExtensions": [
-			"&&Undo",
-			"Undo",
-			"&&Redo",
-			"Redo",
-			"&&Select All",
-			"Select All"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/coreActions": [
-			"Notebook",
-			"Execute Cell",
-			"Execute Cell",
-			"Stop Cell Execution",
-			"Stop Cell Execution",
-			"Execute Cell",
-			"Cancel Execution",
-			"Delete Cell",
-			"Execute Notebook Cell and Select Below",
-			"Execute Notebook Cell and Insert Below",
-			"Render All Markdown Cells",
-			"Execute Notebook",
-			"Execute Notebook",
-			"Cancel Notebook Execution",
-			"Cancel Notebook Execution",
-			"Insert Cell",
-			"Notebook Cell",
-			"Execute Notebook (Run all cells)",
-			"Stop Notebook Execution",
-			"Change Cell to Code",
-			"Change Cell to Markdown",
-			"Insert Code Cell Above",
-			"Insert Code Cell Below",
-			"Add Code Cell At Top",
-			"Add Markdown Cell At Top",
-			"$(add) Code",
-			"Add Code Cell",
-			"$(add) Code",
-			"Add Code Cell",
-			"Insert Markdown Cell Above",
-			"Insert Markdown Cell Below",
-			"$(add) Markdown",
-			"Add Markdown Cell",
-			"$(add) Markdown",
-			"Add Markdown Cell",
-			"Edit Cell",
-			"Stop Editing Cell",
-			"Delete Cell",
-			"Move Cell Up",
-			"Move Cell Down",
-			"Copy Cell",
-			"Cut Cell",
-			"Paste Cell",
-			"Paste Cell Above",
-			"Copy Cell Up",
-			"Copy Cell Down",
-			"Focus Next Cell Editor",
-			"Focus Previous Cell Editor",
-			"Focus In Active Cell Output",
-			"Focus Out Active Cell Output",
-			"Focus First Cell",
-			"Focus Last Cell",
-			"Clear Cell Outputs",
-			"Change Cell Language",
-			"({0}) - Current Language",
-			"({0})",
-			"Select Language Mode",
-			"Clear All Cells Outputs",
-			"Split Cell",
-			"Join With Previous Cell",
-			"Join With Next Cell",
-			"Center Active Cell",
-			"Collapse Cell Input",
-			"Expand Cell Content",
-			"Collapse Cell Output",
-			"Expand Cell Output",
-			"Inspect Notebook Layout"
+		"vs/workbench/browser/editor": [
+			"Text Editor",
+			"Built-in",
+			"Configure which editor to use for specific file types.",
+			"The unique id of the editor to use.",
+			"Glob pattern specifying which files the editor should be used for.",
+			"Source: {0}"
 		],
 		"vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor": [
 			"Start Extension Host Profile",
@@ -11924,6 +12477,24 @@
 			"Attach Extension Host"
 		],
 		"vs/workbench/common/editor": [
+			"Whether the active editor is dirty",
+			"Whether the active editor is not in preview mode",
+			"Whether the active editor is pinned",
+			"Whether the active editor is readonly",
+			"The identifier of the active editor",
+			"The available editor identifiers that are usable for the active editor",
+			"Whether a text compare editor is visible",
+			"Whether a text compare editor is active",
+			"The number of opened editor groups",
+			"Whether the active editor group is empty",
+			"The index of the active editor group",
+			"Whether the active editor group is the last group",
+			"Whether there are multiple editor groups opened",
+			"Whether an editor is open",
+			"Whether Zen mode is enabled",
+			"Whether centered layout is enabled",
+			"Whether editors split vertically",
+			"Whether the editor area is visible",
 			"{0} - {1}",
 			"{0}, preview",
 			"{0}, pinned"
@@ -11959,6 +12530,9 @@
 			"Cannot register '{0}'. This property is already registered."
 		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
+			"A single path to a shell executable or an array of paths that will be used as fallbacks when one fails.",
+			"An optional set of arguments to run the shell executable with.",
+			"Controls whether or not the profile name overrides the auto detected one.",
 			"Integrated Terminal",
 			"Dispatches most keybindings to the terminal instead of the workbench, overriding `#terminal.integrated.commandsToSkipShell#`, which can be used alternatively for fine tuning.",
 			"A path that when set will override {0} and ignore {1} values for automation-related terminal usage like tasks and debug.",
@@ -11969,6 +12543,12 @@
 			"The command line arguments to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
 			"The command line arguments to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
 			"The command line arguments in [command-line format](https://msdn.microsoft.com/en-au/08dfcab2-eb6e-49a4-80eb-87d4076c98c6) to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The Windows profiles to present when creating a new terminal via the terminal dropdown. Set to null to exclude them, use the {0} property to use the default detected configuration. Or, set the {1} and optional {2}",
+			"A profile source that will auto detect the paths to the shell.",
+			"Controls whether or not the profile name overrides the auto detected one.",
+			"The macOS profiles to present when creating a new terminal via the terminal dropdown. When set, these will override the default detected profiles. They are comprised of a {0} and optional {1}",
+			"The Linux profiles to present when creating a new terminal via the terminal dropdown. When set, these will override the default detected profiles. They are comprised of a {0} and optional {1}",
+			"Controls whether or not WSL distros are shown in the terminal dropdown",
 			"Controls whether to treat the option key as the meta key in the terminal on macOS.",
 			"Controls whether to force selection when using Option+click on macOS. This will force a regular (line) selection and disallow the use of column selection mode. This enables copying and pasting using the regular terminal selection, for example, when mouse mode is enabled in tmux.",
 			"If enabled, alt/option + click will reposition the prompt cursor to underneath the mouse when `#editor.multiCursorModifier#` is set to `'alt'` (the default value). This may not work reliably depending on your shell.",
@@ -12017,6 +12597,7 @@
 			"Disable the indicator.",
 			"Enable the indicator.",
 			"Only show the warning indicator when a terminal's environment is 'stale', not the information indicator that shows a terminal has had its environment modified by an extension.",
+			"Whether to relaunch terminals automatically if extension want to contribute to their environment and have not been interacted with yet.",
 			"Controls whether to show the alert \"The terminal process terminated with exit code\" when exit code is non-zero.",
 			"Controls the working directory a split terminal starts with.",
 			"A new split terminal will use the workspace root as the working directory. In a multi-root workspace a choice for which root folder to use is offered.",
@@ -12033,9 +12614,7 @@
 			"Experimental: length of network delay, in milliseconds, where local edits will be echoed on the terminal without waiting for server acknowledgement. If '0', local echo will always be on, and if '-1' it will be disabled.",
 			"Experimental: local echo will be disabled when any of these program names are found in the terminal title.",
 			"Experimental: terminal style of locally echoed text; either a font style or an RGB color.",
-			"Experimental: spawn remote terminals from the remote agent process instead of the remote extension host",
-			"Experimental: persist terminal sessions for the workspace across window reloads. Currently only supported in VS Code Remote workspaces.",
-			"Experimental: whether to enable flow control which will slow the program on the remote side to avoid flooding remote connections with terminal output. This setting has no effect for local terminals and terminals where the output/input is controlled by an extension. Changing this will only affect new terminals.",
+			"Persist terminal sessions for the workspace across window reloads.",
 			"Integrated Terminal",
 			"The path of the shell that the terminal uses on Linux. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
 			"The path of the shell that the terminal uses on macOS. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
@@ -12044,10 +12623,11 @@
 			"The path of the shell that the terminal uses on macOS (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
 			"The path of the shell that the terminal uses on Windows (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."
 		],
-		"vs/workbench/contrib/codeEditor/electron-browser/startDebugTextMate": [
-			"Start Text Mate Syntax Grammar Logging"
-		],
 		"vs/workbench/contrib/terminal/common/terminal": [
+			"Whether the terminal is focused",
+			"The shell type of the active terminal",
+			"Whether text is selected in the active terminal",
+			"Whether terminal processes can be launched",
 			"Terminal",
 			"Contributes terminal functionality.",
 			"Defines additional terminal types that the user can create.",
@@ -12062,16 +12642,20 @@
 			"'{0}' failed with exit code {1}",
 			"can't find terminal application '{0}'"
 		],
-		"vs/workbench/contrib/performance/electron-browser/startupProfiler": [
-			"Successfully created profiles.",
-			"Please create an issue and manually attach the following files:\n{0}",
-			"&&Create Issue and Restart",
-			"&&Restart",
-			"Thanks for helping us.",
-			"A final restart is required to continue to use '{0}'. Again, thank you for your contribution.",
-			"&&Restart"
+		"vs/platform/dialogs/common/dialogs": [
+			"...1 additional file not shown",
+			"...{0} additional files not shown"
+		],
+		"vs/platform/contextkey/common/contextkeys": [
+			"Whether the operating system is macOS",
+			"Whether the operating system is Linux",
+			"Whether the operating system is Windows",
+			"Whether the platform is a web browser",
+			"Whether the operating system is macOS on a non-browser platform",
+			"Whether keyboard focus is inside an input box"
 		],
 		"vs/workbench/contrib/tasks/common/tasks": [
+			"Whether a task is currently running.",
 			"Tasks",
 			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
 		],
@@ -12093,14 +12677,6 @@
 			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
 			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
 		],
-		"vs/workbench/contrib/tasks/node/processTaskSystem": [
-			"The task system is configured for version 0.1.0 (see tasks.json file), which can only execute custom tasks. Upgrade to version 2.0.0 to run the task: {0}",
-			"A unknown error has occurred while executing a task. See task output log for details.",
-			"\nWatching build tasks has finished.",
-			"Failed to launch external program {0} {1}.",
-			"\nThe task '{0}' was terminated per user request.",
-			"Problem matcher {0} can't be resolved. The matcher will be ignored"
-		],
 		"vs/workbench/contrib/tasks/node/processRunnerDetector": [
 			"Running gulp --tasks-simple didn't list any tasks. Did you run npm install?",
 			"Running jake --tasks didn't list any tasks. Did you run npm install?",
@@ -12111,24 +12687,12 @@
 			"Build task named '{0}' detected.",
 			"Test task named '{0}' detected."
 		],
-		"vs/platform/markers/common/markers": [
-			"Error",
-			"Warning",
-			"Info"
-		],
-		"vs/workbench/common/views": [
-			"Default view icon.",
-			"A view with id '{0}' is already registered"
-		],
-		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+		"vs/workbench/contrib/tasks/node/processTaskSystem": [
+			"The task system is configured for version 0.1.0 (see tasks.json file), which can only execute custom tasks. Upgrade to version 2.0.0 to run the task: {0}",
 			"A unknown error has occurred while executing a task. See task output log for details.",
-			"There is a dependency cycle. See task \"{0}\".",
-			"Couldn't resolve dependent task '{0}' in workspace folder '{1}'",
-			"Task {0} is a background task but uses a problem matcher without a background pattern",
-			"Task - {0}",
-			"Press any key to close the terminal.",
-			"Terminal will be reused by tasks, press any key to close it.",
-			"Can't execute a shell command on an UNC drive using cmd.exe.",
+			"\nWatching build tasks has finished.",
+			"Failed to launch external program {0} {1}.",
+			"\nThe task '{0}' was terminated per user request.",
 			"Problem matcher {0} can't be resolved. The matcher will be ignored"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
@@ -12212,23 +12776,43 @@
 			"Select the task to show its output",
 			"No task is running"
 		],
+		"vs/workbench/contrib/tasks/common/taskService": [
+			"Whether CustomExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
+			"Whether ShellExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
+			"Whether ProcessExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution."
+		],
+		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+			"A unknown error has occurred while executing a task. See task output log for details.",
+			"There is a dependency cycle. See task \"{0}\".",
+			"Couldn't resolve dependent task '{0}' in workspace folder '{1}'",
+			"Task {0} is a background task but uses a problem matcher without a background pattern",
+			"Task - {0}",
+			"Press any key to close the terminal.",
+			"Terminal will be reused by tasks, press any key to close it.",
+			"Can't execute a shell command on an UNC drive using cmd.exe.",
+			"Problem matcher {0} can't be resolved. The matcher will be ignored"
+		],
+		"vs/platform/markers/common/markers": [
+			"Error",
+			"Warning",
+			"Info"
+		],
+		"vs/workbench/common/views": [
+			"Default view icon.",
+			"A view with id '{0}' is already registered",
+			"The identifier of the view that has keyboard focus"
+		],
 		"vs/workbench/services/preferences/common/preferences": [
 			"User Settings",
 			"Workspace Settings"
 		],
-		"vs/base/common/actions": [
-			"(empty)"
-		],
-		"vs/workbench/services/userDataSync/common/userDataSync": [
-			"Settings",
-			"Keyboard Shortcuts",
-			"User Snippets",
-			"Extensions",
-			"UI State",
-			"Settings Sync",
-			"View icon of the settings sync view."
+		"vs/platform/workspace/common/workspaceTrust": [
+			"Trusted",
+			"Untrusted",
+			"Unknown"
 		],
 		"vs/workbench/api/common/extHostExtensionService": [
+			"Cannot load test runner.",
 			"Path {0} does not point to a valid extension test runner."
 		],
 		"vs/workbench/api/common/extHostTerminalService": [
@@ -12240,12 +12824,21 @@
 		"vs/base/node/processes": [
 			"Can't execute a shell command on a UNC drive."
 		],
+		"vs/platform/terminal/node/terminalProcess": [
+			"Starting directory (cwd) \"{0}\" is not a directory",
+			"Starting directory (cwd) \"{0}\" does not exist",
+			"Path to shell executable \"{0}\" is not a file of a symlink",
+			"Path to shell executable \"{0}\" does not exist"
+		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			"OK",
 			"Path does not exist",
 			"URI can not be opened",
 			"The path '{0}' does not seem to exist anymore on disk.",
 			"The URI '{0}' is not valid and can not be opened."
+		],
+		"vs/platform/workspaces/common/workspaces": [
+			"Code Workspace"
 		],
 		"vs/platform/issue/electron-main/issueMainService": [
 			"Local",
@@ -12261,8 +12854,6 @@
 		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
 			"New Window",
 			"Opens a new window",
-			"{0} {1}",
-			"{0} {1}",
 			"Recent Folders & Workspaces",
 			"Recent Folders",
 			"Untitled (Workspace)",
@@ -12301,8 +12892,12 @@
 		"vs/platform/extensionManagement/node/extensionsScanner": [
 			"Unable to delete the existing folder '{0}' while installing the extension '{1}'. Please delete the folder manually and try again",
 			"Cannot read the extension from {0}",
+			"Cannot read the extension from {0}",
 			"Unknown error while renaming {0} to {1}",
 			"Extension invalid: package.json is not a JSON file."
+		],
+		"vs/base/common/actions": [
+			"(empty)"
 		],
 		"vs/platform/userDataSync/common/keybindingsSync": [
 			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it.",
@@ -12311,6 +12906,38 @@
 		"vs/platform/userDataSync/common/settingsSync": [
 			"Unable to sync settings as there are errors/warning in settings file."
 		],
+		"vs/base/common/date": [
+			"in {0}",
+			"now",
+			"{0} sec ago",
+			"{0} secs ago",
+			"{0} sec",
+			"{0} secs",
+			"{0} min ago",
+			"{0} mins ago",
+			"{0} min",
+			"{0} mins",
+			"{0} hr ago",
+			"{0} hrs ago",
+			"{0} hr",
+			"{0} hrs",
+			"{0} day ago",
+			"{0} days ago",
+			"{0} day",
+			"{0} days",
+			"{0} wk ago",
+			"{0} wks ago",
+			"{0} wk",
+			"{0} wks",
+			"{0} mo ago",
+			"{0} mos ago",
+			"{0} mo",
+			"{0} mos",
+			"{0} yr ago",
+			"{0} yrs ago",
+			"{0} yr",
+			"{0} yrs"
+		],
 		"vs/base/browser/ui/tree/abstractTree": [
 			"Clear",
 			"Disable Filter on Type",
@@ -12318,26 +12945,12 @@
 			"No elements found",
 			"Matched {0} out of {1} elements"
 		],
-		"vs/workbench/services/authentication/browser/authenticationService": [
-			"The id of the authentication provider.",
-			"The human readable name of the authentication provider.",
-			"Contributes authentication",
-			"Loading...",
-			"An authentication contribution must specify an id.",
-			"An authentication contribution must specify a label.",
-			"This authentication id '{0}' has already been registered",
-			"You are not signed in to any accounts",
-			"Loading...",
-			"Sign in requested",
-			"Sign in to use {0} (1)",
-			"Sign in requested"
-		],
 		"vs/platform/list/browser/listService": [
 			"Workbench",
 			"Maps to `Control` on Windows and Linux and to `Command` on macOS.",
 			"Maps to `Alt` on Windows and Linux and to `Option` on macOS.",
 			"The modifier to be used to add an item in trees and lists to a multi-selection with the mouse (for example in the explorer, open editors and scm view). The 'Open to Side' mouse gestures - if supported - will adapt such that they do not conflict with the multiselect modifier.",
-			"Controls how to open items in trees and lists using the mouse (if supported). For parents with children in trees, this setting will control if a single click expands the parent or a double click. Note that some trees and lists might choose to ignore this setting if it is not applicable. ",
+			"Controls how to open items in trees and lists using the mouse (if supported). Note that some trees and lists might choose to ignore this setting if it is not applicable.",
 			"Controls whether lists and trees support horizontal scrolling in the workbench. Warning: turning on this setting has a performance implication.",
 			"Controls tree indentation in pixels.",
 			"Controls whether the tree should render indent guides.",
@@ -12347,15 +12960,18 @@
 			"Filter keyboard navigation will filter out and hide all the elements which do not match the keyboard input.",
 			"Controls the keyboard navigation style for lists and trees in the workbench. Can be simple, highlight and filter.",
 			"Controls whether keyboard navigation in lists and trees is automatically triggered simply by typing. If set to `false`, keyboard navigation is only triggered when executing the `list.toggleKeyboardNavigation` command, for which you can assign a keyboard shortcut.",
-			"Controls how tree folders are expanded when clicking the folder names."
+			"Controls how tree folders are expanded when clicking the folder names. Note that some trees and lists might choose to ignore this setting if it is not applicable."
+		],
+		"vs/platform/contextkey/browser/contextKeyService": [
+			"A command that returns information about context keys"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"The default size.",
-			"Increases the size, so it can be grabbed more easily with the mouse",
+			"Increases the size, so it can be grabbed more easily with the mouse.",
 			"Controls the height of the scrollbars used for tabs and breadcrumbs in the editor title area.",
 			"Controls whether opened editors should show in tabs or not.",
 			"Controls whether tabs should be wrapped over multiple lines when exceeding available space or whether a scrollbar should appear instead. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
-			"Controls whether scrolling over tabs will open them or not. By default tabs will only reveal upon scrolling, but not open. You can press and hold the Shift-key while scrolling to change this behaviour for that duration. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"Controls whether scrolling over tabs will open them or not. By default tabs will only reveal upon scrolling, but not open. You can press and hold the Shift-key while scrolling to change this behavior for that duration. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
 			"Controls whether a top border is drawn on modified (dirty) editor tabs or not. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
 			"Controls whether editor file decorations should use badges.",
 			"Controls whether editor file decorations should use colors.",
@@ -12367,6 +12983,7 @@
 			"The name of the untitled file is derived from the contents of its first line unless it has an associated file path. It will fallback to the name in case the line is empty or contains no word characters.",
 			"The name of the untitled file is not derived from the contents of the file.",
 			"Controls the format of the label for an untitled editor.",
+			"Controls if the untitled hint should be inline text in the editor or a floating button or hidden.",
 			"Controls the position of the editor's tabs close buttons, or disables them when set to 'off'. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
 			"Always keep tabs large enough to show the full editor label.",
 			"Allow tabs to get smaller when the available space is not enough to show all tabs at once.",
@@ -12386,7 +13003,7 @@
 			"Controls whether editors remain in preview when a code navigation is started from them. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing). This value is ignored when `#workbench.editor.enablePreview#` is disabled.",
 			"Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data.",
 			"Controls where editors open. Select `left` or `right` to open editors to the left or right of the currently active one. Select `first` or `last` to open editors independently from the currently active one.",
-			"Controls the default direction of editors that are opened side by side (e.g. from the explorer). By default, editors will open on the right hand side of the currently active one. If changed to `down`, the editors will open below the currently active one.",
+			"Controls the default direction of editors that are opened side by side (for example, from the Explorer). By default, editors will open on the right hand side of the currently active one. If changed to `down`, the editors will open below the currently active one.",
 			"Controls the behavior of empty editor groups when the last tab in the group is closed. When enabled, empty groups will automatically close. When disabled, empty groups will remain part of the grid.",
 			"Controls whether an editor is revealed in any of the visible groups if opened. If disabled, an editor will prefer to open in the currently active editor group. If enabled, an already opened editor will be revealed instead of opened again in the currently active editor group. Note that there are some cases where this setting is ignored, e.g. when forcing an editor to open in a specific group or to the side of the currently active group.",
 			"Navigate between open files using mouse buttons four and five if provided.",
@@ -12422,6 +13039,7 @@
 			"Use the settings UI editor.",
 			"Use the JSON file editor.",
 			"Determines which settings editor to use by default.",
+			"Controls the delay in milliseconds after which the hover is shown for workbench items (ex. some extension provided tree view items). Already visible items may require a refresh before reflecting this setting change.",
 			"Controls the window title based on the active editor. Variables are substituted based on the context:",
 			"`${activeEditorShort}`: the file name (e.g. myFile.txt).",
 			"`${activeEditorMedium}`: the path of the file relative to the workspace folder (e.g. myFolder/myFileFolder/myFile.txt).",
@@ -12439,12 +13057,14 @@
 			"`${separator}`: a conditional separator (\" - \") that only shows when surrounded by variables with values or static text.",
 			"Window",
 			"Separator used by `window.title`.",
-			"Menu is only hidden in full screen mode.",
-			"Menu is always visible even in full screen mode.",
-			"Menu is hidden but can be displayed via Alt key.",
+			"Menu is displayed at the top of the window and only hidden in full screen mode.",
+			"Menu is always visible at the top of the window even in full screen mode.",
+			"Menu is hidden but can be displayed at the top of the window by executing the `Focus Application Menu` command.",
+			"Menu is hidden but can be displayed at the top of the window via the Alt key.",
 			"Menu is always hidden.",
 			"Menu is displayed as a compact button in the sidebar. This value is ignored when `#window.titleBarStyle#` is `native`.",
-			"Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen.",
+			"Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and executing `Focus Application Menu` will show it. A setting of 'compact' will move the menu into the sidebar.",
+			"Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. A setting of 'compact' will move the menu into the sidebar.",
 			"Controls whether the main menus can be opened via Alt-key shortcuts. Disabling mnemonics allows to bind these Alt-key shortcuts to editor commands instead.",
 			"Controls whether the menu bar will be focused by pressing the Alt-key. This setting has no effect on toggling the menu bar with the Alt-key.",
 			"Files will open in a new window.",
@@ -12471,14 +13091,6 @@
 			"Controls whether a window should restore to zen mode if it was exited in zen mode.",
 			"Controls whether notifications are shown while in zen mode. If true, only error notifications will pop out."
 		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"Undo",
-			"Redo",
-			"Cut",
-			"Copy",
-			"Paste",
-			"Select All"
-		],
 		"vs/workbench/browser/actions/developerActions": [
 			"Inspect Context Keys",
 			"Toggle Screencast Mode",
@@ -12492,24 +13104,13 @@
 			"Controls the color in hex (#RGB, #RGBA, #RRGGBB or #RRGGBBAA) of the mouse indicator in screencast mode.",
 			"Controls the size (in pixels) of the mouse indicator in screencast mode."
 		],
-		"vs/workbench/browser/actions/helpActions": [
-			"Keyboard Shortcuts Reference",
-			"Documentation",
-			"Introductory Videos",
-			"Tips and Tricks",
-			"Signup for the VS Code Newsletter",
-			"Join Us on Twitter",
-			"Search Feature Requests",
-			"View License",
-			"Privacy Statement",
-			"&&Documentation",
-			"&&Keyboard Shortcuts Reference",
-			"Introductory &&Videos",
-			"Tips and Tri&&cks",
-			"&&Join Us on Twitter",
-			"&&Search Feature Requests",
-			"View &&License",
-			"Privac&&y Statement"
+		"vs/workbench/browser/actions/textInputActions": [
+			"Undo",
+			"Redo",
+			"Cut",
+			"Copy",
+			"Paste",
+			"Select All"
 		],
 		"vs/workbench/browser/actions/layoutActions": [
 			"Close Side Bar",
@@ -12564,6 +13165,25 @@
 			"Decrease Editor Width",
 			"Decrease Editor Height"
 		],
+		"vs/workbench/browser/actions/helpActions": [
+			"Keyboard Shortcuts Reference",
+			"Documentation",
+			"Introductory Videos",
+			"Tips and Tricks",
+			"Signup for the VS Code Newsletter",
+			"Join Us on Twitter",
+			"Search Feature Requests",
+			"View License",
+			"Privacy Statement",
+			"&&Documentation",
+			"&&Keyboard Shortcuts Reference",
+			"Introductory &&Videos",
+			"Tips and Tri&&cks",
+			"&&Join Us on Twitter",
+			"&&Search Feature Requests",
+			"View &&License",
+			"Privac&&y Statement"
+		],
 		"vs/workbench/browser/actions/navigationActions": [
 			"Navigate to the View on the Left",
 			"Navigate to the View on the Right",
@@ -12604,6 +13224,12 @@
 			"&&Full Screen",
 			"&&About"
 		],
+		"vs/workbench/browser/actions/workspaceCommands": [
+			"Add Folder to Workspace...",
+			"&&Add",
+			"Add Folder to Workspace",
+			"Select workspace folder"
+		],
 		"vs/workbench/browser/actions/workspaceActions": [
 			"Open File...",
 			"Open Folder...",
@@ -12615,17 +13241,13 @@
 			"Remove Folder from Workspace...",
 			"Save Workspace As...",
 			"Duplicate As Workspace in New Window",
+			"Manage Workspace Trust",
+			"Workspaces",
 			"Workspaces",
 			"A&&dd Folder to Workspace...",
 			"Save Workspace As...",
 			"Close &&Folder",
 			"Close &&Workspace"
-		],
-		"vs/workbench/browser/actions/workspaceCommands": [
-			"Add Folder to Workspace...",
-			"&&Add",
-			"Add Folder to Workspace",
-			"Select workspace folder"
 		],
 		"vs/workbench/browser/actions/quickAccessActions": [
 			"Go to File...",
@@ -12638,7 +13260,9 @@
 			"The Command Palette",
 			"The touch bar (macOS only)",
 			"The editor title menu",
+			"Run submenu inside the editor title menu",
 			"The editor context menu",
+			"'Copy as' submenu in the editor context menu",
 			"The file explorer context menu",
 			"The editor tabs context menu",
 			"The debug callstack view context menu",
@@ -12646,11 +13270,12 @@
 			"The debug toolbar menu",
 			"The top level file menu",
 			"The home indicator context menu (web only)",
+			"'Copy as' submenu in the top level Edit menu",
 			"The Source Control title menu",
 			"The Source Control menu",
-			"The Source Control resource group context menu",
 			"The Source Control resource state context menu",
 			"The Source Control resource folder context menu",
+			"The Source Control resource group context menu",
 			"The Source Control inline change menu",
 			"The window indicator menu in the status bar",
 			"The contributed view title menu",
@@ -12659,10 +13284,14 @@
 			"The contributed comment thread context menu, rendered as buttons below the comment editor",
 			"The contributed comment title menu",
 			"The contributed comment context menu, rendered as buttons below the comment editor",
+			"The contributed notebook toolbar menu",
 			"The contributed notebook cell title menu",
+			"The contributed test item menu",
 			"The extension context menu",
 			"The Timeline view title menu",
 			"The Timeline view item context menu",
+			"The Ports view item context menu",
+			"The Ports view item origin inline menu",
 			"property `{0}` is mandatory and must be of type `string`",
 			"property `{0}` can be omitted or must be of type `string`",
 			"property `{0}` can be omitted or must be of type `string`",
@@ -12753,6 +13382,126 @@
 			"The remote server where the workspace is located. Only used by unsaved remote workspaces.",
 			"Unknown workspace configuration property"
 		],
+		"vs/workbench/browser/parts/editor/editor.contribution": [
+			"Text Editor",
+			"Text Diff Editor",
+			"Binary Diff Editor",
+			"Side by Side Editor",
+			"Type the name of an editor to open it.",
+			"Show Editors in Active Group by Most Recently Used",
+			"Type the name of an editor to open it.",
+			"Show All Opened Editors By Appearance",
+			"Type the name of an editor to open it.",
+			"Show All Opened Editors By Most Recently Used",
+			"File",
+			"Split Up",
+			"Split Down",
+			"Split Left",
+			"Split Right",
+			"Close",
+			"Close",
+			"Close Others",
+			"Close to the Right",
+			"Close Saved",
+			"Close All",
+			"Keep Open",
+			"Pin",
+			"Unpin",
+			"Split Up",
+			"Split Down",
+			"Split Left",
+			"Split Right",
+			"Inline View",
+			"Show Opened Editors",
+			"Close All",
+			"Close Saved",
+			"Keep Editors Open",
+			"Run",
+			"Split Editor Right",
+			"Split Editor Down",
+			"Split Editor Down",
+			"Split Editor Right",
+			"Close",
+			"Close All",
+			"Close",
+			"Close All",
+			"Unpin",
+			"Close",
+			"Unpin",
+			"Close",
+			"Icon for the previous change action in the diff editor.",
+			"Icon for the next change action in the diff editor.",
+			"Icon for the toggle whitespace action in the diff editor.",
+			"Previous Change",
+			"Next Change",
+			"Ignore Leading/Trailing Whitespace Differences",
+			"Show Leading/Trailing Whitespace Differences",
+			"Keep Editor",
+			"Pin Editor",
+			"Unpin Editor",
+			"Close Editor",
+			"Close Pinned Editor",
+			"Close All Editors in Group",
+			"Close Saved Editors in Group",
+			"Close Other Editors in Group",
+			"Close Editors to the Right in Group",
+			"Close Editor Group",
+			"&&Reopen Closed Editor",
+			"&&Clear Recently Opened",
+			"Editor &&Layout",
+			"Split &&Up",
+			"Split &&Down",
+			"Split &&Left",
+			"Split &&Right",
+			"&&Single",
+			"&&Two Columns",
+			"T&&hree Columns",
+			"T&&wo Rows",
+			"Three &&Rows",
+			"&&Grid (2x2)",
+			"Two R&&ows Right",
+			"Two &&Columns Bottom",
+			"&&Back",
+			"&&Forward",
+			"&&Last Edit Location",
+			"&&Next Editor",
+			"&&Previous Editor",
+			"&&Next Used Editor",
+			"&&Previous Used Editor",
+			"&&Next Editor in Group",
+			"&&Previous Editor in Group",
+			"&&Next Used Editor in Group",
+			"&&Previous Used Editor in Group",
+			"Switch &&Editor",
+			"Group &&1",
+			"Group &&2",
+			"Group &&3",
+			"Group &&4",
+			"Group &&5",
+			"&&Next Group",
+			"&&Previous Group",
+			"Group &&Left",
+			"Group &&Right",
+			"Group &&Above",
+			"Group &&Below",
+			"Switch &&Group"
+		],
+		"vs/workbench/browser/parts/activitybar/activitybarPart": [
+			"Settings icon in the view bar.",
+			"Accounts icon in the view bar.",
+			"Menu",
+			"Menu",
+			"Accounts",
+			"Accounts",
+			"Hide Activity Bar",
+			"Reset Location",
+			"Reset Location",
+			"Manage",
+			"Manage",
+			"Accounts",
+			"Accounts",
+			"Focus Activity Bar"
+		],
 		"vs/workbench/api/browser/viewsExtensionPoint": [
 			"Unique id used to identify the container in which views can be contributed using 'views' contribution point",
 			"Human readable string used to render the container",
@@ -12789,7 +13538,6 @@
 			"property `{0}` is mandatory and must be of type `string`. Only alphanumeric characters, '_', and '-' are allowed.",
 			"property `{0}` is mandatory and must be of type `string`",
 			"property `{0}` is mandatory and must be of type `string`",
-			"Show {0}",
 			"View container '{0}' requires 'enableProposedApi' turned on to be added to 'Remote'.",
 			"View container '{0}' does not exist and all views registered to it will be added to 'Explorer'.",
 			"Cannot register multiple views with same id `{0}`",
@@ -12803,27 +13551,6 @@
 			"property `{0}` can be omitted or must be of type `string`",
 			"property `{0}` can be omitted or must be one of {1}"
 		],
-		"vs/workbench/browser/parts/activitybar/activitybarPart": [
-			"Settings icon in the view bar.",
-			"Accounts icon in the view bar.",
-			"Home Button",
-			"Home Button",
-			"Menu",
-			"Menu",
-			"Accounts",
-			"Accounts",
-			"Hide Activity Bar",
-			"Reset Location",
-			"Reset Location",
-			"Home",
-			"Home",
-			"Home",
-			"Manage",
-			"Manage",
-			"Accounts",
-			"Accounts",
-			"Focus Activity Bar"
-		],
 		"vs/workbench/browser/parts/panel/panelPart": [
 			"Hide Panel",
 			"Reset Location",
@@ -12833,13 +13560,35 @@
 		"vs/workbench/browser/parts/sidebar/sidebarPart": [
 			"Focus into Side Bar"
 		],
+		"vs/workbench/browser/parts/statusbar/statusbarPart": [
+			"Whether the status bar has keyboard focus",
+			"Hide '{0}'",
+			"Hide Status Bar"
+		],
 		"vs/workbench/browser/parts/views/viewsService": [
+			"Show {0}",
+			"Toggle {0}",
+			"Show {0}",
+			"Toggle {0}",
 			"Focus on {0} View",
 			"Reset Location"
 		],
-		"vs/workbench/browser/parts/statusbar/statusbarPart": [
-			"Hide '{0}'",
-			"Hide Status Bar"
+		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
+			"Allow an extension to open this URI?",
+			"Don't ask again for this extension.",
+			"&&Open",
+			"Extension '{0}' is not loaded. Would you like to reload the window to load the extension and open the URL?",
+			"&&Reload Window and Open",
+			"Extension '{0}' is disabled. Would you like to enable the extension and reload the window to open the URL?",
+			"&&Enable and Open",
+			"Extension '{0}' is not installed. Would you like to install the extension and reload the window to open this URL?",
+			"&&Install",
+			"Installing Extension '{0}'...",
+			"Would you like to reload the window and open the URL '{0}'?",
+			"Reload Window and Open",
+			"Manage Authorized Extension URIs...",
+			"Extensions",
+			"There are currently no authorized extension URIs."
 		],
 		"vs/platform/undoRedo/common/undoRedoService": [
 			"The following files have been closed and modified on disk: {0}.",
@@ -12863,23 +13612,6 @@
 			"Could not redo '{0}' across all files because there is already an undo or redo operation running on {1}",
 			"Could not redo '{0}' across all files because an undo or redo operation occurred in the meantime",
 			"Could not redo '{0}' because there is already an undo or redo operation running."
-		],
-		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
-			"Allow an extension to open this URI?",
-			"Don't ask again for this extension.",
-			"&&Open",
-			"Extension '{0}' is not loaded. Would you like to reload the window to load the extension and open the URL?",
-			"&&Reload Window and Open",
-			"Extension '{0}' is disabled. Would you like to enable the extension and reload the window to open the URL?",
-			"&&Enable and Open",
-			"Extension '{0}' is not installed. Would you like to install the extension and reload the window to open this URL?",
-			"&&Install",
-			"Installing Extension '{0}'...",
-			"Would you like to reload the window and open the URL '{0}'?",
-			"Reload Window and Open",
-			"Manage Authorized Extension URIs...",
-			"Extensions",
-			"There are currently no authorized extension URIs."
 		],
 		"vs/workbench/services/keybinding/common/keybindingEditing": [
 			"Unable to write because the keybindings configuration file is dirty. Please save it first and then try again.",
@@ -12914,7 +13646,16 @@
 			"Unable to write into the file because the file is dirty. Please save the file and try again."
 		],
 		"vs/workbench/services/editor/browser/editorService": [
-			"Source: {0}"
+			"Currently Active",
+			"Set as default editor for '{0}' files",
+			"Select editor for '{0}'",
+			"Select editor"
+		],
+		"vs/workbench/services/history/browser/history": [
+			"Whether it is possible to navigate back in editor history",
+			"Whether it is possible to navigate forward in editor history",
+			"Whether it is possible to navigate to the last edit location",
+			"Whether it is possible to reopen the last closed editor"
 		],
 		"vs/workbench/services/keybinding/browser/keybindingService": [
 			"expected non-empty value.",
@@ -12990,6 +13731,10 @@
 			"No workspace.",
 			"Cannot change enablement of {0} extension in workspace because it contributes authentication providers"
 		],
+		"vs/workbench/services/notification/common/notificationService": [
+			"Don't Show Again",
+			"Don't Show Again"
+		],
 		"vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig": [
 			"Remove extension recommendation from",
 			"Add extension recommendation to",
@@ -12998,9 +13743,9 @@
 			"Workspace Folder",
 			"Workspace"
 		],
-		"vs/workbench/services/notification/common/notificationService": [
-			"Don't Show Again",
-			"Don't Show Again"
+		"vs/workbench/services/views/browser/viewDescriptorService": [
+			"Hide '{0}'",
+			"Reset Location"
 		],
 		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
 			"Settings sync cannot be turned on because there are no authentication providers available.",
@@ -13033,9 +13778,25 @@
 			"Settings sync is suspended because of successive authorization failures. Please sign in again to continue synchronizing",
 			"Sign in"
 		],
-		"vs/workbench/services/views/browser/viewDescriptorService": [
-			"Hide '{0}'",
-			"Reset Location"
+		"vs/workbench/services/authentication/browser/authenticationService": [
+			"The id of the authentication provider.",
+			"The human readable name of the authentication provider.",
+			"Contributes authentication",
+			"Loading...",
+			"An authentication contribution must specify an id.",
+			"An authentication contribution must specify a label.",
+			"This authentication id '{0}' has already been registered",
+			"Loading...",
+			"Sign in requested",
+			"The extension '{0}' wants to access the {1} account '{2}'.",
+			"Allow",
+			"Deny",
+			"Cancel",
+			"Sign in to another account",
+			"The extension '{0}' wants to access a {1} account",
+			"Select an account for '{0}' to use or Esc to cancel",
+			"Grant access to {0}... (1)",
+			"Sign in to use {0} (1)"
 		],
 		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
 			"Default Preferences Editor",
@@ -13093,12 +13854,6 @@
 		"vs/workbench/contrib/performance/browser/performance.contribution": [
 			"Startup Performance"
 		],
-		"vs/workbench/contrib/testing/browser/testing.contribution": [
-			"Test",
-			"No test providers are registered for this workspace.",
-			"[Search Marketplace](command:{0})",
-			"Test Explorer"
-		],
 		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
 			"{0} ⟷ {1}",
 			"Notebook",
@@ -13106,6 +13861,12 @@
 			"Where the cell toolbar should be shown, or whether it should be hidden.",
 			"Whether the cell status bar should be shown.",
 			"Whether to use the enhanced text diff editor for notebook."
+		],
+		"vs/workbench/contrib/testing/browser/testing.contribution": [
+			"Test",
+			"No test providers are registered for this workspace.",
+			"[Search Marketplace](command:{0})",
+			"Test Explorer"
 		],
 		"vs/workbench/contrib/logs/common/logs.contribution": [
 			"Settings Sync",
@@ -13134,6 +13895,8 @@
 			"View icon of the open editors view.",
 			"Folders",
 			"Explorer",
+			"Explorer",
+			"&&Explorer",
 			"You have not yet added a folder to the workspace.\n[Add Folder](command:{0})",
 			"Connected to remote.\n[Open Folder](command:{0})",
 			"You have not yet opened a folder.\n[Open Folder](command:{0})"
@@ -13184,7 +13947,6 @@
 			"Go to &&File..."
 		],
 		"vs/workbench/contrib/files/browser/files.contribution": [
-			"Show Explorer",
 			"Binary File Editor",
 			"Disable hot exit. A prompt will show when attempting to close a window with dirty files.",
 			"Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu). All windows without folders opened will be restored upon next launch. A list of previously opened windows with unsaved files can be accessed via `File > Open Recent > More...`",
@@ -13249,8 +14011,7 @@
 			"Appends the word \"copy\" at the end of the duplicated name potentially followed by a number",
 			"Adds a number at the end of the duplicated name. If some number is already part of the name, tries to increase that number",
 			"Controls what naming strategy to use when a giving a new name to a duplicated explorer item on paste.",
-			"Controls whether the explorer should render folders in a compact form. In such a form, single child folders will be compressed in a combined tree element. Useful for Java package structures, for example.",
-			"&&Explorer"
+			"Controls whether the explorer should render folders in a compact form. In such a form, single child folders will be compressed in a combined tree element. Useful for Java package structures, for example."
 		],
 		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
 			"Made no edits",
@@ -13302,6 +14063,7 @@
 			"Go to Symbol in Workspace...",
 			"Search",
 			"Search",
+			"&&Search",
 			"Open the search viewlet",
 			"A set of options for the search viewlet",
 			"Find in Files",
@@ -13317,8 +14079,8 @@
 			"Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.",
 			"Controls where new `Search: Find in Files` and `Find in Folder` operations occur: either in the sidebar's search view, or in a search editor",
 			"Search in the search view, either in the panel or sidebar.",
-			"Search in an existing search editor if present, otherwise in a new search editor",
-			"Search in a new search editor",
+			"Search in an existing search editor if present, otherwise in a new search editor.",
+			"Search in a new search editor.",
 			"This setting is deprecated and now falls back on \"search.usePCRE2\".",
 			"Deprecated. Consider \"search.usePCRE2\" for advanced regex feature support.",
 			"When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.",
@@ -13351,7 +14113,7 @@
 			"Double clicking opens the result in the active editor group.",
 			"Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.",
 			"Configure effect of double clicking a result in a search editor.",
-			"When enabled, new Search Editors will reuse the includes, excludes, and flags of the previously opened Search Editor",
+			"When enabled, new Search Editors will reuse the includes, excludes, and flags of the previously opened Search Editor.",
 			"The default number of surrounding context lines to use when creating new Search Editors. If using `#search.searchEditor.reusePriorSearchConfiguration#`, this can be set to `null` (empty) to use the prior Search Editor's configuration.",
 			"Results are sorted by folder and file names, in alphabetical order.",
 			"Results are sorted by file names ignoring folder order, in alphabetical order.",
@@ -13360,8 +14122,6 @@
 			"Results are sorted by count per file, in descending order.",
 			"Results are sorted by count per file, in ascending order.",
 			"Controls sorting order of search results.",
-			"Experimental. When enabled, an option is provided to make workspace search only search files that have been opened. **Requires restart to take effect.**",
-			"&&Search",
 			"Go to Symbol in &&Workspace..."
 		],
 		"vs/workbench/contrib/search/browser/searchView": [
@@ -13369,8 +14129,10 @@
 			"Toggle Search Details",
 			"files to include",
 			"Search Include Patterns",
+			"(e.g. *.ts, src/**/include)",
 			"files to exclude",
 			"Search Exclude Patterns",
+			"(e.g. *.ts, src/**/exclude)",
 			"Replace All",
 			"&&Replace",
 			"Replaced {0} occurrence across {1} file with '{2}'.",
@@ -13407,18 +14169,17 @@
 			"Learn More",
 			"Search returned {0} results in {1} files",
 			" - Search: {0}",
-			" - exclude settings and ignore files are disabled",
-			"Open in editor",
+			"exclude settings and ignore files are disabled",
+			"enable",
+			"Use Exclude Settings and Ignore Files",
 			"Copy current search results to an editor",
+			"Open in editor",
 			"{0} result in {1} file",
 			"{0} result in {1} files",
 			"{0} results in {1} file",
 			"{0} results in {1} files",
 			"You have not opened or specified a folder. Only open files are currently searched - ",
 			"Open Folder"
-		],
-		"vs/workbench/contrib/sash/browser/sash.contribution": [
-			"Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it's hard to resize views using the mouse."
 		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
 			"Search Editor",
@@ -13439,13 +14200,17 @@
 			"Select All Matches",
 			"Open New Search Editor from View"
 		],
+		"vs/workbench/contrib/sash/browser/sash.contribution": [
+			"Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it's hard to resize views using the mouse.",
+			"Controls the hover feedback delay in milliseconds of the dragging area in between views/editors."
+		],
 		"vs/workbench/contrib/scm/browser/scm.contribution": [
-			"View icon of the source control view.",
+			"View icon of the Source Control view.",
 			"Source Control",
 			"No source control providers registered.",
 			"Source Control",
+			"S&&CM",
 			"Source Control Repositories",
-			"Show SCM",
 			"SCM",
 			"Show the diff decorations in all available locations.",
 			"Show the diff decorations only in the editor gutter.",
@@ -13474,9 +14239,9 @@
 			"Controls the default Source Control repository view mode.",
 			"Controls whether the SCM view should automatically reveal and select files when opening them.",
 			"Controls the font for the input message. Use `default` for the workbench user interface font family, `editor` for the `#editor.fontFamily#`'s value, or a custom font family.",
+			"Controls the font size for the input message in pixels.",
 			"Controls whether repositories should always be visible in the SCM view.",
 			"Controls how many repositories are visible in the Source Control Repositories section. Set to `0` to be able to manually resize the view.",
-			"S&&CM",
 			"SCM: Accept Input",
 			"SCM: View Next Commit",
 			"SCM: View Previous Commit",
@@ -13498,11 +14263,12 @@
 			"Copy Value",
 			"Copy as Expression",
 			"Add to Watch",
-			"Break When Value Changes",
+			"Break on Value Read",
+			"Break on Value Change",
+			"Break on Value Access",
 			"Edit Expression",
 			"Copy Value",
 			"Remove Expression",
-			"&&Run",
 			"&&Start Debugging",
 			"Run &&Without Debugging",
 			"&&Stop Debugging",
@@ -13517,7 +14283,9 @@
 			"&&Install Additional Debuggers...",
 			"Debug Console",
 			"Debug Console",
-			"Run",
+			"De&&bug Console",
+			"Run and Debug",
+			"&&Run",
 			"Variables",
 			"Watch",
 			"Call Stack",
@@ -13533,6 +14301,7 @@
 			"Show debug in status bar only after debug was started for the first time",
 			"Controls when the debug status bar should be visible.",
 			"Controls if the debug console should be automatically closed when the debug session ends.",
+			"Before starting a new debug session in an integrated or external terminal, clear the terminal.",
 			"Controls when the debug view should open.",
 			"Controls whether the debug sub-sessions are shown in the debug tool bar. When this setting is false the stop command on a sub-session will also stop the parent session.",
 			"Controls the font size in pixels in the debug console.",
@@ -13540,6 +14309,7 @@
 			"Controls the line height in pixels in the debug console. Use 0 to compute the line height from the font size.",
 			"Controls if the lines should wrap in the debug console.",
 			"Controls if the debug console should suggest previously typed input.",
+			"Controls if the debug console should collapse identical lines and show a number of occurrences with a badge.",
 			"Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces.",
 			"Controls whether the workbench window should be focused when the debugger breaks.",
 			"Ignore task errors and start debugging.",
@@ -13548,7 +14318,11 @@
 			"Cancel debugging.",
 			"Controls what to do when errors are encountered after running a preLaunchTask.",
 			"Controls whether breakpoints should be shown in the overview ruler.",
-			"Controls whether inline breakpoints candidate decorations should be shown in the editor while debugging."
+			"Controls whether inline breakpoints candidate decorations should be shown in the editor while debugging.",
+			"Controls what editors to save before starting a debug session.",
+			"Save all editors in the active group before starting a debug session.",
+			"Save all editors in the active group except untitled ones before starting a debug session.",
+			"Don't save any editors before starting a debug session."
 		],
 		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
 			"Add Configuration..."
@@ -13597,15 +14371,6 @@
 			"Background color for the highlight of line at the top stack frame position.",
 			"Background color for the highlight of line at focused stack frame position."
 		],
-		"vs/workbench/contrib/debug/browser/debugViewlet": [
-			"Show Run and Debug",
-			"Open &&Configurations",
-			"Select a workspace folder to create a launch.json file in or add it to the workspace config file",
-			"Debug Console",
-			"De&&bug Console",
-			"Debug Console",
-			"Start Additional Session"
-		],
 		"vs/workbench/contrib/debug/browser/repl": [
 			"Filter (e.g. text, !exclude)",
 			"Debug Console",
@@ -13621,6 +14386,12 @@
 			"Paste",
 			"Copy All",
 			"Copy"
+		],
+		"vs/workbench/contrib/debug/browser/debugViewlet": [
+			"Open &&Configurations",
+			"Select a workspace folder to create a launch.json file in or add it to the workspace config file",
+			"Debug Console",
+			"Start Additional Session"
 		],
 		"vs/workbench/contrib/markers/browser/markers.contribution": [
 			"View icon of the markers view.",
@@ -13661,6 +14432,7 @@
 			"Manage Extensions",
 			"Extension",
 			"Extensions",
+			"E&&xtensions",
 			"Extensions",
 			"When enabled, automatically installs updates for extensions. The updates are fetched from a Microsoft online service.",
 			"When enabled, automatically checks extensions for updates. If an extension has an update, it is marked as outdated in the Extensions view. The updates are fetched from a Microsoft online service.",
@@ -13681,9 +14453,7 @@
 			"Query to use in search",
 			"Type the name of an extension to install or search.",
 			"Install or Search Extensions",
-			"Show Extensions",
 			"&&Extensions",
-			"E&&xtensions",
 			"Extensions",
 			"Install Extensions",
 			"Keymaps",
@@ -13692,12 +14462,6 @@
 			"Language Extensions",
 			"Check for Extension Updates",
 			"All extensions are up to date.",
-			"An extension update is available.",
-			"{0} extension updates are available.",
-			"An update to an extension which is disabled is available.",
-			"{0} extension updates are available. One of them is for a disabled extension.",
-			"{0} extension updates are available. All of them are for disabled extensions.",
-			"{0} extension updates are available. {1} of them are for disabled extensions.",
 			"Disable Auto Updating Extensions",
 			"Update All Extensions",
 			"Enable Auto Updating Extensions",
@@ -13764,27 +14528,6 @@
 			"Extensions",
 			"Extensions"
 		],
-		"vs/workbench/contrib/output/browser/output.contribution": [
-			"View icon of the output view.",
-			"Output",
-			"Output",
-			"Log Viewer",
-			"Switch to Output",
-			"Clear Output",
-			"Output was cleared",
-			"Toggle Auto Scrolling",
-			"Turn Auto Scrolling Off",
-			"Turn Auto Scrolling On",
-			"Open Log Output File",
-			"Toggle Output",
-			"Show Logs...",
-			"Select Log",
-			"Open Log File...",
-			"Select Log file",
-			"&&Output",
-			"Output",
-			"Enable/disable the ability of smart scrolling in the output view. Smart scrolling allows you to lock scrolling automatically when you click in the output view and unlocks when you click in the last line."
-		],
 		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
 			"Installed",
 			"Install Local Extensions in '{0}'...",
@@ -13817,6 +14560,26 @@
 			"We have uninstalled '{0}' which was reported to be problematic.",
 			"Reload Now"
 		],
+		"vs/workbench/contrib/output/browser/output.contribution": [
+			"View icon of the output view.",
+			"Output",
+			"Output",
+			"&&Output",
+			"Log Viewer",
+			"Switch to Output",
+			"Clear Output",
+			"Output was cleared",
+			"Toggle Auto Scrolling",
+			"Turn Auto Scrolling Off",
+			"Turn Auto Scrolling On",
+			"Open Log Output File",
+			"Show Logs...",
+			"Select Log",
+			"Open Log File...",
+			"Select Log file",
+			"Output",
+			"Enable/disable the ability of smart scrolling in the output view. Smart scrolling allows you to lock scrolling automatically when you click in the output view and unlocks when you click in the last line."
+		],
 		"vs/workbench/contrib/output/browser/outputView": [
 			"{0} - Output",
 			"Output channel for '{0}'",
@@ -13830,13 +14593,13 @@
 			"Type the name of a terminal to open.",
 			"Show All Opened Terminals",
 			"Terminal",
-			"Terminal"
+			"Terminal",
+			"&&Terminal"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalView": [
 			"Use 'monospace'",
-			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font."
-		],
-		"vs/workbench/contrib/terminal/browser/remoteTerminalService": [
+			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font.",
+			"Open Terminals.",
 			"Starting..."
 		],
 		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
@@ -13899,17 +14662,32 @@
 			"Override the kind of an extension. `ui` extensions are installed and run on the local machine while `workspace` extensions are run on the remote. By overriding an extension's default kind using this setting, you specify if that extension should be installed and enabled locally or remotely.",
 			"Restores the ports you forwarded in a workspace.",
 			"When enabled, new running processes are detected and ports that they listen on are automatically forwarded.",
-			"A port, or range of ports (ex. \"40000-55000\") that the attributes should apply to",
+			"Sets the source from which ports are automatically forwarded when `remote.autoForwardPorts` is true. On Windows and Mac remotes, the `process` option has no effect and `output` will be used. Requires a reload to take effect.",
+			"Ports will be automatically forwarded when discovered by watching for processes that are started and include a port.",
+			"Ports will be automatically forwarded when discovered by reading terminal and debug output. Not all processes that use ports will print to the integrated terminal or debug console, so some ports will be missed. Ports forwarded based on output will not be \"un-forwarded\" until reload or until the port is closed by the user in the Ports view.",
+			"A port, range of ports (ex. \"40000-55000\"), or regular expression (ex. \".+\\\\/server.js\").  For a port number or range, the attributes will apply to that port number or range of port numbers. Attributes which use a regular expression will apply to ports whose associated process command line matches the expression.",
 			"Shows a notification when a port is automatically forwarded.",
 			"Opens the browser when the port is automatically forwarded. Depending on your settings, this could open an embedded browser.",
+			"Opens a preview in the same window when the port is automatically forwarded.",
 			"Shows no notification and takes no action when this port is automatically forwarded.",
 			"This port will not be automatically forwarded.",
 			"Defines the action that occurs when the port is discovered for automatic forwarding",
 			"Automatically prompt for elevation (if needed) when this port is forwarded. Elevate is required if the local port is a privileged port.",
 			"Label that will be shown in the UI for this port.",
-			"Labeled Port",
-			"Labeled Port",
-			"Allows setting of default properties that are set when a specific port number is forwarded. For example:\n\n```\n\"3000\": {\n  \"label\": \"Labeled Port\"\n},\n\"40000-55000\": {\n  \"onAutoForward\": \"ignore\"\n}\n```"
+			"Application",
+			"Application",
+			"Set properties that are applied when a specific port number is forwarded. For example:\n\n```\n\"3000\": {\n  \"label\": \"Application\"\n},\n\"40000-55000\": {\n  \"onAutoForward\": \"ignore\"\n},\n\".+\\\\/server.js\": {\n \"onAutoForward\": \"openPreview\"\n}\n```",
+			"Must be a port number, range of port numbers, or regular expression.",
+			"Shows a notification when a port is automatically forwarded.",
+			"Opens the browser when the port is automatically forwarded. Depending on your settings, this could open an embedded browser.",
+			"Opens a preview in the same window when the port is automatically forwarded.",
+			"Shows no notification and takes no action when this port is automatically forwarded.",
+			"This port will not be automatically forwarded.",
+			"Defines the action that occurs when the port is discovered for automatic forwarding",
+			"Automatically prompt for elevation (if needed) when this port is forwarded. Elevate is required if the local port is a privileged port.",
+			"Label that will be shown in the UI for this port.",
+			"Application",
+			"Set default properties that are applied to all ports that don't get properties from the setting `remote.portsAttributes`. For example:\n\n```\n{\n  \"onAutoForward\": \"ignore\"\n}\n```"
 		],
 		"vs/workbench/contrib/remote/browser/remote": [
 			"Contributes help information for Remote",
@@ -13927,7 +14705,6 @@
 			"Remote Help",
 			"Remote Explorer",
 			"Remote Explorer",
-			"Show Remote Explorer",
 			"Attempting to reconnect in {0} second...",
 			"Attempting to reconnect in {0} seconds...",
 			"Reconnect Now",
@@ -13999,6 +14776,22 @@
 			"User &&Snippets",
 			"User Snippets"
 		],
+		"vs/workbench/contrib/update/browser/update.contribution": [
+			"&&Release Notes"
+		],
+		"vs/workbench/contrib/watermark/browser/watermark": [
+			"Show All Commands",
+			"Go to File",
+			"Open File",
+			"Open Folder",
+			"Open File or Folder",
+			"Open Recent",
+			"New Untitled File",
+			"Toggle Terminal",
+			"Find in Files",
+			"Start Debugging",
+			"When enabled, will show the watermark tips when no editor is open."
+		],
 		"vs/workbench/contrib/themes/browser/themes.contribution": [
 			"Color Theme",
 			"light themes",
@@ -14024,27 +14817,16 @@
 			"File Icon Theme",
 			"Product Icon Theme"
 		],
-		"vs/workbench/contrib/update/browser/update.contribution": [
-			"&&Release Notes"
-		],
-		"vs/workbench/contrib/watermark/browser/watermark": [
-			"Show All Commands",
-			"Go to File",
-			"Open File",
-			"Open Folder",
-			"Open File or Folder",
-			"Open Recent",
-			"New Untitled File",
-			"Toggle Terminal",
-			"Find in Files",
-			"Start Debugging",
-			"When enabled, will show the watermark tips when no editor is open."
-		],
 		"vs/workbench/contrib/surveys/browser/nps.contribution": [
 			"Do you mind taking a quick feedback survey?",
 			"Take Survey",
 			"Remind Me later",
 			"Don't Show Again"
+		],
+		"vs/workbench/contrib/surveys/browser/ces.contribution": [
+			"Got a moment to help the VS Code team? Please tell us about your experience with VS Code so far.",
+			"Give Feedback",
+			"Remind Me later"
 		],
 		"vs/workbench/contrib/surveys/browser/languageSurveys.contribution": [
 			"Help us improve our support for {0}",
@@ -14066,25 +14848,58 @@
 			"Hide Interface Overview"
 		],
 		"vs/workbench/contrib/welcome/page/browser/welcomePage.contribution": [
-			"Start without an editor.",
-			"Open the Welcome page (default).",
-			"Open the README when opening a folder that contains one, fallback to 'welcomePage' otherwise.",
-			"Open a new untitled file (only applies when opening an empty window).",
-			"Open the Welcome page when opening an empty workbench.",
-			"Open the Getting Started page (experimental).",
-			"Controls which editor is shown at startup, if none are restored from the previous session.",
 			"&&Welcome"
 		],
 		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution": [
 			"Getting Started",
 			"Help",
-			"Enables an experimental Getting Started page, available via the Help menu."
+			"Getting Started",
+			"Getting Started",
+			"Go Back",
+			"Next",
+			"Previous",
+			"Mark Task Complete",
+			"Mark Task Incomplete",
+			"Hide categories of the welcome page's getting started section that are not relevant to you.",
+			"Contribute collections of tasks to help users with your extension. Experimental, available in VS Code Insiders only.",
+			"Unique identifier for this walkthrough.",
+			"Title of walkthrough.",
+			"Description of walkthrough.",
+			"if this is a `primary` walkthrough, hinting if it should be opened on install of the extension. The first `primary` walkthough with a `when` condition matching the current context may be opened by core on install of the extension.",
+			"Context key expression to control the visibility of this walkthrough.",
+			"Tasks to complete as part of this walkthrough.",
+			"Unique identifier for this task. This is used to keep track of which tasks have been completed.",
+			"Title of task.",
+			"Description of task.",
+			"The task's button, which can either link to an external resource or run a command",
+			"Title of button.",
+			"Command to run when button is clicked.",
+			"Title of button.",
+			"Link to open when button is clicked. Opening this link will mark the task completed.",
+			"Image to show alongside this task.",
+			"Path to an image, relative to extension directory.",
+			"Alternate text to display when the image cannot be loaded or in screen readers.",
+			"Signal to mark task as complete.",
+			"Mark task done when the specified command is executed.",
+			"Context key expression to control the visibility of this task."
+		],
+		"vs/workbench/contrib/welcome/walkthroughs/browser/walkthroughs.contribution": [
+			"Walkthroughs",
+			"Help",
+			"Walkthroughs",
+			"Walkthroughs",
+			"Go Back",
+			"Next",
+			"Previous"
 		],
 		"vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution": [
 			"Interactive Playground",
 			"I&&nteractive Playground"
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
+			"Whether a call hierarchy provider is available",
+			"Whether call hierarchy peek is currently showing",
+			"Whether call hierarchy shows incoming or outgoing calls",
 			"No results",
 			"Failed to show call hierarchy",
 			"Peek Call Hierarchy",
@@ -14094,9 +14909,6 @@
 			"Icon for outgoing calls in the call hierarchy view.",
 			"Refocus Call Hierarchy",
 			"Close"
-		],
-		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
-			"Document Symbols"
 		],
 		"vs/workbench/contrib/outline/browser/outline.contribution": [
 			"View icon of the outline view.",
@@ -14133,6 +14945,9 @@
 			"When enabled outline shows `operator`-symbols.",
 			"When enabled outline shows `typeParameter`-symbols."
 		],
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
+			"Document Symbols"
+		],
 		"vs/workbench/contrib/experiments/browser/experiments.contribution": [
 			"Fetches experiments to run from a Microsoft online service."
 		],
@@ -14144,10 +14959,40 @@
 			"View icon of the timeline view.",
 			"Icon for the open timeline action.",
 			"Timeline",
-			"An array of Timeline sources that should be excluded from the Timeline view",
-			"The number of items to show in the Timeline view by default and when loading more items. Setting to `null` (the default) will automatically choose a page size based on the visible area of the Timeline view",
-			"Experimental. Controls whether the Timeline view will load the next page of items when you scroll to the end of the list",
+			"An array of Timeline sources that should be excluded from the Timeline view.",
+			"The number of items to show in the Timeline view by default and when loading more items. Setting to `null` (the default) will automatically choose a page size based on the visible area of the Timeline view.",
+			"Experimental. Controls whether the Timeline view will load the next page of items when you scroll to the end of the list.",
 			"Open Timeline"
+		],
+		"vs/workbench/contrib/workspace/browser/workspace.contribution": [
+			"Icon for workspace trust badge.",
+			"Some features require workspace trust.",
+			"A feature you are trying to use may be a security risk if you do not trust the source of the files or folders you currently have open.",
+			"Continue",
+			"Learn More",
+			"Cancel",
+			"Do you trust the files in this folder?",
+			"{0}\n\nYou should only trust this workspace if you trust its source. Otherwise, features will be enabled that may compromise your device or personal information.",
+			"In order for this change to take effect, the window needs to be reloaded. Do you want to reload the window now?",
+			"Workspace Trust",
+			"Workspace Trust",
+			"Workspace Trust",
+			"Workspace Trust Editor",
+			"Grant Workspace Trust",
+			"Workspaces",
+			"Grant Workspace Trust",
+			"Granting trust to the workspace will enable features that may pose a security risk if the contents of the workspace cannot be trusted. Are you sure you want to trust this workspace?",
+			"Yes",
+			"No",
+			"Deny Workspace Trust",
+			"Workspaces",
+			"Deny Workspace Trust",
+			"Denying trust to the workspace will disable features that may pose a security risk if the contents of the workspace cannot be trusted. Are you sure you want to deny trust to this workspace?",
+			"Yes",
+			"No",
+			"Manage Workspace Trust",
+			"Workspaces",
+			"Manage Workspace Trust (1)"
 		],
 		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
 			"This folder contains a workspace file '{0}'. Do you want to open it? [Learn more]({1}) about workspace files.",
@@ -14170,6 +15015,12 @@
 			"OK",
 			"&&Copy"
 		],
+		"vs/workbench/services/textfile/browser/textFileService": [
+			"File seems to be binary and cannot be opened as text",
+			"'{0}' already exists. Do you want to replace it?",
+			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
+			"&&Replace"
+		],
 		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
 			"Your changes will be lost if you don't save them.",
 			"Do you want to save the changes you made to {0}?",
@@ -14187,6 +15038,15 @@
 			"Save As",
 			"All Files",
 			"No Extension"
+		],
+		"vs/workbench/services/userDataSync/common/userDataSync": [
+			"Settings",
+			"Keyboard Shortcuts",
+			"User Snippets",
+			"Extensions",
+			"UI State",
+			"Settings Sync",
+			"View icon of the Settings Sync view."
 		],
 		"vs/workbench/services/textMate/browser/abstractTextMateService": [
 			"Already Logging.",
@@ -14224,8 +15084,7 @@
 			"Cannot uninstall extension '{0}'. Extensions '{1}' and '{2}' depend on this.",
 			"Cannot uninstall extension '{0}'. Extensions '{1}', '{2}' and others depend on this.",
 			"Installing Extension {0} failed: Manifest is not found.",
-			"Cannot install '{0}' because this extension has defined that it cannot run on the remote server.",
-			"Cannot install '{0}' because this extension has defined that it cannot run on the web server.",
+			"Cannot install the '{0}' extension because it is not available in this setup.",
 			"Install Extension",
 			"Install Extensions",
 			"Install",
@@ -14233,6 +15092,9 @@
 			"Cancel",
 			"Would you like to install and synchronize '{0}' extension across your devices?",
 			"Would you like to install and synchronize extensions across your devices?"
+		],
+		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
+			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'."
 		],
 		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
 			"Open Logs Folder",
@@ -14276,8 +15138,10 @@
 			"An activation event emitted whenever the specified view is expanded.",
 			"An activation event emitted whenever the specified user identity.",
 			"An activation event emitted whenever a system-wide Uri directed towards this extension is open.",
+			"An activation event emitted whenever a external uri (such as an http or https link) is being opened.",
 			"An activation event emitted whenever the specified custom editor becomes visible.",
 			"An activation event emitted whenever the specified notebook document is opened.",
+			"An activation event emitted whenever sessions are requested from the specified authentication provider.",
 			"An activation event emitted on VS Code startup. To ensure a great end user experience, please use this activation event in your extension only when no other activation events combination works in your use-case.",
 			"Array of badges to display in the sidebar of the Marketplace's extension page.",
 			"Badge image URL.",
@@ -14332,18 +15196,66 @@
 			"Restart with {0} MB",
 			"Configure Memory Limit"
 		],
+		"vs/editor/common/editorContextKeys": [
+			"Whether the editor text has focus (cursor is blinking)",
+			"Whether the editor or an editor widget has focus (e.g. focus is in the find widget)",
+			"Whether an editor or a rich text input has focus (cursor is blinking)",
+			"Whether the editor is read only",
+			"Whether the context is a diff editor",
+			"Whether `editor.columnSelection` is enabled",
+			"Whether the editor has text selected",
+			"Whether the editor has multiple selections",
+			"Whether `Tab` will move focus out of the editor",
+			"Whether the editor hover is visible",
+			"Whether the editor is part of a larger editor (e.g. notebooks)",
+			"The language identifier of the editor",
+			"Whether the editor has a completion item provider",
+			"Whether the editor has a code actions provider",
+			"Whether the editor has a code lens provider",
+			"Whether the editor has a definition provider",
+			"Whether the editor has a declaration provider",
+			"Whether the editor has an implementation provider",
+			"Whether the editor has a type definition provider",
+			"Whether the editor has a hover provider",
+			"Whether the editor has a document highlight provider",
+			"Whether the editor has a document symbol provider",
+			"Whether the editor has a reference provider",
+			"Whether the editor has a rename provider",
+			"Whether the editor has a signature help provider",
+			"Whether the editor has an inline hints provider",
+			"Whether the editor has a document formatting provider",
+			"Whether the editor has a document selection formatting provider",
+			"Whether the editor has multiple document formatting providers",
+			"Whether the editor has multiple document selection formatting providers"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileCommands": [
+			"Open a file first to reveal"
+		],
+		"vs/workbench/common/resources": [
+			"The scheme of the rsource",
+			"The file name of the resource",
+			"The folder name the resource is contained in",
+			"The full path of the resource",
+			"The language identifier of the resource",
+			"The full value of the resource including scheme and path",
+			"The extension name of the resource",
+			"Whether a resource is present or not",
+			"Whether the resource is backed by a file system provider"
+		],
 		"vs/workbench/contrib/backup/electron-sandbox/backupTracker": [
 			"The following dirty editors could not be saved to the back up location.",
 			"The following dirty editors could not be saved or reverted.",
 			"Try saving or reverting the dirty editors first and then try again.",
 			"OK",
-			"Waiting for dirty editors to save..."
-		],
-		"vs/workbench/contrib/files/electron-sandbox/fileCommands": [
-			"Open a file first to reveal"
+			"Waiting for dirty editors to backup...",
+			"Waiting for dirty editors to save...",
+			"Waiting for dirty editors to revert..."
 		],
 		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
 			"Paste Selection Clipboard"
+		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate": [
+			"Start Text Mate Syntax Grammar Logging"
 		],
 		"vs/workbench/contrib/issue/electron-sandbox/issueActions": [
 			"Open Process Explorer",
@@ -14368,85 +15280,39 @@
 			"Please select a file.",
 			"Please select a folder."
 		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"No new notifications",
-			"Notifications",
-			"Notification Center Actions"
+		"vs/workbench/contrib/terminal/electron-sandbox/localTerminalService": [
+			"Restart pty host",
+			"The connection to the terminal's pty host process is unresponsive, the terminals may stop working."
 		],
-		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
-			"Error: {0}",
-			"Warning: {0}",
-			"Info: {0}"
+		"vs/workbench/contrib/performance/electron-sandbox/startupProfiler": [
+			"Successfully created profiles.",
+			"Please create an issue and manually attach the following files:\n{0}",
+			"&&Create Issue and Restart",
+			"&&Restart",
+			"Thanks for helping us.",
+			"A final restart is required to continue to use '{0}'. Again, thank you for your contribution.",
+			"&&Restart"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsStatus": [
-			"Notifications",
-			"Notifications",
-			"Hide Notifications",
-			"No Notifications",
-			"No New Notifications",
-			"1 New Notification",
-			"{0} New Notifications",
-			"No New Notifications ({0} in progress)",
-			"1 New Notification ({0} in progress)",
-			"{0} New Notifications ({1} in progress)",
-			"Status Message"
+		"vs/workbench/browser/workbench": [
+			"Failed to load a required file. Please restart the application to try again. Details: {0}"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsCommands": [
-			"Notifications",
-			"Show Notifications",
-			"Hide Notifications",
-			"Clear All Notifications",
-			"Focus Notification Toast"
+		"vs/workbench/electron-sandbox/window": [
+			"Learn More",
+			"Resolving your shell environment is taking very long. Please review your shell configuration.",
+			"Unable to resolve your shell environment in a reasonable time. Please review your shell configuration.",
+			"Proxy Authentication Required",
+			"&&Log In",
+			"&&Cancel",
+			"Username",
+			"Password",
+			"The proxy {0} requires a username and password.",
+			"Remember my credentials",
+			"It is not recommended to run {0} as root user.",
+			"There is a dependency cycle in the AMD modules that needs to be resolved!",
+			"OK"
 		],
-		"vs/platform/actions/browser/menuEntryActionViewItem": [
-			"{0} ({1})"
-		],
-		"vs/workbench/services/configuration/common/configurationEditingService": [
-			"Open Tasks Configuration",
-			"Open Launch Configuration",
-			"Open Settings",
-			"Open Tasks Configuration",
-			"Open Launch Configuration",
-			"Save and Retry",
-			"Save and Retry",
-			"Open Settings",
-			"Unable to write to {0} because {1} is not a registered configuration.",
-			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
-			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
-			"Unable to write to Folder Settings because {0} does not support the folder resource scope.",
-			"Unable to write to User Settings because {0} does not support for global scope.",
-			"Unable to write to Workspace Settings because {0} does not support for workspace scope in a multi folder workspace.",
-			"Unable to write to Folder Settings because no resource is provided.",
-			"Unable to write to Language Settings because {0} is not a resource language setting.",
-			"Unable to write to {0} because no workspace is opened. Please open a workspace first and try again.",
-			"Unable to write into the tasks configuration file. Please open it to correct errors/warnings in it and try again.",
-			"Unable to write into the launch configuration file. Please open it to correct errors/warnings in it and try again.",
-			"Unable to write into user settings. Please open the user settings to correct errors/warnings in it and try again.",
-			"Unable to write into remote user settings. Please open the remote user settings to correct errors/warnings in it and try again.",
-			"Unable to write into workspace settings. Please open the workspace settings to correct errors/warnings in the file and try again.",
-			"Unable to write into folder settings. Please open the '{0}' folder settings to correct errors/warnings in it and try again.",
-			"Unable to write into tasks configuration file because the file is dirty. Please save it first and then try again.",
-			"Unable to write into launch configuration file because the file is dirty. Please save it first and then try again.",
-			"Unable to write into user settings because the file is dirty. Please save the user settings file first and then try again.",
-			"Unable to write into remote user settings because the file is dirty. Please save the remote user settings file first and then try again.",
-			"Unable to write into workspace settings because the file is dirty. Please save the workspace settings file first and then try again.",
-			"Unable to write into folder settings because the file is dirty. Please save the '{0}' folder settings file first and then try again.",
-			"Unable to write into tasks configuration file because the content of the file is newer.",
-			"Unable to write into launch configuration file because the content of the file is newer.",
-			"Unable to write into user settings because the content of the file is newer.",
-			"Unable to write into remote user settings because the content of the file is newer.",
-			"Unable to write into workspace settings because the content of the file is newer.",
-			"Unable to write into folder settings because the content of the file is newer.",
-			"User Settings",
-			"Remote User Settings",
-			"Workspace Settings",
-			"Folder Settings"
-		],
-		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
-			"Failed to save '{0}': {1}"
-		],
-		"vs/editor/common/modes/modesRegistry": [
-			"Plain Text"
+		"vs/workbench/services/remote/electron-sandbox/remoteAgentServiceImpl": [
+			"Failed to connect to the remote extension host server (Error: {0})"
 		],
 		"vs/workbench/services/extensions/node/extensionPoints": [
 			"Invalid manifest file {0}: Not an JSON object.",
@@ -14478,39 +15344,8 @@
 		"vs/workbench/contrib/webview/browser/baseWebviewElement": [
 			"Error loading webview: {0}"
 		],
-		"vs/workbench/contrib/notebook/browser/notebookIcons": [
-			"Configure icon in kernel configuation widget in notebook editors.",
-			"Configure icon to select a kernel in notebook editors.",
-			"Icon to execute in notebook editors.",
-			"Icon to stop an execution in notebook editors.",
-			"Icon to delete a cell in notebook editors.",
-			"Icon to execute all cells in notebook editors.",
-			"Icon to edit a cell in notebook editors.",
-			"Icon to stop editing a cell in notebook editors.",
-			"Icon to move a cell up in notebook editors.",
-			"Icon to move a cell down in notebook editors.",
-			"Icon to clear cell outputs in notebook editors.",
-			"Icon to split a cell in notebook editors.",
-			"Icon to unfold a cell in notebook editors.",
-			"Icon to indicate a success state in notebook editors.",
-			"Icon to indicate a error state in notebook editors.",
-			"Icon to annotated a collapsed section in notebook editors.",
-			"Icon to annotated a expanded section in notebook editors.",
-			"Icon to open the notebook in a text editor.",
-			"Icon to revert in notebook editors.",
-			"Icon to render output in diff editor.",
-			"Icon for a mime type in notebook editors."
-		],
-		"vs/workbench/contrib/extensions/electron-browser/extensionsSlowActions": [
-			"Performance Issue",
-			"Report Issue",
-			"Did you attach the CPU-Profile?",
-			"OK",
-			"This is a reminder to make sure that you have not forgotten to attach '{0}' to the issue you have just created.",
-			"Show Issues",
-			"Did you attach the CPU-Profile?",
-			"OK",
-			"This is a reminder to make sure that you have not forgotten to attach '{0}' to an existing performance issue."
+		"vs/workbench/common/configuration": [
+			"Workbench"
 		],
 		"vs/workbench/contrib/extensions/electron-browser/reportExtensionIssueAction": [
 			"Report Issue"
@@ -14530,11 +15365,60 @@
 			"Disable",
 			"Show Running Extensions"
 		],
-		"vs/workbench/contrib/terminal/node/terminalProcess": [
-			"Starting directory (cwd) \"{0}\" is not a directory",
-			"Starting directory (cwd) \"{0}\" does not exist",
-			"Path to shell executable \"{0}\" is not a file of a symlink",
-			"Path to shell executable \"{0}\" does not exist"
+		"vs/workbench/contrib/extensions/electron-browser/extensionsSlowActions": [
+			"Performance Issue",
+			"Report Issue",
+			"Did you attach the CPU-Profile?",
+			"OK",
+			"This is a reminder to make sure that you have not forgotten to attach '{0}' to the issue you have just created.",
+			"Show Issues",
+			"Did you attach the CPU-Profile?",
+			"OK",
+			"This is a reminder to make sure that you have not forgotten to attach '{0}' to an existing performance issue."
+		],
+		"vs/workbench/contrib/debug/common/debug": [
+			"Debug type of the active debug session. For example 'python'.",
+			"Debug type of the selected launch configuration. For example 'python'.",
+			"State that the focused debug session is in. One of the following: 'inactive', 'initializing', 'stopped' or 'running'.",
+			"Debug UX state. When there are no debug configurations it is 'simple', otherwise 'default'. Used to decide when to show welcome views in the debug viewlet.",
+			"True when debugging, false otherwise.",
+			"True when focus is in the debug console, false otherwise.",
+			"True when breakpoint editor zone widget is visible, false otherwise.",
+			"True when focus is in the breakpoint editor zone widget, false otherwise.",
+			"True when the BREAKPOINTS view is focused, false otherwise.",
+			"True when the WATCH view is focused, false otherwsie.",
+			"True when at least one watch expression exists, false otherwise.",
+			"True when the VARIABLES views is focused, false otherwsie",
+			"True when an expression input box is open in either the WATCH or the VARIABLES view, false otherwise.",
+			"True when the input box has focus in the BREAKPOINTS view.",
+			"Represents the item type of the focused element in the CALL STACK view. For example: 'session', 'thread', 'stackFrame'",
+			"True when the session in the CALL STACK view is attach, false otherwise. Used internally for inline menus in the CALL STACK view.",
+			"True when the focused item in the CALL STACK is stopped. Used internaly for inline menus in the CALL STACK view.",
+			"True when the focused session in the CALL STACK view has exactly one thread. Used internally for inline menus in the CALL STACK view.",
+			"Represents the item type of the focused element in the WATCH view. For example: 'expression', 'variable'",
+			"Represents the item type of the focused element in the BREAKPOINTS view. For example: 'breakpoint', 'exceptionBreakppint', 'functionBreakpoint', 'dataBreakpoint'",
+			"Represents the access type of the focused data breakpoint in the BREAKPOINTS view. For example: 'read', 'readWrite', 'write'",
+			"True when the focused breakpoint supports conditions.",
+			"True when the focused sessions supports the LOADED SCRIPTS view",
+			"Represents the item type of the focused element in the LOADED SCRIPTS view.",
+			"True when the focused session is 'attach'.",
+			"True when the focused session supports 'stepBack' requests.",
+			"True when the focused session supports 'restartFrame' requests.",
+			"True when the focused stack frame suppots 'restartFrame'.",
+			"True when the focused session supports 'jumpToCursor' request.",
+			"True when the focused session supports 'stepIntoTargets' request.",
+			"True when at least one breakpoint exists.",
+			"True when there is at least one debug extensions active.",
+			"Represents the context the debug adapter sets on the focused variable in the VARIABLES view.",
+			"True when the focused session supports 'setVariable' request.",
+			"True when the focused session supports to break when value changes.",
+			"True when the focused breakpoint supports to break when value is accessed.",
+			"True when the focused breakpoint supports to break when value is read.",
+			"True when the focused variable has an 'evalauteName' field set",
+			"True when the exception widget is visible.",
+			"True when there is more than 1 debug console.",
+			"True when there is more than 1 active debug session.",
+			"Controls when the internal debug console should open."
 		],
 		"vs/workbench/contrib/terminal/electron-browser/terminalRemote": [
 			"Create New Integrated Terminal (Local)"
@@ -14549,8 +15433,8 @@
 			"Controls whether copying without a selection copies the current line.",
 			"Controls whether the cursor should jump to find matches while typing.",
 			"Controls whether the search string in the Find Widget is seeded from the editor selection.",
-			"Never turn on Find in selection automatically (default)",
-			"Always turn on Find in selection automatically",
+			"Never turn on Find in selection automatically (default).",
+			"Always turn on Find in selection automatically.",
 			"Turn on Find in selection automatically when multiple lines of content are selected.",
 			"Controls the condition for turning on find in selection automatically.",
 			"Controls whether the Find Widget should read or modify the shared find clipboard on macOS.",
@@ -14614,7 +15498,7 @@
 			"Insert suggestion and overwrite text right of the cursor.",
 			"Controls whether words are overwritten when accepting completions. Note that this depends on extensions opting into this feature.",
 			"Controls whether filtering and sorting suggestions accounts for small typos.",
-			"Controls whether sorting favours words that appear close to the cursor.",
+			"Controls whether sorting favors words that appear close to the cursor.",
 			"Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).",
 			"Controls whether an active snippet prevents quick suggestions.",
 			"Controls whether to show or hide icons in suggestions.",
@@ -14654,11 +15538,14 @@
 			"Controls whether suggestions should be accepted on commit characters. For example, in JavaScript, the semi-colon (`;`) can be a commit character that accepts a suggestion and types that character.",
 			"Only accept a suggestion with `Enter` when it makes a textual change.",
 			"Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions.",
-			"Controls the number of lines in the editor that can be read out by a screen reader. Warning: this has a performance implication for numbers larger than the default.",
+			"Controls the number of lines in the editor that can be read out by a screen reader at once. When we detect a screen reader we automatically set the default to be 2000. Warning: this has a performance implication for numbers larger than the default.",
+			"This setting is deprecated, editor will automatically choose the accessibility page size when we detect a screen reader. 2000 lines will be the new default.",
 			"Editor content",
 			"Use language configurations to determine when to autoclose brackets.",
 			"Autoclose brackets only when the cursor is to the left of whitespace.",
 			"Controls whether the editor should automatically close brackets after the user adds an opening bracket.",
+			"Remove adjacent closing quotes or brackets only if they were automatically inserted.",
+			"Controls whether the editor should remove adjacent closing quotes or brackets when deleting.",
 			"Type over closing quotes or brackets only if they were automatically inserted.",
 			"Controls whether the editor should type over closing quotes or brackets.",
 			"Use language configurations to determine when to autoclose quotes.",
@@ -14674,7 +15561,7 @@
 			"Surround with quotes but not brackets.",
 			"Surround with brackets but not quotes.",
 			"Controls whether the editor should automatically surround selections when typing quotes or brackets.",
-			"Emulate selection behaviour of tab characters when using spaces for indentation. Selection will stick to tab stops.",
+			"Emulate selection behavior of tab characters when using spaces for indentation. Selection will stick to tab stops.",
 			"Controls whether the editor shows CodeLens.",
 			"Controls the font family for CodeLens.",
 			"Controls the font size in pixels for CodeLens. When set to `0`, the 90% of `#editor.fontSize#` is used.",
@@ -14730,10 +15617,10 @@
 			"Render last line number when the file ends with a newline.",
 			"Highlights both the gutter and the current line.",
 			"Controls how the editor should render the current line highlight.",
-			"Controls if the editor should render the current line highlight only when the editor is focused",
+			"Controls if the editor should render the current line highlight only when the editor is focused.",
 			"Render whitespace characters except for single spaces between words.",
 			"Render whitespace characters only on selected text.",
-			"Render only trailing whitespace characters",
+			"Render only trailing whitespace characters.",
 			"Controls how the editor should render whitespace characters.",
 			"Controls whether selections should have rounded corners.",
 			"Controls the number of extra characters beyond which the editor will scroll horizontally.",
@@ -14783,9 +15670,6 @@
 			"Assumes that all characters are of the same width. This is a fast algorithm that works correctly for monospace fonts and certain scripts (like Latin characters) where glyphs are of equal width.",
 			"Delegates wrapping points computation to the browser. This is a slow algorithm, that might cause freezes for large files, but it works correctly in all cases.",
 			"Controls the algorithm that computes wrapping points."
-		],
-		"vs/workbench/contrib/performance/browser/perfviewEditor": [
-			"Startup Performance"
 		],
 		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
 			"The actual task type. Please note that types starting with a '$' are reserved for internal usage.",
@@ -14864,13 +15748,6 @@
 			"ESLint stylish problems",
 			"Go problems"
 		],
-		"vs/platform/theme/common/iconRegistry": [
-			"The id of the font to use. If not set, the font that is defined first is used.",
-			"The font character associated with the icon definition.",
-			"Icon for the close action in widgets.",
-			"Icon for goto previous editor location.",
-			"Icon for goto next editor location."
-		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"Executes .NET Core build command",
 			"Executes the build target",
@@ -14878,17 +15755,18 @@
 			"Executes common maven commands"
 		],
 		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
-			"This folder has tasks ({0}) defined in 'tasks.json' that run automatically when you open this folder. Do you allow automatic tasks to run when you open this folder?",
+			"This workspace has tasks ({0}) defined ({1}) that run automatically when you open this workspace. Do you allow automatic tasks to run when you open this workspace?",
 			"Allow and run",
 			"Disallow",
-			"Open tasks.json",
+			"Open file",
+			"Open files",
 			"Manage Automatic Tasks in Folder",
 			"Allow Automatic Tasks in Folder",
 			"Disallow Automatic Tasks in Folder"
 		],
 		"vs/workbench/contrib/tasks/browser/taskQuickPick": [
 			"Show All Tasks...",
-			"Configration icon in the tasks selection list.",
+			"Configuration icon in the tasks selection list.",
 			"Icon for remove in the tasks selection list.",
 			"Configure Task",
 			"contributed",
@@ -14900,6 +15778,13 @@
 			"Go back ↩",
 			"No {0} tasks found. Go back ↩",
 			"There is no task provider registered for tasks of type \"{0}\"."
+		],
+		"vs/platform/theme/common/iconRegistry": [
+			"The id of the font to use. If not set, the font that is defined first is used.",
+			"The font character associated with the icon definition.",
+			"Icon for the close action in widgets.",
+			"Icon for goto previous editor location.",
+			"Icon for goto next editor location."
 		],
 		"vs/workbench/api/common/extHostExtensionActivator": [
 			"Cannot activate extension '{0}' because it depends on extension '{1}', which failed to activate.",
@@ -14928,14 +15813,14 @@
 		"vs/workbench/api/node/extHostDebugService": [
 			"debuggee"
 		],
-		"vs/code/electron-main/window": [
+		"vs/platform/windows/electron-main/window": [
 			"&&Reopen",
 			"&&Keep Waiting",
 			"&&Close",
 			"The window is no longer responding",
 			"You can reopen or close the window or keep waiting.",
-			"The window has crashed (reason: '{0}')",
 			"The window has crashed",
+			"The window has crashed (reason: '{0}')",
 			"&&Reopen",
 			"&&Close",
 			"We are sorry for the inconvenience! You can reopen the window to continue where you left off.",
@@ -15010,12 +15895,16 @@
 			"Overview ruler marker color for warnings.",
 			"Overview ruler marker color for infos."
 		],
+		"vs/editor/common/modes/modesRegistry": [
+			"Plain Text"
+		],
 		"vs/editor/common/model/editStack": [
 			"Typing"
 		],
 		"vs/editor/browser/controller/coreCommands": [
 			"Stick to the end even when going to longer lines",
-			"Stick to the end even when going to longer lines"
+			"Stick to the end even when going to longer lines",
+			"Removed secondary cursors"
 		],
 		"vs/editor/browser/widget/codeEditorWidget": [
 			"The number of cursors has been limited to {0}."
@@ -15033,18 +15922,18 @@
 			"Line decoration for removals in the diff editor.",
 			"Cannot compare files because one file is too large."
 		],
+		"vs/editor/contrib/bracketMatching/bracketMatching": [
+			"Overview ruler marker color for matching brackets.",
+			"Go to Bracket",
+			"Select to Bracket",
+			"Go to &&Bracket"
+		],
 		"vs/editor/contrib/caretOperations/caretOperations": [
 			"Move Selected Text Left",
 			"Move Selected Text Right"
 		],
 		"vs/editor/contrib/caretOperations/transpose": [
 			"Transpose Letters"
-		],
-		"vs/editor/contrib/bracketMatching/bracketMatching": [
-			"Overview ruler marker color for matching brackets.",
-			"Go to Bracket",
-			"Select to Bracket",
-			"Go to &&Bracket"
 		],
 		"vs/editor/contrib/codelens/codelensController": [
 			"Show CodeLens Commands For Current Line"
@@ -15091,6 +15980,8 @@
 			"Fold All Block Comments",
 			"Fold All Regions",
 			"Unfold All Regions",
+			"Fold All Regions Except Selected",
+			"Unfold All Regions Except Selected",
 			"Fold All",
 			"Unfold All",
 			"Fold Level {0}",
@@ -15222,6 +16113,8 @@
 			"Trigger Parameter Hints"
 		],
 		"vs/editor/contrib/multicursor/multicursor": [
+			"Cursor added: {0}",
+			"Cursors added: {0}",
 			"Add Cursor Above",
 			"&&Add Cursor Above",
 			"Add Cursor Below",
@@ -15240,6 +16133,12 @@
 			"Select All &&Occurrences",
 			"Change All Occurrences"
 		],
+		"vs/editor/contrib/smartSelect/smartSelect": [
+			"Expand Selection",
+			"&&Expand Selection",
+			"Shrink Selection",
+			"&&Shrink Selection"
+		],
 		"vs/editor/contrib/rename/rename": [
 			"No result.",
 			"An unknown error occurred while resolving rename location",
@@ -15251,11 +16150,10 @@
 			"Rename Symbol",
 			"Enable/disable the ability to preview changes before renaming"
 		],
-		"vs/editor/contrib/smartSelect/smartSelect": [
-			"Expand Selection",
-			"&&Expand Selection",
-			"Shrink Selection",
-			"&&Shrink Selection"
+		"vs/editor/contrib/snippet/snippetController2": [
+			"Whether the editor in current in snippet mode",
+			"Whether there is a next tab stop when in snippet mode",
+			"Whether there is a previous tab stop when in snippet mode"
 		],
 		"vs/editor/contrib/suggest/suggestController": [
 			"Accepting '{0}' made {1} additional edits",
@@ -15269,13 +16167,13 @@
 			"show more",
 			"Reset Suggest Widget Size"
 		],
-		"vs/editor/contrib/tokenization/tokenization": [
-			"Developer: Force Retokenize"
-		],
 		"vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode": [
 			"Toggle Tab Key Moves Focus",
 			"Pressing Tab will now move focus to the next focusable element",
 			"Pressing Tab will now insert the tab character"
+		],
+		"vs/editor/contrib/tokenization/tokenization": [
+			"Developer: Force Retokenize"
 		],
 		"vs/editor/contrib/unusualLineTerminators/unusualLineTerminators": [
 			"Unusual Line Terminators",
@@ -15359,6 +16257,34 @@
 			"'configuration.colors.id' must only contain letters, digits and dots and can not start with a dot",
 			"'configuration.colors.description' must be defined and can not be empty",
 			"'configuration.colors.defaults' must be defined and must contain 'light', 'dark' and 'highContrast'"
+		],
+		"vs/workbench/services/themes/common/iconExtensionPoint": [
+			"Contributes extension defined themable icons",
+			"The identifier of the themable icon",
+			"Identifiers can only contain letters, digits and minuses and need to consist of at least two segments in the form `component-iconname`.",
+			"The description of the themable icon",
+			"The id of the icon font that defines the icon.",
+			"The character for the icon in the icon font.",
+			"The default of the icon. Either a reference to an extisting ThemeIcon or an icon in an icon font.",
+			"Contributes icon fonts to be used by icon contributions.",
+			"The ID of the font.",
+			"The ID must only contain letters, numbers, underscore and minus.",
+			"The location of the font.",
+			"The font path, relative to the current extension location.",
+			"The format of the font.",
+			"'configuration.icons is a proposed contribution point and only available when running out of dev or with the following command line switch: --enable-proposed-api {0}",
+			"'configuration.icons' must be a array",
+			"'configuration.icons.id' must be defined and can not be empty",
+			"'configuration.icons.id' can only contain letter, digits and minuses and need to consist of at least two segments in the form `component-iconname`.",
+			"'configuration.icons.description' must be defined and can not be empty",
+			"'configuration.icons.default' must be either a reference to the id of an other theme icon (string) or a icon definition (object) with properties `fontId` and `fontCharacter`.",
+			"'configuration.iconFonts is a proposed contribution point and only available when running out of dev or with the following command line switch: --enable-proposed-api {0}",
+			"'configuration.iconFonts' must be a array",
+			"'configuration.iconFonts.id' must be defined and can not be empty",
+			"'configuration.iconFonts.id'  must only contain letters, numbers, underscore and minus.",
+			"'configuration.iconFonts.src' must be an array with locations of the icon font.",
+			"Expected `contributes.iconFonts.src.path` ({0}) to be included inside extension's folder ({0}). This might make the extension non-portable.",
+			"Items of 'configuration.iconFonts.src' must be objects with properties 'path' and 'format'"
 		],
 		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
 			"Contributes semantic token types.",
@@ -15451,7 +16377,7 @@
 			"Describes the number of characters to remove from the new line's indentation."
 		],
 		"vs/workbench/api/browser/mainThreadCLICommands": [
-			"Cannot install '{0}' because this extension has defined that it cannot run on the remote server."
+			"Cannot install the '{0}' extension because it is declared to not run in this setup."
 		],
 		"vs/workbench/api/browser/mainThreadExtensionService": [
 			"Cannot activate the '{0}' extension because it depends on the '{1}' extension, which is not loaded. Would you like to reload the window to load the extension?",
@@ -15460,7 +16386,7 @@
 			"Enable and Reload",
 			"Cannot activate the '{0}' extension because it depends on the '{1}' extension, which is not installed. Would you like to install the extension and reload the window?",
 			"Install and Reload",
-			"Cannot activate the '{0}' extension because it depends on an unknown '{1}' extension ."
+			"Cannot activate the '{0}' extension because it depends on an unknown '{1}' extension."
 		],
 		"vs/workbench/api/browser/mainThreadFileSystemEventService": [
 			"Extension '{0}' wants to make refactoring changes with this file creation",
@@ -15524,47 +16450,220 @@
 			"Has not used this account",
 			"Manage Trusted Extensions",
 			"Choose which extensions can access this account",
-			"Sign out of {0}",
-			"The account {0} has been used by: \n\n{1}\n\n Sign out of these features?",
-			"Sign out of {0}?",
-			"Successfully signed out.",
-			"Sign in to another account",
-			"The extension '{0}' wants to access a {1} account",
-			"Select an account for '{0}' to use or Esc to cancel",
-			"The extension '{0}' wants to access the {1} account '{2}'.",
-			"Allow",
+			"The account '{0}' has been used by: \n\n{1}\n\n Sign out from these extensions?",
+			"Sign out of '{0}'?",
+			"Sign out",
 			"Cancel",
+			"Successfully signed out.",
 			"The extension '{0}' wants to sign in using {1}.",
 			"Allow",
 			"Cancel"
 		],
-		"vs/workbench/common/configuration": [
-			"Workbench"
+		"vs/workbench/common/viewlet": [
+			"Whether the sidebar is visible",
+			"Whether the sidebar has keyboard focus",
+			"The identifier of the active viewlet"
 		],
-		"vs/workbench/browser/parts/views/treeView": [
-			"There is no data provider registered that can provide view data.",
-			"Refresh",
-			"Collapse All",
-			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
+		"vs/workbench/browser/contextkeys": [
+			"The kind of workspace opened in the window, either 'empty' (no workspace), 'folder' (single folder) or 'workspace' (multi-root workspace)",
+			"The number of root folders in the workspace",
+			"Wether there are any dirty working copies",
+			"The name of the remote the window is connected to or an empty string if not connected to any remote",
+			"Whether the window is in fullscreen mode"
 		],
-		"vs/workbench/browser/parts/views/viewPaneContainer": [
-			"Views",
-			"Move View Up",
-			"Move View Left",
-			"Move View Down",
-			"Move View Right"
+		"vs/workbench/browser/quickaccess": [
+			"Whether keyboard focus is inside the quick open control"
 		],
-		"vs/workbench/contrib/remote/browser/remoteExplorer": [
-			"Ports",
-			"1 forwarded port",
-			"{0} forwarded ports",
-			"Forwarded Ports",
-			"No Ports Forwarded",
-			"Forwarded Ports: {0}",
-			"Your service running on port {0} is available.  ",
-			"[See all forwarded ports](command:{0}.focus)",
-			"You'll need to run as superuser to use port {0} locally.  ",
-			"Use Port {0} as Sudo..."
+		"vs/workbench/browser/parts/editor/textResourceEditor": [
+			"Text Editor"
+		],
+		"vs/workbench/common/editor/diffEditorInput": [
+			"{0} ↔ {1}"
+		],
+		"vs/workbench/browser/parts/editor/textDiffEditor": [
+			"Text Diff Editor"
+		],
+		"vs/workbench/browser/parts/editor/untitledHint": [
+			"Select a Language",
+			"Select a language {0}",
+			" to get started. Start typing to dismiss, or ",
+			"don't show",
+			" this again."
+		],
+		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
+			"{0} ↔ {1}"
+		],
+		"vs/workbench/browser/parts/editor/editorStatus": [
+			"Ln {0}, Col {1} ({2} selected)",
+			"Ln {0}, Col {1}",
+			"{0} selections ({1} characters selected)",
+			"{0} selections",
+			"LF",
+			"CRLF",
+			"Are you using a screen reader to operate VS Code? (word wrap is disabled when using a screen reader)",
+			"Yes",
+			"No",
+			"No text editor active at this time",
+			"The active code editor is read-only.",
+			"convert file",
+			"change view",
+			"Select Action",
+			"Tab Moves Focus",
+			"Disable Accessibility Mode",
+			"Accessibility Mode",
+			"Column Selection",
+			"Disable Column Selection Mode",
+			"Column Selection Mode",
+			"Screen Reader Optimized",
+			"Screen Reader Mode",
+			"Go to Line/Column",
+			"Editor Selection",
+			"Select Indentation",
+			"Editor Indentation",
+			"Select Encoding",
+			"Editor Encoding",
+			"Select End of Line Sequence",
+			"Editor End of Line",
+			"Select Language Mode",
+			"Editor Language",
+			"File Information",
+			"File Information",
+			"Spaces: {0}",
+			"Tab Size: {0}",
+			"Current Problem",
+			"Search Marketplace Extensions for '{0}'...",
+			"Change Language Mode",
+			"No text editor active at this time",
+			"({0}) - Configured Language",
+			"({0})",
+			"languages (identifier)",
+			"Configure '{0}' language based settings...",
+			"Configure File Association for '{0}'...",
+			"Auto Detect",
+			"Select Language Mode",
+			"Current Association",
+			"Select Language Mode to Associate with '{0}'",
+			"Change End of Line Sequence",
+			"No text editor active at this time",
+			"The active code editor is read-only.",
+			"Select End of Line Sequence",
+			"Change File Encoding",
+			"No text editor active at this time",
+			"No text editor active at this time",
+			"No file active at this time",
+			"Save with Encoding",
+			"Reopen with Encoding",
+			"Select Action",
+			"Guessed from content",
+			"Select File Encoding to Reopen File",
+			"Select File Encoding to Save with"
+		],
+		"vs/workbench/browser/parts/editor/editorActions": [
+			"Split Editor",
+			"Split Editor Orthogonal",
+			"Split Editor Left",
+			"Split Editor Right",
+			"Split Editor Up",
+			"Split Editor Down",
+			"Join Editor Group with Next Group",
+			"Join All Editor Groups",
+			"Navigate Between Editor Groups",
+			"Focus Active Editor Group",
+			"Focus First Editor Group",
+			"Focus Last Editor Group",
+			"Focus Next Editor Group",
+			"Focus Previous Editor Group",
+			"Focus Left Editor Group",
+			"Focus Right Editor Group",
+			"Focus Above Editor Group",
+			"Focus Below Editor Group",
+			"Close Editor",
+			"Unpin Editor",
+			"Close",
+			"Revert and Close Editor",
+			"Close Editors to the Left in Group",
+			"Close All Editors",
+			"Close All Editor Groups",
+			"Close Editors in Other Groups",
+			"Close Editor in All Groups",
+			"Move Editor Group Left",
+			"Move Editor Group Right",
+			"Move Editor Group Up",
+			"Move Editor Group Down",
+			"Duplicate Editor Group Left",
+			"Duplicate Editor Group Right",
+			"Duplicate Editor Group Up",
+			"Duplicate Editor Group Down",
+			"Maximize Editor Group",
+			"Reset Editor Group Sizes",
+			"Toggle Editor Group Sizes",
+			"Maximize Editor Group and Hide Side Bar",
+			"Open Next Editor",
+			"Open Previous Editor",
+			"Open Next Editor in Group",
+			"Open Previous Editor in Group",
+			"Open First Editor in Group",
+			"Open Last Editor in Group",
+			"Go Forward",
+			"Go Back",
+			"Go to Last Edit Location",
+			"Go Last",
+			"Reopen Closed Editor",
+			"Clear Recently Opened",
+			"Show Editors in Active Group By Most Recently Used",
+			"Show All Editors By Appearance",
+			"Show All Editors By Most Recently Used",
+			"Quick Open Previous Recently Used Editor",
+			"Quick Open Least Recently Used Editor",
+			"Quick Open Previous Recently Used Editor in Group",
+			"Quick Open Least Recently Used Editor in Group",
+			"Quick Open Previous Editor from History",
+			"Open Next Recently Used Editor",
+			"Open Previous Recently Used Editor",
+			"Open Next Recently Used Editor In Group",
+			"Open Previous Recently Used Editor In Group",
+			"Clear Editor History",
+			"Move Editor Left",
+			"Move Editor Right",
+			"Move Editor into Previous Group",
+			"Move Editor into Next Group",
+			"Move Editor into Above Group",
+			"Move Editor into Below Group",
+			"Move Editor into Left Group",
+			"Move Editor into Right Group",
+			"Move Editor into First Group",
+			"Move Editor into Last Group",
+			"Single Column Editor Layout",
+			"Two Columns Editor Layout",
+			"Three Columns Editor Layout",
+			"Two Rows Editor Layout",
+			"Three Rows Editor Layout",
+			"Grid Editor Layout (2x2)",
+			"Two Columns Bottom Editor Layout",
+			"Two Rows Right Editor Layout",
+			"New Editor Group to the Left",
+			"New Editor Group to the Right",
+			"New Editor Group Above",
+			"New Editor Group Below",
+			"Reopen Editor With...",
+			"Toggle Editor Type"
+		],
+		"vs/workbench/browser/codeeditor": [
+			"Open Workspace"
+		],
+		"vs/workbench/browser/parts/editor/editorCommands": [
+			"Move the active editor by tabs or groups",
+			"Active editor move argument",
+			"Argument Properties:\n\t* 'to': String value providing where to move.\n\t* 'by': String value providing the unit for move (by tab or by group).\n\t* 'value': Number value providing how many positions or an absolute position to move.",
+			"Toggle Inline View",
+			"Compare"
+		],
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"No matching editors",
+			"{0}, dirty, {1}",
+			"{0}, {1}",
+			"{0}, dirty",
+			"Close Editor"
 		],
 		"vs/workbench/browser/parts/editor/editorGroupView": [
 			"Editor group actions",
@@ -15580,115 +16679,11 @@
 		"vs/workbench/browser/parts/editor/editorDropTarget": [
 			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
 		],
-		"vs/workbench/browser/parts/editor/editor.contribution": [
-			"Text Editor",
-			"Text Diff Editor",
-			"Binary Diff Editor",
-			"Side by Side Editor",
-			"Type the name of an editor to open it.",
-			"Show Editors in Active Group by Most Recently Used",
-			"Type the name of an editor to open it.",
-			"Show All Opened Editors By Appearance",
-			"Type the name of an editor to open it.",
-			"Show All Opened Editors By Most Recently Used",
-			"File",
-			"Split Up",
-			"Split Down",
-			"Split Left",
-			"Split Right",
-			"Close",
-			"Close",
-			"Close Others",
-			"Close to the Right",
-			"Close Saved",
-			"Close All",
-			"Keep Open",
-			"Pin",
-			"Unpin",
-			"Split Up",
-			"Split Down",
-			"Split Left",
-			"Split Right",
-			"Toggle Inline View",
-			"Show Opened Editors",
-			"Close All",
-			"Close Saved",
-			"Keep Editors Open",
-			"Split Editor Right",
-			"Split Editor Down",
-			"Split Editor Down",
-			"Split Editor Right",
-			"Close",
-			"Close All",
-			"Close",
-			"Close All",
-			"Unpin",
-			"Close",
-			"Unpin",
-			"Close",
-			"Icon for the previous change action in the diff editor.",
-			"Icon for the next change action in the diff editor.",
-			"Icon for the toggle whitespace action in the diff editor.",
-			"Previous Change",
-			"Next Change",
-			"Ignore Leading/Trailing Whitespace Differences",
-			"Show Leading/Trailing Whitespace Differences",
-			"Keep Editor",
-			"Pin Editor",
-			"Unpin Editor",
-			"Close Editor",
-			"Close Pinned Editor",
-			"Close All Editors in Group",
-			"Close Saved Editors in Group",
-			"Close Other Editors in Group",
-			"Close Editors to the Right in Group",
-			"Close Editor Group",
-			"&&Reopen Closed Editor",
-			"&&Clear Recently Opened",
-			"Editor &&Layout",
-			"Split &&Up",
-			"Split &&Down",
-			"Split &&Left",
-			"Split &&Right",
-			"&&Single",
-			"&&Two Columns",
-			"T&&hree Columns",
-			"T&&wo Rows",
-			"Three &&Rows",
-			"&&Grid (2x2)",
-			"Two R&&ows Right",
-			"Two &&Columns Bottom",
-			"&&Back",
-			"&&Forward",
-			"&&Last Edit Location",
-			"&&Next Editor",
-			"&&Previous Editor",
-			"&&Next Used Editor",
-			"&&Previous Used Editor",
-			"&&Next Editor in Group",
-			"&&Previous Editor in Group",
-			"&&Next Used Editor in Group",
-			"&&Previous Used Editor in Group",
-			"Switch &&Editor",
-			"Group &&1",
-			"Group &&2",
-			"Group &&3",
-			"Group &&4",
-			"Group &&5",
-			"&&Next Group",
-			"&&Previous Group",
-			"Group &&Left",
-			"Group &&Right",
-			"Group &&Above",
-			"Group &&Below",
-			"Switch &&Group"
-		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
-			"Go Home",
-			"Hide Home Button",
 			"Manage Trusted Extensions",
 			"Sign Out",
 			"{0} is currently unavailable",
+			"You are not signed in to any accounts",
 			"Hide Accounts",
 			"Previous Side Bar View",
 			"Next Side Bar View"
@@ -15724,8 +16719,57 @@
 			"Downloading Update...",
 			"Install &&Update...",
 			"Installing Update...",
-			"Restart to &&Update",
-			"Go Home"
+			"Restart to &&Update"
+		],
+		"vs/workbench/browser/parts/views/treeView": [
+			"There is no data provider registered that can provide view data.",
+			"Whether the the tree view with id {0} enables collapse all.",
+			"Whether collapse all is toggled for the tree view with id {0}.",
+			"Whether the tree view with id {0} enables refresh.",
+			"Refresh",
+			"Collapse All",
+			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
+		],
+		"vs/workbench/browser/parts/views/viewPaneContainer": [
+			"Views",
+			"Move View Up",
+			"Move View Left",
+			"Move View Down",
+			"Move View Right"
+		],
+		"vs/workbench/contrib/files/common/files": [
+			"True when the EXPLORER viewlet is visible.",
+			"True when the focused item in the EXPLORER is a folder.",
+			"True when the focused item in the EXPLORER is readonly.",
+			"True when the focused item in the EXPLORER is a root folder.",
+			"True when an item in the EXPLORER has been cut for cut and paste.",
+			"True when the focused item in the EXPLORER can be moved to trash.",
+			"True when the focus is inside the EXPLORER view.",
+			"True when the OPEN EDITORS view is visible.",
+			"True when the focus is inside the OPEN EDITORS view.",
+			"True when the focus is inside the EXPLORER viewlet.",
+			"True when the focused item in the EXPLORER view is a compact item.",
+			"True when the focus is inside a compact item's first part in the EXPLORER view.",
+			"True when the focus is inside a compact item's last part in the EXPLORER view."
+		],
+		"vs/workbench/contrib/remote/browser/remoteExplorer": [
+			"Ports",
+			"1 forwarded port",
+			"{0} forwarded ports",
+			"Forwarded Ports",
+			"No Ports Forwarded",
+			"Forwarded Ports: {0}",
+			"Your application running on port {0} is available.  ",
+			"[See all forwarded ports](command:{0}.focus)",
+			"You'll need to run as superuser to use port {0} locally.  ",
+			"Use Port {0} as Sudo..."
+		],
+		"vs/workbench/common/panel": [
+			"The identifier of the active panel",
+			"Whether the panel has keyboard focus",
+			"The position of the panel, either 'left', 'right' or 'bottom'",
+			"Whether the panel is visible",
+			"Whether the panel is maximized"
 		],
 		"vs/workbench/browser/parts/compositePart": [
 			"{0} actions",
@@ -15770,23 +16814,19 @@
 		"vs/workbench/services/textfile/common/textFileEditorModel": [
 			"The file is dirty. Please save it first before reopening it with another encoding."
 		],
-		"vs/workbench/common/editor/diffEditorInput": [
-			"{0} ↔ {1}"
-		],
-		"vs/workbench/services/editor/common/editorOpenWith": [
-			"Currently Active",
-			"Set as default editor for '{0}' files",
-			"Select editor for '{0}'",
-			"Built-in",
-			"Text Editor",
-			"Configure which editor to use for specific file types.",
-			"The unique id of the editor to use.",
-			"Glob pattern specifying which files the editor should be used for.",
-			"Text Editor"
-		],
 		"vs/platform/keybinding/common/abstractKeybindingService": [
 			"({0}) was pressed. Waiting for second key of chord...",
 			"The key combination ({0}, {1}) is not a command."
+		],
+		"vs/workbench/services/themes/common/colorThemeData": [
+			"Problems parsing JSON theme file: {0}",
+			"Invalid format for JSON theme file: Object expected.",
+			"Problem parsing color theme file: {0}. Property 'colors' is not of type 'object'.",
+			"Problem parsing color theme file: {0}. Property 'tokenColors' should be either an array specifying colors or a path to a TextMate theme file",
+			"Problem parsing color theme file: {0}. Property 'semanticTokenColors' contains a invalid selector",
+			"Problem parsing tmTheme file: {0}. 'settings' is not array.",
+			"Problems parsing tmTheme file: {0}",
+			"Problems loading tmTheme file {0}: {1}"
 		],
 		"vs/workbench/services/themes/common/fileIconThemeSchema": [
 			"The folder icon for expanded folders. The expanded folder icon is optional. If not set, the icon defined for folder will be shown.",
@@ -15821,16 +16861,6 @@
 			"Optional associations for file icons in light color themes.",
 			"Optional associations for file icons in high contrast color themes.",
 			"Configures whether the file explorer's arrows should be hidden when this theme is active."
-		],
-		"vs/workbench/services/themes/common/colorThemeData": [
-			"Problems parsing JSON theme file: {0}",
-			"Invalid format for JSON theme file: Object expected.",
-			"Problem parsing color theme file: {0}. Property 'colors' is not of type 'object'.",
-			"Problem parsing color theme file: {0}. Property 'tokenColors' should be either an array specifying colors or a path to a TextMate theme file",
-			"Problem parsing color theme file: {0}. Property 'semanticTokenColors' contains a invalid selector",
-			"Problem parsing tmTheme file: {0}. 'settings' is not array.",
-			"Problems parsing tmTheme file: {0}",
-			"Problems loading tmTheme file {0}: {1}"
 		],
 		"vs/workbench/services/themes/browser/fileIconThemeData": [
 			"Problems parsing file icons file: {0}",
@@ -15920,6 +16950,16 @@
 			"Skipping icon definition '{0}'. Unknown font.",
 			"Skipping icon definition '{0}'. Unknown fontCharacter."
 		],
+		"vs/workbench/services/themes/common/productIconThemeSchema": [
+			"The ID of the font.",
+			"The ID must only contain letters, numbers, underscore and minus.",
+			"The location of the font.",
+			"The font path, relative to the current product icon theme file.",
+			"The format of the font.",
+			"The weight of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for valid values.",
+			"The style of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-style for valid values.",
+			"Association of icon name to a font character."
+		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
 			"Extension Bisect is active and has disabled {0} extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
 			"Start Extension Bisect",
@@ -15945,20 +16985,15 @@
 			"Stop Extension Bisect",
 			"Help"
 		],
-		"vs/workbench/services/themes/common/productIconThemeSchema": [
-			"The ID of the font.",
-			"The ID must only contain letters, numbers, underscore and minus.",
-			"The location of the font.",
-			"The font path, relative to the current product icon theme file.",
-			"The format of the font.",
-			"The weight of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for valid values.",
-			"The style of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-style for valid values.",
-			"Association of icon name to a font character."
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"Configure Language Specific Settings...",
-			"({0})",
-			"Select Language"
+		"vs/editor/contrib/suggest/suggest": [
+			"Whether suggestion are visible",
+			"Whether suggestion details are visible",
+			"Whether there are multiple suggestions to pick from",
+			"Whether inserting the current suggestion yields in a change or has everything already been typed",
+			"Whether suggestions are inserted when pressing Enter",
+			"Whether the current suggestion has insert and replace behaviour",
+			"Whether the default behaviour is to insert or replace",
+			"Whether the current suggestion supports to resolve further details"
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"Record Keys",
@@ -15994,6 +17029,11 @@
 			"Keybindings",
 			"No Keybinding assigned.",
 			"No when context."
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"Configure Language Specific Settings...",
+			"({0})",
+			"Select Language"
 		],
 		"vs/workbench/contrib/preferences/browser/preferencesEditor": [
 			"Search settings",
@@ -16031,19 +17071,19 @@
 			"Controls the behavior of the settings editor Table of Contents while searching."
 		],
 		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
-			"Icon for an expanded section in the split JSON settings editor.",
-			"Icon for an collapsed section in the split JSON settings editor.",
-			"Icon for the folder dropdown button in the split JSON settings editor.",
-			"Icon for the 'more actions' action in the settings UI.",
+			"Icon for an expanded section in the split JSON Settings editor.",
+			"Icon for a collapsed section in the split JSON Settings editor.",
+			"Icon for the folder dropdown button in the split JSON Settings editor.",
+			"Icon for the 'more actions' action in the Settings UI.",
 			"Icon for the 'record keys' action in the keybinding UI.",
 			"Icon for the 'sort by precedence' toggle in the keybinding UI.",
 			"Icon for the edit action in the keybinding UI.",
 			"Icon for the add action in the keybinding UI.",
-			"Icon for the edit action in the settings UI.",
-			"Icon for the add action in the settings UI.",
-			"Icon for the remove action in the settings UI.",
-			"Icon for the discard action in the settings UI.",
-			"Icon for clear input in the settings and keybinding UI.",
+			"Icon for the edit action in the Settings UI.",
+			"Icon for the add action in the Settings UI.",
+			"Icon for the remove action in the Settings UI.",
+			"Icon for the discard action in the Settings UI.",
+			"Icon for clear input in the Settings and keybinding UI.",
 			"Icon for open settings commands."
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
@@ -16052,71 +17092,8 @@
 			"{0} existing commands have this keybinding",
 			"chord to"
 		],
-		"vs/workbench/browser/codeeditor": [
-			"Open Workspace"
-		],
-		"vs/workbench/contrib/testing/browser/icons": [
-			"View icon of the test view.",
-			"Icon of the \"run test\" action.",
-			"Icon of the \"run all tests\" action.",
-			"Icon of the \"debug test\" action.",
-			"Icon to cancel ongoing test runs.",
-			"Icon shown when the test explorer is disabled as a tree.",
-			"Icon shown when the test explorer is disabled as a list.",
-			"Icon shown for tests that have an error.",
-			"Icon shown for tests that failed.",
-			"Icon shown for tests that passed.",
-			"Icon shown for tests that are queued.",
-			"Icon shown for tests that are skipped.",
-			"Icon shown for tests that are in an unset state."
-		],
-		"vs/workbench/contrib/testing/browser/testingDecorations": [
-			"Click to run tests, right click for more options",
-			"Run Test",
-			"Debug Test",
-			"Reveal in Test Explorer"
-		],
-		"vs/workbench/contrib/testing/browser/testingExplorerFilter": [
-			"Filter (e.g. text, !exclude)",
-			"Filter"
-		],
-		"vs/workbench/contrib/testing/browser/testingExplorerView": [
-			"Test Explorer",
-			"{0} ({1})",
-			"{0}/{1} tests passed ({2}%)",
-			"{0}/{1} tests passed ({2}%, {3} skipped)",
-			"Test run is starting...",
-			"Test run in progress",
-			"{0} tests failed"
-		],
-		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
-			"Close"
-		],
-		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
-			"Testing"
-		],
-		"vs/workbench/contrib/testing/common/testServiceImpl": [
-			"An error occurred attempting to run tests: {0}"
-		],
-		"vs/workbench/contrib/testing/browser/testExplorerActions": [
-			"Test",
-			"Debug Test",
-			"Run Test",
-			"Run Selected Tests",
-			"Debug Selected Tests",
-			"Run All Tests",
-			"No tests found in this workspace. You may need to install a test provider extension",
-			"Debug All Tests",
-			"No debuggable tests found in this workspace. You may need to install a test provider extension",
-			"Cancel Test Run",
-			"View as List",
-			"View as Tree",
-			"Sort by Name",
-			"Sort by Status",
-			"Collapse All Tests",
-			"Refresh Tests",
-			"Show Test",
-			"Open Focused Test in Editor"
+		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+			"Startup Performance"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookEditor": [
 			"Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed or enabled.",
@@ -16125,8 +17102,74 @@
 		"vs/workbench/contrib/notebook/browser/notebookServiceImpl": [
 			"Built-in"
 		],
+		"vs/workbench/contrib/customEditor/common/customEditor": [
+			"The viewType of the currently active custom editor."
+		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor": [
 			"Notebook Text Diff"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
+			"Copy Cell",
+			"Cut Cell",
+			"Paste Cell",
+			"Paste Cell Above"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/coreActions": [
+			"Notebook",
+			"Execute Cell",
+			"Execute Cell",
+			"Stop Cell Execution",
+			"Stop Cell Execution",
+			"Delete Cell",
+			"Execute Notebook Cell and Select Below",
+			"Execute Notebook Cell and Insert Below",
+			"Render All Markdown Cells",
+			"Execute Notebook",
+			"Execute Notebook",
+			"Cancel Notebook Execution",
+			"Cancel Notebook Execution",
+			"Insert Cell",
+			"Notebook Cell",
+			"Execute Notebook (Run all cells)",
+			"Stop Notebook Execution",
+			"Change Cell to Code",
+			"Change Cell to Markdown",
+			"Insert Code Cell Above",
+			"Insert Code Cell Below",
+			"Add Code Cell At Top",
+			"Add Markdown Cell At Top",
+			"$(add) Code",
+			"Add Code Cell",
+			"$(add) Code",
+			"Add Code Cell",
+			"Insert Markdown Cell Above",
+			"Insert Markdown Cell Below",
+			"$(add) Markdown",
+			"Add Markdown Cell",
+			"$(add) Markdown",
+			"Add Markdown Cell",
+			"Edit Cell",
+			"Stop Editing Cell",
+			"Delete Cell",
+			"Focus Next Cell Editor",
+			"Focus Previous Cell Editor",
+			"Focus In Active Cell Output",
+			"Focus Out Active Cell Output",
+			"Focus First Cell",
+			"Focus Last Cell",
+			"Clear Cell Outputs",
+			"Change Cell Language",
+			"Change Cell Language",
+			"({0}) - Current Language",
+			"({0})",
+			"Select Language Mode",
+			"Clear All Cells Outputs",
+			"Center Active Cell",
+			"Collapse Cell Input",
+			"Expand Cell Input",
+			"Collapse Cell Output",
+			"Expand Cell Output",
+			"Inspect Notebook Layout"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/find/findController": [
 			"Hide Find in Notebook",
@@ -16156,12 +17199,134 @@
 			"Choose kernel for current notebook",
 			"Choose kernel for current notebook"
 		],
+		"vs/workbench/contrib/notebook/browser/contrib/cellOperations/cellOperations": [
+			"Move Cell Up",
+			"Move Cell Down",
+			"Copy Cell Up",
+			"Copy Cell Down",
+			"Split Cell",
+			"Join With Previous Cell",
+			"Join With Next Cell"
+		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions": [
 			"Open Text Diff Editor",
 			"Revert Metadata",
 			"Switch Output Rendering",
 			"Revert Outputs",
-			"Revert Input"
+			"Revert Input",
+			"Show Outputs Differences",
+			"Show Metadata Differences",
+			"Hide Metadata Differences",
+			"Hide Outputs Differences"
+		],
+		"vs/workbench/contrib/testing/browser/icons": [
+			"View icon of the test view.",
+			"Icon of the \"run test\" action.",
+			"Icon of the \"run all tests\" action.",
+			"Icon of the \"debug test\" action.",
+			"Icon to cancel ongoing test runs.",
+			"Icon for the 'Filter' action in the testing view.",
+			"Icon for the 'Autorun' toggle in the testing view.",
+			"Icon shown beside hidden tests, when they've been shown.",
+			"Icon shown when the test explorer is disabled as a tree.",
+			"Icon shown when the test explorer is disabled as a list.",
+			"Icon shown for tests that have an error.",
+			"Icon shown for tests that failed.",
+			"Icon shown for tests that passed.",
+			"Icon shown for tests that are queued.",
+			"Icon shown for tests that are skipped.",
+			"Icon shown for tests that are in an unset state."
+		],
+		"vs/workbench/contrib/testing/browser/testingDecorations": [
+			"{0} has failed. ",
+			"Peek Error",
+			"Click to run tests, right click for more options",
+			"Run Test",
+			"Debug Test",
+			"Reveal in Test Explorer"
+		],
+		"vs/workbench/contrib/testing/browser/testingExplorerFilter": [
+			"More Filters...",
+			"Filter (e.g. text, !exclude)",
+			"Show Only Failed Tests",
+			"Show Only Executed Tests",
+			"Show All Tests",
+			"Show Hidden Tests",
+			"Unhide All Tests",
+			"Show in Active File Only",
+			"Filter"
+		],
+		"vs/workbench/contrib/testing/browser/testingExplorerView": [
+			"No tests have been found in this workspace yet.",
+			"Find Test Extensions",
+			"Test Explorer",
+			"{0} ({1})",
+			"{0}, outdated result"
+		],
+		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
+			"Expected result",
+			"Actual result",
+			"Close"
+		],
+		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
+			"Running {0} tests, {1}/{2} passed ({3}%)",
+			"Running {0} tests, {1}/{2} tests passed ({3}%, {4} skipped)",
+			"{0}/{1} tests passed ({2}%)",
+			"{0}/{1} tests passed ({2}%, {3} skipped)"
+		],
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"Testing"
+		],
+		"vs/workbench/contrib/testing/common/configuration": [
+			"Testing",
+			"Controls which tests are automatically run.",
+			"Automatically runs all discovered test when auto-run is toggled. Re-runs individual tests when they are changed.",
+			"Re-runs individual tests when they are changed. Will not automatically run any tests that have not been already executed.",
+			"How long to wait, in milliseconds, after a test is marked as outdated and starting a new run.",
+			"Configures when the error peek view is automatically opened.",
+			"Open automatically no matter where the failure is.",
+			"Open automatically when a test fails in a visible document.",
+			"Controls whether to automatically open the peek view during auto-run mode."
+		],
+		"vs/workbench/contrib/testing/common/testingContextKeys": [
+			"ID of the current test item, set when creating or opening menus on test items"
+		],
+		"vs/workbench/contrib/testing/common/testServiceImpl": [
+			"An error occurred attempting to run tests: {0}"
+		],
+		"vs/workbench/contrib/testing/browser/testExplorerActions": [
+			"Test",
+			"Unhide Test",
+			"Hide Test",
+			"Debug Test",
+			"Run Test",
+			"Run Selected Tests",
+			"Debug Selected Tests",
+			"Discovering Tests",
+			"Run All Tests",
+			"No tests found in this workspace. You may need to install a test provider extension",
+			"Debug All Tests",
+			"No debuggable tests found in this workspace. You may need to install a test provider extension",
+			"Cancel Test Run",
+			"View as List",
+			"View as Tree",
+			"Sort by Name",
+			"Sort by Location",
+			"Collapse All Tests",
+			"Refresh Tests",
+			"Clear All Results",
+			"Open Focused Test in Editor",
+			"Turn On Auto Run",
+			"Turn Off Auto Run",
+			"Run Test at Cursor",
+			"Debug Test at Cursor",
+			"Run Tests in Current File",
+			"Debug Tests in Current File",
+			"Re-run Failed Tests",
+			"Debug Failed Tests",
+			"Re-run Last Run",
+			"Debug Last Run",
+			"Search for Test Extension"
 		],
 		"vs/workbench/contrib/logs/common/logsActions": [
 			"Set Log Level...",
@@ -16181,6 +17346,11 @@
 			"Select Session",
 			"Select Log file"
 		],
+		"vs/platform/quickinput/browser/helpQuickAccess": [
+			"global commands",
+			"editor commands",
+			"{0}, {1}"
+		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"No matching views",
 			"Side Bar",
@@ -16199,11 +17369,6 @@
 			"Show All Commands",
 			"Clear Command History"
 		],
-		"vs/platform/quickinput/browser/helpQuickAccess": [
-			"global commands",
-			"editor commands",
-			"{0}, {1}"
-		],
 		"vs/workbench/contrib/files/browser/views/explorerView": [
 			"Explorer Section: {0}",
 			"New File",
@@ -16211,15 +17376,16 @@
 			"Refresh Explorer",
 			"Collapse Folders in Explorer"
 		],
-		"vs/workbench/contrib/files/browser/views/emptyView": [
-			"No Folder Opened"
-		],
 		"vs/workbench/contrib/files/browser/views/openEditorsView": [
 			"Open Editors",
 			"{0} unsaved",
 			"Open Editors",
 			"Toggle Vertical/Horizontal Editor Layout",
-			"Flip &&Layout"
+			"Flip &&Layout",
+			"New Untitled File"
+		],
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"No Folder Opened"
 		],
 		"vs/workbench/contrib/files/browser/fileActions": [
 			"New File",
@@ -16305,11 +17471,23 @@
 			"Copy {0}",
 			"The file(s) to paste have been deleted or moved since you copied them. {0}"
 		],
+		"vs/workbench/contrib/files/browser/fileCommands": [
+			"Save As...",
+			"Save",
+			"Save without Formatting",
+			"Save All",
+			"Remove Folder from Workspace",
+			"New Untitled File",
+			"{0} (in file) ↔ {1}",
+			"Open a file first to copy its path",
+			"Failed to save '{0}': {1}",
+			"Retry",
+			"Discard",
+			"Failed to revert '{0}': {1}"
+		],
 		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
 			"Use the actions in the editor tool bar to either undo your changes or overwrite the content of the file with your changes.",
 			"Failed to save '{0}': The content of the file is newer. Please compare your version with the file contents or overwrite the content of the file with your changes.",
-			"Retry",
-			"Discard",
 			"Failed to save '{0}': File is read-only. Select 'Overwrite as Admin' to retry as administrator.",
 			"Failed to save '{0}': File is read-only. Select 'Overwrite as Sudo' to retry as superuser.",
 			"Failed to save '{0}': File is read-only. Select 'Overwrite' to attempt to make it writeable.",
@@ -16324,28 +17502,11 @@
 			"Overwrite as Sudo...",
 			"Retry as Admin...",
 			"Retry as Sudo...",
+			"Retry",
+			"Discard",
 			"Overwrite",
 			"Overwrite",
 			"Configure"
-		],
-		"vs/workbench/contrib/files/browser/fileCommands": [
-			"Save As...",
-			"Save",
-			"Save without Formatting",
-			"Save All",
-			"Remove Folder from Workspace",
-			"New Untitled File",
-			"{0} (in file) ↔ {1}",
-			"Open a file first to copy its path",
-			"Failed to save '{0}': {1}",
-			"Failed to revert '{0}': {1}"
-		],
-		"vs/workbench/browser/parts/editor/editorCommands": [
-			"Move the active editor by tabs or groups",
-			"Active editor move argument",
-			"Argument Properties:\n\t* 'to': String value providing where to move.\n\t* 'by': String value providing the unit for move (by tab or by group).\n\t* 'value': Number value providing how many positions or an absolute position to move.",
-			"Toggle Inline View",
-			"Compare"
 		],
 		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
 			"Binary File Viewer"
@@ -16367,7 +17528,7 @@
 			"Only suggest words from the active document.",
 			"Suggest words from all open documents of the same language.",
 			"Suggest words from all open documents.",
-			"Controls form what documents word based completions are computed.",
+			"Controls from which documents word based completions are computed.",
 			"Semantic highlighting enabled for all color themes.",
 			"Semantic highlighting disabled for all color themes.",
 			"Semantic highlighting is configured by the current color theme's `semanticHighlighting` setting.",
@@ -16402,7 +17563,7 @@
 		],
 		"vs/editor/contrib/quickAccess/gotoLineQuickAccess": [
 			"Open a text editor first to go to a line.",
-			"Go to line {0} and column {1}.",
+			"Go to line {0} and character {1}.",
 			"Go to line {0}.",
 			"Current Line: {0}, Character: {1}. Type a line number between 1 and {2} to navigate to.",
 			"Current Line: {0}, Character: {1}. Type a line number to navigate to."
@@ -16425,7 +17586,6 @@
 			"Remove from Recently Opened"
 		],
 		"vs/workbench/contrib/search/browser/searchActions": [
-			"Show Search",
 			"Replace in Files",
 			"Toggle Search on Type",
 			"Focus Next Search Result",
@@ -16468,6 +17628,10 @@
 		],
 		"vs/workbench/contrib/search/common/queryBuilder": [
 			"Workspace folder does not exist: {0}"
+		],
+		"vs/platform/actions/browser/menuEntryActionViewItem": [
+			"{0} ({1})",
+			"{0} ({1})"
 		],
 		"vs/workbench/browser/parts/views/viewPane": [
 			"Icon for an expanded view pane container.",
@@ -16526,6 +17690,7 @@
 		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
 			"{0} of {1} changes",
 			"{0} of {1} change",
+			"Close",
 			"Show Previous Change",
 			"Show Next Change",
 			"Next &&Change",
@@ -16545,23 +17710,22 @@
 		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
 			"Source Control"
 		],
-		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
-			"Source Control Repositories"
-		],
 		"vs/workbench/contrib/scm/browser/scmViewPane": [
 			"Source Control Management",
 			"Source Control Input",
-			"Repositories",
 			"View & Sort",
-			"Toggle View Mode",
+			"Repositories",
 			"View as List",
 			"View as Tree",
 			"Sort by Name",
 			"Sort by Path",
 			"Sort by Status",
-			"Expand All Repositories",
 			"Collapse All Repositories",
+			"Expand All Repositories",
 			"SCM Provider separator border."
+		],
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"Source Control Repositories"
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"Expression condition: {0}",
@@ -16574,8 +17738,8 @@
 			"Type expression. Function breakpoint will break when expression evaluates to true",
 			"Break when hit count is met",
 			"Type hit count. Function breakpoint will break when hit count is met.",
-			"Break when expression evaluates to true",
 			"Type exception breakpoint condition",
+			"Break when expression evaluates to true",
 			"Breakpoints",
 			"Disabled Logpoint",
 			"Disabled Breakpoint",
@@ -16604,6 +17768,8 @@
 			"Disable A&&ll Breakpoints",
 			"Reapply All Breakpoints",
 			"Edit Condition...",
+			"Edit Condition...",
+			"Edit Hit Count...",
 			"Edit Function Breakpoint...",
 			"Edit Hit Count..."
 		],
@@ -16804,10 +17970,10 @@
 			"Icon for the collapse all action in the debug views.",
 			"Icon for the session icon in the call stack view.",
 			"Icon for the clear all action in the debug console.",
-			"Icon for the remove all action in the watch view.",
+			"Icon for the Remove All action in the watch view.",
 			"Icon for the add action in the watch view.",
 			"Icon for the add function breakpoint action in the watch view.",
-			"Icon for the remove all action in the breakpoints view.",
+			"Icon for the Remove All action in the breakpoints view.",
 			"Icon for the activate action in the breakpoints view.",
 			"Icon for the debug evaluation input marker.",
 			"Icon for the debug evaluation prompt."
@@ -16823,6 +17989,15 @@
 			"Hold {0} key to switch to editor language hover",
 			"Debug Hover",
 			"{0}, value {1}, variables, debug"
+		],
+		"vs/workbench/contrib/debug/common/debugModel": [
+			"Invalid variable attributes",
+			"Please start a debug session to evaluate expressions",
+			"not available",
+			"Paused on {0}",
+			"Paused",
+			"Running",
+			"Unverified breakpoint. File is modified, please restart debug session."
 		],
 		"vs/workbench/contrib/debug/browser/breakpointWidget": [
 			"Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.",
@@ -16840,6 +18015,12 @@
 			"Add Configuration...",
 			"Debug Session"
 		],
+		"vs/workbench/contrib/debug/browser/linkDetector": [
+			"follow link using forwarded port",
+			"follow link",
+			"Cmd + click to {0}",
+			"Ctrl + click to {0}"
+		],
 		"vs/workbench/contrib/debug/browser/replViewer": [
 			"Debug Console",
 			"Variable {0}, value {1}",
@@ -16853,6 +18034,11 @@
 		],
 		"vs/workbench/contrib/debug/browser/replFilter": [
 			"Showing {0} of {1}"
+		],
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"Showing {0} problems",
+			"Showing {0} of {1} problems",
+			"Clear Filters"
 		],
 		"vs/workbench/contrib/markers/browser/messages": [
 			"Toggle Problems (Errors, Warnings, Infos)",
@@ -16899,19 +18085,14 @@
 			"{0} at line {1} and character {2} in {3}",
 			"Show Errors and Warnings"
 		],
-		"vs/workbench/contrib/markers/browser/markersView": [
-			"Showing {0} problems",
-			"Showing {0} of {1} problems",
-			"Clear Filters"
-		],
-		"vs/workbench/contrib/markers/browser/markers": [
-			"Total {0} Problems"
-		],
 		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
 			"Problems",
 			"1 problem in this file",
 			"{0} problems in this file",
 			"Show Errors & Warnings on files and folder."
+		],
+		"vs/workbench/contrib/markers/browser/markers": [
+			"Total {0} Problems"
 		],
 		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
 			"Select Comment Provider",
@@ -16940,15 +18121,10 @@
 			"Find previous",
 			"Reload Webviews"
 		],
-		"vs/workbench/contrib/customEditor/browser/customEditors": [
-			"Currently Active",
-			"Set as default editor for '{0}' files",
-			"Select editor to use for '{0}'..."
-		],
 		"vs/workbench/contrib/externalUriOpener/common/configuration": [
-			"Configure the opener to use for external uris (i.e. http, https).",
-			"Map uri pattern to an opener id.\nExample patterns: \n{0}",
-			"Map uri pattern to an opener id.\nExample patterns: \n{0}",
+			"Configure the opener to use for external URIs (http, https).",
+			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
+			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
 			"Open using VS Code's standard opener."
 		],
 		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
@@ -16960,120 +18136,6 @@
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"Extension: {0}"
 		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
-			"Yes",
-			"No"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionEditor": [
-			"Extension name",
-			"Extension identifier",
-			"Preview",
-			"Preview",
-			"Built-in",
-			"Publisher name",
-			"Install count",
-			"Rating",
-			"Repository",
-			"License",
-			"Version",
-			"Details",
-			"Extension details, rendered from the extension's 'README.md' file",
-			"Feature Contributions",
-			"Lists contributions to VS Code by this extension",
-			"Changelog",
-			"Extension update history, rendered from the extension's 'CHANGELOG.md' file",
-			"Dependencies",
-			"Lists extensions this extension depends on",
-			"You have chosen not to receive recommendations for this extension.",
-			"No README available.",
-			"Extension Pack ({0})",
-			"No README available.",
-			"No Changelog available.",
-			"No Contributions",
-			"No Contributions",
-			"No Dependencies",
-			"Settings ({0})",
-			"Name",
-			"Description",
-			"Default",
-			"Debuggers ({0})",
-			"Name",
-			"Type",
-			"View Containers ({0})",
-			"ID",
-			"Title",
-			"Where",
-			"Views ({0})",
-			"ID",
-			"Name",
-			"Where",
-			"Localizations ({0})",
-			"Language Id",
-			"Language Name",
-			"Language Name (Localized)",
-			"Custom Editors ({0})",
-			"View Type",
-			"Priority",
-			"Filename Pattern",
-			"Code Actions ({0})",
-			"Title",
-			"Kind",
-			"Description",
-			"Languages",
-			"Authentication ({0})",
-			"Label",
-			"Id",
-			"Color Themes ({0})",
-			"File Icon Themes ({0})",
-			"Colors ({0})",
-			"Id",
-			"Description",
-			"Dark Default",
-			"Light Default",
-			"High Contrast Default",
-			"JSON Validation ({0})",
-			"File Match",
-			"Schema",
-			"Commands ({0})",
-			"Name",
-			"Description",
-			"Keyboard Shortcuts",
-			"Menu Contexts",
-			"Languages ({0})",
-			"ID",
-			"Name",
-			"File Extensions",
-			"Grammar",
-			"Snippets",
-			"Activation Events ({0})",
-			"Find",
-			"Find Next",
-			"Find Previous"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
-			"Extensions",
-			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
-			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
-			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
-			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
-			"Activating Extensions..."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"Extensions",
-			"Install Missing Dependencies",
-			"Finished installing missing dependencies. Please reload the window now.",
-			"Reload Window",
-			"There are no missing dependencies to install."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"Type an extension name to install or search.",
-			"Press Enter to search for extension '{0}'.",
-			"Press Enter to install extension '{0}'.",
-			"Press Enter to manage your extensions."
-		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"{0} years ago",
 			"1 year ago",
@@ -17084,11 +18146,15 @@
 			"{0} hours ago",
 			"1 hour ago",
 			"Just now",
-			"Error while updating '{0}' extension.",
-			"Error while installing '{0}' extension.",
+			"VS Code Web",
+			"The '{0}' extension is not available in {1}. Click 'More Information' to learn more.",
+			"Close",
+			"More Information",
 			"Try Downloading Manually...",
 			"Once downloaded, please manually install the downloaded VSIX of '{0}'.",
 			"Install from VSIX...",
+			"Error while updating '{0}' extension.",
+			"Error while installing '{0}' extension.",
 			"Please check the [log]({0}) for more details.",
 			"Installing extension {0} started. An editor is now open with more details on this extension",
 			"Installing extension {0} is completed.",
@@ -17191,6 +18257,7 @@
 			"This extension has defined that it cannot run on the remote server",
 			"Extension is enabled on '{0}' and disabled locally.",
 			"Extension is enabled locally and disabled on '{0}'.",
+			"This extension has been disabled because the current workspace is not trusted",
 			"Reinstall Extension...",
 			"Select Extension to Reinstall",
 			"Please reload Visual Studio Code to complete reinstalling the extension {0}.",
@@ -17215,6 +18282,124 @@
 			"Button foreground color for actions extension that stand out (e.g. install button).",
 			"Button background hover color for actions extension that stand out (e.g. install button)."
 		],
+		"vs/workbench/contrib/extensions/browser/extensionEditor": [
+			"Extension name",
+			"Extension identifier",
+			"Preview",
+			"Preview",
+			"Built-in",
+			"Publisher name",
+			"Install count",
+			"Rating",
+			"Repository",
+			"License",
+			"Version",
+			"Details",
+			"Extension details, rendered from the extension's 'README.md' file",
+			"Feature Contributions",
+			"Lists contributions to VS Code by this extension",
+			"Changelog",
+			"Extension update history, rendered from the extension's 'CHANGELOG.md' file",
+			"Dependencies",
+			"Lists extensions this extension depends on",
+			"Extension Pack",
+			"Lists extensions those will be installed together with this extension",
+			"You have chosen not to receive recommendations for this extension.",
+			"No README available.",
+			"Extension Pack ({0})",
+			"No README available.",
+			"No Changelog available.",
+			"No Contributions",
+			"No Contributions",
+			"No Dependencies",
+			"No Extensions",
+			"Settings ({0})",
+			"Name",
+			"Description",
+			"Default",
+			"Debuggers ({0})",
+			"Name",
+			"Type",
+			"View Containers ({0})",
+			"ID",
+			"Title",
+			"Where",
+			"Views ({0})",
+			"ID",
+			"Name",
+			"Where",
+			"Localizations ({0})",
+			"Language Id",
+			"Language Name",
+			"Language Name (Localized)",
+			"Custom Editors ({0})",
+			"View Type",
+			"Priority",
+			"Filename Pattern",
+			"Code Actions ({0})",
+			"Title",
+			"Kind",
+			"Description",
+			"Languages",
+			"Authentication ({0})",
+			"Label",
+			"Id",
+			"Color Themes ({0})",
+			"File Icon Themes ({0})",
+			"Product Icon Themes ({0})",
+			"Colors ({0})",
+			"Id",
+			"Description",
+			"Dark Default",
+			"Light Default",
+			"High Contrast Default",
+			"JSON Validation ({0})",
+			"File Match",
+			"Schema",
+			"Commands ({0})",
+			"Name",
+			"Description",
+			"Keyboard Shortcuts",
+			"Menu Contexts",
+			"Languages ({0})",
+			"ID",
+			"Name",
+			"File Extensions",
+			"Grammar",
+			"Snippets",
+			"Activation Events ({0})",
+			"Find",
+			"Find Next",
+			"Find Previous"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
+			"Extensions",
+			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
+			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
+		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
+			"Yes",
+			"No"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"Activating Extensions..."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"Extensions",
+			"Install Missing Dependencies",
+			"Finished installing missing dependencies. Please reload the window now.",
+			"Reload Window",
+			"There are no missing dependencies to install."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"Type an extension name to install or search.",
+			"Press Enter to search for extension '{0}'.",
+			"Press Enter to install extension '{0}'.",
+			"Press Enter to manage your extensions."
+		],
 		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
 			"Manifest is not found",
 			"This extension is reported to be problematic.",
@@ -17226,6 +18411,16 @@
 			"Cannot disable '{0}' extension alone. '{1}' extension depends on this. Do you want to disable all these extensions?",
 			"Cannot disable '{0}' extension alone. '{1}' and '{2}' extensions depend on this. Do you want to disable all these extensions?",
 			"Cannot disable '{0}' extension alone. '{1}', '{2}' and other extensions depend on this. Do you want to disable all these extensions?"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
+			"Don't Show Again",
+			"Do you want to ignore all extension recommendations?",
+			"Yes, Ignore All",
+			"No",
+			"Do you want to install the recommended extensions for this repository?",
+			"Install",
+			"Install (Do not sync)",
+			"Show Recommendations"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
 			"View icon of the extensions view.",
@@ -17245,23 +18440,11 @@
 			"Half star icon used for the rating in the extensions editor.",
 			"Empty star icon used for the rating in the extensions editor.",
 			"Icon shown with a warning message in the extensions editor.",
-			"Icon shown with an info message in the extensions editor."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
-			"Don't Show Again",
-			"Do you want to ignore all extension recommendations?",
-			"Yes, Ignore All",
-			"No",
-			"Do you want to install the recommended extensions for this repository?",
-			"Install",
-			"Install (Do not sync)",
-			"Show Recommendations"
-		],
-		"vs/workbench/contrib/output/browser/logViewer": [
-			"Log viewer"
+			"Icon shown with an info message in the extensions editor.",
+			"Icon shown with a workspace trust message in the extension editor."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsViews": [
-			"{0}, {1}, {2}, press enter for extension details.",
+			"{0}, {1}, {2}, {3}",
 			"Extensions",
 			"We cannot connect to the Extensions Marketplace at this time, please try again later.",
 			"Error while loading extensions. {0}",
@@ -17270,43 +18453,16 @@
 			"Open User Settings",
 			"There are no extensions to install."
 		],
-		"vs/workbench/browser/parts/editor/textResourceEditor": [
-			"Text Editor"
+		"vs/workbench/contrib/output/browser/logViewer": [
+			"Log viewer"
 		],
 		"vs/base/browser/ui/actionbar/actionViewItems": [
 			"{0} ({1})"
 		],
-		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
-			"The background color of the terminal, this allows coloring the terminal differently to the panel.",
-			"The foreground color of the terminal.",
-			"The foreground color of the terminal cursor.",
-			"The background color of the terminal cursor. Allows customizing the color of a character overlapped by a block cursor.",
-			"The selection background color of the terminal.",
-			"The color of the border that separates split panes within the terminal. This defaults to panel.border.",
-			"'{0}' ANSI color in the terminal."
-		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
-			"Select current working directory for new terminal",
-			"Toggle Integrated Terminal",
-			"Kill the Active Terminal Instance",
-			"Kill Terminal",
-			"Copy Selection",
-			"Copy",
-			"Select All",
-			"Create New Integrated Terminal",
-			"New Terminal",
-			"Select current working directory for new terminal",
-			"Split Terminal",
-			"Split",
-			"Split Terminal (In Active Workspace)",
-			"Paste into Active Terminal",
-			"Paste",
-			"Select Default Shell",
+			"Select Default Profile",
 			"Configure Terminal Settings",
-			"Switch Terminal",
-			"Open Terminals.",
-			"Starting...",
-			"Clear",
+			"Select current working directory for new terminal",
 			"Open Help",
 			"Create New Integrated Terminal (In Active Workspace)",
 			"Focus Previous Pane",
@@ -17337,6 +18493,7 @@
 			"Focus Find",
 			"Hide Find",
 			"Attach to Session",
+			"There are no unattached terminals to attach to",
 			"Switch Active Terminal",
 			"Scroll To Previous Command",
 			"Scroll To Next Command",
@@ -17358,14 +18515,50 @@
 			"Find Previous",
 			"Search Workspace",
 			"Relaunch Active Terminal",
-			"Show Environment Information"
+			"Show Environment Information",
+			"Split Terminal",
+			"Split",
+			"Split Terminal (In Active Workspace)",
+			"Select All",
+			"Create New Integrated Terminal",
+			"Select current working directory for new terminal",
+			"New Terminal",
+			"Kill the Active Terminal Instance",
+			"Kill Terminal",
+			"Clear",
+			"Select Default Profile",
+			"Copy Selection",
+			"Copy",
+			"Paste into Active Terminal",
+			"Paste",
+			"Switch Terminal"
+		],
+		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
+			"The background color of the terminal, this allows coloring the terminal differently to the panel.",
+			"The foreground color of the terminal.",
+			"The foreground color of the terminal cursor.",
+			"The background color of the terminal cursor. Allows customizing the color of a character overlapped by a block cursor.",
+			"The selection background color of the terminal.",
+			"The color of the border that separates split panes within the terminal. This defaults to panel.border.",
+			"'{0}' ANSI color in the terminal."
 		],
 		"vs/workbench/contrib/terminal/common/terminalMenu": [
-			"&&Terminal",
 			"&&New Terminal",
 			"&&Split Terminal",
 			"Run &&Active File",
 			"Run &&Selected Text"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"Allow Workspace Shell Configuration",
+			"Disallow Workspace Shell Configuration",
+			"There is an active terminal session, do you want to kill it?",
+			"There are {0} active terminal sessions, do you want to kill them?",
+			"Select your default terminal profile",
+			"Enter terminal profile name",
+			"A terminal profile already exists with that name",
+			"profiles",
+			"detected",
+			"Configure Terminal Profile"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
 			"Rename Terminal",
@@ -17376,14 +18569,12 @@
 			"View icon of the terminal view.",
 			"Icon for rename in the terminal quick menu.",
 			"Icon for killing a terminal instance.",
-			"Icon for creating a new terminal instance."
+			"Icon for creating a new terminal instance.",
+			"Icon for creating a new terminal profile."
 		],
-		"vs/workbench/contrib/terminal/browser/terminalService": [
-			"Allow Workspace Shell Configuration",
-			"Disallow Workspace Shell Configuration",
-			"There is an active terminal session, do you want to kill it?",
-			"There are {0} active terminal sessions, do you want to kill them?",
-			"Select your preferred terminal shell, you can change this later in your settings"
+		"vs/workbench/contrib/terminal/browser/remoteTerminalService": [
+			"Restart pty host",
+			"The connection to the terminal's pty host process is unresponsive, the terminals may stop working."
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
 			"Task version 0.1.0 is deprecated. Please use 2.0.0",
@@ -17478,10 +18669,6 @@
 			"No matching tasks",
 			"Select the task to run"
 		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"Emmet: Expand Abbreviation",
-			"Emmet: E&&xpand Abbreviation"
-		],
 		"vs/workbench/contrib/remote/browser/explorerViewItems": [
 			"Switch Remote",
 			"Switch Remote"
@@ -17497,6 +18684,7 @@
 			"Reconnecting to {0}...",
 			"Disconnected from {0}",
 			"Disconnected from {0}",
+			"Editing on {0}",
 			"Editing on {0}",
 			"Open a Remote Window",
 			"Remote Host",
@@ -17516,7 +18704,16 @@
 			"Icon representing a public remote port.",
 			"Icon for the forward action.",
 			"Icon for the stop forwarding action.",
-			"Icon for the open browser action."
+			"Icon for the open browser action.",
+			"Icon for the open preview action.",
+			"Icon for the copy local address action.",
+			"Icon for the label port action.",
+			"Icon for forwarded ports that don't have a running process.",
+			"Icon for forwarded ports that do have a running process."
+		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"Emmet: Expand Abbreviation",
+			"Emmet: E&&xpand Abbreviation"
 		],
 		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
 			"Now changing the setting `editor.accessibilitySupport` to 'on'.",
@@ -17562,6 +18759,10 @@
 			"Go to Line/Column",
 			"Go to Line/Column..."
 		],
+		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
+			"Toggle Column Selection Mode",
+			"Column &&Selection Mode"
+		],
 		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
 			"Running '{0}' Formatter ([configure](command:workbench.action.openSettings?%5B%22editor.formatOnSave%22%5D)).",
 			"Quick Fixes",
@@ -17582,15 +18783,12 @@
 			"Toggle Control Characters",
 			"Render &&Control Characters"
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
-			"Toggle Column Selection Mode",
-			"Column &&Selection Mode"
-		],
 		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
 			"Toggle Render Whitespace",
 			"&&Render Whitespace"
 		],
 		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
+			"Whether the editor is currently using word wrapping.",
 			"View: Toggle Word Wrap",
 			"Disable wrapping for this file",
 			"Enable wrapping for this file",
@@ -17607,6 +18805,7 @@
 			"{0}, {1}"
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
+			"None",
 			"None",
 			"Extension '{0}' cannot format '{1}'",
 			"There are multiple formatters for '{0}' files. Select a default formatter to continue.",
@@ -17665,18 +18864,37 @@
 			"Install Update... (1)",
 			"Installing Update...",
 			"Restart to Update (1)",
+			"Switch to Insiders Version...",
+			"Switch to Stable Version...",
 			"Changing the version requires a reload to take effect",
 			"Press the reload button to switch to the nightly pre-production version of VSCode.",
 			"Press the reload button to switch to the monthly released stable version of VSCode.",
 			"&&Reload",
-			"Switch to Insiders Version...",
-			"Switch to Stable Version...",
+			"Choose the settings sync service to use after changing the version",
+			"Insiders",
+			"Stable (current)",
+			"Cancel",
+			"Insiders version of VSCode will synchronize your settings, keybindings, extensions, snippets and UI State using separate insiders settings sync service by default.",
 			"Check for Updates..."
 		],
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"Unbound"
 		],
 		"vs/workbench/contrib/welcome/page/browser/welcomePage": [
+			"Start without an editor.",
+			"Open the Welcome page.",
+			"Open the README when opening a folder that contains one, fallback to 'welcomePage' otherwise.",
+			"Open a new untitled file (only applies when opening an empty window).",
+			"Open the Welcome page when opening an empty workbench.",
+			"Open the Getting Started page.",
+			"Controls which editor is shown at startup, if none are restored from the previous session.",
+			"Start without an editor.",
+			"Open the Welcome page.",
+			"Open the README when opening a folder that contains one, fallback to 'welcomePage' otherwise.",
+			"Open a new untitled file (only applies when opening an empty window).",
+			"Open the Welcome page when opening an empty workbench.",
+			"Open the Getting Started page.",
+			"Controls which editor is shown at startup, if none are restored from the previous session.",
 			"Welcome",
 			"JavaScript",
 			"Python",
@@ -17707,13 +18925,40 @@
 			"Details"
 		],
 		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted": [
+			"Getting Started. Overview of how to get up to speed with your editor.",
+			"More",
+			"Hide",
+			"No remaining walkthroughs.",
+			"Configure visibility?",
+			"Visual Studio Code",
+			"Editing evolved",
 			"Getting Started",
-			"Skip",
-			"Next"
+			"Show welcome page on startup",
+			"Open folder {0} with path {1}",
+			"Recent",
+			"Start",
+			"Next",
+			"Next Page",
+			"Image showing {0}"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedInput": [
+			"Getting Started"
 		],
 		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedIcons": [
 			"Used to represent getting started items which have not been completed",
 			"Used to represent getting started items which have been completed"
+		],
+		"vs/workbench/contrib/welcome/walkthroughs/browser/walkthroughs": [
+			"Getting Started",
+			"More",
+			"Getting Started. Overview of how to get up to speed with your editor.",
+			"Press Enter to Select",
+			"Press Enter to Select",
+			"Visual Studio Code",
+			"Walkthroughs",
+			"Image showing {0}",
+			"Next",
+			"Next Page"
 		],
 		"vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart": [
 			"unbound",
@@ -17732,6 +18977,7 @@
 			"No callers of '{0}'"
 		],
 		"vs/editor/contrib/peekView/peekView": [
+			"Whether the current code editor is embedded inside peek",
 			"Close",
 			"Background color of the peek view title area.",
 			"Color of the peek view title.",
@@ -17747,6 +18993,17 @@
 			"Match highlight color in the peek view result list.",
 			"Match highlight color in the peek view editor.",
 			"Match highlight border in the peek view editor."
+		],
+		"vs/workbench/contrib/outline/browser/outlinePane": [
+			"The active editor cannot provide outline information.",
+			"Loading document symbols for '{0}'...",
+			"No symbols found in document '{0}'",
+			"Collapse All",
+			"Follow Cursor",
+			"Filter on Type",
+			"Sort By: Position",
+			"Sort By: Name",
+			"Sort By: Category"
 		],
 		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree": [
 			"{0} ({1})",
@@ -17778,57 +19035,7 @@
 			"string",
 			"struct",
 			"type parameter",
-			"variable",
-			"The foreground color for array symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for boolean symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for class symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for color symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for constant symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for constructor symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for enumerator symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for enumerator member symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for event symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for field symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for file symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for folder symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for function symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for interface symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for key symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for keyword symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for method symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for module symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for namespace symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for null symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for number symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for object symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for operator symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for package symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for property symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for reference symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for snippet symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for string symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for struct symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for text symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for type parameter symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for unit symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
-			"The foreground color for variable symbols. These symbols appear in the outline, breadcrumb, and suggest widget."
-		],
-		"vs/workbench/contrib/outline/browser/outlinePane": [
-			"The active editor cannot provide outline information.",
-			"Loading document symbols for '{0}'...",
-			"No symbols found in document '{0}'",
-			"Collapse All",
-			"Follow Cursor",
-			"Filter on Type",
-			"Sort By: Position",
-			"Sort By: Name",
-			"Sort By: Category"
-		],
-		"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem": [
-			"Tweet Feedback",
-			"Tweet Feedback",
-			"Tweet Feedback",
-			"Tweet Feedback"
+			"variable"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
 			"{0}: Turn On...",
@@ -17850,7 +19057,7 @@
 			"Error while accepting changes. Please check [logs]({0}) for more details.",
 			"Settings sync was turned off because current session is expired, please sign in again to turn on sync.",
 			"Turn on Settings Sync...",
-			"Settings sync was turned off from another device, please sign in again to turn on sync.",
+			"Settings sync was turned off from another device, please turn on sync again.",
 			"Turn on Settings Sync...",
 			"Disabled syncing {0} because size of the {1} file to sync is larger than {2}. Please open the file and reduce the size and enable sync",
 			"Settings sync is disabled because the current version ({0}, {1}) is not compatible with the sync service. Please update before turning on sync.",
@@ -17858,7 +19065,11 @@
 			"Settings sync is disabled because your data in the cloud is older than that of the client. Please clear your data in the cloud before turning on sync.",
 			"Clear Data in Cloud...",
 			"Show Synced Data",
-			"Settings sync now uses a separate service, more information is available in the [release notes](https://code.visualstudio.com/updates/v1_48#_settings-sync).",
+			"Settings Sync has been switched to insiders service",
+			"Settings Sync has been switched to stable service",
+			"Settings sync now uses a separate service, more information is available in the [Settings Sync Documentation](https://aka.ms/vscode-settings-sync-help#_syncing-stable-versus-insiders).",
+			"Settings sync was turned off because {0} now uses a separate service. Please turn on sync again.",
+			"Turn on Settings Sync...",
 			"Operation Id: {0}",
 			"Open {0} File",
 			"Unable to sync {0} because the content in the file is not valid. Please open the file and correct it.",
@@ -17927,6 +19138,12 @@
 			"Could not resolve conflicts as there is new local version available. Please try again.",
 			"Error while accepting changes. Please check [logs]({0}) for more details."
 		],
+		"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem": [
+			"Tweet Feedback",
+			"Tweet Feedback",
+			"Tweet Feedback",
+			"Tweet Feedback"
+		],
 		"vs/workbench/contrib/codeActions/common/codeActionsContribution": [
 			"Controls whether auto fix action should be run on file save.",
 			"Code action kinds to be run on save.",
@@ -17982,6 +19199,26 @@
 			"Include: {0}",
 			"Timeline"
 		],
+		"vs/workbench/contrib/workspace/browser/workspaceTrustEditor": [
+			"This workspace is trusted",
+			"This workspace is not trusted",
+			"Do you want to trust this workspace?",
+			"Trust is required for certain extensions to function in this workspace. [Learn more](https://aka.ms/vscode-workspace-trust).",
+			"Trust",
+			"Don't Trust",
+			"Disabled Extensions",
+			"The following extensions require the workspace to be trusted. They will be disabled while the workspace is not trusted.",
+			"Limited Extensions",
+			"The following extensions can function partially in a non-trusted workspace. Some functionality will be turned off while the workspace is not trusted.",
+			"Configure All Workspaces",
+			"Features Affected By Workspace Trust"
+		],
+		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
+			"Workspace Trust"
+		],
+		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
+			"Failed to save '{0}': {1}"
+		],
 		"vs/workbench/services/textMate/common/TMGrammars": [
 			"Contributes textmate tokenizers.",
 			"Language identifier for which this syntax is contributed to.",
@@ -18017,50 +19254,79 @@
 			"Yes, glad to help",
 			"No, thanks"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsList": [
-			"{0}, notification",
-			"{0}, source: {1}, notification",
-			"Notifications List"
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"No new notifications",
+			"Notifications",
+			"Notification Center Actions"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsActions": [
-			"Icon for the clear action in notifications.",
-			"Icon for the clear all action in notifications.",
-			"Icon for the hide action in notifications.",
-			"Icon for the expand action in notifications.",
-			"Icon for the collapse action in notifications.",
-			"Icon for the configure action in notifications.",
-			"Clear Notification",
-			"Clear All Notifications",
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"Error: {0}",
+			"Warning: {0}",
+			"Info: {0}"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsStatus": [
+			"Notifications",
+			"Notifications",
 			"Hide Notifications",
-			"Expand Notification",
-			"Collapse Notification",
-			"Configure Notification",
-			"Copy Text"
+			"No Notifications",
+			"No New Notifications",
+			"1 New Notification",
+			"{0} New Notifications",
+			"No New Notifications ({0} in progress)",
+			"1 New Notification ({0} in progress)",
+			"{0} New Notifications ({1} in progress)",
+			"Status Message"
 		],
-		"vs/base/common/keybindingLabels": [
-			"Ctrl",
-			"Shift",
-			"Alt",
-			"Windows",
-			"Ctrl",
-			"Shift",
-			"Alt",
-			"Super",
-			"Control",
-			"Shift",
-			"Alt",
-			"Command",
-			"Control",
-			"Shift",
-			"Alt",
-			"Windows",
-			"Control",
-			"Shift",
-			"Alt",
-			"Super"
+		"vs/workbench/browser/parts/notifications/notificationsCommands": [
+			"Whether a notification has keyboard focus",
+			"Whether the notifications center is visible",
+			"Whether a notification toast is visible",
+			"Notifications",
+			"Show Notifications",
+			"Hide Notifications",
+			"Clear All Notifications",
+			"Focus Notification Toast"
 		],
-		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
-			"Saving '{0}'"
+		"vs/workbench/services/configuration/common/configurationEditingService": [
+			"Open Tasks Configuration",
+			"Open Launch Configuration",
+			"Open Settings",
+			"Open Tasks Configuration",
+			"Open Launch Configuration",
+			"Save and Retry",
+			"Save and Retry",
+			"Open Settings",
+			"Unable to write to {0} because {1} is not a registered configuration.",
+			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
+			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
+			"Unable to write to Folder Settings because {0} does not support the folder resource scope.",
+			"Unable to write to User Settings because {0} does not support for global scope.",
+			"Unable to write to Workspace Settings because {0} does not support for workspace scope in a multi folder workspace.",
+			"Unable to write to Folder Settings because no resource is provided.",
+			"Unable to write to Language Settings because {0} is not a resource language setting.",
+			"Unable to write to {0} because no workspace is opened. Please open a workspace first and try again.",
+			"Unable to write into the tasks configuration file. Please open it to correct errors/warnings in it and try again.",
+			"Unable to write into the launch configuration file. Please open it to correct errors/warnings in it and try again.",
+			"Unable to write into user settings. Please open the user settings to correct errors/warnings in it and try again.",
+			"Unable to write into remote user settings. Please open the remote user settings to correct errors/warnings in it and try again.",
+			"Unable to write into workspace settings. Please open the workspace settings to correct errors/warnings in the file and try again.",
+			"Unable to write into folder settings. Please open the '{0}' folder settings to correct errors/warnings in it and try again.",
+			"Unable to write into tasks configuration file because the file is dirty. Please save it first and then try again.",
+			"Unable to write into launch configuration file because the file is dirty. Please save it first and then try again.",
+			"Unable to write into user settings because the file is dirty. Please save the user settings file first and then try again.",
+			"Unable to write into remote user settings because the file is dirty. Please save the remote user settings file first and then try again.",
+			"Unable to write into workspace settings because the file is dirty. Please save the workspace settings file first and then try again.",
+			"Unable to write into folder settings because the file is dirty. Please save the '{0}' folder settings file first and then try again.",
+			"Unable to write into tasks configuration file because the content of the file is newer.",
+			"Unable to write into launch configuration file because the content of the file is newer.",
+			"Unable to write into user settings because the content of the file is newer.",
+			"Unable to write into remote user settings because the content of the file is newer.",
+			"Unable to write into workspace settings because the content of the file is newer.",
+			"Unable to write into folder settings because the content of the file is newer.",
+			"User Settings",
+			"Remote User Settings",
+			"Workspace Settings",
+			"Folder Settings"
 		],
 		"vs/base/common/jsonErrorMessages": [
 			"Invalid symbol",
@@ -18159,6 +19425,10 @@
 			"Auto Fix...",
 			"No auto fixes available"
 		],
+		"vs/editor/contrib/folding/foldingDecorations": [
+			"Icon for expanded ranges in the editor glyph margin.",
+			"Icon for collapsed ranges in the editor glyph margin."
+		],
 		"vs/editor/contrib/find/findWidget": [
 			"Icon for 'Find in Selection' in the editor find widget.",
 			"Icon to indicate that the editor find widget is collapsed.",
@@ -18187,10 +19457,6 @@
 			"{0} found for '{1}'",
 			"Ctrl+Enter now inserts line break instead of replacing all. You can modify the keybinding for editor.action.replaceAll to override this behavior."
 		],
-		"vs/editor/contrib/folding/foldingDecorations": [
-			"Icon for expanded ranges in the editor glyph margin.",
-			"Icon for collapsed ranges in the editor glyph margin."
-		],
 		"vs/editor/contrib/format/format": [
 			"Made 1 formatting edit on line {0}",
 			"Made {0} formatting edits on line {1}",
@@ -18198,25 +19464,13 @@
 			"Made {0} formatting edits between lines {1} and {2}"
 		],
 		"vs/editor/contrib/message/messageController": [
+			"Whether the editor is currently showing an inline message",
 			"Cannot edit in read-only editor"
 		],
 		"vs/editor/contrib/gotoSymbol/peek/referencesController": [
+			"Whether reference peek is visible, like 'Peek References' or 'Peek Definition'",
 			"Loading...",
 			"{0} ({1})"
-		],
-		"vs/editor/contrib/gotoSymbol/referencesModel": [
-			"symbol in {0} on line {1} at column {2}",
-			"symbol in {0} on line {1} at column {2}, {3}",
-			"1 symbol in {0}, full path {1}",
-			"{0} symbols in {1}, full path {2}",
-			"No results found",
-			"Found 1 symbol in {0}",
-			"Found {0} symbols in {1}",
-			"Found {0} symbols in {1} files"
-		],
-		"vs/editor/contrib/gotoSymbol/symbolNavigation": [
-			"Symbol {0} of {1}, {2} for next",
-			"Symbol {0} of {1}"
 		],
 		"vs/editor/contrib/gotoError/gotoErrorWidget": [
 			"Error",
@@ -18231,14 +19485,30 @@
 			"Editor marker navigation widget info color.",
 			"Editor marker navigation widget background."
 		],
-		"vs/editor/contrib/rename/renameInputField": [
-			"Rename input. Type new name and press Enter to commit.",
-			"{0} to Rename, {1} to Preview"
+		"vs/editor/contrib/gotoSymbol/symbolNavigation": [
+			"Whether there are symbol locations that can be navigated via keyboard-only.",
+			"Symbol {0} of {1}, {2} for next",
+			"Symbol {0} of {1}"
+		],
+		"vs/editor/contrib/gotoSymbol/referencesModel": [
+			"symbol in {0} on line {1} at column {2}",
+			"symbol in {0} on line {1} at column {2}, {3}",
+			"1 symbol in {0}, full path {1}",
+			"{0} symbols in {1}, full path {2}",
+			"No results found",
+			"Found 1 symbol in {0}",
+			"Found {0} symbols in {1}",
+			"Found {0} symbols in {1} files"
 		],
 		"vs/editor/contrib/parameterHints/parameterHintsWidget": [
 			"Icon for show next parameter hint.",
 			"Icon for show previous parameter hint.",
 			"{0}, hint"
+		],
+		"vs/editor/contrib/rename/renameInputField": [
+			"Whether the rename input widget is visible",
+			"Rename input. Type new name and press Enter to commit.",
+			"{0} to Rename, {1} to Preview"
 		],
 		"vs/editor/contrib/suggest/suggestWidget": [
 			"Background color of the suggest widget.",
@@ -18293,14 +19563,14 @@
 			"Style to use for symbols that are async.",
 			"Style to use for symbols that are readonly."
 		],
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"An error occurred while loading view: {0}"
+		],
 		"vs/workbench/browser/parts/editor/textEditor": [
 			"Editor"
 		],
 		"vs/workbench/api/browser/mainThreadCustomEditors": [
 			"Edit"
-		],
-		"vs/workbench/api/browser/mainThreadWebviews": [
-			"An error occurred while loading view: {0}"
 		],
 		"vs/workbench/contrib/comments/browser/commentsView": [
 			"Comments for current workspace",
@@ -18312,24 +19582,64 @@
 			"Image: {0}",
 			"Image"
 		],
+		"vs/workbench/browser/parts/editor/binaryEditor": [
+			"Binary Viewer",
+			"The file is not displayed in the editor because it is too large ({0}).",
+			"The file is not displayed in the editor because it is either binary or uses an unsupported text encoding.",
+			"Do you want to open it anyway?"
+		],
+		"vs/workbench/browser/parts/editor/tabsTitleControl": [
+			"Tab actions"
+		],
+		"vs/base/browser/ui/menu/menubar": [
+			"Application Menu",
+			"More"
+		],
+		"vs/base/browser/ui/menu/menu": [
+			"{0} ({1})"
+		],
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"Collapse All"
+		],
+		"vs/base/browser/ui/splitview/paneview": [
+			"{0} Section"
+		],
 		"vs/workbench/contrib/remote/browser/tunnelView": [
-			"Forward a Port...",
-			"Existing Tunnels",
-			"Not Forwarded",
+			"Whether the Ports view is enabled.",
+			"Add Port",
+			"Port",
+			"The label and remote port number of the forwarded port.",
+			"Local Address",
+			"The address that the forwarded port is available at locally.",
+			"Running Process",
+			"The command line of the process that is using the port.",
+			"Origin",
+			"The source that a forwarded port originates from. Can be an extension, user forwarded, statically forwarded, or automatically forwarded.",
+			"Privacy",
+			"The availability of the forwarded port.",
+			"Public",
+			"Private",
 			"Press Enter to confirm or Escape to cancel.",
-			"{0}",
-			"{0} → {1}",
-			"{0}",
-			"{0} → {1}",
+			"User Forwarded",
+			"Statically Forwarded",
+			"Auto Forwarded",
+			"Command line unavailable",
+			"Remote port {0}:{1} forwarded to local address {2}. ",
+			"Remote port {0}:{1} not forwarded. ",
+			"Port has running process.",
+			"No running process.",
+			"Port labeled {0}. ",
+			"Accessible publicly. ",
+			"Only accessible from this machine. ",
+			"Whether the Ports view has focus.",
 			"Ports",
-			"Remote port {0}:{1} forwarded to local address {2}",
-			"Remote port {0}:{1} not forwarded",
 			"Tunnel View",
-			"Set Label",
+			"Set Port Label",
 			"Port label",
 			"Forwarded port is invalid.",
 			"Port number must be ≥ 0 and < {0}.",
 			"May Require Sudo",
+			"Port is already forwarded",
 			"Forward a Port",
 			"Forward Port",
 			"Port number or address (eg. 3000 or 10.10.10.10:2000).",
@@ -18338,202 +19648,19 @@
 			"Stop Forwarding Port",
 			"Choose a port to stop forwarding",
 			"Open in Browser",
+			"Preview in Editor",
 			"Open Port in Browser",
 			"No ports currently forwarded. Open the Ports view to get started.",
 			"Open the Ports view...",
 			"Choose the port to open",
-			"Copy Address",
+			"Copy Local Address",
 			"Copy Forwarded Port Address",
 			"Choose a forwarded port",
-			"Change Local Port",
+			"Change Local Address Port",
 			"The local port {0} is not available. Port number {1} has been used instead",
 			"New local port",
 			"Make Public",
 			"Make Private"
-		],
-		"vs/base/browser/ui/tree/treeDefaults": [
-			"Collapse All"
-		],
-		"vs/base/browser/ui/splitview/paneview": [
-			"{0} Section"
-		],
-		"vs/workbench/browser/parts/editor/tabsTitleControl": [
-			"Tab actions"
-		],
-		"vs/workbench/browser/parts/editor/textDiffEditor": [
-			"Text Diff Editor"
-		],
-		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
-			"{0} ↔ {1}"
-		],
-		"vs/workbench/browser/parts/editor/editorQuickAccess": [
-			"No matching editors",
-			"{0}, dirty, {1}",
-			"{0}, {1}",
-			"{0}, dirty",
-			"Close Editor"
-		],
-		"vs/workbench/browser/parts/editor/editorStatus": [
-			"Ln {0}, Col {1} ({2} selected)",
-			"Ln {0}, Col {1}",
-			"{0} selections ({1} characters selected)",
-			"{0} selections",
-			"LF",
-			"CRLF",
-			"Are you using a screen reader to operate VS Code? (word wrap is disabled when using a screen reader)",
-			"Yes",
-			"No",
-			"No text editor active at this time",
-			"The active code editor is read-only.",
-			"convert file",
-			"change view",
-			"Select Action",
-			"Tab Moves Focus",
-			"Disable Accessibility Mode",
-			"Accessibility Mode",
-			"Column Selection",
-			"Disable Column Selection Mode",
-			"Column Selection Mode",
-			"Screen Reader Optimized",
-			"Screen Reader Mode",
-			"Go to Line/Column",
-			"Editor Selection",
-			"Select Indentation",
-			"Editor Indentation",
-			"Select Encoding",
-			"Editor Encoding",
-			"Select End of Line Sequence",
-			"Editor End of Line",
-			"Select Language Mode",
-			"Editor Language",
-			"File Information",
-			"File Information",
-			"Spaces: {0}",
-			"Tab Size: {0}",
-			"Current Problem",
-			"Search Marketplace Extensions for '{0}'...",
-			"Change Language Mode",
-			"No text editor active at this time",
-			"({0}) - Configured Language",
-			"({0})",
-			"languages (identifier)",
-			"Configure '{0}' language based settings...",
-			"Configure File Association for '{0}'...",
-			"Auto Detect",
-			"Select Language Mode",
-			"Current Association",
-			"Select Language Mode to Associate with '{0}'",
-			"Change End of Line Sequence",
-			"No text editor active at this time",
-			"The active code editor is read-only.",
-			"Select End of Line Sequence",
-			"Change File Encoding",
-			"No text editor active at this time",
-			"No text editor active at this time",
-			"No file active at this time",
-			"Save with Encoding",
-			"Reopen with Encoding",
-			"Select Action",
-			"Guessed from content",
-			"Select File Encoding to Reopen File",
-			"Select File Encoding to Save with"
-		],
-		"vs/workbench/browser/parts/editor/editorActions": [
-			"Split Editor",
-			"Split Editor Orthogonal",
-			"Split Editor Left",
-			"Split Editor Right",
-			"Split Editor Up",
-			"Split Editor Down",
-			"Join Editor Group with Next Group",
-			"Join All Editor Groups",
-			"Navigate Between Editor Groups",
-			"Focus Active Editor Group",
-			"Focus First Editor Group",
-			"Focus Last Editor Group",
-			"Focus Next Editor Group",
-			"Focus Previous Editor Group",
-			"Focus Left Editor Group",
-			"Focus Right Editor Group",
-			"Focus Above Editor Group",
-			"Focus Below Editor Group",
-			"Close Editor",
-			"Unpin Editor",
-			"Close",
-			"Revert and Close Editor",
-			"Close Editors to the Left in Group",
-			"Close All Editors",
-			"Close All Editor Groups",
-			"Close Editors in Other Groups",
-			"Close Editor in All Groups",
-			"Move Editor Group Left",
-			"Move Editor Group Right",
-			"Move Editor Group Up",
-			"Move Editor Group Down",
-			"Duplicate Editor Group Left",
-			"Duplicate Editor Group Right",
-			"Duplicate Editor Group Up",
-			"Duplicate Editor Group Down",
-			"Maximize Editor Group",
-			"Reset Editor Group Sizes",
-			"Toggle Editor Group Sizes",
-			"Maximize Editor Group and Hide Side Bar",
-			"Open Next Editor",
-			"Open Previous Editor",
-			"Open Next Editor in Group",
-			"Open Previous Editor in Group",
-			"Open First Editor in Group",
-			"Open Last Editor in Group",
-			"Go Forward",
-			"Go Back",
-			"Go to Last Edit Location",
-			"Go Last",
-			"Reopen Closed Editor",
-			"Clear Recently Opened",
-			"Show Editors in Active Group By Most Recently Used",
-			"Show All Editors By Appearance",
-			"Show All Editors By Most Recently Used",
-			"Quick Open Previous Recently Used Editor",
-			"Quick Open Least Recently Used Editor",
-			"Quick Open Previous Recently Used Editor in Group",
-			"Quick Open Least Recently Used Editor in Group",
-			"Quick Open Previous Editor from History",
-			"Open Next Recently Used Editor",
-			"Open Previous Recently Used Editor",
-			"Open Next Recently Used Editor In Group",
-			"Open Previous Recently Used Editor In Group",
-			"Clear Editor History",
-			"Move Editor Left",
-			"Move Editor Right",
-			"Move Editor into Previous Group",
-			"Move Editor into Next Group",
-			"Move Editor into Above Group",
-			"Move Editor into Below Group",
-			"Move Editor into Left Group",
-			"Move Editor into Right Group",
-			"Move Editor into First Group",
-			"Move Editor into Last Group",
-			"Single Column Editor Layout",
-			"Two Columns Editor Layout",
-			"Three Columns Editor Layout",
-			"Two Rows Editor Layout",
-			"Three Rows Editor Layout",
-			"Grid Editor Layout (2x2)",
-			"Two Columns Bottom Editor Layout",
-			"Two Rows Right Editor Layout",
-			"New Editor Group to the Left",
-			"New Editor Group to the Right",
-			"New Editor Group Above",
-			"New Editor Group Below",
-			"Reopen Editor With...",
-			"Toggle Editor Type"
-		],
-		"vs/base/browser/ui/menu/menubar": [
-			"Application Menu",
-			"More"
-		],
-		"vs/base/browser/ui/menu/menu": [
-			"{0} ({1})"
 		],
 		"vs/base/browser/ui/toolbar/toolbar": [
 			"More Actions..."
@@ -18576,9 +19703,9 @@
 		],
 		"vs/base/parts/quickinput/browser/quickInput": [
 			"Back",
+			"Press 'Enter' to confirm your input or 'Escape' to cancel",
 			"{0}/{1}",
 			"Type to narrow down results.",
-			"Press 'Enter' to confirm your input or 'Escape' to cancel",
 			"{0} (Press 'Enter' to confirm or 'Escape' to cancel)",
 			"{0} Results",
 			"{0} Selected",
@@ -18586,6 +19713,20 @@
 			"Custom",
 			"Back ({0})",
 			"Back"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
+			"Place your settings here to override the Default Settings.",
+			"Place your settings here to override the User Settings.",
+			"Place your folder settings here to override those from the Workspace Settings.",
+			"Edit",
+			"Replace in Settings",
+			"Copy to Settings",
+			"Unknown Configuration Setting",
+			"This setting cannot be applied in this window. It will be applied when you open a local window.",
+			"This setting cannot be applied in this workspace. It will be applied when you open the containing workspace folder directly.",
+			"This setting can be applied only in application user settings",
+			"This setting can only be applied in user settings in local window or in remote settings in remote window.",
+			"Unsupported Property"
 		],
 		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
 			"Place your settings in the right hand side editor to override.",
@@ -18622,6 +19763,7 @@
 			"Explorer",
 			"Search",
 			"Debug",
+			"Testing",
 			"SCM",
 			"Extensions",
 			"Terminal",
@@ -18639,28 +19781,32 @@
 			"Telemetry",
 			"Settings Sync"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
-			"Place your settings here to override the Default Settings.",
-			"Place your settings here to override the User Settings.",
-			"Place your folder settings here to override those from the Workspace Settings.",
-			"Edit",
-			"Replace in Settings",
-			"Copy to Settings",
-			"Unknown Configuration Setting",
-			"This setting cannot be applied in this window. It will be applied when you open local window.",
-			"This setting cannot be applied in this workspace. It will be applied when you open the containing workspace folder directly.",
-			"This setting can be applied only in application user settings",
-			"This setting can only be applied in user settings in local window or in remote settings in remote window.",
-			"Unsupported Property"
+		"vs/workbench/contrib/preferences/browser/settingsTree": [
+			"Extensions",
+			"Sync: Ignored",
+			"Modified",
+			"More Actions... ",
+			"Also modified in",
+			"Modified in",
+			"Show matching extensions",
+			"Edit in settings.json",
+			"default",
+			"Modified",
+			"Reset Setting",
+			"Validation Error.",
+			"Validation Error.",
+			"Modified.",
+			"Also modified in",
+			"Modified in",
+			"Settings",
+			"Copy Setting ID",
+			"Copy Setting as JSON",
+			"Sync This Setting"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsTreeModels": [
 			"Workspace",
 			"Remote",
 			"User"
-		],
-		"vs/workbench/contrib/preferences/browser/tocTree": [
-			"Settings Table of Contents",
-			"{0}, group"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsWidgets": [
 			"The foreground color for a section header or active title.",
@@ -18709,27 +19855,123 @@
 			"Item",
 			"Value"
 		],
-		"vs/workbench/contrib/preferences/browser/settingsTree": [
-			"Extensions",
-			"Sync: Ignored",
-			"Modified",
-			"More Actions... ",
-			"Also modified in",
-			"Modified in",
-			"Show matching extensions",
-			"Edit in settings.json",
-			"default",
-			"Modified",
-			"Reset Setting",
-			"Validation Error.",
-			"Validation Error.",
-			"Modified.",
-			"Also modified in",
-			"Modified in",
-			"Settings",
-			"Copy Setting ID",
-			"Copy Setting as JSON",
-			"Sync This Setting"
+		"vs/workbench/contrib/preferences/browser/tocTree": [
+			"Settings Table of Contents",
+			"{0}, group"
+		],
+		"vs/base/common/keybindingLabels": [
+			"Ctrl",
+			"Shift",
+			"Alt",
+			"Windows",
+			"Ctrl",
+			"Shift",
+			"Alt",
+			"Super",
+			"Control",
+			"Shift",
+			"Alt",
+			"Command",
+			"Control",
+			"Shift",
+			"Alt",
+			"Windows",
+			"Control",
+			"Shift",
+			"Alt",
+			"Super"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookKernelAssociation": [
+			"Defines a default kernel provider which takes precedence over all other kernel providers settings. Must be the identifier of an extension contributing a kernel provider."
+		],
+		"vs/workbench/contrib/notebook/browser/extensionPoint": [
+			"Contributes notebook document provider.",
+			"Unique identifier of the notebook.",
+			"Human readable name of the notebook.",
+			"Set of globs that the notebook is for.",
+			"Glob that the notebook is enabled for.",
+			"Glob that the notebook is disabled for.",
+			"Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.",
+			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
+			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.",
+			"Contributes notebook output renderer provider.",
+			"Unique identifier of the notebook output renderer.",
+			"Rename `viewType` to `id`.",
+			"Unique identifier of the notebook output renderer.",
+			"Human readable name of the notebook output renderer.",
+			"Set of globs that the notebook is for.",
+			"File to load in the webview to render the extension.",
+			"Contributes a renderer for markdown cells in notebooks.",
+			"Unique identifier of the notebook markdown renderer.",
+			"Human readable name of the notebook markdown renderer.",
+			"File to load in the webview to render the extension."
+		],
+		"vs/workbench/contrib/notebook/common/notebookEditorModel": [
+			"The contents of the file has changed on disk. Would you like to open the updated version or overwrite the file with your changes?",
+			"Revert",
+			"Overwrite",
+			"Save Notebook"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookEditorWidget": [
+			"Notebook",
+			"The border color for notebook cells.",
+			"The color of the notebook cell editor border.",
+			"The error icon color of notebook cells in the cell status bar.",
+			"The error icon color of notebook cells in the cell status bar.",
+			"The running icon color of notebook cells in the cell status bar.",
+			"The Color of the notebook output container background.",
+			"The color of the separator in the cell bottom toolbar",
+			"The background color of a cell when the cell is focused.",
+			"The background color of a cell when the cell is selected.",
+			"The background color of a cell when the cell is hovered.",
+			"The color of the cell's top and bottom border when the cell is selected but not focused.",
+			"The color of the cell's borders when multiple cells are selected.",
+			"The color of the cell's borders when the cell is focused.",
+			"The color of the cell's top and bottom border when a cell is focused while the primary focus is outside of the editor.",
+			"The background color of notebook cell status bar items.",
+			"The color of the notebook cell insertion indicator.",
+			"Notebook scrollbar slider background color.",
+			"Notebook scrollbar slider background color when hovering.",
+			"Notebook scrollbar slider background color when clicked on.",
+			"Background color of highlighted cell"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookIcons": [
+			"Configure icon in kernel configuration widget in notebook editors.",
+			"Configure icon to select a kernel in notebook editors.",
+			"Icon to execute in notebook editors.",
+			"Icon to stop an execution in notebook editors.",
+			"Icon to delete a cell in notebook editors.",
+			"Icon to execute all cells in notebook editors.",
+			"Icon to edit a cell in notebook editors.",
+			"Icon to stop editing a cell in notebook editors.",
+			"Icon to move up a cell in notebook editors.",
+			"Icon to move down a cell in notebook editors.",
+			"Icon to clear cell outputs in notebook editors.",
+			"Icon to split a cell in notebook editors.",
+			"Icon to unfold a cell in notebook editors.",
+			"Icon to indicate a success state in notebook editors.",
+			"Icon to indicate an error state in notebook editors.",
+			"Icon to annotate a collapsed section in notebook editors.",
+			"Icon to annotate an expanded section in notebook editors.",
+			"Icon to open the notebook in a text editor.",
+			"Icon to revert in notebook editors.",
+			"Icon to render output in diff editor.",
+			"Icon for a mime type in notebook editors."
+		],
+		"vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget": [
+			"Find",
+			"Find",
+			"Previous match",
+			"Next match",
+			"Close",
+			"Toggle Replace mode",
+			"Replace",
+			"Replace",
+			"Replace",
+			"Replace All"
+		],
+		"vs/base/browser/ui/iconLabel/iconLabel": [
+			"Loading..."
 		],
 		"vs/workbench/contrib/testing/browser/theme": [
 			"Color for the 'failed' icon in the test explorer.",
@@ -18757,73 +19999,6 @@
 			"Running",
 			"Skipped",
 			"Unset"
-		],
-		"vs/workbench/contrib/notebook/browser/extensionPoint": [
-			"Contributes notebook document provider.",
-			"Unique identifier of the notebook.",
-			"Human readable name of the notebook.",
-			"Set of globs that the notebook is for.",
-			"Glob that the notebook is enabled for.",
-			"Glob that the notebook is disabled for.",
-			"Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.",
-			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
-			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.",
-			"Contributes notebook output renderer provider.",
-			"Unique identifier of the notebook output renderer.",
-			"Rename `viewType` to `id`.",
-			"Unique identifier of the notebook output renderer.",
-			"Human readable name of the notebook output renderer.",
-			"Set of globs that the notebook is for.",
-			"File to load in the webview to render the extension."
-		],
-		"vs/workbench/contrib/notebook/browser/notebookKernelAssociation": [
-			"Defines a default kernel provider which takes precedence over all other kernel providers settings. Must be the identifier of an extension contributing a kernel provider."
-		],
-		"vs/workbench/contrib/notebook/common/model/notebookTextModel": [
-			"Edit"
-		],
-		"vs/workbench/contrib/notebook/common/notebookEditorModel": [
-			"The contents of the file has changed on disk. Would you like to open the updated version or overwrite the file with your changes?",
-			"Revert",
-			"Overwrite"
-		],
-		"vs/workbench/contrib/notebook/browser/notebookEditorWidget": [
-			"Notebook",
-			"Select a notebook kernel to run this notebook",
-			"Set as default kernel provider for '{0}'",
-			"The border color for notebook cells.",
-			"The color of the notebook cell editor border.",
-			"The error icon color of notebook cells in the cell status bar.",
-			"The error icon color of notebook cells in the cell status bar.",
-			"The running icon color of notebook cells in the cell status bar.",
-			"The Color of the notebook output container background.",
-			"The color of the separator in the cell bottom toolbar",
-			"The background color of a cell when the cell is focused.",
-			"The background color of a cell when the cell is hovered.",
-			"The color of the cell's top and bottom border when the cell is selected but not focused.",
-			"The color of the cell's top and bottom border when the cell is focused.",
-			"The color of the cell's top and bottom border when a cell is focused while the primary focus is outside of the editor.",
-			"The background color of notebook cell status bar items.",
-			"The color of the notebook cell insertion indicator.",
-			"Notebook scrollbar slider background color.",
-			"Notebook scrollbar slider background color when hovering.",
-			"Notebook scrollbar slider background color when clicked on.",
-			"Background color of highlighted cell"
-		],
-		"vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget": [
-			"Find",
-			"Find",
-			"Previous match",
-			"Next match",
-			"Close",
-			"Toggle Replace mode",
-			"Replace",
-			"Replace",
-			"Replace",
-			"Replace All"
-		],
-		"vs/base/browser/ui/iconLabel/iconLabel": [
-			"Loading..."
 		],
 		"vs/platform/quickinput/browser/commandsQuickAccess": [
 			"{0}, {1}",
@@ -18874,12 +20049,6 @@
 			"Copying {0}",
 			"Move {0}",
 			"Moving {0}"
-		],
-		"vs/workbench/browser/parts/editor/binaryEditor": [
-			"Binary Viewer",
-			"The file is not displayed in the editor because it is too large ({0}).",
-			"The file is not displayed in the editor because it is either binary or uses an unsupported text encoding.",
-			"Do you want to open it anyway?"
 		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
 			"Bulk Edit",
@@ -18937,36 +20106,12 @@
 		"vs/workbench/contrib/search/browser/replaceService": [
 			"{0} ↔ {1} (Replace Preview)"
 		],
-		"vs/workbench/contrib/debug/common/debugModel": [
-			"Invalid variable attributes",
-			"Please start a debug session to evaluate expressions",
-			"not available",
-			"Paused on {0}",
-			"Paused",
-			"Running",
-			"Unverified breakpoint. File is modified, please restart debug session."
-		],
 		"vs/workbench/contrib/debug/browser/debugConfigurationManager": [
 			"Select Launch Configuration",
 			"Edit Debug Configuration in launch.json",
 			"Unable to create 'launch.json' file inside the '.vscode' folder ({0}).",
 			"workspace",
 			"user settings"
-		],
-		"vs/workbench/contrib/debug/browser/debugTaskRunner": [
-			"Errors exist after running preLaunchTask '{0}'.",
-			"Error exists after running preLaunchTask '{0}'.",
-			"The preLaunchTask '{0}' terminated with exit code {1}.",
-			"The preLaunchTask '{0}' terminated.",
-			"Debug Anyway",
-			"Show Errors",
-			"Abort",
-			"Remember my choice in user settings",
-			"Task '{0}' can not be referenced from a launch configuration that is in a different workspace folder.",
-			"Could not find the task '{0}'.",
-			"Could not find the specified task.",
-			"The specified task cannot be tracked.",
-			"The task '{0}' cannot be tracked."
 		],
 		"vs/workbench/contrib/debug/browser/debugSession": [
 			"No debugger available, can not send '{0}'",
@@ -19004,13 +20149,31 @@
 			"Debugging started.",
 			"Debugging stopped."
 		],
+		"vs/workbench/contrib/debug/browser/debugTaskRunner": [
+			"Errors exist after running preLaunchTask '{0}'.",
+			"Error exists after running preLaunchTask '{0}'.",
+			"The preLaunchTask '{0}' terminated with exit code {1}.",
+			"The preLaunchTask '{0}' terminated.",
+			"Debug Anyway",
+			"Show Errors",
+			"Abort",
+			"Remember my choice in user settings",
+			"Debug Anyway",
+			"Cancel",
+			"Remember my choice for this task",
+			"Task '{0}' can not be referenced from a launch configuration that is in a different workspace folder.",
+			"Could not find the task '{0}'.",
+			"Could not find the specified task.",
+			"The task '{0}' cannot be tracked. Make sure to have a problem matcher defined.",
+			"The task '{0}' cannot be tracked. Make sure to have a problem matcher defined."
+		],
+		"vs/workbench/contrib/debug/common/debugSource": [
+			"Unknown Source"
+		],
 		"vs/workbench/contrib/debug/browser/debugAdapterManager": [
 			"Debugger 'type' can not be omitted and must be of type 'string'.",
 			"More...",
 			"Select Environment"
-		],
-		"vs/workbench/contrib/debug/common/debugSource": [
-			"Unknown Source"
 		],
 		"vs/base/browser/ui/findinput/findInput": [
 			"input"
@@ -19049,20 +20212,22 @@
 			"Type a new comment"
 		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
+			"Text Editor",
 			"Built-in",
-			"Text Editor"
+			"Built-in"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"Rated by 1 user",
 			"Rated by {0} users",
 			"No rating",
 			"Extension in {0}",
-			"This extension is ignored during sync."
+			"This extension is ignored during sync.",
+			"The icon color for extension ratings."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
 			"Error",
 			"Unknown Extension:",
-			"{0}, {1}, {2}, press enter for extension details.",
+			"{0}, {1}, {2}, {3}",
 			"Extensions"
 		],
 		"vs/workbench/contrib/extensions/browser/dynamicWorkspaceRecommendations": [
@@ -19074,9 +20239,6 @@
 		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
 			"This extension is recommended by users of the current workspace."
 		],
-		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
-			"This extension is recommended because of the current workspace configuration"
-		],
 		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
 			"Search Marketplace",
 			"This extension is recommended based on the files you recently opened.",
@@ -19084,12 +20246,37 @@
 			"The Marketplace has extensions that can help with '.{0}' files",
 			"Don't Show Again for '.{0}' files"
 		],
+		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
+			"This extension is recommended because of the current workspace configuration"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
 			"Do you allow this workspace to modify your terminal shell? {0}",
 			"Allow",
 			"Disallow",
 			"The '{0}' extension is recommended for opening a terminal in WSL.",
 			"Install"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalTab": [
+			"{0} (disconnected)"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalInstance": [
+			"Terminal input",
+			"Too much output to announce, navigate to rows manually to read",
+			"Some keybindings don't go to the terminal by default and are handled by {0} instead.",
+			"Configure Terminal Settings",
+			"Yes",
+			"No",
+			"Don't Show Again",
+			"The standard renderer for the integrated terminal appears to be slow on your computer. Would you like to switch to the alternative DOM-based renderer which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered).",
+			"The terminal has no selection to copy",
+			"The terminal process \"{0}\" failed to launch (exit code: {1}).",
+			"The terminal process failed to launch (exit code: {0}).",
+			"The terminal process \"{0}\" terminated with exit code: {1}.",
+			"The terminal process terminated with exit code: {0}.",
+			"The terminal process failed to launch: {0}.",
+			"Terminal {0}, {1}",
+			"Terminal {0}",
+			"Terminal {0} environment is stale, run the 'Show Environment Information' command for more information"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
 			"Additional command options",
@@ -19133,25 +20320,6 @@
 			"Prefix to indicate that an argument is task.",
 			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
 			"The task configurations. Usually these are enrichments of task already defined in the external task runner."
-		],
-		"vs/workbench/contrib/terminal/browser/terminalInstance": [
-			"Terminal input",
-			"Too much output to announce, navigate to rows manually to read",
-			"Some keybindings are dispatched to the workbench by default.",
-			"Configure Terminal Settings",
-			"Yes",
-			"No",
-			"Don't Show Again",
-			"The standard renderer for the integrated terminal appears to be slow on your computer. Would you like to switch to the alternative DOM-based renderer which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered).",
-			"The terminal has no selection to copy",
-			"The terminal process \"{0}\" failed to launch (exit code: {1}).",
-			"The terminal process failed to launch (exit code: {0}).",
-			"The terminal process \"{0}\" terminated with exit code: {1}.",
-			"The terminal process terminated with exit code: {0}.",
-			"The terminal process failed to launch: {0}.",
-			"Terminal {0}, {1}",
-			"Terminal {0}",
-			"Terminal {0} environment is stale, run the 'Show Environment Information' command for more information"
 		],
 		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
 			"'env.', 'config.' and 'command.' are deprecated, use 'env:', 'config:' and 'command:' instead."
@@ -19214,6 +20382,9 @@
 			"Nov",
 			"Dec"
 		],
+		"vs/editor/browser/core/keybindingCancellation": [
+			"Whether the editor runs a cancellable operation, e.g. like 'Peek References'"
+		],
 		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
 			"Release Notes: {0}",
 			"unassigned"
@@ -19222,6 +20393,9 @@
 			"Background color for the buttons on the Welcome page.",
 			"Hover background color for the buttons on the Welcome page.",
 			"Background color for the Welcome page.",
+			"Background color for the tiles on the Get Started page.",
+			"Hover background color for the tiles on the Get Started.",
+			"Shadow color for the Welcome page walkthrough category buttons.",
 			"Foreground color for the Welcome page progress bars.",
 			"Background color for the Welcome page progress bars."
 		],
@@ -19265,40 +20439,116 @@
 			"Interactive playground",
 			"Try out essential editor features in a short walkthrough"
 		],
-		"vs/workbench/contrib/welcome/gettingStarted/browser/vs_code_editor_getting_started": [
-			"Visual Studio Code",
-			"Code editing. Redefined"
+		"vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent": [
+			"Icon used for the setup category of getting started",
+			"Icon used for the beginner category of getting started",
+			"Icon used for the codespaces category of getting started",
+			"New File",
+			"Start with a new empty file",
+			"Open...",
+			"Open a file or folder to start working",
+			"Open File...",
+			"Open a file to start working",
+			"Open Folder...",
+			"Open a folder to start working",
+			"Clone Git Repository...",
+			"Clone a git repository",
+			"Run a Command...",
+			"Use the command palette to view and run all of vscode's commands",
+			"Primer on Codespaces",
+			"Get up and running with your instant code environment.",
+			"Build & run your app",
+			"Build, run & debug your code in the cloud, right from the browser.",
+			"Start Debugging (F5)",
+			"Access your running application",
+			"Ports running within your codespace are automatically forwarded to the web, so you can open them in your browser.",
+			"Show Ports Panel",
+			"Pull requests at your fingertips",
+			"Bring your GitHub workflow closer to your code, so you can review pull requests, add comments, merge branches, and more.",
+			"Open GitHub View",
+			"Run tasks in the integrated terminal",
+			"Perform quick command-line tasks using the built-in terminal.",
+			"Focus Terminal",
+			"Develop remotely in VS Code",
+			"Access the power of your cloud development environment from your local VS Code. Set it up by installing the GitHub Codespaces extension and connecting your GitHub account.",
+			"Open in VS Code",
+			"Quick Setup",
+			"Extend and customize VS Code to make it yours.",
+			"Customize the look with themes",
+			"Pick a color theme to match your taste and mood while coding.",
+			"Pick a Theme",
+			"Code in any language",
+			"VS Code supports over 50+ programming languages. While many are built-in, others can be easily installed as extensions in one click.",
+			"Browse Language Extensions",
+			"Migrate your keyboard shortcuts",
+			"Keymap extensions bring your favorite keyboard shortcuts from other editors to VS Code.",
+			"Keymap Extensions",
+			"Sync your favorite setup",
+			"Never lose the perfect VS Code setup! Settings Sync will back up and share settings, keybindings & extensions across several VS Code instances.",
+			"Enable Settings Sync",
+			"Open your project",
+			"Open a project folder to get started!",
+			"Pick a Folder",
+			"Open your project",
+			"Open a folder to get started!",
+			"Pick a Folder",
+			"Learn the Fundamentals",
+			"Jump right into VS Code and get an overview of the must-have features.",
+			"Find & run commands",
+			"The easiest way to find everything VS Code can do. If you're ever looking for a feature or a shortcut, check here first!",
+			"Open Command Palette",
+			"Convenient built-in terminal",
+			"Quickly run shell commands and monitor build output, right next to your code.",
+			"Show Terminal Panel",
+			"Limitless extensibility",
+			"Extensions are VS Code's power-ups. They range from handy productivity hacks, expanding out-of-the-box features, to adding completely new capabilities.",
+			"Browse Recommended Extensions",
+			"Everything is a setting",
+			"Optimize every part of VS Code's look & feel to your liking. Enabling Settings Sync lets you share your personal tweaks across machines.",
+			"Tweak my Settings",
+			"Lean back and learn",
+			"Watch the first in a series of short & practical video tutorials for VS Code's key features.",
+			"Watch Tutorial"
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
 			"Call Hierarchy",
 			"calls from {0}",
 			"callers of {0}"
 		],
-		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
-			"Merges",
-			"Synced Machines",
-			"Edit Name",
-			"Turn off Settings Sync",
-			"Sync Activity (Remote)",
-			"Sync Activity (Local)",
-			"Show raw JSON sync data",
-			"Restore",
-			"Would you like to replace your current {0} with selected?",
-			"Open Changes",
-			"{0} (Remote)",
-			"{0} (Local)",
-			"{0} ↔ {1}",
-			"Settings Sync",
-			"Reset Synced Data",
-			"Current",
-			"No Machines",
-			"Current",
-			"machine not found with id: {0}",
-			"Are you sure you want to turn off sync on {0}?",
-			"&&Turn off",
-			"Enter the name of the machine",
-			"machine not found with id: {0}",
-			"Machine name should be unique and not empty"
+		"vs/editor/contrib/symbolIcons/symbolIcons": [
+			"The foreground color for array symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for boolean symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for class symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for color symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for constant symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for constructor symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for enumerator symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for enumerator member symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for event symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for field symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for file symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for folder symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for function symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for interface symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for key symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for keyword symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for method symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for module symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for namespace symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for null symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for number symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for object symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for operator symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for package symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for property symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for reference symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for snippet symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for string symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for struct symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for text symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for type parameter symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for unit symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for variable symbols. These symbols appear in the outline, breadcrumb, and suggest widget."
 		],
 		"vs/workbench/contrib/feedback/browser/feedback": [
 			"Tweet Feedback",
@@ -19322,10 +20572,64 @@
 			"character left",
 			"characters left"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsViewer": [
-			"Click to execute command '{0}'",
-			"Notification Actions",
-			"Source: {0}"
+		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
+			"Merges",
+			"Synced Machines",
+			"Edit Name",
+			"Turn off Settings Sync",
+			"Sync Activity (Remote)",
+			"Sync Activity (Local)",
+			"Show raw JSON sync data",
+			"Restore",
+			"Would you like to replace your current {0} with selected?",
+			"Reset Synced Data",
+			"{0} (Remote)",
+			"{0} (Local)",
+			"{0} ↔ {1}",
+			"Current",
+			"No Machines",
+			"Current",
+			"machine not found with id: {0}",
+			"Are you sure you want to turn off sync on {0}?",
+			"&&Turn off",
+			"Enter the name of the machine",
+			"machine not found with id: {0}",
+			"Machine name should be unique and not empty"
+		],
+		"vs/workbench/contrib/workspace/browser/workspaceTrustTree": [
+			"Modified",
+			"Trusted Folders",
+			"All workspaces under the following folders will be trusted. In the event of a conflict with untrusted folders, the nearest parent will determine trust.",
+			"Untrusted Folders",
+			"All workspaces under the following folders will not be trusted. In the event of a conflict with trusted folders, the nearest parent will determine trust.",
+			"Workspace Trust Setting"
+		],
+		"vs/workbench/contrib/workspace/browser/workspaceTrustColors": [
+			"Color used when indicating a workspace is trusted.",
+			"Color used when indicating a workspace is not trusted."
+		],
+		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
+			"Saving '{0}'"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"{0}, notification",
+			"{0}, source: {1}, notification",
+			"Notifications List"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsActions": [
+			"Icon for the clear action in notifications.",
+			"Icon for the clear all action in notifications.",
+			"Icon for the hide action in notifications.",
+			"Icon for the expand action in notifications.",
+			"Icon for the collapse action in notifications.",
+			"Icon for the configure action in notifications.",
+			"Clear Notification",
+			"Clear All Notifications",
+			"Hide Notifications",
+			"Expand Notification",
+			"Collapse Notification",
+			"Configure Notification",
+			"Copy Text"
 		],
 		"vs/editor/browser/controller/textAreaHandler": [
 			"editor",
@@ -19342,7 +20646,7 @@
 			"References"
 		],
 		"vs/editor/contrib/hover/markerHoverParticipant": [
-			"Peek Problem",
+			"View Problem",
 			"No quick fixes available",
 			"Checking for quick fixes...",
 			"No quick fixes available",
@@ -19351,12 +20655,12 @@
 		"vs/editor/contrib/hover/markdownHoverParticipant": [
 			"Loading..."
 		],
+		"vs/editor/contrib/suggest/suggestWidgetStatus": [
+			"{0} ({1})"
+		],
 		"vs/editor/contrib/suggest/suggestWidgetDetails": [
 			"Close",
 			"Loading..."
-		],
-		"vs/editor/contrib/suggest/suggestWidgetStatus": [
-			"{0} ({1})"
 		],
 		"vs/editor/contrib/suggest/suggestWidgetRenderer": [
 			"Icon for more information in the suggest widget.",
@@ -19370,6 +20674,9 @@
 			"{0} (+{1})"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
+			"Whether the editor can show breadcrumbs",
+			"Whether breadcrumbs are currently visible",
+			"Whether breadcrumbs have focus",
 			"Toggle Breadcrumbs",
 			"Show &&Breadcrumbs",
 			"Focus Breadcrumbs"
@@ -19377,8 +20684,17 @@
 		"vs/base/parts/quickinput/browser/quickInputList": [
 			"Quick Input"
 		],
+		"vs/workbench/contrib/notebook/browser/notebookEditorKernelManager": [
+			"Select a notebook kernel to run this notebook",
+			"Set as default kernel provider for '{0}'"
+		],
 		"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer": [
-			"Expand"
+			"Expand",
+			"Executing",
+			"Pending"
+		],
+		"vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel": [
+			"Empty markdown cell, double click or press enter to edit."
 		],
 		"vs/workbench/contrib/debug/common/debugSchemas": [
 			"Contributes debug adapters.",
@@ -19417,6 +20733,11 @@
 			"Controls whether manually terminating one session will stop all of the compound sessions.",
 			"Task to run before any of the compound configurations start."
 		],
+		"vs/workbench/contrib/debug/browser/rawDebugSession": [
+			"No debug adapter, can not start debug session.",
+			"No debugger available found. Can not send '{0}'.",
+			"More Info"
+		],
 		"vs/workbench/contrib/debug/common/debugger": [
 			"Cannot find debug adapter for type '{0}'.",
 			"Use IntelliSense to learn about possible attributes.",
@@ -19433,11 +20754,6 @@
 			"Windows specific launch configuration attributes.",
 			"OS X specific launch configuration attributes.",
 			"Linux specific launch configuration attributes."
-		],
-		"vs/workbench/contrib/debug/browser/rawDebugSession": [
-			"No debug adapter, can not start debug session.",
-			"No debugger available found. Can not send '{0}'.",
-			"More Info"
 		],
 		"vs/base/browser/ui/selectBox/selectBoxCustom": [
 			"Select Box"
@@ -19466,65 +20782,12 @@
 			"alt + click",
 			"cmd + click",
 			"ctrl + click",
-			"Follow Link using Forwarded Port",
-			"Follow Link",
+			"Follow link using forwarded port",
+			"Follow link",
 			"Link"
 		],
-		"vs/workbench/services/gettingStarted/common/gettingStartedContent": [
-			"Icon used for the setup category of getting started",
-			"Icon used for the beginner category of getting started",
-			"Icon used for the codespaces category of getting started",
-			"Primer on Codespaces",
-			"Get up and running with your instant code environment.",
-			"Build & run your app",
-			"Build, run & debug your code in the cloud, right from the browser.",
-			"Start Debugging (F5)",
-			"Access your running application",
-			"Ports running within your codespace are automatically forwarded to the web, so you can open them in your browser.",
-			"Show Ports Panel",
-			"Pull requests at your fingertips",
-			"Bring your GitHub workflow closer to your code, so you can review pull requests, add comments, merge branches, and more.",
-			"Open GitHub View",
-			"Run tasks in the integrated terminal",
-			"Perform quick command-line tasks using the built-in terminal.",
-			"Focus Terminal",
-			"Develop remotely in VS Code",
-			"Access the power of your cloud development environment from your local VS Code. Set it up by installing the GitHub Codespaces extension and connecting your GitHub account.",
-			"Open in VS Code",
-			"Quick Setup",
-			"Extend and customize VS Code to make it yours.",
-			"Customize the look with themes",
-			"Pick a color theme to match your taste and mood while coding.",
-			"Pick a Theme",
-			"Code in any language, without switching editors",
-			"VS Code supports over 50+ programming languages. While many are built-in, others can be easily installed as extensions in one click.",
-			"Browse Language Extensions",
-			"Sync your favorite setup",
-			"Never lose the perfect VS Code setup! Settings Sync will back up and share settings, keybindings & extensions across several VS Code instances.",
-			"Enable Settings Sync",
-			"Open your project",
-			"Open a project folder to get started!",
-			"Pick a Folder",
-			"Open your project",
-			"Open a folder to get started!",
-			"Pick a Folder",
-			"Learn the Fundamentals",
-			"Save time with these must-have shortcuts & features.",
-			"Find & run commands",
-			"The easiest way to find everything VS Code can do. If you're ever looking for a feature or a shortcut, check here first!",
-			"Open Command Palette",
-			"Run tasks in the integrated terminal",
-			"Quickly run shell commands and monitor build output, right next to your code.",
-			"Open Terminal",
-			"Limitless extensibility",
-			"Extensions are VS Code's power-ups. They range from handy productivity hacks, expanding out-of-the-box features, to adding completely new capabilities.",
-			"Browse Recommended Extensions",
-			"Everything is a setting",
-			"Optimize every part of VS Code's look & feel to your liking. Enabling Settings Sync lets you share your personal tweaks across machines.",
-			"Tweak my Settings",
-			"Lean back and learn",
-			"Watch the first in a series of short & practical video tutorials for VS Code's key features.",
-			"Watch Tutorial"
+		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
+			"Restarting the terminal because the connection to the shell process was lost..."
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncMergesView": [
 			"Please go through each entry and merge to enable sync.",
@@ -19550,6 +20813,11 @@
 			"Accept Remote",
 			"Accept Local",
 			"Accept Merges"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsViewer": [
+			"Click to execute command '{0}'",
+			"Notification Actions",
+			"Source: {0}"
 		],
 		"vs/editor/contrib/codeAction/lightBulbWidget": [
 			"Show Fixes. Preferred Fix Available ({0})",
@@ -19607,6 +20875,9 @@
 		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
 			"Breadcrumbs"
 		],
+		"vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets": [
+			"Select Cell Language Mode"
+		],
 		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
 			"Choose a different output mimetype, available mimetypes: {0}",
 			"Currently Active",
@@ -19615,20 +20886,11 @@
 			"built-in",
 			"built-in"
 		],
-		"vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel": [
-			"Empty markdown cell, double click or press enter to edit."
-		],
-		"vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets": [
-			"Select Cell Language Mode"
-		],
 		"vs/workbench/contrib/comments/browser/reactionsAction": [
 			"Pick Reactions..."
 		],
 		"vs/workbench/contrib/terminal/browser/links/terminalWordLinkProvider": [
 			"Search workspace"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy": [
-			"Starting..."
 		],
 		"vs/workbench/contrib/terminal/browser/environmentVariableInfo": [
 			"Extensions want to make the following changes to the terminal's environment:",
@@ -19677,6 +20939,7 @@
 			"vs/base/parts/quickinput/browser/quickInputList",
 			"vs/editor/browser/controller/coreCommands",
 			"vs/editor/browser/controller/textAreaHandler",
+			"vs/editor/browser/core/keybindingCancellation",
 			"vs/editor/browser/editorExtensions",
 			"vs/editor/browser/widget/codeEditorWidget",
 			"vs/editor/browser/widget/diffEditorWidget",
@@ -19684,6 +20947,7 @@
 			"vs/editor/browser/widget/inlineDiffMargin",
 			"vs/editor/common/config/commonEditorConfig",
 			"vs/editor/common/config/editorOptions",
+			"vs/editor/common/editorContextKeys",
 			"vs/editor/common/model/editStack",
 			"vs/editor/common/modes/modesRegistry",
 			"vs/editor/common/standaloneStrings",
@@ -19733,12 +20997,15 @@
 			"vs/editor/contrib/rename/rename",
 			"vs/editor/contrib/rename/renameInputField",
 			"vs/editor/contrib/smartSelect/smartSelect",
+			"vs/editor/contrib/snippet/snippetController2",
 			"vs/editor/contrib/snippet/snippetVariables",
+			"vs/editor/contrib/suggest/suggest",
 			"vs/editor/contrib/suggest/suggestController",
 			"vs/editor/contrib/suggest/suggestWidget",
 			"vs/editor/contrib/suggest/suggestWidgetDetails",
 			"vs/editor/contrib/suggest/suggestWidgetRenderer",
 			"vs/editor/contrib/suggest/suggestWidgetStatus",
+			"vs/editor/contrib/symbolIcons/symbolIcons",
 			"vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode",
 			"vs/editor/contrib/tokenization/tokenization",
 			"vs/editor/contrib/unusualLineTerminators/unusualLineTerminators",
@@ -19746,6 +21013,8 @@
 			"vs/editor/contrib/wordOperations/wordOperations",
 			"vs/platform/actions/browser/menuEntryActionViewItem",
 			"vs/platform/configuration/common/configurationRegistry",
+			"vs/platform/contextkey/browser/contextKeyService",
+			"vs/platform/contextkey/common/contextkeys",
 			"vs/platform/dialogs/common/dialogs",
 			"vs/platform/extensionManagement/common/extensionManagement",
 			"vs/platform/extensionManagement/common/extensionManagementCLIService",
@@ -19773,6 +21042,7 @@
 			"vs/platform/userDataSync/common/userDataAutoSyncService",
 			"vs/platform/userDataSync/common/userDataSync",
 			"vs/platform/userDataSync/common/userDataSyncMachines",
+			"vs/platform/workspace/common/workspaceTrust",
 			"vs/platform/workspaces/common/workspaces",
 			"vs/workbench/api/browser/mainThreadAuthentication",
 			"vs/workbench/api/browser/mainThreadCLICommands",
@@ -19802,6 +21072,8 @@
 			"vs/workbench/browser/actions/workspaceActions",
 			"vs/workbench/browser/actions/workspaceCommands",
 			"vs/workbench/browser/codeeditor",
+			"vs/workbench/browser/contextkeys",
+			"vs/workbench/browser/editor",
 			"vs/workbench/browser/parts/activitybar/activitybarActions",
 			"vs/workbench/browser/parts/activitybar/activitybarPart",
 			"vs/workbench/browser/parts/compositeBar",
@@ -19825,6 +21097,7 @@
 			"vs/workbench/browser/parts/editor/textEditor",
 			"vs/workbench/browser/parts/editor/textResourceEditor",
 			"vs/workbench/browser/parts/editor/titleControl",
+			"vs/workbench/browser/parts/editor/untitledHint",
 			"vs/workbench/browser/parts/notifications/notificationsActions",
 			"vs/workbench/browser/parts/notifications/notificationsAlerts",
 			"vs/workbench/browser/parts/notifications/notificationsCenter",
@@ -19842,13 +21115,17 @@
 			"vs/workbench/browser/parts/views/viewPane",
 			"vs/workbench/browser/parts/views/viewPaneContainer",
 			"vs/workbench/browser/parts/views/viewsService",
+			"vs/workbench/browser/quickaccess",
 			"vs/workbench/browser/workbench",
 			"vs/workbench/browser/workbench.contribution",
 			"vs/workbench/common/actions",
 			"vs/workbench/common/configuration",
 			"vs/workbench/common/editor",
 			"vs/workbench/common/editor/diffEditorInput",
+			"vs/workbench/common/panel",
+			"vs/workbench/common/resources",
 			"vs/workbench/common/theme",
+			"vs/workbench/common/viewlet",
 			"vs/workbench/common/views",
 			"vs/workbench/contrib/backup/electron-sandbox/backupTracker",
 			"vs/workbench/contrib/bulkEdit/browser/bulkEditService",
@@ -19882,8 +21159,8 @@
 			"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter",
 			"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace",
 			"vs/workbench/contrib/codeEditor/browser/toggleWordWrap",
-			"vs/workbench/contrib/codeEditor/electron-browser/startDebugTextMate",
 			"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard",
+			"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate",
 			"vs/workbench/contrib/comments/browser/commentGlyphWidget",
 			"vs/workbench/contrib/comments/browser/commentNode",
 			"vs/workbench/contrib/comments/browser/commentThreadWidget",
@@ -19893,8 +21170,8 @@
 			"vs/workbench/contrib/comments/browser/commentsView",
 			"vs/workbench/contrib/comments/browser/reactionsAction",
 			"vs/workbench/contrib/comments/common/commentModel",
-			"vs/workbench/contrib/customEditor/browser/customEditors",
 			"vs/workbench/contrib/customEditor/common/contributedCustomEditors",
+			"vs/workbench/contrib/customEditor/common/customEditor",
 			"vs/workbench/contrib/customEditor/common/extensionPoint",
 			"vs/workbench/contrib/debug/browser/breakpointEditorContribution",
 			"vs/workbench/contrib/debug/browser/breakpointWidget",
@@ -19919,6 +21196,7 @@
 			"vs/workbench/contrib/debug/browser/debugToolBar",
 			"vs/workbench/contrib/debug/browser/debugViewlet",
 			"vs/workbench/contrib/debug/browser/exceptionWidget",
+			"vs/workbench/contrib/debug/browser/linkDetector",
 			"vs/workbench/contrib/debug/browser/loadedScriptsView",
 			"vs/workbench/contrib/debug/browser/rawDebugSession",
 			"vs/workbench/contrib/debug/browser/repl",
@@ -19991,6 +21269,7 @@
 			"vs/workbench/contrib/files/browser/views/openEditorsView",
 			"vs/workbench/contrib/files/common/dirtyFilesIndicator",
 			"vs/workbench/contrib/files/common/editors/fileEditorInput",
+			"vs/workbench/contrib/files/common/files",
 			"vs/workbench/contrib/files/common/workspaceWatcher",
 			"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution",
 			"vs/workbench/contrib/files/electron-sandbox/fileCommands",
@@ -20015,6 +21294,8 @@
 			"vs/workbench/contrib/markers/browser/markersView",
 			"vs/workbench/contrib/markers/browser/markersViewActions",
 			"vs/workbench/contrib/markers/browser/messages",
+			"vs/workbench/contrib/notebook/browser/contrib/cellOperations/cellOperations",
+			"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard",
 			"vs/workbench/contrib/notebook/browser/contrib/coreActions",
 			"vs/workbench/contrib/notebook/browser/contrib/find/findController",
 			"vs/workbench/contrib/notebook/browser/contrib/fold/folding",
@@ -20027,6 +21308,7 @@
 			"vs/workbench/contrib/notebook/browser/extensionPoint",
 			"vs/workbench/contrib/notebook/browser/notebook.contribution",
 			"vs/workbench/contrib/notebook/browser/notebookEditor",
+			"vs/workbench/contrib/notebook/browser/notebookEditorKernelManager",
 			"vs/workbench/contrib/notebook/browser/notebookEditorWidget",
 			"vs/workbench/contrib/notebook/browser/notebookIcons",
 			"vs/workbench/contrib/notebook/browser/notebookKernelAssociation",
@@ -20035,7 +21317,6 @@
 			"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer",
 			"vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets",
 			"vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel",
-			"vs/workbench/contrib/notebook/common/model/notebookTextModel",
 			"vs/workbench/contrib/notebook/common/notebookEditorModel",
 			"vs/workbench/contrib/outline/browser/outline.contribution",
 			"vs/workbench/contrib/outline/browser/outlinePane",
@@ -20044,7 +21325,7 @@
 			"vs/workbench/contrib/output/browser/outputView",
 			"vs/workbench/contrib/performance/browser/performance.contribution",
 			"vs/workbench/contrib/performance/browser/perfviewEditor",
-			"vs/workbench/contrib/performance/electron-browser/startupProfiler",
+			"vs/workbench/contrib/performance/electron-sandbox/startupProfiler",
 			"vs/workbench/contrib/preferences/browser/keybindingWidgets",
 			"vs/workbench/contrib/preferences/browser/keybindingsEditor",
 			"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution",
@@ -20101,6 +21382,7 @@
 			"vs/workbench/contrib/snippets/browser/snippets.contribution",
 			"vs/workbench/contrib/snippets/browser/snippetsFile",
 			"vs/workbench/contrib/snippets/browser/snippetsService",
+			"vs/workbench/contrib/surveys/browser/ces.contribution",
 			"vs/workbench/contrib/surveys/browser/languageSurveys.contribution",
 			"vs/workbench/contrib/surveys/browser/nps.contribution",
 			"vs/workbench/contrib/tasks/browser/abstractTaskService",
@@ -20115,6 +21397,7 @@
 			"vs/workbench/contrib/tasks/common/problemMatcher",
 			"vs/workbench/contrib/tasks/common/taskConfiguration",
 			"vs/workbench/contrib/tasks/common/taskDefinitionRegistry",
+			"vs/workbench/contrib/tasks/common/taskService",
 			"vs/workbench/contrib/tasks/common/taskTemplates",
 			"vs/workbench/contrib/tasks/common/tasks",
 			"vs/workbench/contrib/tasks/electron-browser/taskService",
@@ -20130,16 +21413,17 @@
 			"vs/workbench/contrib/terminal/browser/terminalConfigHelper",
 			"vs/workbench/contrib/terminal/browser/terminalIcons",
 			"vs/workbench/contrib/terminal/browser/terminalInstance",
-			"vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy",
+			"vs/workbench/contrib/terminal/browser/terminalProcessManager",
 			"vs/workbench/contrib/terminal/browser/terminalQuickAccess",
 			"vs/workbench/contrib/terminal/browser/terminalService",
+			"vs/workbench/contrib/terminal/browser/terminalTab",
 			"vs/workbench/contrib/terminal/browser/terminalView",
 			"vs/workbench/contrib/terminal/common/terminal",
 			"vs/workbench/contrib/terminal/common/terminalColorRegistry",
 			"vs/workbench/contrib/terminal/common/terminalConfiguration",
 			"vs/workbench/contrib/terminal/common/terminalMenu",
 			"vs/workbench/contrib/terminal/electron-browser/terminalRemote",
-			"vs/workbench/contrib/terminal/node/terminalProcess",
+			"vs/workbench/contrib/terminal/electron-sandbox/localTerminalService",
 			"vs/workbench/contrib/testing/browser/icons",
 			"vs/workbench/contrib/testing/browser/testExplorerActions",
 			"vs/workbench/contrib/testing/browser/testing.contribution",
@@ -20147,10 +21431,13 @@
 			"vs/workbench/contrib/testing/browser/testingExplorerFilter",
 			"vs/workbench/contrib/testing/browser/testingExplorerView",
 			"vs/workbench/contrib/testing/browser/testingOutputPeek",
+			"vs/workbench/contrib/testing/browser/testingProgressUiService",
 			"vs/workbench/contrib/testing/browser/testingViewPaneContainer",
 			"vs/workbench/contrib/testing/browser/theme",
+			"vs/workbench/contrib/testing/common/configuration",
 			"vs/workbench/contrib/testing/common/constants",
 			"vs/workbench/contrib/testing/common/testServiceImpl",
+			"vs/workbench/contrib/testing/common/testingContextKeys",
 			"vs/workbench/contrib/themes/browser/themes.contribution",
 			"vs/workbench/contrib/timeline/browser/timeline.contribution",
 			"vs/workbench/contrib/timeline/browser/timelinePane",
@@ -20164,7 +21451,7 @@
 			"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution",
 			"vs/workbench/contrib/userDataSync/browser/userDataSyncMergesView",
 			"vs/workbench/contrib/userDataSync/browser/userDataSyncViews",
-			"vs/workbench/contrib/userDataSync/electron-browser/userDataSync.contribution",
+			"vs/workbench/contrib/userDataSync/electron-sandbox/userDataSync.contribution",
 			"vs/workbench/contrib/watermark/browser/watermark",
 			"vs/workbench/contrib/webview/browser/baseWebviewElement",
 			"vs/workbench/contrib/webview/electron-browser/webviewCommands",
@@ -20175,7 +21462,8 @@
 			"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted",
 			"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution",
 			"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedIcons",
-			"vs/workbench/contrib/welcome/gettingStarted/browser/vs_code_editor_getting_started",
+			"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedInput",
+			"vs/workbench/contrib/welcome/gettingStarted/common/gettingStartedContent",
 			"vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay",
 			"vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page",
 			"vs/workbench/contrib/welcome/page/browser/welcomePage",
@@ -20185,6 +21473,12 @@
 			"vs/workbench/contrib/welcome/walkThrough/browser/editor/editorWalkThrough",
 			"vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution",
 			"vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart",
+			"vs/workbench/contrib/welcome/walkthroughs/browser/walkthroughs",
+			"vs/workbench/contrib/welcome/walkthroughs/browser/walkthroughs.contribution",
+			"vs/workbench/contrib/workspace/browser/workspace.contribution",
+			"vs/workbench/contrib/workspace/browser/workspaceTrustColors",
+			"vs/workbench/contrib/workspace/browser/workspaceTrustEditor",
+			"vs/workbench/contrib/workspace/browser/workspaceTrustTree",
 			"vs/workbench/contrib/workspaces/browser/workspaces.contribution",
 			"vs/workbench/electron-sandbox/actions/developerActions",
 			"vs/workbench/electron-sandbox/actions/windowActions",
@@ -20203,12 +21497,11 @@
 			"vs/workbench/services/dialogs/browser/abstractFileDialogService",
 			"vs/workbench/services/dialogs/browser/simpleFileDialog",
 			"vs/workbench/services/editor/browser/editorService",
-			"vs/workbench/services/editor/common/editorOpenWith",
 			"vs/workbench/services/extensionManagement/browser/extensionBisect",
 			"vs/workbench/services/extensionManagement/browser/extensionEnablementService",
 			"vs/workbench/services/extensionManagement/common/extensionManagementService",
 			"vs/workbench/services/extensionManagement/common/webExtensionsScannerService",
-			"vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService",
+			"vs/workbench/services/extensionManagement/electron-sandbox/extensionManagementServerService",
 			"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService",
 			"vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig",
 			"vs/workbench/services/extensions/browser/extensionUrlHandler",
@@ -20221,8 +21514,8 @@
 			"vs/workbench/services/extensions/electron-browser/extensionService",
 			"vs/workbench/services/extensions/electron-browser/localProcessExtensionHost",
 			"vs/workbench/services/extensions/node/extensionPoints",
-			"vs/workbench/services/gettingStarted/common/gettingStartedContent",
-			"vs/workbench/services/integrity/node/integrityService",
+			"vs/workbench/services/history/browser/history",
+			"vs/workbench/services/integrity/electron-sandbox/integrityService",
 			"vs/workbench/services/keybinding/browser/keybindingService",
 			"vs/workbench/services/keybinding/common/keybindingEditing",
 			"vs/workbench/services/label/common/labelService",
@@ -20244,7 +21537,6 @@
 			"vs/workbench/services/textfile/common/textFileEditorModel",
 			"vs/workbench/services/textfile/common/textFileEditorModelManager",
 			"vs/workbench/services/textfile/common/textFileSaveParticipant",
-			"vs/workbench/services/textfile/electron-browser/nativeTextFileService",
 			"vs/workbench/services/themes/browser/fileIconThemeData",
 			"vs/workbench/services/themes/browser/productIconThemeData",
 			"vs/workbench/services/themes/browser/workbenchThemeService",
@@ -20252,6 +21544,7 @@
 			"vs/workbench/services/themes/common/colorThemeData",
 			"vs/workbench/services/themes/common/colorThemeSchema",
 			"vs/workbench/services/themes/common/fileIconThemeSchema",
+			"vs/workbench/services/themes/common/iconExtensionPoint",
 			"vs/workbench/services/themes/common/productIconThemeSchema",
 			"vs/workbench/services/themes/common/themeConfiguration",
 			"vs/workbench/services/themes/common/themeExtensionPoints",
@@ -20260,6 +21553,7 @@
 			"vs/workbench/services/userDataSync/common/userDataSync",
 			"vs/workbench/services/views/browser/viewDescriptorService",
 			"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService",
+			"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput",
 			"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService"
 		],
 		"vs/workbench/services/extensions/worker/extensionHostWorker": [
@@ -20282,6 +21576,7 @@
 			"vs/workbench/common/views",
 			"vs/workbench/contrib/debug/common/abstractDebugAdapter",
 			"vs/workbench/contrib/search/common/queryBuilder",
+			"vs/workbench/contrib/tasks/common/taskService",
 			"vs/workbench/services/configurationResolver/common/variableResolver"
 		],
 		"vs/workbench/contrib/debug/node/telemetryApp": [
@@ -20290,7 +21585,8 @@
 		],
 		"vs/workbench/services/search/node/searchApp": [
 			"vs/base/common/errorMessage",
-			"vs/base/node/processes"
+			"vs/base/node/processes",
+			"vs/platform/files/common/files"
 		],
 		"vs/platform/files/node/watcher/unix/watcherApp": [
 			"vs/base/node/processes",
@@ -20299,6 +21595,11 @@
 		"vs/platform/files/node/watcher/nsfw/watcherApp": [
 			"vs/base/node/processes",
 			"vs/platform/files/common/files"
+		],
+		"vs/platform/terminal/node/ptyHostMain": [
+			"vs/base/common/errorMessage",
+			"vs/base/node/processes",
+			"vs/platform/terminal/node/terminalProcess"
 		],
 		"vs/workbench/services/extensions/node/extensionHostProcess": [
 			"vs/base/common/date",
@@ -20326,8 +21627,7 @@
 			"vs/workbench/contrib/debug/node/debugAdapter",
 			"vs/workbench/contrib/externalTerminal/node/externalTerminalService",
 			"vs/workbench/contrib/search/common/queryBuilder",
-			"vs/workbench/contrib/terminal/common/terminal",
-			"vs/workbench/contrib/terminal/node/terminalProcess",
+			"vs/workbench/contrib/tasks/common/taskService",
 			"vs/workbench/services/configurationResolver/common/variableResolver"
 		],
 		"vs/code/electron-main/main": [
@@ -20337,7 +21637,6 @@
 			"vs/base/node/processes",
 			"vs/code/electron-main/app",
 			"vs/code/electron-main/main",
-			"vs/code/electron-main/window",
 			"vs/platform/configuration/common/configurationRegistry",
 			"vs/platform/dialogs/electron-main/dialogMainService",
 			"vs/platform/environment/node/argv",
@@ -20353,6 +21652,7 @@
 			"vs/platform/request/common/request",
 			"vs/platform/telemetry/common/telemetryService",
 			"vs/platform/update/common/update.config.contribution",
+			"vs/platform/windows/electron-main/window",
 			"vs/platform/windows/electron-main/windowsMainService",
 			"vs/platform/workspaces/common/workspaces",
 			"vs/platform/workspaces/electron-main/workspacesHistoryMainService",
@@ -20409,8 +21709,7 @@
 			"vs/platform/userDataSync/common/settingsSync",
 			"vs/platform/userDataSync/common/userDataAutoSyncService",
 			"vs/platform/userDataSync/common/userDataSync",
-			"vs/platform/userDataSync/common/userDataSyncMachines",
-			"vs/platform/workspaces/common/workspaces"
+			"vs/platform/userDataSync/common/userDataSyncMachines"
 		],
 		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
 			"vs/base/browser/ui/tree/abstractTree",

--- a/packages/editor/src/browser/editor-generated-preference-schema.ts
+++ b/packages/editor/src/browser/editor-generated-preference-schema.ts
@@ -88,7 +88,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             nls.localizeByDefault("Suggest words from all open documents of the same language."),
             nls.localizeByDefault("Suggest words from all open documents.")
         ],
-        "description": nls.localize("theia/editor/editor.wordBasedSuggestionsMode", "Controls from which documents word based completions are computed."),
+        "description": nls.localizeByDefault("Controls from which documents word based completions are computed."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -298,10 +298,10 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.autoClosingDelete": {
         "enumDescriptions": [
             "",
-            nls.localize("theia/editor/editor.autoClosingDelete1", "Remove adjacent closing quotes or brackets only if they were automatically inserted."),
+            nls.localizeByDefault("Remove adjacent closing quotes or brackets only if they were automatically inserted."),
             ""
         ],
-        "description": nls.localize("theia/editor/editor.autoClosingDelete", "Controls whether the editor should remove adjacent closing quotes or brackets when deleting."),
+        "description": nls.localizeByDefault("Controls whether the editor should remove adjacent closing quotes or brackets when deleting."),
         "type": "string",
         "enum": [
             "always",
@@ -657,8 +657,8 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         ],
         "default": "never",
         "enumDescriptions": [
-            nls.localize("theia/editor/editor.find.autoFindInSelection0", "Never turn on Find in Selection automatically (default)."),
-            nls.localize("theia/editor/editor.find.autoFindInSelection1", "Always turn on Find in Selection automatically."),
+            nls.localizeByDefault('Never turn on Find in selection automatically (default).'),
+            nls.localizeByDefault('Always turn on Find in selection automatically.'),
             nls.localizeByDefault('Turn on Find in selection automatically when multiple lines of content are selected.')
         ],
         "description": nls.localizeByDefault('Controls the condition for turning on find in selection automatically.'),
@@ -1461,7 +1461,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.renderLineHighlightOnlyWhenFocus": {
-        "description": nls.localize("theia/editor/editor.renderLineHighlightOnlyWhenFocus", "Controls if the editor should render the current line highlight only when the editor is focused."),
+        "description": nls.localizeByDefault("Controls if the editor should render the current line highlight only when the editor is focused."),
         "type": "boolean",
         "default": false,
         "scope": "language-overridable",
@@ -1472,7 +1472,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             "",
             nls.localizeByDefault("Render whitespace characters except for single spaces between words."),
             nls.localizeByDefault("Render whitespace characters only on selected text."),
-            nls.localize("theia/editor/editor.renderWhitespace3", "Render only trailing whitespace characters."),
+            nls.localizeByDefault("Render only trailing whitespace characters."),
             ""
         ],
         "description": nls.localizeByDefault("Controls how the editor should render whitespace characters."),
@@ -1667,7 +1667,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.stickyTabStops": {
-        "description": nls.localize("theia/editor/editor.stickyTabStops", "Emulate selection behavior of tab characters when using spaces for indentation. Selection will stick to tab stops."),
+        "description": nls.localizeByDefault("Emulate selection behavior of tab characters when using spaces for indentation. Selection will stick to tab stops."),
         "type": "boolean",
         "default": false,
         "scope": "language-overridable",
@@ -1698,7 +1698,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.suggest.localityBonus": {
         "type": "boolean",
         "default": false,
-        "description": nls.localize("theia/editor/editor.suggest.localityBonus", "Controls whether sorting favors words that appear close to the cursor."),
+        "description": nls.localizeByDefault("Controls whether sorting favors words that appear close to the cursor."),
         "scope": "language-overridable",
         "restricted": false
     },

--- a/packages/plugin-ext/src/main/browser/authentication-main.ts
+++ b/packages/plugin-ext/src/main/browser/authentication-main.ts
@@ -289,9 +289,9 @@ export class AuthenticationProviderImpl implements AuthenticationProvider {
         const accountUsages = await readAccountUsages(this.storageService, this.id, accountName);
         const sessionsForAccount = this.accounts.get(accountName);
         const result = await this.messageService.info(accountUsages.length
-            ? nls.localizeByDefault('The account {0} has been used by: \n\n{1}\n\n Sign out of these features?', accountName,
+            ? nls.localizeByDefault("The account '{0}' has been used by: \n\n{1}\n\n Sign out from these extensions?", accountName,
                 accountUsages.map(usage => usage.extensionName).join(', '))
-            : nls.localizeByDefault('Sign out of {0}?', accountName),
+            : nls.localizeByDefault("Sign out of '{0}'?", accountName),
             nls.localizeByDefault('Sign Out'),
             Dialog.CANCEL);
 


### PR DESCRIPTION
#### What it does

Depends on https://github.com/eclipse-theia/theia/pull/11823

Updates our `nls.metadata.json` and everything associated with it (i.e. `nls.localize/nls.localizeByDefault`) to use vscode 1.55.2 as a reference base. All language packs downloaded after  https://github.com/eclipse-theia/theia/pull/11823 will depend on Theia using that.

The automatic localization update before the release will take care of removing unnecessary localization strings by itself.

#### How to test

CI is green/passes.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
