### PR TITLE
Fix the problem that the pseudo-terminal open event is not triggered

### DIFF
--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -39,7 +39,7 @@ export class TasksExtImpl implements TasksExt {
     private adaptersMap = new Map<number, TaskProviderAdapter>();
     private executions = new Map<number, theia.TaskExecution>();
     protected callbackIdBase: string = UUID.uuid4();
-    protected callbackId: number;
+    protected callbackId: number = 0;
     protected customExecutionIds: Map<ExecutionCallback, string> = new Map();
     protected customExecutionFunctions: Map<string, ExecutionCallback> = new Map();
     protected lastStartedTask: number | undefined;

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -158,8 +158,8 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
             terminal.deferredProcessId = new Deferred<number>();
             terminal.deferredProcessId.resolve(processId);
         }
-        // Pseudoterminal is keyed on ID
-        const pseudoTerminal = this._pseudoTerminals.get(id);
+        // Pseudoterminal is keyed on ID or terminalId
+        const pseudoTerminal = this._pseudoTerminals.get(id) || this._pseudoTerminals.get(terminalId.toString());
         if (pseudoTerminal) {
             pseudoTerminal.emitOnOpen(cols, rows);
         }


### PR DESCRIPTION
#### What it does
Fix the problem that the pseudo-terminal open event of the custom task is not triggered

#### How to test
1. install the following test extension [task-provider-samples-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/10253713/task-provider-samples-0.0.1.vsix.zip) (build form [task-provider-sample](https://github.com/microsoft/vscode-extension-samples/blob/main/task-provider-sample/README.md))
2. Open any workspace and create a Rakefile empty file
3. Run task, and select "custombuildscript: 32 incremental" task to run
4. The pseudo-terminal open event is not triggered and the task is not running

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

