### PR TITLE
Fix some webpack warnings

### DIFF
--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -226,7 +226,16 @@ module.exports = [{
     stats: {
         warnings: true,
         children: true
-    }
+    },
+    ignoreWarnings: [
+        // Some packages do not have source maps, that's ok
+        /Failed to parse source map/,
+        {
+            // Monaco uses 'require' in a non-standard way
+            module: /@theia\\/monaco-editor-core/,
+            message: /require function is used in a way in which dependencies cannot be statically extracted/
+        }
+    ]
 },
 {
     mode,

--- a/packages/plugin-ext/src/main/browser/style/index.css
+++ b/packages/plugin-ext/src/main/browser/style/index.css
@@ -35,8 +35,13 @@
 }
 
 .theia-plugin-view-container {
-    -webkit-mask: url('');
-    mask: url('');
+    /*
+        It might take a second or two until the real plugin mask is loaded
+        To prevent flickering on the icon, we set a transparent mask instead
+        Since masks only support images, svg or gradients, we create a transparent gradient here
+    */
+    -webkit-mask: linear-gradient(transparent, transparent);
+    mask: linear-gradient(transparent, transparent);
     background-color: var(--theia-activityBar-inactiveForeground);
 }
 
@@ -51,10 +56,10 @@
 .theia-plugin-root-folder-expanded-icon,
 .theia-plugin-root-folder-expanded-icon::before {
     padding-right: var(--theia-ui-padding);
-	width: var(--theia-icon-size);
-	height: var(--theia-content-line-height);
-	line-height: inherit !important;
-	display: inline-block;
+    width: var(--theia-icon-size);
+    height: var(--theia-content-line-height);
+    line-height: inherit !important;
+    display: inline-block;
 }
 
 .p-TabBar.theia-app-sides .theia-plugin-file-icon,


### PR DESCRIPTION
#### What it does

Related to https://github.com/eclipse-theia/theia/pull/11432

This change fixes/circumvents 3 kinds of webpack warnings:
1. Missing source maps. We ignore those, as these come from dependencies and it doesn't really harm us too much
2. Weird `require` usage in monaco on a path which is never executed. We can ignore that as well
3. Unable to inline `url('')` css. I've replaced the URL with a gradient which serves the same result

#### How to test

Only the third point can actually be tested. It's a regression test against https://github.com/eclipse-theia/theia/issues/7751. The plugin icons should be empty instead of a grey box.

For everything else: The related webpack warnings shouldn't appear anymore when running `theia build`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
