### PR TITLE
[API doc] exclude plugins folder from typedoc config

### DIFF
--- a/configs/typedoc.json
+++ b/configs/typedoc.json
@@ -4,7 +4,8 @@
     "../+(dev-packages|examples|typings|scripts)/**",
     "../packages/*/lib/**",
     "**/node_modules/**",
-    "**/*spec.ts"
+    "**/*spec.ts",
+    "../plugins/*"
   ],
   "excludeExternals": true,
   "external-modulemap": ".*\/packages\/([\\w\\-_]+)\/",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
I noticed some output of typedoc [1] that indicates it's analysing the content of at least some of our vscode builtins. This was unexpected. This PR adds an exclusion to the tool's config, so that this will stop.

[1]:

Warning: Unable to locate entry point: /home/lmcmcds/theia/plugins/EditorConfig.EditorConfig/extension/out/DocumentWatcher.js Warning: Unable to locate entry point: /home/lmcmcds/theia/plugins/EditorConfig.EditorConfig/extension/out/EditorConfigCompletionProvider.js [...]

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Locally, run API doc generation. On Linux:
```
$> export NODE_OPTIONS=--max_old_space_size=9216
$> yarn docs
```
Towards the beginning, there will be a series of "Warning: Unable to locate entry point" printouts, like above [1]. Confirm that content under folder "plugins" is not longer reported in those printouts.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
