### PR TITLE
style: Debug Variable styling fix

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -169,7 +169,6 @@
 }
 
 .theia-debug-console-variable {
-    display: flex;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -207,6 +206,10 @@
 .theia-debug-console-variable .watch-error {
     font-style: italic;
     color: var(--theia-debugConsole-errorForeground);
+}
+
+.theia-debug-watch-expression {
+    display: flex;
 }
 
 /** Editor **/

--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -51,7 +51,7 @@ export class DebugWatchExpression extends ExpressionItem {
     }
 
     override render(): React.ReactNode {
-        return <div className='theia-debug-console-variable'>
+        return <div className='theia-debug-console-variable theia-debug-watch-expression'>
             <div className={TREE_NODE_SEGMENT_GROW_CLASS}>
                 <span title={this.type || this._expression} className='name'>{this._expression}: </span>
                 <span title={this._value} ref={this.setValueRef} className={this.isError ? 'watch-error' : ''}>{this._value}</span>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes: #12085 via CSS

The commit fixes the styling of the debug variables tree-view section including:
- respecting spaces between the variable and the value
- displaying ellipsis when content takes too much space

![image](https://user-images.githubusercontent.com/40359487/213777117-9521fa7b-8282-4dac-aa7b-948c9d6ec36d.png)


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Reproduce the steps on #12085
1. start the application with theia as a workspace
2. set a breakpoint in a `*.spec.ts` file
3. start a debug session with `run mocha tests` config
4. confirm the styling of the debug variables is correct (spacing and ellipsis)
5. add a watch variable
6. confirm the styling to dismiss the variable is correct

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: FernandoAscencio <fernando.ascencio.cama@ericsson.com>
