### PR TITLE
debug: fix `watch` expression errors

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -204,6 +204,11 @@
     margin: auto;
 }
 
+.theia-debug-console-variable .watch-error {
+    font-style: italic;
+    color: var(--theia-debugConsole-errorForeground);
+}
+
 /** Editor **/
 
 .theia-debug-breakpoint-icon {

--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -24,6 +24,7 @@ import { nls } from '@theia/core';
 export class DebugWatchExpression extends ExpressionItem {
 
     readonly id: number;
+    protected isError: boolean;
 
     constructor(protected readonly options: {
         id: number,
@@ -40,9 +41,12 @@ export class DebugWatchExpression extends ExpressionItem {
         await super.evaluate('watch');
     }
 
-    protected override setResult(body?: DebugProtocol.EvaluateResponse['body']): void {
-        // overridden to ignore error
-        super.setResult(body);
+    protected override setResult(body?: DebugProtocol.EvaluateResponse['body'], error?: string): void {
+        if (!this.options.session()) {
+            return;
+        }
+        super.setResult(body, error);
+        this.isError = !!error;
         this.options.onDidChange();
     }
 
@@ -50,7 +54,7 @@ export class DebugWatchExpression extends ExpressionItem {
         return <div className='theia-debug-console-variable'>
             <div className={TREE_NODE_SEGMENT_GROW_CLASS}>
                 <span title={this.type || this._expression} className='name'>{this._expression}: </span>
-                <span title={this._value} ref={this.setValueRef}>{this._value}</span>
+                <span title={this._value} ref={this.setValueRef} className={this.isError ? 'watch-error' : ''}>{this._value}</span>
             </div>
             <div className={codicon('close', true)} title={nls.localizeByDefault('Remove Expression')} onClick={this.options.remove} />
         </div>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes https://github.com/eclipse-theia/theia/issues/11950.

The pull-request updates handling for `watch` expressions to respect the error message rather than hardcode one.
The changes also align the styling with VS Code.

![watch-fix](https://user-images.githubusercontent.com/40359487/205659919-fd1b6f9e-9cae-4482-bcdb-ec0a5348c447.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with theia as a workspace
2. open a `*.spec.ts` file
3. set a breakpoint in the file and trigger the `run mocha tests` debug configuration
4. attempt to create `watch` expressions with variables that are known and unknown
5. known expressions should work
6. unknown expressions should display a proper error message

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
