### PR TITLE
Fix potential race condition when copying files and directories

### DIFF
--- a/packages/filesystem/src/node/disk-file-system-provider.ts
+++ b/packages/filesystem/src/node/disk-file-system-provider.ts
@@ -708,7 +708,7 @@ export class DiskFileSystemProvider implements Disposable,
         copiedSources[source] = true; // remember as copied
 
         // Create folder
-        this.mkdirp(target, fileStat.mode & 511);
+        await this.mkdirp(target, fileStat.mode & 511);
 
         // Copy each file recursively
         const files = await promisify(readdir)(source);


### PR DESCRIPTION
#### What it does
This fixes a potential race condition when copying files with directories. The call to `mkdirp` was not awaited, meaning that subsequent copying of files within the copied directory would occasionally fail as the directory creation had not finished.

#### How to test
We found this issue while duplicating a project in ARM mbed-ide, so presumably, copying a large git project will suffice.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
