### PR TITLE
implemented WorkspaceEditMetadata and added new preference for autosave on refactorings

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -123,6 +123,11 @@ const fileContributionSchema: PreferenceSchema['properties'] = {
         'minimum': 0,
         'markdownDescription': nls.localizeByDefault('Controls the delay in milliseconds after which an editor with unsaved changes is saved automatically. Only applies when `#files.autoSave#` is set to `{0}`.', 'afterDelay')
     },
+    'files.refactoring.autoSave': {
+        'type': 'boolean',
+        'default': true,
+        'markdownDescription': nls.localize('theia/editor/files.refactoring.autoSave', 'Controls if files that were part of a refactoring are saved automaticly.',)
+    }
 };
 
 interface FileContributionEditorPreferences {
@@ -131,6 +136,7 @@ interface FileContributionEditorPreferences {
     'files.eol': '\n' | '\r\n' | 'auto';
     'files.autoSave': 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowChange';
     'files.autoSaveDelay': number;
+    'files.refactoring.autoSave': boolean
 }
 // #endregion
 

--- a/packages/monaco/src/browser/monaco-bulk-edit-service.ts
+++ b/packages/monaco/src/browser/monaco-bulk-edit-service.ts
@@ -38,7 +38,7 @@ export class MonacoBulkEditService implements IBulkEditService {
             editsIn = await this._previewHandler(edits, options);
             return { ariaSummary: '', success: true };
         } else {
-            return this.workspace.applyBulkEdit(edits);
+            return this.workspace.applyBulkEdit(edits, options);
         }
     }
 

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -21,7 +21,7 @@ import { injectable, inject, postConstruct } from '@theia/core/shared/inversify'
 import URI from '@theia/core/lib/common/uri';
 import { Emitter } from '@theia/core/lib/common/event';
 import { FileSystemPreferences } from '@theia/filesystem/lib/browser';
-import { EditorManager } from '@theia/editor/lib/browser';
+import { EditorManager, EditorPreferences } from '@theia/editor/lib/browser';
 import { MonacoTextModelService } from './monaco-text-model-service';
 import { WillSaveMonacoModelEvent, MonacoEditorModel, MonacoModelContentChangedEvent } from './monaco-editor-model';
 import { MonacoEditor } from './monaco-editor';
@@ -31,6 +31,7 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileSystemProviderCapabilities } from '@theia/filesystem/lib/common/files';
 import * as monaco from '@theia/monaco-editor-core';
 import {
+    IBulkEditOptions,
     IBulkEditResult, ResourceEdit, ResourceFileEdit as MonacoResourceFileEdit,
     ResourceTextEdit as MonacoResourceTextEdit
 } from '@theia/monaco-editor-core/esm/vs/editor/browser/services/bulkEditService';
@@ -110,6 +111,9 @@ export class MonacoWorkspace {
 
     @inject(FileSystemPreferences)
     protected readonly filePreferences: FileSystemPreferences;
+
+    @inject(EditorPreferences)
+    protected readonly editorPreferences: EditorPreferences;
 
     @inject(MonacoTextModelService)
     protected readonly textModelService: MonacoTextModelService;
@@ -226,7 +230,7 @@ export class MonacoWorkspace {
         });
     }
 
