### PR TITLE
Improve Breakpoint Decoration Rendering

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -252,7 +252,7 @@ export class DebugEditorModel implements Disposable {
         });
     }
 
-    protected render(): void {
+    render(): void {
         this.renderBreakpoints();
         this.renderCurrentBreakpoints();
     }

--- a/packages/debug/src/browser/editor/debug-editor-service.ts
+++ b/packages/debug/src/browser/editor/debug-editor-service.ts
@@ -16,7 +16,6 @@
 
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
-import URI from '@theia/core/lib/common/uri';
 import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
 import { ContextMenuRenderer } from '@theia/core/lib/browser';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
@@ -50,12 +49,6 @@ export class DebugEditorService {
     protected init(): void {
         this.editors.all.forEach(widget => this.push(widget));
         this.editors.onCreated(widget => this.push(widget));
-        this.sessionManager.onDidChangeBreakpoints(({ session, uri }) => {
-            if (!session || session === this.sessionManager.currentSession) {
-                this.render(uri);
-            }
-        });
-        this.breakpoints.onDidChangeBreakpoints(event => this.closeBreakpointIfAffected(event));
     }
 
     protected push(widget: EditorWidget): void {
@@ -70,13 +63,6 @@ export class DebugEditorService {
             debugModel.dispose();
             this.models.delete(uri);
         });
-    }
-
-    protected render(uri: URI): void {
-        const model = this.models.get(uri.toString());
-        if (model) {
-            model.render();
-        }
     }
 
     get model(): DebugEditorModel | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes another part of #11878 by setting decorations on the editor class rather than editor model class. In the latter case, all decorations were shared by all editors referring to the model. With this code, each editor owns a different set of decorations that refer to common state, where appropriate.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Follow instructions from https://github.com/eclipse-theia/theia/pull/12183.
2. Hover over the breakpoint gutter for one of the split editors, but don't add a breakpoint
3. You should see a lighter / less opaque breakpoint marking, but _only_ in the editor whose gutter you're hovering over.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
