### PR TITLE
Added static RefactorMove to CodeActionKind

### DIFF
--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1555,6 +1555,7 @@ export class CodeActionKind {
     public static readonly Refactor = CodeActionKind.Empty.append('refactor');
     public static readonly RefactorExtract = CodeActionKind.Refactor.append('extract');
     public static readonly RefactorInline = CodeActionKind.Refactor.append('inline');
+    public static readonly RefactorMove = CodeActionKind.Refactor.append('move');
     public static readonly RefactorRewrite = CodeActionKind.Refactor.append('rewrite');
     public static readonly Source = CodeActionKind.Empty.append('source');
     public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9180,6 +9180,18 @@ export module '@theia/plugin' {
         static readonly RefactorInline: CodeActionKind;
 
         /**
+         * Base kind for refactoring inline actions: `refactor.inline`
+         *
+         * Example inline actions:
+         *
+         * - Inline function
+         * - Inline variable
+         * - Inline constant
+         * - ...
+         */
+        static readonly RefactorMove: CodeActionKind;
+
+        /**
          * Base kind for refactoring rewrite actions: `refactor.rewrite`
          *
          * Example rewrite actions:

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9180,14 +9180,13 @@ export module '@theia/plugin' {
         static readonly RefactorInline: CodeActionKind;
 
         /**
-         * Base kind for refactoring inline actions: `refactor.inline`
+         * Base kind for refactoring inline actions: `refactor.move`
          *
-         * Example inline actions:
+         * Example move actions:
          *
-         * - Inline function
-         * - Inline variable
-         * - Inline constant
-         * - ...
+         * - Move a function to a new file
+         * - Move a property between classes
+         * - Move method to base class
          */
         static readonly RefactorMove: CodeActionKind;
 


### PR DESCRIPTION
Signed-off-by: Jonah Iden <jonah.iden@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This fixes issue #12021

This PR adds a new static field RefactorKind to CodeActionKind  according to the vscode api. 

i hope i didn't overlooI any mor implementation for it. Though i couldn't find any more this static field itself in the vscode source.

#### How to test
create local vscode plugin for theia and see that new Field is available.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)