### PR TITLE
Fire breakpoint events only if breakpoint metadata changes

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -17,6 +17,7 @@
     "@theia/variable-resolver": "1.34.0",
     "@theia/workspace": "1.34.0",
     "@vscode/debugprotocol": "^1.51.0",
+    "fast-deep-equal": "^3.1.3",
     "jsonc-parser": "^2.2.0",
     "p-debounce": "^2.1.0"
   },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes https://github.com/eclipse-theia/theia/issues/11878.

This PR fixes the stack overflow component of #11878 by ensuring that debug editor models provide the ID of breakpoints they believe have moved rather than retrieving the modified breakpoint from the breakpoint manager (whose state may have been updated in the meantime by a different model for the same editor) using location data and by ensuring that the breakpoint manager doesn't fire events when `setMarkers` is called but no marker - breakpoint - metadata changes.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Add a breakpoint to an editor.
2. Split that editor so that two (or more) editor instances are opened for the file.
3. Perform a text edit in one of the editor instances that moves the breakpoint up or down.
4. The breakpoint should move, the UI should remain responsive, and the console should not show any stack overflow errors.
5. Other breakpoint actions (adding, removing, modifying with conditions, etc.) should work as before.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
