### PR TITLE
Plugin localization service does not await on init

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-localization-service.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-localization-service.ts
@@ -23,7 +23,7 @@ import { DeployedPlugin, Localization as PluginLocalization, PluginIdentifiers }
 import { URI } from '@theia/core/shared/vscode-uri';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
-import { Disposable } from '@theia/core';
+import { Disposable, MaybePromise } from '@theia/core';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 
 export interface VSCodeNlsConfig {
@@ -56,10 +56,10 @@ export class HostedPluginLocalizationService implements BackendApplicationContri
      */
     ready = this._ready.promise;
 
-    async initialize(): Promise<void> {
-        const cacheDir = await this.getLocalizationCacheDir();
-        await fs.emptyDir(cacheDir);
-        this._ready.resolve();
+    initialize(): MaybePromise<void> {
+        this.getLocalizationCacheDir()
+            .then(cacheDir => fs.emptyDir(cacheDir))
+            .then(() => this._ready.resolve());
     }
 
     deployLocalizations(plugin: DeployedPlugin): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 - This PR changes the initialization (`BackendApplicationContribution#initialize`) of the localization service for plugins. With the proposed changes, the backend initialization does not wait for the cleaning of the localization cache folder.
 - The PR also changes the return type of the `initialize` method from `Promise<void>` to `MaybePromise<void>` not to force downstream projects to use `aync`/`Promise` when doing the customization.

Why?

To speed up the backend startup when the Theia-based app is stated with multiple languages.

Originally from [here](https://github.com/eclipse-theia/theia/pull/11338#issuecomment-1308653707):

> I am seeing slow startup time with multiple languages. It's more than a sec.
> 
> ```
> 2022-11-09T11:46:27.180Z root WARN Backend HostedPluginLocalizationService.initialize took longer than the expected maximum 50 milliseconds: 1070.7 ms [Finished 4.488 s after backend start]
> ```
> 
> Could something like this also work in Theia?
> 
> ```ts
> initialize(): void {
> 	this.getLocalizationCacheDir().then((cacheDir) => fs.emptyDir(cacheDir)).then(() => this._ready.resolve())
> }
> ```
> 
> With the proposed change, the initialization is significantly less.
> 
> ```
> 2022-11-09T12:05:46.544Z root INFO Backend HostedPluginLocalizationService.initialize: 3.0 ms [Finished 2.557 s after backend start]
> ```
> 
> Thank you!



#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
