### PR TITLE
ci: make plugin download sequential

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,11 +73,24 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install and Build
+      - name: Install
         shell: bash
         run: |
           yarn --skip-integrity-check --network-timeout 100000
           ./scripts/check_git_status.sh
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Download Plugins
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          yarn -s download:plugins
+
+      - name: Build
+        shell: bash
+        run: |
           yarn build:examples
           ./scripts/check_git_status.sh
         env:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,7 +12,7 @@ ports:
   - port: 9339 # Node.js debug port
     onOpen: ignore
 tasks:
-  - init: yarn --network-timeout 100000 && yarn build:examples
+  - init: yarn --network-timeout 100000 && yarn build:examples && yarn download:plugins
     command: >
       jwm &
       yarn --cwd examples/browser start ../.. --hostname=0.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [preferences] `PreferenceHeaderRendererContribution` moved to `preference-node-renderer-creator.ts`. [#11432](https://github.com/eclipse-theia/theia/pull/11432)
 - [workspace] removed `workspace.supportMultiRootWorkspace` preference [#11538](https://github.com/eclipse-theia/theia/pull/11538)
 - [workspace] removed method `isMultiRootWorkspaceEnabled` from `WorkspaceService` [#11538](https://github.com/eclipse-theia/theia/pull/11538)
+- [repo] the `download:plugins` script resolves plugins sequentially by default [#11860](https://github.com/eclipse-theia/theia/pull/11860)
 
 ## v1.31.0 - 10/27/2022
 

--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -86,7 +86,7 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
         ignoreErrors = false,
         apiVersion = DEFAULT_SUPPORTED_API_VERSION,
         apiUrl = 'https://open-vsx.org/api',
-        parallel = true,
+        parallel = false,
         proxyUrl,
         proxyAuthorization,
         strictSsl

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -343,7 +343,7 @@ async function theiaCli(): Promise<void> {
                 'parallel': {
                     describe: 'Download in parallel',
                     boolean: true,
-                    default: true
+                    default: false
                 },
                 'proxy-url': {
                     describe: 'Proxy URL'

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -36,7 +36,7 @@ commands:
         component: che-dev
         command: >
           killall node;
-          yarn && yarn build:examples
+          yarn && yarn download:plugins && yarn build:examples
         workdir: /projects/theia
   - name: >
       theia: Launch Browser Backend

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "browser": "yarn -s --cwd examples/browser",
     "build": "yarn -s compile && yarn -s build:examples",
     "build-p": "yarn -s compile && lerna run --scope=\"@theia/example-*\" bundle --parallel",
-    "build:examples": "yarn -s download:plugins && lerna run --scope=\"@theia/example-*\" bundle --parallel",
+    "build:examples": "lerna run --scope=\"@theia/example-*\" bundle --parallel",
     "clean": "yarn -s rebuild:clean && yarn -s lint:clean && node scripts/run-reverse-topo.js yarn -s clean",
     "compile": "echo Compiling TypeScript sources... && yarn -s compile:clean && yarn -s compile:tsc",
     "compile:clean": "ts-clean dev-packages/* packages/*",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates the `download:plugins` script to use `sequential` downloads as the new default (rather than `parallel`).

The changes include:
- the default for `download:plugins` is now set to `parallel=false` (sequential)
- the `build` step during CI is broken down into their respective parts (Install, Download Plugins and Build)
- we no longer unnecessarily call `download;plugins` for MacOS and Windows as we do not run integration tests there

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Errors related to `download:plugins` (429) should occur less during CI.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
