### PR TITLE
Added localization for debug level selector

### DIFF
--- a/packages/core/src/common/severity.ts
+++ b/packages/core/src/common/severity.ts
@@ -20,6 +20,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DiagnosticSeverity } from 'vscode-languageserver-protocol';
+import { nls } from '../common';
 
 export enum Severity {
     Ignore = 0,
@@ -29,13 +30,13 @@ export enum Severity {
     Log = 4
 }
 
-export namespace Severity {
-    const error = 'Errors';
-    const warning = 'Warnings';
-    const info = 'Info';
-    const log = 'Log';
-    const ignore = 'All';
+const error = 'Errors';
+const warning = 'Warnings';
+const info = 'Info';
+const log = 'Log';
+const ignore = 'All';
 
+export namespace Severity {
     export function fromValue(value: string | undefined): Severity {
         value = value && value.toLowerCase();
 
@@ -88,6 +89,19 @@ export namespace Severity {
             default:
                 return ignore;
         }
+    }
+
+    export function toLocaleString(severity: string | Severity): string {
+        if (severity === Severity.Error || severity === error)
+            return nls.localize('theia/core/severity/errors', 'Errors');
+        else if (severity === Severity.Warning || severity === warning)
+            return nls.localize('theia/core/severity/warnings', 'Warnings');
+        else if (severity === Severity.Info || severity === info)
+            return nls.localize('theia/core/severity/info', 'Info');
+        else if (severity === Severity.Log || severity === log)
+            return nls.localize('theia/core/severity/log', 'Log');
+        else
+            return nls.localize('theia/core/severity/all', 'All');
     }
 
     export function toArray(): string[] {

--- a/packages/core/src/common/severity.ts
+++ b/packages/core/src/common/severity.ts
@@ -20,7 +20,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DiagnosticSeverity } from 'vscode-languageserver-protocol';
-import { nls } from '../common';
+import { nls } from './nls';
 
 export enum Severity {
     Ignore = 0,
@@ -92,16 +92,17 @@ export namespace Severity {
     }
 
     export function toLocaleString(severity: string | Severity): string {
-        if (severity === Severity.Error || severity === error)
+        if (severity === Severity.Error || severity === error) {
             return nls.localize('theia/core/severity/errors', 'Errors');
-        else if (severity === Severity.Warning || severity === warning)
+        } else if (severity === Severity.Warning || severity === warning) {
             return nls.localize('theia/core/severity/warnings', 'Warnings');
-        else if (severity === Severity.Info || severity === info)
-            return nls.localize('theia/core/severity/info', 'Info');
-        else if (severity === Severity.Log || severity === log)
+        } else if (severity === Severity.Info || severity === info) {
+            return nls.localizeByDefault('Info');
+        } else if (severity === Severity.Log || severity === log) {
             return nls.localize('theia/core/severity/log', 'Log');
-        else
+        } else {
             return nls.localize('theia/core/severity/all', 'All');
+        }
     }
 
     export function toArray(): string[] {

--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -183,7 +183,8 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
 
     protected renderSeveritySelector(widget: Widget | undefined): React.ReactNode {
         const severityElements: SelectOption[] = Severity.toArray().map(e => ({
-            value: e
+            value: e,
+            label: Severity.toLocaleString(e)
         }));
 
         return <SelectComponent


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11973.

Adds localization support for debug console severity.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

* Start theia and open folder
* Create js file and write different log calls (`console.error('My Error'); console.info('My Info');`
* Add `debugger;` call or set breakpoint
* Start debugger for created js file
* Open debug console view
* Write some js call and press enter (in my case debug console was empty until some call was made from console)
* Switch debug levels, it will show messages with chosen level

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
