### PR TITLE
Raise VS Code API level to 1.68.1. 

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.55.2';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.68.1';


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #12029

Contributed on behalf of STMicroelectronics

#### How to test
1. Remove the default plugins from `./plugins`.
2. Built theia
3. do `yarn download:plugins`
4. Make sure the downloaded plugins are at elvel 1.68.1
5. Run theia and make sure everything works as usual. A good test case would be developing Theia itself.

#### Review checklist
- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
