### PR TITLE
focus out possible again for debug configuration

### DIFF
--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -388,7 +388,6 @@ export class DebugConfigurationManager {
         }
         const root = await this.quickPickService.show(items, {
             placeholder: nls.localize('theia/debug/addConfigurationPlaceholder', 'Select workspace root to add configuration to'),
-            ignoreFocusOut: true
         });
         return root?.value;
     }

--- a/packages/debug/src/browser/view/debug-configuration-select.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-select.tsx
@@ -103,7 +103,7 @@ export class DebugConfigurationSelect extends React.Component<DebugConfiguration
         if (!value) {
             return false;
         } else if (value === DebugConfigurationSelect.ADD_CONFIGURATION) {
-            this.manager.addConfiguration();
+            setTimeout(() => this.manager.addConfiguration());
         } else if (value.startsWith(DebugConfigurationSelect.PICK)) {
             const providerType = this.parsePickValue(value);
             this.selectDynamicConfigFromQuickPick(providerType);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
fixes #11992

this makes the call to configurationManager.addConfiguration() execute after react has closed the dropdown. Through this it's possible to remove the prevous ignoreFocusOut fix and make it possible again to click outside of the quick select to cancel it.

#### How to test
1. have at least 2 roots in your workspace
2. go to the debug view
3. open debug select and "Add Configuration"
4. quick select for which root to choose should open (and not close instantly again)
5. click outside and see it cancels the action.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
