### PR TITLE
Use file system path for copy commands

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -737,7 +737,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             execute: async uris => {
                 if (uris.length) {
                     const lineDelimiter = isWindows ? '\r\n' : '\n';
-                    const text = uris.map(resource => resource.path).join(lineDelimiter);
+                    const text = uris.map(resource => resource.path.fsPath()).join(lineDelimiter);
                     await this.clipboardService.writeText(text);
                 } else {
                     await this.messageService.info('Open a file first to copy its path');

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -316,9 +316,9 @@ export class WorkspaceCommandContribution implements CommandContribution {
                 const text = uris.map((uri: URI) => {
                     const workspaceRoot = this.workspaceService.getWorkspaceRootUri(uri);
                     if (workspaceRoot) {
-                        return workspaceRoot.relative(uri);
+                        return workspaceRoot.relative(uri)?.fsPath();
                     } else {
-                        return uri.path;
+                        return uri.path.fsPath();
                     }
                 }).join(lineDelimiter);
                 await this.clipboardService.writeText(text);
@@ -425,7 +425,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
 
     protected trimFileName(name: string): string {
         if (name && name.length > 30) {
-            return `${name.substr(0, 30)}...`;
+            return `${name.substring(0, 30)}...`;
         }
         return name;
     }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/8098

#### How to test

1. Open Theia on Windows (either browser or Electron)
2. Use the `Copy Path` and `Copy Relative Path` commands from the context menu of the navigator
3. Assert that the clipboard contains valid Windows file paths. (e.g. `C:\user\file.txt` instead of `/c:/user/file.txt`).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
