### PR TITLE
Prioritize TreeView label provider

### DIFF
--- a/packages/core/src/browser/icon-theme-service.ts
+++ b/packages/core/src/browser/icon-theme-service.ts
@@ -67,7 +67,7 @@ export class NoneIconTheme implements IconTheme, LabelProviderContribution {
         if (this.toDeactivate.disposed) {
             return 0;
         }
-        return Number.MAX_SAFE_INTEGER;
+        return Number.MAX_SAFE_INTEGER - 1024;
     }
 
     getIcon(): string {

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -369,7 +369,7 @@ export class LabelProvider implements FrontendApplicationContribution {
     protected handleRequest(element: object, method: keyof Omit<LabelProviderContribution, 'canHandle' | 'onDidChange' | 'affects'>): string | undefined {
         for (const contribution of this.findContribution(element, method)) {
             const value = contribution[method]?.(element);
-            if (!!value) {
+            if (value !== undefined) {
                 return value;
             }
         }

--- a/packages/plugin-ext/src/main/browser/view/plugin-tree-view-node-label-provider.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-tree-view-node-label-provider.ts
@@ -34,7 +34,7 @@ export class PluginTreeViewNodeLabelProvider implements LabelProviderContributio
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     canHandle(element: TreeViewNode | any): number {
         if (TreeNode.is(element) && ('resourceUri' in element || 'themeIcon' in element)) {
-            return this.treeLabelProvider.canHandle(element) + 1;
+            return Number.MAX_SAFE_INTEGER - 512;
         }
         return 0;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR reverts #11889 and instead increases the priority assigned to the `PluginTreeViewNodeLabelProvider` for handling TreeView nodes and decreases the priority assigned to the `NoneIconService`. This ensures that icons assigned directly on nodes will be respected, and for icons representing files, the `PluginTreeViewNodeLabelProvider` still delegates to the `LabelProvider` for URI's, so it will still respect the `none` file icon setting.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
