### PR TITLE
Fix plugin proxy support

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -45,7 +45,7 @@
     "semver": "^5.4.1",
     "uuid": "^8.0.0",
     "vhost": "^3.0.2",
-    "vscode-proxy-agent": "^0.11.0",
+    "vscode-proxy-agent": "^0.12.0",
     "vscode-textmate": "^7.0.3"
   },
   "publishConfig": {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -690,6 +690,7 @@ export interface WorkspaceMain {
     $updateWorkspaceFolders(start: number, deleteCount?: number, ...rootsToAdd: string[]): Promise<void>;
     $getWorkspace(): Promise<files.FileStat | undefined>;
     $requestWorkspaceTrust(options?: theia.WorkspaceTrustRequestOptions): Promise<boolean | undefined>;
+    $resolveProxy(url: string): Promise<string | undefined>;
 }
 
 export interface WorkspaceExt {

--- a/packages/plugin-ext/src/hosted/node/plugin-host-proxy.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-proxy.ts
@@ -20,10 +20,11 @@ import * as tls from 'tls';
 
 import { createHttpPatch, createProxyResolver, createTlsPatch, ProxySupportSetting } from 'vscode-proxy-agent';
 import { PreferenceRegistryExtImpl } from '../../plugin/preference-registry';
+import { WorkspaceExtImpl } from '../../plugin/workspace';
 
-export function connectProxyResolver(configProvider: PreferenceRegistryExtImpl): void {
+export function connectProxyResolver(workspaceExt: WorkspaceExtImpl, configProvider: PreferenceRegistryExtImpl): void {
     const resolveProxy = createProxyResolver({
-        resolveProxy: async url => url,
+        resolveProxy: async url => workspaceExt.resolveProxy(url),
         getHttpProxySetting: () => configProvider.getConfiguration('http').get('proxy'),
         log: () => { },
         getLogLevel: () => 0,
@@ -43,7 +44,7 @@ interface PatchedModules {
 
 function createPatchedModules(configProvider: PreferenceRegistryExtImpl, resolveProxy: ReturnType<typeof createProxyResolver>): PatchedModules {
     const proxySetting = {
-        config: 'off' as ProxySupportSetting
+        config: configProvider.getConfiguration('http')?.get<ProxySupportSetting>('proxySupport') || 'off' as ProxySupportSetting
     };
     const certSetting = {
         config: false

--- a/packages/plugin-ext/src/hosted/node/plugin-host-proxy.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-proxy.ts
@@ -43,15 +43,16 @@ interface PatchedModules {
 }
 
 function createPatchedModules(configProvider: PreferenceRegistryExtImpl, resolveProxy: ReturnType<typeof createProxyResolver>): PatchedModules {
+    const defaultConfig = 'override' as ProxySupportSetting;
     const proxySetting = {
-        config: configProvider.getConfiguration('http')?.get<ProxySupportSetting>('proxySupport') || 'off' as ProxySupportSetting
+        config: defaultConfig
     };
     const certSetting = {
         config: false
     };
     configProvider.onDidChangeConfiguration(() => {
         const httpConfig = configProvider.getConfiguration('http');
-        proxySetting.config = httpConfig?.get<ProxySupportSetting>('proxySupport') || 'off';
+        proxySetting.config = httpConfig?.get<ProxySupportSetting>('proxySupport') || defaultConfig;
         certSetting.config = !!httpConfig?.get<boolean>('systemCertificates');
     });
 

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -82,7 +82,7 @@ export class PluginHostRPC {
             clipboardExt,
             webviewExt
         );
-        connectProxyResolver(preferenceRegistryExt);
+        connectProxyResolver(workspaceExt, preferenceRegistryExt);
     }
 
     async terminate(): Promise<void> {

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -31,6 +31,7 @@ import { FileSystemPreferences } from '@theia/filesystem/lib/browser';
 import { SearchInWorkspaceService } from '@theia/search-in-workspace/lib/browser/search-in-workspace-service';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { MonacoQuickInputService } from '@theia/monaco/lib/browser/monaco-quick-input-service';
+import { RequestService } from '@theia/core/shared/@theia/request';
 
 export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
 
@@ -50,6 +51,8 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
 
     private pluginServer: PluginServer;
 
+    private requestService: RequestService;
+
     private workspaceService: WorkspaceService;
 
     private workspaceTrustService: WorkspaceTrustService;
@@ -68,6 +71,7 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
         this.searchInWorkspaceService = container.get(SearchInWorkspaceService);
         this.resourceResolver = container.get(TextContentResourceResolver);
         this.pluginServer = container.get(PluginServer);
+        this.requestService = container.get(RequestService);
         this.workspaceService = container.get(WorkspaceService);
         this.workspaceTrustService = container.get(WorkspaceTrustService);
         this.fsPreferences = container.get(FileSystemPreferences);
@@ -85,6 +89,10 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
 
     dispose(): void {
         this.toDispose.dispose();
+    }
+
+    $resolveProxy(url: string): Promise<string | undefined> {
+        return this.requestService.resolveProxy(url);
     }
 
     protected async processWorkspaceFoldersChanged(roots: string[]): Promise<void> {

--- a/packages/plugin-ext/src/plugin/preference-registry.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.ts
@@ -93,12 +93,16 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
     }
 
     init(data: PreferenceData): void {
-        this._preferences = this.parse(data);
+        this.preferencesChanged(data);
     }
 
     $acceptConfigurationChanged(data: PreferenceData, eventData: PreferenceChangeExt[]): void {
-        this.init(data);
-        this._onDidChangeConfiguration.fire(this.toConfigurationChangeEvent(eventData));
+        this.preferencesChanged(data, eventData);
+    }
+
+    private preferencesChanged(data: PreferenceData, eventData?: PreferenceChangeExt[]): void {
+        this._preferences = this.parse(data);
+        this._onDidChangeConfiguration.fire(this.toConfigurationChangeEvent(eventData ?? []));
     }
 
     getConfiguration(rawSection?: string, rawScope?: theia.ConfigurationScope | null, extensionId?: string): theia.WorkspaceConfiguration {

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -90,6 +90,10 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         return undefined;
     }
 
+    resolveProxy(url: string): Promise<string | undefined> {
+        return this.proxy.$resolveProxy(url);
+    }
+
     $onWorkspaceFoldersChanged(event: WorkspaceRootsChangeEvent): void {
         const newRoots = event.roots || [];
         const newFolders = newRoots.map((root, index) => this.toWorkspaceFolder(root, index));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4143,11 +4143,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-uri-to-buffer@3:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
-  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
-
 data-urls@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -5340,11 +5335,6 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
-file-uri-to-path@2:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
-  integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
-
 filelist@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
@@ -5630,14 +5620,6 @@ fstream@^1.0.12:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-ftp@^0.3.10:
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
-  integrity sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==
-  dependencies:
-    readable-stream "1.1.x"
-    xregexp "2.0.0"
-
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -5779,18 +5761,6 @@ get-symbol-description@^1.0.0:
   dependencies:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
-
-get-uri@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-3.0.2.tgz#f0ef1356faabc70e1f9404fa3b66b2ba9bfc725c"
-  integrity sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==
-  dependencies:
-    "@tootallnate/once" "1"
-    data-uri-to-buffer "3"
-    debug "4"
-    file-uri-to-path "2"
-    fs-extra "^8.1.0"
-    ftp "^0.3.10"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -6368,7 +6338,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -9516,16 +9486,6 @@ read@1, read@^1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-readable-stream@1.1.x:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  integrity sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
@@ -10452,11 +10412,6 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
-
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -11349,15 +11304,14 @@ vscode-oniguruma@^1.6.1:
   resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
   integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
 
-vscode-proxy-agent@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/vscode-proxy-agent/-/vscode-proxy-agent-0.11.0.tgz#9dc8d2bb9d448f1e33bb1caef97a741289660f2f"
-  integrity sha512-Y5mHjDGq/OKOvKG0IwCYfj25cvQ2cLEil8ce8n55IZHRAP9RF3e1sKU4ZUNDB8X2NIpKwyltrWpK9tFFE/kc3g==
+vscode-proxy-agent@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/vscode-proxy-agent/-/vscode-proxy-agent-0.12.0.tgz#0775f464b9519b0c903da4dcf50851e1453f4e48"
+  integrity sha512-jS7950hE9Kq6T18vYewVl0N9acEBD3d+scbPew2Nti7d61THBrhVF9FQjc8TLfrUZ//UzzOFO8why+F0kHDdNw==
   dependencies:
     "@tootallnate/once" "^1.1.2"
     agent-base "^6.0.2"
     debug "^4.3.1"
-    get-uri "^3.0.2"
     http-proxy-agent "^4.0.1"
     https-proxy-agent "^5.0.0"
     socks-proxy-agent "^5.0.0"
@@ -11742,11 +11696,6 @@ xmlhttprequest-ssl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz#91360c86b914e67f44dce769180027c0da618c67"
   integrity sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==
-
-xregexp@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
-  integrity sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11911
Closes https://github.com/eclipse-theia/theia/pull/12267

The actual fix for the issue is doing the following:

```diff
-resolveProxy: async url => url,
+resolveProxy: async url => workspaceExt.resolveProxy(url),
```

The function isn't supposed to return the original URL, but a proxied url __or undefined__. The current implementation broke http-requests in the plugin host if the proxy support for the plugin host wasn't turned off.

#### How to test

Repeat the testing steps from https://github.com/eclipse-theia/theia/pull/11043 and confirm that nothing has regressed.

Also repeat the testing steps without a proxy in place.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
