### PR TITLE
[CI] [license check] Always specify project

### DIFF
--- a/scripts/check_3pp_licenses.js
+++ b/scripts/check_3pp_licenses.js
@@ -66,10 +66,10 @@ async function main() {
         fs.renameSync(dashLicensesSummary, `${dashLicensesSummary}.old`);
     }
     info('Running dash-licenses...');
-    const args = ['-jar', dashLicensesJar, 'yarn.lock', '-batch', '50', '-timeout', '240', '-summary', dashLicensesSummary];
+    const args = ['-jar', dashLicensesJar, 'yarn.lock', '-batch', '50', '-timeout', '240', '-project', project, '-summary', dashLicensesSummary];
     if (autoReviewMode && personalAccessToken) {
         info(`Using "review" mode for project: ${project}`);
-        args.push('-review', '-token', personalAccessToken, '-project', project);
+        args.push('-review', '-token', personalAccessToken);
     }
     const dashError = getErrorFromStatus(spawn('java', args, {
         stdio: ['ignore', 'ignore', 'inherit']


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
During CI we run `dash-licenses` to check that the project's 3PP dependencies are approved by the Eclipse foundation. When a PR originates from the main repo, a token is available that permits running the tool in "automated review mode", which opens IP tickets automatically towards the Eclipse Foundation. When a PR originates from elsewhere, that token is not available and so we fall-back to reporting issues in the CI log.

Until now, the "-project" option of `dash-licenses` was only thought useful in "automated review" mode, but it turns-out there is a rare case where we benefit providing this information all the time: when a 3PP dependency was narrowly approved, for use in Eclipse Theia only. Here is one such dependency:

https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/2734

The dependency above is part of a recent PR from an outside contributor (non-committer), that originated from a fork:

https://github.com/eclipse-theia/theia/pull/12141

So far, for PRs originating from a fork, we would not provide the project when running `dash-licenses` and so such dependency are incorrectly flagged as unapproved:

https://github.com/eclipse-theia/theia/actions/runs/4075784869/jobs/7077702838#step:5:186

This commit provides the project all the time, so that such dependencies will be correctly assessed, based on what's approved for our project, even for non-committer contributors.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Locally add the following 3PP dependency and then run license check without a Gitlab token defined, confirm that the license check succeeds.

3PP: npm/npmjs/-/playwright-core/1.30.0

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
