### PR TITLE
Fix broken toolbar drag/drop behavior in dropzones

### DIFF
--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -221,6 +221,7 @@ export class ToolbarImpl extends TabBarToolbar {
                 data-column={`${alignment}`}
                 data-center-position={position}
                 onDrop={this.handleOnDrop}
+                onDragOver={this.handleOnDragEnter}
                 onDragEnter={this.handleOnDragEnter}
                 onDragLeave={this.handleOnDragLeave}
                 key={`column-space-${alignment}-${position}`}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #12256 by adding an `onDragOver` attribute to the toolbar's dropzones which points to the existing `handleOnDragEnter` handler. The addition of the lines below from #12065 in `frontend-application.ts` seem to have overridden the existing `onDragEnter` handler

![image](https://user-images.githubusercontent.com/62660714/222769427-d67837c2-f7f1-4b61-933d-bb2ccd893906.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Build this branch and try dragging a toolbar item in the toolbar's dropzones which can be found on the left/right sides of each toolbar column

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
