### PR TITLE
vscode: fix `separator` in quick-open

### DIFF
--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -635,16 +635,18 @@ export class QuickPickExt<T extends theia.QuickPickItem> extends QuickInputExt i
             this._handlesToItems.set(i, item);
             this._itemsToHandles.set(item, i);
         });
-        this.update({
-            items: items.map((item, i) => {
-                if (item.kind === QuickPickItemKind.Separator) {
-                    return { kind: item.kind, label: item.label };
-                }
-                return {
+
+        const pickItems: TransferQuickPickItems[] = [];
+        for (let handle = 0; handle < items.length; handle++) {
+            const item = items[handle];
+            if (item.kind === QuickPickItemKind.Separator) {
+                pickItems.push({ type: 'separator', label: item.label, handle });
+            } else {
+                pickItems.push({
                     kind: item.kind,
                     label: item.label,
                     description: item.description,
-                    handle: i,
+                    handle,
                     detail: item.detail,
                     picked: item.picked,
                     alwaysShow: item.alwaysShow,
@@ -654,8 +656,12 @@ export class QuickPickExt<T extends theia.QuickPickItem> extends QuickInputExt i
                         tooltip: button.tooltip,
                         handle: button === QuickInputButtons.Back ? -1 : index,
                     }))
-                };
-            })
+                });
+            }
+        }
+
+        this.update({
+            items: pickItems,
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: https://github.com/eclipse-theia/theia/issues/9758.

The pull-request fixes the `separator` `kind` for quick-open menus contributed by plugins.

_Before_:

https://user-images.githubusercontent.com/40359487/199991703-a45c40f9-46fb-46d2-bb5f-87fa74ee7e1a.mp4

_After_:

https://user-images.githubusercontent.com/40359487/199991767-f5da070e-0640-4838-89d0-e42cc5011c23.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test extension ([separator-0.0.2.zip](https://github.com/eclipse-theia/theia/files/9938989/separator-0.0.2.zip))
2. start the application
3. trigger the command `QuickOpen: Separator`
4. confirm that the `separator` kind is properly rendered

The extension performs the following:

```ts
export function activate(context: vscode.ExtensionContext) {
    let disposable = vscode.commands.registerCommand('separator.menu', () => {
        const pick = vscode.window.createQuickPick();
        pick.title = 'Separator Example';
        pick.items = [
            { label: 'A', },
            { label: '', kind: vscode.QuickPickItemKind.Separator },
            { label: 'B' },
            { label: '', kind: vscode.QuickPickItemKind.Separator },
            { label: 'C' }
        ];
        pick.show();
        pick.onDidAccept(() => vscode.window.showInformationMessage(`${pick.activeItems[0]?.label} selected.`));
    });

    context.subscriptions.push(disposable);
}
```


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>