### PR TITLE
Fix SCM Inline commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 <a name="breaking_changes_1.36.0">[Breaking Changes:](#breaking_changes_1.36.0)</a>
 
 - [plugin] renamed `TreeViewExtImpl#toTreeItem()` to `TreeViewExtImpl#toTreeElement()`
+- [scm] Fixing 'scm' inline commands, introduces the following breaking changes: [#12295](https://github.com/eclipse-theia/theia/pull/12295)
+    - Interface ScmInlineAction removes 'commands: CommandRegistry'
+    - Interface ScmInlineActions removes 'commands: CommandRegistry'
+    - Interface ScmTreeWidget.Props removes 'commands: CommandRegistry'
 
 ## v1.35.0 - 02/23/2023
 

--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -98,7 +98,7 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
             ['scm/resourceFolder/context', toScmArgs],
             ['scm/resourceGroup/context', toScmArgs],
             ['scm/resourceState/context', toScmArgs],
-            ['scm/title', () => this.toScmArg(this.scmService.selectedRepository)],
+            ['scm/title', () => [this.toScmArg(this.scmService.selectedRepository)]],
             ['timeline/item/context', (...args) => this.toTimelineArgs(...args)],
             ['view/item/context', (...args) => this.toTreeArgs(...args)],
             ['view/title', noArgs],


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: #12173
Fixes: #12238

SCM inline commands were executed before adapting their arguments to its 'rpc' format.
This caused an infinite loop while trying to package and serialize argument objects before sending them to the 'rpc' channel.

The adapters exist and were originally used by context menus.

This update uses the 'MenuCommandExecutor' to channel the execution of SCM inline commands through the existing registered adapters.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Inspired by #12173

1. start the application without `@theia/git` in either the `browser` or `electron`'s package.json
2. comment out the following so `yarn download:plugins` pulls the [builtins https://github.com/eclipse-theia/theia/blob/v1.35.0/package.json#L113-L114](https://github.com/eclipse-theia/theia/blob/v1.35.0/package.json#L113-L114)
5. build, download plugins, and start the application
6. open a workspace under git version control
7. make changes
8. attempt to interact with the `scm` view with the inline toolbar item for the changes
9. They show work as shown in the following video.

https://user-images.githubusercontent.com/76971376/224791305-408e48a7-2c0d-477b-98fd-84af1a47a7cf.mp4


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
