### PR TITLE
Correctly pass selected workspace root to terminal profile

### DIFF
--- a/packages/terminal/src/browser/shell-terminal-profile.ts
+++ b/packages/terminal/src/browser/shell-terminal-profile.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { IShellTerminalServerOptions } from '../common/shell-terminal-protocol';
+import { URI } from '@theia/core';
 import { TerminalService } from './base/terminal-service';
 import { TerminalWidget, TerminalWidgetOptions } from './base/terminal-widget';
 import { TerminalProfile } from './terminal-profile-service';
@@ -34,7 +34,7 @@ export class ShellTerminalProfile implements TerminalProfile {
      * @param options the options to override
      * @returns a modified copy of this profile
      */
-    modify(options: IShellTerminalServerOptions): TerminalProfile {
+    modify(options: { cwd?: string | URI }): TerminalProfile {
         return new ShellTerminalProfile(this.terminalService, { ...this.options, ...options });
     }
 }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -932,14 +932,17 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
     }
 
     protected async openTerminal(options?: ApplicationShell.WidgetOptions): Promise<void> {
-        const cwd = await this.selectTerminalCwd();
         let profile = this.profileService.defaultProfile;
 
         if (!profile) {
             throw new Error('There are not profiles registered');
         }
         if (profile instanceof ShellTerminalProfile) {
-            profile = profile.modify({ rootURI: cwd });
+            const cwd = await this.selectTerminalCwd();
+            if (!cwd) {
+                return;
+            }
+            profile = profile.modify({ cwd });
         }
 
         const termWidget = await profile?.start();
@@ -955,7 +958,10 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
         let profile = result[1];
         if (profile instanceof ShellTerminalProfile) {
             const cwd = await this.selectTerminalCwd();
-            profile = profile.modify({ rootURI: cwd });
+            if (!cwd) {
+                return;
+            }
+            profile = profile.modify({ cwd });
         }
         const termWidget = await profile.start();
         this.open(termWidget, { widgetOptions: options });


### PR DESCRIPTION
#### What it does

Pass selected workspace root as `cwd` when modifying shell profile instead of `rootUri`.

Fixes https://github.com/eclipse-theia/theia/issues/12197

Contributed on behalf of STMicroelectronics

#### How to test
Test starting new terminal view the terminal menu in single- and multiroot workspaces.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
