### PR TITLE
Implement VS Code extensions namespace

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -671,6 +671,24 @@ export function createAPIFactory(
             get onDidChangeLogLevel(): theia.Event<theia.LogLevel> { return onDidChangeLogLevel.event; }
         });
 
+        const extensions: typeof theia.extensions = Object.freeze({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            getExtension<T = any>(extensionId: string): theia.Extension<T> | undefined {
+                const plg = pluginManager.getPluginById(extensionId.toLowerCase());
+                if (plg) {
+                    return new PluginExt(pluginManager, plg);
+                }
+                return undefined;
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            get all(): readonly theia.Extension<any>[] {
+                return pluginManager.getAllPlugins().map(plg => new PluginExt(pluginManager, plg));
+            },
+            get onDidChange(): theia.Event<void> {
+                return pluginManager.onDidChange;
+            }
+        });
+
         const languages: typeof theia.languages = {
             getLanguages(): PromiseLike<string[]> {
                 return languagesExt.getLanguages();
@@ -971,6 +989,7 @@ export function createAPIFactory(
             window,
             workspace,
             env,
+            extensions,
             languages,
             plugins,
             debug,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9523,6 +9523,27 @@ export module '@theia/plugin' {
         provideDocumentRangeSemanticTokens(document: TextDocument, range: Range, token: CancellationToken): ProviderResult<SemanticTokens>;
     }
 
+    export namespace extensions {
+        /**
+         * Get an extension by its full identifier in the form of: `publisher.name`.
+         *
+         * @param extensionId An extension identifier.
+         * @return An extension or `undefined`.
+         */
+        export function getExtension<T = any>(extensionId: string): Extension<T> | undefined;
+
+        /**
+         * All extensions currently known to the system.
+         */
+        export const all: readonly Extension<any>[];
+
+        /**
+         * An event which fires when `extensions.all` changes. This can happen when extensions are
+         * installed, uninstalled, enabled or disabled.
+         */
+        export const onDidChange: Event<void>;
+    }
+
     export namespace languages {
         /**
          * Return the identifiers of all known languages.


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR implements the extensions namespace in the VS Code API which is currently marked as not implemented in [the comparison coverage report](https://eclipse-theia.github.io/vscode-theia-comparator/status.html).

The functionality was already implemented, but exposed under the `plugins` export.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

You can test the extensions `onDidChange` event by hooking into it in a VS Code extension.
You can test the `getExtension` function by calling it from a VS Code extension. You can then activate this extension and access the functionality on it using this pattern:

https://github.com/Marus/cortex-debug-db-stm32f4/blob/master/src/extension.ts#L15

Note: access to plugins is currently only possible within the same extensionHost (this matches VS Code functionality)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
