### PR TITLE
Fix package resolving failure in CLI

### DIFF
--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -38,6 +38,7 @@
     "is-electron": "^2.1.0",
     "nano": "^9.0.5",
     "request": "^2.82.0",
+    "resolve-package-path": "^4.0.3",
     "semver": "^5.4.1",
     "write-json-file": "^2.2.0"
   },

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -21,6 +21,7 @@ import { Extension, ExtensionPackage, ExtensionPackageOptions, RawExtensionPacka
 import { ExtensionPackageCollector } from './extension-package-collector';
 import { ApplicationProps } from './application-props';
 import deepmerge = require('deepmerge');
+import resolvePackagePath = require('resolve-package-path');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ApplicationLog = (message?: any, ...optionalParams: any[]) => void;
@@ -281,8 +282,14 @@ export class ApplicationPackage {
      */
     get resolveModule(): ApplicationModuleResolver {
         if (!this._moduleResolver) {
-            const resolutionPaths = [this.packagePath || process.cwd()];
-            this._moduleResolver = modulePath => require.resolve(modulePath, { paths: resolutionPaths });
+            const resolutionPaths = this.packagePath || process.cwd();
+            this._moduleResolver = modulePath => {
+                const resolved = resolvePackagePath(modulePath, resolutionPaths);
+                if (!resolved) {
+                    throw new Error('Could not resolve module: ' + modulePath);
+                }
+                return resolved;
+            };
         }
         return this._moduleResolver!;
     }

--- a/dev-packages/application-package/src/extension-package-collector.ts
+++ b/dev-packages/application-package/src/extension-package-collector.ts
@@ -62,8 +62,8 @@ export class ExtensionPackageCollector {
 
         let packagePath: string | undefined;
         try {
-            packagePath = this.resolveModule(name + '/package.json');
-        } catch (error) {
+            packagePath = this.resolveModule(name);
+        } catch {
             console.warn(`Failed to resolve module: ${name}`);
         }
         if (!packagePath) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9209,6 +9209,18 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+  integrity sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  integrity sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==
+  dependencies:
+    path-root-regex "^0.1.0"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -10043,6 +10055,13 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-package-path@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-4.0.3.tgz#31dab6897236ea6613c72b83658d88898a9040aa"
+  integrity sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==
+  dependencies:
+    path-root "^0.1.1"
 
 resolve@^1.10.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.3.2, resolve@^1.9.0:
   version "1.22.1"


### PR DESCRIPTION
#### What it does

With the introduction of ESM modules, a lot of packages have started to utilize the `exports` field of the package.json file. This came with a change in the `require.resolve` function which automatically tried to resolve the default export of package.json, preventing us to actually get the path to the `package.json` file. For more information see [here](https://stackoverflow.com/a/63441056).

The package `resolve-package-path` simulates the node.js package resolving algorithm and prevents the `Failed to resolve module` warning to appear which confuses a lot of developers (see https://github.com/eclipse-theia/theia/issues/11822 for example).

#### How to test

1. Run the `theia build` command
2. Assert that no `Failed to resolve module` warning is printed to the console.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
