### PR TITLE
core: refine typing of `isObject<T>`

### DIFF
--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -278,12 +278,12 @@ export class ShellLayoutRestorer implements CommandContribution {
                     });
                 }
                 return widgets;
-            } else if (isObject<Record<string, WidgetDescription>>(value) && !Array.isArray(value)) {
+            } else if (isObject(value) && !Array.isArray(value)) {
                 const copy: Record<string, unknown> = {};
                 for (const p in value) {
                     if (this.isWidgetProperty(p)) {
                         parseContext.push(async context => {
-                            copy[p] = await this.convertToWidget(value[p], context);
+                            copy[p] = await this.convertToWidget(value[p] as WidgetDescription, context);
                         });
                     } else {
                         copy[p] = value[p];

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -17,7 +17,7 @@
 export { ArrayUtils } from './array-utils';
 export { Prioritizeable } from './prioritizeable';
 
-type UnknownObject = Record<string | number | symbol, unknown>;
+type UnknownObject<T extends object> = Record<string | number | symbol, unknown> & { [K in keyof T]: unknown };
 
 export type Deferred<T> = { [P in keyof T]: Promise<T[P]> };
 export type MaybeArray<T> = T | T[];
@@ -56,7 +56,7 @@ export function isFunction<T extends (...args: unknown[]) => unknown>(value: unk
     return typeof value === 'function';
 }
 
-export function isObject<T extends object = UnknownObject>(value: unknown): value is UnknownObject & { [K in keyof T]: unknown } {
+export function isObject<T extends object>(value: unknown): value is UnknownObject<T> {
     // eslint-disable-next-line no-null/no-null
     return typeof value === 'object' && value !== null;
 }

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -17,6 +17,8 @@
 export { ArrayUtils } from './array-utils';
 export { Prioritizeable } from './prioritizeable';
 
+type UnknownObject = Record<string | number | symbol, unknown>;
+
 export type Deferred<T> = { [P in keyof T]: Promise<T[P]> };
 export type MaybeArray<T> = T | T[];
 export type MaybeNull<T> = { [P in keyof T]: T[P] | null };
@@ -54,7 +56,7 @@ export function isFunction<T extends (...args: unknown[]) => unknown>(value: unk
     return typeof value === 'function';
 }
 
-export function isObject<T = Record<string | number | symbol, unknown>>(value: unknown): value is T {
+export function isObject<T extends object = UnknownObject>(value: unknown): value is UnknownObject & { [K in keyof T]: unknown } {
     // eslint-disable-next-line no-null/no-null
     return typeof value === 'object' && value !== null;
 }

--- a/packages/markers/src/browser/problem/problem-selection.ts
+++ b/packages/markers/src/browser/problem/problem-selection.ts
@@ -25,7 +25,7 @@ export interface ProblemSelection {
 }
 export namespace ProblemSelection {
     export function is(arg: unknown): arg is ProblemSelection {
-        return isObject<ProblemSelection>(arg) && Marker.is(arg.marker) && ProblemMarker.is(arg.marker);
+        return isObject<ProblemSelection>(arg) && ProblemMarker.is(arg.marker);
     }
 
     export class CommandHandler extends SelectionCommandHandler<ProblemSelection> {

--- a/packages/markers/src/browser/problem/problem-selection.ts
+++ b/packages/markers/src/browser/problem/problem-selection.ts
@@ -25,7 +25,7 @@ export interface ProblemSelection {
 }
 export namespace ProblemSelection {
     export function is(arg: unknown): arg is ProblemSelection {
-        return isObject<ProblemSelection>(arg) && ProblemMarker.is(arg.marker);
+        return isObject<ProblemSelection>(arg) && Marker.is(arg.marker) && ProblemMarker.is(arg.marker);
     }
 
     export class CommandHandler extends SelectionCommandHandler<ProblemSelection> {

--- a/packages/markers/src/common/marker.ts
+++ b/packages/markers/src/common/marker.ts
@@ -14,6 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { isObject, isString } from '@theia/core/lib/common/types';
+
 /*
 * A marker represents meta information for a given uri
 */
@@ -36,4 +38,16 @@ export interface Marker<T> {
      * marker kind specific data
      */
     data: T;
+}
+export namespace Marker {
+    export function is(value: unknown): value is Marker<object>;
+    export function is<T>(value: unknown, subTypeCheck: (value: unknown) => value is T): value is Marker<T>;
+    export function is(value: unknown, subTypeCheck?: (value: unknown) => boolean): boolean {
+        subTypeCheck ??= isObject;
+        return isObject<Marker<object>>(value)
+            && !Array.isArray(value)
+            && subTypeCheck(value.data)
+            && isString(value.uri)
+            && isString(value.owner);
+    }
 }

--- a/packages/markers/src/common/problem-marker.ts
+++ b/packages/markers/src/common/problem-marker.ts
@@ -24,7 +24,7 @@ export interface ProblemMarker extends Marker<Diagnostic> {
 }
 
 export namespace ProblemMarker {
-    export function is(node: Marker<object>): node is ProblemMarker {
-        return 'kind' in node && node.kind === PROBLEM_KIND;
+    export function is(node: unknown): node is ProblemMarker {
+        return Marker.is(node) && node.kind === PROBLEM_KIND;
     }
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -404,7 +404,7 @@ export class Position {
         return result!;
     }
 
-    static isPosition(other: {}): other is Position {
+    static isPosition(other: unknown): other is Position {
         if (!other) {
             return false;
         }
@@ -546,8 +546,6 @@ export class Range {
             return true;
         }
         return isObject<theia.Range>(arg)
-            && isObject(arg.start)
-            && isObject(arg.end)
             && Position.isPosition(arg.start)
             && Position.isPosition(arg.end);
     }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -546,6 +546,8 @@ export class Range {
             return true;
         }
         return isObject<theia.Range>(arg)
+            && isObject(arg.start)
+            && isObject(arg.end)
             && Position.isPosition(arg.start)
             && Position.isPosition(arg.end);
     }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -408,6 +408,9 @@ export class Position {
         if (!other) {
             return false;
         }
+        if (typeof other !== 'object' || Array.isArray(other)) {
+            return false;
+        }
         if (other instanceof Position) {
             return true;
         }


### PR DESCRIPTION
The template parameter for `isObject` is currently used to force cast the value passed to the function, although there is no guarantee nor check done to ensure that this is really the case.

This commit updates the typings so that the type passed to `isObject` is used to guide TypeScript during subsequent field type checking, assuming each field value is `unknown` and must also be type checked.

Example:

```ts
interface MyType {
    foo: string
}

const unknownValue: unknown = { foo: 2 };

if (isObject<MyType>(unknownValue)) {
    // We enter this branch because `unknownValue` is indeed an object,
    // and TypeScript now knows we might want to access the `foo` field
    // from our interface. But we can't yet assume to know the type of
    // `foo`, so it is still typed as `unknown` and we must check:
    if (isString(unknownValue.foo)) {
        // We won't get in this branch. But if we did, then `foo` is
        // now properly typed (and checked) as `string`.
    }
}
```

Fix https://github.com/eclipse-theia/theia/issues/12253
Fix https://github.com/eclipse-theia/theia/issues/12250

Close https://github.com/eclipse-theia/theia/pull/12251

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### How to test

Should compile.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
