### PR TITLE
Editor: restore `highlightModifiedTabs` functionality

### DIFF
--- a/packages/core/src/browser/common-styling-participants.ts
+++ b/packages/core/src/browser/common-styling-participants.ts
@@ -194,15 +194,49 @@ export class TabbarStylingParticipant implements StylingParticipant {
             `);
         }
         const tabActiveBackground = theme.getColor('tab.activeBackground');
-        const tabActiveBorderTop = theme.getColor('tab.activeBorderTop') || (highContrast && contrastBorder) || 'transparent';
+        const tabActiveBorderTop = theme.getColor('tab.activeBorderTop');
+        const tabUnfocusedActiveBorderTop = theme.getColor('tab.unfocusedActiveBorderTop');
         const tabActiveBorder = theme.getColor('tab.activeBorder') || (highContrast && contrastBorder) || 'transparent';
+        const tabUnfocusedActiveBorder = theme.getColor('tab.unfocusedActiveBorder') || (highContrast && contrastBorder) || 'transparent';
         collector.addRule(`
             #theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
                 color: var(--theia-tab-activeForeground);
-                ${tabActiveBackground && `background: ${tabActiveBackground};`}
-                box-shadow: 0 1px 0 ${tabActiveBorderTop} inset, 0 -1px 0 ${tabActiveBorder} inset;
+                ${tabActiveBackground ? `background: ${tabActiveBackground};` : ''}
+                ${tabActiveBorderTop ? `border-top: 1px solid ${tabActiveBorderTop};` : ''}
+                border-bottom: 1px solid ${tabActiveBorder};
+            }
+            #theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.p-mod-current {
+                background: var(--theia-tab-unfocusedActiveBackground);
+                color: var(--theia-tab-unfocusedActiveForeground);
+                ${tabUnfocusedActiveBorderTop ? `border-top: 1px solid ${tabUnfocusedActiveBorderTop};` : ''}
+                border-bottom: 1px solid ${tabUnfocusedActiveBorder};
             }
         `);
+
+        // Highlight Modified Tabs
+        const tabActiveModifiedBorder = theme.getColor('tab.activeModifiedBorder');
+        const tabUnfocusedInactiveModifiedBorder = theme.getColor('tab.unfocusedInactiveModifiedBorder');
+        const tabInactiveModifiedBorder = theme.getColor('tab.inactiveModifiedBorder');
+        if (tabActiveModifiedBorder || tabInactiveModifiedBorder) {
+            collector.addRule(`
+                body.theia-editor-highlightModifiedTabs
+                #theia-main-content-panel .p-TabBar .p-TabBar-tab.theia-mod-dirty {
+                    border-top: 2px solid ${tabInactiveModifiedBorder};
+                    padding-bottom: 1px;
+                }
+
+                body.theia-editor-highlightModifiedTabs
+                #theia-main-content-panel .p-TabBar.theia-tabBar-active .p-TabBar-tab.theia-mod-dirty.p-mod-current {
+                    border-top: 2px solid ${tabActiveModifiedBorder};
+                }
+                
+                body.theia-editor-highlightModifiedTabs
+                #theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.theia-mod-dirty:not(.p-mod-current) {
+                    border-top: 2px solid ${tabUnfocusedInactiveModifiedBorder};
+                }
+            `);
+        }
+
         // Hover Background
         const tabHoverBackground = theme.getColor('tab.hoverBackground');
         if (tabHoverBackground) {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -80,18 +80,14 @@
 
 #theia-main-content-panel .p-TabBar .p-TabBar-tab {
     border-right: 1px solid var(--theia-tab-border);
+    border-top: 1px solid transparent;
+    border-bottom: 1px solid transparent;
     background: var(--theia-tab-inactiveBackground);
     color: var(--theia-tab-inactiveForeground);
 }
 
 #theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab {
     color: var(--theia-tab-unfocusedInactiveForeground);
-}
-
-#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.p-mod-current {
-    background: var(--theia-tab-unfocusedActiveBackground);
-    color: var(--theia-tab-unfocusedActiveForeground);
-    box-shadow: 0 1px 0 var(--theia-tab-unfocusedActiveBorderTop) inset, 0 -1px 0 var(--theia-tab-unfocusedActiveBorder) inset;
 }
 
 .p-TabBar.theia-app-centers {


### PR DESCRIPTION
#### What it does
Closes #12185

Use of box-shadow parameter causes several issues when several box-shadow parameters apply to a single element.
Specially since one parameter is used to manage two independent visual cues (`borderTop` and `borderBottom`)
There are situations when the top border will have no assigned color and this will cause the entire `box-shadow` parameter to not render. Meaning that a missing color for `borderTop` causes an active `borderBottom` to disappear and vice-versa. To add to the issue, the parameter will overwrite other applicable `box-shadow`, so you can end up with other stylings not showing when they should.

There are two possible solutions:
- First one involves a complicated system that checks if the colors for top and bottom exist and then builds a `box-shadow` parameter out of the results and finally adding it to the style sheet.
- The second is changing `box-shadow` for `border-top` and `border-bottom` decoupling their dependency on one another.
For editor tabs, there is no real difference between using `box-shadow` and `border`. Thus, this commit changes the use of `box-shadow` to `border`.

This commit also fixes a tangential issue with High Contrast themes and how borders did not properly render when `workbench.editor.highlightModifiedTabs` was active.

#### How to test
Similarly to #12185
1. Open Theia (browser or electron), set auto-save to off and workbench.editor.highlightModifiedTabs to true
2. Select a file, modify it and see the top border appear.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
