### PR TITLE
terminal: add context menu

### DIFF
--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -137,6 +137,11 @@ export abstract class TerminalWidget extends BaseWidget {
      */
     abstract clearOutput(): void;
 
+    /**
+     * Select entire content in the terminal.
+     */
+    abstract selectAll(): void;
+
     abstract writeLine(line: string): void;
 
     abstract write(data: string): void;

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -18,7 +18,9 @@ import { Terminal, RendererType } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { ContributionProvider, Disposable, Event, Emitter, ILogger, DisposableCollection, Channel, OS } from '@theia/core';
-import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop, KeyCode, codicon, ExtractableWidget } from '@theia/core/lib/browser';
+import {
+    Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop, KeyCode, codicon, ExtractableWidget, ContextMenuRenderer
+} from '@theia/core/lib/browser';
 import { isOSX } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ShellTerminalServerProxy, IShellTerminalPreferences } from '../common/shell-terminal-protocol';
@@ -39,6 +41,7 @@ import { TerminalThemeService } from './terminal-theme-service';
 import { CommandLineOptions, ShellCommandBuilder } from '@theia/process/lib/common/shell-command-builder';
 import { Key } from '@theia/core/lib/browser/keys';
 import { nls } from '@theia/core/lib/common/nls';
+import { TerminalMenus } from './terminal-frontend-contribution';
 
 export const TERMINAL_WIDGET_FACTORY_ID = 'terminal';
 
@@ -93,6 +96,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     @inject(TerminalCopyOnSelectionHandler) protected readonly copyOnSelectionHandler: TerminalCopyOnSelectionHandler;
     @inject(TerminalThemeService) protected readonly themeService: TerminalThemeService;
     @inject(ShellCommandBuilder) protected readonly shellCommandBuilder: ShellCommandBuilder;
+    @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer;
 
     protected readonly onDidOpenEmitter = new Emitter<void>();
     readonly onDidOpen: Event<void> = this.onDidOpenEmitter.event;
@@ -250,6 +254,14 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         this.onDispose(() => {
             this.node.removeEventListener('mousemove', mouseListener);
         });
+
+        const contextMenuListener = (event: MouseEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            this.contextMenuRenderer.render({ menuPath: TerminalMenus.TERMINAL_CONTEXT_MENU, anchor: event });
+        };
+        this.node.addEventListener('contextmenu', contextMenuListener);
+        this.onDispose(() => this.node.removeEventListener('contextmenu', contextMenuListener));
 
         this.toDispose.push(this.term.onSelectionChange(() => {
             if (this.copyOnSelection) {
@@ -435,6 +447,10 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
     clearOutput(): void {
         this.term.clear();
+    }
+
+    selectAll(): void {
+        this.term.selectAll();
     }
 
     async hasChildProcesses(): Promise<boolean> {


### PR DESCRIPTION
#### What it does
Adds a context menu to the terminal widget that covers roughly the same menu items as VS Code.

* New Terminal
* Split Terminal
* Copy
* Paste
* Select All
* Clear
* Kill Terminal

Therefore, this change also creates the two new commands *Select All* and *Kill Terminal*.

Fixes #7632
Contributed on behalf of STMicroelectronics.
Change-Id: Icb23f6fbdc44cdc5e018277e44ed5fe46c8ac26a

#### How to test
Open a terminal and try out all context menu items (list see above).
It may be worth making sure that the commands also work when triggered via the command palette.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
