### PR TITLE
added a max height and overflow to select-dropdown

### DIFF
--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -47,6 +47,7 @@
     outline: var(--theia-focusBorder) solid 1px;
     outline-offset: -1px;
     user-select: none;
+    overflow: auto;
 }
 
 .theia-select-component-dropdown .theia-select-component-option {

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -317,6 +317,7 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             bottom: invert ? clientRect.top + clientRect.height - this.state.dimensions.top : 'none',
             left: this.state.dimensions.left,
             width: Math.min(calculatedWidth, maxWidth),
+            maxHeight: clientRect.height - (invert ? clientRect.height - this.state.dimensions.bottom : this.state.dimensions.top) - this.state.dimensions.height,
             position: 'absolute'
         }}>
             {items}

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -53,6 +53,7 @@ export const SELECT_COMPONENT_CONTAINER = 'select-component-container';
 export class SelectComponent extends React.Component<SelectComponentProps, SelectComponentState> {
     protected dropdownElement: HTMLElement;
     protected fieldRef = React.createRef<HTMLDivElement>();
+    protected dropdownRef = React.createRef<HTMLDivElement>();
     protected mountedListeners: Map<string, EventListenerOrEventListenerObject> = new Map();
     protected optimalWidth = 0;
     protected optimalHeight = 0;
@@ -124,8 +125,10 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
     }
 
     protected attachListeners(): void {
-        const hide = () => {
-            this.hide();
+        const hide = (event: MouseEvent) => {
+            if (!this.dropdownRef.current?.contains(event.target as Node)) {
+                this.hide();
+            }
         };
         this.mountedListeners.set('scroll', hide);
         this.mountedListeners.set('wheel', hide);
@@ -319,7 +322,7 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             width: Math.min(calculatedWidth, maxWidth),
             maxHeight: clientRect.height - (invert ? clientRect.height - this.state.dimensions.bottom : this.state.dimensions.top) - this.state.dimensions.height,
             position: 'absolute'
-        }}>
+        }} ref={this.dropdownRef}>
             {items}
         </div>;
     }


### PR DESCRIPTION
auto to the select-component-dropdown,
so that the dropdown can't get bigger than the

Signed-off-by: Jonah Iden <jonah.iden@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes: #11991 .
Added a default "overflow: auto" and a max-height to the select-component dropdown. The max-height is calculated so that the dropdown is never outside of the visible area (clientRect).

#### How to test

Best way to test is probably adding a lot of debug configurations to the launch.json. Then in the debug window the configuration dropdown should on go to the bottom of the page and have a scrollbar. 
For the inverted state i testet it thorugh the preferences (Terminal › Integrated: Font Weight Bold is a good select-box for that) by making the browser very small. 
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
