### PR TITLE
Handle the case where no default terminal profile is set no startup

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -256,7 +256,7 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
 
         // extension contributions get read after this point: need to set the default profile if necessary
         this.profileService.onAdded(id => {
-            let defaultProfileId = undefined;
+            let defaultProfileId: string | undefined;
             switch (OS.backend.type()) {
                 case OS.Type.Windows: {
                     defaultProfileId = this.terminalPreferences['terminal.integrated.defaultProfile.windows'];

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -254,9 +254,9 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
         });
         this.mergePreferencesPromise = this.mergePreferencesPromise.finally(() => this.mergePreferences());
 
+        // extension contributions get read after this point: need to set the default profile if necessary
         this.profileService.onAdded(id => {
-            // extension contributions get read after this point: need to set the default profile if necessary
-            let defaultProfileId;
+            let defaultProfileId = undefined;
             switch (OS.backend.type()) {
                 case OS.Type.Windows: {
                     defaultProfileId = this.terminalPreferences['terminal.integrated.defaultProfile.windows'];
@@ -271,7 +271,9 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
                     break;
                 }
             }
-            this.profileService.setDefaultProfile(defaultProfileId);
+            if (defaultProfileId) {
+                this.profileService.setDefaultProfile(defaultProfileId);
+            }
         });
     }
 


### PR DESCRIPTION
#### What it does
We are handling the `contributes.terminal` extension point later than we are initializing terminal profiles from the preferences. So the default profile in the preferences might not be present yet in the terminal profile registry when we read the preferences. So we try to set the default whenever a new profile is added. In this endeavor, we were not handling the case that no default profile is set in the preferences.

Fixes https://github.com/eclipse-theia/theia/issues/12119

#### How to test
1. Make sure you have not default profile setting in the Theia preferences
2. Make sure you have the default extensions downloaded
3. Start the electron version of Theia
4. Observe: you do not get the exception from the issue
5. Now set a default profile to "Javascript Debug Terminal"
6. Restart Theia
7. Observe: the default terminal is correctly set.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
