### PR TITLE
monaco: fixed issue where scrollbar preferences are not being applied

### DIFF
--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -134,12 +134,12 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
             lightbulb: { enabled: true },
             fixedOverflowWidgets: true,
             scrollbar: {
-                ...options?.scrollbar,
                 useShadows: false,
                 verticalHasArrows: false,
                 horizontalHasArrows: false,
                 verticalScrollbarSize: 10,
-                horizontalScrollbarSize: 10
+                horizontalScrollbarSize: 10,
+                ...options?.scrollbar,
             }
         } as IStandaloneEditorConstructionOptions;
         const instantiator = this.getInstantiatorWithOverrides(override);

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -69,14 +69,6 @@
   background: var(--theia-scrollbarSlider-activeBackground) !important;
 }
 
-.monaco-scrollable-element > .scrollbar.vertical > .slider {
-  width: var(--theia-scrollbar-width) !important;
-}
-
-.monaco-scrollable-element > .scrollbar.horizontal > .slider {
-  height: var(--theia-scrollbar-width) !important;
-}
-
 .monaco-editor .codicon.codicon-debug-start {
   color: var(--theia-debugIcon-startForeground) !important;
 }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11732

The pull-request fixes an issue where the horizontal and vertical preferences for the editor were not applied due to defaults overriding the preference value, and incorrectly re-styling monaco with css.

#### How to test

1. start the application, and open an editor with enough content the scrollbar appears
2. confirm that both the vertical and horizontal scrollbar size is correct
3. update the preference `editor.scrollbar.verticalScrollbarSize` and confirm the editor's vertical scrollbar is properly updated
4. update the preference `editor.scrollbar.horizontalScrollbarSize` and confirm the editor's horizontal scrollbar is properly updated
5. open a new editor and confirm the preference is properly applied.

**Note**: the changes only apply for the scrollbar of the editor:
**please note these change only apply to the scrollbar of the editor.

https://user-images.githubusercontent.com/113064863/202728535-ef12bc4f-8355-41df-b1e7-7f22b84bd740.mp4

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
