### PR TITLE
Support multi-selection of tree items in tree views

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -787,7 +787,7 @@ export interface TreeViewItem {
 
 export interface TreeViewItemReference {
     viewId: string
-    itemId: string,
+    itemId: string
 }
 export namespace TreeViewItemReference {
     export function is(arg: unknown): arg is TreeViewItemReference {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -727,7 +727,7 @@ export interface TreeViewRevealOptions {
 }
 
 export interface TreeViewsMain {
-    $registerTreeDataProvider(treeViewId: string, dragMimetypes: string[] | undefined, dropMimetypes: string[] | undefined): void;
+    $registerTreeDataProvider(treeViewId: string, canSelectMany: boolean | undefined, dragMimetypes: string[] | undefined, dropMimetypes: string[] | undefined): void;
     $readDroppedFile(contentId: string): Promise<BinaryBuffer>;
     $unregisterTreeDataProvider(treeViewId: string): void;
     $refresh(treeViewId: string): Promise<void>;
@@ -785,13 +785,13 @@ export interface TreeViewItem {
 
 }
 
-export interface TreeViewSelection {
-    treeViewId: string
-    treeItemId: string
+export interface TreeViewItemReference {
+    viewId: string
+    itemId: string,
 }
-export namespace TreeViewSelection {
-    export function is(arg: unknown): arg is TreeViewSelection {
-        return isObject(arg) && 'treeViewId' in arg && 'treeItemId' in arg;
+export namespace TreeViewItemReference {
+    export function is(arg: unknown): arg is TreeViewItemReference {
+        return !!arg && typeof arg === 'object' && 'viewId' in arg && 'itemId' in arg;
     }
 }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -720,6 +720,12 @@ export interface DialogsMain {
     $showUploadDialog(options: UploadDialogOptionsMain): Promise<string[] | undefined>;
 }
 
+export interface RegisterTreeDataProviderOptions {
+    canSelectMany?: boolean
+    dragMimeTypes?: string[]
+    dropMimeTypes?: string[]
+}
+
 export interface TreeViewRevealOptions {
     select: boolean
     focus: boolean
@@ -727,7 +733,7 @@ export interface TreeViewRevealOptions {
 }
 
 export interface TreeViewsMain {
-    $registerTreeDataProvider(treeViewId: string, canSelectMany: boolean | undefined, dragMimetypes: string[] | undefined, dropMimetypes: string[] | undefined): void;
+    $registerTreeDataProvider(treeViewId: string, options?: RegisterTreeDataProviderOptions): void;
     $readDroppedFile(contentId: string): Promise<BinaryBuffer>;
     $unregisterTreeDataProvider(treeViewId: string): void;
     $refresh(treeViewId: string): Promise<void>;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -110,7 +110,7 @@ import type {
 import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
 import { ThemeType } from '@theia/core/lib/common/theme';
 import { Disposable } from '@theia/core/lib/common/disposable';
-import { isObject, PickOptions, QuickInputButtonHandle } from '@theia/core/lib/common';
+import { isString, isObject, PickOptions, QuickInputButtonHandle } from '@theia/core/lib/common';
 import { Severity } from '@theia/core/lib/common/severity';
 import { DebugConfiguration, DebugSessionOptions } from '@theia/debug/lib/common/debug-configuration';
 
@@ -791,7 +791,7 @@ export interface TreeViewItemReference {
 }
 export namespace TreeViewItemReference {
     export function is(arg: unknown): arg is TreeViewItemReference {
-        return !!arg && typeof arg === 'object' && 'viewId' in arg && 'itemId' in arg;
+        return isObject(arg) && isString(arg.viewId) && isString(arg.itemId);
     }
 }
 

--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -22,7 +22,7 @@ import { TreeWidgetSelection } from '@theia/core/lib/browser/tree/tree-widget-se
 import { ScmRepository } from '@theia/scm/lib/browser/scm-repository';
 import { ScmService } from '@theia/scm/lib/browser/scm-service';
 import { TimelineItem } from '@theia/timeline/lib/common/timeline-model';
-import { ScmCommandArg, TimelineCommandArg, TreeViewSelection } from '../../../common';
+import { ScmCommandArg, TimelineCommandArg, TreeViewItemReference } from '../../../common';
 import { PluginScmProvider, PluginScmResource, PluginScmResourceGroup } from '../scm-main';
 import { TreeViewWidget } from '../view/tree-view-widget';
 import { CodeEditorWidgetUtil, codeToTheiaMappings, ContributionPoint } from './vscode-theia-menu-mappings';
@@ -238,19 +238,21 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
     protected toTreeArgs(...args: any[]): any[] {
         const treeArgs: any[] = [];
         for (const arg of args) {
-            if (TreeViewSelection.is(arg)) {
+            if (TreeViewItemReference.is(arg)) {
                 treeArgs.push(arg);
+            } else if (Array.isArray(arg)) {
+                treeArgs.push(arg.filter(TreeViewItemReference.is));
             }
         }
         return treeArgs;
     }
 
-    protected getSelectedResources(): [CodeUri | TreeViewSelection | undefined, CodeUri[] | undefined] {
+    protected getSelectedResources(): [CodeUri | TreeViewItemReference | undefined, CodeUri[] | undefined] {
         const selection = this.selectionService.selection;
         const resourceKey = this.resourceContextKey.get();
         const resourceUri = resourceKey ? CodeUri.parse(resourceKey) : undefined;
         const firstMember = TreeWidgetSelection.is(selection) && selection.source instanceof TreeViewWidget && selection[0]
-            ? selection.source.toTreeViewSelection(selection[0])
+            ? selection.source.toTreeViewItemReference(selection[0])
             : UriSelection.getUri(selection)?.['codeUri'] ?? resourceUri;
         const secondMember = TreeWidgetSelection.is(selection)
             ? UriSelection.getUris(selection).map(uri => uri['codeUri'])

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -148,14 +148,15 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(DnDFileContentStore).toSelf().inSingletonScope();
     bind(WidgetFactory).toDynamicValue(({ container }) => ({
         id: PLUGIN_VIEW_DATA_FACTORY_ID,
-        createWidget: (identifier: TreeViewWidgetOptions) => {
+        createWidget: (options: TreeViewWidgetOptions) => {
             const props = {
                 contextMenuPath: VIEW_ITEM_CONTEXT_MENU,
                 expandOnlyOnExpansionToggleClick: true,
                 expansionTogglePadding: 22,
                 globalSelection: true,
                 leftPadding: 8,
-                search: true
+                search: true,
+                multiSelect: options.multiSelect
             };
             const child = createTreeContainer(container, {
                 props,
@@ -164,7 +165,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
                 widget: TreeViewWidget,
                 decoratorService: TreeViewDecoratorService
             });
-            child.bind(TreeViewWidgetOptions).toConstantValue(identifier);
+            child.bind(TreeViewWidgetOptions).toConstantValue(options);
             return child.get(TreeWidget);
         }
     })).inSingletonScope();

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -718,7 +718,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected renderInlineCommand(actionMenuNode: ActionMenuNode, index: number, tabbable: boolean, args: any[]): React.ReactNode {
-        if (!actionMenuNode.icon || !this.commands.isVisible(actionMenuNode.command, args) || !actionMenuNode.when || !this.contextKeys.match(actionMenuNode.when)) {
+        if (!actionMenuNode.icon || !this.commands.isVisible(actionMenuNode.command, ...args) || !actionMenuNode.when || !this.contextKeys.match(actionMenuNode.when)) {
             return false;
         }
         const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, actionMenuNode.icon, ACTION_ITEM, 'theia-tree-view-inline-action'].join(' ');

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -697,36 +697,35 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         }
     }
 
-    protected override renderTailDecorations(node: TreeViewNode, props: NodeProps): React.ReactNode {
-        return this.contextKeys.with({ view: this.id, viewItem: node.contextValue }, () => {
+    protected override renderTailDecorations(treeViewNode: TreeViewNode, props: NodeProps): React.ReactNode {
+        return this.contextKeys.with({ view: this.id, viewItem: treeViewNode.contextValue }, () => {
             const menu = this.menus.getMenu(VIEW_ITEM_INLINE_MENU);
-            const args = this.toContextMenuArgs(node);
+            const args = this.toContextMenuArgs(treeViewNode);
             const inlineCommands = menu.children.filter((item): item is ActionMenuNode => item instanceof ActionMenuNode);
-            const tailDecorations = super.renderTailDecorations(node, props);
+            const tailDecorations = super.renderTailDecorations(treeViewNode, props);
             return <React.Fragment>
                 {inlineCommands.length > 0 && <div className={TREE_NODE_SEGMENT_CLASS + ' flex'}>
-                    {inlineCommands.map((item, index) => this.renderInlineCommand(item, index, this.focusService.hasFocus(node), args))}
+                    {inlineCommands.map((item, index) => this.renderInlineCommand(item, index, this.focusService.hasFocus(treeViewNode), args))}
                 </div>}
                 {tailDecorations !== undefined && <div className={TREE_NODE_SEGMENT_CLASS + ' flex'}>{tailDecorations}</div>}
             </React.Fragment>;
         });
     }
 
-    toTreeViewItemReference(node: TreeNode): TreeViewItemReference {
-        return { viewId: this.id, itemId: node.id };
+    toTreeViewItemReference(treeNode: TreeNode): TreeViewItemReference {
+        return { viewId: this.id, itemId: treeNode.id };
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected renderInlineCommand(node: ActionMenuNode, index: number, tabbable: boolean, args: any[]): React.ReactNode {
-        const { icon } = node;
-        if (!icon || !this.commands.isVisible(node.command, args) || !node.when || !this.contextKeys.match(node.when)) {
+    protected renderInlineCommand(actionMenuNode: ActionMenuNode, index: number, tabbable: boolean, args: any[]): React.ReactNode {
+        if (!actionMenuNode.icon || !this.commands.isVisible(actionMenuNode.command, args) || !actionMenuNode.when || !this.contextKeys.match(actionMenuNode.when)) {
             return false;
         }
-        const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, icon, ACTION_ITEM, 'theia-tree-view-inline-action'].join(' ');
+        const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, actionMenuNode.icon, ACTION_ITEM, 'theia-tree-view-inline-action'].join(' ');
         const tabIndex = tabbable ? 0 : undefined;
-        return <div key={index} className={className} title={node.label} tabIndex={tabIndex} onClick={e => {
+        return <div key={index} className={className} title={actionMenuNode.label} tabIndex={tabIndex} onClick={e => {
             e.stopPropagation();
-            this.commands.executeCommand(node.command, ...args);
+            this.commands.executeCommand(actionMenuNode.command, ...args);
         }} />;
     }
 

--- a/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { interfaces } from '@theia/core/shared/inversify';
-import { MAIN_RPC_CONTEXT, TreeViewsMain, TreeViewsExt, TreeViewRevealOptions } from '../../../common/plugin-api-rpc';
+import { MAIN_RPC_CONTEXT, TreeViewsMain, TreeViewsExt, TreeViewRevealOptions, RegisterTreeDataProviderOptions } from '../../../common/plugin-api-rpc';
 import { RPCProtocol } from '../../../common/rpc-protocol';
 import { PluginViewRegistry, PLUGIN_VIEW_DATA_FACTORY_ID } from './plugin-view-registry';
 import {
@@ -58,15 +58,14 @@ export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
         this.toDispose.dispose();
     }
 
-    async $registerTreeDataProvider(treeViewId: string, canSelectMany: boolean | undefined, dragMimeTypes: string[] | undefined, dropMimeTypes: string[] | undefined): Promise<void> {
+    async $registerTreeDataProvider(treeViewId: string, $options: RegisterTreeDataProviderOptions): Promise<void> {
         this.treeViewProviders.set(treeViewId, this.viewRegistry.registerViewDataProvider(treeViewId, async ({ state, viewInfo }) => {
             const options: TreeViewWidgetOptions = {
                 id: treeViewId,
-                multiSelect: canSelectMany,
-                dragMimeTypes,
-                dropMimeTypes
+                multiSelect: $options.canSelectMany,
+                dragMimeTypes: $options.dragMimeTypes,
+                dropMimeTypes: $options.dropMimeTypes
             };
-
             const widget = await this.widgetManager.getOrCreateWidget<TreeViewWidget>(PLUGIN_VIEW_DATA_FACTORY_ID, options);
             widget.model.viewInfo = viewInfo;
             if (state) {

--- a/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
@@ -58,10 +58,11 @@ export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
         this.toDispose.dispose();
     }
 
-    async $registerTreeDataProvider(treeViewId: string, dragMimeTypes: string[] | undefined, dropMimeTypes: string[] | undefined): Promise<void> {
+    async $registerTreeDataProvider(treeViewId: string, canSelectMany: boolean | undefined, dragMimeTypes: string[] | undefined, dropMimeTypes: string[] | undefined): Promise<void> {
         this.treeViewProviders.set(treeViewId, this.viewRegistry.registerViewDataProvider(treeViewId, async ({ state, viewInfo }) => {
             const options: TreeViewWidgetOptions = {
                 id: treeViewId,
+                multiSelect: canSelectMany,
                 dragMimeTypes,
                 dropMimeTypes
             };

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -219,12 +219,11 @@ class TreeViewExtImpl<T> implements Disposable {
         private proxy: TreeViewsMain,
         readonly commandsConverter: CommandsConverter
     ) {
-        const dragTypes = options.dragAndDropController?.dragMimeTypes ? [...options.dragAndDropController.dragMimeTypes] : undefined;
-        const dropTypes = options.dragAndDropController?.dropMimeTypes ? [...options.dragAndDropController.dropMimeTypes] : undefined;
-
-        proxy.$registerTreeDataProvider(treeViewId, options.canSelectMany, dragTypes, dropTypes);
+        // make copies of optionally provided MIME types:
+        const dragMimeTypes = options.dragAndDropController?.dragMimeTypes?.slice();
+        const dropMimeTypes = options.dragAndDropController?.dropMimeTypes?.slice();
+        proxy.$registerTreeDataProvider(treeViewId, { canSelectMany: options.canSelectMany, dragMimeTypes, dropMimeTypes });
         this.toDispose.push(Disposable.create(() => this.proxy.$unregisterTreeDataProvider(treeViewId)));
-
         options.treeDataProvider.onDidChangeTreeData?.(() => {
             this.pendingRefresh = proxy.$refresh(treeViewId);
         });

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5670,6 +5670,12 @@ export module '@theia/plugin' {
          * An optional interface to implement drag and drop in the tree view.
          */
         dragAndDropController?: TreeDragAndDropController<T>;
+        /**
+         * Whether the tree supports multi-select. When the tree supports multi-select and a command is executed from the tree,
+         * the first argument to the command is the tree item that the command was executed on and the second argument is an
+         * array containing all selected tree items.
+         */
+        canSelectMany?: boolean;
     }
 
     /**


### PR DESCRIPTION
#### What it does
Adds multi-selection support to tree views contributed via VS Code API

Fixes #9074

Contributed on behalf of STMicroelectronics

#### How to test
The attached extension contributes a tree view that has multi-select enabled. There is a command "Print Selection" which prints out the selected items on the extension side. Make sure the behavior is consistent with VS Code.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
