### PR TITLE
search-in-workspace: IncludeInputBox contextKey typo

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -652,8 +652,8 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         </div>;
     }
 
-    protected handleFocusIncludesInputBox = () => this.contextKeyService.setPatternExcludesInputBoxFocus(true);
-    protected handleBlurIncludesInputBox = () => this.contextKeyService.setPatternExcludesInputBoxFocus(false);
+    protected handleFocusIncludesInputBox = () => this.contextKeyService.setPatternIncludesInputBoxFocus(true);
+    protected handleBlurIncludesInputBox = () => this.contextKeyService.setPatternIncludesInputBoxFocus(false);
 
     protected handleFocusExcludesInputBox = () => this.contextKeyService.setPatternExcludesInputBoxFocus(true);
     protected handleBlurExcludesInputBox = () => this.contextKeyService.setPatternExcludesInputBoxFocus(false);


### PR DESCRIPTION
#### What it does
This commit fixes a typo where the `handleFocusIncludesInputBox` called the `setPatternExcludesInputBoxFocus` instead of the `setPatternIncludesInputBoxFocus`

#### How to test
You can test this by calling a command restricted by the context-key. You can do this by modifying the keybindings.
1. Load Theia in Browser
2. Open `keymaps.json`
3. Add the following 
![image](https://user-images.githubusercontent.com/48699277/230910906-14f2b371-e55f-45ac-96e8-b7cdfe3454ff.png)
4. Using the keybinds while focused in the **exclude** inputbox should call the `About` dialog.
5. Move focus on the **include** inputbox.
6. Check whether the `About` dialog can be opened using the keybinding.

Issue
![IssueContextKeySIW2](https://user-images.githubusercontent.com/48699277/230464459-da6c7c5b-b5f1-4211-bf76-5542e07fb2d4.gif)

Fixed
![FixedContextKeySIW2](https://user-images.githubusercontent.com/48699277/230465376-27399bab-f6f0-4d7b-aa1a-716b343ec82c.gif)


##### Notes
For this test to properly work you need your preferences to have `"window.titleBarStyle": "custom"` as the native menus in electron do not support the `when` clause properly. To avoid this, you can use the browser version.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
