### PR TITLE
fix: readonly permissions with disk FS provider

### DIFF
--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -15,6 +15,7 @@
     "minimatch": "^5.1.0",
     "multer": "1.4.4-lts.1",
     "rimraf": "^2.6.2",
+    "stat-mode": "^1.0.0",
     "tar-fs": "^1.16.2",
     "trash": "^7.2.0",
     "uuid": "^8.0.0",

--- a/packages/filesystem/src/node/disk-file-system-provider.spec.ts
+++ b/packages/filesystem/src/node/disk-file-system-provider.spec.ts
@@ -1,0 +1,116 @@
+// *****************************************************************************
+// Copyright (C) 2023 Arduino SA and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import {
+    Disposable,
+    DisposableCollection,
+} from '@theia/core/lib/common/disposable';
+import { EncodingService } from '@theia/core/lib/common/encoding-service';
+import { ILogger } from '@theia/core/lib/common/logger';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { IPCConnectionProvider } from '@theia/core/lib/node/messaging/ipc-connection-provider';
+import { Container, ContainerModule } from '@theia/core/shared/inversify';
+import { equal, fail } from 'assert';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import * as temp from 'temp';
+import { v4 } from 'uuid';
+import { FilePermission } from '../common/files';
+import { DiskFileSystemProvider } from './disk-file-system-provider';
+import { bindFileSystemWatcherServer } from './filesystem-backend-module';
+
+const tracked = temp.track();
+
+describe('disk-file-system-provider', () => {
+    let toDisposeAfter: DisposableCollection;
+    let fsProvider: DiskFileSystemProvider;
+
+    before(() => {
+        fsProvider = createContainer().get<DiskFileSystemProvider>(
+            DiskFileSystemProvider
+        );
+        toDisposeAfter = new DisposableCollection(
+            fsProvider,
+            Disposable.create(() => tracked.cleanupSync())
+        );
+    });
+
+    after(() => {
+        toDisposeAfter.dispose();
+    });
+
+    describe('stat', () => {
+        it("should omit the 'permissions' property of the stat if the file can be both read and write", async () => {
+            const tempDirPath = tracked.mkdirSync();
+            const tempFilePath = join(tempDirPath, `${v4()}.txt`);
+            await fs.writeFile(tempFilePath, 'some content', { encoding: 'utf8' });
+
+            let content = await fs.readFile(tempFilePath, { encoding: 'utf8' });
+            equal(content, 'some content');
+
+            await fs.writeFile(tempFilePath, 'other content', { encoding: 'utf8' });
+
+            content = await fs.readFile(tempFilePath, { encoding: 'utf8' });
+            equal(content, 'other content');
+
+            const stat = await fsProvider.stat(FileUri.create(tempFilePath));
+            equal(stat.permissions, undefined);
+        });
+
+        it("should set the 'permissions' property to `Readonly` if the file can be read but not write", async () => {
+            const tempDirPath = tracked.mkdirSync();
+            const tempFilePath = join(tempDirPath, `${v4()}.txt`);
+            await fs.writeFile(tempFilePath, 'readonly content', {
+                encoding: 'utf8',
+            });
+
+            await fs.chmod(tempFilePath, '444'); // read-only for owner/group/world
+
+            try {
+                await fs.writeFile(tempFilePath, 'should not happen', {
+                    encoding: 'utf8',
+                });
+                fail('Expected an EACCES error for readonly (chmod 444) files');
+            } catch (err) {
+                equal(err instanceof Error, true);
+                equal('code' in err, true);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                equal((err as any).code, 'EACCES');
+            }
+
+            const content = await fs.readFile(tempFilePath, { encoding: 'utf8' });
+            equal(content, 'readonly content');
+
+            const stat = await fsProvider.stat(FileUri.create(tempFilePath));
+            equal(stat.permissions, FilePermission.Readonly);
+        });
+    });
+
+    function createContainer(): Container {
+        const container = new Container({ defaultScope: 'Singleton' });
+        const module = new ContainerModule((bind) => {
+            bind(DiskFileSystemProvider).toSelf().inSingletonScope();
+            bind(EncodingService).toSelf().inSingletonScope();
+            bindFileSystemWatcherServer(bind);
+            bind(MockLogger).toSelf().inSingletonScope();
+            bind(ILogger).toService(MockLogger);
+            bind(IPCConnectionProvider).toSelf().inSingletonScope();
+        });
+        container.load(module);
+        return container;
+    }
+});

--- a/packages/filesystem/src/node/disk-file-system-provider.spec.ts
+++ b/packages/filesystem/src/node/disk-file-system-provider.spec.ts
@@ -102,7 +102,7 @@ describe('disk-file-system-provider', () => {
 
     function createContainer(): Container {
         const container = new Container({ defaultScope: 'Singleton' });
-        const module = new ContainerModule((bind) => {
+        const module = new ContainerModule(bind => {
             bind(DiskFileSystemProvider).toSelf().inSingletonScope();
             bind(EncodingService).toSelf().inSingletonScope();
             bindFileSystemWatcherServer(bind);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10360,6 +10360,11 @@ ssri@9.0.1, ssri@^9.0.0:
   dependencies:
     minipass "^3.1.1"
 
+stat-mode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-1.0.0.tgz#68b55cb61ea639ff57136f36b216a291800d1465"
+  integrity sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Sets the `permissions` of the stat retrieved from the disk filesystem provider to `FilePermissions.Readonly` if the owner does not have write access.

Closes https://github.com/eclipse-theia/theia/issues/199
Closes #12342


https://user-images.githubusercontent.com/1405703/227970880-0285f58a-72c2-4595-9b8c-c13d44802364.mp4



#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Remove the owner write permission from one of the files on your disk, and open it in the editor. The editor is readonly. You see the 🔒 in the editor tab, or please reference the attached screencast. 👆

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
