### PR TITLE
Explorer: added styling for nodes at root

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -862,7 +862,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             } else {
                 classNames.push(renderIndentGuides === 'onHover' ? 'hover' : 'always');
             }
-            const paddingLeft = this.props.leftPadding * depth;
+            const paddingLeft = this.getDepthPadding(depth);
             indentDivs.unshift(<div key={depth} className={classNames.join(' ')} style={{
                 paddingLeft: `${paddingLeft}px`
             }} />);
@@ -969,7 +969,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     protected getPaddingLeft(node: TreeNode, props: NodeProps): number {
-        return props.depth * this.props.leftPadding + (this.needsExpansionTogglePadding(node) ? this.props.expansionTogglePadding : 0);
+        return this.getDepthPadding(props.depth) + (this.needsExpansionTogglePadding(node) ? this.props.expansionTogglePadding : 0);
     }
 
     /**
@@ -1419,7 +1419,9 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected toNodeDescription(node: TreeNode): string {
         return this.labelProvider.getLongName(node);
     }
-
+    protected getDepthPadding(depth: number): number {
+        return depth * this.props.leftPadding;
+    }
 }
 export namespace TreeWidget {
     /**

--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -315,4 +315,8 @@ export class FileTreeWidget extends CompressedTreeWidget {
         return inflated;
     }
 
+    protected override getDepthPadding(depth: number): number {
+        // add additional depth so file nodes are rendered with padding in relation to the top level root node.
+        return super.getDepthPadding(depth + 1);
+    }
 }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11896.

The pull-request updates the rendering of nodes in `FileTreeWidget` by including additional depth padding to help differentiate nodes from the top-level root.

#### How to test

1. start the application with 'theia' as workspace
2. open the explorer and confirm that nodes (directories and files) at the root of the workspace have padding
3. confirm that expanding directories works correctly
4. confirm that the indent guide for the tree works correctly
5. confirm that other `FileTreeWidget` or extensions of the tree work correctly

<details>

<summary>Videos</summary>

<br />

https://user-images.githubusercontent.com/113064863/206200758-3671c632-9928-42cb-8799-3f0db99cc374.mp4

https://user-images.githubusercontent.com/113064863/206195981-fef90060-54e2-4380-b7a1-e573677e7819.mp4

</details>

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
