### PR TITLE
Use vscode builtin extensions v1.70.2

### DIFF
--- a/examples/api-tests/src/typescript.spec.js
+++ b/examples/api-tests/src/typescript.spec.js
@@ -57,7 +57,7 @@ describe('TypeScript', function () {
     const pluginViewRegistry = container.get(PluginViewRegistry);
 
     const typescriptPluginId = 'vscode.typescript-language-features';
-    const referencesPluginId = 'ms-vscode.references-view';
+    const referencesPluginId = 'vscode.references-view';
     const eslintPluginId = 'dbaeumer.vscode-eslint';
     /** @type Uri.URI */
     const rootUri = workspaceService.tryGetRoots()[0].resource;
@@ -199,8 +199,17 @@ describe('TypeScript', function () {
     async function closePeek(editor) {
         await assertPeekOpened(editor);
 
+        console.log('closePeek() - Attempt to close by sending "Escape"');
         keybindings.dispatchKeyDown('Escape');
-        await waitForAnimation(() => !contextKeyService.match('listFocus'));
+        await waitForAnimation(() => {
+            const isClosed = !contextKeyService.match('listFocus');
+            if (!isClosed) {
+                console.log('...');
+                keybindings.dispatchKeyDown('Escape');
+                return false;
+            }
+            return true;
+        });
         assert.isTrue(contextKeyService.match('editorTextFocus'));
         assert.isFalse(contextKeyService.match('referenceSearchVisible'));
         assert.isFalse(contextKeyService.match('listFocus'));

--- a/package.json
+++ b/package.json
@@ -100,10 +100,9 @@
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode.markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.64.2/file/vscode.markdown-language-features-1.64.2.vsix",
-    "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.66.2/file/eclipse-theia.builtin-extension-pack-1.66.2.vsix",
+    "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.70.2/file/eclipse-theia.builtin-extension-pack-1.70.2.vsix",
     "EditorConfig.EditorConfig": "https://open-vsx.org/api/EditorConfig/EditorConfig/0.14.4/file/EditorConfig.EditorConfig-0.14.4.vsix",
-    "dbaeumer.vscode-eslint": "https://open-vsx.org/api/dbaeumer/vscode-eslint/2.1.20/file/dbaeumer.vscode-eslint-2.1.20.vsix",
-    "ms-vscode.references-view": "https://open-vsx.org/api/ms-vscode/references-view/0.0.89/file/ms-vscode.references-view-0.0.89.vsix"
+    "dbaeumer.vscode-eslint": "https://open-vsx.org/api/dbaeumer/vscode-eslint/2.1.20/file/dbaeumer.vscode-eslint-2.1.20.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",
@@ -113,6 +112,7 @@
     "vscode.github",
     "vscode.github-authentication",
     "vscode.ipynb",
-    "vscode.microsoft-authentication"
+    "vscode.microsoft-authentication",
+    "ms-vscode.references-view"
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Some time between 1.66.2 and 1.70.2, the references-view extension "ms-vscode.references-view" has gone from a standalone extension, that has its own repository, to a vscode built-in extension, that's part of the vscode repository. With that change, the extension's publisher has been updated from "ms-vscode" to "vscode". As of 1.70.2, this extension is referenced in the builtins extension pack and no longer needs to be specifically referenced in `package,json`.

This PR contains the following:
Example application:
- update the builtin extension pack to v1.70.2 
- remove entry for old `references-view` extension, add it to "theiaPluginsExcludeIds"
- remove pinning for typescript extensions.

typescript browser tests: 
- use new publisher when referencing `references-view` builtin
- re-try sending "Escape" to close the peek widget if it remains opened

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Note: This PR is expected to fail CI until the vscode builtins v1.70.2 are published to `openvsx.org`. Once that's done, we should be able to fetch the new builtin pack and the extensions it refers-to, including the recently renamed `vscode.references-view` extension, using `yarn download:plugins`.

To test:
- build the repo and example application
- [ ] verify that the new builtins seem to work ok (at least the important ones like typescript, ...)
- [ ] verify that CI passes

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
