### PR TITLE
monaco: parseSnippet RangeError handling

### DIFF
--- a/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
+++ b/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
@@ -247,7 +247,7 @@ export interface JsonSerializedSnippet {
     isFileTemplate?: boolean;
     body: string | string[];
     scope?: string;
-    prefix: string | string[] | undefined;
+    prefix?: string | string[];
     description: string;
 }
 export namespace JsonSerializedSnippet {


### PR DESCRIPTION
#### What it does
Closes #12434

- Changes `parseSnippets` from recursive function to nested for-loops.
- Eliminates 'prefix' requirement for `JsonSerializedSnippet.is()` as it is in VS Code.
- Changes handling to account for missing 'prefix' parameter.
- Add `isFileTemplate` param to Snippet to bring it in line with VSCode.

##### Notes
As discussed [here](https://github.com/FernandoAscencio/theia/pull/24) there are three parameters in VS Code `Snippet` that are not present in Theia's: `snippetSource`, `snippetIdentifier`, and `extensionId`. Their inclusion or exclusion seems to be out of this PR's scope.

When adding a prefix to the error causing snippet as seen [here](https://github.com/FernandoAscencio/theia/pull/24#issuecomment-1521973356) it does not follow VS Code's display as seen [here](https://github.com/FernandoAscencio/theia/pull/24#issuecomment-1522288708).


#### How to test
Follow the steps in #12434.
1. Build the example application, browser or Electron, from the master branch
2. Delete all extensions from folder ./plugins/. Unzip html-1.72.1.zip into it: [html-1.72.1.zip](https://github.com/eclipse-theia/theia/files/11275450/html-1.72.1.zip)
3. Start example app. The error should not appear when loading.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
