### PR TITLE
repo: drop support for `Node 14`

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, ubuntu-latest, macos-11]
-        node: [14.x, 16.x]
+        node: [16.x]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -128,10 +128,10 @@ jobs:
         with:
           fetch-depth: 0 # To fetch all history for all branches and tags. (Will be required for caching with lerna: https://github.com/markuplint/markuplint/pull/111)
 
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Use Python 3.x

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -17,7 +17,7 @@ RUN sudo apt-get update \
 
 ENV SHELL=/bin/bash
 
-ENV NODE_VERSION="14.19.0"
+ENV NODE_VERSION="16.14.0"
 RUN bash -c ". .nvm/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm use $NODE_VERSION \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.35.0 - 02/23/2023
+
+<a name="breaking_changes_1.35.0">[Breaking Changes:](#breaking_changes_1.35.0)</a>
+
+- [repo] drop support for `Node 14` [#12169](https://github.com/eclipse-theia/theia/pull/12169)
+
 ## v1.34.0 - 01/26/2023
 
 - [application-package] bumped the default supported API version from `1.55.2` to `1.66.2` [#12104](https://github.com/eclipse-theia/theia/pull/12104)

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -52,8 +52,7 @@ For Windows instructions [click here](#building-on-windows).
 
 ## Prerequisites
 
- - Node.js `>= 14.18.0`.
-   - We recommend using Node's LTS: currently 16.x
+ - Node.js `>= 16.14.0` and `< 17`.
    - If you are interested in Theia's VS Code Extension support then you should use a Node version at least compatible with the one included in the version of Electron used by [VS Code](https://github.com/microsoft/vscode).
  - [Yarn package manager](https://yarnpkg.com/en/docs/install)  `>= 1.7.0` **AND** `< 2.x.x`.
  - git (If you would like to use the Git-extension too, you will need to have git version 2.11.0 or higher.)

--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -20,6 +20,13 @@ For example:
 }
 ```
 
+### v1.35.0
+
+#### Drop support for `Node 14`
+
+The framework no longer supports `Node 14` in order to better support plugins targeting the default supported VS Code API of `1.68.1`.
+It is always possible to build using the `yarn --ignore-engines` workaround, but we advise against it.
+
 ### v1.32.0
 
 #### Removal of `CircularDependencyPlugin`

--- a/doc/runtime-policy.md
+++ b/doc/runtime-policy.md
@@ -45,5 +45,5 @@ with VS Code's Node runtime, which depends on the Electron version that they end
 You should look for this information in the [VS Code repository](https://github.com/microsoft/vscode).
 
 VS Code Extensions being meant to run in VS Code, developers may use any API available in the runtime in which their
-extension runs. So if they expect to run in Node 14, then they may use Node 14 APIs. Running your Theia application
-on Node 12 then means that some plugin features might not work because of missing APIs from the Node runtime.
+extension runs. So if they expect to run in Node 16, then they may use Node 16 APIs. Running your Theia application
+on Node 14 then means that some plugin features might not work because of missing APIs from the Node runtime.

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "version": "0.0.0",
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=14.18.0"
+    "node": ">=16.14.0 <17"
   },
   "resolutions": {
-    "**/@types/node": "14"
+    "**/@types/node": "16"
   },
   "devDependencies": {
     "@types/chai": "4.3.0",
     "@types/chai-spies": "1.0.3",
     "@types/chai-string": "^1.4.0",
     "@types/jsdom": "^11.0.4",
-    "@types/node": "14",
+    "@types/node": "16",
     "@types/puppeteer": "^2.0.0",
     "@types/sinon": "^10.0.6",
     "@types/temp": "^0.8.29",

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -496,7 +496,9 @@ export class ElectronMainApplication {
                         try {
                             // If we forked the process for the clusters, we need to manually terminate it.
                             // See: https://github.com/eclipse-theia/theia/issues/835
-                            process.kill(backendProcess.pid);
+                            if (backendProcess.pid) {
+                                process.kill(backendProcess.pid);
+                            }
                         } catch (error) {
                             // See https://man7.org/linux/man-pages/man2/kill.2.html#ERRORS
                             if (error.code === 'ESRCH') {

--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -157,7 +157,7 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
     }
 
     terminate(): void {
-        if (this.isPluginRunning) {
+        if (this.isPluginRunning && !!this.hostedInstanceProcess.pid) {
             this.hostedPluginProcess.killProcessTree(this.hostedInstanceProcess.pid);
             this.hostedPluginSupport.sendLog({ data: 'Hosted instance has been terminated', type: LogType.Info });
             this.isPluginRunning = false;

--- a/packages/plugin-dev/src/node/hosted-plugins-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-plugins-manager.ts
@@ -96,7 +96,7 @@ export class HostedPluginsManagerImpl implements HostedPluginsManager {
             throw new Error('Watcher is not running in ' + pluginPath);
         }
 
-        this.killProcessTree(watchProcess.pid);
+        this.killProcessTree(watchProcess.pid!);
         return Promise.resolve();
     }
 

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -126,7 +126,7 @@ export class HostedPluginProcess implements ServerPluginRunner {
             await waitForTerminated.promise;
         }
 
-        this.killProcessTree(cp.pid);
+        this.killProcessTree(cp.pid!);
     }
 
     killProcessTree(parentPid: number): void {
@@ -206,7 +206,7 @@ export class HostedPluginProcess implements ServerPluginRunner {
         childProcess.stderr!.on('data', data => this.logger.error(`[${options.serverName}: ${childProcess.pid}] ${data.toString().trim()}`));
 
         this.logger.debug(`[${options.serverName}: ${childProcess.pid}] IPC started`);
-        childProcess.once('exit', (code: number, signal: string) => this.onChildProcessExit(options.serverName, childProcess.pid, code, signal));
+        childProcess.once('exit', (code: number, signal: string) => this.onChildProcessExit(options.serverName, childProcess.pid!, code, signal));
         childProcess.on('error', err => this.onChildProcessError(err));
         return childProcess;
     }

--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -141,7 +141,7 @@ export class RawProcess extends Process {
     }
 
     get pid(): number {
-        if (!this.process) {
+        if (!this.process || !this.process.pid) {
             throw new Error('process did not start correctly');
         }
         return this.process.pid;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2639,10 +2639,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@14", "@types/node@>=10.0.0", "@types/node@^10.14.22", "@types/node@^14.6.2":
-  version "14.18.36"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.36.tgz#c414052cb9d43fab67d679d5f3c641be911f5835"
-  integrity sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==
+"@types/node@*", "@types/node@16", "@types/node@>=10.0.0", "@types/node@^10.14.22", "@types/node@^14.6.2":
+  version "16.18.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.12.tgz#e3bfea80e31523fde4292a6118f19ffa24fd6f65"
+  integrity sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request drops support for **Node 14** in the framework in oder to better support the runtime plugins expect when targeting the `1.68.1` VS Code API.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>