### PR TITLE
fix #11932: add missing localization for disassembly-view title

### DIFF
--- a/packages/debug/src/browser/disassembly-view/disassembly-view-widget.ts
+++ b/packages/debug/src/browser/disassembly-view/disassembly-view-widget.ts
@@ -82,7 +82,7 @@ export class DisassemblyViewWidget extends BaseWidget {
         this.id = DisassemblyViewWidget.ID;
         this.addClass(DisassemblyViewWidget.ID);
         this.title.closable = true;
-        this.title.label = 'Disassembly';
+        this.title.label = nls.localize('theia/debug/disassembly-view/disassembly', 'Disassembly');
         const updateIcon = () => this.title.iconClass = this.labelProvider.getIcon(this.iconReferenceUri) + ' file-icon';
         updateIcon();
         this.toDispose.push(this.labelProvider.onDidChange(updateIcon));
@@ -461,4 +461,3 @@ export class DisassemblyViewWidget extends BaseWidget {
         return disposable;
     }
 }
-


### PR DESCRIPTION
#### What it does
FIxed a simple missing localization key for the `disassembly-view` title.
#### How to test
Copied from https://github.com/eclipse-theia/theia/issues/11932:
> Steps to Reproduce:
> If you want to test that the label is not localized you can:
> 
> follow the steps from https://github.com/eclipse-theia/theia/pull/11186
> install a language pack through configure display language
> confirm that the label is only in english

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
