### PR TITLE
Fix treeview item icon

### DIFF
--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -369,7 +369,7 @@ export class LabelProvider implements FrontendApplicationContribution {
     protected handleRequest(element: object, method: keyof Omit<LabelProviderContribution, 'canHandle' | 'onDidChange' | 'affects'>): string | undefined {
         for (const contribution of this.findContribution(element, method)) {
             const value = contribution[method]?.(element);
-            if (value !== undefined) {
+            if (!!value) {
                 return value;
             }
         }


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The [label-provider](https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/label-provider.ts#L369) class seems to iterate contributions for specified functionality until something is returned.

Both the [icon-theme-service](https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/icon-theme-service.ts#L73) and [plugin-tree-view-node-label-provider](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/main/browser/view/plugin-tree-view-node-label-provider.ts#L42) contribution offer a `getIcon()` function.

Multiple contributions offering features seems to be mitigated by checking the return value is not `undefined`, however `icon-theme-service.getIcon()` returns an empty string instead and seems to get called first. This means all treeview icons are always empty.

This PR adds the additional check for an empty string which fixes the issue and the correct contribution is called, but I can't help feel this architecture is a messy approach and needs some further attention.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Load an extension with a treeview which has items with icons.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
