### PR TITLE
Handle OnEnterRule patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,9 +103,7 @@
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.66.2/file/eclipse-theia.builtin-extension-pack-1.66.2.vsix",
     "EditorConfig.EditorConfig": "https://open-vsx.org/api/EditorConfig/EditorConfig/0.14.4/file/EditorConfig.EditorConfig-0.14.4.vsix",
     "dbaeumer.vscode-eslint": "https://open-vsx.org/api/dbaeumer/vscode-eslint/2.1.20/file/dbaeumer.vscode-eslint-2.1.20.vsix",
-    "ms-vscode.references-view": "https://open-vsx.org/api/ms-vscode/references-view/0.0.89/file/ms-vscode.references-view-0.0.89.vsix",
-    "vscode.typescript": "https://open-vsx.org/api/vscode/typescript/1.62.3/file/vscode.typescript-1.62.3.vsix",
-    "vscode.typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.62.3/file/vscode.typescript-language-features-1.62.3.vsix"
+    "ms-vscode.references-view": "https://open-vsx.org/api/ms-vscode/references-view/0.0.89/file/ms-vscode.references-view-0.0.89.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -726,10 +726,15 @@ export interface FoldingRules {
     markers?: FoldingMarkers;
 }
 
+export interface OnEnterRuleRegExp {
+    pattern: string;
+    flags?: string;
+}
+
 export interface OnEnterRule {
-    beforeText: string;
-    afterText?: string;
-    previousLineText?: string;
+    beforeText: string | OnEnterRuleRegExp;
+    afterText?: string | OnEnterRuleRegExp;
+    previousLineText?: string | OnEnterRuleRegExp;
     action: EnterAction;
 }
 

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -21,7 +21,7 @@ import { TextmateRegistry, getEncodedLanguageId, MonacoTextmateService, GrammarD
 import { MenusContributionPointHandler } from './menus/menus-contribution-handler';
 import { PluginViewRegistry } from './view/plugin-view-registry';
 import { PluginCustomEditorRegistry } from './custom-editors/plugin-custom-editor-registry';
-import { PluginContribution, IndentationRules, FoldingRules, ScopeMap, DeployedPlugin, GrammarsContribution, EnterAction, OnEnterRule } from '../../common';
+import { PluginContribution, IndentationRules, FoldingRules, ScopeMap, DeployedPlugin, GrammarsContribution, EnterAction, OnEnterRule, OnEnterRuleRegExp } from '../../common';
 import {
     DefaultUriLabelProviderContribution,
     LabelProviderContribution,
@@ -488,11 +488,14 @@ export class PluginContributionHandler {
         return Disposable.NULL;
     }
 
-    private createRegex(value: string | undefined): RegExp | undefined {
+    private createRegex(value: string | OnEnterRuleRegExp | undefined): RegExp | undefined {
         if (typeof value === 'string') {
             return new RegExp(value, '');
         }
-        return undefined;
+        if (typeof value == 'undefined') {
+            return undefined;
+        }
+        return new RegExp(value.pattern, value.flags);
     }
 
     private convertIndentationRules(rules?: IndentationRules): monaco.languages.IndentationRule | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes https://github.com/eclipse-theia/theia/issues/12217 and the issue raised in https://github.com/eclipse-theia/theia/pull/12212 .

The format of `OnEnterRule` had been defined with `beforeText`, `afterText`, and `previousLineText` as only strings. However they are often quasi-RegExp objects with `pattern` and `flags` string fields.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. With TypeScript plugins 1.66.2 or later, in a JavaScript or TypeScript file, if you hit Enter to create a new line, do you still get ` * ` appended in appropriately?
2. Similarly in HTML files, if you hit Enter to create a new line, do you still get two new lines inappropriately?
3. Do other insertions (e.g. for JsDoc strings) still work properly?

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

Note: I've only tested on RHEL7, electron & browser modes, and a limited set of circumstances involving insertions of newlines.

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