-    async applyBulkEdit(edits: ResourceEdit[]): Promise<IBulkEditResult & { success: boolean }> {
+    async applyBulkEdit(edits: ResourceEdit[], options?: IBulkEditOptions): Promise<IBulkEditResult & { success: boolean }> {
         try {
             let totalEdits = 0;
             let totalFiles = 0;
@@ -248,6 +252,13 @@ export class MonacoWorkspace {
                 await this.performSnippetEdits(<MonacoResourceTextEdit[]>snippetEdits);
             }
 
+            // when enabled (option AND setting) loop over all dirty working copies and trigger save
+            // for those that were involved in this bulk edit operation.
+            const resources = new Set<string>(edits.filter(edit => edit instanceof MonacoResourceTextEdit).map(edit => (edit as MonacoResourceTextEdit).resource.toString()));
+            if (options?.respectAutoSaveConfig && this.editorPreferences.get('files.refactoring.autoSave') === true && resources.size > 0) {
+                await this.saveAll(resources);
+            }
+
             const ariaSummary = this.getAriaSummary(totalEdits, totalFiles);
             return { ariaSummary, success: true };
         } catch (e) {
@@ -257,6 +268,13 @@ export class MonacoWorkspace {
                 success: false
             };
         }
+    }
+
+    protected saveAll(resources: Set<string>) {
+        for (const uri of resources.values()) {
+            this.textModelService.get(uri)?.save();
+        }
+
     }
 
     protected getAriaSummary(totalEdits: number, totalFiles: number): string {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1246,7 +1246,7 @@ export interface TextEditorsMain {
     $tryRevealRange(id: string, range: Range, revealType: TextEditorRevealType): Promise<void>;
     $trySetSelections(id: string, selections: Selection[]): Promise<void>;
     $tryApplyEdits(id: string, modelVersionId: number, edits: SingleEditOperation[], opts: ApplyEditsOptions): Promise<boolean>;
-    $tryApplyWorkspaceEdit(workspaceEditDto: WorkspaceEditDto): Promise<boolean>;
+    $tryApplyWorkspaceEdit(workspaceEditDto: WorkspaceEditDto, metadata?: WorkspaceEditMetdataDto): Promise<boolean>;
     $tryInsertSnippet(id: string, template: string, selections: Range[], opts: UndoStopOptions): Promise<boolean>;
     $saveAll(includeUntitled?: boolean): Promise<boolean>;
     // $getDiffInformation(id: string): Promise<editorCommon.ILineChange[]>;
@@ -1418,7 +1418,7 @@ export interface CodeActionDto {
     disabled?: string;
 }
 
-export interface WorkspaceEditMetadataDto {
+export interface WorkspaceEditEntryMetadataDto {
     needsConfirmation: boolean;
     label: string;
     description?: string;
@@ -1434,14 +1434,14 @@ export interface WorkspaceFileEditDto {
     oldResource?: UriComponents;
     newResource?: UriComponents;
     options?: FileOperationOptions;
-    metadata?: WorkspaceEditMetadataDto;
+    metadata?: WorkspaceEditEntryMetadataDto;
 }
 
 export interface WorkspaceTextEditDto {
     resource: UriComponents;
     modelVersionId?: number;
     textEdit: TextEdit & { insertAsSnippet?: boolean };
-    metadata?: WorkspaceEditMetadataDto;
+    metadata?: WorkspaceEditEntryMetadataDto;
 }
 export namespace WorkspaceTextEditDto {
     export function is(arg: WorkspaceTextEditDto | WorkspaceFileEditDto): arg is WorkspaceTextEditDto {
@@ -1452,6 +1452,9 @@ export namespace WorkspaceTextEditDto {
             && typeof arg.textEdit === 'object';
     }
 }
+export interface WorkspaceEditMetdataDto {
+    isRefactoring?: boolean;
+} 
 
 export interface WorkspaceEditDto {
     edits: Array<WorkspaceTextEditDto | WorkspaceFileEditDto>;

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -30,6 +30,7 @@ import {
     DecorationOptions,
     WorkspaceEditDto,
     DocumentsMain,
+    WorkspaceEditMetdataDto,
 } from '../../common/plugin-api-rpc';
 import { Range, TextDocumentShowOptions } from '../../common/plugin-api-rpc-model';
 import { EditorsAndDocumentsMain } from './editors-and-documents-main';
@@ -126,11 +127,11 @@ export class TextEditorsMainImpl implements TextEditorsMain, Disposable {
         return Promise.resolve(this.editorsAndDocuments.getEditor(id)!.applyEdits(modelVersionId, edits, opts));
     }
 
-    async $tryApplyWorkspaceEdit(dto: WorkspaceEditDto): Promise<boolean> {
+    async $tryApplyWorkspaceEdit(dto: WorkspaceEditDto, metadata?: WorkspaceEditMetdataDto): Promise<boolean> {
         const workspaceEdit = toMonacoWorkspaceEdit(dto);
         try {
             const edits = ResourceEdit.convert(workspaceEdit);
-            const { success } = await this.bulkEditService.apply(edits);
+            const { success } = await this.bulkEditService.apply(edits, { respectAutoSaveConfig: metadata?.isRefactoring });
             return success;
         } catch {
             return false;

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -670,8 +670,8 @@ export function createAPIFactory(
             saveAll(includeUntitled?: boolean): PromiseLike<boolean> {
                 return editors.saveAll(includeUntitled);
             },
-            applyEdit(edit: theia.WorkspaceEdit): PromiseLike<boolean> {
-                return editors.applyWorkspaceEdit(edit);
+            applyEdit(edit: theia.WorkspaceEdit, metadata?: theia.WorkspaceEditMetadata): PromiseLike<boolean> {
+                return editors.applyWorkspaceEdit(edit, metadata);
             },
             registerTextDocumentContentProvider(scheme: string, provider: theia.TextDocumentContentProvider): theia.Disposable {
                 return workspaceExt.registerTextDocumentContentProvider(scheme, provider);

--- a/packages/plugin-ext/src/plugin/text-editors.ts
+++ b/packages/plugin-ext/src/plugin/text-editors.ts
@@ -119,9 +119,9 @@ export class TextEditorsExtImpl implements TextEditorsExt {
         return new TextEditorDecorationType(this.proxy, options);
     }
 
-    applyWorkspaceEdit(edit: theia.WorkspaceEdit): Promise<boolean> {
+    applyWorkspaceEdit(edit: theia.WorkspaceEdit, metadata?: theia.WorkspaceEditMetadata): Promise<boolean> {
         const dto = Converters.fromWorkspaceEdit(edit, this.editorsAndDocuments);
-        return this.proxy.$tryApplyWorkspaceEdit(dto);
+        return this.proxy.$tryApplyWorkspaceEdit(dto, metadata);
     }
 
     saveAll(includeUntitled?: boolean): PromiseLike<boolean> {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7205,9 +7205,10 @@ export module '@theia/plugin' {
          * not be attempted, when a single edit fails.
          *
          * @param edit A workspace edit.
+         * @param metadata Optional {@link WorkspaceEditMetadata metadata} for the edit.
          * @return A thenable that resolves when the edit could be applied.
          */
-        export function applyEdit(edit: WorkspaceEdit): Thenable<boolean>;
+        export function applyEdit(edit: WorkspaceEdit, metadata?: WorkspaceEditMetadata): Thenable<boolean>;
 
         /**
          * Register a filesystem provider for a given scheme, e.g. `ftp`.
@@ -9747,6 +9748,16 @@ export module '@theia/plugin' {
          * The icon path or {@link ThemeIcon ThemeIcon} for the edit.
          */
         iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+    }
+
+    /**
+     * Additional data about a workspace edit.
+     */
+    export interface WorkspaceEditMetadata {
+        /**
+         * Signal to the editor that this edit is a refactoring.
+         */
+        isRefactoring?: boolean;
     }
 
     /**


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
resolves #12018
this implements `WorkspaceEditMetadata` for the vscode api and adds "files.refactoring.autoSave" as a new preference for autosaving all affected files after applying a refactoring, when normal autosave is disabled and the refactoring is marked as such through `WorkspaceEditMetadata `.

#### How to test
You can find a test extension here: https://github.com/jonah-iden/workspace-metadata-test
or download it here: [workspace-metadata-test-0.0.1.zip](https://github.com/eclipse-theia/theia/files/10767644/workspace-metadata-test-0.0.1.zip)

steps to test
1. Install extension 
2. Turn `files.autoSave` to `off`, `files.refactoring.autoSave ` should be true by default
3. Open at least two files
4. Execute `apply workspaceEdit with refactoring`. See files should have been saved since the edit was marked as refactoring.
5. Execute `apply workspaceEdit without refactoring`. Edit should have been applied but files should have **not** been saved

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
