### PR TITLE
Support for vscode `l10n` API

### DIFF
--- a/packages/core/src/common/i18n/localization.ts
+++ b/packages/core/src/common/i18n/localization.ts
@@ -39,22 +39,12 @@ export type FormatType = string | number | boolean | undefined;
 
 export namespace Localization {
 
-    export function format(message: string, args: FormatType[]): string {
-        let result = message;
-        if (args.length > 0) {
-            result = message.replace(/\{(\d+)\}/g, (match, rest) => {
-                const index = rest[0];
-                const arg = args[index];
-                let replacement = match;
-                if (typeof arg === 'string') {
-                    replacement = arg;
-                } else if (typeof arg === 'number' || typeof arg === 'boolean' || !arg) {
-                    replacement = String(arg);
-                }
-                return replacement;
-            });
-        }
-        return result;
+    const formatRegexp = /{([^}]+)}/g;
+
+    export function format(message: string, args: FormatType[]): string;
+    export function format(message: string, args: Record<string | number, FormatType>): string;
+    export function format(message: string, args: Record<string | number, FormatType> | FormatType[]): string {
+        return message.replace(formatRegexp, (match, group) => (args[group] ?? match) as string);
     }
 
     export function localize(localization: Localization | undefined, key: string, defaultValue: string, ...args: FormatType[]): string {

--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -20,6 +20,8 @@ export namespace nls {
 
     export let localization: Localization | undefined;
 
+    export const defaultLocale = 'en';
+
     export const localeId = 'localeId';
 
     export const locale = typeof window === 'object' && window && window.localStorage.getItem(localeId) || undefined;
@@ -57,7 +59,7 @@ export namespace nls {
     }
 
     export function isSelectedLocale(id: string): boolean {
-        if (locale === undefined && id === 'en') {
+        if (locale === undefined && id === defaultLocale) {
             return true;
         }
         return locale === id;

--- a/packages/core/src/node/i18n/localization-backend-contribution.ts
+++ b/packages/core/src/node/i18n/localization-backend-contribution.ts
@@ -16,6 +16,7 @@
 
 import * as express from 'express';
 import { inject, injectable } from 'inversify';
+import { nls } from '../../common/nls';
 import { Deferred } from '../../common/promise-util';
 import { BackendApplicationContribution } from '../backend-application';
 import { LocalizationRegistry } from './localization-contribution';
@@ -44,7 +45,7 @@ export class LocalizationBackendContribution implements BackendApplicationContri
         app.get('/i18n/:locale', async (req, res) => {
             await this.waitForInitialization();
             let locale = req.params.locale;
-            locale = this.localizationProvider.getAvailableLanguages().some(e => e.languageId === locale) ? locale : 'en';
+            locale = this.localizationProvider.getAvailableLanguages().some(e => e.languageId === locale) ? locale : nls.defaultLocale;
             this.localizationProvider.setCurrentLanguage(locale);
             res.send(this.localizationProvider.loadLocalization(locale));
         });

--- a/packages/core/src/node/i18n/localization-provider.ts
+++ b/packages/core/src/node/i18n/localization-provider.ts
@@ -15,13 +15,14 @@
 // *****************************************************************************
 
 import { injectable } from 'inversify';
+import { nls } from '../../common/nls';
 import { LanguageInfo, Localization } from '../../common/i18n/localization';
 
 @injectable()
 export class LocalizationProvider {
 
     protected localizations: Localization[] = [];
-    protected currentLanguage = 'en';
+    protected currentLanguage = nls.defaultLocale;
 
     addLocalizations(...localizations: Localization[]): void {
         this.localizations.push(...localizations);

--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -68,6 +68,7 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
             },
             entryPoint,
             iconUrl: plugin.icon && PluginPackage.toPluginUrl(plugin, plugin.icon),
+            l10n: plugin.l10n,
             readmeUrl: PluginPackage.toPluginUrl(plugin, './README.md'),
             licenseUrl: PluginPackage.toPluginUrl(plugin, './LICENSE')
         };

--- a/packages/plugin-ext/src/common/language-pack-service.ts
+++ b/packages/plugin-ext/src/common/language-pack-service.ts
@@ -1,0 +1,34 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Starting with vscode 1.73.0, language pack bundles have changed their shape to accomodate the new `l10n` API.
+ * They are now a record of { [englishValue]: translation }
+ */
+export interface LanguagePackBundle {
+    contents: Record<string, string>
+    uri: string
+}
+
+export const languagePackServicePath = '/services/languagePackService';
+
+export const LanguagePackService = Symbol('LanguagePackService');
+
+export interface LanguagePackService {
+    storeBundle(pluginId: string, locale: string, bundle: LanguagePackBundle): void;
+    deleteBundle(pluginId: string, locale?: string): void;
+    getBundle(pluginId: string, locale: string): Promise<LanguagePackBundle | undefined>;
+}

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2112,7 +2112,7 @@ export const PLUGIN_RPC_CONTEXT = {
     THEMING_MAIN: <ProxyIdentifier<ThemingMain>>createProxyIdentifier<ThemingMain>('ThemingMain'),
     COMMENTS_MAIN: <ProxyIdentifier<CommentsMain>>createProxyIdentifier<CommentsMain>('CommentsMain'),
     TABS_MAIN: <ProxyIdentifier<TabsMain>>createProxyIdentifier<TabsMain>('TabsMain'),
-    L10N_MAIN: <ProxyIdentifier<LocalizationMain>>createProxyIdentifier<LocalizationMain>('LocalizationMain'),
+    LOCALIZATION_MAIN: <ProxyIdentifier<LocalizationMain>>createProxyIdentifier<LocalizationMain>('LocalizationMain'),
 };
 
 export const MAIN_RPC_CONTEXT = {
@@ -2222,7 +2222,7 @@ export interface IdentifiableInlineCompletion extends InlineCompletion {
 
 export interface LocalizationExt {
     getMessage(pluginId: string, details: StringDetails): string;
-    getBundle(pluginId: string): { [key: string]: string } | undefined;
+    getBundle(pluginId: string): Record<string, string> | undefined;
     getBundleUri(pluginId: string): theia.Uri | undefined;
     initializeLocalizedMessages(plugin: Plugin, currentLanguage: string): Promise<void>;
 }

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2221,7 +2221,7 @@ export interface IdentifiableInlineCompletion extends InlineCompletion {
 }
 
 export interface LocalizationExt {
-    getMessage(pluginId: string, details: StringDetails): string;
+    translateMessage(pluginId: string, details: StringDetails): string;
     getBundle(pluginId: string): Record<string, string> | undefined;
     getBundleUri(pluginId: string): theia.Uri | undefined;
     initializeLocalizedMessages(plugin: Plugin, currentLanguage: string): Promise<void>;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -115,6 +115,7 @@ import { Disposable } from '@theia/core/lib/common/disposable';
 import { isString, isObject, PickOptions, QuickInputButtonHandle } from '@theia/core/lib/common';
 import { Severity } from '@theia/core/lib/common/severity';
 import { DebugConfiguration, DebugSessionOptions } from '@theia/debug/lib/common/debug-configuration';
+import { LanguagePackBundle } from './language-pack-service';
 
 export interface PreferenceData {
     [scope: number]: any;
@@ -2110,7 +2111,8 @@ export const PLUGIN_RPC_CONTEXT = {
     TIMELINE_MAIN: <ProxyIdentifier<TimelineMain>>createProxyIdentifier<TimelineMain>('TimelineMain'),
     THEMING_MAIN: <ProxyIdentifier<ThemingMain>>createProxyIdentifier<ThemingMain>('ThemingMain'),
     COMMENTS_MAIN: <ProxyIdentifier<CommentsMain>>createProxyIdentifier<CommentsMain>('CommentsMain'),
-    TABS_MAIN: <ProxyIdentifier<TabsMain>>createProxyIdentifier<TabsMain>('TabsMain')
+    TABS_MAIN: <ProxyIdentifier<TabsMain>>createProxyIdentifier<TabsMain>('TabsMain'),
+    L10N_MAIN: <ProxyIdentifier<LocalizationMain>>createProxyIdentifier<LocalizationMain>('LocalizationMain'),
 };
 
 export const MAIN_RPC_CONTEXT = {
@@ -2216,4 +2218,21 @@ export interface IdentifiableInlineCompletions extends InlineCompletions<Identif
 
 export interface IdentifiableInlineCompletion extends InlineCompletion {
     idx: number;
+}
+
+export interface LocalizationExt {
+    getMessage(pluginId: string, details: StringDetails): string;
+    getBundle(pluginId: string): { [key: string]: string } | undefined;
+    getBundleUri(pluginId: string): theia.Uri | undefined;
+    initializeLocalizedMessages(plugin: Plugin, currentLanguage: string): Promise<void>;
+}
+
+export interface StringDetails {
+    message: string;
+    args?: Record<string | number, any>;
+    comment?: string | string[];
+}
+
+export interface LocalizationMain {
+    $fetchBundle(id: string): Promise<LanguagePackBundle | undefined>;
 }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -59,6 +59,7 @@ export interface PluginPackage {
     activationEvents?: string[];
     extensionDependencies?: string[];
     extensionPack?: string[];
+    l10n?: string;
     icon?: string;
     extensionKind?: Array<'ui' | 'workspace'>
 }
@@ -544,6 +545,7 @@ export interface PluginModel {
      */
     packagePath: string;
     iconUrl?: string;
+    l10n?: string;
     readmeUrl?: string;
     licenseUrl?: string;
 }

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -510,7 +510,7 @@ export class HostedPluginSupport {
                 workspaceState,
                 env: {
                     queryParams: getQueryParameters(),
-                    language: nls.locale || 'en',
+                    language: nls.locale || nls.defaultLocale,
                     shell: defaultShell,
                     uiKind: isElectron ? UIKind.Desktop : UIKind.Web,
                     appName: FrontendApplicationConfigProvider.get().applicationName,

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -36,6 +36,7 @@ import { WorkspaceExtImpl } from '../../../plugin/workspace';
 import { createDebugExtStub } from './debug-stub';
 import { loadManifest } from './plugin-manifest-loader';
 import { WorkerEnvExtImpl } from './worker-env-ext';
+import { LocalizationExtImpl } from '../../../plugin/localization';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ctx = self as any;
@@ -77,6 +78,7 @@ const debugExt = createDebugExtStub(rpc);
 const clipboardExt = new ClipboardExt(rpc);
 const webviewExt = new WebviewsExtImpl(rpc, workspaceExt);
 const secretsExt = new SecretsExtImpl(rpc);
+const localizationExt = new LocalizationExtImpl(rpc);
 const terminalService: TerminalServiceExt = new TerminalServiceExtImpl(rpc);
 
 const pluginManager = new PluginManagerExtImpl({
@@ -171,7 +173,7 @@ const pluginManager = new PluginManagerExtImpl({
             }
         }
     }
-}, envExt, terminalService, storageProxy, secretsExt, preferenceRegistryExt, webviewExt, rpc);
+}, envExt, terminalService, storageProxy, secretsExt, preferenceRegistryExt, webviewExt, localizationExt, rpc);
 
 const apiFactory = createAPIFactory(
     rpc,
@@ -183,7 +185,8 @@ const apiFactory = createAPIFactory(
     workspaceExt,
     messageRegistryExt,
     clipboardExt,
-    webviewExt
+    webviewExt,
+    localizationExt
 );
 let defaultApi: typeof theia;
 

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -36,7 +36,7 @@ import { WorkspaceExtImpl } from '../../../plugin/workspace';
 import { createDebugExtStub } from './debug-stub';
 import { loadManifest } from './plugin-manifest-loader';
 import { WorkerEnvExtImpl } from './worker-env-ext';
-import { LocalizationExtImpl } from '../../../plugin/localization';
+import { LocalizationExtImpl } from '../../../plugin/localization-ext';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ctx = self as any;

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -174,7 +174,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             const { type } = entry;
             const deployed: DeployedPlugin = { metadata, type };
             deployed.contributes = this.reader.readContribution(manifest);
-            this.localizationService.deployLocalizations(deployed);
+            await this.localizationService.deployLocalizations(deployed);
             deployedPlugins.set(id, deployed);
             deployPlugin.debug(`Deployed ${entryPoint} plugin "${id}" from "${metadata.model.entryPoint[entryPoint] || pluginPath}"`);
         } catch (e) {

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -133,7 +133,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             if (await this.deployPlugin(plugin, 'backend')) { successes++; }
         }
         // rebuild translation config after deployment
-        this.localizationService.buildTranslationConfig([...this.deployedBackendPlugins.values()]);
+        await this.localizationService.buildTranslationConfig([...this.deployedBackendPlugins.values()]);
         // resolve on first deploy
         this.backendPluginsMetadataDeferred.resolve(undefined);
         return successes;

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-localization-service.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-localization-service.ts
@@ -19,12 +19,12 @@ import * as fs from '@theia/core/shared/fs-extra';
 import { LocalizationProvider } from '@theia/core/lib/node/i18n/localization-provider';
 import { Localization } from '@theia/core/lib/common/i18n/localization';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { DeployedPlugin, Localization as PluginLocalization, PluginIdentifiers } from '../../common';
-import { URI } from '@theia/core/shared/vscode-uri';
+import { DeployedPlugin, Localization as PluginLocalization, PluginIdentifiers, Translation } from '../../common';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
-import { Disposable, isObject, MaybePromise } from '@theia/core';
+import { Disposable, DisposableCollection, isObject, MaybePromise, nls, URI } from '@theia/core';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { LanguagePackBundle, LanguagePackService } from '../../common/language-pack-service';
 
 export interface VSCodeNlsConfig {
     locale: string
@@ -41,6 +41,9 @@ export class HostedPluginLocalizationService implements BackendApplicationContri
 
     @inject(LocalizationProvider)
     protected readonly localizationProvider: LocalizationProvider;
+
+    @inject(LanguagePackService)
+    protected readonly languagePackService: LanguagePackService;
 
     @inject(EnvVariablesServer)
     protected readonly envVariables: EnvVariablesServer;
@@ -62,15 +65,24 @@ export class HostedPluginLocalizationService implements BackendApplicationContri
             .then(() => this._ready.resolve());
     }
 
-    deployLocalizations(plugin: DeployedPlugin): void {
+    async deployLocalizations(plugin: DeployedPlugin): Promise<void> {
+        const disposable = new DisposableCollection();
         if (plugin.contributes?.localizations) {
             const localizations = buildLocalizations(plugin.contributes.localizations);
-            const versionedId = PluginIdentifiers.componentsToVersionedId(plugin.metadata.model);
-            this.localizationDisposeMap.set(versionedId, Disposable.create(() => {
+            disposable.push(Disposable.create(() => {
                 this.localizationProvider.removeLocalizations(...localizations);
-                this.localizationDisposeMap.delete(versionedId);
             }));
             this.localizationProvider.addLocalizations(...localizations);
+        }
+        if (plugin.metadata.model.l10n || plugin.contributes?.localizations) {
+            disposable.push(await this.updateLanguagePackBundles(plugin));
+        }
+        if (!disposable.disposed) {
+            const versionedId = PluginIdentifiers.componentsToVersionedId(plugin.metadata.model);
+            disposable.push(Disposable.create(() => {
+                this.localizationDisposeMap.delete(versionedId);
+            }));
+            this.localizationDisposeMap.set(versionedId, disposable);
         }
     }
 
@@ -78,10 +90,52 @@ export class HostedPluginLocalizationService implements BackendApplicationContri
         this.localizationDisposeMap.get(plugin)?.dispose();
     }
 
+    protected async updateLanguagePackBundles(plugin: DeployedPlugin): Promise<Disposable> {
+        const disposable = new DisposableCollection();
+        const pluginId = plugin.metadata.model.id;
+        const packageUri = new URI(plugin.metadata.model.packageUri);
+        if (plugin.contributes?.localizations) {
+            for (const localization of plugin.contributes.localizations) {
+                for (const translation of localization.translations) {
+                    const l10n = getL10nTranslation(translation);
+                    if (l10n) {
+                        const translatedPluginId = translation.id;
+                        const translationUri = packageUri.resolve(translation.path);
+                        const locale = localization.languageId;
+                        // We store a bundle for another extension in here
+                        // Hence we use `translatedPluginId` instead of `pluginId`
+                        this.languagePackService.storeBundle(translatedPluginId, locale, {
+                            contents: processL10nBundle(l10n),
+                            uri: translationUri.toString()
+                        });
+                        disposable.push(Disposable.create(() => {
+                            // Only dispose the deleted locale for the specific plugin
+                            this.languagePackService.deleteBundle(translatedPluginId, locale);
+                        }));
+                    }
+                }
+            }
+        }
+        if (plugin.metadata.model.l10n) {
+            const bundleDirectory = packageUri.resolve(plugin.metadata.model.l10n);
+            const bundles = await loadPluginBundles(bundleDirectory);
+            if (bundles) {
+                for (const [locale, bundle] of Object.entries(bundles)) {
+                    this.languagePackService.storeBundle(pluginId, locale, bundle);
+                }
+                disposable.push(Disposable.create(() => {
+                    // Dispose all bundles contributed by the deleted plugin
+                    this.languagePackService.deleteBundle(pluginId);
+                }));
+            }
+        }
+        return disposable;
+    }
+
     async localizePlugin(plugin: DeployedPlugin): Promise<DeployedPlugin> {
         const currentLanguage = this.localizationProvider.getCurrentLanguage();
         const localization = this.localizationProvider.loadLocalization(currentLanguage);
-        const pluginPath = URI.parse(plugin.metadata.model.packageUri).fsPath;
+        const pluginPath = new URI(plugin.metadata.model.packageUri).path.fsPath();
         const pluginId = plugin.metadata.model.id;
         try {
             const translations = await loadPackageTranslations(pluginPath, currentLanguage);
@@ -98,7 +152,7 @@ export class HostedPluginLocalizationService implements BackendApplicationContri
     getNlsConfig(): VSCodeNlsConfig {
         const locale = this.localizationProvider.getCurrentLanguage();
         const configFile = this.translationConfigFiles.get(locale);
-        if (locale === 'en' || !configFile) {
+        if (locale === nls.defaultLocale || !configFile) {
             return { locale, availableLanguages: {} };
         }
         const cache = path.dirname(configFile);
@@ -118,7 +172,7 @@ export class HostedPluginLocalizationService implements BackendApplicationContri
         const configs = new Map<string, Record<string, string>>();
         for (const plugin of plugins) {
             if (plugin.contributes?.localizations) {
-                const pluginPath = URI.parse(plugin.metadata.model.packageUri).fsPath;
+                const pluginPath = new URI(plugin.metadata.model.packageUri).path.fsPath();
                 for (const localization of plugin.contributes.localizations) {
                     const config = configs.get(localization.languageId) || {};
                     for (const translation of localization.translations) {
@@ -140,11 +194,57 @@ export class HostedPluginLocalizationService implements BackendApplicationContri
     }
 
     protected async getLocalizationCacheDir(): Promise<string> {
-        const configDir = URI.parse(await this.envVariables.getConfigDirUri()).fsPath;
+        const configDir = new URI(await this.envVariables.getConfigDirUri()).path.fsPath();
         const cacheDir = path.join(configDir, 'localization-cache');
         return cacheDir;
     }
 }
+
+// New plugin localization logic using vscode.l10n
+
+function getL10nTranslation(translation: Translation): UnprocessedL10nBundle | undefined {
+    // 'bundle' is a special key that contains all translations for the l10n vscode API
+    // If that doesn't exist, we can assume that the language pack is using the old vscode-nls API
+    return translation.contents.bundle;
+}
+
+async function loadPluginBundles(l10nUri: URI): Promise<Record<string, LanguagePackBundle> | undefined> {
+    try {
+        const directory = l10nUri.path.fsPath();
+        const files = await fs.readdir(directory);
+        const result: Record<string, LanguagePackBundle> = {};
+        await Promise.all(files.map(async fileName => {
+            const match = fileName.match(/^bundle\.l10n\.([\w\-]+)\.json$/);
+            if (match) {
+                const locale = match[1];
+                const contents = await fs.readJSON(path.join(directory, fileName));
+                result[locale] = {
+                    contents,
+                    uri: l10nUri.resolve(fileName).toString()
+                };
+            }
+        }));
+        return result;
+    } catch {
+        // The directory either doesn't exist or its contents cannot be parsed
+        // In any way we should just safely return undefined
+        return undefined;
+    }
+}
+
+type UnprocessedL10nBundle = Record<string, string | { message: string }>;
+
+function processL10nBundle(bundle: UnprocessedL10nBundle): Record<string, string> {
+    const processedBundle: Record<string, string> = {};
+    for (const [name, value] of Object.entries(bundle)) {
+        const stringValue = typeof value === 'string' ? value : value.message;
+        processedBundle[name] = stringValue;
+    }
+    return processedBundle;
+}
+
+// Old plugin localization logic for vscode-nls
+// vscode-nls was used until version 1.73 of VSCode to translate extensions
 
 function buildLocalizations(localizations: PluginLocalization[]): Localization[] {
     const theiaLocalizations: Localization[] = [];
@@ -172,6 +272,10 @@ function buildLocalizations(localizations: PluginLocalization[]): Localization[]
 function buildTranslationKey(pluginId: string, scope: string, key: string): string {
     return `${pluginId}/${Localization.transformKey(scope)}/${key}`;
 }
+
+// Localization logic for `package.json` entries
+// Extensions can use `package.nls.json` files to store translations for values in their package.json
+// This logic has not changed with the introduction of the vscode.l10n API
 
 interface PackageTranslation {
     translation?: Record<string, string>

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -34,6 +34,10 @@ import { HostedPluginDeployerHandler } from './hosted-plugin-deployer-handler';
 import { PluginUriFactory } from './scanners/plugin-uri-factory';
 import { FilePluginUriFactory } from './scanners/file-plugin-uri-factory';
 import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
+import { LanguagePackService, languagePackServicePath } from '../../common/language-pack-service';
+import { PluginLanguagePackService } from './plugin-language-pack-service';
+import { JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
+import { ConnectionHandler } from '@theia/core/lib/common/messaging/handler';
 
 const commonHostedConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService }) => {
     bind(HostedPluginProcess).toSelf().inSingletonScope();
@@ -63,6 +67,14 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(BackendApplicationContribution).toService(HostedPluginLocalizationService);
     bind(HostedPluginDeployerHandler).toSelf().inSingletonScope();
     bind(PluginDeployerHandler).toService(HostedPluginDeployerHandler);
+
+    bind(PluginLanguagePackService).toSelf().inSingletonScope();
+    bind(LanguagePackService).toService(PluginLanguagePackService);
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new JsonRpcConnectionHandler(languagePackServicePath, () =>
+            ctx.container.get(LanguagePackService)
+        )
+    ).inSingletonScope();
 
     bind(GrammarsReader).toSelf().inSingletonScope();
     bind(HostedPluginProcessConfiguration).toConstantValue({

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -16,7 +16,7 @@
 
 import { dynamicRequire } from '@theia/core/lib/node/dynamic-require';
 import { PluginManagerExtImpl } from '../../plugin/plugin-manager';
-import { MAIN_RPC_CONTEXT, Plugin, PluginAPIFactory } from '../../common/plugin-api-rpc';
+import { LocalizationExt, MAIN_RPC_CONTEXT, Plugin, PluginAPIFactory } from '../../common/plugin-api-rpc';
 import { PluginMetadata } from '../../common/plugin-protocol';
 import { createAPIFactory } from '../../plugin/plugin-context';
 import { EnvExtImpl } from '../../plugin/env';
@@ -35,6 +35,7 @@ import { TerminalServiceExtImpl } from '../../plugin/terminal-ext';
 import { SecretsExtImpl } from '../../plugin/secrets-ext';
 import { BackendInitializationFn } from '../../common';
 import { connectProxyResolver } from './plugin-host-proxy';
+import { LocalizationExtImpl } from '../../plugin/localization';
 
 /**
  * Handle the RPC calls.
@@ -61,7 +62,8 @@ export class PluginHostRPC {
         const webviewExt = new WebviewsExtImpl(this.rpc, workspaceExt);
         const terminalService = new TerminalServiceExtImpl(this.rpc);
         const secretsExt = new SecretsExtImpl(this.rpc);
-        this.pluginManager = this.createPluginManager(envExt, terminalService, storageProxy, preferenceRegistryExt, webviewExt, secretsExt, this.rpc);
+        const localizationExt = new LocalizationExtImpl(this.rpc);
+        this.pluginManager = this.createPluginManager(envExt, terminalService, storageProxy, preferenceRegistryExt, webviewExt, secretsExt, localizationExt, this.rpc);
         this.rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, this.pluginManager);
         this.rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, editorsAndDocumentsExt);
         this.rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, workspaceExt);
@@ -80,7 +82,8 @@ export class PluginHostRPC {
             workspaceExt,
             messageRegistryExt,
             clipboardExt,
-            webviewExt
+            webviewExt,
+            localizationExt
         );
         connectProxyResolver(workspaceExt, preferenceRegistryExt);
     }
@@ -102,7 +105,7 @@ export class PluginHostRPC {
 
     createPluginManager(
         envExt: EnvExtImpl, terminalService: TerminalServiceExtImpl, storageProxy: KeyValueStorageProxy,
-        preferencesManager: PreferenceRegistryExtImpl, webview: WebviewsExtImpl, secretsExt: SecretsExtImpl,
+        preferencesManager: PreferenceRegistryExtImpl, webview: WebviewsExtImpl, secretsExt: SecretsExtImpl, localization: LocalizationExt,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         rpc: any
     ): PluginManagerExtImpl {
@@ -239,7 +242,7 @@ export class PluginHostRPC {
                     `Path ${extensionTestsPath} does not point to a valid extension test runner.`
                 );
             } : undefined
-        }, envExt, terminalService, storageProxy, secretsExt, preferencesManager, webview, rpc);
+        }, envExt, terminalService, storageProxy, secretsExt, preferencesManager, webview, localization, rpc);
         return pluginManager;
     }
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -35,7 +35,7 @@ import { TerminalServiceExtImpl } from '../../plugin/terminal-ext';
 import { SecretsExtImpl } from '../../plugin/secrets-ext';
 import { BackendInitializationFn } from '../../common';
 import { connectProxyResolver } from './plugin-host-proxy';
-import { LocalizationExtImpl } from '../../plugin/localization';
+import { LocalizationExtImpl } from '../../plugin/localization-ext';
 
 /**
  * Handle the RPC calls.

--- a/packages/plugin-ext/src/hosted/node/plugin-language-pack-service.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-language-pack-service.ts
@@ -1,0 +1,43 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { LanguagePackBundle, LanguagePackService } from '../../common/language-pack-service';
+
+@injectable()
+export class PluginLanguagePackService implements LanguagePackService {
+
+    protected readonly storage = new Map<string, Map<string, LanguagePackBundle>>();
+
+    storeBundle(pluginId: string, locale: string, bundle: LanguagePackBundle): void {
+        if (!this.storage.has(pluginId)) {
+            this.storage.set(pluginId, new Map());
+        }
+        this.storage.get(pluginId)!.set(locale, bundle);
+    }
+
+    deleteBundle(pluginId: string, locale?: string): void {
+        if (locale) {
+            this.storage.get(pluginId)?.delete(locale);
+        } else {
+            this.storage.delete(pluginId);
+        }
+    }
+
+    async getBundle(pluginId: string, locale: string): Promise<LanguagePackBundle | undefined> {
+        return this.storage.get(pluginId)?.get(locale);
+    }
+}

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -116,6 +116,7 @@ export class TheiaPluginScanner implements PluginScanner {
             version: plugin.version,
             displayName: plugin.displayName,
             description: plugin.description,
+            l10n: plugin.l10n,
             engine: {
                 type: this._apiType,
                 version: plugin.engines[this._apiType]

--- a/packages/plugin-ext/src/main/browser/localization-main.ts
+++ b/packages/plugin-ext/src/main/browser/localization-main.ts
@@ -1,0 +1,34 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { interfaces } from '@theia/core/shared/inversify';
+import { LocalizationMain } from '../../common/plugin-api-rpc';
+import { LanguagePackBundle, LanguagePackService } from '../../common/language-pack-service';
+
+export class LocalizationMainImpl implements LocalizationMain {
+
+    private readonly languagePackService: LanguagePackService;
+
+    constructor(container: interfaces.Container) {
+        this.languagePackService = container.get(LanguagePackService);
+    }
+
+    async $fetchBundle(id: string): Promise<LanguagePackBundle | undefined> {
+        const bundle = await this.languagePackService.getBundle(id, nls.locale ?? nls.defaultLocale);
+        return bundle;
+    }
+}

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -59,6 +59,7 @@ import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
 import { UntitledResourceResolver } from '@theia/core/lib/common/resource';
 import { ThemeService } from '@theia/core/lib/browser/theming';
 import { TabsMainImpl } from './tabs/tabs-main';
+import { LocalizationMainImpl } from './localization-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const authenticationMain = new AuthenticationMainImpl(rpc, container);
@@ -184,4 +185,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const tabsMain = new TabsMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.TABS_MAIN, tabsMain);
+
+    const localizationMain = new LocalizationMainImpl(container);
+    rpc.set(PLUGIN_RPC_CONTEXT.L10N_MAIN, localizationMain);
 }

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -187,5 +187,5 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     rpc.set(PLUGIN_RPC_CONTEXT.TABS_MAIN, tabsMain);
 
     const localizationMain = new LocalizationMainImpl(container);
-    rpc.set(PLUGIN_RPC_CONTEXT.L10N_MAIN, localizationMain);
+    rpc.set(PLUGIN_RPC_CONTEXT.LOCALIZATION_MAIN, localizationMain);
 }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -83,6 +83,7 @@ import './theme-icon-override';
 import { PluginTerminalRegistry } from './plugin-terminal-registry';
 import { DnDFileContentStore } from './view/dnd-file-content-store';
 import { WebviewContextKeys } from './webview/webview-context-keys';
+import { LanguagePackService, languagePackServicePath } from '../../common/language-pack-service';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
@@ -249,4 +250,9 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(AuthenticationService).toService(PluginAuthenticationServiceImpl);
 
     bind(PluginTerminalRegistry).toSelf().inSingletonScope();
+
+    bind(LanguagePackService).toDynamicValue(ctx => {
+        const provider = ctx.container.get(WebSocketConnectionProvider);
+        return provider.createProxy<LanguagePackService>(languagePackServicePath);
+    }).inSingletonScope();
 });

--- a/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
+++ b/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
@@ -62,7 +62,7 @@ export class PluginsKeyValueStorage {
 
         const data = await this.readFromFile(dataPath);
 
-        if (value === undefined || value === {}) {
+        if (value === undefined) {
             delete data[key];
         } else {
             data[key] = value;

--- a/packages/plugin-ext/src/plugin/localization-ext.ts
+++ b/packages/plugin-ext/src/plugin/localization-ext.ts
@@ -34,7 +34,7 @@ export class LocalizationExtImpl implements LocalizationExt {
         this._proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.LOCALIZATION_MAIN);
     }
 
-    getMessage(pluginId: string, details: StringDetails): string {
+    translateMessage(pluginId: string, details: StringDetails): string {
         const { message, args, comment } = details;
         if (this.isDefaultLanguage) {
             return Localization.format(message, (args ?? {}));

--- a/packages/plugin-ext/src/plugin/localization-ext.ts
+++ b/packages/plugin-ext/src/plugin/localization-ext.ts
@@ -31,7 +31,7 @@ export class LocalizationExtImpl implements LocalizationExt {
     private readonly bundleCache = new Map<string, LanguagePackBundle | undefined>();
 
     constructor(rpc: RPCProtocol) {
-        this._proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.L10N_MAIN);
+        this._proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.LOCALIZATION_MAIN);
     }
 
     getMessage(pluginId: string, details: StringDetails): string {

--- a/packages/plugin-ext/src/plugin/localization.ts
+++ b/packages/plugin-ext/src/plugin/localization.ts
@@ -1,0 +1,84 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { nls } from '@theia/core';
+import { Localization } from '@theia/core/lib/common/i18n/localization';
+import { LocalizationExt, LocalizationMain, Plugin, PLUGIN_RPC_CONTEXT, StringDetails } from '../common';
+import { LanguagePackBundle } from '../common/language-pack-service';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { URI } from './types-impl';
+
+export class LocalizationExtImpl implements LocalizationExt {
+
+    private readonly _proxy: LocalizationMain;
+    private currentLanguage?: string;
+    private isDefaultLanguage = true;
+    private readonly bundleCache = new Map<string, LanguagePackBundle | undefined>();
+
+    constructor(rpc: RPCProtocol) {
+        this._proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.L10N_MAIN);
+    }
+
+    getMessage(pluginId: string, details: StringDetails): string {
+        const { message, args, comment } = details;
+        if (this.isDefaultLanguage) {
+            return Localization.format(message, (args ?? {}));
+        }
+
+        let key = message;
+        if (comment && comment.length > 0) {
+            key += `/${Array.isArray(comment) ? comment.join() : comment}`;
+        }
+        const str = this.bundleCache.get(pluginId)?.contents[key];
+        return Localization.format(str ?? message, (args ?? {}));
+    }
+
+    getBundle(pluginId: string): { [key: string]: string } | undefined {
+        return this.bundleCache.get(pluginId)?.contents;
+    }
+
+    getBundleUri(pluginId: string): URI | undefined {
+        const uri = this.bundleCache.get(pluginId)?.uri;
+        return uri ? URI.parse(uri) : undefined;
+    }
+
+    async initializeLocalizedMessages(plugin: Plugin, currentLanguage: string): Promise<void> {
+        this.currentLanguage ??= currentLanguage;
+        this.isDefaultLanguage = this.currentLanguage === nls.defaultLocale;
+
+        if (this.isDefaultLanguage) {
+            return;
+        }
+
+        if (this.bundleCache.has(plugin.model.id)) {
+            return;
+        }
+
+        let bundle: LanguagePackBundle | undefined;
+
+        try {
+            bundle = await this._proxy.$fetchBundle(plugin.model.id);
+        } catch (e) {
+            console.error(`Failed to load translations for ${plugin.model.id}: ${e.message}`);
+            return;
+        }
+
+        this.bundleCache.set(plugin.model.id, bundle);
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -234,7 +234,7 @@ import { PluginPackage } from '../common';
 import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { FilePermission } from '@theia/filesystem/lib/common/files';
 import { TabsExtImpl } from './tabs';
-import { LocalizationExtImpl } from './localization';
+import { LocalizationExtImpl } from './localization-ext';
 
 export function createAPIFactory(
     rpc: RPCProtocol,

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -1084,9 +1084,9 @@ export function createAPIFactory(
                     // We have either rest args which are Array<string | number | boolean> or an array with a single Record<string, any>.
                     // This ensures we get a Record<string | number, any> which will be formatted correctly.
                     const argsFormatted = !params || typeof params[0] !== 'object' ? params : params[0];
-                    return localizationExt.getMessage(plugin.model.id, { message: key, args: argsFormatted as Record<string | number, any> | undefined });
+                    return localizationExt.translateMessage(plugin.model.id, { message: key, args: argsFormatted as Record<string | number, any> | undefined });
                 }
-                return localizationExt.getMessage(plugin.model.id, params[0]);
+                return localizationExt.translateMessage(plugin.model.id, params[0]);
             },
             get bundle() {
                 return localizationExt.getBundle(plugin.model.id);

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -26,7 +26,8 @@ import {
     ConfigStorage,
     PluginManagerInitializeParams,
     PluginManagerStartParams,
-    TerminalServiceExt
+    TerminalServiceExt,
+    LocalizationExt
 } from '../common/plugin-api-rpc';
 import { PluginMetadata, PluginJsonValidationContribution } from '../common/plugin-protocol';
 import * as theia from '@theia/plugin';
@@ -122,6 +123,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         private readonly secrets: SecretsExtImpl,
         private readonly preferencesManager: PreferenceRegistryExtImpl,
         private readonly webview: WebviewsExtImpl,
+        private readonly localization: LocalizationExt,
         private readonly rpc: RPCProtocol
     ) {
         this.messageRegistryProxy = this.rpc.getProxy(PLUGIN_RPC_CONTEXT.MESSAGE_REGISTRY_MAIN);
@@ -398,6 +400,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         }
         const id = plugin.model.displayName || plugin.model.id;
         if (typeof pluginMain[plugin.lifecycle.startMethod] === 'function') {
+            await this.localization.initializeLocalizedMessages(plugin, this.envExt.language);
             const pluginExport = await pluginMain[plugin.lifecycle.startMethod].apply(getGlobal(), [pluginContext]);
             this.activatedPlugins.set(plugin.model.id, new ActivatedPlugin(pluginContext, pluginExport, stopFn));
         } else {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -13713,6 +13713,82 @@ export module '@theia/plugin' {
     }
 
     /**
+     * Namespace for localization-related functionality in the extension API. To use this properly,
+     * you must have `l10n` defined in your extension manifest and have bundle.l10n.<language>.json files.
+     * For more information on how to generate bundle.l10n.<language>.json files, check out the
+     * [vscode-l10n repo](https://github.com/microsoft/vscode-l10n).
+     *
+     * Note: Built-in extensions (for example, Git, TypeScript Language Features, GitHub Authentication)
+     * are excluded from the `l10n` property requirement. In other words, they do not need to specify
+     * a `l10n` in the extension manifest because their translated strings come from Language Packs.
+     */
+    export namespace l10n {
+        /**
+         * Marks a string for localization. If a localized bundle is available for the language specified by
+         * {@link env.language} and the bundle has a localized value for this message, then that localized
+         * value will be returned (with injected {@link args} values for any templated values).
+         * @param message - The message to localize. Supports index templating where strings like `{0}` and `{1}` are
+         * replaced by the item at that index in the {@link args} array.
+         * @param args - The arguments to be used in the localized string. The index of the argument is used to
+         * match the template placeholder in the localized string.
+         * @returns localized string with injected arguments.
+         * @example `l10n.t('Hello {0}!', 'World');`
+         */
+        export function t(message: string, ...args: Array<string | number | boolean>): string;
+
+        /**
+         * Marks a string for localization. If a localized bundle is available for the language specified by
+         * {@link env.language} and the bundle has a localized value for this message, then that localized
+         * value will be returned (with injected {@link args} values for any templated values).
+         * @param message The message to localize. Supports named templating where strings like `{foo}` and `{bar}` are
+         * replaced by the value in the Record for that key (foo, bar, etc).
+         * @param args The arguments to be used in the localized string. The name of the key in the record is used to
+         * match the template placeholder in the localized string.
+         * @returns localized string with injected arguments.
+         * @example `l10n.t('Hello {name}', { name: 'Erich' });`
+         */
+        export function t(message: string, args: Record<string, any>): string;
+        /**
+         * Marks a string for localization. If a localized bundle is available for the language specified by
+         * {@link env.language} and the bundle has a localized value for this message, then that localized
+         * value will be returned (with injected args values for any templated values).
+         * @param options The options to use when localizing the message.
+         * @returns localized string with injected arguments.
+         */
+        export function t(options: {
+            /**
+             * The message to localize. If {@link args} is an array, this message supports index templating where strings like
+             * `{0}` and `{1}` are replaced by the item at that index in the {@link args} array. If `args` is a `Record<string, any>`,
+             * this supports named templating where strings like `{foo}` and `{bar}` are replaced by the value in
+             * the Record for that key (foo, bar, etc).
+             */
+            message: string;
+            /**
+             * The arguments to be used in the localized string. As an array, the index of the argument is used to
+             * match the template placeholder in the localized string. As a Record, the key is used to match the template
+             * placeholder in the localized string.
+             */
+            args?: Array<string | number | boolean> | Record<string, any>;
+            /**
+             * A comment to help translators understand the context of the message.
+             */
+            comment: string | string[];
+        }): string;
+        /**
+         * The bundle of localized strings that have been loaded for the extension.
+         * It's undefined if no bundle has been loaded. The bundle is typically not loaded if
+         * there was no bundle found or when we are running with the default language.
+         */
+        export const bundle: { [key: string]: string } | undefined;
+        /**
+         * The URI of the localization bundle that has been loaded for the extension.
+         * It's undefined if no bundle has been loaded. The bundle is typically not loaded if
+         * there was no bundle found or when we are running with the default language.
+         */
+        export const uri: Uri | undefined;
+    }
+
+    /**
      * The tab represents a single text based resource.
      */
     export class TabInputText {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11893

VSCode 1.73 not only brought the new `l10n` namespace with it, but also changed the way language packs for vscode built-ins work. Theia now supports both _old_ and _new_ language packs and extension localization APIs (`l10n` and `vscode-nls`).

#### How to test

You will need 4 extensions to test this feature:
* [l10n-test](https://github.com/eclipse-theia/theia/files/10767190/l10n-test-0.0.1.zip) ([source here](https://github.com/msujew/vscode-l10n-test))
* [German language pack@1.75](https://github.com/eclipse-theia/theia/files/10767197/vscode-language-pack-de-1.75.2023021509.zip)
* [css@1.75](https://github.com/eclipse-theia/theia/files/10767205/css-1.0.0.zip)
* [css-language-features@1.75](https://github.com/eclipse-theia/theia/files/10839511/css-language-features-1.0.1.zip)

1. Install `l10n-test` and execute the `l10n:*` commands.
    1. The `Hello World` command will create a notification with `"Hello World!"`
    2. The `Show URI` command will show `UNDEFINED`
    3. The `Show Bundle` command will also show undefined.
2. Install the German language pack and change the locale to `German/de`
3. Repeat step 1 (search for `l10n`, the command names are localized)
    1. The `Hello World` command will create a notification with `"Hallo Welt!"`
    2. The `Show URI` command will show the file uri to the German language bundle of the `l10n-test` extension
    3. The `Show Bundle` command will display a JSON containing the language bundle content
4. Delete the builtin `css-language-features` extension
5. Install the provided `css` and `css-language-features` extensions.
6. Open a CSS file, and hover over a selector. It should show `Selektorspezifität` (German) instead of `Selector Specificity` (English) in the hover. This step asserts that extensions can still be localized using language packs.

Also make sure to test for regressions with existing language pack functionality:

1. Confirm that old (< 1.73 API version) language packs still work as expected.
2. Confirm that this also works in conjunction with localized built-in extensions (such as the `typescript-language-features` extension)
3. Deinstalling language packs and consequently reloading the application should actually delete all contributed localizations/language pack bundles.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
