### PR TITLE
outline: add 'expand-all' toolbar item

### DIFF
--- a/packages/outline-view/src/browser/outline-view-tree-model.ts
+++ b/packages/outline-view/src/browser/outline-view-tree-model.ts
@@ -49,4 +49,29 @@ export class OutlineViewTreeModel extends TreeModelImpl {
             this.onOpenNodeEmitter.fire(node);
         }
     }
+
+    expandAll(raw?: TreeNode): void {
+        if (CompositeTreeNode.is(raw)) {
+            for (const child of raw.children) {
+                if (ExpandableTreeNode.is(child)) {
+                    this.expandAll(child);
+                }
+            }
+        }
+        if (ExpandableTreeNode.is(raw)) {
+            this.expandNode(raw);
+        }
+    }
+
+    areNodesCollapsed(): boolean {
+        if (CompositeTreeNode.is(this.root)) {
+            for (const child of this.root.children) {
+                if (!ExpandableTreeNode.isCollapsed(child)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for the `expand-all` toolbar item for the `outline-view` in order to expand rendered nodes. The changes mean that the toolbar item for `collapse-all` and `expand-all` will be toggleable based on the state of the view.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application and open editors
2. for a given editor, confirm that the outline-view is correctly displayed
3. using the toolbar-item should collapse-all or expand-all respectfully 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
