### PR TITLE
#12203 Fixes VSCode modal inform message focus

### DIFF
--- a/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
@@ -12,6 +12,9 @@
 // https://www.gnu.org/software/classpath/license.html.
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+//
+// Contributors:
+//      Pavel Nikolaev <pnik@1c.ru> (1C-Soft LLC) - Issue #12203
 // *****************************************************************************
 import { injectable } from '@theia/core/shared/inversify';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
@@ -77,8 +80,13 @@ export class ModalNotification extends AbstractDialog<string | undefined> {
             detailElement.textContent = options.detail;
         }
 
-        actions.forEach((action: MainMessageItem) => {
-            const button = this.createButton(action.title);
+        actions.forEach((action: MainMessageItem, index: number) => {
+            let button;
+            if (index === 0) {
+                button = this.appendAcceptButton(action.title);
+            } else {
+                button = this.createButton(action.title);
+            }
             button.classList.add('main');
             this.controlPanel.appendChild(button);
             this.addKeyListener(button,

--- a/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
@@ -81,12 +81,9 @@ export class ModalNotification extends AbstractDialog<string | undefined> {
         }
 
         actions.forEach((action: MainMessageItem, index: number) => {
-            let button;
-            if (index === 0) {
-                button = this.appendAcceptButton(action.title);
-            } else {
-                button = this.createButton(action.title);
-            }
+            const button = index === 0
+                ? this.appendAcceptButton(action.title)
+                : this.createButton(action.title);
             button.classList.add('main');
             this.controlPanel.appendChild(button);
             this.addKeyListener(button,

--- a/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
@@ -12,9 +12,6 @@
 // https://www.gnu.org/software/classpath/license.html.
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-//
-// Contributors:
-//      Pavel Nikolaev <pnik@1c.ru> (1C-Soft LLC) - Issue #12203
 // *****************************************************************************
 import { injectable } from '@theia/core/shared/inversify';
 import { Message } from '@theia/core/shared/@phosphor/messaging';


### PR DESCRIPTION
Fixes VSCode modal information message focus.
Now focus will be on the first button, not on a background as it was before. 

Closes #12203
Closes https://github.com/eclipse-theia/theia/pull/12204
Signed-off-by: Pavel Nikolaev <pnik@1c.ru>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Added a condition, if there is a first button on a Modal Message, it will be created by appendAcceptButton, other buttons will be created with createButton, except "Cancel".

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start Theia and install the extension [modalinformmessage-0.0.1.zip](https://github.com/eclipse-theia/theia/files/10803197/modalinformmessage-0.0.1.zip)
2. Call the comand "Focus Test"
3. It will open the dialog and focus will be on the first button (onot on a background as it was before)
4. If you press "Enter", the dialog will close and notification "Button was onFocus" will pop up.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
