### PR TITLE
repo: add `@babel` deps to our baseline

### DIFF
--- a/dependency-check-baseline.json
+++ b/dependency-check-baseline.json
@@ -3,5 +3,12 @@
   "npm/npmjs/-/jschardet/2.3.0": "Approved for Eclipse Theia: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22481",
   "npm/npmjs/-/jsdom/11.12.0": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640",
   "npm/npmjs/-/lzma-native/8.0.6": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1850",
-  "npm/npmjs/-/playwright-core/1.22.2": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/2734"
+  "npm/npmjs/-/playwright-core/1.22.2": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/2734",
+  "npm/npmjs/@babel/helper-compilation-targets/7.20.7": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5989",
+  "npm/npmjs/@babel/helper-member-expression-to-functions/7.20.7": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5986",
+  "npm/npmjs/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.20.7": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5987",
+  "npm/npmjs/@babel/plugin-transform-arrow-functions/7.20.7": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5990",
+  "npm/npmjs/@babel/plugin-transform-async-to-generator/7.20.7": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/6230",
+  "npm/npmjs/@babel/plugin-transform-computed-properties/7.20.7": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5984",
+  "npm/npmjs/@babel/template/7.20.7": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5988"
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates our dependencies baseline (ultimately used for `dash-licenses`) to include entries for `@babel` which are still under-review. Currently the `dash-licenses` check fails due to these entries, and given that the dependencies are `devDependencies` and still under review for over 2 weeks (likely due to the holidays) we can mark them as compatible for the time being and catch actual issues with our deps.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- CI for "3PP License Check" should pass

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>


cc @paul-marechal @JonasHelming do you see an issue with marking the `@babel` deps as compatible, or should we downgrade the dependency that introduces these newer versions?