### PR TITLE
added localization to "preparing download" Message;

### DIFF
--- a/packages/core/i18n/nls.de.json
+++ b/packages/core/i18n/nls.de.json
@@ -180,6 +180,8 @@
     },
     "filesystem": {
       "copyDownloadLink": "Download-Link kopieren",
+      "prepareDownloadLink": "Download-Link wird vorbereitet...",
+      "prepareDownload": "Download wird vorbereitet...",
       "dialog": {
         "initialLocation": "Zum Ausgangsort gehen",
         "multipleItemMessage": "Sie können nur ein Element auswählen",

--- a/packages/core/i18n/nls.json
+++ b/packages/core/i18n/nls.json
@@ -179,6 +179,8 @@
       }
     },
     "filesystem": {
+      "prepareDownloadLink": "Preparing download link...",
+      "prepareDownload": "Preparing download...",
       "copyDownloadLink": "Copy Download Link",
       "dialog": {
         "initialLocation": "Go To Initial Location",

--- a/packages/core/i18n/nls.json
+++ b/packages/core/i18n/nls.json
@@ -179,8 +179,6 @@
       }
     },
     "filesystem": {
-      "prepareDownloadLink": "Preparing download link...",
-      "prepareDownload": "Preparing download...",
       "copyDownloadLink": "Copy Download Link",
       "dialog": {
         "initialLocation": "Go To Initial Location",

--- a/packages/core/src/common/message-service-protocol.ts
+++ b/packages/core/src/common/message-service-protocol.ts
@@ -16,6 +16,7 @@
 
 import { injectable } from 'inversify';
 import { CancellationToken } from './cancellation';
+import { nls } from './nls';
 
 export const messageServicePath = '/services/messageService';
 
@@ -52,7 +53,7 @@ export interface ProgressMessage extends Message {
     readonly options?: ProgressMessageOptions;
 }
 export namespace ProgressMessage {
-    export const Cancel = 'Cancel';
+    export const Cancel = nls.localizeByDefault('Cancel');
     export function isCancelable(message: ProgressMessage): boolean {
         return !!message.options?.cancelable;
     }

--- a/packages/filesystem/src/browser/download/file-download-service.ts
+++ b/packages/filesystem/src/browser/download/file-download-service.ts
@@ -21,6 +21,7 @@ import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { FileDownloadData } from '../../common/download/file-download-data';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { addClipboardListener } from '@theia/core/lib/browser/widgets';
+import { nls } from '@theia/core';
 
 @injectable()
 export class FileDownloadService {
@@ -53,9 +54,13 @@ export class FileDownloadService {
         }
         const copyLink = options && options.copyLink ? true : false;
         try {
+            const text: string = copyLink ?
+                nls.localize('theia/filesystem/prepareDownloadLink', 'Preparing download link...') :
+                nls.localize('theia/filesystem/prepareDownload', 'Preparing download...');
             const [progress, result] = await Promise.all([
                 this.messageService.showProgress({
-                    text: `Preparing download${copyLink ? ' link' : ''}...`, options: { cancelable: true }
+                    text: text,
+                    options: { cancelable: true }
                 }, () => { cancel = true; }),
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 new Promise<{ response: Response, jsonResponse: any }>(async resolve => {


### PR DESCRIPTION
Also added translations for newly localized values for german and english

Signed-off-by: Jonah Iden <jonah.iden@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This fixes issue #11988
adds localization to the in the picture marked texts. Also added german translation for these.
![grafik](https://user-images.githubusercontent.com/34068281/210817128-24c7dcf5-a07f-4d1b-95ba-2d08d92557c1.png)


#### How to test
(copied from issue)
1.     start the browser application (the download command is not available on electron) with theia as a workpace
2.     execute F1 > Configure Display Language, install a new language-pack, and restart the application
3.     open the explorer
4.     attempt to download a big resource (ex: node_modules) by right-clicking the directory and choosing the "download" command (will be localized)
5.     confirm that the progress notification is not localized


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
