### PR TITLE
ci: replace `xvfb` action

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -105,15 +105,13 @@ jobs:
 
       - name: Test (browser)
         if: matrix.tests != 'skip' && runner.os == 'Linux'
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: yarn browser test
+        run: |
+          xvfb-run -a yarn browser test
 
       - name: Test (electron)
         if: matrix.tests != 'skip' && runner.os == 'Linux'
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: yarn electron test
+        run: |
+          xvfb-run -a yarn electron test
 
   publish:
     needs: build


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates our gh workflow to remove the deprecated `GabrielBB/xvfb-action@v1` in favor of the default `xvfb` provided by the `ubuntu-latest` runner. The previous action did not seem to be actively maintained, and was using Node 12 which GitHub marked as deprecated.

The following annotations should be fixed as a result:

![image](https://user-images.githubusercontent.com/40359487/205334265-08bf1854-f2a6-486e-845a-5e694f93e479.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Confirm that CI passes
- Confirm that there are no annotations on the summary page regarding deprecated actions (ex: [summary](https://github.com/eclipse-theia/theia/actions/runs/3603224983))

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
