### PR TITLE
preferences: fix merge method in PreferenceProvider

### DIFF
--- a/packages/core/src/browser/preferences/preference-provider.spec.ts
+++ b/packages/core/src/browser/preferences/preference-provider.spec.ts
@@ -1,0 +1,36 @@
+// *****************************************************************************
+// Copyright (C) 2023 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceProvider } from './preference-provider';
+const { expect } = require('chai');
+
+describe('PreferenceProvider', () => {
+    it('should preserve extra source fields on merge', () => {
+        const result = PreferenceProvider.merge({ 'configurations': [], 'compounds': [] }, { 'configurations': [] });
+        expect(result).deep.equals({ 'configurations': [], 'compounds': [] });
+    });
+    it('should preserve extra target fields on merge', () => {
+        const result = PreferenceProvider.merge({ 'configurations': [] }, { 'configurations': [], 'compounds': [] });
+        expect(result).deep.equals({ 'configurations': [], 'compounds': [] });
+    });
+    it('should merge array values', () => {
+        const result = PreferenceProvider.merge(
+            { 'configurations': [{ 'name': 'test1', 'request': 'launch' }], 'compounds': [] },
+            { 'configurations': [{ 'name': 'test2' }] }
+        );
+        expect(result).deep.equals({ 'configurations': [{ 'name': 'test1', 'request': 'launch' }, { 'name': 'test2' }], 'compounds': [] });
+    });
+});

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -235,6 +235,9 @@ export abstract class PreferenceProvider implements Disposable {
                 if (JSONExt.isObject(source[key]) && JSONExt.isObject(value)) {
                     this.merge(source[key], value);
                     continue;
+                } else if (JSONExt.isArray(source[key]) && JSONExt.isArray(value)) {
+                    source[key] = [...JSONExt.deepCopy(source[key] as any), ...JSONExt.deepCopy(value)];
+                    continue;
                 }
             }
             source[key] = JSONExt.deepCopy(value);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When merging preferences, in the PreferenceProvider, also merge properties of type array. Currently, properties of type object are merged, but for arrays only the value from the target JSON is used.

This fixes the first use case described in issue https://github.com/eclipse-theia/theia/issues/8987, where launch configs defined in the workspace are not visible, if other launch configs exist in a `launch.json` file.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Create a workspace with a test folder and a `.theia-workspace` file, e.g.:
```
{
    "folders": [
        {
            "path": "test"
        }
    ],
    "settings": {
        "launch": {
            "configurations": [
                {
                    "name": "from .theia-workspace",
                    "request": "launch",
                    "type": "node",
                }
            ]
        }
    }
}
```
2. Go to the `Debug` view and check that the launch configs from the workspace file are present in the dropdown at the top of the view. 
3. Add a `.theia/launch.json` file with at least one launch configuration, e.g.: 
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "from .theia",
            "request": "launch",
            "type": "node",
        }
    ]
}
```
4. Go to the `Debug` view and check that the launch configs from  `launch.json` are visible in the dropdown, alongside the ones from the workspace file.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
