### PR TITLE
terminal: Spawning Speed issue fix

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -830,7 +830,7 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
 
     async newTerminal(options: TerminalWidgetOptions): Promise<TerminalWidget> {
         const widget = <TerminalWidget>await this.widgetManager.getOrCreateWidget(TERMINAL_WIDGET_FACTORY_ID, <TerminalWidgetFactoryOptions>{
-            created: new Date().toString(),
+            created: new Date().toISOString(),
             ...options
         });
         return widget;


### PR DESCRIPTION
#### What it does
Closes #1733.

The pull-request fixes an issue where if multiple terminals are spawned quickly, their content would incorrectly be rendered in a previous terminal. The issue is related to the `created` option which would not take into account milliseconds which meant calls to `getOrCreateWidget` would return a previous widget rather than create a new one as intended.

#### How to test

1. start the application
2. use the keybinding <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>`</kbd> to quickly spawn multiple terminals
3. confirm that the terminal creation is correct, and that content is not appended to previous terminals

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
