### PR TITLE
nls: add localizations for preference validation

### DIFF
--- a/packages/preferences/src/browser/views/components/preference-number-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-number-input.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { nls } from '@theia/core';
 import { injectable, interfaces } from '@theia/core/shared/inversify';
 import { Preference } from '../../util/preference-types';
 import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
@@ -101,16 +102,16 @@ export class PreferenceNumberInputRenderer extends PreferenceLeafNodeRenderer<nu
         const errorMessages: string[] = [];
 
         if (input === '' || isNaN(inputValue)) {
-            return { value: NaN, message: 'Value must be a number.' };
+            return { value: NaN, message: nls.localizeByDefault('Value must be a number.') };
         }
         if (data.minimum && inputValue < data.minimum) {
-            errorMessages.push(`Value must be greater than or equal to ${data.minimum}.`);
+            errorMessages.push(nls.localizeByDefault('Value must be greater than or equal to {0}.', data.minimum));
         };
         if (data.maximum && inputValue > data.maximum) {
-            errorMessages.push(`Value must be less than or equal to ${data.maximum}.`);
+            errorMessages.push(nls.localizeByDefault('Value must be less than or equal to {0}.', data.maximum));
         };
         if (data.type === 'integer' && !Number.isInteger(inputValue)) {
-            errorMessages.push('Value must be an integer.');
+            errorMessages.push(nls.localizeByDefault('Value must be an integer.'));
         }
 
         return {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds localizations for the validation messages of numeric input fields in the preferences-view.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open the preferences-view
3. search for a numeric input field (ex: `fontSize)
4. input a string - a validation message should appear
5. use `configure display language` to switch language
6. perform the same steps again and confirm the validation message is localized

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
