### PR TITLE
preferences: fix duplicated call to `FoldersPreferencesProvider`

### DIFF
--- a/examples/api-tests/src/launch-preferences.spec.js
+++ b/examples/api-tests/src/launch-preferences.spec.js
@@ -478,7 +478,7 @@ describe('Launch Preferences', function () {
         if (typeof config2 === 'object' && !Array.isArray(config2)) {
             result = { ...(result ?? {}), ...config2 }
         }
-        //merge configurations and compounds arrays
+        // merge configurations and compounds arrays
         const mergedConfigurations = mergeArrays(config1?.configurations, config2?.configurations);
         if (mergedConfigurations) {
             result.configurations = mergedConfigurations

--- a/packages/core/src/browser/preferences/preference-provider.spec.ts
+++ b/packages/core/src/browser/preferences/preference-provider.spec.ts
@@ -1,0 +1,36 @@
+// *****************************************************************************
+// Copyright (C) 2023 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceProvider } from './preference-provider';
+const { expect } = require('chai');
+
+describe('PreferenceProvider', () => {
+    it('should preserve extra source fields on merge', () => {
+        const result = PreferenceProvider.merge({ 'configurations': [], 'compounds': [] }, { 'configurations': [] });
+        expect(result).deep.equals({ 'configurations': [], 'compounds': [] });
+    });
+    it('should preserve extra target fields on merge', () => {
+        const result = PreferenceProvider.merge({ 'configurations': [] }, { 'configurations': [], 'compounds': [] });
+        expect(result).deep.equals({ 'configurations': [], 'compounds': [] });
+    });
+    it('should merge array values', () => {
+        const result = PreferenceProvider.merge(
+            { 'configurations': [{ 'name': 'test1', 'request': 'launch' }], 'compounds': [] },
+            { 'configurations': [{ 'name': 'test2' }] }
+        );
+        expect(result).deep.equals({ 'configurations': [{ 'name': 'test1', 'request': 'launch' }, { 'name': 'test2' }], 'compounds': [] });
+    });
+});

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -267,4 +267,8 @@ export abstract class PreferenceProvider implements Disposable {
         }
         return preferences;
     }
+
+    canHandleScope(scope: PreferenceScope): boolean {
+        return true;
+    }
 }

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -235,6 +235,9 @@ export abstract class PreferenceProvider implements Disposable {
                 if (JSONExt.isObject(source[key]) && JSONExt.isObject(value)) {
                     this.merge(source[key], value);
                     continue;
+                } else if (JSONExt.isArray(source[key]) && JSONExt.isArray(value)) {
+                    source[key] = [...JSONExt.deepCopy(source[key] as any), ...JSONExt.deepCopy(value)];
+                    continue;
                 }
             }
             source[key] = JSONExt.deepCopy(value);

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -565,7 +565,7 @@ export class PreferenceServiceImpl implements PreferenceService {
         for (const scope of PreferenceScope.getScopes()) {
             if (this.schema.isValidInScope(preferenceName, scope)) {
                 const provider = this.getProvider(scope);
-                if (provider) {
+                if (provider?.canHandleScope(scope)) {
                     const { configUri, value } = provider.resolve<T>(preferenceName, resourceUri);
                     if (value !== undefined) {
                         result.configUri = configUri;

--- a/packages/preferences/src/browser/folders-preferences-provider.ts
+++ b/packages/preferences/src/browser/folders-preferences-provider.ts
@@ -18,7 +18,7 @@
 
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
-import { PreferenceProvider, PreferenceResolveResult } from '@theia/core/lib/browser/preferences/preference-provider';
+import { PreferenceProvider, PreferenceResolveResult, PreferenceScope } from '@theia/core/lib/browser/preferences';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/preference-configurations';
 import { FolderPreferenceProvider, FolderPreferenceProviderFactory } from './folder-preference-provider';
@@ -187,6 +187,10 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
         }
 
         return false;
+    }
+
+    override canHandleScope(scope: PreferenceScope): boolean {
+        return this.workspaceService.isMultiRootWorkspaceOpened && scope === PreferenceScope.Folder || scope === PreferenceScope.Workspace;
     }
 
     protected groupProvidersByConfigName(resourceUri?: string): Map<string, FolderPreferenceProvider[]> {


### PR DESCRIPTION
Properly inhibit preference providers when they shouldn't apply during resolution.

#### How to test

Debug the following method:

https://github.com/eclipse-theia/theia/blob/7971705d4d5fbd381042c0be50892b49b39fd807/packages/core/src/browser/preferences/preference-service.ts#L563-L581

Make sure it doesn't end up calling the same provider twice.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
