### PR TITLE
fixed debug hover widget overflowing when content tree is too big

### DIFF
--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -97,6 +97,10 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
         this.contentNode.className = 'theia-debug-hover-content';
         this.domNode.appendChild(this.contentNode);
 
+
+        // for stopping scroll events from contentNode going to the editor 
+        this.contentNode.addEventListener("wheel", e => e.stopPropagation());
+
         this.editor.getControl().addContentWidget(this);
         this.source = this.hoverSource;
         this.toDispose.pushAll([

--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -97,9 +97,8 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
         this.contentNode.className = 'theia-debug-hover-content';
         this.domNode.appendChild(this.contentNode);
 
-
-        // for stopping scroll events from contentNode going to the editor 
-        this.contentNode.addEventListener("wheel", e => e.stopPropagation());
+        // for stopping scroll events from contentNode going to the editor
+        this.contentNode.addEventListener('wheel', e => e.stopPropagation());
 
         this.editor.getControl().addContentWidget(this);
         this.source = this.hoverSource;

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -338,7 +338,7 @@
 
 /** Hover */
 .theia-debug-hover {
-    display: flex;
+    display: flex !important;
     flex-direction: column;
     border: 1px solid var(--theia-editorHoverWidget-border);
     background: var(--theia-editorHoverWidget-background);


### PR DESCRIPTION
Signed-off-by: Jonah Iden <jonah.iden@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
fixes #11297

This fixes the overflowing of the `DebugHoverWidget` when the content tree gets too large.
The problem was, that by default monaco overwrites the `display` css property of the domNode (contentWidget#setPosition) to `display: block `instead of the given `display: flex`. with the !important it stays as flex as intended.

#### How to test

1. create a breakpoint and start a debug session
    a. (i used the `Run Mocha Tests`  target and made a breakpoint in `frontend-application-config-provider.spec.ts`)
2. hover over a variable and see the debug hover widget appear
3. expand the tree nodes so that the tree gets bigger than the widget
4. see it doews not overflow scrolling should now be possible

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
