### PR TITLE
QuickInput: First Element Fallback on Enter

### DIFF
--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -61,6 +61,17 @@ export class SampleCommandContribution implements CommandContribution {
     protected readonly messageService: MessageService;
 
     registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand({ id: 'create-quick-pick-sample', label: 'Internal QuickPick' }, {
+            execute: () => {
+                const pick = this.quickInputService.createQuickPick();
+                pick.items = [{ label: '1' }, { label: '2' }, { label: '3' }];
+                pick.onDidAccept(() => {
+                    console.log(`accepted: ${pick.selectedItems[0]?.label}`);
+                    pick.hide();
+                });
+                pick.show();
+            }
+        });
         commands.registerCommand(SampleCommand, {
             execute: () => {
                 alert('This is a sample command!');


### PR DESCRIPTION
#### What it does
Closes #11979 

#### How to test
1. Run Theia
2. Open as a many quick input menus as you can think of
3. Check that the first item on each of them is highlighted unless there is an active setting such as Dark (Theia) theme.

Some example menus that have been tested:
1. `?` or the help menu
2. `>` or the command menu
3. `F5` on `Attach By Process ID`
4. Quick checkout menu in the status bar
5. `New Terminal (With Profile)...` menu
6. `Ctrl`+`K`, `Ctrl`+`T` or the  Color Theme menu.
7. File Icon Theme menu.
8. [This](https://github.com/eclipse-theia/theia/files/10805816/quick-pick-0.0.1.zip) plugin.
9. Using the `Internal QuickPick` command added in this request.


![QuickInputFirstItemFocusFinal](https://user-images.githubusercontent.com/48699277/220677858-924345dc-9da4-4f0c-913d-e99b00e67c7e.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-Off-By: FernandoAscencio <fernando.ascencio.cama@ericsson.com>
