### PR TITLE
Use tree item path for tree node id. Fixes #12111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.36.0
+
+<a name="breaking_changes_1.36.0">[Breaking Changes:](#breaking_changes_1.36.0)</a>
+
+- [plugin] renamed `TreeViewExtImpl#toTreeItem()` to `TreeViewExtImpl#toTreeElement()`
+
 ## v1.35.0 - 02/23/2023
 
 - [application-package] updated default supported VS Code API to `1.70.1` [#12200](https://github.com/eclipse-theia/theia/pull/12200)

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -315,13 +315,9 @@ class TreeViewExtImpl<T> implements Disposable {
             // parent is inconsistent
             return undefined;
         }
-        let possibleIndex = children.length;
-        // find the right element id by searching all possible id names in the cache
-        while (possibleIndex-- > 0) {
-            const candidateId = this.buildTreeItemId(parentId, treeItem);
-            if (this.nodes.has(candidateId)) {
-                return chain.concat(candidateId);
-            }
+        const candidateId = this.buildTreeItemId(parentId, treeItem);
+        if (this.nodes.has(candidateId)) {
+            return chain.concat(candidateId);
         }
         // couldn't calculate consistent parent chain and id
         return undefined;

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -355,7 +355,7 @@ class TreeViewExtImpl<T> implements Disposable {
         // note: the front end tree implementation cannot handle reparenting items, hence the id is set to the "path" of individual ids
         let id = typeof item.id === 'string' ? item.id : this.getItemLabel(item);
         if (id) {
-            // we use '' as the id of the root, we don't consider that a valid id 
+            // we use '' as the id of the root, we don't consider that a valid id
             id = TreeViewExtImpl.ID_ITEM + id;
         } else {
             id = TreeViewExtImpl.ID_COMPUTED + this.nextItemId++;

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -352,6 +352,7 @@ class TreeViewExtImpl<T> implements Disposable {
         let id = typeof item.id === 'string' ? item.id : this.getItemLabel(item);
         if (id) {
             // we use '' as the id of the root, we don't consider that a valid id
+            // since '' is falsy, we'll never get '' in this branch
             id = TreeViewExtImpl.ID_ITEM + id;
         } else {
             id = TreeViewExtImpl.ID_COMPUTED + this.nextItemId++;

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -323,7 +323,7 @@ class TreeViewExtImpl<T> implements Disposable {
         return undefined;
     }
 
-    private getLabelString(treeItem: TreeItem): string | undefined {
+    private getTreeItemLabel(treeItem: TreeItem): string | undefined {
         const treeItemLabel: string | TreeItemLabel | undefined = treeItem.label;
         return typeof treeItemLabel === 'object' ? treeItemLabel.label : treeItemLabel;
     }
@@ -334,7 +334,7 @@ class TreeViewExtImpl<T> implements Disposable {
     }
 
     private getItemLabel(treeItem: TreeItem): string | undefined {
-        let idLabel = this.getLabelString(treeItem);
+        let idLabel = this.getTreeItemLabel(treeItem);
         // Use resource URI if label is not set
         if (idLabel === undefined && treeItem.resourceUri) {
             idLabel = treeItem.resourceUri.path.toString();


### PR DESCRIPTION
- Since our front end tree is not safe for reparenting nodes, use the path of tree item ids as the tree node id.
- Rename TreeViewExt.getTreeItem to getElement, since that is what it does.

Contributed on behalf of ST Microelectronics

Signed-off-by: Thomas Mäder <t.s.maeder@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #12111
Since the Theia front end tree cannot handle reparenting tree nodes with the same id, this PR fixes the problem for tree views contributed via the VS Code API. The idea is to concatenate the id of the parent `TreeItem` with the id of the tree item itself to use as the id of the `TreeViewItem` that is sent to the front end. Thus, the id of the tree node in the front end will be different when being reparented, thus working around the problem.

#### How to test
Install the extension from https://github.com/eclipse-theia/theia/pull/12065#issuecomment-1380392900 and test that elements can be properly reparented and that selection and expansion behaviour is as expected. Note that, since the id changes when reparenting, an item that is dragged to a different folder will not be selected after the move. I consider this an acceptable trade-off considering the current state may lead to an endless loop. I was not able to think of a fix that would avoid this without thoroughly refactoring the tree subsystem.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
