### PR TITLE
Fix handling of submenu children of toolbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.33.0 - unreleased
+
+<a name="breaking_changes_1.33.0">[Breaking Changes:](#breaking_changes_1.33.0)</a>
+
+- [core] returns of many methods of `MenuModelRegistry` changed from `CompositeMenuNode` to `MutableCompoundMenuNode`. To mutate a menu, use the `updateOptions` method or add a check for `instanceof CompositeMenuNode`, which will be true in most cases.
+
 ## v1.32.0 - 11/24/2022
 
 - [application-manager] fixed various webpack warnings during the build [#11830](https://github.com/eclipse-theia/theia/pull/11830)

--- a/examples/api-samples/src/browser/menu/sample-browser-menu-module.ts
+++ b/examples/api-samples/src/browser/menu/sample-browser-menu-module.ts
@@ -17,7 +17,7 @@
 import { injectable, ContainerModule } from '@theia/core/shared/inversify';
 import { Menu as MenuWidget } from '@theia/core/shared/@phosphor/widgets';
 import { Disposable } from '@theia/core/lib/common/disposable';
-import { MenuNode, CompositeMenuNode, MenuPath } from '@theia/core/lib/common/menu';
+import { MenuNode, CompoundMenuNode, MenuPath } from '@theia/core/lib/common/menu';
 import { BrowserMainMenuFactory, MenuCommandRegistry, DynamicMenuWidget, BrowserMenuOptions } from '@theia/core/lib/browser/menu/browser-menu-plugin';
 import { PlaceholderMenuNode } from './sample-menu-contribution';
 
@@ -36,13 +36,13 @@ class SampleBrowserMainMenuFactory extends BrowserMainMenuFactory {
         }
     }
 
-    protected override createMenuCommandRegistry(menu: CompositeMenuNode, args: unknown[] = []): MenuCommandRegistry {
+    protected override createMenuCommandRegistry(menu: CompoundMenuNode, args: unknown[] = []): MenuCommandRegistry {
         const menuCommandRegistry = new SampleMenuCommandRegistry(this.services);
         this.registerMenu(menuCommandRegistry, menu, args);
         return menuCommandRegistry;
     }
 
-    override createMenuWidget(menu: CompositeMenuNode, options: BrowserMenuOptions): DynamicMenuWidget {
+    override createMenuWidget(menu: CompoundMenuNode, options: BrowserMenuOptions): DynamicMenuWidget {
         return new SampleDynamicMenuWidget(menu, options, this.services);
     }
 

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -16,7 +16,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as React from 'react';
-import { CommandRegistry, CompoundMenuNodeRole, Disposable, DisposableCollection, MenuCommandExecutor, MenuModelRegistry, MenuPath, nls } from '../../../common';
+import { CommandRegistry, Disposable, DisposableCollection, MenuCommandExecutor, MenuModelRegistry, MenuPath, nls } from '../../../common';
 import { Anchor, ContextMenuAccess, ContextMenuRenderer } from '../../context-menu-renderer';
 import { LabelIcon, LabelParser } from '../../label-parser';
 import { ACTION_ITEM, codicon, ReactWidget, Widget } from '../../widgets';
@@ -176,11 +176,11 @@ export class TabBarToolbar extends ReactWidget {
         this.addClass('menu-open');
         toDisposeOnHide.push(Disposable.create(() => this.removeClass('menu-open')));
         if (subpath) {
-            toDisposeOnHide.push(this.menus.linkSubmenu(TAB_BAR_TOOLBAR_CONTEXT_MENU, subpath, { role: CompoundMenuNodeRole.Flat, when: '' }));
+            toDisposeOnHide.push(this.menus.linkSubmenu(TAB_BAR_TOOLBAR_CONTEXT_MENU, subpath));
         } else {
             for (const item of this.more.values() as IterableIterator<AnyToolbarItem>) {
                 if (item.menuPath && !item.command) {
-                    toDisposeOnHide.push(this.menus.linkSubmenu(TAB_BAR_TOOLBAR_CONTEXT_MENU, item.menuPath, { role: CompoundMenuNodeRole.Flat, when: '' }, item.group));
+                    toDisposeOnHide.push(this.menus.linkSubmenu(TAB_BAR_TOOLBAR_CONTEXT_MENU, item.menuPath, undefined, item.group));
                 } else if (item.command) {
                     // Register a submenu for the item, if the group is in format `<submenu group>/<submenu name>/.../<item group>`
                     if (item.group?.includes('/')) {

--- a/packages/core/src/common/menu/menu-types.ts
+++ b/packages/core/src/common/menu/menu-types.ts
@@ -14,6 +14,55 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { Disposable } from '../disposable';
+
+export type MenuPath = string[];
+export const MAIN_MENU_BAR: MenuPath = ['menubar'];
+export const SETTINGS_MENU: MenuPath = ['settings_menu'];
+export const ACCOUNTS_MENU: MenuPath = ['accounts_menu'];
+export const ACCOUNTS_SUBMENU = [...ACCOUNTS_MENU, '1_accounts_submenu'];
+
+/**
+ * @internal For most use cases, refer to {@link MenuAction} or {@link MenuNode}
+ */
+export interface MenuNodeMetadata {
+    /**
+     * technical identifier.
+     */
+    readonly id: string;
+    /**
+     * Menu nodes are sorted in ascending order based on their `sortString`.
+     */
+    readonly sortString: string;
+    /**
+     * Condition under which the menu node should be rendered.
+     * See https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts
+     */
+    readonly when?: string;
+    /**
+     * A reference to the parent node - useful for determining the menu path by which the node can be accessed.
+     */
+    readonly parent?: MenuNode;
+}
+
+/**
+ * Metadata for the visual presentation of a node.
+ * @internal For most uses cases, refer to {@link MenuNode}, {@link CommandMenuNode}, or {@link CompoundMenuNode}
+ */
+export interface MenuNodeRenderingData {
+    /**
+     * Optional label. Will be rendered as text of the menu item.
+     */
+    readonly label?: string;
+    /**
+     * Icon classes for the menu node. If present, these will produce an icon to the left of the label in browser-style menus.
+     */
+    readonly icon?: string;
+}
+
+/** @internal For most use cases refer to {@link MenuNode}, {@link CommandMenuNode}, or {@link CompoundMenuNode} */
+export interface MenuNodeBase extends MenuNodeMetadata, MenuNodeRenderingData { }
+
 /**
  * A menu entry representing an action, e.g. "New File".
  */
@@ -44,50 +93,12 @@ export namespace MenuAction {
 /**
  * Additional options when creating a new submenu.
  */
-export interface SubMenuOptions extends Pick<MenuAction, 'order'>, Pick<MenuNodeMetadata, 'when'>, Partial<Pick<CompoundMenuNodeMetadata, 'role'>> {
+export interface SubMenuOptions extends Pick<MenuAction, 'order'>, Pick<MenuNodeMetadata, 'when'>, Partial<Pick<CompoundMenuNode, 'role' | 'label' | 'icon'>> {
     /**
      * The class to use for the submenu icon.
+     * @deprecated use `icon` instead;
      */
     iconClass?: string;
-}
-
-export type MenuPath = string[];
-
-export const MAIN_MENU_BAR: MenuPath = ['menubar'];
-
-export const SETTINGS_MENU: MenuPath = ['settings_menu'];
-export const ACCOUNTS_MENU: MenuPath = ['accounts_menu'];
-export const ACCOUNTS_SUBMENU = [...ACCOUNTS_MENU, '1_accounts_submenu'];
-
-export interface MenuNodeMetadata {
-    /**
-     * technical identifier.
-     */
-    readonly id: string;
-    /**
-     * Menu nodes are sorted in ascending order based on their `sortString`.
-     */
-    readonly sortString: string;
-    /**
-     * Condition under which the menu node should be rendered.
-     * See https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts
-     */
-    readonly when?: string;
-    /**
-     * A reference to the parent node - useful for determining the menu path by which the node can be accessed.
-     */
-    readonly parent?: MenuNode;
-}
-
-export interface MenuNodeRenderingData {
-    /**
-     * Optional label. Will be rendered as text of the menu item.
-     */
-    readonly label?: string;
-    /**
-     * Icon classes for the menu node. If present, these will produce an icon to the left of the label in browser-style menus.
-     */
-    readonly icon?: string;
 }
 
 export const enum CompoundMenuNodeRole {
@@ -99,15 +110,44 @@ export const enum CompoundMenuNodeRole {
     Flat,
 }
 
-export interface CompoundMenuNode {
+export interface CompoundMenuNode extends MenuNodeBase {
     /**
      * Items that are grouped under this menu.
      */
     readonly children: ReadonlyArray<MenuNode>
+    /**
+     * @deprecated @since 1.28 use `role` instead.
+     * Whether the item should be rendered as a submenu.
+     */
+    readonly isSubmenu: boolean;
+    /**
+     * How the node and its children should be rendered. See {@link CompoundMenuNodeRole}.
+     */
+    readonly role: CompoundMenuNodeRole;
+}
+
+export interface MutableCompoundMenuNode extends CompoundMenuNode {
+    /**
+     * Inserts the given node at the position indicated by `sortString`.
+     *
+     * @returns a disposable which, when called, will remove the given node again.
+     */
+    addNode(node: MenuNode): Disposable;
+    /**
+     * Removes the first node with the given id.
+     *
+     * @param id node id.
+     */
+    removeNode(id: string): void;
+
+    /**
+     * Fills any `undefined` fields with the values from the {@link options}.
+     */
+    updateOptions(options: SubMenuOptions): void;
 }
 
 export namespace CompoundMenuNode {
-    export function is(node: MenuNode): node is MenuNode & CompoundMenuNode { return Array.isArray(node.children); }
+    export function is(node?: MenuNode): node is CompoundMenuNode { return !!node && Array.isArray(node.children); }
     export function getRole(node: MenuNode): CompoundMenuNodeRole | undefined {
         if (!is(node)) { return undefined; }
         return node.role ?? (node.label ? CompoundMenuNodeRole.Submenu : CompoundMenuNodeRole.Group);
@@ -142,41 +182,37 @@ export namespace CompoundMenuNode {
      * @returns `true` when the given node is a {@link CompoundMenuNode} with id `navigation`,
      * `false` otherwise.
      */
-    export function isNavigationGroup(node: MenuNode): node is MenuNode & CompoundMenuNode {
+    export function isNavigationGroup(node: MenuNode): node is CompoundMenuNode {
         return is(node) && node.id === 'navigation';
+    }
+
+    export function isMutable(node?: MenuNode): node is MutableCompoundMenuNode {
+        const candidate = node as MutableCompoundMenuNode;
+        return is(candidate) && typeof candidate.addNode === 'function' && typeof candidate.removeNode === 'function';
     }
 }
 
-export interface CompoundMenuNodeMetadata {
-    /**
-     * @deprecated @since 1.28 use `role` instead.
-     * Whether the item should be rendered as a submenu.
-     */
-    readonly isSubmenu: boolean;
-    /**
-     * How the node and its children should be rendered. See {@link CompoundMenuNodeRole}.
-     */
-    readonly role: CompoundMenuNodeRole;
-}
-
-export interface CommandMenuNode {
+export interface CommandMenuNode extends MenuNodeBase {
     command: string;
 }
 
 export namespace CommandMenuNode {
-    export function is(candidate: MenuNode): candidate is MenuNode & CommandMenuNode { return Boolean(candidate.command); }
+    export function is(candidate: MenuNode): candidate is CommandMenuNode { return Boolean(candidate.command); }
+    export function hasAltHandler(candidate: MenuNode): candidate is AlternativeHandlerMenuNode {
+        const asAltNode = candidate as AlternativeHandlerMenuNode;
+        return is(asAltNode) && is(asAltNode.altNode);
+    }
 }
 
-export interface AlternativeHandlerMenuNode {
-    altNode: MenuNodeMetadata & MenuNodeRenderingData & CommandMenuNode;
+export interface AlternativeHandlerMenuNode extends CommandMenuNode {
+    altNode: CommandMenuNode;
 }
 
 /**
  * Base interface of the nodes used in the menu tree structure.
  */
-export interface MenuNode extends MenuNodeMetadata,
-    MenuNodeRenderingData,
-    Partial<CompoundMenuNode>,
-    Partial<CommandMenuNode>,
-    Partial<CompoundMenuNodeMetadata>,
-    Partial<AlternativeHandlerMenuNode> { }
+export type MenuNode = MenuNodeMetadata
+    & MenuNodeRenderingData
+    & Partial<CompoundMenuNode>
+    & Partial<CommandMenuNode>
+    & Partial<AlternativeHandlerMenuNode>;

--- a/packages/core/src/common/menu/menu-types.ts
+++ b/packages/core/src/common/menu/menu-types.ts
@@ -197,10 +197,10 @@ export interface CommandMenuNode extends MenuNodeBase {
 }
 
 export namespace CommandMenuNode {
-    export function is(candidate: MenuNode): candidate is CommandMenuNode { return Boolean(candidate.command); }
-    export function hasAltHandler(candidate: MenuNode): candidate is AlternativeHandlerMenuNode {
+    export function is(candidate?: MenuNode): candidate is CommandMenuNode { return Boolean(candidate?.command); }
+    export function hasAltHandler(candidate?: MenuNode): candidate is AlternativeHandlerMenuNode {
         const asAltNode = candidate as AlternativeHandlerMenuNode;
-        return is(asAltNode) && is(asAltNode.altNode);
+        return is(asAltNode) && is(asAltNode?.altNode);
     }
 }
 

--- a/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
@@ -28,7 +28,7 @@ import { CommentsService } from './comments-service';
 import {
     ActionMenuNode,
     CommandRegistry,
-    CompositeMenuNode,
+    CompoundMenuNode,
     MenuModelRegistry,
     MenuPath
 } from '@theia/core/lib/common';
@@ -52,7 +52,7 @@ export class CommentThreadWidget extends BaseWidget {
     protected readonly zoneWidget: MonacoEditorZoneWidget;
     protected readonly containerNodeRoot: Root;
     protected readonly commentGlyphWidget: CommentGlyphWidget;
-    protected readonly contextMenu: CompositeMenuNode;
+    protected readonly contextMenu: CompoundMenuNode;
     protected readonly commentFormRef: RefObject<CommentForm> = React.createRef<CommentForm>();
 
     protected isExpanded?: boolean;
@@ -316,7 +316,7 @@ namespace CommentForm {
 }
 
 export class CommentForm<P extends CommentForm.Props = CommentForm.Props> extends React.Component<P, CommentForm.State> {
-    private readonly menu: CompositeMenuNode;
+    private readonly menu: CompoundMenuNode;
     private inputRef: RefObject<HTMLTextAreaElement> = React.createRef<HTMLTextAreaElement>();
     private inputValue: string = '';
     private readonly getInput = () => this.inputValue;
@@ -619,7 +619,7 @@ namespace CommentActions {
     export interface Props {
         contextKeyService: CommentsContextKeyService;
         commands: CommandRegistry;
-        menu: CompositeMenuNode;
+        menu: CompoundMenuNode;
         commentThread: CommentThread;
         getInput: () => string;
         clearInput: () => void;

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -23,7 +23,7 @@ import { isOSX } from '@theia/core/lib/common/os';
 import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
 import { TreeWidget, TreeNode, SelectableTreeNode, TreeModel, TreeProps, NodeProps, TREE_NODE_SEGMENT_CLASS, TREE_NODE_SEGMENT_GROW_CLASS } from '@theia/core/lib/browser/tree';
 import { ScmTreeModel, ScmFileChangeRootNode, ScmFileChangeGroupNode, ScmFileChangeFolderNode, ScmFileChangeNode } from './scm-tree-model';
-import { MenuModelRegistry, ActionMenuNode, CompositeMenuNode, MenuPath } from '@theia/core/lib/common/menu';
+import { MenuModelRegistry, ActionMenuNode, CompoundMenuNode, MenuPath } from '@theia/core/lib/common/menu';
 import { ScmResource } from './scm-provider';
 import { CommandRegistry } from '@theia/core/lib/common/command';
 import { ContextMenuRenderer, LabelProvider, CorePreferences, DiffUris, ACTION_ITEM } from '@theia/core/lib/browser';
@@ -762,7 +762,7 @@ export class ScmInlineActions extends React.Component<ScmInlineActions.Props> {
 export namespace ScmInlineActions {
     export interface Props {
         hover: boolean;
-        menu: CompositeMenuNode;
+        menu: CompoundMenuNode;
         commands: CommandRegistry;
         model: ScmTreeModel;
         treeNode: TreeNode;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes the error reported [here](https://github.com/eclipse-theia/theia/issues/11730#issuecomment-1318819598), but does not register the menus at the heart of #11730.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Install the Git builtin.
2. Open the `...` menu on the SCM view container.
3. You should see a group of menus like this:

![image](https://user-images.githubusercontent.com/62660806/203427830-31712f6d-5355-40f0-8a18-abadd16cf1fd.png)

Or, without the `@theia/git` package:

![image](https://user-images.githubusercontent.com/62660806/203426801-d2113474-4756-4ece-8088-44dddbc99619.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
