### PR TITLE
Ensure progress bar shown during `swapValues` operation in Toolbar and remove redundant save

### DIFF
--- a/packages/toolbar/src/browser/toolbar-controller.ts
+++ b/packages/toolbar/src/browser/toolbar-controller.ts
@@ -126,11 +126,10 @@ export class ToolbarController {
         newPosition: ToolbarItemPosition,
         direction: 'location-left' | 'location-right',
     ): Promise<boolean> {
-        await this.openOrCreateJSONFile(false);
-        this.toolbarProviderBusyEmitter.fire(true);
-        const success = this.storageProvider.swapValues(oldPosition, newPosition, direction);
-        this.toolbarProviderBusyEmitter.fire(false);
-        return success;
+        return this.withBusy<boolean>(async () => {
+            await this.openOrCreateJSONFile(false);
+            return this.storageProvider.swapValues(oldPosition, newPosition, direction);
+        });
     }
 
     async clearAll(): Promise<boolean> {

--- a/packages/toolbar/src/browser/toolbar-storage-provider.ts
+++ b/packages/toolbar/src/browser/toolbar-storage-provider.ts
@@ -289,7 +289,7 @@ export class ToolbarStorageProvider implements Disposable {
                         forceMoveMarkers: false,
                     });
                 }
-                await this.monacoWorkspace.applyBackgroundEdit(this.model, editOperations);
+                await this.monacoWorkspace.applyBackgroundEdit(this.model, editOperations, false);
                 await this.model.save();
                 return true;
             } catch (e) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #12261 by using the `withBusy` utility to ensure a progress bar is shown during the `swapValues` operation.

Also passes `shouldSave = false` flag to `MonacoWorkspace`'s `applyBackgroundEdit` method call from the toolbar to avoid saving the `toolbar.json` file twice 
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Build Theia browser version
2. Open Theia in a chrome window 
3. Ensure the toolbar is shown
4. Open the Chrome developer tools and select the network tab
5. Click on the "No throttling" dropdown and  add a custom profile with a Down speed of ~15kbit/s (these values can be finicky and sometimes they don't seem to take effect immediately)
6. After you've added the new profile, ensure that it is selected in the dropdown
7. Drag a toolbar item to a new location to the left or right of an existing toolbar item (not in the large dropzone areas, but in the smaller drag zones that appear on each item)
8. Drop the item, and observe that there **is** a progress bar shown immediately on drop. After the operation completes, the progress bar should disappear
9. You should also observe that it takes ~half the time to complete the operation since we are no longer saving twice

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
