### PR TITLE
Close duplicate editors on same tabbar

### DIFF
--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -93,9 +93,11 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
     }
 
     protected handleTabBarChange(oldTabBar?: TabBar<Widget>, newTabBar?: TabBar<Widget>): void {
-        const competingEditors = newTabBar?.titles.filter(title => title !== this.title
+        const ownSaveable = Saveable.get(this);
+        const competingEditors = ownSaveable && newTabBar?.titles.filter(title => title !== this.title
             && (title.owner instanceof EditorWidget)
             && title.owner.editor.uri.isEqual(this.editor.uri)
+            && Saveable.get(title.owner) === ownSaveable
         );
         competingEditors?.forEach(title => title.owner.close());
     }

--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -14,12 +14,16 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Disposable, SelectionService, Event, UNTITLED_SCHEME } from '@theia/core/lib/common';
-import { Widget, BaseWidget, Message, Saveable, SaveableSource, Navigatable, StatefulWidget, lock } from '@theia/core/lib/browser';
+import { Disposable, SelectionService, Event, UNTITLED_SCHEME, DisposableCollection } from '@theia/core/lib/common';
+import { Widget, BaseWidget, Message, Saveable, SaveableSource, Navigatable, StatefulWidget, lock, TabBar, DockPanel } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
+import { find } from '@theia/core/shared/@phosphor/algorithm';
 import { TextEditor } from './editor';
 
 export class EditorWidget extends BaseWidget implements SaveableSource, Navigatable, StatefulWidget {
+
+    protected toDisposeOnTabbarChange = new DisposableCollection();
+    protected currentTabbar: TabBar<Widget> | undefined;
 
     constructor(
         readonly editor: TextEditor,
@@ -31,6 +35,7 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
             lock(this.title);
         }
         this.toDispose.push(this.editor);
+        this.toDispose.push(this.toDisposeOnTabbarChange);
         this.toDispose.push(this.editor.onSelectionChanged(() => this.setSelection()));
         this.toDispose.push(this.editor.onFocusChanged(() => this.setSelection()));
         this.toDispose.push(Disposable.create(() => {
@@ -68,6 +73,31 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
         if (this.isVisible) {
             this.editor.refresh();
         }
+        this.checkForTabbarChange();
+    }
+
+    protected checkForTabbarChange(): void {
+        const { parent } = this;
+        if (parent instanceof DockPanel) {
+            const newTabbar = find(parent.tabBars(), tabbar => !!tabbar.titles.find(title => title === this.title));
+            if (this.currentTabbar !== newTabbar) {
+                this.toDisposeOnTabbarChange.dispose();
+                const listener = () => this.checkForTabbarChange();
+                parent.layoutModified.connect(listener);
+                this.toDisposeOnTabbarChange.push(Disposable.create(() => parent.layoutModified.disconnect(listener)));
+                const last = this.currentTabbar;
+                this.currentTabbar = newTabbar;
+                this.handleTabBarChange(last, newTabbar);
+            }
+        }
+    }
+
+    protected handleTabBarChange(oldTabBar?: TabBar<Widget>, newTabBar?: TabBar<Widget>): void {
+        const competingEditors = newTabBar?.titles.filter(title => title !== this.title
+            && (title.owner instanceof EditorWidget)
+            && title.owner.editor.uri.isEqual(this.editor.uri)
+        );
+        competingEditors?.forEach(title => title.owner.close());
     }
 
     protected override onAfterShow(msg: Message): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Implements behavior similar to VSCode's where editors already on a given tabbar for a given URI are closed when a new editor for that URI is moved onto the tabbar.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Split an editor.
2. Change the states of the two editors.
3. Move one editor onto the other's tabbar.
4. Observe that the moved editor remains open, and the other editor is closed.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
