### PR TITLE
core: fix displaying for large `ConfirmDialog` dialogs

### DIFF
--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { QuickInputService } from '@theia/core/lib/browser';
+import { ConfirmDialog, QuickInputService } from '@theia/core/lib/browser';
 import {
     Command, CommandContribution, CommandRegistry, MAIN_MENU_BAR,
     MenuContribution, MenuModelRegistry, MenuNode, MessageService, SubMenuOptions
@@ -29,6 +29,10 @@ const SampleCommand2: Command = {
     id: 'sample-command2',
     label: 'Sample Command2'
 };
+const SampleCommandConfirmDialog: Command = {
+    id: 'sample-command-confirm-dialog',
+    label: 'Sample Confirm Dialog'
+}
 const SampleCommandWithProgressMessage: Command = {
     id: 'sample-command-with-progress',
     label: 'Sample Command With Progress Message'
@@ -61,6 +65,18 @@ export class SampleCommandContribution implements CommandContribution {
         commands.registerCommand(SampleCommand2, {
             execute: () => {
                 alert('This is sample command2!');
+            }
+        });
+        commands.registerCommand(SampleCommandConfirmDialog, {
+            execute: async () => {
+                const choice = await new ConfirmDialog({
+                    title: 'Sample Confirm Dialog',
+                    msg: 'This is a ssample with lots of text:' + Array(100)
+                        .fill(undefined)
+                        .map((element, index) => `\n\nExtra line #${index}`)
+                        .join('')
+                }).open();
+                this.messageService.info(`Sample confirm dialog returned with: \`${JSON.stringify(choice)}\``);
             }
         });
         commands.registerCommand(SampleQuickInputCommand, {

--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -85,16 +85,17 @@ export class SampleCommandContribution implements CommandContribution {
         });
         commands.registerCommand(SampleComplexCommandConfirmDialog, {
             execute: async () => {
-                const mainDiv: HTMLElement = document.createElement('div');
-                for (let i = 0; i <= 3; i++) {
+                const mainDiv = document.createElement('div');
+                for (const color of ['#FF00007F', '#00FF007F', '#0000FF7F']) {
                     const innerDiv = document.createElement('div');
-                    innerDiv.textContent = 'This is a sample with lots of text:' + Array(100)
+                    innerDiv.textContent = 'This is a sample with lots of text:' + Array(50)
                         .fill(undefined)
                         .map((_, index) => `\n\nExtra line #${index}`)
                         .join('');
+                    innerDiv.style.backgroundColor = color;
+                    innerDiv.style.padding = '5px';
                     mainDiv.appendChild(innerDiv);
                 }
-
                 const choice = await new ConfirmDialog({
                     title: 'Sample Confirm Dialog',
                     msg: mainDiv

--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -32,7 +32,11 @@ const SampleCommand2: Command = {
 const SampleCommandConfirmDialog: Command = {
     id: 'sample-command-confirm-dialog',
     label: 'Sample Confirm Dialog'
-}
+};
+const SampleComplexCommandConfirmDialog: Command = {
+    id: 'sample-command-complex-confirm-dialog',
+    label: 'Sample Complex Confirm Dialog'
+};
 const SampleCommandWithProgressMessage: Command = {
     id: 'sample-command-with-progress',
     label: 'Sample Command With Progress Message'
@@ -71,10 +75,29 @@ export class SampleCommandContribution implements CommandContribution {
             execute: async () => {
                 const choice = await new ConfirmDialog({
                     title: 'Sample Confirm Dialog',
-                    msg: 'This is a ssample with lots of text:' + Array(100)
+                    msg: 'This is a sample with lots of text:' + Array(100)
                         .fill(undefined)
                         .map((element, index) => `\n\nExtra line #${index}`)
                         .join('')
+                }).open();
+                this.messageService.info(`Sample confirm dialog returned with: \`${JSON.stringify(choice)}\``);
+            }
+        });
+        commands.registerCommand(SampleComplexCommandConfirmDialog, {
+            execute: async () => {
+                const mainDiv: HTMLElement = document.createElement('div');
+                for (let i = 0; i <= 3; i++) {
+                    const innerDiv = document.createElement('div');
+                    innerDiv.textContent = 'This is a sample with lots of text:' + Array(100)
+                        .fill(undefined)
+                        .map((_, index) => `\n\nExtra line #${index}`)
+                        .join('');
+                    mainDiv.appendChild(innerDiv);
+                }
+
+                const choice = await new ConfirmDialog({
+                    title: 'Sample Confirm Dialog',
+                    msg: mainDiv
                 }).open();
                 this.messageService.info(`Sample confirm dialog returned with: \`${JSON.stringify(choice)}\``);
             }

--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -64,10 +64,14 @@
     justify-content: space-around;
     align-items: stretch;
     position: relative;
-    margin: calc(var(--theia-ui-padding)*2);
+    padding: calc(var(--theia-ui-padding)*2);
     white-space: pre-line;
     max-height: 50vh;
     overflow-y: auto;
+}
+
+.p-Widget.dialogOverlay .dialogContent > * {
+    height: 100%;
 }
 
 .p-Widget.dialogOverlay .dialogControl {

--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -76,7 +76,7 @@
 
 .p-Widget.dialogOverlay .dialogControl {
     padding: calc(var(--theia-ui-padding)*2);
-    padding-top: 0px;
+    padding-top: var(--theia-ui-padding);
     display: flex;
     flex-direction: row;
     align-content: right;

--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -64,7 +64,10 @@
     justify-content: space-around;
     align-items: stretch;
     position: relative;
-    padding: calc(var(--theia-ui-padding)*2);
+    margin: calc(var(--theia-ui-padding)*2);
+    white-space: pre-line;
+    max-height: 50vh;
+    overflow-y: auto;
 }
 
 .p-Widget.dialogOverlay .dialogControl {

--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -76,7 +76,6 @@
 
 .p-Widget.dialogOverlay .dialogControl {
     padding: calc(var(--theia-ui-padding)*2);
-    padding-top: var(--theia-ui-padding);
     display: flex;
     flex-direction: row;
     align-content: right;


### PR DESCRIPTION
Signed-off-by: Jonah Iden <jonah.iden@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes: https://github.com/eclipse-theia/theia/issues/11985.

smaller css fixes for the confirm dialog so that it respects linebreaks and is scrollable in case of too much text.
I used pre-line for automatic line breaks so the dialog only needs vertical scroll though it could be nice if stacktraces or simmilar long lines are supposed to be displayed in it, to also give it horizontal scrolling

#### How to test
in `sample-menu-contributions.ts` in the sample command instead of returning an alert we can create a ConfirmDialog.
something like this
```
dialog = new ConfirmDialog({
    title: 'Sample Dialog',
    msg: 'A\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\nA\r\n'
});
return dialog.open();
```
clicking on sampleCommand in theia should then open the dialog with scrollable multiline message.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
