### PR TITLE
bump default supported VS Code API version to 1.68.1 (#12090)

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.66.2';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.68.1';


### PR DESCRIPTION
This is a backport of https://github.com/eclipse-theia/theia/pull/12090. See there for motivation and testing.
