### PR TITLE
Align terminal command ids with VS Code. Fixes #12084

### DIFF
--- a/packages/plugin-ext/src/plugin/dialogs.ts
+++ b/packages/plugin-ext/src/plugin/dialogs.ts
@@ -30,8 +30,8 @@ export class DialogsExtImpl {
             title: options.title,
             openLabel: options.openLabel,
             defaultUri: options.defaultUri ? options.defaultUri.path : undefined,
-            canSelectFiles: options.canSelectFiles ? options.canSelectFiles : true,
-            canSelectFolders: options.canSelectFolders ? options.canSelectFolders : false,
+            canSelectFiles: typeof options.canSelectFiles === 'boolean' ? options.canSelectFiles : true,
+            canSelectFolders: typeof options.canSelectFolders === 'boolean' ? options.canSelectFolders : false,
             canSelectMany: options.canSelectMany,
             filters: options.filters
         } as OpenDialogOptionsMain;

--- a/packages/plugin-ext/src/plugin/known-commands.ts
+++ b/packages/plugin-ext/src/plugin/known-commands.ts
@@ -66,7 +66,7 @@ export namespace KnownCommands {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ID = (args: any[]) => args;
+    const identity = (args: any[]) => args;
 
     mappings['editor.action.select.all'] = ['editor.action.select.all', CONVERT_VSCODE_TO_MONACO];
     mappings['editor.action.toggleHighContrast'] = ['editor.action.toggleHighContrast', CONVERT_VSCODE_TO_MONACO];
@@ -308,15 +308,15 @@ export namespace KnownCommands {
     mappings['vscode.diff'] = ['vscode.diff', CONVERT_VSCODE_TO_MONACO];
 
     // terminal commands
-    mappings['workbench.action.terminal.new'] = ['terminal:new', ID];
-    mappings['workbench.action.terminal.newWithProfile'] = ['terminal:new:profile', ID];
-    mappings['workbench.action.terminal.selectDefaultShell'] = ['terminal:profile:default', ID];
-    mappings['workbench.action.terminal.newInActiveWorkspace'] = ['terminal:new:active:workspace', ID];
-    mappings['workbench.action.terminal.clear'] = ['terminal:clear', ID];
+    mappings['workbench.action.terminal.new'] = ['terminal:new', identity];
+    mappings['workbench.action.terminal.newWithProfile'] = ['terminal:new:profile', identity];
+    mappings['workbench.action.terminal.selectDefaultShell'] = ['terminal:profile:default', identity];
+    mappings['workbench.action.terminal.newInActiveWorkspace'] = ['terminal:new:active:workspace', identity];
+    mappings['workbench.action.terminal.clear'] = ['terminal:clear', identity];
     mappings['openInTerminal'] = ['terminal:context', createConversionFunction((uri: URI) => new TheiaURI(uri))];
-    mappings['workbench.action.terminal.split'] = ['terminal:split', ID];
-    mappings['workbench.action.terminal.focusFind'] = ['terminal:find', ID];
-    mappings['workbench.action.terminal.hideFind'] = ['terminal:find:cancel', ID];
+    mappings['workbench.action.terminal.split'] = ['terminal:split', identity];
+    mappings['workbench.action.terminal.focusFind'] = ['terminal:find', identity];
+    mappings['workbench.action.terminal.hideFind'] = ['terminal:find:cancel', identity];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function map<T>(id: string, args: any[] | undefined, toDo: (mappedId: string, mappedArgs: any[] | undefined, mappedResult: ConversionFunction | undefined) => T): T {

--- a/packages/plugin-ext/src/plugin/known-commands.ts
+++ b/packages/plugin-ext/src/plugin/known-commands.ts
@@ -14,8 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Range as R, Position as P, Location as L } from '@theia/core/shared/vscode-languageserver-protocol';
 import * as theia from '@theia/plugin';
+import { Range as R, Position as P, Location as L } from '@theia/core/shared/vscode-languageserver-protocol';
+import { URI as TheiaURI } from '@theia/core/lib/common/uri';
 import { cloneAndChange } from '../common/objects';
 import { Position, Range, Location, CallHierarchyItem, TypeHierarchyItem, URI, TextDocumentShowOptions } from './types-impl';
 import {
@@ -26,8 +27,6 @@ import {
     isModelCallHierarchyIncomingCall, toCallHierarchyIncomingCall,
     isModelCallHierarchyOutgoingCall, toCallHierarchyOutgoingCall, fromTextDocumentShowOptions
 } from './type-converters';
-
-import { URI as TheiaURI } from '@theia/core/lib/common/uri';
 
 // Here is a mapping of VSCode commands to monaco commands with their conversions
 export namespace KnownCommands {

--- a/packages/plugin-ext/src/plugin/known-commands.ts
+++ b/packages/plugin-ext/src/plugin/known-commands.ts
@@ -27,6 +27,8 @@ import {
     isModelCallHierarchyOutgoingCall, toCallHierarchyOutgoingCall, fromTextDocumentShowOptions
 } from './type-converters';
 
+import { URI as TheiaURI } from '@theia/core/lib/common/uri';
+
 // Here is a mapping of VSCode commands to monaco commands with their conversions
 export namespace KnownCommands {
 
@@ -62,6 +64,9 @@ export namespace KnownCommands {
             return createConversionFunction(...argStack)(args);
         }
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ID = (args: any[]) => args;
 
     mappings['editor.action.select.all'] = ['editor.action.select.all', CONVERT_VSCODE_TO_MONACO];
     mappings['editor.action.toggleHighContrast'] = ['editor.action.toggleHighContrast', CONVERT_VSCODE_TO_MONACO];
@@ -301,6 +306,17 @@ export namespace KnownCommands {
 
     mappings['vscode.open'] = ['vscode.open', CONVERT_VSCODE_TO_MONACO];
     mappings['vscode.diff'] = ['vscode.diff', CONVERT_VSCODE_TO_MONACO];
+
+    // terminal commands
+    mappings['workbench.action.terminal.new'] = ['terminal:new', ID];
+    mappings['workbench.action.terminal.newWithProfile'] = ['terminal:new:profile', ID];
+    mappings['workbench.action.terminal.selectDefaultShell'] = ['terminal:profile:default', ID];
+    mappings['workbench.action.terminal.newInActiveWorkspace'] = ['terminal:new:active:workspace', ID];
+    mappings['workbench.action.terminal.clear'] = ['terminal:clear', ID];
+    mappings['openInTerminal'] = ['terminal:context', createConversionFunction((uri: URI) => new TheiaURI(uri))];
+    mappings['workbench.action.terminal.split'] = ['terminal:split', ID];
+    mappings['workbench.action.terminal.focusFind'] = ['terminal:find', ID];
+    mappings['workbench.action.terminal.hideFind'] = ['terminal:find:cancel', ID];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function map<T>(id: string, args: any[] | undefined, toDo: (mappedId: string, mappedArgs: any[] | undefined, mappedResult: ConversionFunction | undefined) => T): T {


### PR DESCRIPTION
#### What it does
This PR aligns the command ids of commands related to terminals with their counterparts in VS Code. 
The change includes a "drive-by" fix for the file open dialog that I needed for testing "Open in Terminal".

Fixes #12084

Contributed on behalf of STMicroelectronics

#### How to test
The attached extension contributes commands that invokes each terminal command via its VS Code id.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
