### PR TITLE
Fix tab top border

### DIFF
--- a/packages/core/src/browser/common-styling-participants.ts
+++ b/packages/core/src/browser/common-styling-participants.ts
@@ -200,7 +200,7 @@ export class TabbarStylingParticipant implements StylingParticipant {
             #theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
                 color: var(--theia-tab-activeForeground);
                 ${tabActiveBackground && `background: ${tabActiveBackground};`}
-                box-shadow: 0 1px 0 ${tabActiveBorderTop}, 0 -1px 0 ${tabActiveBorder} inset;
+                box-shadow: 0 1px 0 ${tabActiveBorderTop} inset, 0 -1px 0 ${tabActiveBorder} inset;
             }
         `);
         // Hover Background


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11616. Apparently an `inset` was missing...

#### How to test

Follow the steps outlined in https://github.com/eclipse-theia/theia/issues/11616, assert that the tab top border is visible.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
