### PR TITLE
[chore] update default service API to 1.74.2

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.72.2';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.74.2';


### PR DESCRIPTION
#### What it does
This pull-request updates the default vscode api from 1.72.2 to 1.74.2. With https://github.com/eclipse-theia/theia/issues/12019 being fixed, the API compatibility can be raised.

#### How to test
N/A

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
Reminder for reviewers
- [x]  As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)