### PR TITLE
Properly return instruction breakpoints in DebugSession

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2018 Red Hat, Inc. and others.
+// Copyright (C) 2018-2023 Red Hat, Inc. and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -573,7 +573,7 @@ export class DebugSession implements CompositeTreeElement {
 
     getInstructionBreakpoints(): DebugInstructionBreakpoint[] {
         if (this.capabilities.supportsInstructionBreakpoints) {
-            return this.getBreakpoints(BreakpointManager.FUNCTION_URI)
+            return this.getBreakpoints(BreakpointManager.INSTRUCTION_URI)
                 .filter((breakpoint): breakpoint is DebugInstructionBreakpoint => breakpoint instanceof DebugInstructionBreakpoint);
         }
         return this.breakpoints.getInstructionBreakpoints().map(origin => new DebugInstructionBreakpoint(origin, this.asDebugBreakpointOptions()));

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2018-2023 Red Hat, Inc. and others.
+// Copyright (C) 2018 Red Hat, Inc. and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
Fixes https://github.com/eclipse-theia/theia/issues/12189

#### What it does
Fixes https://github.com/eclipse-theia/theia/issues/12189

#### How to test
Start a debug session, open the Disassembly view and add an instruction breakpoint. The debug view should be updated with the instruction breakpoint but it does not as the session does not return it properly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
