### PR TITLE
Remove unncessary use of RPCProtocol. Fixes #11970

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -17,7 +17,7 @@
 import { Terminal, RendererType } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
-import { ContributionProvider, Disposable, Event, Emitter, ILogger, DisposableCollection, RpcProtocol, RequestHandler } from '@theia/core';
+import { ContributionProvider, Disposable, Event, Emitter, ILogger, DisposableCollection, Channel } from '@theia/core';
 import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop, KeyCode, codicon, ExtractableWidget } from '@theia/core/lib/browser';
 import { isOSX } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -66,7 +66,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     protected searchBox: TerminalSearchWidget;
     protected restored = false;
     protected closeOnDispose = true;
-    protected waitForConnection: Deferred<RpcProtocol> | undefined;
+    protected waitForConnection: Deferred<Channel> | undefined;
     protected linkHover: HTMLDivElement;
     protected linkHoverButton: HTMLAnchorElement;
     protected lastTouchEnd: TouchEvent | undefined;
@@ -563,23 +563,18 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         }
         this.toDisposeOnConnect.dispose();
         this.toDispose.push(this.toDisposeOnConnect);
-        const waitForConnection = this.waitForConnection = new Deferred<RpcProtocol>();
+        const waitForConnection = this.waitForConnection = new Deferred<Channel>();
         this.webSocketConnectionProvider.listen({
             path: `${terminalsPath}/${this.terminalId}`,
             onConnection: connection => {
-                const requestHandler: RequestHandler = _method => this.logger.warn('Received an unhandled RPC request from the terminal process');
-
-                const rpc = new RpcProtocol(connection, requestHandler);
-                rpc.onNotification(event => {
-                    if (event.method === 'onData') {
-                        this.write(event.args[0]);
-                    }
+                connection.onMessage(e => {
+                    this.write(e().readString());
                 });
 
                 // Excludes the device status code emitted by Xterm.js
                 const sendData = (data?: string) => {
                     if (data && !this.deviceStatusCodes.has(data) && !this.disableEnterWhenAttachCloseListener()) {
-                        return rpc.sendRequest('write', [data]);
+                        connection.getWriteBuffer().writeString(data).commit();
                     }
                 };
 
@@ -590,7 +585,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 connection.onClose(() => disposable.dispose());
 
                 if (waitForConnection) {
-                    waitForConnection.resolve(rpc);
+                    waitForConnection.resolve(connection);
                 }
             }
         }, { reconnecting: false });
@@ -664,7 +659,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     sendText(text: string): void {
         if (this.waitForConnection) {
             this.waitForConnection.promise.then(connection =>
-                connection.sendRequest('write', [text])
+                connection.getWriteBuffer().writeString(text).commit()
             );
         }
     }

--- a/packages/terminal/src/node/buffering-stream.spec.ts
+++ b/packages/terminal/src/node/buffering-stream.spec.ts
@@ -16,12 +16,12 @@
 
 import { wait } from '@theia/core/lib/common/promise-util';
 import { expect } from 'chai';
-import { BufferingStream } from './buffering-stream';
+import { BufferBufferingStream } from './buffering-stream';
 
 describe('BufferringStream', () => {
 
     it('should emit whatever data was buffered before the timeout', async () => {
-        const buffer = new BufferingStream({ emitInterval: 1000 });
+        const buffer = new BufferBufferingStream({ emitInterval: 1000 });
         const chunkPromise = waitForChunk(buffer);
         buffer.push(Buffer.from([0]));
         await wait(100);
@@ -33,14 +33,14 @@ describe('BufferringStream', () => {
     });
 
     it('should not emit chunks bigger than maxChunkSize', async () => {
-        const buffer = new BufferingStream({ maxChunkSize: 2 });
+        const buffer = new BufferBufferingStream({ maxChunkSize: 2 });
         buffer.push(Buffer.from([0, 1, 2, 3, 4, 5]));
         expect(await waitForChunk(buffer)).deep.eq(Buffer.from([0, 1]));
         expect(await waitForChunk(buffer)).deep.eq(Buffer.from([2, 3]));
         expect(await waitForChunk(buffer)).deep.eq(Buffer.from([4, 5]));
     });
 
-    function waitForChunk(buffer: BufferingStream): Promise<Buffer> {
+    function waitForChunk(buffer: BufferBufferingStream): Promise<Buffer> {
         return new Promise(resolve => buffer.onData(resolve));
     }
 });


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <t.s.maeder@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #11970
Removes the unnecessary use of a `RPCProtocol` instance to communicate with shell processes in terminals. 

Contributed on behalf of ST Microelectronics


#### How to test
Open terminals and make sure they work as usual. Tested on Windows 11. It might be interesting to test this on OSX and Linux. I've made sure performance is not significantly affected for large, fast output. For example, you can output the contents of large files in the terminal.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
