### PR TITLE
[vscode] Support ViewBadge and tree/webview view badge property

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -59,7 +59,9 @@ export interface DescriptionWidget {
 
 export interface BadgeWidget {
     badge?: number;
+    badgeTooltip?: string;
     onDidChangeBadge: CommonEvent<void>;
+    onDidChangeBadgeTooltip: CommonEvent<void>;
 }
 
 export namespace DescriptionWidget {
@@ -70,7 +72,7 @@ export namespace DescriptionWidget {
 
 export namespace BadgeWidget {
     export function is(arg: unknown): arg is BadgeWidget {
-        return isObject(arg) && 'onDidChangeBadge' in arg;
+        return isObject(arg) && 'onDidChangeBadge' in arg && 'onDidChangeBadgeTooltip' in arg;
     }
 }
 
@@ -927,6 +929,8 @@ export class ViewContainerPart extends BaseWidget {
     readonly onDidChangeDescription = this.onDidChangeDescriptionEmitter.event;
     protected readonly onDidChangeBadgeEmitter = new Emitter<void>();
     readonly onDidChangeBadge = this.onDidChangeBadgeEmitter.event;
+    protected readonly onDidChangeBadgeTooltipEmitter = new Emitter<void>();
+    readonly onDidChangeBadgeTooltip = this.onDidChangeBadgeTooltipEmitter.event;
 
     protected readonly toolbar: TabBarToolbar;
 
@@ -962,7 +966,8 @@ export class ViewContainerPart extends BaseWidget {
         }
 
         if (BadgeWidget.is(this.wrapped)) {
-            this.wrapped?.onDidChangeBadge(() => this.onDidChangeBadgeEmitter.fire(), undefined, this.toDispose);
+            this.wrapped.onDidChangeBadge(() => this.onDidChangeBadgeEmitter.fire(), undefined, this.toDispose);
+            this.wrapped.onDidChangeBadgeTooltip(() => this.onDidChangeBadgeTooltipEmitter.fire(), undefined, this.toDispose);
         }
 
         const { header, body, disposable } = this.createContent();
@@ -982,6 +987,7 @@ export class ViewContainerPart extends BaseWidget {
             this.onTitleChangedEmitter,
             this.onDidChangeDescriptionEmitter,
             this.onDidChangeBadgeEmitter,
+            this.onDidChangeBadgeTooltipEmitter,
             this.registerContextMenu(),
             this.onDidFocusEmitter,
             // focus event does not bubble, capture it
@@ -1170,14 +1176,17 @@ export class ViewContainerPart extends BaseWidget {
             description.innerText = DescriptionWidget.is(this.wrapped) && !this.collapsed && this.wrapped.description || '';
         };
         const updateBadge = () => {
-            const visibleToolBarItems = this.toolbarRegistry.visibleItems(this.wrapped).length > 0;
-            const badge = BadgeWidget.is(this.wrapped) && this.wrapped.badge;
-            if (typeof badge === 'number' && !visibleToolBarItems) {
-                badgeSpan.innerText = badge.toString();
-                badgeContainer.style.display = badgeContainerDisplay;
-            } else {
-                badgeContainer.style.display = 'none';
+            if (BadgeWidget.is(this.wrapped)) {
+                const visibleToolBarItems = this.toolbarRegistry.visibleItems(this.wrapped).length > 0;
+                const badge = this.wrapped.badge;
+                if (badge && !visibleToolBarItems) {
+                    badgeSpan.innerText = badge.toString();
+                    badgeSpan.title = this.wrapped.badgeTooltip || '';
+                    badgeContainer.style.display = badgeContainerDisplay;
+                    return;
+                }
             }
+            badgeContainer.style.display = 'none';
         };
 
         updateTitle();
@@ -1191,6 +1200,7 @@ export class ViewContainerPart extends BaseWidget {
             this.onDidMove(updateTitle),
             this.onDidChangeDescription(updateDescription),
             this.onDidChangeBadge(updateBadge),
+            this.onDidChangeBadgeTooltip(updateBadge),
             this.onCollapsed(updateDescription)
         ]);
         header.appendChild(title);

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -744,6 +744,7 @@ export interface TreeViewsMain {
     $setMessage(treeViewId: string, message: string): void;
     $setTitle(treeViewId: string, title: string): void;
     $setDescription(treeViewId: string, description: string): void;
+    $setBadge(treeViewId: string, badge: theia.ViewBadge | undefined): void;
 }
 export class DataTransferFileDTO {
     constructor(readonly name: string, readonly contentId: string, readonly uri?: UriComponents) { }
@@ -1710,6 +1711,7 @@ export interface WebviewsMain {
     $reveal(handle: string, showOptions: theia.WebviewPanelShowOptions): void;
     $setTitle(handle: string, value: string): void;
     $setIconPath(handle: string, value: IconUrl | undefined): void;
+    $setBadge(handle: string, badge: theia.ViewBadge | undefined): void;
     $setHtml(handle: string, value: string): void;
     $setOptions(handle: string, options: theia.WebviewOptions): void;
     $postMessage(handle: string, value: any): Thenable<boolean>;
@@ -1735,6 +1737,7 @@ export interface WebviewViewsMain extends Disposable {
 
     $setWebviewViewTitle(handle: string, value: string | undefined): void;
     $setWebviewViewDescription(handle: string, value: string | undefined): void;
+    $setBadge(handle: string, badge: theia.ViewBadge | undefined): void;
 
     $show(handle: string, preserveFocus: boolean): void;
 }

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -397,6 +397,14 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             get description(): string | undefined { return _description; },
             set description(value: string | undefined) { _description = value; },
 
+            get badge(): number | undefined { return webview.badge; },
+            set badge(badge: number | undefined) { webview.badge = badge; },
+
+            get badgeTooltip(): string | undefined { return webview.badgeTooltip; },
+            set badgeTooltip(badgeTooltip: string | undefined) { webview.badgeTooltip = badgeTooltip; },
+            onDidChangeBadge: webview.onDidChangeBadge,
+            onDidChangeBadgeTooltip: webview.onDidChangeBadgeTooltip,
+
             dispose: webview.dispose,
             show: webview.show
         };

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
@@ -21,7 +21,7 @@ import { CommandRegistry } from '@theia/core/lib/common/command';
 import { StatefulWidget } from '@theia/core/lib/browser/shell/shell-layout-restorer';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
 import { TreeViewWidget } from './tree-view-widget';
-import { DescriptionWidget } from '@theia/core/lib/browser/view-container';
+import { BadgeWidget, DescriptionWidget } from '@theia/core/lib/browser/view-container';
 import { DisposableCollection, Emitter, Event } from '@theia/core/lib/common';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 
@@ -32,16 +32,20 @@ export class PluginViewWidgetIdentifier {
 }
 
 @injectable()
-export class PluginViewWidget extends Panel implements StatefulWidget, DescriptionWidget {
+export class PluginViewWidget extends Panel implements StatefulWidget, DescriptionWidget, BadgeWidget {
 
     currentViewContainerId?: string;
 
     protected _message?: string;
     protected _description: string = '';
+    protected _badge?: number | undefined;
+    protected _badgeTooltip?: string | undefined;
     protected _suppressUpdateViewVisibility = false;
     protected updatingViewVisibility = false;
     protected onDidChangeDescriptionEmitter = new Emitter<void>();
-    protected toDispose = new DisposableCollection(this.onDidChangeDescriptionEmitter);
+    protected onDidChangeBadgeEmitter = new Emitter<void>();
+    protected onDidChangeBadgeTooltipEmitter = new Emitter<void>();
+    protected toDispose = new DisposableCollection(this.onDidChangeDescriptionEmitter, this.onDidChangeBadgeEmitter, this.onDidChangeBadgeTooltipEmitter);
 
     @inject(MenuModelRegistry)
     protected readonly menus: MenuModelRegistry;
@@ -71,6 +75,14 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
 
     get onDidChangeDescription(): Event<void> {
         return this.onDidChangeDescriptionEmitter.event;
+    }
+
+    get onDidChangeBadge(): Event<void> {
+        return this.onDidChangeBadgeEmitter.event;
+    }
+
+    get onDidChangeBadgeTooltip(): Event<void> {
+        return this.onDidChangeBadgeTooltipEmitter.event;
     }
 
     protected override onActivateRequest(msg: Message): void {
@@ -138,6 +150,32 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
         this.onDidChangeDescriptionEmitter.fire();
     }
 
+    get badge(): number | undefined {
+        const widget = this.widgets[0];
+        if (BadgeWidget.is(widget)) {
+            return widget.badge;
+        }
+        return this._badge;
+    }
+
+    set badge(badge: number | undefined) {
+        this._badge = badge;
+        this.onDidChangeBadgeEmitter.fire();
+    }
+
+    get badgeTooltip(): string | undefined {
+        const widget = this.widgets[0];
+        if (BadgeWidget.is(widget)) {
+            return widget.badgeTooltip;
+        }
+        return this._badgeTooltip;
+    }
+
+    set badgeTooltip(badgeTooltip: string | undefined) {
+        this._badgeTooltip = badgeTooltip;
+        this.onDidChangeBadgeTooltipEmitter.fire();
+    }
+
     private updateWidgetMessage(): void {
         const widget = this.widgets[0];
         if (widget) {
@@ -149,6 +187,10 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
 
     override addWidget(widget: Widget): void {
         super.addWidget(widget);
+        if (BadgeWidget.is(widget)) {
+            widget.onDidChangeBadge(() => this.onDidChangeBadgeEmitter.fire());
+            widget.onDidChangeBadgeTooltip(() => this.onDidChangeBadgeTooltipEmitter.fire());
+        }
         this.updateWidgetMessage();
     }
 

--- a/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
@@ -30,6 +30,7 @@ import { TreeViewWidget, TreeViewNode, PluginTreeModel, TreeViewWidgetOptions } 
 import { PluginViewWidget } from './plugin-view-widget';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { DnDFileContentStore } from './dnd-file-content-store';
+import { ViewBadge } from '@theia/plugin';
 
 export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
 
@@ -170,6 +171,14 @@ export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
         const viewPanel = await this.viewRegistry.getView(treeViewId);
         if (viewPanel) {
             viewPanel.description = description;
+        }
+    }
+
+    async $setBadge(treeViewId: string, badge: ViewBadge | undefined): Promise<void> {
+        const viewPanel = await this.viewRegistry.getView(treeViewId);
+        if (viewPanel) {
+            viewPanel.badge = badge?.value;
+            viewPanel.badgeTooltip = badge?.tooltip;
         }
     }
 

--- a/packages/plugin-ext/src/main/browser/webview-views/webview-views-main.ts
+++ b/packages/plugin-ext/src/main/browser/webview-views/webview-views-main.ts
@@ -28,6 +28,7 @@ import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { WebviewsMainImpl } from '../webviews-main';
 import { Widget, WidgetManager } from '@theia/core/lib/browser';
 import { PluginViewRegistry } from '../view/plugin-view-registry';
+import { ViewBadge } from '@theia/plugin';
 
 export class WebviewViewsMainImpl implements WebviewViewsMain, Disposable {
 
@@ -124,6 +125,14 @@ export class WebviewViewsMainImpl implements WebviewViewsMain, Disposable {
     $setWebviewViewDescription(handle: string, value: string | undefined): void {
         const webviewView = this.getWebviewView(handle);
         webviewView.description = value;
+    }
+
+    async $setBadge(handle: string, badge: ViewBadge | undefined): Promise<void> {
+        const webviewView = this.getWebviewView(handle);
+        if (webviewView) {
+            webviewView.badge = badge?.value;
+            webviewView.badgeTooltip = badge?.tooltip;
+        }
     }
 
     $show(handle: string, preserveFocus: boolean): void {

--- a/packages/plugin-ext/src/main/browser/webview-views/webview-views.ts
+++ b/packages/plugin-ext/src/main/browser/webview-views/webview-views.ts
@@ -25,9 +25,13 @@ import { WebviewWidget } from '../webview/webview';
 export interface WebviewView {
     title?: string;
     description?: string;
+    badge?: number | undefined;
+    badgeTooltip?: string | undefined;
     readonly webview: WebviewWidget;
     readonly onDidChangeVisibility: Event<boolean>;
     readonly onDidDispose: Event<void>;
+    readonly onDidChangeBadge: Event<void>;
+    readonly onDidChangeBadgeTooltip: Event<void>;
 
     dispose(): void;
     show(preserveFocus: boolean): void;

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -19,7 +19,7 @@ import { URI } from '@theia/core/shared/vscode-uri';
 import { interfaces } from '@theia/core/shared/inversify';
 import { WebviewsMain, MAIN_RPC_CONTEXT, WebviewsExt, WebviewPanelViewState } from '../../common/plugin-api-rpc';
 import { RPCProtocol } from '../../common/rpc-protocol';
-import { WebviewOptions, WebviewPanelOptions, WebviewPanelShowOptions } from '@theia/plugin';
+import { ViewBadge, WebviewOptions, WebviewPanelOptions, WebviewPanelShowOptions } from '@theia/plugin';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 import { WebviewWidget, WebviewWidgetIdentifier } from './webview/webview';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
@@ -158,6 +158,14 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
     async $setTitle(handle: string, value: string): Promise<void> {
         const webview = await this.getWebview(handle);
         webview.title.label = value;
+    }
+
+    async $setBadge(handle: string, badge: ViewBadge | undefined): Promise<void> {
+        const webview = await this.getWebview(handle);
+        if (webview) {
+            webview.badge = badge?.value;
+            webview.badgeTooltip = badge?.tooltip;
+        }
     }
 
     async $setIconPath(handle: string, iconUrl: IconUrl | undefined): Promise<void> {

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -18,7 +18,7 @@
 
 import {
     TreeDataProvider, TreeView, TreeViewExpansionEvent, TreeItem, TreeItemLabel,
-    TreeViewSelectionChangeEvent, TreeViewVisibilityChangeEvent, CancellationToken, DataTransferFile, TreeViewOptions
+    TreeViewSelectionChangeEvent, TreeViewVisibilityChangeEvent, CancellationToken, DataTransferFile, TreeViewOptions, ViewBadge
 } from '@theia/plugin';
 // TODO: extract `@theia/util` for event, disposable, cancellation and common types
 // don't use @theia/core directly from plugin host
@@ -119,6 +119,12 @@ export class TreeViewsExtImpl implements TreeViewsExt {
             },
             set description(description: string) {
                 treeView.description = description;
+            },
+            get badge(): ViewBadge | undefined {
+                return treeView.badge;
+            },
+            set badge(badge: ViewBadge | undefined) {
+                treeView.badge = badge;
             },
             reveal: (element: T, revealOptions?: Partial<TreeViewRevealOptions>): Thenable<void> =>
                 treeView.reveal(element, revealOptions),
@@ -275,6 +281,15 @@ class TreeViewExtImpl<T> implements Disposable {
     set description(description: string) {
         this._description = description;
         this.proxy.$setDescription(this.treeViewId, this._description);
+    }
+
+    private _badge?: ViewBadge = undefined;
+    get badge(): ViewBadge | undefined {
+        return this._badge;
+    }
+    set badge(badge: ViewBadge | undefined) {
+        this._badge = badge;
+        this.proxy.$setBadge(this.treeViewId, badge ? { value: badge.value, tooltip: badge.tooltip } : undefined);
     }
 
     getElement(treeItemId: string): T | undefined {

--- a/packages/plugin-ext/src/plugin/webview-views.ts
+++ b/packages/plugin-ext/src/plugin/webview-views.ts
@@ -133,6 +133,7 @@ export class WebviewViewExtImpl implements theia.WebviewView {
     _isVisible: boolean;
     _title: string | undefined;
     _description: string | undefined;
+    _badge: theia.ViewBadge | undefined;
 
     constructor(
         handle: string,
@@ -140,7 +141,7 @@ export class WebviewViewExtImpl implements theia.WebviewView {
         viewType: string,
         title: string | undefined,
         webview: WebviewImpl,
-        isVisible: boolean,
+        isVisible: boolean
     ) {
         this._viewType = viewType;
         this._title = title;
@@ -183,6 +184,19 @@ export class WebviewViewExtImpl implements theia.WebviewView {
         if (this._description !== value) {
             this._description = value;
             this.proxy.$setWebviewViewDescription(this.handle, value);
+        }
+    }
+
+    get badge(): theia.ViewBadge | undefined {
+        this.assertNotDisposed();
+        return this._badge;
+    }
+
+    set badge(badge: theia.ViewBadge | undefined) {
+        this.assertNotDisposed();
+        if (this._badge !== badge) {
+            this._badge = badge;
+            this.proxy.$setBadge(this.handle, badge ? { value: badge.value, tooltip: badge.tooltip } : undefined);
         }
     }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4629,6 +4629,12 @@ export module '@theia/plugin' {
         readonly visible: boolean;
 
         /**
+         * The badge to display for this webview view.
+         * To remove the badge, set to undefined.
+         */
+        badge?: ViewBadge | undefined;
+
+        /**
          * Event fired when the visibility of the view changes.
          *
          * Actions that trigger a visibility change:
@@ -6008,6 +6014,22 @@ export module '@theia/plugin' {
     }
 
     /**
+     * A badge presenting a value for a view
+     */
+    export interface ViewBadge {
+
+        /**
+         * A label to present in tooltip for the badge.
+         */
+        readonly tooltip: string;
+
+        /**
+         * The value to present in the badge.
+         */
+        readonly value: number;
+    }
+
+    /**
      * Represents a Tree view
      */
     export interface TreeView<T> extends Disposable {
@@ -6059,6 +6081,12 @@ export module '@theia/plugin' {
          * Setting the description to null, undefined, or empty string will remove the message from the view.
          */
         description?: string;
+
+        /**
+         * The badge to display for this TreeView.
+         * To remove the badge, set to undefined.
+         */
+        badge: ViewBadge | undefined;
 
         /**
          * Reveal an element. By default revealed element is selected.

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
@@ -52,6 +52,9 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
     protected _badge?: number;
     protected onDidChangeBadgeEmitter = new Emitter<void>();
 
+    protected _badgeTooltip?: string;
+    protected onDidChangeBadgeTooltipEmitter = new Emitter<void>();
+
     @inject(VSXExtensionsWidgetOptions)
     protected readonly options: VSXExtensionsWidgetOptions;
 
@@ -88,6 +91,19 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
     set badge(count: number | undefined) {
         this._badge = count;
         this.onDidChangeBadgeEmitter.fire();
+    }
+
+    get onDidChangeBadgeTooltip(): Event<void> {
+        return this.onDidChangeBadgeTooltipEmitter.event;
+    }
+
+    get badgeTooltip(): string | undefined {
+        return this._badgeTooltip;
+    }
+
+    set badgeTooltip(tooltip: string | undefined) {
+        this._badgeTooltip = tooltip;
+        this.onDidChangeBadgeTooltipEmitter.fire();
     }
 
     protected computeTitle(): string {


### PR DESCRIPTION
#### What it does

Adds support for [ViewBadge](https://code.visualstudio.com/api/references/vscode-api#ViewBadge) and badge for tree views and Webview views 

Fixes [#12020](https://github.com/eclipse-theia/theia/issues/12020)

Contributed on behalf of STMicroelectronics

#### How to test
This PR adds a badge to Tree based views and webviews contributed by extensions. Thus 2 extensions based on vscode samples are to be tested with this patch.

[custom-view-samples-0.0.2.zip](https://github.com/eclipsesource/theia/files/11019492/custom-view-samples-0.0.2.zip) This one provides a tree view with 2 actions (change badge value and change tooltip value). The first one will ask for a new value, the second for a new tooltip. 

![tree-view-badge](https://user-images.githubusercontent.com/3964263/226382718-2bb3978a-b8b8-4fcc-b6bd-c53f2b3005e0.gif)

[calico-colors-0.0.13.zip](https://github.com/eclipsesource/theia/files/11019747/calico-colors-0.0.13.zip) This one slightly updates the webview view  vscode extensions sample, to change the tooltip when the add color is triggered, and to remove the tooltip (set to undefined) when the clear colors is triggered.

![webview-view-badge](https://user-images.githubusercontent.com/3964263/226383482-b9e5fa7c-61ec-40ee-86e3-5a66b8f017bc.gif)

To test, install the extensions and trigger the action:
- 'Test View: change badge/tooltip value' to change the badge or its tooltip on the Test View
- 'Calico Colors: Add color' to add a tooltip to the calico colors test view. The first color does not add a badge, it only shows after the second one.
- 'Calico Colors: Clear color'  to set the badge to undefined, and as indicated by the doc of ViewBadge, the badge is deleted.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
