### PR TITLE
Automatically generate plugin activation events

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -72,6 +72,7 @@ export namespace PluginPackage {
  * This interface describes a package.json contribution section object.
  */
 export interface PluginPackageContribution {
+    authentication?: PluginPackageAuthenticationProvider[];
     configuration?: RecursivePartial<PreferenceSchema> | RecursivePartial<PreferenceSchema>[];
     configurationDefaults?: RecursivePartial<PreferenceSchemaProperties>;
     languages?: PluginPackageLanguageContribution[];
@@ -96,16 +97,29 @@ export interface PluginPackageContribution {
     resourceLabelFormatters?: ResourceLabelFormatter[];
     localizations?: PluginPackageLocalization[];
     terminal?: PluginPackageTerminal;
+    notebooks?: PluginPackageNotebook[];
+}
+
+export interface PluginPackageNotebook {
+    type: string;
+    displayName: string;
+    selector?: readonly { filenamePattern?: string; excludeFileNamePattern?: string }[];
+    priority?: string;
+}
+
+export interface PluginPackageAuthenticationProvider {
+    id: string;
+    label: string;
 }
 
 export interface PluginPackageTerminalProfile {
-    title: string,
-    id: string,
-    icon?: string
+    title: string;
+    id: string;
+    icon?: string;
 }
 
 export interface PluginPackageTerminal {
-    profiles: PluginPackageTerminalProfile[]
+    profiles: PluginPackageTerminalProfile[];
 }
 
 export interface PluginPackageLocalization {
@@ -544,6 +558,7 @@ export interface PluginEntryPoint {
  */
 export interface PluginContribution {
     activationEvents?: string[];
+    authentication?: AuthenticationProviderInformation[];
     configuration?: PreferenceSchema[];
     configurationDefaults?: PreferenceSchemaProperties;
     languages?: LanguageContribution[];
@@ -567,6 +582,19 @@ export interface PluginContribution {
     resourceLabelFormatters?: ResourceLabelFormatter[];
     localizations?: Localization[];
     terminalProfiles?: TerminalProfile[];
+    notebooks?: NotebookContribution[];
+}
+
+export interface NotebookContribution {
+    type: string;
+    displayName: string;
+    selector?: readonly { filenamePattern?: string; excludeFileNamePattern?: string }[];
+    priority?: string;
+}
+
+export interface AuthenticationProviderInformation {
+    id: string;
+    label: string;
 }
 
 export interface TerminalProfile {

--- a/packages/plugin-ext/src/hosted/node/plugin-activation-events.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-activation-events.ts
@@ -1,0 +1,111 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { flatten } from '../../common/arrays';
+import { isStringArray, isObject } from '@theia/core/lib/common/types';
+import {
+    PluginPackage,
+    PluginPackageAuthenticationProvider,
+    PluginPackageCommand,
+    PluginPackageCustomEditor,
+    PluginPackageLanguageContribution,
+    PluginPackageNotebook,
+    PluginPackageView
+} from '../../common/plugin-protocol';
+
+/**
+ * Most activation events can be automatically deduced from the package manifest.
+ * This function will update the manifest based on the plugin contributions.
+ */
+export function updateActivationEvents(manifest: PluginPackage): void {
+    if (!isObject(manifest) || !isObject(manifest.contributes) || !manifest.contributes) {
+        return;
+    }
+
+    const activationEvents = new Set(isStringArray(manifest.activationEvents) ? manifest.activationEvents : []);
+
+    if (manifest.contributes.commands) {
+        const value = manifest.contributes.commands;
+        const commands = Array.isArray(value) ? value : [value];
+        updateCommandsContributions(commands, activationEvents);
+    }
+    if (Array.isArray(manifest.contributes.views)) {
+        const views = flatten(Object.values(manifest.contributes.views)) as PluginPackageView[];
+        updateViewsContribution(views, activationEvents);
+    }
+    if (Array.isArray(manifest.contributes.customEditors)) {
+        updateCustomEditorsContribution(manifest.contributes.customEditors, activationEvents);
+    }
+    if (Array.isArray(manifest.contributes.authentication)) {
+        updateAuthenticationProviderContributions(manifest.contributes.authentication, activationEvents);
+    }
+    if (Array.isArray(manifest.contributes.languages)) {
+        updateLanguageContributions(manifest.contributes.languages, activationEvents);
+    }
+    if (Array.isArray(manifest.contributes.notebooks)) {
+        updateNotebookContributions(manifest.contributes.notebooks, activationEvents);
+    }
+
+    manifest.activationEvents = Array.from(activationEvents);
+}
+
+function updateViewsContribution(views: PluginPackageView[], activationEvents: Set<string>): void {
+    for (const view of views) {
+        if (isObject(view) && typeof view.id === 'string') {
+            activationEvents.add(`onView:${view.id}`);
+        }
+    }
+}
+
+function updateCustomEditorsContribution(customEditors: PluginPackageCustomEditor[], activationEvents: Set<string>): void {
+    for (const customEditor of customEditors) {
+        if (isObject(customEditor) && typeof customEditor.viewType === 'string') {
+            activationEvents.add(`onCustomEditor:${customEditor.viewType}`);
+        }
+    }
+}
+
+function updateCommandsContributions(commands: PluginPackageCommand[], activationEvents: Set<string>): void {
+    for (const command of commands) {
+        if (isObject(command) && typeof command.command === 'string') {
+            activationEvents.add(`onCommand:${command.command}`);
+        }
+    }
+}
+
+function updateAuthenticationProviderContributions(authProviders: PluginPackageAuthenticationProvider[], activationEvents: Set<string>): void {
+    for (const authProvider of authProviders) {
+        if (isObject(authProvider) && typeof authProvider.id === 'string') {
+            activationEvents.add(`onAuthenticationRequest:${authProvider.id}`);
+        }
+    }
+}
+
+function updateLanguageContributions(languages: PluginPackageLanguageContribution[], activationEvents: Set<string>): void {
+    for (const language of languages) {
+        if (isObject(language) && typeof language.id === 'string') {
+            activationEvents.add(`onLanguage:${language.id}`);
+        }
+    }
+}
+
+function updateNotebookContributions(notebooks: PluginPackageNotebook[], activationEvents: Set<string>): void {
+    for (const notebook of notebooks) {
+        if (isObject(notebook) && typeof notebook.type === 'string') {
+            activationEvents.add(`onNotebookSerializer:${notebook.type}`);
+        }
+    }
+}

--- a/packages/plugin-ext/src/hosted/node/plugin-manifest-loader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-manifest-loader.ts
@@ -16,10 +16,10 @@
 
 import * as path from 'path';
 import * as fs from '@theia/core/shared/fs-extra';
-import { PluginIdentifiers } from '../../common';
+import { PluginIdentifiers, PluginPackage } from '../../common';
+import { updateActivationEvents } from './plugin-activation-events';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function loadManifest(pluginPath: string): Promise<any> {
+export async function loadManifest(pluginPath: string): Promise<PluginPackage> {
     const manifest = await fs.readJson(path.join(pluginPath, 'package.json'));
     // translate vscode builtins, as they are published with a prefix. See https://github.com/theia-ide/vscode-builtin-extensions/blob/master/src/republish.js#L50
     const built_prefix = '@theia/vscode-builtin-';
@@ -27,5 +27,6 @@ export async function loadManifest(pluginPath: string): Promise<any> {
         manifest.name = manifest.name.substr(built_prefix.length);
     }
     manifest.publisher ??= PluginIdentifiers.UNPUBLISHED;
+    updateActivationEvents(manifest);
     return manifest;
 }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12161

When loading a plugin, this change automatically deduces some of its activation events from the plugin manifest. 

This change also adds a few more entries to the manifest types, which were required for this to work correctly.

I also did a drive-by cleanup of the `scanner-theia` file. A lot of the non-null assertions were no longer required due to advancements of TypeScript type checker.

#### How to test
1.  Download and install this [test extension](https://github.com/eclipse-theia/theia/files/10697444/activation-events-0.0.1.zip). The extension is the default hello world extension from vscode, with all of its `activationEvents` removed.
2. Run the `Hello World` command
3. Assert that the extension starts and a notification is displayed.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
