### PR TITLE
Allow to remove watch expressions one by one

### DIFF
--- a/packages/core/src/browser/source-tree/source-tree-widget.tsx
+++ b/packages/core/src/browser/source-tree/source-tree-widget.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { injectable, postConstruct, interfaces, Container } from 'inversify';
 import { DisposableCollection } from '../../common/disposable';
-import { TreeWidget, TreeNode, createTreeContainer, TreeProps, TreeModel } from '../tree';
+import { TreeWidget, TreeNode, createTreeContainer, TreeProps, TreeModel, TREE_NODE_SEGMENT_GROW_CLASS } from '../tree';
 import { TreeSource, TreeElement } from './tree-source';
 import { SourceTree, TreeElementNode, TreeSourceNode } from './source-tree';
 
@@ -86,7 +86,7 @@ export class SourceTreeWidget extends TreeWidget {
         return undefined;
     }
     protected createTreeElementNodeClassNames(node: TreeElementNode): string[] {
-        return ['theia-tree-element-node'];
+        return [TREE_NODE_SEGMENT_GROW_CLASS];
     }
 
     override storeState(): object {

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -171,10 +171,6 @@
     opacity: var(--theia-mod-disabled-opacity);
 }
 
-.theia-tree-element-node {
-    width: 100%
-}
-
 .theia-tree-node-indent {
     position: absolute;
     height: var(--theia-content-line-height);

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -195,6 +195,15 @@
     color: var(--theia-variable-name-color);
 }
 
+.theia-TreeNode:not(:hover) .theia-debug-console-variable .action-label {
+    visibility: hidden;
+}
+
+.theia-debug-console-variable .action-label {
+    /* Vertically center the button in the tree node */
+    margin: auto;
+}
+
 /** Editor **/
 
 .theia-debug-breakpoint-icon {

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -169,7 +169,7 @@
 }
 
 .theia-debug-console-variable {
-    width: 100%;
+    display: flex;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/debug/src/browser/view/debug-view-model.ts
+++ b/packages/debug/src/browser/view/debug-view-model.ts
@@ -165,11 +165,12 @@ export class DebugViewModel implements Disposable {
     }
 
     async addWatchExpression(expression: string = ''): Promise<DebugWatchExpression | undefined> {
-        const watchExpression = new DebugWatchExpression({
+        const watchExpression: DebugWatchExpression = new DebugWatchExpression({
             id: Number.MAX_SAFE_INTEGER,
             expression,
             session: () => this.currentSession,
-            onDidChange: () => { /* no-op */ }
+            remove: () => this.removeWatchExpression(watchExpression),
+            onDidChange: () => { /* no-op */ },
         });
         await watchExpression.open();
         if (!watchExpression.expression) {
@@ -194,10 +195,11 @@ export class DebugViewModel implements Disposable {
             toRemove.delete(id);
             if (!this._watchExpressions.has(id)) {
                 added = true;
-                const watchExpression = new DebugWatchExpression({
+                const watchExpression: DebugWatchExpression = new DebugWatchExpression({
                     id,
                     expression,
                     session: () => this.currentSession,
+                    remove: () => this.removeWatchExpression(watchExpression),
                     onDidChange: () => this.fireDidChangeWatchExpressions()
                 });
                 this._watchExpressions.set(id, watchExpression);

--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -18,6 +18,8 @@ import * as React from '@theia/core/shared/react';
 import { SingleTextInputDialog } from '@theia/core/lib/browser/dialogs';
 import { ExpressionItem, DebugSessionProvider } from '../console/debug-console-items';
 import { DebugProtocol } from '@vscode/debugprotocol';
+import { codicon, TREE_NODE_SEGMENT_GROW_CLASS } from '@theia/core/lib/browser';
+import { nls } from '@theia/core';
 
 export class DebugWatchExpression extends ExpressionItem {
 
@@ -27,6 +29,7 @@ export class DebugWatchExpression extends ExpressionItem {
         id: number,
         expression: string,
         session: DebugSessionProvider,
+        remove: () => void,
         onDidChange: () => void
     }) {
         super(options.expression, options.session);
@@ -45,9 +48,12 @@ export class DebugWatchExpression extends ExpressionItem {
 
     override render(): React.ReactNode {
         return <div className='theia-debug-console-variable'>
-            <span title={this.type || this._expression} className='name'>{this._expression}: </span>
-            <span title={this._value} ref={this.setValueRef}>{this._value}</span>
-        </div >;
+            <div className={TREE_NODE_SEGMENT_GROW_CLASS}>
+                <span title={this.type || this._expression} className='name'>{this._expression}: </span>
+                <span title={this._value} ref={this.setValueRef}>{this._value}</span>
+            </div>
+            <div className={codicon('close', true)} title={nls.localizeByDefault('Remove Expression')} onClick={this.options.remove} />
+        </div>;
     }
 
     async open(): Promise<void> {


### PR DESCRIPTION
#### What it does

I noticed in https://github.com/eclipse-theia/theia/pull/11953 that watch expressions can only be removed in bulk. This change aligns the UX to vscode, where users are able to remove watched expressions one by one.

Also fixes an existing issue where watched expressions which evaluate to an object result in an overflow:

![image](https://user-images.githubusercontent.com/4377073/205694196-bfa7bf36-76e0-481f-a2a0-067a6f2f672b.png)


#### How to test

1. Start debugging a Test in Theia
2. Add multiple watched expressions
3. Confirm that they can be removed one by one

![image](https://user-images.githubusercontent.com/4377073/205693491-7bf8ff14-d35c-406d-9793-d9b756a21d31.png)

I believe the `theia-tree-element-node` css class is reused in the debug console to display evaluated expressions. Assert that no regressions appeared due to my changes.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
