### PR TITLE
Notifications: Toaster Container did not close when empty

### DIFF
--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -131,7 +131,7 @@ export class NotificationManager extends MessageClient {
             return;
         }
         this.deferredResults.delete(messageId);
-        if (this.centerVisible && this.notifications.size === 0) {
+        if ((this.centerVisible && !this.notifications.size) || (this.toastsVisible && !this.toasts.size)) {
             this.visibilityState = 'hidden';
         }
         result.resolve(action);


### PR DESCRIPTION
#### What it does
This commit adds:
- Condition so that the toaster container will close when empty.

This can be tested when running the `Quick Input: Hello World` command after extracting the [quickpickesctest-0.0.2.zip](https://github.com/eclipse-theia/theia/files/11327222/quickpickesctest-0.0.2.zip)
When, after closing the toaster notifications and focusing in the inputbox, pressing `esc` once does not close the inputbox.

#### How to test
1. Run Theia
2. Run the command from the mentioned extension
3. Close all notifications using the `x` button
4. Focus on the input box /Quick Input and press `esc` once
5. Check if the quick input has closed.

Before
![closeEmptyToasterIssue](https://user-images.githubusercontent.com/48699277/234417646-3a92275a-a47d-4e04-a054-1b1c5e02f6c0.gif)

After
![closeEmptyToaster](https://user-images.githubusercontent.com/48699277/234419412-30ede93a-66e2-4aca-9b99-b09509745f28.gif)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
