### PR TITLE
monaco-quick-input-service: set context key "inQuickOpen"

### DIFF
--- a/examples/api-tests/src/monaco-api.spec.js
+++ b/examples/api-tests/src/monaco-api.spec.js
@@ -32,7 +32,8 @@ describe('Monaco API', async function () {
     const { TokenizationRegistry } = require('@theia/monaco-editor-core/esm/vs/editor/common/languages');
     const { MonacoContextKeyService } = require('@theia/monaco/lib/browser/monaco-context-key-service');
     const { URI } = require('@theia/monaco-editor-core/esm/vs/base/common/uri');
-
+    const { animationFrame } = require('@theia/core/lib/browser/browser');
+    
     const container = window.theia.container;
     const editorManager = container.get(EditorManager);
     const workspaceService = container.get(WorkspaceService);
@@ -183,6 +184,22 @@ describe('Monaco API', async function () {
         assert.isTrue(contextKeys.match(`${key} == ${firstValue}`));
         await commands.executeCommand(setContext, key, secondValue);
         assert.isTrue(contextKeys.match(`${key} == ${secondValue}`));
+    });
+
+    it('Supports context key: inQuickOpen', async () => {
+        const inQuickOpenContextKey = 'inQuickOpen';
+        const quickOpenCommands = ['file-search.openFile', 'workbench.action.showCommands'];
+        const CommandThatChangesFocus = 'workbench.files.action.focusFilesExplorer';
+
+        for (const cmd of quickOpenCommands) {
+            assert.isFalse(contextKeys.match(inQuickOpenContextKey));
+            await commands.executeCommand(cmd);
+            assert.isTrue(contextKeys.match(inQuickOpenContextKey));
+
+            await commands.executeCommand(CommandThatChangesFocus);
+            await animationFrame();
+            assert.isFalse(contextKeys.match(inQuickOpenContextKey));
+        }
     });
 
 });

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -30,6 +30,7 @@ import { MonacoResolvedKeybinding } from './monaco-resolved-keybinding';
 import { IQuickAccessController } from '@theia/monaco-editor-core/esm/vs/platform/quickinput/common/quickAccess';
 import { QuickAccessController } from '@theia/monaco-editor-core/esm/vs/platform/quickinput/browser/quickAccess';
 import { ContextKeyService as VSCodeContextKeyService } from '@theia/monaco-editor-core/esm/vs/platform/contextkey/browser/contextKeyService';
+import { IContextKey } from '@theia/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
 import { IListOptions, List } from '@theia/monaco-editor-core/esm/vs/base/browser/ui/list/listWidget';
 import * as monaco from '@theia/monaco-editor-core';
 import { ResolvedKeybinding } from '@theia/monaco-editor-core/esm/vs/base/common/keybindings';
@@ -76,6 +77,7 @@ export class MonacoQuickInputImplementation implements IQuickInputService {
 
     @inject(VSCodeContextKeyService)
     protected readonly contextKeyService: VSCodeContextKeyService;
+    protected contextKey: IContextKey;
 
     protected container: HTMLElement;
     private quickInputList: List<unknown>;
@@ -100,7 +102,7 @@ export class MonacoQuickInputImplementation implements IQuickInputService {
 
     setContextKey(key: string | undefined): void {
         if (key) {
-            this.contextKeyService.createKey<string>(key, undefined);
+            this.contextKey = this.contextKeyService.createKey<string>(key, undefined);
         }
     }
 
@@ -177,6 +179,9 @@ export class MonacoQuickInputImplementation implements IQuickInputService {
 
     private initController(): void {
         this.controller = new QuickInputController(this.getOptions());
+        this.setContextKey('inQuickOpen');
+        this.onShow(() => { this.contextKey.set(true); });
+        this.onHide(() => { this.contextKey.set(false); });
         this.updateLayout();
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Context Key ""inQuickOpen"" exists in vscode and its value (true or false) reflects whether the Quick Open, AKA Quick Input, is currently open/visible or not.

This context key can be useful in Theia too, e.g. it can be used in the "when" clause of commands registered by vscode extensions, or set programmatically whenever it's useful to know the state of the Quick Open UI.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I have provided a test in the browser suite. Confirm that CI passes.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
