### PR TITLE
Do not (re)store state of Open Editors

### DIFF
--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -266,6 +266,7 @@ export class OpenEditorsWidget extends AbstractNavigatorTreeWidget {
         return this.props.leftPadding;
     }
 
+    // The state of this widget is derived from external factors. No need to store or restore it.
     override storeState(): object { return {}; }
     override restoreState(): void { }
 }

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -265,4 +265,7 @@ export class OpenEditorsWidget extends AbstractNavigatorTreeWidget {
         }
         return this.props.leftPadding;
     }
+
+    override storeState(): object { return {}; }
+    override restoreState(): void { }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Removes state restoration for Open Editors widget. Because tree nodes in the Open Editors widget include a reference to a `widget`, they were triggering double state restoration for all editor widgets in the application. Since the state of the Open Editors widget is entirely derived, there's no need to store or restore it.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start the application.
2. Open and close editors.
3. The Open Editors widget should behave normally.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
