### PR TITLE
[ci][playwright] Solidify flaky Playwright tests

### DIFF
--- a/examples/playwright/src/tests/theia-explorer-view.test.ts
+++ b/examples/playwright/src/tests/theia-explorer-view.test.ts
@@ -29,6 +29,7 @@ test.describe('Theia Explorer View', () => {
         const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
         app = await TheiaApp.load(page, ws);
         explorer = await app.openView(TheiaExplorerView);
+        await explorer.waitForVisibleFileNodes();
     });
 
     test('should be visible and active after being opened', async () => {

--- a/examples/playwright/src/theia-app.ts
+++ b/examples/playwright/src/theia-app.ts
@@ -109,6 +109,7 @@ export class TheiaApp {
             throw Error('TheiaExplorerView could not be opened.');
         }
         if (expectFileNodes) {
+            await explorer.waitForVisibleFileNodes();
             const fileStatElements = await explorer.visibleFileStatNodes(DOT_FILES_FILTER);
             if (fileStatElements.length < 1) {
                 throw Error('TheiaExplorerView is empty.');

--- a/examples/playwright/src/theia-explorer-view.ts
+++ b/examples/playwright/src/theia-explorer-view.ts
@@ -148,6 +148,10 @@ export class TheiaExplorerView extends TheiaView {
             await treeNode.focus();
         } else {
             await treeNode.click({ modifiers: ['Control'] });
+            // make sure the click has been acted-upon before returning
+            while (!await this.isTreeNodeSelected(filePath)) {
+                console.debug('Waiting for clicked tree node to be selected: ' + filePath);
+            }
         }
     }
 
@@ -229,6 +233,20 @@ export class TheiaExplorerView extends TheiaView {
         confirm ? await renameDialog.confirm() : await renameDialog.close();
         await renameDialog.waitForClosed();
         await this.refresh();
+    }
+
+    override async waitForVisible(): Promise<void> {
+        await super.waitForVisible();
+        await this.page.waitForSelector(this.tabSelector, { state: 'visible' });
+    }
+
+    /**
+     * Waits until some non-dot file nodes are visible
+     */
+    async waitForVisibleFileNodes(): Promise<void> {
+        while ((await this.visibleFileStatNodes(DOT_FILES_FILTER)).length === 0) {
+            console.debug('Awaiting for tree nodes to appear');
+        }
     }
 
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This is an attempt at solidifying the playwright test suite, that has had testcases intermitently failing. I have been lucky to be able to observe some race conditions rather consistently locally, and so be able to debug them and solidify against them.

The race conditions are very slight - the Playwright test suite takes a screenshot at every failure, and consistently I see the correct state on those, meaning that the state is what it should be, by the time the screenshot is taken.

In consequence, I wound that, for a given flaky scenario, addressing one race consition would often mask a second one, present in the same scenario. It's possible that under a different execution context, more race conditions would occur. Here are the race coditions I have found:

- When the Theia explorer view is created (at frontend reload or when explicitly closed and then re-opened in a test case), it can take some time for its file nodes to appear in the UI. Some tests were assuming that once the view was visible, they would be too \[1\]
- Similarly, it can take some time for the Explorer's view tab to be created, after the view is. Some test cases were checking immediately for the view tab being visible, and failing when it was not \[2\]
- Also related to the explorer view, in at least one testcase, method "selectTreeNode" was used to select a file node and assumed that it would be selected immediately after clicking on it \[3\]

closes #12063

\[1\] Example of a testcase failing because of the expectation that file tree nodes should be immediately visible after opening the explorer view:
```
1) ../../src/tests/theia-text-editor.test.ts:38:9 › Theia Text Editor › should be visible and active after opening "sample.txt" 

    Error: TheiaExplorerView is empty.

       at ../../src/theia-app.ts:114

      112 |             const fileStatElements = await explorer.visibleFileStatNodes(DOT_FILES_FILTER);
      113 |             if (fileStatElements.length < 1) {
    > 114 |                 throw Error('TheiaExplorerView is empty.');
          |                       ^
      115 |             }
      116 |         }
      117 |         const fileNode = await explorer.fileStatNode(filePath);

        at TheiaApp.openEditor (/home/<user>/theia/examples/playwright/src/theia-app.ts:114:23)
        at /home/<user>/theia/examples/playwright/src/tests/theia-text-editor.test.ts:39:34
```


\[2\] Example of a testcase failing because the Explorer view tab is not immediately visible after Explorer view creation:
```
  1) ../../src/tests/theia-explorer-view.test.ts:49:9 › Theia Explorer View › should be possible to close and reopen it 

    Error: expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      52 |
      53 |         explorer = await app.openView(TheiaExplorerView);
    > 54 |         expect(await explorer.isTabVisible()).toBe(true);
         |                                               ^
      55 |         expect(await explorer.isDisplayed()).toBe(true);
      56 |         expect(await explorer.isActive()).toBe(true);
      57 |     });

        at /home/<user>/theia/examples/playwright/src/tests/theia-explorer-view.test.ts:54:47
```
\[3\] Example of failed testcase where explorer tree node selection was tested before it became effective:
```
  1) ../../src/tests/theia-explorer-view.test.ts:57:9 › Theia Explorer View › should show one folder named "sampleFolder" and one file named "sample.txt" 

    Error: expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      58 |         await explorer.waitForTreeNodesVisible();
      59 |         await explorer.selectTreeNode('sampleFolder');
    > 60 |         expect(await explorer.isTreeNodeSelected('sampleFolder')).toBe(true);
         |                                                                   ^
      61 |         const fileStatElements = await explorer.visibleFileStatNodes(DOT_FILES_FILTER);
      62 |         expect(fileStatElements.length).toBe(2);
      63 |

        at /home/<user>/theia/examples/playwright/src/tests/theia-explorer-view.test.ts:60:67
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Make sure the playwright test suite passes

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
