### PR TITLE
fixed  #12392. Tab indices now updated

### DIFF
--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -253,6 +253,7 @@ export class TabsMainImpl implements TabsMain, Disposable {
     private onTabClosed(tabInfo: TabInfo, title: Title<Widget>): void {
         tabInfo.group.tabs.splice(tabInfo.tabIndex, 1);
         this.tabInfoLookup.delete(title);
+        this.updateTabIndices(this.applicationShell.getTabBarFor(title.owner));
         this.proxy.$acceptTabOperation({
             kind: TabModelOperationKind.TAB_CLOSE,
             index: tabInfo.tabIndex,
@@ -267,6 +268,7 @@ export class TabsMainImpl implements TabsMain, Disposable {
         const tabDto = this.createTabDto(args.title, tabInfo.group.groupId);
         tabInfo.group.tabs.splice(args.fromIndex, 1);
         tabInfo.group.tabs.splice(args.toIndex, 0, tabDto);
+        this.updateTabIndices(tabBar);
         this.proxy.$acceptTabOperation({
             kind: TabModelOperationKind.TAB_MOVE,
             index: args.toIndex,
@@ -288,6 +290,17 @@ export class TabsMainImpl implements TabsMain, Disposable {
     // #region Messages received from Ext Host
     $moveTab(tabId: string, index: number, viewColumn: number, preserveFocus?: boolean): void {
         return;
+    }
+
+    updateTabIndices(tabBar?: TabBar<Widget>): void {
+        if (tabBar) {
+            tabBar.titles.forEach((title, index) => {
+                const tabInfo = this.tabInfoLookup.get(title);
+                if (tabInfo) {
+                    tabInfo.tabIndex = index;
+                }
+            });
+        }
     }
 
     async $closeTab(tabIds: string[], preserveFocus?: boolean): Promise<boolean> {

--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -292,9 +292,9 @@ export class TabsMainImpl implements TabsMain, Disposable {
         return;
     }
 
-    updateTabIndices(tabInfo: TabInfo, beginnIndex: number): void {
+    updateTabIndices(tabInfo: TabInfo, beginIndex: number): void {
         for (const tab of this.tabInfoLookup.values()) {
-            if (tab.group === tabInfo.group && tab.tabIndex >= beginnIndex) {
+            if (tab.group === tabInfo.group && tab.tabIndex >= beginIndex) {
                 tab.tabIndex = tab.group.tabs.indexOf(tab.tab);
             }
         }

--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -292,9 +292,9 @@ export class TabsMainImpl implements TabsMain, Disposable {
         return;
     }
 
-    updateTabIndices(tabInfo: TabInfo, beginIndex: number): void {
+    updateTabIndices(tabInfo: TabInfo, startIndex: number): void {
         for (const tab of this.tabInfoLookup.values()) {
-            if (tab.group === tabInfo.group && tab.tabIndex >= beginIndex) {
+            if (tab.group === tabInfo.group && tab.tabIndex >= startIndex) {
                 tab.tabIndex = tab.group.tabs.indexOf(tab.tab);
             }
         }

--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -253,7 +253,7 @@ export class TabsMainImpl implements TabsMain, Disposable {
     private onTabClosed(tabInfo: TabInfo, title: Title<Widget>): void {
         tabInfo.group.tabs.splice(tabInfo.tabIndex, 1);
         this.tabInfoLookup.delete(title);
-        this.updateTabIndices(this.applicationShell.getTabBarFor(title.owner));
+        this.updateTabIndices(tabInfo, tabInfo.tabIndex);
         this.proxy.$acceptTabOperation({
             kind: TabModelOperationKind.TAB_CLOSE,
             index: tabInfo.tabIndex,
@@ -268,7 +268,7 @@ export class TabsMainImpl implements TabsMain, Disposable {
         const tabDto = this.createTabDto(args.title, tabInfo.group.groupId);
         tabInfo.group.tabs.splice(args.fromIndex, 1);
         tabInfo.group.tabs.splice(args.toIndex, 0, tabDto);
-        this.updateTabIndices(tabBar);
+        this.updateTabIndices(tabInfo, args.fromIndex);
         this.proxy.$acceptTabOperation({
             kind: TabModelOperationKind.TAB_MOVE,
             index: args.toIndex,
@@ -292,14 +292,11 @@ export class TabsMainImpl implements TabsMain, Disposable {
         return;
     }
 
-    updateTabIndices(tabBar?: TabBar<Widget>): void {
-        if (tabBar) {
-            tabBar.titles.forEach((title, index) => {
-                const tabInfo = this.tabInfoLookup.get(title);
-                if (tabInfo) {
-                    tabInfo.tabIndex = index;
-                }
-            });
+    updateTabIndices(tabInfo: TabInfo, beginnIndex: number): void {
+        for (const tab of this.tabInfoLookup.values()) {
+            if (tab.group === tabInfo.group && tab.tabIndex >= beginnIndex) {
+                tab.tabIndex = tab.group.tabs.indexOf(tab.tab);
+            }
         }
     }
 


### PR DESCRIPTION
after deleting and moving a tab

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #12392
updates tabs indeces of all tabs in a group when a tab is deleted or moved

#### How to test
as described in the issue
1. Open 4 editors
2. Close the second-to-last (third) tab
3. Close the last tab
4. no execption should be thrown anymore

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
