### PR TITLE
plugin: fix `notebook` stubs

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -1075,7 +1075,7 @@ export function createAPIFactory(
                         notebook: theia.NotebookDocument,
                         controller: theia.NotebookController
                     ): (void | Thenable<void>) { },
-                    onDidChangeSelectedNotebooks: ({} as theia.Event<{ readonly notebook: theia.NotebookDocument; readonly selected: boolean }>),
+                    onDidChangeSelectedNotebooks: () => Disposable.create(() => {}),
                     updateNotebookAffinity: (notebook: theia.NotebookDocument, affinity: theia.NotebookControllerAffinity) => undefined,
                     dispose: () => undefined,
                 };
@@ -1086,8 +1086,8 @@ export function createAPIFactory(
             ) {
                 return {
                     rendererId,
-                    onDidReceiveMessage: ({} as theia.Event<{ readonly editor: theia.NotebookEditor; readonly message: any }>),
-                    postMessage: (message: any, editor?: theia.NotebookEditor) => ({} as Thenable<boolean>),
+                    onDidReceiveMessage: () => Disposable.create(() => {} ),
+                    postMessage: () => Promise.resolve({}),
                 };
             },
             registerNotebookCellStatusBarItemProvider(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/pull/11993#issuecomment-1355024235.

The pull-request fixes some stubs from the `notebook` API which prevented extensions from activating and producing errors.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test extension ([vscode-github-issue-notebooks-0.0.130.zip](https://github.com/eclipse-theia/theia/files/10247270/vscode-github-issue-notebooks-0.0.130.zip))
2. start the application
3. execute the command "New GitHub Issue Notebook"
4. confirm that the extension activates and does not produce an error notification
5. confirm on master that the same steps will produce an error

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>