### PR TITLE
vscode: align typings for provideHover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [plugin] added `Task#runOptions` field and `RunOptions` interface [#11759](https://github.com/eclipse-theia/theia/pull/11759) - Contributed on behalf of STMicroelectronics
 - [tasks] added support for `reevaluateOnRerun` run option [#11759](https://github.com/eclipse-theia/theia/pull/11759) - Contributed on behalf of STMicroelectronics
 - [plugin] updated the default VS Code API version from `1.53.2` to `1.55.2` [#11823](https://github.com/eclipse-theia/theia/pull/11823)
+- [plugin] aligned typings for `HoverProvider.provideHover` with VS Code [#11862](https://github.com/eclipse-theia/theia/pull/11862) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.32.0">[Breaking Changes:](#breaking_changes_1.32.0)</a>
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -490,19 +490,22 @@ In case if a few providers are registered the chain will be executed until one o
 To contribute a hover it is only needed to provide a function that can be called with a `TextDocument` and a `Position` returning hover info. Registration is done using a document selector which either a language id ('typescript', 'javascript' etc.) or a more complex filter like `{scheme: 'file', language: 'typescript'}`.
 
 For example,
+
 ```typescript
 theia.languages.registerHoverProvider('typescript', {
-    provideHover(doc: theia.TextDocument, position: theia.Position) {
+    provideHover(doc: theia.TextDocument, position: theia.Position, token: theia.CancellationToken) {
         return new theia.Hover('Hover for all **typescript** files.');
     }
 });
 ```
+
 will show the hover message for all `typescript` files.
 
 The code below puts word under cursor into hover message:
+
 ```typescript
 theia.languages.registerHoverProvider({scheme: 'file'}, {
-    provideHover(doc: theia.TextDocument, position: theia.Position) {
+    provideHover(doc: theia.TextDocument, position: theia.Position, token: theia.CancellationToken) {
         const range = doc.getWordRangeAtPosition(position);
         const text = doc.getText(range);
         return new theia.Hover(text);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10079,7 +10079,7 @@ export module '@theia/plugin' {
          * @return A hover or a thenable that resolves to such. The lack of a result can be
          * signaled by returning `undefined` or `null`.
          */
-        provideHover(document: TextDocument, position: Position, token: CancellationToken | undefined): ProviderResult<Hover>;
+        provideHover(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Hover>;
     }
 
     /**


### PR DESCRIPTION
#### What it does

Aligns the typings of `HoverProvider.provideHover` with the API of VS Code.
This change also updates the documentation to include the token parameter in the signature of the hover provider examples. Technically, this isn't necessary, but for the sake of completeness, I thought it makes sense.

Fixes https://github.com/eclipse-theia/theia/issues/11827

Contributed on behalf of STMicroelectronics

#### How to test

This isn't really a breaking change and only impacts the external extension API, which isn't used directly (I assume) anyway, as people most likely implement against the VS Code API anyway. Also, this method is never invoked directly from within Theia too. So there is nothing really to test, imho.

I locally confirmed that this change makes the [report](https://eclipse-theia.github.io/vscode-theia-comparator/status.html) happy.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
