### PR TITLE
Toolbars: ToolbarItem.when field is evaluated and respected

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -246,7 +246,7 @@ export class TabBarToolbar extends ReactWidget {
         return this.commands.isToggled(command, this.current);
     }
 
-    protected evalualteWhenClause(whenClause: string | undefined): boolean {
+    protected evaluateWhenClause(whenClause: string | undefined): boolean {
         return whenClause ? this.contextKeyService.match(whenClause) : true;
     }
 

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -149,7 +149,7 @@ export class TabBarToolbar extends ReactWidget {
         }
         const tooltip = item.tooltip || (command && command.label);
 
-        const toolbarItemClassNames = this.getToolbarItemClassNames(command?.id ?? item.command, this.evalualteWhenClause(item.when));
+        const toolbarItemClassNames = this.getToolbarItemClassNames(command?.id ?? item.command, this.evaluateWhenClause(item.when));
         if (item.menuPath && !item.command) { toolbarItemClassNames.push('enabled'); }
         return <div key={item.id}
             ref={this.onRender}
@@ -255,7 +255,7 @@ export class TabBarToolbar extends ReactWidget {
         e.stopPropagation();
 
         const item: AnyToolbarItem | undefined = this.inline.get(e.currentTarget.id);
-        if (this.evalualteWhenClause(item?.when)) {
+        if (this.evaluateWhenClause(item?.when)) {
             if (item?.command && item.menuPath) {
                 this.menuCommandExecutor.executeCommand(item.menuPath, item.command, this.current);
             } else if (item?.command) {

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -16,6 +16,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as React from 'react';
+import { ContextKeyService } from '../../context-key-service';
 import { CommandRegistry, Disposable, DisposableCollection, MenuCommandExecutor, MenuModelRegistry, MenuPath, nls } from '../../../common';
 import { Anchor, ContextMenuAccess, ContextMenuRenderer } from '../../context-menu-renderer';
 import { LabelIcon, LabelParser } from '../../label-parser';
@@ -41,12 +42,15 @@ export class TabBarToolbar extends ReactWidget {
     protected inline = new Map<string, TabBarToolbarItem | ReactTabBarToolbarItem>();
     protected more = new Map<string, TabBarToolbarItem>();
 
+    protected contextKeyListener: Disposable | undefined;
+
     @inject(CommandRegistry) protected readonly commands: CommandRegistry;
     @inject(LabelParser) protected readonly labelParser: LabelParser;
     @inject(MenuModelRegistry) protected readonly menus: MenuModelRegistry;
     @inject(MenuCommandExecutor) protected readonly menuCommandExecutor: MenuCommandExecutor;
     @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer;
     @inject(TabBarToolbarRegistry) protected readonly toolbarRegistry: TabBarToolbarRegistry;
+    @inject(ContextKeyService) protected readonly contextKeyService: ContextKeyService;
 
     constructor() {
         super();
@@ -60,13 +64,22 @@ export class TabBarToolbar extends ReactWidget {
     updateItems(items: Array<TabBarToolbarItem | ReactTabBarToolbarItem>, current: Widget | undefined): void {
         this.inline.clear();
         this.more.clear();
+
+        const contextKeys: Set<string> = new Set();
         for (const item of items.sort(TabBarToolbarItem.PRIORITY_COMPARATOR).reverse()) {
             if ('render' in item || item.group === undefined || item.group === 'navigation') {
                 this.inline.set(item.id, item);
             } else {
                 this.more.set(item.id, item);
             }
+
+            if (item.when) {
+                this.contextKeyService.parseKeys(item.when)?.forEach(key => contextKeys.add(key));
+            }
         }
+
+        this.updateContextKeyListener(contextKeys);
+
         this.setCurrent(current);
         if (!items.length) {
             this.hide();
@@ -97,6 +110,17 @@ export class TabBarToolbar extends ReactWidget {
         }
     }
 
+    protected updateContextKeyListener(contextKeys: Set<string>): void {
+        this.contextKeyListener?.dispose();
+        if (contextKeys.size > 0) {
+            this.contextKeyListener = this.contextKeyService.onDidChange(event => {
+                if (event.affects(contextKeys)) {
+                    this.update();
+                }
+            });
+        }
+    }
+
     protected render(): React.ReactNode {
         return <React.Fragment>
             {this.renderMore()}
@@ -124,7 +148,8 @@ export class TabBarToolbar extends ReactWidget {
             classNames.push(iconClass);
         }
         const tooltip = item.tooltip || (command && command.label);
-        const toolbarItemClassNames = this.getToolbarItemClassNames(command?.id ?? item.command);
+
+        const toolbarItemClassNames = this.getToolbarItemClassNames(command?.id ?? item.command, this.evalualteWhenClause(item.when));
         if (item.menuPath && !item.command) { toolbarItemClassNames.push('enabled'); }
         return <div key={item.id}
             ref={this.onRender}
@@ -139,10 +164,10 @@ export class TabBarToolbar extends ReactWidget {
         </div>;
     }
 
-    protected getToolbarItemClassNames(commandId: string | undefined): string[] {
+    protected getToolbarItemClassNames(commandId: string | undefined, whenClauseResult: boolean): string[] {
         const classNames = [TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM];
         if (commandId) {
-            if (this.commandIsEnabled(commandId)) {
+            if (this.commandIsEnabled(commandId) && whenClauseResult) {
                 classNames.push('enabled');
             }
             if (this.commandIsToggled(commandId)) {
@@ -221,17 +246,23 @@ export class TabBarToolbar extends ReactWidget {
         return this.commands.isToggled(command, this.current);
     }
 
+    protected evalualteWhenClause(whenClause: string | undefined): boolean {
+        return whenClause ? this.contextKeyService.match(whenClause) : true;
+    }
+
     protected executeCommand = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
         e.stopPropagation();
 
         const item: AnyToolbarItem | undefined = this.inline.get(e.currentTarget.id);
-        if (item?.command && item.menuPath) {
-            this.menuCommandExecutor.executeCommand(item.menuPath, item.command, this.current);
-        } else if (item?.command) {
-            this.commands.executeCommand(item.command, this.current);
-        } else if (item?.menuPath) {
-            this.renderMoreContextMenu(this.toAnchor(e), item.menuPath);
+        if (this.evalualteWhenClause(item?.when)) {
+            if (item?.command && item.menuPath) {
+                this.menuCommandExecutor.executeCommand(item.menuPath, item.command, this.current);
+            } else if (item?.command) {
+                this.commands.executeCommand(item.command, this.current);
+            } else if (item?.menuPath) {
+                this.renderMoreContextMenu(this.toAnchor(e), item.menuPath);
+            }
         }
         this.update();
     };
@@ -245,7 +276,6 @@ export class TabBarToolbar extends ReactWidget {
     protected onMouseUpEvent = (e: React.MouseEvent<HTMLElement>) => {
         e.currentTarget.classList.remove('active');
     };
-
 }
 
 export namespace TabBarToolbar {

--- a/packages/toolbar/src/browser/toolbar-preference-schema.ts
+++ b/packages/toolbar/src/browser/toolbar-preference-schema.ts
@@ -31,7 +31,8 @@ const toolbarColumnGroup: IJSONSchema = {
                 'command': { 'type': 'string' },
                 'icon': { 'type': 'string' },
                 'tooltip': { 'type': 'string' },
-                'group': { 'enum': ['contributed'] }
+                'group': { 'enum': ['contributed'] },
+                'when': { 'type': 'string' },
             },
             'required': [
                 'id',

--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -235,7 +235,7 @@ export class ToolbarImpl extends TabBarToolbar {
 
         if (TabBarToolbarItem.is(item)) {
             toolbarItemClassNames = TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM;
-            if (this.evalualteWhenClause(item.when)) {
+            if (this.evaluateWhenClause(item.when)) {
                 toolbarItemClassNames += ' enabled';
             }
             renderBody = this.renderItem(item);

--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -78,7 +78,7 @@ export class ToolbarImpl extends TabBarToolbar {
         this.inline.clear();
         const { items } = this.model.toolbarItems;
 
-        const contextKeys: Set<string> = new Set();
+        const contextKeys = new Set<string>();
         for (const column of Object.keys(items)) {
             for (const group of items[column as ToolbarAlignment]) {
                 for (const item of group) {

--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -77,13 +77,20 @@ export class ToolbarImpl extends TabBarToolbar {
     protected updateInlineItems(): void {
         this.inline.clear();
         const { items } = this.model.toolbarItems;
+
+        const contextKeys: Set<string> = new Set();
         for (const column of Object.keys(items)) {
             for (const group of items[column as ToolbarAlignment]) {
                 for (const item of group) {
                     this.inline.set(item.id, item);
+
+                    if (item.when) {
+                        this.contextKeyService.parseKeys(item.when)?.forEach(key => contextKeys.add(key));
+                    }
                 }
             }
         }
+        this.updateContextKeyListener(contextKeys);
     }
 
     protected handleContextMenu = (e: React.MouseEvent<HTMLDivElement>): ContextMenuAccess => this.doHandleContextMenu(e);
@@ -225,8 +232,12 @@ export class ToolbarImpl extends TabBarToolbar {
         const stringifiedPosition = JSON.stringify(position);
         let toolbarItemClassNames = '';
         let renderBody: React.ReactNode;
+
         if (TabBarToolbarItem.is(item)) {
-            toolbarItemClassNames = [TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM, 'enabled'].join(' ');
+            toolbarItemClassNames = TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM;
+            if (this.evalualteWhenClause(item.when)) {
+                toolbarItemClassNames += ' enabled';
+            }
             renderBody = this.renderItem(item);
         } else {
             const contribution = this.model.getContributionByID(item.id);


### PR DESCRIPTION
ToolbarItem.when field is evaluated and respected
by toolbar and tab-bar-toolbar +
when clause can be set in toolbar.json

Signed-off-by: Jonah Iden <jonah.iden@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Implements/fixes #11705

This PR implements the funcitionality for toolbars to evaluate and respect the when field/clause of `ConditionalToolbarItem`.
Also allows setting the when field in `toolbar.json`.

#### How to test
easiest way to test is probably through the toolbar.json file:

1. press Alt+T to open the toolbar 
2. right click it and click Customize Toolbar (open JSON)
3. either add a new toolbar item or edit an existing one. Add "when": "inDebugMode" and save the file
4. see the icon gets grayed out and does not react to clicks
5. start a debug session
6. see icon is white again and reacts to clicks
7. stop debug session
8. icon disabled again

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
