### PR TITLE
Add `isObject` check to ProblemMarker

### DIFF
--- a/packages/markers/src/common/problem-marker.ts
+++ b/packages/markers/src/common/problem-marker.ts
@@ -16,6 +16,7 @@
 
 import { Marker } from './marker';
 import { Diagnostic } from '@theia/core/shared/vscode-languageserver-protocol';
+import { isObject } from '@theia/core/lib/common';
 
 export const PROBLEM_KIND = 'problem';
 
@@ -24,7 +25,7 @@ export interface ProblemMarker extends Marker<Diagnostic> {
 }
 
 export namespace ProblemMarker {
-    export function is(node: Marker<object>): node is ProblemMarker {
-        return 'kind' in node && node.kind === PROBLEM_KIND;
+    export function is(node: unknown): node is ProblemMarker {
+        return isObject<Marker<object>>(node) && node.kind === PROBLEM_KIND;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Use isObject check in problem-marker class instead of `'kind' in node` check to not get type errors which occur on non marker. These occur because a previously existing check was removed in problem-selection.ts . The error prevents the context menu from showing all entries.

Contributed on behalf of STMicroelectronics

Fixes #12250

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open problems view
2. Create a problem marker eg by creating an invalid js file
3. right click on the problem in the problems view
4. See that without the fix there is only one entry: `Collapse All` , with the fix 3 entries are shown: `Copy`, `Copy Message` and `Collapse All`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
