### PR TITLE
Revert "Fix starting pseudoterminal (#10780)"

### DIFF
--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -189,8 +189,7 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
             terminal.deferredProcessId = new Deferred<number>();
             terminal.deferredProcessId.resolve(processId);
         }
-        // Pseudoterminal is keyed on ID
-        const pseudoTerminal = this._pseudoTerminals.get(id);
+        const pseudoTerminal = this._pseudoTerminals.get(terminalId.toString());
         if (pseudoTerminal) {
             pseudoTerminal.emitOnOpen(cols, rows);
         }


### PR DESCRIPTION
Signed-off-by: robmor01 <Rob.Moran@arm.com>

This reverts commit 363e5216dac77e4c3fa419f201cc161955084c43.

This reverts the previous fix for opening pseudoterminals as they now work as expected.

Supersedes: #12005
Fixes: #11858

Tested in browser and electron examples. Test steps from #12005 can be used (thanks @zvzuola)

cc @arekzaluski @zvzuola
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
