### PR TITLE
electron: bump to `23.2.4`

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -75,6 +75,6 @@
   },
   "devDependencies": {
     "@theia/cli": "1.36.0",
-    "electron": "^22.3.2"
+    "electron": "^23.2.4"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -70,7 +70,7 @@ export class SomeClass {
 
 - `@theia/core/electron-shared/...`
     - `native-keymap` (from [`native-keymap@^2.2.1`](https://www.npmjs.com/package/native-keymap))
-    - `electron` (from [`electron@^22.3.2`](https://www.npmjs.com/package/electron))
+    - `electron` (from [`electron@^23.2.4`](https://www.npmjs.com/package/electron))
     - `electron-store` (from [`electron-store@^8.0.0`](https://www.npmjs.com/package/electron-store))
     - `fix-path` (from [`fix-path@^3.0.0`](https://www.npmjs.com/package/fix-path))
 - `@theia/core/shared/...`

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -18,7 +18,7 @@ The `@theia/electron` extension bundles all Electron-specific dependencies and c
 
 - `@theia/electron/shared/...`
     - `native-keymap` (from [`native-keymap@^2.2.1`](https://www.npmjs.com/package/native-keymap))
-    - `electron` (from [`electron@^22.3.2`](https://www.npmjs.com/package/electron))
+    - `electron` (from [`electron@^23.2.4`](https://www.npmjs.com/package/electron))
     - `electron-store` (from [`electron-store@^8.0.0`](https://www.npmjs.com/package/electron-store))
     - `fix-path` (from [`fix-path@^3.0.0`](https://www.npmjs.com/package/fix-path))
 

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -12,7 +12,7 @@
     "@theia/re-exports": "1.36.0"
   },
   "peerDependencies": {
-    "electron": "^22.3.2"
+    "electron": "^23.2.4"
   },
   "theiaReExports": {
     "shared": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4470,10 +4470,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^22.3.2:
-  version "22.3.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.2.tgz#6adf34561acc23938bfbe35ae771281eaf8706f2"
-  integrity sha512-rcE01ammPJ9RVDF3sCETyeHiDEVxV49Ywn+wXUGiG+jGtOB6erLx5jnBTf2eSVYoTXqoIbigoxGHLq4nLMLLUg==
+electron@^23.2.4:
+  version "23.2.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-23.2.4.tgz#6f19be9e45c5e5cdf736d0ed747ce4ed4c4bbfeb"
+  integrity sha512-ceFd+KIhzK3srGY22kcBu8QH7hV1G3DHlgrg2LGjg7mgtzxlXeyKzk2Efq0iFNu3ly14QKfiN5gYdvEenmzOAA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^16.11.26"


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: #12461.

The pull-request bumps our version of `electron` to `23.2.4` which includes a [backport](https://github.com/electron/electron/pull/37908) fix for native menus.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the example electron application
2. confirm that `window.titleBarStyle` is set to `native`
3. resize the window - confirm that the submenus in the main-menu are working properly
4. maximize the window with window controls - confirm that the submenus in the main-menu are working properly

#### Additional Information

- [x] basic dash-licenses approval for `electron@23.2.4` (https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/7913)
- [ ] question about future IP checks (https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/7912)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
