### PR TITLE
Set http proxy default to `off` for browser

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -134,7 +134,7 @@ export const corePreferenceSchema: PreferenceSchema = {
                 nls.localizeByDefault('Enable proxy support for extensions, fall back to request options, when no proxy found.'),
                 nls.localizeByDefault('Enable proxy support for extensions, override request options.'),
             ],
-            default: 'override',
+            default: environment.electron.is() ? 'override' : 'off',
             description: nls.localizeByDefault('Use the proxy support for extensions.'),
             scope: 'application'
         },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

With reference to #11911, it was suggested to set the http proxy default setting for browsers to `off`. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Open a browser app and confirm the `http.proxySupport` setting defaults to `off`. Electron apps should still default to `override`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
