### PR TITLE
Reduce plugin logging to debug level

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
@@ -121,7 +121,7 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
             plugin.rootPath = plugin.path();
             plugin.updatePath(pluginPath);
         }
-        console.log(`Resolved "${plugin.id()}" to a VS Code extension "${pck.name}@${pck.version}" with engines:`, pck.engines);
+        console.debug(`Resolved "${plugin.id()}" to a VS Code extension "${pck.name}@${pck.version}" with engines:`, pck.engines);
         return true;
     }
 

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -375,6 +375,7 @@ export class HostedPluginSupport {
         const loadPluginsMeasurement = this.measure('loadPlugins');
 
         const hostContributions = new Map<PluginHost, PluginContributions[]>();
+        console.log(`[${this.clientId}] Loading plugin contributions`);
         for (const contributions of this.contributions.values()) {
             const plugin = contributions.plugin.metadata;
             const pluginId = plugin.model.id;
@@ -384,7 +385,7 @@ export class HostedPluginSupport {
                 contributions.push(Disposable.create(() => console.log(`[${pluginId}]: Unloaded plugin.`)));
                 contributions.push(this.contributionHandler.handleContributions(this.clientId, contributions.plugin));
                 contributions.state = PluginContributions.State.LOADED;
-                console.log(`[${this.clientId}][${pluginId}]: Loaded contributions.`);
+                console.debug(`[${this.clientId}][${pluginId}]: Loaded contributions.`);
                 loaded++;
             }
 
@@ -396,7 +397,7 @@ export class HostedPluginSupport {
                 hostContributions.set(host, dynamicContributions);
                 toDisconnect.push(Disposable.create(() => {
                     contributions!.state = PluginContributions.State.LOADED;
-                    console.log(`[${this.clientId}][${pluginId}]: Disconnected.`);
+                    console.debug(`[${this.clientId}][${pluginId}]: Disconnected.`);
                 }));
             }
         }
@@ -446,14 +447,15 @@ export class HostedPluginSupport {
                     if (toDisconnect.disposed) {
                         return;
                     }
+                    console.log(`[${this.clientId}] Starting plugins.`);
                     for (const contributions of hostContributions) {
                         started++;
                         const plugin = contributions.plugin;
                         const id = plugin.metadata.model.id;
                         contributions.state = PluginContributions.State.STARTED;
-                        console.log(`[${this.clientId}][${id}]: Started plugin.`);
+                        console.debug(`[${this.clientId}][${id}]: Started plugin.`);
                         toDisconnect.push(contributions.push(Disposable.create(() => {
-                            console.log(`[${this.clientId}][${id}]: Stopped plugin.`);
+                            console.debug(`[${this.clientId}][${id}]: Stopped plugin.`);
                             manager.$stop(id);
                         })));
 

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -176,7 +176,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             deployed.contributes = this.reader.readContribution(manifest);
             this.localizationService.deployLocalizations(deployed);
             deployedPlugins.set(id, deployed);
-            deployPlugin.log(`Deployed ${entryPoint} plugin "${id}" from "${metadata.model.entryPoint[entryPoint] || pluginPath}"`);
+            deployPlugin.debug(`Deployed ${entryPoint} plugin "${id}" from "${metadata.model.entryPoint[entryPoint] || pluginPath}"`);
         } catch (e) {
             deployPlugin.error(`Failed to deploy ${entryPoint} plugin from '${pluginPath}' path`, e);
             return success = false;

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -91,7 +91,7 @@ export class PluginHostRPC {
 
     initContext(contextPath: string, plugin: Plugin): void {
         const { name, version } = plugin.rawModel;
-        console.log('PLUGIN_HOST(' + process.pid + '): initializing(' + name + '@' + version + ' with ' + contextPath + ')');
+        console.debug('PLUGIN_HOST(' + process.pid + '): initializing(' + name + '@' + version + ' with ' + contextPath + ')');
         try {
             const backendInit = dynamicRequire<{ doInitialization: BackendInitializationFn }>(contextPath);
             backendInit.doInitialization(this.apiFactory, plugin);
@@ -111,7 +111,7 @@ export class PluginHostRPC {
         const pluginManager = new PluginManagerExtImpl({
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             loadPlugin(plugin: Plugin): any {
-                console.log('PLUGIN_HOST(' + process.pid + '): PluginManagerExtImpl/loadPlugin(' + plugin.pluginPath + ')');
+                console.debug('PLUGIN_HOST(' + process.pid + '): PluginManagerExtImpl/loadPlugin(' + plugin.pluginPath + ')');
                 // cleaning the cache for all files of that plug-in.
                 Object.keys(require.cache).forEach(function (key): void {
                     const mod: NodeJS.Module = require.cache[key]!;

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-directory-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-directory-handler.ts
@@ -34,7 +34,7 @@ export class PluginTheiaDirectoryHandler implements PluginDeployerDirectoryHandl
 
     accept(resolvedPlugin: PluginDeployerEntry): boolean {
 
-        console.log('PluginTheiaDirectoryHandler: accepting plugin with path', resolvedPlugin.path());
+        console.debug('PluginTheiaDirectoryHandler: accepting plugin with path', resolvedPlugin.path());
 
         // handle only directories
         if (resolvedPlugin.isFile()) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

At the moment, on startup and sometimes on shutdown, we log a separate message for various lifecycle events for every single plugin in the application. That's a lot of logs, most of which are completely uninformative. This PR converts them to `debug` level logs so that they are still available if they're of interest but won't be displayed routinely.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start the application.
2. Everything should work as normal.
3. There should be a couple hundred fewer lines in your log.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
