### PR TITLE
Option to toggle hidden folders/files in browser file dialog

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog-hidden-files-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-hidden-files-renderer.tsx
@@ -28,7 +28,7 @@ export interface HiddenFilesToggleRendererFactory {
     (fileDialogTree: FileDialogTree): FileDialogHiddenFilesToggleRenderer;
 }
 export class FileDialogHiddenFilesToggleRenderer extends ReactRenderer {
-    @inject(FileDialogTree) _fileDialogTree: FileDialogTree;
+    @inject(FileDialogTree) fileDialogTree: FileDialogTree;
 
     @postConstruct()
     protected init(): void {
@@ -52,8 +52,7 @@ export class FileDialogHiddenFilesToggleRenderer extends ReactRenderer {
 
     protected onCheckboxChanged(e: React.ChangeEvent<HTMLInputElement>): void {
         const { checked } = e.target;
-        console.log('is checked', checked);
-        // this.fileDialogTree.showHidden = checked;
+        this.fileDialogTree.showHidden = checked;
         e.stopPropagation();
     }
 }

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-hidden-files-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-hidden-files-renderer.tsx
@@ -1,0 +1,59 @@
+// *****************************************************************************
+// Copyright (C) 2023 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ReactRenderer, } from '@theia/core/lib/browser';
+import { inject, postConstruct } from '@theia/core/shared/inversify';
+import * as React from '@theia/core/shared/react';
+import { FileDialogTree } from './file-dialog-tree';
+
+const TOGGLE_HIDDEN_PANEL_CLASS = 'theia-ToggleHiddenPanel';
+const TOGGLE_HIDDEN_CONTAINER_CLASS = 'theia-ToggleHiddenInputContainer';
+const CHECKBOX_CLASS = 'theia-ToggleHiddenInputCheckbox';
+
+export const HiddenFilesToggleRendererFactory = Symbol('HiddenFilesToggleRendererFactory');
+export interface HiddenFilesToggleRendererFactory {
+    (fileDialogTree: FileDialogTree): FileDialogHiddenFilesToggleRenderer;
+}
+export class FileDialogHiddenFilesToggleRenderer extends ReactRenderer {
+    @inject(FileDialogTree) _fileDialogTree: FileDialogTree;
+
+    @postConstruct()
+    protected init(): void {
+        this.host.classList.add(TOGGLE_HIDDEN_PANEL_CLASS);
+        this.render();
+    }
+
+    protected readonly handleCheckboxChanged = (e: React.ChangeEvent<HTMLInputElement>): void => this.onCheckboxChanged(e);
+    protected override doRender(): React.ReactNode {
+        return (
+            <div className={TOGGLE_HIDDEN_CONTAINER_CLASS}>
+                Show hidden files
+                <input
+                    type='checkbox'
+                    className={CHECKBOX_CLASS}
+                    onChange={this.handleCheckboxChanged}
+                />
+            </div>
+        );
+    }
+
+    protected onCheckboxChanged(e: React.ChangeEvent<HTMLInputElement>): void {
+        const { checked } = e.target;
+        console.log('is checked', checked);
+        // this.fileDialogTree.showHidden = checked;
+        e.stopPropagation();
+    }
+}

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-hidden-files-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-hidden-files-renderer.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { nls } from '@theia/core';
-import { ReactRenderer, } from '@theia/core/lib/browser';
+import { ReactRenderer } from '@theia/core/lib/browser';
 import { inject, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { FileDialogTree } from './file-dialog-tree';

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-hidden-files-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-hidden-files-renderer.tsx
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { nls } from '@theia/core';
 import { ReactRenderer, } from '@theia/core/lib/browser';
 import { inject, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
@@ -40,7 +41,7 @@ export class FileDialogHiddenFilesToggleRenderer extends ReactRenderer {
     protected override doRender(): React.ReactNode {
         return (
             <div className={TOGGLE_HIDDEN_CONTAINER_CLASS}>
-                Show hidden files
+                {nls.localize('theia/fileDialog/showHidden', 'Show hidden files')}
                 <input
                     type='checkbox'
                     className={CHECKBOX_CLASS}

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-module.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-module.ts
@@ -16,7 +16,9 @@
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { LocationListRenderer, LocationListRendererFactory, LocationListRendererOptions } from '../location';
+import { FileDialogHiddenFilesToggleRenderer, HiddenFilesToggleRendererFactory } from './file-dialog-hidden-files-renderer';
 import { DefaultFileDialogService, FileDialogService } from './file-dialog-service';
+import { FileDialogTree } from './file-dialog-tree';
 import { FileDialogTreeFiltersRenderer, FileDialogTreeFiltersRendererFactory, FileDialogTreeFiltersRendererOptions } from './file-dialog-tree-filters-renderer';
 export default new ContainerModule(bind => {
     bind(DefaultFileDialogService).toSelf().inSingletonScope();
@@ -32,5 +34,11 @@ export default new ContainerModule(bind => {
         childContainer.bind(FileDialogTreeFiltersRendererOptions).toConstantValue(options);
         childContainer.bind(FileDialogTreeFiltersRenderer).toSelf().inSingletonScope();
         return childContainer.get(FileDialogTreeFiltersRenderer);
+    });
+    bind(HiddenFilesToggleRendererFactory).toFactory(({ container }) => (fileDialogTree: FileDialogTree) => {
+        const child = container.createChild();
+        child.bind(FileDialogTree).toConstantValue(fileDialogTree);
+        child.bind(FileDialogHiddenFilesToggleRenderer).toSelf().inSingletonScope();
+        return child.get(FileDialogHiddenFilesToggleRenderer);
     });
 });

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree.ts
@@ -21,6 +21,22 @@ import { FileStat } from '../../common/files';
 
 @injectable()
 export class FileDialogTree extends FileTree {
+    protected _showHidden = false;
+    set showHidden(show: boolean) {
+        this._showHidden = show;
+        this.refresh();
+    }
+
+    get showHidden(): boolean {
+        return this._showHidden;
+    }
+
+    protected isHiddenFile = (fileStat: FileStat): boolean => {
+        const { name } = fileStat;
+        const filename = name ?? '';
+        const isHidden = filename.startsWith('.');
+        return isHidden;
+    };
     /**
      * Extensions for files to be shown
      */
@@ -56,6 +72,9 @@ export class FileDialogTree extends FileTree {
      * @param fileStat resource to check
      */
     protected isVisible(fileStat: FileStat): boolean {
+        if (!this._showHidden && this.isHiddenFile(fileStat)) {
+            return false;
+        }
         if (fileStat.isDirectory) {
             return true;
         }

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree.ts
@@ -21,7 +21,6 @@ import { FileStat } from '../../common/files';
 
 @injectable()
 export class FileDialogTree extends FileTree {
-
     /**
      * Extensions for files to be shown
      */

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -26,6 +26,7 @@ import { FileDialogTreeFiltersRenderer, FileDialogTreeFilters, FileDialogTreeFil
 import URI from '@theia/core/lib/common/uri';
 import { Panel } from '@theia/core/shared/@phosphor/widgets';
 import * as DOMPurify from '@theia/core/shared/dompurify';
+import { FileDialogHiddenFilesToggleRenderer, HiddenFilesToggleRendererFactory } from './file-dialog-hidden-files-renderer';
 
 export const OpenFileDialogFactory = Symbol('OpenFileDialogFactory');
 export interface OpenFileDialogFactory {
@@ -127,11 +128,13 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
     protected up: HTMLSpanElement;
     protected locationListRenderer: LocationListRenderer;
     protected treeFiltersRenderer: FileDialogTreeFiltersRenderer | undefined;
+    protected hiddenFilesToggleRenderer: FileDialogHiddenFilesToggleRenderer;
     protected treePanel: Panel;
 
     @inject(FileDialogWidget) readonly widget: FileDialogWidget;
     @inject(LocationListRendererFactory) readonly locationListFactory: LocationListRendererFactory;
     @inject(FileDialogTreeFiltersRendererFactory) readonly treeFiltersFactory: FileDialogTreeFiltersRendererFactory;
+    @inject(HiddenFilesToggleRendererFactory) readonly hiddenFilesToggleFactory: HiddenFilesToggleRendererFactory;
 
     constructor(
         @inject(FileDialogProps) override readonly props: FileDialogProps
@@ -173,6 +176,10 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
         this.toDispose.push(this.locationListRenderer);
         this.locationListRenderer.host.classList.add(NAVIGATION_LOCATION_LIST_PANEL_CLASS);
         navigationPanel.appendChild(this.locationListRenderer.host);
+
+        this.hiddenFilesToggleRenderer = this.hiddenFilesToggleFactory(this.widget.model.tree);
+        console.log('the renderer', this.hiddenFilesToggleRenderer);
+        this.contentNode.appendChild(this.hiddenFilesToggleRenderer.host);
 
         if (this.props.filters) {
             this.treeFiltersRenderer = this.treeFiltersFactory({ suppliedFilters: this.props.filters, fileDialogTree: this.widget.model.tree });

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -178,7 +178,6 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
         navigationPanel.appendChild(this.locationListRenderer.host);
 
         this.hiddenFilesToggleRenderer = this.hiddenFilesToggleFactory(this.widget.model.tree);
-        console.log('the renderer', this.hiddenFilesToggleRenderer);
         this.contentNode.appendChild(this.hiddenFilesToggleRenderer.host);
 
         if (this.props.filters) {

--- a/packages/filesystem/src/browser/style/file-dialog.css
+++ b/packages/filesystem/src/browser/style/file-dialog.css
@@ -22,7 +22,7 @@
     --theia-private-navigation-panel-line-height: 23px;
 }
 
-/*
+ /*
   * Open and Save file dialogs
   */
 
@@ -37,7 +37,6 @@
 
 
 @media only screen and (max-height: 700px) {
-
     .dialogContent .theia-FileDialog,
     .dialogContent .theia-SaveFileDialog,
     .dialogContent .theia-ResponsiveFileDialog {
@@ -131,7 +130,8 @@
 }
 
 .dialogContent .theia-LocationList,
-.dialogContent .theia-LocationTextInput {
+.dialogContent .theia-LocationTextInput
+{
     box-sizing: content-box;
     padding: unset;
     position: absolute;
@@ -142,7 +142,8 @@
 }
 
 .dialogContent .theia-LocationList,
-.dialogContent .theia-LocationTextInput {
+.dialogContent .theia-LocationTextInput
+{
     padding-left: var(--theia-private-navigation-panel-icon-size);
     width: calc(100% - var(--theia-private-navigation-panel-icon-size));
 }
@@ -198,7 +199,7 @@
     margin-bottom: 0px;
 }
 
-.dialogContent .theia-ControlPanel>* {
+.dialogContent .theia-ControlPanel > * {
     margin-left: 4px;
 }
 

--- a/packages/filesystem/src/browser/style/file-dialog.css
+++ b/packages/filesystem/src/browser/style/file-dialog.css
@@ -22,7 +22,7 @@
     --theia-private-navigation-panel-line-height: 23px;
 }
 
- /*
+/*
   * Open and Save file dialogs
   */
 
@@ -37,6 +37,7 @@
 
 
 @media only screen and (max-height: 700px) {
+
     .dialogContent .theia-FileDialog,
     .dialogContent .theia-SaveFileDialog,
     .dialogContent .theia-ResponsiveFileDialog {
@@ -130,8 +131,7 @@
 }
 
 .dialogContent .theia-LocationList,
-.dialogContent .theia-LocationTextInput
-{
+.dialogContent .theia-LocationTextInput {
     box-sizing: content-box;
     padding: unset;
     position: absolute;
@@ -142,8 +142,7 @@
 }
 
 .dialogContent .theia-LocationList,
-.dialogContent .theia-LocationTextInput
-{
+.dialogContent .theia-LocationTextInput {
     padding-left: var(--theia-private-navigation-panel-icon-size);
     width: calc(100% - var(--theia-private-navigation-panel-icon-size));
 }
@@ -199,6 +198,13 @@
     margin-bottom: 0px;
 }
 
-.dialogContent .theia-ControlPanel > * {
+.dialogContent .theia-ControlPanel>* {
     margin-left: 4px;
+}
+
+.dialogContent .theia-ToggleHiddenInputContainer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding-top: var(--theia-ui-padding);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Resolves #9215 by adding a toggle to show hidden folders and files in the browser's file dialog

![image](https://user-images.githubusercontent.com/62660714/218590514-5faa0230-69ea-4b79-97f1-ba451d914ec1.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Build this branch for browser
- Open a save or open file dialog and test out the toggle
- Does it work as expected?
#### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
