### PR TITLE
In MonacoEditorModel, use value for snapshot

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -550,7 +550,7 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
         }
 
         const contentLength = this.model.getValueLength();
-        const content = this.model.createSnapshot() || this.model.getValue();
+        const content = this.model.getValue();
         try {
             const encoding = this.getEncoding();
             const version = this.resourceVersion;
@@ -656,7 +656,7 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
     }
 
     createSnapshot(preserveBOM?: boolean): ITextSnapshot {
-        return this.model.createSnapshot(preserveBOM);
+        return { read: () => this.model.getValue(undefined, preserveBOM) };
     }
 
     applySnapshot(snapshot: Saveable.Snapshot): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #12406 by changing the snapshotting logic in `MonacoEditorModel`

It turns out that the brand of `ITextModel` that we use in Monaco has this size restriction on its snapshots:

https://github.com/microsoft/vscode/blob/7bd1368261677fa160c28ff043c444d905331ee7/src/vs/editor/common/model/textModel.ts#L155-L157

That means that in general, we want to use the value rather than delegating to that implementation of `createSnapshot`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Create a large file (> 64kb)
2. Use save as to create a copy of that file.
3. Check that the new file has the same size and content as the original.
4. Create a large untitled file.
5. Use save (as) to save it.
6. Ensure that the new file has the same size and content as its untitled source.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
