### PR TITLE
[vscode] stub continuous test runs API

### DIFF
--- a/packages/plugin-ext/src/plugin/stubs/tests-api.ts
+++ b/packages/plugin-ext/src/plugin/stubs/tests-api.ts
@@ -27,12 +27,14 @@ export const createRunProfile = (
         token: CancellationToken
     ) => Thenable<void> | void,
     isDefault?: boolean,
-    tag?: theia.TestTag
+    tag?: theia.TestTag,
+    supportsContinuousRun?: boolean
 ) => ({
     label,
     kind,
     isDefault: isDefault ?? false,
     tag,
+    supportsContinuousRun: supportsContinuousRun ?? false,
     runHandler,
     configureHandler: undefined,
     dispose: () => undefined,

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -3115,6 +3115,7 @@ export class TestRunRequest implements theia.TestRunRequest {
         public readonly include: theia.TestItem[] | undefined = undefined,
         public readonly exclude: theia.TestItem[] | undefined = undefined,
         public readonly profile: theia.TestRunProfile | undefined = undefined,
+        public readonly continuous: boolean | undefined = undefined,
     ) { }
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -15573,6 +15573,14 @@ export interface TestRunProfile {
     isDefault: boolean;
 
     /**
+     * Whether this profile supports continuous running of requests. If so,
+     * then {@link TestRunRequest.continuous} may be set to `true`. Defaults
+     * to false.
+     * @stubbed
+     */
+    supportsContinuousRun: boolean;
+
+    /**
      * Associated tag for the profile. If this is set, only {@link TestItem}
      * instances with the same tag will be eligible to execute in this profile.
      * @stubbed
@@ -15593,6 +15601,11 @@ export interface TestRunProfile {
      * {@link TestController.createTestRun} at least once, and all test runs
      * associated with the request should be created before the function returns
      * or the returned promise is resolved.
+     *
+     * If {@link supportsContinuousRun} is set, then {@link TestRunRequest.continuous}
+     * may be `true`. In this case, the profile should observe changes to
+     * source code and create new test runs by calling {@link TestController.createTestRun},
+     * until the cancellation is requested on the `token`.
      *
      * @param request Request information for the test run.
      * @param cancellationToken Token that signals the used asked to abort the
@@ -15653,11 +15666,12 @@ export interface TestController {
      * @param runHandler Function called to start a test run.
      * @param isDefault Whether this is the default action for its kind.
      * @param tag Profile test tag.
+     * @param supportsContinuousRun Whether the profile supports continuous running.
      * @returns An instance of a {@link TestRunProfile}, which is automatically
      * associated with this controller.
      * @stubbed
      */
-    createRunProfile(label: string, kind: TestRunProfileKind, runHandler: (request: TestRunRequest, token: CancellationToken) => Thenable<void> | void, isDefault?: boolean, tag?: TestTag): TestRunProfile;
+    createRunProfile(label: string, kind: TestRunProfileKind, runHandler: (request: TestRunRequest, token: CancellationToken) => Thenable<void> | void, isDefault?: boolean, tag?: TestTag, supportsContinuousRun?: boolean): TestRunProfile;
 
     /**
      * A function provided by the extension that the editor may call to request
@@ -15778,11 +15792,18 @@ export class TestRunRequest {
     readonly profile: TestRunProfile | undefined;
 
     /**
+     * Whether the profile should run continuously as source code changes. Only
+     * relevant for profiles that set {@link TestRunProfile.supportsContinuousRun}.
+     */
+    readonly continuous?: boolean;
+
+    /**
      * @param include Array of specific tests to run, or undefined to run all tests
      * @param exclude An array of tests to exclude from the run.
      * @param profile The run profile used for this request.
+     * @param continuous Whether to run tests continuously as source changes.
      */
-    constructor(include?: readonly TestItem[], exclude?: readonly TestItem[], profile?: TestRunProfile);
+    constructor(include?: readonly TestItem[], exclude?: readonly TestItem[], profile?: TestRunProfile, continuous?: boolean);
 }
 
 /**


### PR DESCRIPTION
#### What it does

Stubs the additional test API introduced with vscode 1.77, such as TestRunRequest.continuous and TestRunProfile.supportsContinuousRun in TestRunProfile

Fixes #12374 

Contributed on behalf of ST Microelectronics

#### How to test 
Of course, as the API is stubbed, there won't be much to test in this PR. However, we can have the results of the API analysis between theia and vscode.
![testRunProfile-stubbed](https://user-images.githubusercontent.com/3964263/234401493-1b68e5e7-f139-4d15-860d-dac5fe86b905.png)
![testRunRequest_impl](https://user-images.githubusercontent.com/3964263/234401524-64ab5f1c-2897-4c66-84bb-266b16a28e95.png)

Also, I provided here a vscode API sample to install to verify that an extension is still working when using this stubbed API and other implemented APIs. 

1. Install forked extension [test-provider-sample-0.0.2.vsix](https://github.com/rschnekenbu/vscode-extension-samples/releases/download/continuous-test-sample-0.0.2/test-provider-sample-0.0.2.vsix) vsix file - [Source](https://github.com/rschnekenbu/vscode-extension-samples/tree/continuous-test-sample)

2. [A message is printed](https://github.com/microsoft/vscode-extension-samples/blob/e4f235080d45093624cdcf6a9838949b41c45ebd/test-provider-sample/src/extension.ts#L52) in the console at the end of the activation, after [some calls](https://github.com/microsoft/vscode-extension-samples/blob/e4f235080d45093624cdcf6a9838949b41c45ebd/test-provider-sample/src/extension.ts#L27) related to stubbed API are done. 

The console should display: `test-provider-sample activated` once extension is activated.

3. Extension will also display a message in the console as soon as the content of a markdown file is edited.

![test-sample](https://user-images.githubusercontent.com/3964263/234399321-ed136950-44bb-4b20-a42a-adbac83239e2.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

