### PR TITLE
core: fallback to `applicationName`

### DIFF
--- a/packages/core/src/browser/window/window-title-service.ts
+++ b/packages/core/src/browser/window/window-title-service.ts
@@ -100,7 +100,7 @@ export class WindowTitleService {
         if (developmentHost) {
             this._title = developmentHost + this.separator + this._title;
         }
-        document.title = this._title;
+        document.title = this._title || FrontendApplicationConfigProvider.get().applicationName;
         this.onDidChangeTitleEmitter.fire(this._title);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit adds handling to fallback to the `applicationName` when setting the window title which would previously display either `index.html` in electron  or `localhost:3000` in the browser.

_Before_:

<img width="1232" alt="Screen Shot 2023-03-07 at 3 40 20 PM" src="https://user-images.githubusercontent.com/40359487/223547297-3ef5776a-18a7-4121-b507-52b810d578ef.png">


_After_:

<img width="1232" alt="Screen Shot 2023-03-07 at 3 38 43 PM" src="https://user-images.githubusercontent.com/40359487/223547026-059bf93a-03f0-452e-871b-4c61ea41e125.png">


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. for both the **browser** and **electron** example applications start the app without a workspace
2. confirm that with views open the tab or window title relects the current widget (ex: getting started, preferences, keyboard shortcuts)
3. close all open widgets
4. the title should fallback to the `applicationName`
5. confirm the behavior is correct with a workspace

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
