### PR TITLE
Allow plugins to access language overrides with bracket syntax

### DIFF
--- a/packages/plugin-ext/src/plugin/preference-registry.spec.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.spec.ts
@@ -229,6 +229,11 @@ describe.only('PreferenceRegistryExtImpl:', () => {
             expect(pythonOverrides).not.to.be.undefined;
             expect(pythonOverrides?.['editor.renderWhitespace']).equal('all');
         });
+        // https://github.com/eclipse-theia/theia/issues/12043
+        it('Allows access preferences without specifying the section', () => {
+            const inspection = preferenceRegistryExtImpl.getConfiguration().inspect('editor.fontSize');
+            expect(inspection?.defaultValue).equal(14);
+        });
     });
 
     describe('Proxy Behavior', () => {

--- a/packages/plugin-ext/src/plugin/preference-registry.spec.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.spec.ts
@@ -230,7 +230,7 @@ describe.only('PreferenceRegistryExtImpl:', () => {
             expect(pythonOverrides?.['editor.renderWhitespace']).equal('all');
         });
         // https://github.com/eclipse-theia/theia/issues/12043
-        it('Allows access preferences without specifying the section', () => {
+        it('Allows access to preferences without specifying the section', () => {
             const inspection = preferenceRegistryExtImpl.getConfiguration().inspect('editor.fontSize');
             expect(inspection?.defaultValue).equal(14);
         });

--- a/packages/plugin-ext/src/plugin/preference-registry.spec.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.spec.ts
@@ -23,7 +23,7 @@ import { URI } from './types-impl';
 const expect = chai.expect;
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-describe.only('PreferenceRegistryExtImpl:', () => {
+describe('PreferenceRegistryExtImpl:', () => {
     const workspaceRoot = URI.parse('/workspace-root');
     let preferenceRegistryExtImpl: PreferenceRegistryExtImpl;
     const getProxy = (proxyId: ProxyIdentifier<unknown>) => { };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: #12129

In VSCode, it is possible to access language-overridden preferences using [`vscode.workspace.getConfiguration().get('[languageId]')`](https://github.com/redhat-developer/vscode-xml/blob/efd52ad1f6e89e962c576795c324621aed7d8370/src/settings/settings.ts#L112). That has not been possible with the way preferences were being parsed in the `PreferenceRegistryExtImpl`. This PR adjusts the parsing routine to enable that style of access.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Testcases have been added - if CI passes, the code is working as intended.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
