### PR TITLE
terminal: fix 'new terminal' handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - Interface ScmInlineAction removes 'commands: CommandRegistry'
     - Interface ScmInlineActions removes 'commands: CommandRegistry'
     - Interface ScmTreeWidget.Props removes 'commands: CommandRegistry'
+- [terminal] removed `openTerminalFromProfile` method from `TerminalFrontendContribution` [#12322](https://github.com/eclipse-theia/theia/pull/12322)
 
 ## v1.35.0 - 02/23/2023
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request fixes a regression from https://github.com/eclipse-theia/theia/pull/12199 which prevented new terminals from being opened without a workspace present. Previously the code would prompt users to select a `cwd` and exit early when no `cwd` was selected or no workspace was present. The code now adds handling to only prompt to select the `cwd` if a workspace is present.

The code also refactors the logic for `openTerminal` and removes `openTerminalFromProfile` which duplicated code.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

_No Workspace_:

1. start the application without a workspace
2. confirm that `new terminal` and `new terminal (with profile)` correctly spawn a terminal with the appropriate profile at the user's home (no cwd)

_Non-Multi Root Workspace_:

1. start the application with a workspace
2. confirm that `new terminal` and `new terminal (with profile)` correctly spawn a terminal with the appropriate profile at the workspace's root 

_Multi-Root Workspace_:

1. start the application with a multi-root workspace (you can use `add folder to workspace commands`)
2. execute `new terminal`
3. confirm that the prompt to select the root appears
4. escape the prompt - a terminal should not be opened
5. repeat steps 2-3 - select a root and confirm the cwd is correct
6. repeat the same steps for `new terminal (with profile)



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
