### PR TITLE
Remove reference to comparator's filtered report

### DIFF
--- a/doc/Plugin-API.md
+++ b/doc/Plugin-API.md
@@ -20,7 +20,6 @@ Feel free to [open new issues](https://github.com/eclipse-theia/theia/issues/new
 The report can be found here:
 
 [![API Compatibility](https://img.shields.io/badge/API_Compatibility-Status_Report-blue.svg?style=flat-curved)](https://eclipse-theia.github.io/vscode-theia-comparator/status.html)
-[![API Compatibility](https://img.shields.io/badge/API_Compatibility-Filtered_Status_Report_(unsupported_only)-blue.svg?style=flat-curved)](https://eclipse-theia.github.io/vscode-theia-comparator/filtered-status.html)
 
 ## Relevant Theia source code
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes #11847

Removes a reference to the 'filtered report' from the VSCode-Theia comparator, since the two reports [have now been combined](https://github.com/eclipse-theia/vscode-theia-comparator/pull/36).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Confirm that the remaining badge points to a page that allows you to toggle between filtered and unfiltered.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
