### PR TITLE
Fix some API inconsistencies related to web views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
 ## v1.34.0 - 01/26/2023
-
+- [plugin] Fixed some API inconsistencies related to web views [#12087](https://github.com/eclipse-theia/theia/issues/12087) - Contributed on behalf of STMicroelectronics
 - [plugin] added support for `isTransient` of `TerminalOptions` and `ExternalTerminalOptions` VS Code API [#12055](https://github.com/eclipse-theia/theia/pull/12055) - Contributed on behalf of STMicroelectronics
 - [terminal] added support for preference `terminal.integrated.enablePersistentSessions` to allow disabling restoring terminals on reload [#12055](https://github.com/eclipse-theia/theia/pull/12055) - Contributed on behalf of STMicroelectronics
 

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -76,7 +76,7 @@ export interface WebviewContentOptions {
     readonly allowForms?: boolean;
     readonly localResourceRoots?: ReadonlyArray<string>;
     readonly portMapping?: ReadonlyArray<WebviewPortMapping>;
-    readonly enableCommandUris?: boolean;
+    readonly enableCommandUris?: boolean | readonly string[];
 }
 
 @injectable()
@@ -450,8 +450,12 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
             }
             return link;
         }
-        if (!!this.contentOptions.enableCommandUris && link.scheme === Schemes.command) {
-            return link;
+        if (link.scheme === Schemes.command) {
+            if (Array.isArray(this.contentOptions.enableCommandUris) && this.contentOptions.enableCommandUris.some(value => value === link.path.toString())) {
+                return link;
+            } else if (this.contentOptions.enableCommandUris === true) {
+                return link;
+            }
         }
         return undefined;
     }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3871,9 +3871,11 @@ export module '@theia/plugin' {
         /**
          * Controls whether command uris are enabled in webview content or not.
          *
-         * Defaults to false.
+         * Defaults to `false` (command uris are disabled).
+         *
+         * If you pass in an array, only the commands in the array are allowed.
          */
-        readonly enableCommandUris?: boolean;
+        readonly enableCommandUris?: boolean | readonly string[];
 
         /**
          * Root paths from which the webview can load local (filesystem) resources using the `theia-resource:` scheme.
@@ -5026,7 +5028,7 @@ export module '@theia/plugin' {
          *
          * @return New webview panel.
          */
-        export function createWebviewPanel(viewType: string, title: string, showOptions: ViewColumn | WebviewPanelShowOptions,
+        export function createWebviewPanel(viewType: string, title: string, showOptions: ViewColumn | { readonly viewColumn: ViewColumn; readonly preserveFocus?: boolean },
             options?: WebviewPanelOptions & WebviewOptions): WebviewPanel;
 
         /**


### PR DESCRIPTION
#### What it does
Fixes a typing difference in `createWebViewPanel` as well as support for filtering command links via an array of command id's passed to `enableCommandUris`.

Fixes #12087

Contributed on behalf of STMicroelectronics

#### How to test
The attached extension opens three web views at startup: one where the `openFolder` link works, but `openFile` is disabled, one where command links are generally enabled and one where they are generally turned off.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
