### PR TITLE
Ensure DebugWidget properly reports change in trackable widgets

### DIFF
--- a/packages/debug/src/browser/view/debug-session-widget.ts
+++ b/packages/debug/src/browser/view/debug-session-widget.ts
@@ -111,7 +111,7 @@ export class DebugSessionWidget extends BaseWidget implements StatefulWidget, Ap
     }
 
     getTrackableWidgets(): Widget[] {
-        return this.viewContainer.getTrackableWidgets();
+        return [this.viewContainer];
     }
 
     storeState(): object {

--- a/packages/debug/src/browser/view/debug-widget.ts
+++ b/packages/debug/src/browser/view/debug-widget.ts
@@ -83,7 +83,7 @@ export class DebugWidget extends BaseWidget implements StatefulWidget, Applicati
     }
 
     getTrackableWidgets(): Widget[] {
-        return this.sessionWidget.getTrackableWidgets();
+        return [this.sessionWidget];
     }
 
     storeState(): object {


### PR DESCRIPTION
#### What it does
Necessary because the debug session widgets are created lazily after the layout has been initialized.

Fixes https://github.com/eclipse-theia/theia/issues/12240

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Add watch expression in the 'Watch' section of the Debug widget.
2. Context menu should work
4. Reset Workbench Layout > context menu should work 
3. Reload Window > context menu should work

![issue-debug-layout-fix](https://user-images.githubusercontent.com/19170971/221925712-0bb9b0bd-0d69-43b8-8e61-d5fb079fe375.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
