### PR TITLE
Remove circular dependency check

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -39,7 +39,6 @@
     "@types/semver": "^7.3.8",
     "babel-loader": "^8.2.2",
     "buffer": "^6.0.3",
-    "circular-dependency-plugin": "^5.2.2",
     "compression-webpack-plugin": "^9.0.0",
     "copy-webpack-plugin": "^8.1.1",
     "css-loader": "^6.2.0",

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -57,7 +57,6 @@ const path = require('path');
 const webpack = require('webpack');
 const yargs = require('yargs');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const CircularDependencyPlugin = require('circular-dependency-plugin');
 const CompressionPlugin = require('compression-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
@@ -89,10 +88,6 @@ const plugins = [
 if (staticCompression) {
     plugins.push(new CompressionPlugin({}));
 }
-plugins.push(new CircularDependencyPlugin({
-    exclude: /(node_modules|examples)[\\\\|\/]./,
-    failOnError: false // https://github.com/nodejs/readable-stream/issues/280#issuecomment-297076462
-}));
 
 module.exports = [{
     mode,

--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -20,6 +20,20 @@ For example:
 }
 ```
 
+### v1.32.0
+
+#### Removal of `CircularDependencyPlugin`
+
+We no longer enforce usage of the `CircularDependencyPlugin` in the generated webpack configuration. This plugin previously informed users of any non-fatal circular dependencies in their JavaScript imports.
+Note that Theia adopters can enable the plugin again by manually adding `circular-dependency-plugin` as a dev dependency and adding the following snippet to their `webpack.config.js` file.
+
+```js
+config[0].module.plugins.push(new CircularDependencyPlugin({
+    exclude: /(node_modules)[\\\\|\/]./,
+    failOnError: false
+}));
+```
+
 ### v1.30.0
 
 #### lerna 5.5.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,11 +4170,6 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-circular-dependency-plugin@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz#39e836079db1d3cf2f988dc48c5188a44058b600"
-  integrity sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==
-
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"


### PR DESCRIPTION
#### What it does

See https://github.com/eclipse-theia/theia/discussions/11863

Removes circular dependency checking from the generated webpack build. Downstream users still have the option to add the check themselves

#### How to test

Build the application. No circular dependency warnings should appear. In fact, this should remove all warnings that are left in the webpack build.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
