### PR TITLE
Style: Indent decoration blocked pointer events

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -177,6 +177,7 @@
     position: absolute;
     height: var(--theia-content-line-height);
     border-right: var(--theia-border-width) solid transparent;
+    pointer-events: none;
 }
 
 .theia-tree-node-indent.always,


### PR DESCRIPTION
#### What it does
This commit fixes a small issue where the indent decoration blocked right and left clicks.

Before:
![IndentIssue](https://user-images.githubusercontent.com/48699277/233442635-040fdb49-bad2-4220-af83-4d43457f45fa.gif)

After:
![IndentIssueFixed](https://user-images.githubusercontent.com/48699277/233442667-79867462-30ff-4a49-a01d-d8a01fbd9330.gif)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
