### PR TITLE
[vscode] support TelemetryLogger

### DIFF
--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -46,4 +46,5 @@ export * from './strings';
 export * from './types';
 export { default as URI } from './uri';
 export * from './view-column';
+export * from './telemetry';
 

--- a/packages/core/src/common/objects.ts
+++ b/packages/core/src/common/objects.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { isObject } from './types';
+import { isObject, isUndefined } from './types';
 
 export function deepClone<T>(obj: T): T {
     if (!isObject(obj)) {
@@ -69,4 +69,51 @@ export function notEmpty<T>(arg: T | undefined | null): arg is T {
  */
 export function isEmpty(arg: Object): boolean {
     return Object.keys(arg).length === 0 && arg.constructor === Object;
+}
+
+// copied and modified from https://github.com/microsoft/vscode/blob/1.76.0/src/vs/base/common/objects.ts#L45-L83
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function cloneAndChange(obj: any, changer: (orig: any) => any, seen: Set<any>): any {
+    // impossible to clone an undefined or null object
+    // eslint-disable-next-line no-null/no-null
+    if (isUndefined(obj) || obj === null) {
+        return obj;
+    }
+
+    const changed = changer(obj);
+    if (!isUndefined(changed)) {
+        return changed;
+    }
+
+    if (Array.isArray(obj)) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const r1: any[] = [];
+        for (const e of obj) {
+            r1.push(cloneAndChange(e, changer, seen));
+        }
+        return r1;
+    }
+
+    if (isObject(obj)) {
+        if (seen.has(obj)) {
+            throw new Error('Cannot clone recursive data-structure');
+        }
+        seen.add(obj);
+        const r2 = {};
+        for (const i2 in obj) {
+            if (_hasOwnProperty.call(obj, i2)) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (r2 as any)[i2] = cloneAndChange(obj[i2], changer, seen);
+            }
+        }
+        seen.delete(obj);
+        return r2;
+    }
+
+    return obj;
 }

--- a/packages/core/src/common/telemetry.ts
+++ b/packages/core/src/common/telemetry.ts
@@ -1,0 +1,45 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export class TelemetryTrustedValue<T> {
+    readonly value: T;
+
+    constructor(value: T) {
+        this.value = value;
+    }
+}
+
+export interface TelemetryLogger {
+    readonly sender: TelemetrySender;
+    readonly options: TelemetryLoggerOptions | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logUsage(eventName: string, data?: Record<string, any | TelemetryTrustedValue<any>>): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logError(eventNameOrException: string | Error, data?: Record<string, any | TelemetryTrustedValue<any>>): void;
+
+    dispose(): void;
+}
+
+interface TelemetrySender {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sendEventData(eventName: string, data?: Record<string, any>): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sendErrorData(error: Error, data?: Record<string, any>): void;
+    flush?(): void | Thenable<void>;
+}
+
+interface TelemetryLoggerOptions {
+}

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2079,6 +2079,12 @@ export interface TabsMain {
     $closeGroup(groupIds: number[], preserveFocus?: boolean): Promise<boolean>;
 }
 
+export interface TelemetryMain {
+}
+
+export interface TelemetryExt {
+}
+
 // endregion
 
 export const PLUGIN_RPC_CONTEXT = {
@@ -2116,6 +2122,7 @@ export const PLUGIN_RPC_CONTEXT = {
     THEMING_MAIN: <ProxyIdentifier<ThemingMain>>createProxyIdentifier<ThemingMain>('ThemingMain'),
     COMMENTS_MAIN: <ProxyIdentifier<CommentsMain>>createProxyIdentifier<CommentsMain>('CommentsMain'),
     TABS_MAIN: <ProxyIdentifier<TabsMain>>createProxyIdentifier<TabsMain>('TabsMain'),
+    TELEMETRY_MAIN: <ProxyIdentifier<TelemetryMain>>createProxyIdentifier<TelemetryMain>('TelemetryMain'),
     LOCALIZATION_MAIN: <ProxyIdentifier<LocalizationMain>>createProxyIdentifier<LocalizationMain>('LocalizationMain'),
 };
 
@@ -2151,7 +2158,8 @@ export const MAIN_RPC_CONTEXT = {
     TIMELINE_EXT: createProxyIdentifier<TimelineExt>('TimeLineExt'),
     THEMING_EXT: createProxyIdentifier<ThemingExt>('ThemingExt'),
     COMMENTS_EXT: createProxyIdentifier<CommentsExt>('CommentsExt'),
-    TABS_EXT: createProxyIdentifier<TabsExt>('TabsExt')
+    TABS_EXT: createProxyIdentifier<TabsExt>('TabsExt'),
+    TELEMETRY_EXT: createProxyIdentifier<TelemetryExt>('TelemetryExt)')
 };
 
 export interface TasksExt {

--- a/packages/plugin-ext/src/plugin/env.ts
+++ b/packages/plugin-ext/src/plugin/env.ts
@@ -14,7 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Emitter, Event } from '@theia/core/lib/common/event';
 import * as theia from '@theia/plugin';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { EnvMain, PLUGIN_RPC_CONTEXT } from '../common/plugin-api-rpc';
@@ -31,16 +30,12 @@ export abstract class EnvExtImpl {
     private envMachineId: string;
     private envSessionId: string;
     private host: string;
-    private _isTelemetryEnabled: boolean;
     private _remoteName: string | undefined;
-    private onDidChangeTelemetryEnabledEmitter = new Emitter<boolean>();
 
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.ENV_MAIN);
         this.envSessionId = v4();
         this.envMachineId = v4();
-        // we don't support telemetry at the moment
-        this._isTelemetryEnabled = false;
         this._remoteName = undefined;
     }
 
@@ -99,14 +94,6 @@ export abstract class EnvExtImpl {
 
     get appHost(): string {
         return this.host;
-    }
-
-    get isTelemetryEnabled(): boolean {
-        return this._isTelemetryEnabled;
-    }
-
-    get onDidChangeTelemetryEnabled(): Event<boolean> {
-        return this.onDidChangeTelemetryEnabledEmitter.event;
     }
 
     get remoteName(): string | undefined {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -163,6 +163,7 @@ import {
     InlayHint,
     InlayHintKind,
     InlayHintLabelPart,
+    TelemetryTrustedValue,
     NotebookCell,
     NotebookCellKind,
     NotebookCellStatusBarAlignment,
@@ -236,6 +237,7 @@ import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { FilePermission } from '@theia/filesystem/lib/common/files';
 import { TabsExtImpl } from './tabs';
 import { LocalizationExtImpl } from './localization-ext';
+import { TelemetryExtImpl } from './telemetry-ext';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -277,6 +279,7 @@ export function createAPIFactory(
     const tabsExt = rpc.set(MAIN_RPC_CONTEXT.TABS_EXT, new TabsExtImpl(rpc));
     const customEditorExt = rpc.set(MAIN_RPC_CONTEXT.CUSTOM_EDITORS_EXT, new CustomEditorsExtImpl(rpc, documents, webviewExt, workspaceExt));
     const webviewViewsExt = rpc.set(MAIN_RPC_CONTEXT.WEBVIEW_VIEWS_EXT, new WebviewViewsExtImpl(rpc, webviewExt));
+    const telemetryExt = rpc.set(MAIN_RPC_CONTEXT.TELEMETRY_EXT, new TelemetryExtImpl());
     rpc.set(MAIN_RPC_CONTEXT.DEBUG_EXT, debugExt);
 
     return function (plugin: InternalPlugin): typeof theia {
@@ -724,9 +727,12 @@ export function createAPIFactory(
             get appHost(): string { return envExt.appHost; },
             get language(): string { return envExt.language; },
             get isNewAppInstall(): boolean { return envExt.isNewAppInstall; },
-            get isTelemetryEnabled(): boolean { return envExt.isTelemetryEnabled; },
+            get isTelemetryEnabled(): boolean { return telemetryExt.isTelemetryEnabled; },
             get onDidChangeTelemetryEnabled(): theia.Event<boolean> {
-                return envExt.onDidChangeTelemetryEnabled;
+                return telemetryExt.onDidChangeTelemetryEnabled;
+            },
+            createTelemetryLogger(sender: theia.TelemetrySender, options?: theia.TelemetryLoggerOptions): theia.TelemetryLogger {
+                return telemetryExt.createTelemetryLogger(sender, options);
             },
             get remoteName(): string | undefined { return envExt.remoteName; },
             get machineId(): string { return envExt.machineId; },
@@ -1307,6 +1313,7 @@ export function createAPIFactory(
             InlayHint,
             InlayHintKind,
             InlayHintLabelPart,
+            TelemetryTrustedValue,
             NotebookCellData,
             NotebookCellKind,
             NotebookCellOutput,

--- a/packages/plugin-ext/src/plugin/telemetry-ext.ts
+++ b/packages/plugin-ext/src/plugin/telemetry-ext.ts
@@ -1,0 +1,299 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+import { Event, Emitter } from '@theia/core/lib/common/event';
+import { cloneAndChange } from '@theia/core';
+import { mixin } from '../common/types';
+import { TelemetryTrustedValue, TelemetryLoggerOptions } from './types-impl';
+
+export class TelemetryExtImpl {
+
+    _isTelemetryEnabled: boolean = false; // telemetry not activated by default
+    private readonly onDidChangeTelemetryEnabledEmitter = new Emitter<boolean>();
+    readonly onDidChangeTelemetryEnabled: Event<boolean> = this.onDidChangeTelemetryEnabledEmitter.event;
+
+    get isTelemetryEnabled(): boolean {
+        return this._isTelemetryEnabled;
+    }
+
+    set isTelemetryEnabled(isTelemetryEnabled: boolean) {
+        if (this._isTelemetryEnabled !== isTelemetryEnabled) {
+            this._isTelemetryEnabled = isTelemetryEnabled;
+            this.onDidChangeTelemetryEnabledEmitter.fire(this._isTelemetryEnabled);
+        }
+    }
+
+    createTelemetryLogger(sender: TelemetrySender, options?: TelemetryLoggerOptions | undefined): TelemetryLogger {
+        const logger = new TelemetryLogger(sender, this._isTelemetryEnabled, options);
+        this.onDidChangeTelemetryEnabled(isEnabled => {
+            logger.telemetryEnabled = isEnabled;
+        });
+        return logger;
+    }
+}
+
+export class TelemetryLogger {
+    private sender: TelemetrySender | undefined;
+    readonly options: TelemetryLoggerOptions | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly commonProperties: Record<string, any>;
+    telemetryEnabled: boolean;
+
+    private readonly onDidChangeEnableStatesEmitter: Emitter<TelemetryLogger> = new Emitter();
+    readonly onDidChangeEnableStates: Event<TelemetryLogger> = this.onDidChangeEnableStatesEmitter.event;
+    private _isUsageEnabled: boolean;
+    private _isErrorsEnabled: boolean;
+
+    constructor(sender: TelemetrySender, telemetryEnabled: boolean, options?: TelemetryLoggerOptions) {
+        this.sender = sender;
+        this.options = options;
+        this.commonProperties = this.getCommonProperties();
+        this._isErrorsEnabled = true;
+        this._isUsageEnabled = true;
+        this.telemetryEnabled = telemetryEnabled;
+    }
+
+    get isUsageEnabled(): boolean {
+        return this._isUsageEnabled;
+    }
+
+    set isUsageEnabled(isUsageEnabled: boolean) {
+        if (this._isUsageEnabled !== isUsageEnabled) {
+            this._isUsageEnabled = isUsageEnabled;
+            this.onDidChangeEnableStatesEmitter.fire(this);
+        }
+    }
+
+    get isErrorsEnabled(): boolean {
+        return this._isErrorsEnabled;
+    }
+
+    set isErrorsEnabled(isErrorsEnabled: boolean) {
+        if (this._isErrorsEnabled !== isErrorsEnabled) {
+            this._isErrorsEnabled = isErrorsEnabled;
+            this.onDidChangeEnableStatesEmitter.fire(this);
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logUsage(eventName: string, data?: Record<string, any | TelemetryTrustedValue<any>>): void {
+        if (!this.telemetryEnabled || !this.isUsageEnabled) {
+            return;
+        }
+        this.logEvent(eventName, data);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logError(eventNameOrException: string | Error, data?: Record<string, any | TelemetryTrustedValue<any>>): void {
+        if (!this.telemetryEnabled || !this.isErrorsEnabled || !this.sender) {
+            // no sender available or error shall not be sent
+            return;
+        }
+        if (typeof eventNameOrException === 'string') {
+            this.logEvent(eventNameOrException, data);
+        } else {
+            this.sender.sendErrorData(eventNameOrException, data);
+        }
+    }
+
+    dispose(): void {
+        if (this.sender?.flush) {
+            let tempSender: TelemetrySender | undefined = this.sender;
+            this.sender = undefined;
+            Promise.resolve(tempSender.flush!()).then(tempSender = undefined);
+        } else {
+            this.sender = undefined;
+        }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private logEvent(eventName: string, data?: Record<string, any>): void {
+        // No sender means likely disposed of, we should no-op
+        if (!this.sender) {
+            return;
+        }
+        data = mixInCommonPropsAndCleanData(data || {}, this.options?.additionalCommonProperties, this.options?.ignoreBuiltInCommonProperties ? undefined : this.commonProperties);
+        this.sender?.sendEventData(eventName, data);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private getCommonProperties(): Record<string, any> {
+        return [];
+    }
+}
+
+interface TelemetrySender {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sendEventData(eventName: string, data?: Record<string, any>): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sendErrorData(error: Error, data?: Record<string, any>): void;
+    flush?(): void | Thenable<void>;
+}
+
+// copied and modified from https://github.com/microsoft/vscode/blob/1.76.0/src/vs/workbench/api/common/extHostTelemetry.ts
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mixInCommonPropsAndCleanData(data: Record<string, any>, additionalProperties?: Record<string, any>, commonProperties?: Record<string, any>): Record<string, any> {
+    let updatedData = data.properties ?? data;
+
+    // We don't clean measurements since they are just numbers
+    updatedData = cleanData(updatedData, []);
+
+    if (additionalProperties) {
+        updatedData = mixin(updatedData, additionalProperties);
+    }
+
+    if (commonProperties) {
+        updatedData = mixin(updatedData, commonProperties);
+    }
+
+    if (data.properties) {
+        data.properties = updatedData;
+    } else {
+        data = updatedData;
+    }
+
+    return data;
+}
+
+// copied and modified from https://github.com/microsoft/vscode/blob/1.76.0/src/vs/platform/telemetry/common/telemetryUtils.ts#L321-L442
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Cleans a given stack of possible paths
+ * @param stack The stack to sanitize
+ * @param cleanupPatterns Cleanup patterns to remove from the stack
+ * @returns The cleaned stack
+ */
+function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
+
+    // Fast check to see if it is a file path to avoid doing unnecessary heavy regex work
+    if (!stack || (!stack.includes('/') && !stack.includes('\\'))) {
+        return stack;
+    }
+
+    let updatedStack = stack;
+
+    const cleanUpIndexes: [number, number][] = [];
+    for (const regexp of cleanupPatterns) {
+        while (true) {
+            const result = regexp.exec(stack);
+            if (!result) {
+                break;
+            }
+            cleanUpIndexes.push([result.index, regexp.lastIndex]);
+        }
+    }
+
+    const nodeModulesRegex = /^[\\\/]?(node_modules|node_modules\.asar)[\\\/]/;
+    const fileRegex = /(file:\/\/)?([a-zA-Z]:(\\\\|\\|\/)|(\\\\|\\|\/))?([\w-\._]+(\\\\|\\|\/))+[\w-\._]*/g;
+    let lastIndex = 0;
+    updatedStack = '';
+
+    while (true) {
+        const result = fileRegex.exec(stack);
+        if (!result) {
+            break;
+        }
+
+        // Check to see if the any cleanupIndexes partially overlap with this match
+        const overlappingRange = cleanUpIndexes.some(([start, end]) => result.index < end && start < fileRegex.lastIndex);
+
+        // anonymize user file paths that do not need to be retained or cleaned up.
+        if (!nodeModulesRegex.test(result[0]) && !overlappingRange) {
+            updatedStack += stack.substring(lastIndex, result.index) + '<REDACTED: user-file-path>';
+            lastIndex = fileRegex.lastIndex;
+        }
+    }
+    if (lastIndex < stack.length) {
+        updatedStack += stack.substr(lastIndex);
+    }
+
+    return updatedStack;
+}
+
+/**
+ * Attempts to remove commonly leaked PII
+ * @param property The property which will be removed if it contains user data
+ * @returns The new value for the property
+ */
+function removePropertiesWithPossibleUserInfo(property: string): string {
+    // If for some reason it is undefined we skip it (this shouldn't be possible);
+    if (!property) {
+        return property;
+    }
+
+    const value = property.toLowerCase();
+
+    const userDataRegexes = [
+        { label: 'Google API Key', regex: /AIza[0-9A-Za-z-_]{35}/ },
+        { label: 'Slack Token', regex: /xox[pbar]\-[A-Za-z0-9]/ },
+        { label: 'Generic Secret', regex: /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/ },
+        { label: 'Email', regex: /@[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+/ } // Regex which matches @*.site
+    ];
+
+    // Check for common user data in the telemetry events
+    for (const secretRegex of userDataRegexes) {
+        if (secretRegex.regex.test(value)) {
+            return `<REDACTED: ${secretRegex.label}>`;
+        }
+    }
+
+    return property;
+}
+
+/**
+ * Does a best possible effort to clean a data object from any possible PII.
+ * @param data The data object to clean
+ * @param paths Any additional patterns that should be removed from the data set
+ * @returns A new object with the PII removed
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function cleanData(data: Record<string, any>, cleanUpPatterns: RegExp[]): Record<string, any> {
+    return cloneAndChange(data, value => {
+
+        // If it's a trusted value it means it's okay to skip cleaning so we don't clean it
+        if (value instanceof TelemetryTrustedValue) {
+            return value.value;
+        }
+
+        // We only know how to clean strings
+        if (typeof value === 'string') {
+            let updatedProperty = value.replace(/%20/g, ' ');
+
+            // First we anonymize any possible file paths
+            updatedProperty = anonymizeFilePaths(updatedProperty, cleanUpPatterns);
+
+            // Then we do a simple regex replace with the defined patterns
+            for (const regexp of cleanUpPatterns) {
+                updatedProperty = updatedProperty.replace(regexp, '');
+            }
+
+            // Lastly, remove commonly leaked PII
+            updatedProperty = removePropertiesWithPossibleUserInfo(updatedProperty);
+
+            return updatedProperty;
+        }
+        return undefined;
+    }, new Set());
+}
+

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -3413,6 +3413,54 @@ export class WebviewEditorTabInput {
     constructor(readonly viewType: string) { }
 }
 
+export class TelemetryTrustedValue<T> {
+    readonly value: T;
+
+    constructor(value: T) {
+        this.value = value;
+    }
+}
+
+export class TelemetryLogger {
+    readonly onDidChangeEnableStates: theia.Event<TelemetryLogger>;
+    readonly isUsageEnabled: boolean;
+    readonly isErrorsEnabled: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logUsage(eventName: string, data?: Record<string, any | TelemetryTrustedValue<any>>): void { }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logError(eventNameOrError: string | Error, data?: Record<string, any | TelemetryTrustedValue<any>>): void { }
+    dispose(): void { }
+    constructor(readonly sender: TelemetrySender, readonly options?: TelemetryLoggerOptions) { }
+}
+
+export interface TelemetrySender {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sendEventData(eventName: string, data?: Record<string, any>): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sendErrorData(error: Error, data?: Record<string, any>): void;
+    flush?(): void | Thenable<void>;
+}
+
+export interface TelemetryLoggerOptions {
+    /**
+     * Whether or not you want to avoid having the built-in common properties such as os, extension name, etc injected into the data object.
+     * Defaults to `false` if not defined.
+     */
+    readonly ignoreBuiltInCommonProperties?: boolean;
+
+    /**
+     * Whether or not unhandled errors on the extension host caused by your extension should be logged to your sender.
+     * Defaults to `false` if not defined.
+     */
+    readonly ignoreUnhandledErrors?: boolean;
+
+    /**
+     * Any additional common properties which should be injected into the data object.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly additionalCommonProperties?: Record<string, any>;
+}
+
 export class NotebookEditorTabInput {
     constructor(readonly uri: URI, readonly notebookType: string) { }
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7566,6 +7566,15 @@ export module '@theia/plugin' {
         export const onDidChangeTelemetryEnabled: Event<boolean>;
 
         /**
+         * Creates a new {@link TelemetryLogger telemetry logger}.
+         *
+         * @param sender The telemetry sender that is used by the telemetry logger.
+         * @param options Options for the telemetry logger.
+         * @returns A new telemetry logger
+         */
+        export function createTelemetryLogger(sender: TelemetrySender, options?: TelemetryLoggerOptions): TelemetryLogger;
+
+        /**
          * The name of a remote. Defined by extensions, popular samples are `wsl` for the Windows
          * Subsystem for Linux or `ssh-remote` for remotes using a secure shell.
          *
@@ -14207,6 +14216,144 @@ export module '@theia/plugin' {
          * @returns A promise that resolves to `true` when all tab groups have been closed.
          */
         close(tabGroup: TabGroup | readonly TabGroup[], preserveFocus?: boolean): Thenable<boolean>;
+    }
+
+    /**
+     * A special value wrapper denoting a value that is safe to not clean.
+     * This is to be used when you can guarantee no identifiable information is contained in the value and the cleaning is improperly redacting it.
+     */
+    export class TelemetryTrustedValue<T = any> {
+        readonly value: T;
+
+        constructor(value: T);
+    }
+
+    /**
+     * A telemetry logger which can be used by extensions to log usage and error telemetry.
+     *
+     * A logger wraps around a {@link TelemetrySender sender} but it guarantees that
+     * - user settings to disable or tweak telemetry are respected, and that
+     * - potential sensitive data is removed
+     *
+     * It also enables an "echo UI" that prints whatever data is send and it allows the editor
+     * to forward unhandled errors to the respective extensions.
+     *
+     * To get an instance of a `TelemetryLogger`, use
+     * {@link env.createTelemetryLogger `createTelemetryLogger`}.
+     */
+    export interface TelemetryLogger {
+
+        /**
+         * An {@link Event} which fires when the enablement state of usage or error telemetry changes.
+         */
+        readonly onDidChangeEnableStates: Event<TelemetryLogger>;
+
+        /**
+         * Whether or not usage telemetry is enabled for this logger.
+         */
+        readonly isUsageEnabled: boolean;
+
+        /**
+         * Whether or not error telemetry is enabled for this logger.
+         */
+        readonly isErrorsEnabled: boolean;
+
+        /**
+         * Log a usage event.
+         *
+         * After completing cleaning, telemetry setting checks, and data mix-in calls `TelemetrySender.sendEventData` to log the event.
+         * Automatically supports echoing to extension telemetry output channel.
+         * @param eventName The event name to log
+         * @param data The data to log
+         */
+        logUsage(eventName: string, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+        /**
+         * Log an error event.
+         *
+         * After completing cleaning, telemetry setting checks, and data mix-in calls `TelemetrySender.sendEventData` to log the event. Differs from `logUsage` in that it will log the event if the telemetry setting is Error+.
+         * Automatically supports echoing to extension telemetry output channel.
+         * @param eventName The event name to log
+         * @param data The data to log
+         */
+        logError(eventName: string, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+        /**
+         * Log an error event.
+         *
+         * Calls `TelemetrySender.sendErrorData`. Does cleaning, telemetry checks, and data mix-in.
+         * Automatically supports echoing to extension telemetry output channel.
+         * Will also automatically log any exceptions thrown within the extension host process.
+         * @param error The error object which contains the stack trace cleaned of PII
+         * @param data Additional data to log alongside the stack trace
+         */
+        logError(error: Error, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+        /**
+         * Dispose this object and free resources.
+         */
+        dispose(): void;
+    }
+
+    /**
+     * The telemetry sender is the contract between a telemetry logger and some telemetry service. **Note** that extensions must NOT
+     * call the methods of their sender directly as the logger provides extra guards and cleaning.
+     *
+     * ```js
+     * const sender: vscode.TelemetrySender = {...};
+     * const logger = vscode.env.createTelemetryLogger(sender);
+     *
+     * // GOOD - uses the logger
+     * logger.logUsage('myEvent', { myData: 'myValue' });
+     *
+     * // BAD - uses the sender directly: no data cleansing, ignores user settings, no echoing to the telemetry output channel etc
+     * sender.logEvent('myEvent', { myData: 'myValue' });
+     * ```
+     */
+    export interface TelemetrySender {
+        /**
+         * Function to send event data without a stacktrace. Used within a {@link TelemetryLogger}
+         *
+         * @param eventName The name of the event which you are logging
+         * @param data A serializable key value pair that is being logged
+         */
+        sendEventData(eventName: string, data?: Record<string, any>): void;
+
+        /**
+         * Function to send an error. Used within a {@link TelemetryLogger}
+         *
+         * @param error The error being logged
+         * @param data Any additional data to be collected with the exception
+         */
+        sendErrorData(error: Error, data?: Record<string, any>): void;
+
+        /**
+         * Optional flush function which will give this sender a chance to send any remaining events
+         * as its {@link TelemetryLogger} is being disposed
+         */
+        flush?(): void | Thenable<void>;
+    }
+
+    /**
+     * Options for creating a {@link TelemetryLogger}
+     */
+    export interface TelemetryLoggerOptions {
+        /**
+         * Whether or not you want to avoid having the built-in common properties such as os, extension name, etc injected into the data object.
+         * Defaults to `false` if not defined.
+         */
+        readonly ignoreBuiltInCommonProperties?: boolean;
+
+        /**
+         * Whether or not unhandled errors on the extension host caused by your extension should be logged to your sender.
+         * Defaults to `false` if not defined.
+         */
+        readonly ignoreUnhandledErrors?: boolean;
+
+        /**
+         * Any additional common properties which should be injected into the data object.
+         */
+        readonly additionalCommonProperties?: Record<string, any>;
     }
 
     /**


### PR DESCRIPTION
#### What it does

Fixes #12232 

_Add Telemetry support for extensions._ 
This adds the TelemetryLogger API and some additional types related to the TelemetryLogger. Telemetry is still declared as not enabled, so it won't change anything to the current behavior. However, extensions relying on Telemetry API will be able to run without any issues. As soon as the Telemetry API will be declared as mature enough, it will be possible to enable it with the support of preferences or a command line parameter (to be decided later).
TelemetrySender has no implementation, as this is really depending on the needs and the infrastructure of the extensions. This is basically the same for vscode, where an implementation using Application Insights is provided as an [additional module](https://github.com/microsoft/vscode-extension-telemetry/).

- [x] [IP Check Approved](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/7970)

Contributed on behalf of ST Microelectronics

#### How to test 

Telemetry is still declared as not available according to: https://github.com/eclipsesource/theia/blob/bb71e70f6305b252aa5d663f0f73c1468b884821/packages/plugin-ext/src/plugin/telemetry-ext.ts#L20
So running the following actions won't produce anything until the flag is set to `true`.
1. Install [telemetry-sample ](https://github.com/rschnekenbu/vscode-extension-samples/releases/download/telemetry-sample-0.0.1/telemetry-sample-0.0.1.vsix) extension (forked from vscode extension samples) - [source](https://github.com/rschnekenbu/vscode-extension-samples/tree/telemetry-sample)
2. Trigger the command `Log Telemetry event`. This will result on a notification on the test UI (directly displayed from the extension command before logging) and a log in the console if telemetry is activated. The log in the console is printed by the basic TelemetrySender provided in the sample. The logged data is cleaned as documented in the API (removal based on regex matching email, file path, Google key, etc.)
3. The same can be done with the command `Log Telemetry Exception`

![telemetry-sample](https://user-images.githubusercontent.com/3964263/234110120-9ec9a2a7-6ff1-4b17-b94a-75358c1c5078.gif)

Note: No output is currently produced in the telemetry output channel as it is described in the vscode API. Goal of this task was only to initiate the main implementation. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
