### PR TITLE
preferences: fix duplicated resolution

### DIFF
--- a/examples/api-tests/src/launch-preferences.spec.js
+++ b/examples/api-tests/src/launch-preferences.spec.js
@@ -37,6 +37,7 @@ describe('Launch Preferences', function () {
     const { FileResourceResolver } = require('@theia/filesystem/lib/browser/file-resource');
     const { AbstractResourcePreferenceProvider } = require('@theia/preferences/lib/browser/abstract-resource-preference-provider');
     const { waitForEvent } = require('@theia/core/lib/common/promise-util');
+    const { FoldersPreferencesProvider } = require('@theia/preferences/lib/browser/folders-preferences-provider');
 
     const container = window.theia.container;
     /** @type {import('@theia/core/lib/browser/preferences/preference-service').PreferenceService} */
@@ -46,7 +47,7 @@ describe('Launch Preferences', function () {
     /** @type {import('@theia/preferences/lib/browser/workspace-preference-provider').WorkspacePreferenceProvider} */
     const workspacePreferences = container.getNamed(PreferenceProvider, PreferenceScope.Workspace);
     /** @type {import('@theia/preferences/lib/browser/folders-preferences-provider').FoldersPreferencesProvider} */
-    const folderPreferences = container.getNamed(PreferenceProvider, PreferenceScope.Folder);
+    const folderPreferences = container.get(FoldersPreferencesProvider);
     const workspaceService = container.get(WorkspaceService);
     const fileService = container.get(FileService);
     const fileResourceResolver = container.get(FileResourceResolver);

--- a/examples/api-tests/src/preferences.spec.js
+++ b/examples/api-tests/src/preferences.spec.js
@@ -19,12 +19,12 @@
 describe('Preferences', function () {
     this.timeout(5_000);
     const { assert } = chai;
-    const { PreferenceProvider } = require('@theia/core/lib/browser/preferences/preference-provider');
     const { PreferenceService, PreferenceScope } = require('@theia/core/lib/browser/preferences/preference-service');
     const { FileService } = require('@theia/filesystem/lib/browser/file-service');
     const { PreferenceLanguageOverrideService } = require('@theia/core/lib/browser/preferences/preference-language-override-service');
     const { MonacoTextModelService } = require('@theia/monaco/lib/browser/monaco-text-model-service');
     const { PreferenceSchemaProvider } = require('@theia/core/lib/browser/preferences/preference-contribution')
+    const { FoldersPreferencesProvider } = require('@theia/preferences/lib/browser/folders-preferences-provider');
     const { container } = window.theia;
     /** @type {import ('@theia/core/lib/browser/preferences/preference-service').PreferenceService} */
     const preferenceService = container.get(PreferenceService);
@@ -34,7 +34,7 @@ describe('Preferences', function () {
     /** @type {import ('@theia/core/lib/common/uri').default} */
     const uri = preferenceService.getConfigUri(PreferenceScope.Workspace);
     /** @type {import('@theia/preferences/lib/browser/folders-preferences-provider').FoldersPreferencesProvider} */
-    const folderPreferences = container.getNamed(PreferenceProvider, PreferenceScope.Folder);
+    const folderPreferences = container.get(FoldersPreferencesProvider);
     /** @type PreferenceSchemaProvider */
     const schemaProvider = container.get(PreferenceSchemaProvider);
     const modelService = container.get(MonacoTextModelService);

--- a/packages/core/src/browser/preferences/index.ts
+++ b/packages/core/src/browser/preferences/index.ts
@@ -21,3 +21,4 @@ export * from './preference-provider';
 export * from './preference-scope';
 export * from './preference-language-override-service';
 export * from './preference-validation-service';
+export { TogglePreferenceProvider } from './toggle-preference-provider';

--- a/packages/core/src/browser/preferences/toggle-preference-provider.ts
+++ b/packages/core/src/browser/preferences/toggle-preference-provider.ts
@@ -1,0 +1,105 @@
+// *****************************************************************************
+// Copyright (C) 2023 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { URI } from '../../common';
+import { PreferenceProvider, PreferenceProviderDataChanges, PreferenceResolveResult } from './preference-provider';
+
+/**
+ * Allows enabling/disabling a {@link PreferenceProvider} by wrapping it.
+ */
+export class TogglePreferenceProvider extends PreferenceProvider {
+
+    #enabled: boolean;
+
+    constructor(
+        enabled: boolean,
+        protected provider: PreferenceProvider
+    ) {
+        super();
+        this.#enabled = enabled;
+        this.provider.ready.then(() => this._ready.resolve());
+        this.provider.onDidPreferencesChanged(this.handleDidPreferencesChanged, this, this.toDispose);
+    }
+
+    get enabled(): boolean {
+        return this.#enabled;
+    }
+
+    set enabled(value: boolean) {
+        if (this.#enabled !== value) {
+            this.#enabled = value;
+            this.onDidPreferencesChangedEmitter.fire({});
+        }
+    }
+
+    getPreferences(resourceUri?: string): { [p: string]: any; } {
+        if (this.enabled) {
+            return this.provider.getPreferences(resourceUri);
+        }
+        return {};
+    }
+
+    async setPreference(key: string, value: any, resourceUri?: string): Promise<boolean> {
+        if (this.enabled) {
+            return this.provider.setPreference(key, value, resourceUri);
+        }
+        return false;
+    }
+
+    override get<T>(preferenceName: string, resourceUri?: string): T | undefined {
+        if (this.enabled) {
+            return this.provider.get<T>(preferenceName, resourceUri);
+        }
+    }
+
+    override resolve<T>(preferenceName: string, resourceUri?: string): PreferenceResolveResult<T> {
+        if (this.enabled) {
+            return this.provider.resolve<T>(preferenceName, resourceUri);
+        }
+        return {};
+    }
+
+    override getDomain(): string[] | undefined {
+        if (this.enabled) {
+            return this.provider.getDomain();
+        }
+    }
+
+    override getConfigUri(resourceUri?: string, sectionName?: string): URI | undefined {
+        if (this.enabled) {
+            return this.provider.getConfigUri(resourceUri, sectionName);
+        }
+    }
+
+    override getContainingConfigUri?(resourceUri?: string, sectionName?: string): URI | undefined {
+        if (this.enabled) {
+            return this.provider.getContainingConfigUri?.(resourceUri, sectionName);
+        }
+    }
+
+    override dispose(): void {
+        super.dispose();
+        this.provider.dispose();
+    }
+
+    protected handleDidPreferencesChanged(event: PreferenceProviderDataChanges): void {
+        if (this.enabled) {
+            this.onDidPreferencesChangedEmitter.fire(event);
+        }
+    }
+}

--- a/packages/preferences/src/browser/workspace-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-preference-provider.ts
@@ -22,6 +22,7 @@ import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { PreferenceScope, PreferenceProvider } from '@theia/core/lib/browser/preferences';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { WorkspaceFilePreferenceProviderFactory, WorkspaceFilePreferenceProvider } from './workspace-file-preference-provider';
+import { FoldersPreferencesProvider } from './folders-preferences-provider';
 
 @injectable()
 export class WorkspacePreferenceProvider extends PreferenceProvider {
@@ -32,7 +33,7 @@ export class WorkspacePreferenceProvider extends PreferenceProvider {
     @inject(WorkspaceFilePreferenceProviderFactory)
     protected readonly workspaceFileProviderFactory: WorkspaceFilePreferenceProviderFactory;
 
-    @inject(PreferenceProvider) @named(PreferenceScope.Folder)
+    @inject(FoldersPreferencesProvider) @named(PreferenceScope.Workspace)
     protected readonly folderPreferenceProvider: PreferenceProvider;
 
     protected readonly toDisposeOnEnsureDelegateUpToDate = new DisposableCollection();
@@ -102,33 +103,24 @@ export class WorkspacePreferenceProvider extends PreferenceProvider {
     }
 
     override get<T>(preferenceName: string, resourceUri: string | undefined = this.ensureResourceUri()): T | undefined {
-        const delegate = this.delegate;
-        return delegate ? delegate.get<T>(preferenceName, resourceUri) : undefined;
+        return this.delegate?.get<T>(preferenceName, resourceUri);
     }
 
     override resolve<T>(preferenceName: string, resourceUri: string | undefined = this.ensureResourceUri()): { value?: T, configUri?: URI } {
-        const delegate = this.delegate;
-        return delegate ? delegate.resolve<T>(preferenceName, resourceUri) : {};
+        return this.delegate?.resolve<T>(preferenceName, resourceUri) ?? {};
     }
 
     getPreferences(resourceUri: string | undefined = this.ensureResourceUri()): { [p: string]: any } {
-        const delegate = this.delegate;
-        return delegate ? delegate.getPreferences(resourceUri) : {};
+        return this.delegate?.getPreferences(resourceUri) ?? {};
     }
 
     async setPreference(preferenceName: string, value: any, resourceUri: string | undefined = this.ensureResourceUri()): Promise<boolean> {
-        const delegate = this.delegate;
-        if (delegate) {
-            return delegate.setPreference(preferenceName, value, resourceUri);
-        }
-        return false;
+        return this.delegate?.setPreference(preferenceName, value, resourceUri) ?? false;
     }
 
     protected ensureResourceUri(): string | undefined {
         if (this.workspaceService.workspace && !this.workspaceService.isMultiRootWorkspaceOpened) {
             return this.workspaceService.workspace.resource.toString();
         }
-        return undefined;
     }
-
 }


### PR DESCRIPTION
The `WorkspacePreferenceProvider` can do one of two things: It may return preferences from the current workspace folder if the workspace is a single root workspace, or it may return preferences as defined in the workspace file if the workspace is a multi-root workspace.

Whenever we want to resolve a preference, the following scopes are queried: `Default`, `User`, `Workspace`, and `Folder`.

When a single root workspace is opened the following happens:

- Query `Default` scope [...]
- Query `User` scope [...]
- Query `Workspace` scope: use `WorkspacePreferenceProvider` which delegates to `FoldersPreferenceProvider`.
- Query `Folder` scope: use `FoldersPreferenceProvider`.

Conclusion: The `FoldersPreferenceProvider` is queried twice.

In order to fix that issue this commit introduces a new component: `TogglePreferenceProvider` which extends `PreferenceProvider` and wraps another provider so that it can be enabled/disabled.

Whenever we are running a single root workspace, we'll enable the `FoldersPreferenceProvider` used by `WorkspacePreferenceProvider` and disable the one bound to the `Folder` scope.

Whenever we are running a multi root workspace, we'll disable the `FoldersPreferenceProvider` used by `WorkspacePreferenceProvider` and enable the one bound to the `Folder` scope.

Fixes https://github.com/eclipse-theia/theia/issues/12153

#### How to test

See instructions in https://github.com/eclipse-theia/theia/issues/12153

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
