### PR TITLE
Added sticky scroll view toggle and command toggle

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -151,6 +151,14 @@ export namespace EditorCommands {
         label: 'Toggle Word Wrap'
     });
     /**
+     * Command that toggles sticky scroll.
+     */
+    export const TOGGLE_STICKY_SCROLL = Command.toLocalizedCommand({
+        id: 'editor.action.toggleStickyScroll',
+        category: CommonCommands.VIEW_CATEGORY,
+        label: 'Toggle Sticky Scroll',
+    }, 'theia/editor/toggleStickyScroll', EDITOR_CATEGORY_KEY);
+    /**
      * Command that re-opens the last closed editor.
      */
     export const REOPEN_CLOSED_EDITOR = Command.toDefaultLocalizedCommand({
@@ -265,6 +273,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.TOGGLE_MINIMAP);
         registry.registerCommand(EditorCommands.TOGGLE_RENDER_WHITESPACE);
         registry.registerCommand(EditorCommands.TOGGLE_WORD_WRAP);
+        registry.registerCommand(EditorCommands.TOGGLE_STICKY_SCROLL);
         registry.registerCommand(EditorCommands.REOPEN_CLOSED_EDITOR);
 
         registry.registerCommand(CommonCommands.AUTO_SAVE, {

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -173,6 +173,10 @@ export class EditorMenuContribution implements MenuContribution {
             commandId: EditorCommands.TOGGLE_RENDER_WHITESPACE.id,
             order: '3'
         });
+        registry.registerMenuAction(CommonMenus.VIEW_TOGGLE, {
+            commandId: EditorCommands.TOGGLE_STICKY_SCROLL.id,
+            order: '4'
+        });
         registry.registerMenuAction(CommonMenus.FILE_CLOSE, {
             commandId: CommonCommands.CLOSE_MAIN_TAB.id,
             label: nls.localizeByDefault('Close Editor'),

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -100,6 +100,11 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             execute: () => this.toggleWordWrap(),
             isEnabled: () => true,
         });
+        this.commandRegistry.registerHandler(EditorCommands.TOGGLE_STICKY_SCROLL.id, {
+            execute: () => this.toggleStickyScroll(),
+            isEnabled: () => true,
+            isToggled: () => this.isStickyScrollEnabled()
+        });
         this.commandRegistry.registerHandler(EditorCommands.REOPEN_CLOSED_EDITOR.id, {
             execute: () => this.reopenLastClosedEditor()
         });
@@ -186,6 +191,14 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
         if (index > -1) {
             this.preferenceService.set('editor.wordWrap', values[index % values.length], PreferenceScope.User);
         }
+    }
+
+    /**
+     * Toggle the display of sticky scroll in the editor.
+     */
+    protected async toggleStickyScroll(): Promise<void> {
+        const value: boolean | undefined = this.preferenceService.get('editor.stickyScroll.enabled');
+        this.preferenceService.set('editor.stickyScroll.enabled', !value, PreferenceScope.User);
     }
 
     /**
@@ -312,4 +325,7 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
         return !!this.preferenceService.get(EditorNavigationContribution.MOUSE_NAVIGATION_PREFERENCE);
     }
 
+    private isStickyScrollEnabled(): boolean {
+        return !!this.preferenceService.get('editor.stickyScroll.enabled');
+    }
 }


### PR DESCRIPTION
#### What it does
Aligned the support for the sticky scroll toggle in view and command as per VS Code API

#### How to test

For View:
1.	Go into View menu
2.	Scroll down and find the toggle sticky scroll and click on it (to activate or disactivate)
For Command:
1.	Type Ctrl + Shift + P (command menu)
2.	In the command menu Type Toggle Sticky Scroll
3.	Select Toggle Sticky Scroll


https://user-images.githubusercontent.com/113064863/204298653-3d5d63d5-fb57-4cd7-a0a8-423e2662be9a.mp4


https://user-images.githubusercontent.com/113064863/204298678-063a8876-2723-4f22-9d71-bf4ec3251b64.mp4



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
