### PR TITLE
Handle file system permissions

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -31,7 +31,7 @@ import { IconThemeService } from '../icon-theme-service';
 import { BreadcrumbsRenderer, BreadcrumbsRendererFactory } from '../breadcrumbs/breadcrumbs-renderer';
 import { NavigatableWidget } from '../navigatable-types';
 import { IDragEvent } from '@phosphor/dragdrop';
-import { PINNED_CLASS } from '../widgets/widget';
+import { LOCKED_CLASS, PINNED_CLASS } from '../widgets/widget';
 import { CorePreferences } from '../core-preferences';
 import { HoverService } from '../hover-service';
 
@@ -178,7 +178,8 @@ export class TabBarRenderer extends TabBar.Renderer {
                 { className: 'theia-tab-icon-label' },
                 this.renderIcon(data, isInSidePanel),
                 this.renderLabel(data, isInSidePanel),
-                this.renderBadge(data, isInSidePanel)
+                this.renderBadge(data, isInSidePanel),
+                this.renderLock(data, isInSidePanel)
             ),
             h.div({
                 className: 'p-TabBar-tabCloseIcon action-label',
@@ -273,6 +274,12 @@ export class TabBarRenderer extends TabBar.Renderer {
         return isInSidePanel
             ? h.div({ className: 'theia-badge-decorator-sidebar' }, `${limitedBadge}`)
             : h.div({ className: 'theia-badge-decorator-horizontal' }, `${limitedBadge}`);
+    }
+
+    renderLock(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
+        return !isInSidePanel && data.title.className.includes(LOCKED_CLASS)
+            ? h.div({ className: 'p-TabBar-tabLock' })
+            : h.div({});
     }
 
     protected readonly decorations = new Map<Title<Widget>, WidgetDecoration.Data[]>();

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -173,6 +173,18 @@
     background: none;
 }
 
+.p-TabBar-tabLock:after {
+    content: "\ebe7";
+    opacity: 0.75;
+    margin-left: 4px;
+    color: inherit;
+    font-family: codicon;
+    font-size: 16px;
+    font-weight: normal;
+    display: inline-block;
+    vertical-align: top;
+}
+
 /* file icons */
 .p-TabBar[data-orientation='horizontal'] .p-TabBar-tabIcon.file-icon,
 .p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon.file-icon {

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -53,6 +53,7 @@ export const CODICON_LOADING_CLASSES = codiconArray('loading');
 export const SELECTED_CLASS = 'theia-mod-selected';
 export const FOCUS_CLASS = 'theia-mod-focus';
 export const PINNED_CLASS = 'theia-mod-pinned';
+export const LOCKED_CLASS = 'theia-mod-locked';
 export const DEFAULT_SCROLL_OPTIONS: PerfectScrollbar.Options = {
     suppressScrollX: true,
     minScrollbarLength: 35,
@@ -368,6 +369,12 @@ export function pin(title: Title<Widget>): void {
     title.closable = false;
     if (!title.className.includes(PINNED_CLASS)) {
         title.className += ` ${PINNED_CLASS}`;
+    }
+}
+
+export function lock(title: Title<Widget>): void {
+    if (!title.className.includes(LOCKED_CLASS)) {
+        title.className += ` ${LOCKED_CLASS}`;
     }
 }
 

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -55,6 +55,7 @@ export interface Resource extends Disposable {
      * Undefined if a resource did not read content yet.
      */
     readonly encoding?: string | undefined;
+    readonly isReadonly?: boolean;
     /**
      * Reads latest content of this resource.
      *

--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
-import { SelectionService } from '@theia/core/lib/common';
+import { nls, SelectionService } from '@theia/core/lib/common';
 import { NavigatableWidgetOptions, WidgetFactory, LabelProvider } from '@theia/core/lib/browser';
 import { EditorWidget } from './editor-widget';
 import { TextEditorProvider } from './editor';
@@ -72,6 +72,9 @@ export class EditorWidgetFactory implements WidgetFactory {
 
     private setLabels(editor: EditorWidget, uri: URI): void {
         editor.title.caption = uri.path.fsPath();
+        if (editor.editor.isReadonly) {
+            editor.title.caption += ` • ${nls.localize('theia/editor/readOnly', 'Read Only')}`;
+        }
         const icon = this.labelProvider.getIcon(uri);
         editor.title.label = this.labelProvider.getName(uri);
         editor.title.iconClass = icon + ' file-icon';

--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -73,6 +73,7 @@ export class EditorWidgetFactory implements WidgetFactory {
     private setLabels(editor: EditorWidget, uri: URI): void {
         editor.title.caption = uri.path.fsPath();
         if (editor.editor.isReadonly) {
+            // nls-todo: 'Read Only' be available with newer VSCode API
             editor.title.caption += ` • ${nls.localize('theia/editor/readOnly', 'Read Only')}`;
         }
         const icon = this.labelProvider.getIcon(uri);

--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { Disposable, SelectionService, Event, UNTITLED_SCHEME } from '@theia/core/lib/common';
-import { Widget, BaseWidget, Message, Saveable, SaveableSource, Navigatable, StatefulWidget } from '@theia/core/lib/browser';
+import { Widget, BaseWidget, Message, Saveable, SaveableSource, Navigatable, StatefulWidget, lock } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { TextEditor } from './editor';
 
@@ -27,6 +27,9 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
     ) {
         super(editor);
         this.addClass('theia-editor');
+        if (editor.isReadonly) {
+            lock(this.title);
+        }
         this.toDispose.push(this.editor);
         this.toDispose.push(this.editor.onSelectionChanged(() => this.setSelection()));
         this.toDispose.push(this.editor.onFocusChanged(() => this.setSelection()));

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -196,6 +196,7 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
     readonly node: HTMLElement;
 
     readonly uri: URI;
+    readonly isReadonly: boolean;
     readonly document: TextEditorDocument;
     readonly onDocumentContentChanged: Event<TextDocumentChangeEvent>;
 

--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -61,6 +61,9 @@ export class FileResource implements Resource {
     get encoding(): string | undefined {
         return this._version?.encoding;
     }
+    get isReadonly(): boolean {
+        return this.options.isReadonly || this.fileService.hasCapability(this.uri, FileSystemProviderCapabilities.Readonly);
+    }
 
     constructor(
         readonly uri: URI,
@@ -217,7 +220,7 @@ export class FileResource implements Resource {
     saveContents?: Resource['saveContents'];
     saveContentChanges?: Resource['saveContentChanges'];
     protected updateSavingContentChanges(): void {
-        if (this.options.isReadonly || this.fileService.hasCapability(this.uri, FileSystemProviderCapabilities.Readonly)) {
+        if (this.isReadonly) {
             delete this.saveContentChanges;
             delete this.saveContents;
             delete this.saveStream;

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -426,6 +426,16 @@ export class FileService {
         return !!(provider && (provider.capabilities & capability));
     }
 
+    /**
+     * List the schemes and capabilities for registered file system providers
+     */
+    listCapabilities(): { scheme: string; capabilities: FileSystemProviderCapabilities }[] {
+        return Array.from(this.providers.entries()).map(([scheme, provider]) => ({
+            scheme,
+            capabilities: provider.capabilities
+        }));
+    }
+
     protected async withProvider(resource: URI): Promise<FileSystemProvider> {
         // Assert path is absolute
         if (!resource.path.isAbsolute) {

--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -235,6 +235,11 @@ export interface FileStat extends BaseStat {
     isSymbolicLink: boolean;
 
     /**
+     * The resource is read only.
+     */
+    isReadonly: boolean;
+
+    /**
      * The children of the file stat or undefined if none.
      */
     children?: FileStat[];
@@ -277,6 +282,7 @@ export namespace FileStat {
             isFile: (stat.type & FileType.File) !== 0,
             isDirectory: (stat.type & FileType.Directory) !== 0,
             isSymbolicLink: (stat.type & FileType.SymbolicLink) !== 0,
+            isReadonly: !!stat.permissions && (stat.permissions & FilePermission.Readonly) !== 0,
             mtime: stat.mtime,
             ctime: stat.ctime,
             size: stat.size,
@@ -485,6 +491,14 @@ export enum FileType {
     SymbolicLink = 64
 }
 
+export enum FilePermission {
+
+    /**
+     * File is readonly.
+     */
+    Readonly = 1
+}
+
 export interface Stat {
     type: FileType;
 
@@ -499,6 +513,8 @@ export interface Stat {
     ctime: number;
 
     size: number;
+
+    permissions?: FilePermission;
 }
 
 export interface WatchOptions {

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -220,6 +220,10 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
         return this.onDocumentContentChangedEmitter.event;
     }
 
+    get isReadonly(): boolean {
+        return this.document.isReadonly();
+    }
+
     get cursor(): Position {
         const { lineNumber, column } = this.editor.getPosition()!;
         return this.m2p.asPosition(lineNumber, column);

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1829,6 +1829,7 @@ export interface DebugMain {
 }
 
 export interface FileSystemExt {
+    $acceptProviderInfos(scheme: string, capabilities?: files.FileSystemProviderCapabilities): void;
     $stat(handle: number, resource: UriComponents): Promise<files.Stat>;
     $readdir(handle: number, resource: UriComponents): Promise<[string, files.FileType][]>;
     $readFile(handle: number, resource: UriComponents): Promise<BinaryBuffer>;

--- a/packages/plugin-ext/src/plugin/file-system-ext-impl.ts
+++ b/packages/plugin-ext/src/plugin/file-system-ext-impl.ts
@@ -207,7 +207,7 @@ export class FileSystemExtImpl implements FileSystemExt {
     private _linkProviderRegistration?: IDisposable;
     private _handlePool: number = 0;
 
-    readonly fileSystem: ConsumerFileSystem;
+    readonly fileSystem: vscode.FileSystem;
 
     constructor(rpc: RPCProtocol, private _extHostLanguageFeatures: LanguagesExtImpl) {
         this._proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.FILE_SYSTEM_MAIN);

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -201,6 +201,7 @@ import { CustomEditorsExtImpl } from './custom-editors';
 import { WebviewViewsExtImpl } from './webview-views';
 import { PluginPackage } from '../common';
 import { Endpoint } from '@theia/core/lib/browser/endpoint';
+import { FilePermission } from '@theia/filesystem/lib/common/files';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -599,8 +600,8 @@ export function createAPIFactory(
             registerTextDocumentContentProvider(scheme: string, provider: theia.TextDocumentContentProvider): theia.Disposable {
                 return workspaceExt.registerTextDocumentContentProvider(scheme, provider);
             },
-            registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider): theia.Disposable {
-                return fileSystemExt.registerFileSystemProvider(scheme, provider);
+            registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider, options?: { isCaseSensitive?: boolean, isReadonly?: boolean }): theia.Disposable {
+                return fileSystemExt.registerFileSystemProvider(scheme, provider, options);
             },
             getWorkspaceFolder(uri: theia.Uri): theia.WorkspaceFolder | undefined {
                 return workspaceExt.getWorkspaceFolder(uri);
@@ -1065,6 +1066,7 @@ export function createAPIFactory(
             WorkspaceEdit,
             SymbolInformation,
             FileType,
+            FilePermission,
             FileChangeType,
             ShellQuoting,
             ShellExecution,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5961,6 +5961,18 @@ export module '@theia/plugin' {
         SymbolicLink = 64
     }
 
+    export enum FilePermission {
+        /**
+         * The file is readonly.
+         *
+         * *Note:* All `FileStat` from a `FileSystemProvider` that is registered with
+         * the option `isReadonly: true` will be implicitly handled as if `FilePermission.Readonly`
+         * is set. As a consequence, it is not possible to have a readonly file system provider
+         * registered where some `FileStat` are not readonly.
+         */
+        Readonly = 1
+    }
+
     /**
      * The `FileStat`-type represents metadata about a file
      */
@@ -5992,6 +6004,12 @@ export module '@theia/plugin' {
          * example.
          */
         size: number;
+        /**
+         * The permissions of the file, e.g. whether the file is readonly.
+         *
+         * *Note:* This value might be a bitmask, e.g. `FilePermission.Readonly | FilePermission.Other`.
+         */
+        permissions?: FilePermission;
     }
 
     /**
@@ -6301,6 +6319,21 @@ export module '@theia/plugin' {
          * @param options Defines if existing files should be overwritten.
          */
         copy(source: Uri, target: Uri, options?: { overwrite?: boolean }): Thenable<void>;
+
+        /**
+         * Check if a given file system supports writing files.
+         *
+         * Keep in mind that just because a file system supports writing, that does
+         * not mean that writes will always succeed. There may be permissions issues
+         * or other errors that prevent writing a file.
+         *
+         * @param scheme The scheme of the filesystem, for example `file` or `git`.
+         *
+         * @return `true` if the file system supports writing, `false` if it does not
+         * support writing (i.e. it is readonly), and `undefined` if the editor does not
+         * know about the filesystem.
+         */
+        isWritableFileSystem(scheme: string): boolean | undefined;
     }
 
     /**

--- a/packages/property-view/src/browser/resource-property-view/resource-property-data-service.spec.ts
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-data-service.spec.ts
@@ -39,6 +39,7 @@ const mockFileStat: FileStat = {
     isFile: false,
     isDirectory: true,
     isSymbolicLink: false,
+    isReadonly: false,
     resource: new URI('resource'),
     name: 'name'
 };

--- a/packages/workspace/src/browser/workspace-commands.spec.ts
+++ b/packages/workspace/src/browser/workspace-commands.spec.ts
@@ -48,6 +48,7 @@ describe('workspace-commands', () => {
         isFile: true,
         isDirectory: false,
         isSymbolicLink: false,
+        isReadonly: false,
         resource: new URI('foo/bar'),
         name: 'bar',
     };
@@ -56,6 +57,7 @@ describe('workspace-commands', () => {
         isFile: false,
         isDirectory: true,
         isSymbolicLink: false,
+        isReadonly: false,
         resource: new URI('foo'),
         name: 'foo',
         children: [


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11509
Closes https://github.com/eclipse-theia/theia/issues/199

This was more work than initially expected. It seems like we didn't handle readonly editors at all previously (see https://github.com/eclipse-theia/theia/issues/199). So this change not only adds the file system permissions extension API, but also enables us to pass permission information all the way to the monaco model and phosphor tabbars.

#### How to test

1. Download and install [this test extension](https://github.com/eclipse-theia/theia/files/10171750/fs-readonly-0.0.1.zip)
2. Run the 4 contributed `Open file from file system` commands. They should all result in read only editors except for the one that opens the `mutable-in-mutable` file.
3. Readonly editors should be marked as such (a lock icon) and should behave that way (i.e. the document is not editable).
4. Run the `Check file system isWritableFileSystem` command. Input different URI schemes which then displays a notification containing the result of the `isWritableFileSystem` call. The extension contributes the `readonly` and `mutable` file system schemes, which should return `false`/`true` respectively. Calls to `file` should also return `true`. Everything else should return `undefined`, unless contributed by an extension or plugin.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
