### PR TITLE
Search-In-Workspace: Add multiselect functionality

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
@@ -74,6 +74,7 @@ export function createSearchTreeWidget(parent: interfaces.Container): SearchInWo
         widget: SearchInWorkspaceResultTreeWidget,
         props: {
             contextMenuPath: SearchInWorkspaceResultTreeWidget.Menus.BASE,
+            multiSelect: true,
             globalSelection: true
         }
     });

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -737,7 +737,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     }
 
     protected doReplace(node: TreeNode, e: React.MouseEvent<HTMLElement>): void {
-        this.replace(node);
+        const selection = SelectableTreeNode.isSelected(node) ? (this.selectionService.selection as SelectableTreeNode[]) : [node];
+        selection.forEach(n => this.replace(n));
         e.stopPropagation();
     }
 
@@ -899,7 +900,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
 
     protected readonly remove = (node: TreeNode, e: React.MouseEvent<HTMLElement>) => this.doRemove(node, e);
     protected doRemove(node: TreeNode, e: React.MouseEvent<HTMLElement>): void {
-        this.removeNode(node);
+        const selection = SelectableTreeNode.isSelected(node) ? (this.selectionService.selection as SelectableTreeNode[]) : [node];
+        selection.forEach(n => this.removeNode(n));
         e.stopPropagation();
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -507,7 +507,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         if (e.target) {
             this.replaceTerm = (e.target as HTMLInputElement).value;
             this.resultTreeWidget.replaceTerm = this.replaceTerm;
-            this.performSearch();
+            if (KeyCode.createKeyCode(e.nativeEvent).key?.keyCode === Key.ENTER.keyCode) { this.performSearch(); }
             this.update();
         }
     }


### PR DESCRIPTION
#### What it does
Closes #11874

Implements in Search-In-Workspace:
- Multiselect search results.
- `delete` keybinding dismiss selected results.
- `Ctrl`+`C` keybinding to copy selected results.
- Handling for action buttons: `Replace` and `Dismiss`
- `Replace` action in context menu with keybinding

`enter` in replace-inputbox refreshes search results,
instead of on every key.

![Issue11874Fix](https://user-images.githubusercontent.com/48699277/226721149-7ab30a7f-bd76-4f4c-b136-464a4be2152e.gif)

#### How to test
1. Run Theia
2. Open Search tab
3. Search for a word
4. Dismiss one or several selected results with either inline button, context menu or keybinding.
5. Copy one search result using context menu or keybinding.
6. Replace the searched word of selected results using the inline button, context menu or keybinding.

The other context menu options have been made to work as close as possible to VS Code.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
