### PR TITLE
Enable workspace file extension customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 <a name="breaking_changes_1.40.0">[Breaking Changes:](#breaking_changes_1.40.0)</a>
 
+- [workspace] split `CommonWorkspaceUtils` into `WorkspaceFileService` and `UntitledWorkspaceService` [#12420](https://github.com/eclipse-theia/theia/pull/12420)
 
 ## v1.39.0 - 06/29/2023
 

--- a/packages/plugin-ext/src/main/node/plugins-key-value-storage.spec.ts
+++ b/packages/plugin-ext/src/main/node/plugins-key-value-storage.spec.ts
@@ -27,6 +27,7 @@ import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { MockEnvVariablesServerImpl } from '@theia/core/lib/browser/test/mock-env-variables-server';
 import { FileSystemLocking, FileUri } from '@theia/core/lib/node';
 import { FileSystemLockingImpl } from '@theia/core/lib/node/filesystem-locking';
+import { UntitledWorkspaceService } from '@theia/workspace/lib/common/untitled-workspace-service';
 import * as temp from 'temp';
 
 const GlobalStorageKind = undefined;
@@ -39,6 +40,7 @@ describe('Plugins Key Value Storage', () => {
         container = new Container();
         container.bind(PluginsKeyValueStorage).toSelf().inSingletonScope();
         container.bind(PluginCliContribution).toSelf().inSingletonScope();
+        container.bind(UntitledWorkspaceService).toSelf().inSingletonScope();
         container.bind(FileSystemLocking).to(FileSystemLockingImpl).inSingletonScope();
         container.bind(EnvVariablesServer).toConstantValue(new MockEnvVariablesServerImpl(FileUri.create(temp.track().mkdirSync())));
         container.bind(PluginPathsService).to(PluginPathsServiceImpl).inSingletonScope();

--- a/packages/plugin-ext/src/main/node/plugins-key-value-storage.spec.ts
+++ b/packages/plugin-ext/src/main/node/plugins-key-value-storage.spec.ts
@@ -27,6 +27,7 @@ import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { MockEnvVariablesServerImpl } from '@theia/core/lib/browser/test/mock-env-variables-server';
 import { FileSystemLocking, FileUri } from '@theia/core/lib/node';
 import { FileSystemLockingImpl } from '@theia/core/lib/node/filesystem-locking';
+import { WorkspaceFileService } from '@theia/workspace/lib/common';
 import { UntitledWorkspaceService } from '@theia/workspace/lib/common/untitled-workspace-service';
 import * as temp from 'temp';
 
@@ -41,6 +42,7 @@ describe('Plugins Key Value Storage', () => {
         container.bind(PluginsKeyValueStorage).toSelf().inSingletonScope();
         container.bind(PluginCliContribution).toSelf().inSingletonScope();
         container.bind(UntitledWorkspaceService).toSelf().inSingletonScope();
+        container.bind(WorkspaceFileService).toSelf().inSingletonScope();
         container.bind(FileSystemLocking).to(FileSystemLockingImpl).inSingletonScope();
         container.bind(EnvVariablesServer).toConstantValue(new MockEnvVariablesServerImpl(FileUri.create(temp.track().mkdirSync())));
         container.bind(PluginPathsService).to(PluginPathsServiceImpl).inSingletonScope();

--- a/packages/preferences/src/browser/preferences-monaco-contribution.ts
+++ b/packages/preferences/src/browser/preferences-monaco-contribution.ts
@@ -23,8 +23,5 @@ monaco.languages.register({
     ],
     'filenames': [
         'settings.json'
-    ],
-    'extensions': [
-        '.theia-workspace'
     ]
 });

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/core": "1.39.0",
     "@theia/filesystem": "1.39.0",
+    "@theia/monaco-editor-core": "1.72.3",
     "@theia/variable-resolver": "1.39.0",
     "jsonc-parser": "^2.2.0",
     "valid-filename": "^2.0.1"

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -23,7 +23,7 @@ import URI from '@theia/core/lib/common/uri';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { nls, Path } from '@theia/core/lib/common';
-import { CommonWorkspaceUtils } from '../common/utils';
+import { UntitledWorkspaceService } from '../common/untitled-workspace-service';
 
 interface RecentlyOpenedPick extends QuickPickItem {
     resource?: URI
@@ -40,7 +40,7 @@ export class QuickOpenWorkspace {
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(WorkspacePreferences) protected preferences: WorkspacePreferences;
     @inject(EnvVariablesServer) protected readonly envServer: EnvVariablesServer;
-    @inject(CommonWorkspaceUtils) protected workspaceUtils: CommonWorkspaceUtils;
+    @inject(UntitledWorkspaceService) protected untitledWorkspaceService: UntitledWorkspaceService;
 
     protected readonly removeRecentWorkspaceButton: QuickInputButton = {
         iconClass: 'codicon-remove-close',
@@ -65,7 +65,7 @@ export class QuickOpenWorkspace {
             try {
                 stat = await this.fileService.resolve(uri);
             } catch { }
-            if (this.workspaceUtils.isUntitledWorkspace(uri) || !stat) {
+            if (this.untitledWorkspaceService.isUntitledWorkspace(uri) || !stat) {
                 continue; // skip the temporary workspace files or an undefined stat.
             }
             const icon = this.labelProvider.getIcon(stat);

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -378,7 +378,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
             title: WorkspaceCommands.OPEN_WORKSPACE.dialogLabel,
             canSelectFiles: true,
             canSelectFolders: false,
-            filters: WorkspaceFrontendContribution.DEFAULT_FILE_FILTER
+            filters: this.getWorkspaceDialogFileFilters()
         };
         const [rootStat] = await this.workspaceService.roots;
         const workspaceFileUri = await this.fileDialogService.showOpenDialog(props, rootStat);
@@ -412,7 +412,8 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
                 const displayName = selected.displayName;
                 const extensions = this.workspaceFileService.getWorkspaceFileExtensions(true);
                 if (!extensions.some(ext => displayName.endsWith(ext))) {
-                    selected = selected.parent.resolve(`${displayName}${extensions[0]}`);
+                    const defaultExtension = extensions[this.workspaceFileService.defaultFileTypeIndex];
+                    selected = selected.parent.resolve(`${displayName}${defaultExtension}`);
                 }
                 exist = await this.fileService.exists(selected);
                 if (exist) {
@@ -509,7 +510,7 @@ export namespace WorkspaceFrontendContribution {
     /**
      * File filter for all Theia and VS Code workspace file types.
      *
-     * @deprecated Since 1.38.0 Use `WorkspaceFrontendContribution#getWorkspaceDialogFileFilters` instead.
+     * @deprecated Since 1.39.0 Use `WorkspaceFrontendContribution#getWorkspaceDialogFileFilters` instead.
      */
     export const DEFAULT_FILE_FILTER: FileDialogTreeFilters = {
         'Theia Workspace (*.theia-workspace)': [THEIA_EXT],

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -39,7 +39,6 @@ import { FileStat } from '@theia/filesystem/lib/common/files';
 import { UntitledWorkspaceExitDialog } from './untitled-workspace-exit-dialog';
 import { FilesystemSaveResourceService } from '@theia/filesystem/lib/browser/filesystem-save-resource-service';
 import { StopReason } from '@theia/core/lib/common/frontend-application-state';
-import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import * as monaco from '@theia/monaco-editor-core';
 
 export enum WorkspaceStates {

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -30,7 +30,7 @@ import {
 import { StorageService } from '@theia/core/lib/browser/storage-service';
 import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
 import { VariableContribution } from '@theia/variable-resolver/lib/browser';
-import { WorkspaceServer, workspacePath, CommonWorkspaceUtils } from '../common';
+import { WorkspaceServer, workspacePath, UntitledWorkspaceService, WorkspaceFileService } from '../common';
 import { WorkspaceFrontendContribution } from './workspace-frontend-contribution';
 import { WorkspaceService } from './workspace-service';
 import { WorkspaceCommandContribution, FileMenuContribution, EditMenuContribution } from './workspace-commands';
@@ -104,7 +104,8 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(QuickOpenWorkspace).toSelf().inSingletonScope();
 
     bind(WorkspaceUtils).toSelf().inSingletonScope();
-    bind(CommonWorkspaceUtils).toSelf().inSingletonScope();
+    bind(WorkspaceFileService).toSelf().inSingletonScope();
+    bind(UntitledWorkspaceService).toSelf().inSingletonScope();
 
     bind(WorkspaceSchemaUpdater).toSelf().inSingletonScope();
     bind(JsonSchemaContribution).toService(WorkspaceSchemaUpdater);

--- a/packages/workspace/src/browser/workspace-schema-updater.ts
+++ b/packages/workspace/src/browser/workspace-schema-updater.ts
@@ -20,6 +20,7 @@ import { InMemoryResources, isArray, isObject } from '@theia/core/lib/common';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import URI from '@theia/core/lib/common/uri';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { WorkspaceFileService } from '../common';
 
 export interface SchemaUpdateMessage {
     key: string,
@@ -39,6 +40,7 @@ export class WorkspaceSchemaUpdater implements JsonSchemaContribution {
     protected safeToHandleQueue = new Deferred();
 
     @inject(InMemoryResources) protected readonly inmemoryResources: InMemoryResources;
+    @inject(WorkspaceFileService) protected readonly workspaceFileService: WorkspaceFileService;
 
     @postConstruct()
     protected init(): void {
@@ -48,7 +50,7 @@ export class WorkspaceSchemaUpdater implements JsonSchemaContribution {
 
     registerSchemas(context: JsonSchemaRegisterContext): void {
         context.registerSchema({
-            fileMatch: ['*.theia-workspace', '*.code-workspace'],
+            fileMatch: this.workspaceFileService.getWorkspaceFileExtensions(true),
             url: this.uri.toString()
         });
     }

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
-import { WorkspaceServer, CommonWorkspaceUtils } from '../common';
+import { WorkspaceServer, UntitledWorkspaceService, WorkspaceFileService } from '../common';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { DEFAULT_WINDOW_HASH } from '@theia/core/lib/common/window';
 import {
@@ -83,8 +83,11 @@ export class WorkspaceService implements FrontendApplicationContribution {
     @inject(WorkspaceSchemaUpdater)
     protected readonly schemaUpdater: WorkspaceSchemaUpdater;
 
-    @inject(CommonWorkspaceUtils)
-    protected readonly utils: CommonWorkspaceUtils;
+    @inject(UntitledWorkspaceService)
+    protected readonly untitledWorkspaceService: UntitledWorkspaceService;
+
+    @inject(WorkspaceFileService)
+    protected readonly workspaceFileService: WorkspaceFileService;
 
     @inject(WindowTitleService)
     protected readonly windowTitleService: WindowTitleService;
@@ -431,7 +434,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
 
     async getUntitledWorkspace(): Promise<URI> {
         const configDirURI = new URI(await this.envVariableServer.getConfigDirUri());
-        return this.utils.getUntitledWorkspaceUri(
+        return this.untitledWorkspaceService.getUntitledWorkspaceUri(
             configDirURI,
             uri => this.fileService.exists(uri).then(exists => !exists),
             () => this.messageService.warn(nls.localize(
@@ -677,15 +680,15 @@ export class WorkspaceService implements FrontendApplicationContribution {
      * Example: We should not try to read the contents of an .exe file.
      */
     protected isWorkspaceFile(candidate: FileStat | URI): boolean {
-        return this.utils.isWorkspaceFile(candidate);
+        return this.workspaceFileService.isWorkspaceFile(candidate);
     }
 
     isUntitledWorkspace(candidate?: URI): boolean {
-        return this.utils.isUntitledWorkspace(candidate);
+        return this.untitledWorkspaceService.isUntitledWorkspace(candidate);
     }
 
     async isSafeToReload(withURI?: URI): Promise<boolean> {
-        return !withURI || !this.utils.isUntitledWorkspace(withURI) || new URI(await this.getDefaultWorkspaceUri()).isEqual(withURI);
+        return !withURI || !this.untitledWorkspaceService.isUntitledWorkspace(withURI) || new URI(await this.getDefaultWorkspaceUri()).isEqual(withURI);
     }
 
     /**

--- a/packages/workspace/src/common/index.ts
+++ b/packages/workspace/src/common/index.ts
@@ -15,4 +15,5 @@
 // *****************************************************************************
 
 export * from './workspace-protocol';
-export * from './utils';
+export * from './workspace-file-service';
+export * from './untitled-workspace-service';

--- a/packages/workspace/src/common/untitled-workspace-service.ts
+++ b/packages/workspace/src/common/untitled-workspace-service.ts
@@ -31,12 +31,13 @@ export class UntitledWorkspaceService {
 
     async getUntitledWorkspaceUri(configDirUri: URI, isAcceptable: (candidate: URI) => MaybePromise<boolean>, warnOnHits?: () => unknown): Promise<URI> {
         const parentDir = configDirUri.resolve('workspaces');
-        const workspaceExtension = this.workspaceFileService.getWorkspaceFileExtensions()[0];
+        const workspaceExtensions = this.workspaceFileService.getWorkspaceFileExtensions();
+        const defaultFileExtension = workspaceExtensions[this.workspaceFileService.defaultFileTypeIndex];
         let uri;
         let attempts = 0;
         do {
             attempts++;
-            uri = parentDir.resolve(`Untitled-${Math.round(Math.random() * 1000)}.${workspaceExtension}`);
+            uri = parentDir.resolve(`Untitled-${Math.round(Math.random() * 1000)}.${defaultFileExtension}`);
             if (attempts === 10) {
                 warnOnHits?.();
             }

--- a/packages/workspace/src/common/workspace-file-service.ts
+++ b/packages/workspace/src/common/workspace-file-service.ts
@@ -1,0 +1,63 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { URI } from '@theia/core';
+import { injectable } from '@theia/core/shared/inversify';
+import { FileStat } from '@theia/filesystem/lib/common/files';
+
+export interface WorkspaceFileType {
+    extension: string
+    name: string
+}
+
+/**
+ * @deprecated Since 1.38.0. Use `WorkspaceFileService#getWorkspaceFileTypes` instead.
+ */
+export const THEIA_EXT = 'theia-workspace';
+export const VSCODE_EXT = 'code-workspace';
+
+@injectable()
+export class WorkspaceFileService {
+
+    /**
+     * Check if the file should be considered as a workspace file.
+     *
+     * Example: We should not try to read the contents of an .exe file.
+     */
+    isWorkspaceFile(candidate: FileStat | URI): boolean {
+        const uri = FileStat.is(candidate) ? candidate.resource : candidate;
+        const extensions = this.getWorkspaceFileTypes().map(type => `.${type.extension}`);
+        return extensions.includes(uri.path.ext);
+    }
+
+    getWorkspaceFileTypes(): WorkspaceFileType[] {
+        return [
+            {
+                name: 'Theia',
+                extension: THEIA_EXT
+            },
+            {
+                name: 'Visual Studio Code',
+                extension: VSCODE_EXT
+            }
+        ];
+    }
+
+    getWorkspaceFileExtensions(dot?: boolean): string[] {
+        return this.getWorkspaceFileTypes().map(type => dot ? `.${type.extension}` : type.extension);
+    }
+
+}

--- a/packages/workspace/src/common/workspace-file-service.ts
+++ b/packages/workspace/src/common/workspace-file-service.ts
@@ -24,13 +24,22 @@ export interface WorkspaceFileType {
 }
 
 /**
- * @deprecated Since 1.38.0. Use `WorkspaceFileService#getWorkspaceFileTypes` instead.
+ * @deprecated Since 1.39.0. Use `WorkspaceFileService#getWorkspaceFileTypes` instead.
  */
 export const THEIA_EXT = 'theia-workspace';
+/**
+ * @deprecated Since 1.39.0. Use `WorkspaceFileService#getWorkspaceFileTypes` instead.
+ */
 export const VSCODE_EXT = 'code-workspace';
 
 @injectable()
 export class WorkspaceFileService {
+
+    protected _defaultFileTypeIndex = 0;
+
+    get defaultFileTypeIndex(): number {
+        return this._defaultFileTypeIndex;
+    }
 
     /**
      * Check if the file should be considered as a workspace file.
@@ -39,7 +48,7 @@ export class WorkspaceFileService {
      */
     isWorkspaceFile(candidate: FileStat | URI): boolean {
         const uri = FileStat.is(candidate) ? candidate.resource : candidate;
-        const extensions = this.getWorkspaceFileTypes().map(type => `.${type.extension}`);
+        const extensions = this.getWorkspaceFileExtensions(true);
         return extensions.includes(uri.path.ext);
     }
 

--- a/packages/workspace/src/node/default-workspace-server.spec.ts
+++ b/packages/workspace/src/node/default-workspace-server.spec.ts
@@ -19,7 +19,7 @@ import { MockEnvVariablesServerImpl } from '@theia/core/lib/browser/test/mock-en
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node';
-import { CommonWorkspaceUtils } from '../common';
+import { WorkspaceFileService, UntitledWorkspaceService } from '../common';
 import { DefaultWorkspaceServer, WorkspaceCliContribution } from './default-workspace-server';
 import { expect } from 'chai';
 import * as temp from 'temp';
@@ -41,8 +41,9 @@ describe('DefaultWorkspaceServer', function (): void {
             // create a container with the necessary bindings for the DefaultWorkspaceServer
             const container = new Container();
             container.bind(WorkspaceCliContribution).toSelf().inSingletonScope();
-            container.bind(CommonWorkspaceUtils).toSelf().inSingletonScope();
-            container.bind(DefaultWorkspaceServer).toSelf().inSingletonScope();
+            container.bind(WorkspaceFileService).toSelf().inSingletonScope();
+            container.bind(WorkspaceFileService).toSelf().inSingletonScope();
+            container.bind(UntitledWorkspaceService).toSelf().inSingletonScope();
             container.bind(EnvVariablesServer).toConstantValue(new MockEnvVariablesServerImpl(tmpConfigDir));
 
             workspaceServer = container.get(DefaultWorkspaceServer);

--- a/packages/workspace/src/node/default-workspace-server.spec.ts
+++ b/packages/workspace/src/node/default-workspace-server.spec.ts
@@ -41,7 +41,7 @@ describe('DefaultWorkspaceServer', function (): void {
             // create a container with the necessary bindings for the DefaultWorkspaceServer
             const container = new Container();
             container.bind(WorkspaceCliContribution).toSelf().inSingletonScope();
-            container.bind(WorkspaceFileService).toSelf().inSingletonScope();
+            container.bind(DefaultWorkspaceServer).toSelf().inSingletonScope();
             container.bind(WorkspaceFileService).toSelf().inSingletonScope();
             container.bind(UntitledWorkspaceService).toSelf().inSingletonScope();
             container.bind(EnvVariablesServer).toConstantValue(new MockEnvVariablesServerImpl(tmpConfigDir));

--- a/packages/workspace/src/node/workspace-backend-module.ts
+++ b/packages/workspace/src/node/workspace-backend-module.ts
@@ -16,7 +16,7 @@
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common';
-import { WorkspaceServer, workspacePath, CommonWorkspaceUtils } from '../common';
+import { WorkspaceServer, workspacePath, UntitledWorkspaceService, WorkspaceFileService } from '../common';
 import { DefaultWorkspaceServer, WorkspaceCliContribution } from './default-workspace-server';
 import { CliContribution } from '@theia/core/lib/node/cli';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
@@ -27,7 +27,8 @@ export default new ContainerModule(bind => {
     bind(DefaultWorkspaceServer).toSelf().inSingletonScope();
     bind(WorkspaceServer).toService(DefaultWorkspaceServer);
     bind(BackendApplicationContribution).toService(WorkspaceServer);
-    bind(CommonWorkspaceUtils).toSelf().inSingletonScope();
+    bind(UntitledWorkspaceService).toSelf().inSingletonScope();
+    bind(WorkspaceFileService).toSelf().inSingletonScope();
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new RpcConnectionHandler(workspacePath, () =>


### PR DESCRIPTION
#### What it does

As of now, only `.theia-workspace` and `.code-workspace` files are supported when selecting/creating workspace files. This change allows to easily customize the workspace file extension and also to exclude `.code-workspace` files.

#### How to test

1. Change the `WorkspaceFileService#getWorkspaceFileTypes` method to return a different array.
2. Assert that services that interact with workspace files adapt as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
