### PR TITLE
preferences: fix `PreferenceProvider.merge` method

### DIFF
--- a/packages/core/src/browser/preferences/preference-provider.spec.ts
+++ b/packages/core/src/browser/preferences/preference-provider.spec.ts
@@ -1,0 +1,36 @@
+// *****************************************************************************
+// Copyright (C) 2023 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceProvider } from './preference-provider';
+const { expect } = require('chai');
+
+describe('PreferenceProvider', () => {
+    it('should preserve extra source fields on merge', () => {
+        const result = PreferenceProvider.merge({ 'configurations': [], 'compounds': [] }, { 'configurations': [] });
+        expect(result).deep.equals({ 'configurations': [], 'compounds': [] });
+    });
+    it('should preserve extra target fields on merge', () => {
+        const result = PreferenceProvider.merge({ 'configurations': [] }, { 'configurations': [], 'compounds': [] });
+        expect(result).deep.equals({ 'configurations': [], 'compounds': [] });
+    });
+    it('should merge array values', () => {
+        const result = PreferenceProvider.merge(
+            { 'configurations': [{ 'name': 'test1', 'request': 'launch' }], 'compounds': [] },
+            { 'configurations': [{ 'name': 'test2' }] }
+        );
+        expect(result).deep.equals({ 'configurations': [{ 'name': 'test1', 'request': 'launch' }, { 'name': 'test2' }], 'compounds': [] });
+    });
+});

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -235,6 +235,9 @@ export abstract class PreferenceProvider implements Disposable {
                 if (JSONExt.isObject(source[key]) && JSONExt.isObject(value)) {
                     this.merge(source[key], value);
                     continue;
+                } else if (JSONExt.isArray(source[key]) && JSONExt.isArray(value)) {
+                    source[key] = [...JSONExt.deepCopy(source[key] as any), ...JSONExt.deepCopy(value)];
+                    continue;
                 }
             }
             source[key] = JSONExt.deepCopy(value);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This reverts commit a3b9735aa1c7c93ec93675a700be8adda0438edc to readd the fix for the `PreferenceProvider.merge` method originally added in https://github.com/eclipse-theia/theia/pull/12126 and fixes the launch-preferences tests.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
