### PR TITLE
FIX 12154: add margin between input and text

### DIFF
--- a/packages/filesystem/src/browser/style/file-dialog.css
+++ b/packages/filesystem/src/browser/style/file-dialog.css
@@ -202,7 +202,3 @@
 .dialogContent .theia-ControlPanel > * {
     margin-left: 4px;
 }
-
-.dialogContent .theia-input {
-    margin-top: 10px;
-}

--- a/packages/filesystem/src/browser/style/file-dialog.css
+++ b/packages/filesystem/src/browser/style/file-dialog.css
@@ -202,3 +202,7 @@
 .dialogContent .theia-ControlPanel > * {
     margin-left: 4px;
 }
+
+.dialogContent .theia-input {
+    margin-top: 10px;
+}

--- a/packages/workspace/src/browser/workspace-input-dialog.ts
+++ b/packages/workspace/src/browser/workspace-input-dialog.ts
@@ -52,6 +52,7 @@ export class WorkspaceInputDialog extends SingleTextInputDialog {
         icon.style.verticalAlign = 'middle';
         element.style.verticalAlign = 'middle';
         element.style.paddingBottom = '1em';
+
         element.title = this.props.parentUri.path.fsPath();
         element.appendChild(icon);
         element.appendChild(document.createTextNode(label));

--- a/packages/workspace/src/browser/workspace-input-dialog.ts
+++ b/packages/workspace/src/browser/workspace-input-dialog.ts
@@ -51,6 +51,7 @@ export class WorkspaceInputDialog extends SingleTextInputDialog {
         icon.style.marginRight = '0.5em';
         icon.style.verticalAlign = 'middle';
         element.style.verticalAlign = 'middle';
+        element.style.paddingBottom = '1em';
         element.title = this.props.parentUri.path.fsPath();
         element.appendChild(icon);
         element.appendChild(document.createTextNode(label));

--- a/packages/workspace/src/browser/workspace-input-dialog.ts
+++ b/packages/workspace/src/browser/workspace-input-dialog.ts
@@ -52,7 +52,6 @@ export class WorkspaceInputDialog extends SingleTextInputDialog {
         icon.style.verticalAlign = 'middle';
         element.style.verticalAlign = 'middle';
         element.style.paddingBottom = '1em';
-
         element.title = this.props.parentUri.path.fsPath();
         element.appendChild(icon);
         element.appendChild(document.createTextNode(label));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: #12154.

The pull-request fixes an issue with the styling of the `WorkspaceInputDialog`, namely between the content and input field:

<img width="427" alt="Screenshot 2023-02-07 at 22 47 05" src="https://user-images.githubusercontent.com/6393768/217374333-644f6731-9154-45fb-82be-b1027d56558d.png">



#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Follow steps from https://github.com/eclipse-theia/theia/issues/12154.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)