### PR TITLE
[CI] Rename workflow jobs so that they reflect what they do

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,7 +47,7 @@ jobs:
           yarn lint
 
   build:
-    name: Build (${{ matrix.os }}, node-${{ matrix.node }}
+    name: Build and Test (${{ matrix.os }}, node-${{ matrix.node }})
 
     strategy:
       fail-fast: false
@@ -114,6 +114,7 @@ jobs:
           xvfb-run -a yarn electron test
 
   publish:
+    name: Publish to NPM and GitHub pages
     needs: build
     if: github.ref == 'refs/heads/master' && github.event_name != 'schedule' # We still publish the manually dispatched workflows: 'workflow_dispatch'.
     runs-on: ubuntu-latest

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   License-check:
-    name: ${{ matrix.os }}, Node.js v${{ matrix.node }}
+    name: 3PP License Check
 
     strategy:
       fail-fast: false

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-and-test-performance:
-    name: ubuntu-latest, Node.js 16.x
+    name: Performance Tests
     
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-and-test-playwright:
-    name: ubuntu-latest,  Node.js 16.x
+    name: Playwright Tests (ubuntu-latest,  Node.js 16.x)
 
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
As decided in this week's [dev-meeting](https://github.com/eclipse-theia/theia/wiki/Dev-Meetings#2023-03-21), we will try to enable the repo's "Require branches to be up to date before merging" option. When doing so, one needs to select the "checks" that will apply to it. These checks are defined as part of our CI workflows, but they are named after the jobs, not the workflows. Some of our jobs do not have a descriptive name, which results in a confusing list of checks [1]

This PR renames the workflow jobs to reflect more accurately what they do, specially in situations where the workflow name is not present, such as the example above.


[1] ![image](https://user-images.githubusercontent.com/25749063/226954992-95e13e9c-07d0-4dcd-b894-db684564463e.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Look at the CI for this PR and verify that all the job names have reflect what's being done by the job, without having to rely on its workflow name. 

For example, the 3PP license check breaks-down as follows (content here reflects old job name):
"3PP License Check / ubuntu-latest, Node v16.x (pull_request)"
workflow name: "3PP License Check"
job name: "ubuntu-latest, Node v16.x"

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
