### PR TITLE
Use environment-safe platform check in preferences

### DIFF
--- a/packages/plugin-ext/src/plugin/preference-registry.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.ts
@@ -17,13 +17,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { Emitter, Event } from '@theia/core/lib/common/event';
+import { isOSX, isWindows } from '@theia/core/lib/common/os';
 import { URI } from '@theia/core/shared/vscode-uri';
 import { ResourceMap } from '@theia/monaco-editor-core/esm/vs/base/common/map';
 import { IConfigurationOverrides, IOverrides } from '@theia/monaco-editor-core/esm/vs/platform/configuration/common/configuration';
 import { Configuration, ConfigurationModel } from '@theia/monaco-editor-core/esm/vs/platform/configuration/common/configurationModels';
 import { Workspace, WorkspaceFolder } from '@theia/monaco-editor-core/esm/vs/platform/workspace/common/workspace';
 import * as theia from '@theia/plugin';
-import { platform } from 'os';
 import { v4 } from 'uuid';
 import {
     PLUGIN_RPC_CONTEXT, PreferenceChangeExt, PreferenceData, PreferenceRegistryExt,
@@ -74,7 +74,7 @@ function lookUp(tree: any, key: string): any {
 export class TheiaWorkspace extends Workspace {
     constructor(ext: WorkspaceExtImpl) {
         const folders = (ext.workspaceFolders ?? []).map(folder => new WorkspaceFolder(folder));
-        super(v4(), folders, false, ext.workspaceFile ?? null, () => ['win32', 'darwin'].includes(platform()));
+        super(v4(), folders, false, ext.workspaceFile ?? null, () => isOSX || isWindows);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The PR: https://github.com/eclipse-theia/theia/pull/11393

Introduced a dependency on the node `os` module in common plugin source. This had the effect that the preferences system doesn't load for web-based extensions.

This PR fixes the issue by using the environment-safe checks instead.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Load a web extension which accesses user configuration and check it is possible.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
