### PR TITLE
Fix quick pick behaviour for dynamic elements

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -557,15 +557,7 @@ class MonacoQuickPick<T extends QuickPickItem> extends MonacoQuickInput implemen
     }
 
     set items(itemList: readonly (T | QuickPickSeparator)[]) {
-        // We need to store and apply the currently selected active items.
-        // Since monaco compares these items by reference equality, creating new wrapped items will unmark any active items.
-        // Assigning the `activeItems` again will restore all active items even after the items array has changed.
-        // See also the `findMonacoItemReferences` method.
-        const active = this.activeItems;
         this.wrapped.items = itemList.map(item => QuickPickSeparator.is(item) ? item : new MonacoQuickPickItem<T>(item, this.keybindingRegistry));
-        if (active.length !== 0) {
-            this.activeItems = active; // If this is done with an empty activeItems array, then it will undo first item focus on quick menus.
-        }
     }
 
     set activeItems(itemList: readonly T[]) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
It fixes https://github.com/eclipse-theia/theia/issues/12383 . When new elements are dynamically added to a quick pick, the first one is selected by default.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Try to create a new branch using the quick pick using `Enter` to pick an element from the quick pick list instead of using the mouse click.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
