### PR TITLE
workspace: update add and remove folder handling

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -324,34 +324,32 @@ export class WorkspaceCommandContribution implements CommandContribution {
                 await this.clipboardService.writeText(text);
             }
         }));
-        this.preferences.ready.then(() => {
-            registry.registerCommand(WorkspaceCommands.ADD_FOLDER, {
-                isEnabled: () => this.workspaceService.opened,
-                isVisible: () => this.workspaceService.opened,
-                execute: async () => {
-                    const selection = await this.fileDialogService.showOpenDialog({
-                        title: WorkspaceCommands.ADD_FOLDER.label!,
-                        canSelectFiles: false,
-                        canSelectFolders: true,
-                        canSelectMany: true,
-                    });
-                    if (!selection) {
-                        return;
-                    }
-                    const uris = Array.isArray(selection) ? selection : [selection];
-                    const workspaceSavedBeforeAdding = this.workspaceService.saved;
-                    await this.addFolderToWorkspace(...uris);
-                    if (!workspaceSavedBeforeAdding) {
-                        this.saveWorkspaceWithPrompt(registry);
-                    }
+        registry.registerCommand(WorkspaceCommands.ADD_FOLDER, {
+            isEnabled: () => this.workspaceService.opened,
+            isVisible: () => this.workspaceService.opened,
+            execute: async () => {
+                const selection = await this.fileDialogService.showOpenDialog({
+                    title: WorkspaceCommands.ADD_FOLDER.label!,
+                    canSelectFiles: false,
+                    canSelectFolders: true,
+                    canSelectMany: true,
+                });
+                if (!selection) {
+                    return;
                 }
-            });
-            registry.registerCommand(WorkspaceCommands.REMOVE_FOLDER, this.newMultiUriAwareCommandHandler({
-                execute: uris => this.removeFolderFromWorkspace(uris),
-                isEnabled: () => this.workspaceService.isMultiRootWorkspaceOpened,
-                isVisible: uris => this.areWorkspaceRoots(uris) && this.workspaceService.saved
-            }));
+                const uris = Array.isArray(selection) ? selection : [selection];
+                const workspaceSavedBeforeAdding = this.workspaceService.saved;
+                await this.addFolderToWorkspace(...uris);
+                if (!workspaceSavedBeforeAdding) {
+                    this.saveWorkspaceWithPrompt(registry);
+                }
+            }
         });
+        registry.registerCommand(WorkspaceCommands.REMOVE_FOLDER, this.newMultiUriAwareCommandHandler({
+            execute: uris => this.removeFolderFromWorkspace(uris),
+            isEnabled: () => this.workspaceService.isMultiRootWorkspaceOpened,
+            isVisible: uris => this.areWorkspaceRoots(uris) && this.workspaceService.saved
+        }));
     }
 
     openers: OpenHandler[];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request removes the now unnecessary preferences ready event listener when registering the commands  `ADD_FOLDER` and `REMOVE_FOLDER`. The listener is no longer necessary as the framework no longer supports the `workspace.supportMultiRootWorkspace` preference which required the additional logic.

The change should more easily allow downstream extenders/adopters the possibility of unregistering the command if necessary.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open a workspace
3. confirm that "add folder to workspace" works well
4. confirm that "remove folder from workspace" works well
5. confirm on startup that the commands are available given their enableability 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
