### PR TITLE
plugins: vscode-eslint update to 2.1.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vscode.typescript": "https://open-vsx.org/api/vscode/typescript/1.62.3/file/vscode.typescript-1.62.3.vsix",
     "vscode.typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.62.3/file/vscode.typescript-language-features-1.62.3.vsix",
     "EditorConfig.EditorConfig": "https://open-vsx.org/api/EditorConfig/EditorConfig/0.14.4/file/EditorConfig.EditorConfig-0.14.4.vsix",
-    "dbaeumer.vscode-eslint": "https://open-vsx.org/api/dbaeumer/vscode-eslint/2.1.1/file/dbaeumer.vscode-eslint-2.1.1.vsix",
+    "dbaeumer.vscode-eslint": "https://open-vsx.org/api/dbaeumer/vscode-eslint/2.1.20/file/dbaeumer.vscode-eslint-2.1.20.vsix",
     "ms-vscode.references-view": "https://open-vsx.org/api/ms-vscode/references-view/0.0.89/file/ms-vscode.references-view-0.0.89.vsix"
   },
   "theiaPluginsExcludeIds": [


### PR DESCRIPTION
This commit updates the vscode eslint extension to version 2.1.20

Signed-off-by: FernandoAscencio <fernando.ascencio.cama@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fix: #11987

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
As per #11987

1. [Build and start](https://github.com/eclipse-theia/theia/blob/93ab2342efebf2ef55f699aab42cf58e4b88e1c9/doc/Developing.md#quick-start) the Electron example application. `yarn && yarn download:plugins && yarn electron build && yarn electron start`
2. Open file (shortcut: Ctrl+P): `theia.d.ts`
3. Confirm the warnings
4. Confirm the version by looking into: `plugins/dbaeumer.vscode-eslint/extension/package.json`
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
