### PR TITLE
searchInWorkspaceResult: `.map` replaced for `.forEach`

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -842,7 +842,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         const fileNode = node.parent;
         const rightPositionedNodes = fileNode.children.filter(rl => rl.line === node.line && rl.character > node.character);
         const diff = this._replaceTerm.length - this.searchTerm.length;
-        rightPositionedNodes.map(r => r.character += diff);
+        rightPositionedNodes.forEach(r => r.character += diff);
     }
 
     /**

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -630,7 +630,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     }
 
     protected updateCurrentEditorDecorations(): void {
-        this.shell.allTabBars.map(tb => {
+        this.shell.allTabBars.forEach(tb => {
             const currentTitle = tb.currentTitle;
             if (currentTitle && currentTitle.owner instanceof EditorWidget) {
                 const widget = currentTitle.owner;

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -1095,7 +1095,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         }
 
         const lines = content.split('\n');
-        node.children.map(l => {
+        node.children.forEach(l => {
             const leftPositionedNodes = node.children.filter(rl => rl.line === l.line && rl.character < l.character);
             const diff = (this._replaceTerm.length - this.searchTerm.length) * leftPositionedNodes.length;
             const start = lines[l.line - 1].substr(0, l.character - 1 + diff);
@@ -1122,7 +1122,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     protected createEditorDecorations(resultNode: SearchInWorkspaceFileNode | undefined): EditorDecoration[] {
         const decorations: EditorDecoration[] = [];
         if (resultNode) {
-            resultNode.children.map(res => {
+            resultNode.children.forEach(res => {
                 decorations.push({
                     range: {
                         start: {


### PR DESCRIPTION
This commit replaces the the `.map` in several lines for a `.forEach`.

Signed-off-by: FernandoAscencio <fernando.ascencio.cama@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Implements the suggested change in #11897 and #11898

#### How to test
For #11897:
1. Open two examples file with occurrences of the same test String
2. Search for this String in the Theia search view
3. Check that the search String is highlighted in both editors
For #11898:
1. Open an example file with the same search String appearing multiple times in one row, e.g. "test foobar test"
2. Use the Theia search view to search for the test String occurring in the opened file
3. Enter a replace value
4. In the search results, select to replace the first occurrence of the search String only
5. Check that the second hit is correctly highlighted in the editor after the replacement
6. Replace the second hit in the same line

As mentioned, there should be no difference in behavior from before the changes.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
