### PR TITLE
Improve outlines for trees and select component

### DIFF
--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -54,7 +54,8 @@
     text-overflow: ellipsis;
     overflow: hidden;
     display: flex;
-    padding: 2px 5px;
+    padding: 0px 5px;
+    line-height: 22px;
 }
 
 .theia-select-component-dropdown .theia-select-component-description {
@@ -87,8 +88,6 @@
     color: var(--theia-list-activeSelectionForeground);
     cursor: pointer;
     background: var(--theia-list-activeSelectionBackground);
-    outline: var(--theia-focusBorder) solid 1px;
-    outline-offset: -1px;
 }
 
 .theia-select-component-dropdown .theia-select-component-separator {

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -100,6 +100,8 @@
 .theia-Tree:focus-within .theia-TreeNode.theia-mod-selected {
     background: var(--theia-list-activeSelectionBackground);
     color: var(--theia-list-activeSelectionForeground) !important;
+    outline: var(--theia-focusBorder) solid 1px;
+    outline-offset: -1px;
 }
 
 .theia-Tree:focus-within .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,


### PR DESCRIPTION
#### What it does

I believe we used to have outlines for tree items, but I might have accidentally removed them in https://github.com/eclipse-theia/theia/pull/11280. This PR adds them back.

It also removes the outlines for items in our select component, which seemed to have disappeared in the newest vscode version. VSCode has also increased the `line-height` for each individual option, so that's been done in this PR as well.

#### How to test

1. Focus tree items in a tree view (navigator for example). Focused items should have a focus border around them
2. Open select components such as the debug selector. The height and outlines of each individual option should resemble the style of vscode.
3. Please test both of these changes with high contrast themes as well.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
