### PR TITLE
added "enabled" field to SourceControlInputBox for vscode api.

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -919,6 +919,7 @@ export interface ScmMain {
     $setInputBoxValue(sourceControlHandle: number, value: string): void;
     $setInputBoxPlaceholder(sourceControlHandle: number, placeholder: string): void;
     $setInputBoxVisible(sourceControlHandle: number, visible: boolean): void;
+    $setInputBoxEnabled(sourceControlHandle: number, enabled: boolean): void;
 }
 
 export interface SourceControlProviderFeatures {

--- a/packages/plugin-ext/src/main/browser/scm-main.ts
+++ b/packages/plugin-ext/src/main/browser/scm-main.ts
@@ -440,4 +440,14 @@ export class ScmMainImpl implements ScmMain {
 
         repository.input.visible = visible;
     }
+
+    $setInputBoxEnabled(sourceControlHandle: number, enabled: boolean): void {
+        const repository = this.repositories.get(sourceControlHandle);
+
+        if (!repository) {
+            return;
+        }
+
+        repository.input.enabled = enabled;
+    }
 }

--- a/packages/plugin-ext/src/plugin/scm.ts
+++ b/packages/plugin-ext/src/plugin/scm.ts
@@ -322,6 +322,17 @@ export class ScmInputBoxImpl implements theia.SourceControlInputBox {
         this._visible = visible;
     }
 
+    private _enabled: boolean;
+
+    get enabled(): boolean {
+        return this._enabled;
+    }
+
+    set enabled(enabled: boolean) {
+        this.proxy.$setInputBoxEnabled(this.sourceControlHandle, enabled);
+        this._enabled = enabled;
+    }
+
     private _validateInput: ValidateInput | undefined;
 
     get validateInput(): ValidateInput | undefined {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10802,6 +10802,11 @@ export module '@theia/plugin' {
          * Controls whether the input box is visible (default is true).
          */
         visible: boolean;
+
+        /**
+         * Controls whether the input box is enabled (default is `true`).
+         */
+        enabled: boolean;
     }
 
     interface QuickDiffProvider {

--- a/packages/scm/src/browser/scm-commit-widget.tsx
+++ b/packages/scm/src/browser/scm-commit-widget.tsx
@@ -138,6 +138,7 @@ export class ScmCommitWidget extends ReactWidget implements StatefulWidget {
                 spellCheck={false}
                 autoFocus={true}
                 value={input.value}
+                disabled={!input.enabled}
                 onChange={this.setInputValue}
                 ref={this.inputRef}
                 rows={1}

--- a/packages/scm/src/browser/scm-input.ts
+++ b/packages/scm/src/browser/scm-input.ts
@@ -36,14 +36,15 @@ export interface ScmInputValidator {
 }
 
 export interface ScmInputOptions {
-    placeholder?: string
-    validator?: ScmInputValidator
-    visible?: boolean
+    placeholder?: string;
+    validator?: ScmInputValidator;
+    visible?: boolean;
+    enabled?: boolean;
 }
 
 export interface ScmInputData {
-    value?: string
-    issue?: ScmInputIssue
+    value?: string;
+    issue?: ScmInputIssue;
 }
 
 export class ScmInput implements Disposable {
@@ -104,6 +105,19 @@ export class ScmInput implements Disposable {
             return;
         }
         this._visible = visible;
+        this.fireDidChange();
+        this.validate();
+    }
+
+    protected _enabled = this.options.enabled ?? true;
+    get enabled(): boolean {
+        return this._enabled;
+    }
+    set enabled(enabled: boolean) {
+        if (this._enabled === enabled) {
+            return;
+        }
+        this._enabled = enabled;
         this.fireDidChange();
         this.validate();
     }


### PR DESCRIPTION
Signed-off-by: Jonah Iden <jonah.iden@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
closes #12027

Adds the `enabled` field to SourceControlInputBox according to the vs code api

also added some semicolons where they were missing

#### How to test
small extension for testing:
   - download here: [sourcecontrolinputbox-enabled-test-0.0.1.zip](https://github.com/eclipse-theia/theia/files/10411766/sourcecontrolinputbox-enabled-test-0.0.1.zip)
   - build here: https://github.com/jonah-iden/sourcecontrolinputbox-enabled-test

steps for testing

1. remove "@Theia/git" from examples/{browser or election}/package.json
2. build and start theia (browser or electron)
3. download or build and install vsix extension 
4. execute command "Test change SourceControlInputBox status"
5. see new provider is registered and inputBox should be disabled (since executing the command changes the enabled status from default value true to false)
6. execute command again and see input box is enabled again

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
