### PR TITLE
vscode: bump default api to 1.70.2

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.68.1';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.70.2';


### PR DESCRIPTION
#### What it does

This pull-request updates the **default vscode api** from 1.68.1 to 1.70.2. With [#12028](https://github.com/eclipse-theia/theia/issues/12028) being fixed, the API compatibility can be raised.

Contributed on behalf of STMicroelectronics

#### How to test 
N/A

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
