### PR TITLE
navigator: update `open containing folder` command

### DIFF
--- a/packages/navigator/src/electron-browser/electron-navigator-menu-contribution.ts
+++ b/packages/navigator/src/electron-browser/electron-navigator-menu-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core';
+import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, SelectionService } from '@theia/core';
 import { CommonCommands, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import * as electron from '@theia/core/electron-shared/electron';
@@ -22,8 +22,10 @@ import * as electronRemote from '@theia/core/electron-shared/@electron/remote';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FileStatNode } from '@theia/filesystem/lib/browser';
 import { FileNavigatorWidget, FILE_NAVIGATOR_ID } from '../browser';
-import { NavigatorContextMenu } from '../browser/navigator-contribution';
+import { NavigatorContextMenu, SHELL_TABBAR_CONTEXT_REVEAL } from '../browser/navigator-contribution';
 import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export const OPEN_CONTAINING_FOLDER = Command.toDefaultLocalizedCommand({
     id: 'revealFileInOS',
@@ -36,28 +38,37 @@ export const OPEN_CONTAINING_FOLDER = Command.toDefaultLocalizedCommand({
 @injectable()
 export class ElectronNavigatorMenuContribution implements MenuContribution, CommandContribution, KeybindingContribution {
 
+    @inject(SelectionService)
+    protected readonly selectionService: SelectionService;
+
     @inject(WidgetManager)
     protected readonly widgetManager: WidgetManager;
 
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand(OPEN_CONTAINING_FOLDER, {
-            isEnabled: () => this.getSelectedFileStatNodes().length > 0,
-            isVisible: () => this.getSelectedFileStatNodes().length > 0,
-            execute: () => {
+        commands.registerCommand(OPEN_CONTAINING_FOLDER, UriAwareCommandHandler.MonoSelect(this.selectionService, {
+            execute: async uri => {
                 // workaround for https://github.com/electron/electron/issues/4349:
                 // use electron.remote.shell to open the window in the foreground on Windows
                 const shell = isWindows ? electronRemote.shell : electron.shell;
-                this.getSelectedFileStatNodes().forEach(node => {
-                    shell.showItemInFolder(node.uri['codeUri'].fsPath);
-                });
-            }
-        });
+                shell.showItemInFolder(uri['codeUri'].fsPath);
+            },
+            isEnabled: uri => !!this.workspaceService.getWorkspaceRootUri(uri),
+            isVisible: uri => !!this.workspaceService.getWorkspaceRootUri(uri),
+        }));
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
             commandId: OPEN_CONTAINING_FOLDER.id,
             label: OPEN_CONTAINING_FOLDER.label
+        });
+        menus.registerMenuAction(SHELL_TABBAR_CONTEXT_REVEAL, {
+            commandId: OPEN_CONTAINING_FOLDER.id,
+            label: OPEN_CONTAINING_FOLDER.label,
+            order: '4'
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes https://github.com/eclipse-theia/theia/issues/12073.

The pull-request updates the `OPEN_CONTAINING_FOLDER` command simplifying the behavior, and also making it accessible by the tabbar context-menu similarly to VS Code.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the **electron** application with a workspace
2. right-click a folder in the navigator, the option should exist to "open containing folder" (different names for different os')
3. confirm the command works as intended
4. open an editor
5. right-click the editor's tabbar, the option should exist to "open containing folder"
6. confirm the command works as intended
7. de-select the editor in the navigator, confirm that step 5 still works
8. open a regular widget in the main-area or side-areas, confirm the command through right-click does not display

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>