### PR TITLE
Fixed QuickInput behavior on Enter

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -338,7 +338,10 @@ export class MonacoQuickInputService implements QuickInputService {
                         options.onDidAccept();
                     }
                     wrapped.hide();
-                    resolve(wrapped.selectedItems[0]);
+                    const firstSelectedElement = wrapped.selectedItems[0];
+                    const firstElement = wrapped.items.find(i => !QuickPickSeparator.is(i)) as T | undefined;
+                    const result = firstSelectedElement || firstElement;
+                    resolve(result);
                 });
 
                 wrapped.onDidHide(() => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

It fixes https://github.com/eclipse-theia/theia/issues/11979. When clicking enter the first element of a QuickInput is picked by default.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a git-versioned project with Theia
1. Click on the branch name in the status bar (the QuickInput to choose the branch to checkout is presented, first element of the list is "create new branch...")
1. Press Enter. the first element is selected by default.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
