### PR TITLE
Use client side rate limiting for plugin download

### DIFF
--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -44,6 +44,7 @@
     "chalk": "4.0.0",
     "decompress": "^4.2.1",
     "glob": "^8.0.3",
+    "limiter": "^2.1.0",
     "log-update": "^4.0.0",
     "mocha": "^10.1.0",
     "puppeteer": "^2.0.0",

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -343,7 +343,12 @@ async function theiaCli(): Promise<void> {
                 'parallel': {
                     describe: 'Download in parallel',
                     boolean: true,
-                    default: false
+                    default: true
+                },
+                'rate-limit': {
+                    describe: 'Amount of maximum open-vsx requests per second',
+                    number: true,
+                    default: 15
                 },
                 'proxy-url': {
                     describe: 'Proxy URL'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7485,6 +7485,11 @@ just-extend@^4.0.2:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
+just-performance@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/just-performance/-/just-performance-4.3.0.tgz#cc2bc8c9227f09e97b6b1df4cd0de2df7ae16db1"
+  integrity sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q==
+
 keytar@7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/keytar/-/keytar-7.2.0.tgz#4db2bec4f9700743ffd9eda22eebb658965c8440"
@@ -7598,6 +7603,13 @@ libnpmpublish@^6.0.4:
     npm-registry-fetch "^13.0.0"
     semver "^7.3.7"
     ssri "^9.0.0"
+
+limiter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-2.1.0.tgz#d38d7c5b63729bb84fb0c4d8594b7e955a5182a2"
+  integrity sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw==
+  dependencies:
+    just-performance "4.3.0"
 
 line-height@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
#### What it does

Related to https://github.com/eclipse-theia/theia/pull/11860. The publicly managed open-vsx instance is using a rate limiting of 15 requests per second (yielding a `429` status code on too many requests). This change introduces a rate limiter that limits the amount of requests that we send per second to 15, while also handling the `429` status code a bit better.

It also reinstates the parallel-by-default behavior of the plugin download command, which was changed in https://github.com/eclipse-theia/theia/pull/11860. Additionally provides a CLI argument to change the rate limit.


#### How to test

0. The CI should not fail due to 429 errors even though parallel plugin downloads are enabled
1. Delete your `plugins` folder.
2. Run `yarn download:plugins --rate-limit=x` with different values for `x`
3. Assert that the rate limit is applied and the command doesn't return with the 429 http error

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
