### PR TITLE
monaco: improve responsiveness of quick-input menus

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -95,6 +95,7 @@ export class MonacoQuickInputImplementation implements IQuickInputService {
         this.themeService.initialized.then(() => this.controller.applyStyles(this.getStyles()));
         // Hook into the theming service of Monaco to ensure that the updates are ready.
         StandaloneServices.get(IStandaloneThemeService).onDidColorThemeChange(() => this.controller.applyStyles(this.getStyles()));
+        window.addEventListener('resize', () => this.updateLayout());
     }
 
     setContextKey(key: string | undefined): void {
@@ -176,7 +177,17 @@ export class MonacoQuickInputImplementation implements IQuickInputService {
 
     private initController(): void {
         this.controller = new QuickInputController(this.getOptions());
-        this.controller.layout({ width: 600, height: 1200 }, 0);
+        this.updateLayout();
+    }
+
+    private updateLayout(): void {
+        // Initialize the layout using screen dimensions as monaco computes the actual sizing.
+        // https://github.com/microsoft/vscode/blob/6261075646f055b99068d3688932416f2346dd3b/src/vs/base/parts/quickinput/browser/quickInput.ts#L1799
+        this.controller.layout(this.getClientDimension(), 0);
+    }
+
+    private getClientDimension(): monaco.editor.IDimension {
+        return { width: window.innerWidth, height: window.innerHeight };
     }
 
     private getOptions(): IQuickInputOptions {

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -99,8 +99,6 @@
 
 /* Monaco Quick Input */
 .quick-input-widget {
-  width: 600px !important;
-  margin-left: -300px !important;
   background-color: var(--theia-quickInput-background) !important;
   color: var(--theia-foreground) !important;
 }
@@ -121,6 +119,7 @@
   .monaco-icon-label-container
   > .monaco-icon-name-container {
   display: flex !important;
+  overflow: hidden;
 }
 
 .quick-input-list .monaco-list-row.focused {
@@ -170,15 +169,6 @@
   line-height: 22px;
 }
 
-.quick-input-list
-  .quick-input-list-rows
-  > .quick-input-list-row
-  .monaco-icon-label
-  .monaco-icon-label-container
-  > .monaco-icon-name-container {
-  flex: 0 !important;
-}
-
 .quick-input-list-rows
   .quick-input-list-row
   .monaco-icon-label
@@ -198,6 +188,8 @@
     font-family: var(--theia-ui-font-family);
     font-size: var(--theia-ui-font-size1) !important;
     color: var(--theia-foreground) !important;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .quick-input-list .monaco-icon-label::before {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The pull-request fixes an issue where the monaco `quick-input` menus are not responsive and do not display properly when the application is resized. The changes fix a bug when setting the layout of the monaco container to be aware of the client's `width` and `height` (which was previously incorrectly hardcoded), and notify the container when the layout is updated. The change also removes hardcoded width and margin and instead lets monaco handle the display. 


https://user-images.githubusercontent.com/40359487/214359877-9acb1deb-d2c4-44ae-83ad-3c799219a91c.mov



<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. start the application
2. open the command palette (<kbd>F1</kbd>)
3. confirm the display is correct
4. resize the window and confirm the quick-input menu is resized
5. repeat the steps with other menus
6. repeat the steps with the application starting at different window sizes


#### Review checklist
- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: FernandoAscencio <fernando.ascencio.cama@ericsson.com>