### PR TITLE
dialog: add `placeholder` option

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -477,6 +477,7 @@ export async function confirmExitWithOrWithoutSaving(captionsToSave: string[], p
 export class SingleTextInputDialogProps extends DialogProps {
     readonly confirmButtonLabel?: string;
     readonly initialValue?: string;
+    readonly placeholder?: string;
     readonly initialSelectionRange?: {
         start: number
         end: number
@@ -499,6 +500,7 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
         this.inputField.className = 'theia-input';
         this.inputField.spellcheck = false;
         this.inputField.setAttribute('style', 'flex: 0;');
+        this.inputField.placeholder = props.placeholder || '';
         this.inputField.value = props.initialValue || '';
         if (props.initialSelectionRange) {
             this.inputField.setSelectionRange(

--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -239,7 +239,8 @@ export class DebugVariable extends ExpressionContainer {
         }
         const input = new SingleTextInputDialog({
             title: nls.localize('theia/debug/debugVariableInput', 'Set {0} Value', this.name),
-            initialValue: this.value
+            initialValue: this.value,
+            placeholder: nls.localizeByDefault('Value')
         });
         const newValue = await input.open();
         if (newValue) {

--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -63,7 +63,8 @@ export class DebugWatchExpression extends ExpressionItem {
     async open(): Promise<void> {
         const input = new SingleTextInputDialog({
             title: nls.localizeByDefault('Edit Expression'),
-            initialValue: this.expression
+            initialValue: this.expression,
+            placeholder: nls.localizeByDefault('Expression to watch')
         });
         const newValue = await input.open();
         if (newValue !== undefined) {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -237,6 +237,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                         title: nls.localizeByDefault('New File'),
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
+                        placeholder: nls.localize('theia/workspace/newFilePlaceholder', 'File Name'),
                         validate: name => this.validateFileName(name, parent, true)
                     }, this.labelProvider);
 
@@ -261,6 +262,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                         title: nls.localizeByDefault('New Folder'),
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
+                        placeholder: nls.localize('theia/workspace/newFolderPlaceholder', 'Folder Name'),
                         validate: name => this.validateFileName(name, parent, true)
                     }, this.labelProvider);
                     dialog.open().then(async name => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit adds support for passing a `placeholder` option to the `SingleTextInputDialog` which was previously not possible without having to extend the implementation.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. confirm that dialogs modified by the pull-request correctly display a `placeholder` when no input is present

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
