### PR TITLE
[scripts] Fixed the comparison of package references

### DIFF
--- a/dev-packages/private-eslint-plugin/tsconfig.json
+++ b/dev-packages/private-eslint-plugin/tsconfig.json
@@ -6,5 +6,12 @@
   "include": [
     "rules"
   ],
-  "references": []
+  "references": [
+    {
+      "path": "../../packages/core"
+    },
+    {
+      "path": "../private-re-exports"
+    }
+  ]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,6 +12,12 @@
   "references": [
     {
       "path": "../../dev-packages/application-package"
+    },
+    {
+      "path": "../../dev-packages/private-re-exports"
+    },
+    {
+      "path": "../../dev-packages/request"
     }
   ]
 }

--- a/packages/editor-preview/tsconfig.json
+++ b/packages/editor-preview/tsconfig.json
@@ -14,6 +14,9 @@
     },
     {
       "path": "../editor"
+    },
+    {
+      "path": "../navigator"
     }
   ]
 }

--- a/scripts/compile-references.js
+++ b/scripts/compile-references.js
@@ -126,7 +126,10 @@ async function configureTypeScriptReferences(targetPackage, expectedReferences) 
     /** @type {string[]} */
     const currentReferences = (tsconfigJson['references'] || []).map(reference => reference.path);
     // Compare both arrays: if an element is not the same we need to rewrite.
-    needRewrite = needRewrite || currentReferences.some((reference, index) => expectedReferences[index] !== reference);
+    needRewrite = needRewrite
+        || currentReferences.some((reference, index) => expectedReferences[index] !== reference)
+        || expectedReferences.some((reference, index) => currentReferences[index] !== reference);
+
     if (needRewrite) {
         tsconfigJson.references = expectedReferences.map(path => ({ path }));
         const content = JSON.stringify(tsconfigJson, undefined, 2);

--- a/scripts/compile-references.js
+++ b/scripts/compile-references.js
@@ -127,9 +127,8 @@ async function configureTypeScriptReferences(targetPackage, expectedReferences) 
     const currentReferences = (tsconfigJson['references'] || []).map(reference => reference.path);
     // Compare both arrays: if an element is not the same we need to rewrite.
     needRewrite = needRewrite
-        || currentReferences.some((reference, index) => expectedReferences[index] !== reference)
-        || expectedReferences.some((reference, index) => currentReferences[index] !== reference);
-
+        || currentReferences.length !== expectedReferences.length
+        || currentReferences.some((reference, index) => expectedReferences[index] !== reference);
     if (needRewrite) {
         tsconfigJson.references = expectedReferences.map(path => ({ path }));
         const content = JSON.stringify(tsconfigJson, undefined, 2);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

If there are some dependencies in the package.json but developer forgot to add them into the `references` array of the tsconfig.json, the `compile:references` will not add these dependencies into the tsconfig.json. This can lead to build failures due to errors in the compile order of the modules at build time.

![image](https://user-images.githubusercontent.com/33852855/215313724-f5174ca4-c1f2-4627-a04c-deed991efd1e.png)

I think we should add a check instead of requiring developers to ensure references in tsconfig.json are written correctly. So, I added `expectedReferences.some((reference, index) => currentReferences[index] !== reference)` to fix the generation of the tsconfig.json

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Run `yarn compile:references`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
