### PR TITLE
vscode: add support for inline completions

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -81,7 +81,10 @@ import {
     InlayHint,
     CachedSession,
     CachedSessionItem,
-    TypeHierarchyItem
+    TypeHierarchyItem,
+    InlineCompletion,
+    InlineCompletions,
+    InlineCompletionContext
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -1576,6 +1579,8 @@ export interface LanguagesExt {
     $provideSuperTypes(handle: number, sessionId: string, itemId: string, token: theia.CancellationToken): Promise<TypeHierarchyItem[] | undefined>
     $provideSubTypes(handle: number, sessionId: string, itemId: string, token: theia.CancellationToken): Promise<TypeHierarchyItem[] | undefined>;
     $releaseTypeHierarchy(handle: number, session?: string): Promise<boolean>;
+    $provideInlineCompletions(handle: number, resource: UriComponents, position: Position, context: InlineCompletionContext, token: CancellationToken): Promise<IdentifiableInlineCompletions | undefined>;
+    $freeInlineCompletionsList(handle: number, pid: number): void;
 }
 
 export const LanguagesMainFactory = Symbol('LanguagesMainFactory');
@@ -1633,6 +1638,7 @@ export interface LanguagesMain {
     $registerTypeHierarchyProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $setLanguageStatus(handle: number, status: LanguageStatus): void;
     $removeLanguageStatus(handle: number): void;
+    $registerInlineCompletionsSupport(handle: number, selector: SerializedDocumentFilter[]): void;
 }
 
 export interface WebviewInitData {
@@ -2040,3 +2046,11 @@ export interface SecretsMain {
 
 export type InlayHintDto = CachedSessionItem<InlayHint>;
 export type InlayHintsDto = CachedSession<{ hints: InlayHint[] }>;
+
+export interface IdentifiableInlineCompletions extends InlineCompletions<IdentifiableInlineCompletion> {
+    pid: number;
+}
+
+export interface IdentifiableInlineCompletion extends InlineCompletion {
+    idx: number;
+}

--- a/packages/plugin-ext/src/common/reference-map.ts
+++ b/packages/plugin-ext/src/common/reference-map.ts
@@ -1,0 +1,38 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// copied from hhttps://github.com/microsoft/vscode/blob/6261075646f055b99068d3688932416f2346dd3b/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L1291-L1310.
+
+export class ReferenceMap<T> {
+    private readonly _references = new Map<number, T>();
+    private _idPool = 1;
+
+    createReferenceId(value: T): number {
+        const id = this._idPool++;
+        this._references.set(id, value);
+        return id;
+    }
+
+    disposeReferenceId(referenceId: number): T | undefined {
+        const value = this._references.get(referenceId);
+        this._references.delete(referenceId);
+        return value;
+    }
+
+    get(referenceId: number): T | undefined {
+        return this._references.get(referenceId);
+    }
+}

--- a/packages/plugin-ext/src/plugin/languages/inline-completion.ts
+++ b/packages/plugin-ext/src/plugin/languages/inline-completion.ts
@@ -1,0 +1,126 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// copied from https://github.com/microsoft/vscode/blob/6261075646f055b99068d3688932416f2346dd3b/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L1069-L1185.
+
+import * as theia from '@theia/plugin';
+import * as Converter from '../type-converters';
+import { DocumentsExtImpl } from '../documents';
+import { URI } from '@theia/core/shared/vscode-uri';
+import { CommandRegistryImpl } from '../command-registry';
+import { ReferenceMap } from '../../common/reference-map';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { InlineCompletionTriggerKind as TriggerKind } from '../../plugin/types-impl';
+import { Command, InlineCompletionContext, InlineCompletionTriggerKind } from '../../common/plugin-api-rpc-model';
+import { IdentifiableInlineCompletion, IdentifiableInlineCompletions, Position } from '../../common/plugin-api-rpc';
+
+export class InlineCompletionAdapterBase {
+
+    async provideInlineCompletions(
+        _resource: URI,
+        _position: Position,
+        _context: InlineCompletionContext,
+        _token: theia.CancellationToken
+    ): Promise<IdentifiableInlineCompletions | undefined> {
+        return undefined;
+    }
+
+    disposeCompletions(pid: number): void { return; };
+}
+
+export class InlineCompletionAdapter extends InlineCompletionAdapterBase {
+
+    private readonly references = new ReferenceMap<{
+        dispose(): void;
+        items: readonly theia.InlineCompletionItem[];
+    }>();
+
+    constructor(
+        private readonly documents: DocumentsExtImpl,
+        private readonly provider: theia.InlineCompletionItemProvider,
+        private readonly commands: CommandRegistryImpl,
+    ) {
+        super();
+    }
+
+    private readonly languageTriggerKindToVSCodeTriggerKind: Record<InlineCompletionTriggerKind, TriggerKind> = {
+        [InlineCompletionTriggerKind.Automatic]: TriggerKind.Automatic,
+        [InlineCompletionTriggerKind.Explicit]: TriggerKind.Invoke,
+    };
+
+    override async provideInlineCompletions(
+        resource: URI,
+        position: Position,
+        context: InlineCompletionContext,
+        token: theia.CancellationToken
+    ): Promise<IdentifiableInlineCompletions | undefined> {
+        const doc = this.documents.getDocument(resource);
+        const pos = Converter.toPosition(position);
+
+        const result = await this.provider.provideInlineCompletionItems(doc, pos, {
+            selectedCompletionInfo:
+                context.selectedSuggestionInfo
+                    ? {
+                        range: Converter.toRange(context.selectedSuggestionInfo.range),
+                        text: context.selectedSuggestionInfo.text
+                    }
+                    : undefined,
+            triggerKind: this.languageTriggerKindToVSCodeTriggerKind[context.triggerKind]
+        }, token);
+
+        if (!result || token.isCancellationRequested) {
+            return undefined;
+        }
+
+        const normalizedResult = Array.isArray(result) ? result : result.items;
+
+        let disposableCollection: DisposableCollection | undefined = undefined;
+        const pid = this.references.createReferenceId({
+            dispose(): void {
+                disposableCollection?.dispose();
+            },
+            items: normalizedResult
+        });
+
+        return {
+            pid,
+            items: normalizedResult.map<IdentifiableInlineCompletion>((item, idx) => {
+                let command: Command | undefined = undefined;
+                if (item.command) {
+                    if (!disposableCollection) {
+                        disposableCollection = new DisposableCollection();
+                    }
+                    command = this.commands.converter.toSafeCommand(item.command, disposableCollection);
+                }
+
+                const insertText = item.insertText;
+                return ({
+                    insertText: typeof insertText === 'string' ? insertText : { snippet: insertText.value },
+                    filterText: item.filterText,
+                    range: item.range ? Converter.fromRange(item.range) : undefined,
+                    command,
+                    idx: idx
+                });
+            })
+        };
+    }
+
+    override disposeCompletions(pid: number): void {
+        const data = this.references.disposeReferenceId(pid);
+        data?.dispose();
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -159,7 +159,10 @@ import {
     TestTag,
     TestRunRequest,
     TestMessage,
-    ExtensionKind
+    ExtensionKind,
+    InlineCompletionItem,
+    InlineCompletionList,
+    InlineCompletionTriggerKind
 } from './types-impl';
 import { AuthenticationExtImpl } from './authentication-ext';
 import { SymbolKind } from '../common/plugin-api-rpc-model';
@@ -715,6 +718,9 @@ export function createAPIFactory(
             registerCompletionItemProvider(selector: theia.DocumentSelector, provider: theia.CompletionItemProvider, ...triggerCharacters: string[]): theia.Disposable {
                 return languagesExt.registerCompletionItemProvider(selector, provider, triggerCharacters, pluginToPluginInfo(plugin));
             },
+            registerInlineCompletionItemProvider(selector: theia.DocumentSelector, provider: theia.InlineCompletionItemProvider): theia.Disposable {
+                return languagesExt.registerInlineCompletionsProvider(selector, provider);
+            },
             registerDefinitionProvider(selector: theia.DocumentSelector, provider: theia.DefinitionProvider): theia.Disposable {
                 return languagesExt.registerDefinitionProvider(selector, provider, pluginToPluginInfo(plugin));
             },
@@ -1124,7 +1130,10 @@ export function createAPIFactory(
             TestTag,
             TestRunRequest,
             TestMessage,
-            ExtensionKind
+            ExtensionKind,
+            InlineCompletionItem,
+            InlineCompletionList,
+            InlineCompletionTriggerKind
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -992,6 +992,37 @@ export class CompletionList {
     }
 }
 
+export enum InlineCompletionTriggerKind {
+    Invoke = 0,
+    Automatic = 1,
+}
+
+@es5ClassCompat
+export class InlineCompletionItem implements theia.InlineCompletionItem {
+
+    filterText?: string;
+    insertText: string;
+    range?: Range;
+    command?: theia.Command;
+
+    constructor(insertText: string, range?: Range, command?: theia.Command) {
+        this.insertText = insertText;
+        this.range = range;
+        this.command = command;
+    }
+}
+
+@es5ClassCompat
+export class InlineCompletionList implements theia.InlineCompletionList {
+
+    items: theia.InlineCompletionItem[];
+    commands: theia.Command[] | undefined = undefined;
+
+    constructor(items: theia.InlineCompletionItem[]) {
+        this.items = items;
+    }
+}
+
 export enum DiagnosticSeverity {
     Error = 0,
     Warning = 1,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -8293,6 +8293,143 @@ export module '@theia/plugin' {
     }
 
     /**
+     * The inline completion item provider interface defines the contract between extensions and
+     * the inline completion feature.
+     *
+     * Providers are asked for completions either explicitly by a user gesture or implicitly when typing.
+     */
+    export interface InlineCompletionItemProvider {
+
+        /**
+         * Provides inline completion items for the given position and document.
+         * If inline completions are enabled, this method will be called whenever the user stopped typing.
+         * It will also be called when the user explicitly triggers inline completions or explicitly asks for the next or previous inline completion.
+         * In that case, all available inline completions should be returned.
+         * `context.triggerKind` can be used to distinguish between these scenarios.
+         *
+         * @param document The document inline completions are requested for.
+         * @param position The position inline completions are requested for.
+         * @param context A context object with additional information.
+         * @param token A cancellation token.
+         * @return An array of completion items or a thenable that resolves to an array of completion items.
+         */
+        provideInlineCompletionItems(document: TextDocument, position: Position, context: InlineCompletionContext, token: CancellationToken): ProviderResult<InlineCompletionItem[] | InlineCompletionList>;
+    }
+
+    /**
+     * Represents a collection of {@link InlineCompletionItem inline completion items} to be presented
+     * in the editor.
+     */
+    export class InlineCompletionList {
+        /**
+         * The inline completion items.
+         */
+        items: InlineCompletionItem[];
+
+        /**
+         * Creates a new list of inline completion items.
+         */
+        constructor(items: InlineCompletionItem[]);
+    }
+
+    /**
+     * Provides information about the context in which an inline completion was requested.
+     */
+    export interface InlineCompletionContext {
+        /**
+         * Describes how the inline completion was triggered.
+         */
+        readonly triggerKind: InlineCompletionTriggerKind;
+
+        /**
+         * Provides information about the currently selected item in the autocomplete widget if it is visible.
+         *
+         * If set, provided inline completions must extend the text of the selected item
+         * and use the same range, otherwise they are not shown as preview.
+         * As an example, if the document text is `console.` and the selected item is `.log` replacing the `.` in the document,
+         * the inline completion must also replace `.` and start with `.log`, for example `.log()`.
+         *
+         * Inline completion providers are requested again whenever the selected item changes.
+         */
+        readonly selectedCompletionInfo: SelectedCompletionInfo | undefined;
+    }
+
+    /**
+     * Describes the currently selected completion item.
+     */
+    export interface SelectedCompletionInfo {
+        /**
+         * The range that will be replaced if this completion item is accepted.
+         */
+        readonly range: Range;
+
+        /**
+         * The text the range will be replaced with if this completion is accepted.
+         */
+        readonly text: string;
+    }
+
+    /**
+     * Describes how an {@link InlineCompletionItemProvider inline completion provider} was triggered.
+     */
+    export enum InlineCompletionTriggerKind {
+        /**
+         * Completion was triggered explicitly by a user gesture.
+         * Return multiple completion items to enable cycling through them.
+         */
+        Invoke = 0,
+
+        /**
+         * Completion was triggered automatically while editing.
+         * It is sufficient to return a single completion item in this case.
+         */
+        Automatic = 1,
+    }
+
+    /**
+     * An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.
+     *
+     * @see {@link InlineCompletionItemProvider.provideInlineCompletionItems}
+     */
+    export class InlineCompletionItem {
+        /**
+         * The text to replace the range with. Must be set.
+         * Is used both for the preview and the accept operation.
+         */
+        insertText: string | SnippetString;
+
+        /**
+         * A text that is used to decide if this inline completion should be shown. When `falsy`
+         * the {@link InlineCompletionItem.insertText} is used.
+         *
+         * An inline completion is shown if the text to replace is a prefix of the filter text.
+         */
+        filterText?: string;
+
+        /**
+         * The range to replace.
+         * Must begin and end on the same line.
+         *
+         * Prefer replacements over insertions to provide a better experience when the user deletes typed text.
+         */
+        range?: Range;
+
+        /**
+         * An optional {@link Command} that is executed *after* inserting this completion.
+         */
+        command?: Command;
+
+        /**
+         * Creates a new inline completion item.
+         *
+         * @param insertText The text to replace the range with.
+         * @param range The range to replace. If not set, the word at the requested position will be used.
+         * @param command An optional {@link Command} that is executed *after* inserting this completion.
+         */
+        constructor(insertText: string | SnippetString, range?: Range, command?: Command);
+    }
+
+    /**
      * Represents a location inside a resource, such as a line
      * inside a text file.
      */
@@ -9658,6 +9795,19 @@ export module '@theia/plugin' {
          * @return A {@link Disposable disposable} that unregisters this provider when being disposed.
          */
         export function registerCompletionItemProvider(selector: DocumentSelector, provider: CompletionItemProvider, ...triggerCharacters: string[]): Disposable;
+
+        /**
+         * Registers an inline completion provider.
+         *
+         * Multiple providers can be registered for a language. In that case providers are asked in
+         * parallel and the results are merged. A failing provider (rejected promise or exception) will
+         * not cause a failure of the whole operation.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider An inline completion provider.
+         * @return A {@link Disposable} that unregisters this provider when being disposed.
+         */
+        export function registerInlineCompletionItemProvider(selector: DocumentSelector, provider: InlineCompletionItemProvider): Disposable;
 
         /**
          * Register a definition provider.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: #11868.

The pull-request adds support for the VS Code `InlineCompletions` related APIs (non-proposed):
- [`InlineCompletionItem`](https://code.visualstudio.com/api/references/vscode-api#InlineCompletionItem)
- [`InlineCompletionItemProvider`](https://code.visualstudio.com/api/references/vscode-api#InlineCompletionItemProvider)
- [`InlineCompletionList`](https://code.visualstudio.com/api/references/vscode-api#InlineCompletionList)
- [`InlineCompletionTriggerKind`](https://code.visualstudio.com/api/references/vscode-api#InlineCompletionTriggerKind)
- [`InlineCompletionContext`](https://code.visualstudio.com/api/references/vscode-api#InlineCompletionContext)
- `registerInlineCompletionItemProvider`

https://user-images.githubusercontent.com/40359487/203127679-b7e19ebb-3115-4add-916f-1701a4f06a36.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with the following https://github.com/eclipse-theia/theia/files/10059321/inline-completions-0.0.1.zip
2. open an editor
3. `hello world` should be proposed as an inline completion

```ts

import * as vscode from 'vscode';

export function activate(context: vscode.ExtensionContext) {
    const provider = createInlineCompletionItemProvider();
    vscode.languages.registerInlineCompletionItemProvider({ pattern: '**' }, provider);
}

export function deactivate() { }

function createInlineCompletionItemProvider(): vscode.InlineCompletionItemProvider {
    return {
        provideInlineCompletionItems(document, position, context, token) {
            return [{
                insertText: "hello world",
            }];
        },
    }
}
```

#### CQ

- [x] [CQ Approved](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5022)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
