### PR TITLE
Handle top-level preference access from plugins

### DIFF
--- a/packages/plugin-ext/src/plugin/preference-registry.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.ts
@@ -170,7 +170,9 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
             },
             update: (key: string, value: any, targetScope?: ConfigurationTarget | boolean, withLanguageOverride?: boolean): PromiseLike<void> => {
                 const resourceStr = overrides.resource?.toString();
-                const fullPath = `${overrides.overrideIdentifier ? `[${overrides.overrideIdentifier}].` : ''}${rawSection}.${key}`;
+                const overrideSegment = overrides.overrideIdentifier ? `[${overrides.overrideIdentifier}].` : '';
+                const preferenceKey = rawSection ? `${rawSection}.${key}` : key;
+                const fullPath = overrideSegment + preferenceKey;
                 if (typeof value !== 'undefined') {
                     return this.proxy.$updateConfigurationOption(targetScope, fullPath, value, resourceStr, withLanguageOverride);
                 } else {
@@ -178,7 +180,7 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
                 }
             },
             inspect: <T>(key: string): ConfigurationInspect<T> | undefined => {
-                const path = `${rawSection}.${key}`;
+                const path = rawSection ? `${rawSection}.${key}` : key;
                 const result = this._preferences.inspect<T>(path, overrides, new TheiaWorkspace(this.workspace));
 
                 if (!result) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #12043

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Follow the steps in #12043, but observe that there are no keys that include the string `"undefined"`.

You can use [this plugin](https://github.com/colin-grant-work/demo-extensions/tree/main/extension-preference-access) and the command 'Access preferences at the top level'

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
