### PR TITLE
playwright: Wait for file stat nodes

### DIFF
--- a/examples/playwright/src/tests/theia-workspace.test.ts
+++ b/examples/playwright/src/tests/theia-workspace.test.ts
@@ -33,19 +33,20 @@ test.describe('Theia Workspace', () => {
         const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
         const app = await TheiaApp.load(page, ws);
         const explorer = await app.openView(TheiaExplorerView);
-        const fileStatElements = await explorer.visibleFileStatNodes(DOT_FILES_FILTER);
         // resources/sample-files1 contains one folder and one file
-        expect(fileStatElements.length).toBe(2);
+        expect(await explorer.existsDirectoryNode('sampleFolder')).toBe(true);
+        expect(await explorer.existsFileNode('sample.txt')).toBe(true);
     });
 
     test('should be initialized with the contents of multiple file locations', async () => {
         const ws = new TheiaWorkspace(['src/tests/resources/sample-files1', 'src/tests/resources/sample-files2']);
         const app = await TheiaApp.load(page, ws);
         const explorer = await app.openView(TheiaExplorerView);
-        const fileStatElements = await explorer.visibleFileStatNodes(DOT_FILES_FILTER);
         // resources/sample-files1 contains one folder and one file
+        expect(await explorer.existsDirectoryNode('sampleFolder')).toBe(true);
+        expect(await explorer.existsFileNode('sample.txt')).toBe(true);
         // resources/sample-files2 contains one file
-        expect(fileStatElements.length).toBe(3);
+        expect(await explorer.existsFileNode('another-sample.txt')).toBe(true);
     });
 
 });


### PR DESCRIPTION
#### What it does
The `theia-workspace.test.ts` checks for existence of file nodes in the explorer view to verify whether the workspace has been prepared correctly. However, occasionally it may happen that the explorer view doesn't show them yet, as the files are just being loaded.

This resulted in occasionally flaky test executions (#12063).

To fix this problem, we now use the `existsDirectoryNode` and `existsFileNode` checks to explicitly wait for them to appear and only fail if the check times out.

Contributed on behalf of STMicroelectronics.
Fixes #12063

#### How to test
There is nothing really to test other than to make sure the playwright tests have passed and to observe in the future whether this reduces the number of flaky test failures in `theia-workspace.test.ts`.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
