### PR TITLE
vscode: add support for `valueSelection` in `InputBox`

### DIFF
--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -582,7 +582,7 @@ export class InputBoxExt extends QuickInputExt implements theia.InputBox {
     }
 
     set valueSelection(valueSelection: readonly [number, number] | undefined) {
-        this._valueSelection = valueSelection ?? [0, this.value.length];
+        this._valueSelection = valueSelection;
         this.update({ valueSelection });
     }
 

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -543,7 +543,7 @@ export class InputBoxExt extends QuickInputExt implements theia.InputBox {
 
     private _password: boolean;
     private _prompt: string | undefined;
-    private _valueSelection: readonly [number, number]
+    private _valueSelection: readonly [number, number];
     private _validationMessage: string | undefined;
 
     constructor(

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -582,8 +582,8 @@ export class InputBoxExt extends QuickInputExt implements theia.InputBox {
     }
 
     set valueSelection(valueSelection: readonly [number, number] | undefined) {
-        this._valueSelection = valueSelection ? valueSelection : [0, this.value.length]
-        this.update({ valueSelection })
+        this._valueSelection = valueSelection ? valueSelection : [0, this.value.length];
+        this.update({ valueSelection });
     }
 
     get validationMessage(): string | undefined {

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -582,7 +582,7 @@ export class InputBoxExt extends QuickInputExt implements theia.InputBox {
     }
 
     set valueSelection(valueSelection: readonly [number, number] | undefined) {
-        this._valueSelection = valueSelection ? valueSelection : [0, this.value.length];
+        this._valueSelection = valueSelection ?? [0, this.value.length];
         this.update({ valueSelection });
     }
 

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -543,7 +543,7 @@ export class InputBoxExt extends QuickInputExt implements theia.InputBox {
 
     private _password: boolean;
     private _prompt: string | undefined;
-    private _valueSelection: readonly [number, number];
+    private _valueSelection: readonly [number, number] | undefined;
     private _validationMessage: string | undefined;
 
     constructor(
@@ -577,7 +577,7 @@ export class InputBoxExt extends QuickInputExt implements theia.InputBox {
         this.update({ prompt });
     }
 
-    get valueSelection(): readonly [number, number] {
+    get valueSelection(): readonly [number, number] | undefined {
         return this._valueSelection;
     }
 

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -543,6 +543,7 @@ export class InputBoxExt extends QuickInputExt implements theia.InputBox {
 
     private _password: boolean;
     private _prompt: string | undefined;
+    private _valueSelection: readonly [number, number]
     private _validationMessage: string | undefined;
 
     constructor(
@@ -574,6 +575,15 @@ export class InputBoxExt extends QuickInputExt implements theia.InputBox {
     set prompt(prompt: string | undefined) {
         this._prompt = prompt;
         this.update({ prompt });
+    }
+
+    get valueSelection(): readonly [number, number] {
+        return this._valueSelection;
+    }
+
+    set valueSelection(valueSelection: readonly [number, number] | undefined) {
+        this._valueSelection = valueSelection ? valueSelection : [0, this.value.length]
+        this.update({ valueSelection })
     }
 
     get validationMessage(): string | undefined {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5377,7 +5377,6 @@ export module '@theia/plugin' {
          */
         password: boolean;
 
-
         /**
          * Selection range in the input value. Defined as tuple of two number where the
          * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole
@@ -5388,7 +5387,6 @@ export module '@theia/plugin' {
          * but it can be updated by the extension.
          */
         valueSelection: readonly [number, number];
-
 
         /**
          * An event signaling when the value has changed.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5386,7 +5386,7 @@ export module '@theia/plugin' {
          * This property does not get updated when the user types or makes a selection,
          * but it can be updated by the extension.
          */
-        valueSelection: readonly [number, number];
+        valueSelection: readonly [number, number] | undefined;
 
         /**
          * An event signaling when the value has changed.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5377,6 +5377,19 @@ export module '@theia/plugin' {
          */
         password: boolean;
 
+
+        /**
+         * Selection range in the input value. Defined as tuple of two number where the
+         * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole
+         * pre-filled value will be selected, when empty (start equals end) only the cursor will be set,
+         * otherwise the defined range will be selected.
+         *
+         * This property does not get updated when the user types or makes a selection,
+         * but it can be updated by the extension.
+         */
+        valueSelection: readonly [number, number];
+
+
         /**
          * An event signaling when the value has changed.
          */

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5377,7 +5377,6 @@ export module '@theia/plugin' {
          */
         password: boolean;
 
-
         /**
          * Selection range in the input value. Defined as tuple of two number where the
          * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole
@@ -5388,7 +5387,6 @@ export module '@theia/plugin' {
          * but it can be updated by the extension.
          */
         valueSelection: readonly [number, number];
-
 
         /**
          * Selection range in the input value. Defined as tuple of two number where the

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5377,6 +5377,19 @@ export module '@theia/plugin' {
          */
         password: boolean;
 
+
+        /**
+         * Selection range in the input value. Defined as tuple of two number where the
+         * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole
+         * pre-filled value will be selected, when empty (start equals end) only the cursor will be set,
+         * otherwise the defined range will be selected.
+         *
+         * This property does not get updated when the user types or makes a selection,
+         * but it can be updated by the extension.
+         */
+        valueSelection: readonly [number, number];
+
+
         /**
          * Selection range in the input value. Defined as tuple of two number where the
          * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5389,17 +5389,6 @@ export module '@theia/plugin' {
         valueSelection: readonly [number, number];
 
         /**
-         * Selection range in the input value. Defined as tuple of two number where the
-         * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole
-         * pre-filled value will be selected, when empty (start equals end) only the cursor will be set,
-         * otherwise the defined range will be selected.
-         *
-         * This property does not get updated when the user types or makes a selection,
-         * but it can be updated by the extension.
-         */
-        valueSelection: readonly [number, number];
-
-        /**
          * An event signaling when the value has changed.
          */
         readonly onDidChangeValue: Event<string>;


### PR DESCRIPTION
Signed-off-by: Jonah Iden <jonah.iden@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes: #12016.

it adds a new field to the InputBox with which a specific range of text from the InputBox can be slected

#### How to test
i build a small vscode extension for testing found here: https://github.com/jonah-iden/inputBox-ValueSelection-test
and as vsix  [value-selection-test-0.0.1.zip](https://github.com/eclipse-theia/theia/files/10373489/value-selection-test-0.0.1.zip)

it just opens up a input box which selects all text until the firs space character when the text is changed

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
