### PR TITLE
webview: add support for `activeWebviewPanelId`

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -82,6 +82,7 @@ import { PluginMenuCommandAdapter } from './menus/plugin-menu-command-adapter';
 import './theme-icon-override';
 import { PluginTerminalRegistry } from './plugin-terminal-registry';
 import { DnDFileContentStore } from './view/dnd-file-content-store';
+import { WebviewContextKeys } from './webview/webview-context-keys';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
@@ -177,6 +178,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(WebviewWidget).toSelf();
     bind(WebviewWidgetFactory).toDynamicValue(ctx => new WebviewWidgetFactory(ctx.container)).inSingletonScope();
     bind(WidgetFactory).toService(WebviewWidgetFactory);
+    bind(WebviewContextKeys).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(WebviewContextKeys);
 
     bind(CustomEditorContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(CustomEditorContribution);

--- a/packages/plugin-ext/src/main/browser/webview/webview-context-keys.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-context-keys.ts
@@ -1,0 +1,49 @@
+// *****************************************************************************
+// Copyright (C) 2023 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { ApplicationShell, FocusTracker, Widget } from '@theia/core/lib/browser';
+import { WebviewWidget } from './webview';
+
+@injectable()
+export class WebviewContextKeys {
+
+    /**
+     * Context key representing the `viewType` of the active `WebviewWidget`, if any.
+     */
+    activeWebviewPanelId: ContextKey<string | undefined>;
+
+    @inject(ApplicationShell)
+    protected applicationShell: ApplicationShell;
+
+    @inject(ContextKeyService)
+    protected contextKeyService: ContextKeyService;
+
+    @postConstruct()
+    protected postContruct(): void {
+        this.activeWebviewPanelId = this.contextKeyService.createKey('activeWebviewPanelId', undefined);
+        this.applicationShell.onDidChangeActiveWidget(this.handleDidChangeActiveWidget, this);
+    }
+
+    protected handleDidChangeActiveWidget(change: FocusTracker.IChangedArgs<Widget>): void {
+        if (change.newValue instanceof WebviewWidget) {
+            this.activeWebviewPanelId.set(change.newValue.viewType);
+        } else {
+            this.activeWebviewPanelId.set(undefined);
+        }
+    }
+}

--- a/packages/plugin-ext/src/main/browser/webview/webview-context-keys.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-context-keys.ts
@@ -34,9 +34,9 @@ export class WebviewContextKeys {
     protected contextKeyService: ContextKeyService;
 
     @postConstruct()
-    protected postContruct(): void {
+    protected postConstruct(): void {
         this.activeWebviewPanelId = this.contextKeyService.createKey('activeWebviewPanelId', undefined);
-        this.applicationShell.onDidChangeActiveWidget(this.handleDidChangeActiveWidget, this);
+        this.applicationShell.onDidChangeCurrentWidget(this.handleDidChangeActiveWidget, this);
     }
 
     protected handleDidChangeActiveWidget(change: FocusTracker.IChangedArgs<Widget>): void {

--- a/packages/plugin-ext/src/main/browser/webview/webview-context-keys.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-context-keys.ts
@@ -25,7 +25,7 @@ export class WebviewContextKeys {
     /**
      * Context key representing the `viewType` of the active `WebviewWidget`, if any.
      */
-    activeWebviewPanelId: ContextKey<string | undefined>;
+    activeWebviewPanelId: ContextKey<string>;
 
     @inject(ApplicationShell)
     protected applicationShell: ApplicationShell;
@@ -35,15 +35,15 @@ export class WebviewContextKeys {
 
     @postConstruct()
     protected postConstruct(): void {
-        this.activeWebviewPanelId = this.contextKeyService.createKey('activeWebviewPanelId', undefined);
-        this.applicationShell.onDidChangeCurrentWidget(this.handleDidChangeActiveWidget, this);
+        this.activeWebviewPanelId = this.contextKeyService.createKey('activeWebviewPanelId', '');
+        this.applicationShell.onDidChangeCurrentWidget(this.handleDidChangeCurrentWidget, this);
     }
 
-    protected handleDidChangeActiveWidget(change: FocusTracker.IChangedArgs<Widget>): void {
+    protected handleDidChangeCurrentWidget(change: FocusTracker.IChangedArgs<Widget>): void {
         if (change.newValue instanceof WebviewWidget) {
             this.activeWebviewPanelId.set(change.newValue.viewType);
         } else {
-            this.activeWebviewPanelId.set(undefined);
+            this.activeWebviewPanelId.set('');
         }
     }
 }

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -50,7 +50,6 @@ import { FileOperationError, FileOperationResult } from '@theia/filesystem/lib/c
 import { BinaryBufferReadableStream } from '@theia/core/lib/common/buffer';
 import { ViewColumn } from '../../../plugin/types-impl';
 import { ExtractableWidget } from '@theia/core/lib/browser/widgets/extractable-widget';
-import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 
 // Style from core
 const TRANSPARENT_OVERLAY_STYLE = 'theia-transparent-overlay';
@@ -106,11 +105,6 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
     // On `mousedown` we put a transparent div over the `iframe` to avoid losing the mouse tacking.
     protected transparentOverlay: HTMLElement;
 
-    protected _activeWebviewPanelId: ContextKey<string | undefined>;
-    get activeWebviewPanelId(): ContextKey<string | undefined> {
-        return this._activeWebviewPanelId;
-    }
-
     @inject(WebviewWidgetIdentifier)
     readonly identifier: WebviewWidgetIdentifier;
 
@@ -149,9 +143,6 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
 
     @inject(WebviewResourceCache)
     protected readonly resourceCache: WebviewResourceCache;
-
-    @inject(ContextKeyService)
-    protected readonly contextKeyService: ContextKeyService;
 
     viewState: WebviewPanelViewState = {
         visible: false,
@@ -209,15 +200,6 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
         this.toDispose.push(this.mouseTracker.onMouseup(() => {
             if (this.element && this.element.style.display !== 'none') {
                 this.transparentOverlay.style.display = 'none';
-            }
-        }));
-
-        this._activeWebviewPanelId = this.contextKeyService.createKey<string | undefined>('activeWebviewPanelId', undefined);
-        this.toDispose.push(this.onDidChangeVisibility(() => {
-            if (this.isVisible) {
-                this.activeWebviewPanelId.set(this.viewType);
-            } else {
-                this.activeWebviewPanelId.set(undefined);
             }
         }));
     }

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -50,6 +50,7 @@ import { FileOperationError, FileOperationResult } from '@theia/filesystem/lib/c
 import { BinaryBufferReadableStream } from '@theia/core/lib/common/buffer';
 import { ViewColumn } from '../../../plugin/types-impl';
 import { ExtractableWidget } from '@theia/core/lib/browser/widgets/extractable-widget';
+import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 
 // Style from core
 const TRANSPARENT_OVERLAY_STYLE = 'theia-transparent-overlay';
@@ -105,6 +106,11 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
     // On `mousedown` we put a transparent div over the `iframe` to avoid losing the mouse tacking.
     protected transparentOverlay: HTMLElement;
 
+    protected _activeWebviewPanelId: ContextKey<string | undefined>;
+    get activeWebviewPanelId(): ContextKey<string | undefined> {
+        return this._activeWebviewPanelId;
+    }
+
     @inject(WebviewWidgetIdentifier)
     readonly identifier: WebviewWidgetIdentifier;
 
@@ -143,6 +149,9 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
 
     @inject(WebviewResourceCache)
     protected readonly resourceCache: WebviewResourceCache;
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
 
     viewState: WebviewPanelViewState = {
         visible: false,
@@ -200,6 +209,15 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
         this.toDispose.push(this.mouseTracker.onMouseup(() => {
             if (this.element && this.element.style.display !== 'none') {
                 this.transparentOverlay.style.display = 'none';
+            }
+        }));
+
+        this._activeWebviewPanelId = this.contextKeyService.createKey<string | undefined>('activeWebviewPanelId', undefined);
+        this.toDispose.push(this.onDidChangeVisibility(() => {
+            if (this.isVisible) {
+                this.activeWebviewPanelId.set(this.viewType);
+            } else {
+                this.activeWebviewPanelId.set(undefined);
             }
         }));
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for the `activeWebviewPanelId` when context-clause which matches the `viewType` of the currently active webview panel.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


1. start the application with the [cat-coding-0.0.2.zip](https://github.com/eclipse-theia/theia/files/10735339/cat-coding-0.0.2.zip) plugin
2. trigger the command `cat coding: start cat coding session`
3. a webview should appear with a lightbulb toolbar item - clicking the toolbar should trigger an information notification
4. open an editor - it should not show the lightbulb toolbar item
5. switch back to the webview - the toolbar item should appear

https://user-images.githubusercontent.com/40359487/218817442-eb9e9f9a-4131-4c49-b1f8-2f0e84b24423.mp4

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>