### PR TITLE
fix: Remove invasive split terminal action

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -542,7 +542,9 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             execute: () => this.openActiveWorkspaceTerminal()
         });
         commands.registerCommand(TerminalCommands.SPLIT, {
-            execute: () => this.splitTerminal()
+            execute: () => this.splitTerminal(),
+            isEnabled: () => this.shell.currentWidget instanceof TerminalWidget,
+            isVisible: () => this.shell.currentWidget instanceof TerminalWidget,
         });
         commands.registerCommand(TerminalCommands.TERMINAL_CLEAR);
         commands.registerHandler(TerminalCommands.TERMINAL_CLEAR.id, {


### PR DESCRIPTION
#### What it does

Partially removes some intrusive split terminal actions in views

Current situtation:
![terminal-split](https://user-images.githubusercontent.com/3964263/228467120-49776158-a44b-404f-b55f-0b41f4ca5f87.gif)

fix #12357

Contributed on behalf of STMicroelectronics

#### How to test

To test in theia:
- Check that by default, split terminal action does not appear on toolbars for various views.
- Check that on terminal views, the split terminal icon is still present when the terminal view is active
- terminal context menu still displays the split terminal entry

Limitations: when a terminal is active, there are still some polluting split terminal entries on some views.

![terminal-split-after](https://user-images.githubusercontent.com/3964263/228281569-31081208-f933-4b90-bd8e-bbc39ae1fc73.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
