### PR TITLE
styling: TreeWidget Highlighted nodes full display

### DIFF
--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -445,6 +445,10 @@ export class ScmTreeWidget extends TreeWidget {
         return super.getPaddingLeft(node, props);
     }
 
+    protected override getDepthPadding(depth: number): number {
+        return super.getDepthPadding(depth) + 5;
+    }
+
     protected isCurrentThemeLight(): boolean {
         const type = this.themeService.getCurrentTheme().type;
         return type.toLocaleLowerCase().includes('light');

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -19,16 +19,12 @@
   font-size: var(--theia-ui-font-size1);
   max-height: calc(100% - var(--theia-border-width));
   position: relative;
+  padding: 5px 5px 0px 19px;
 }
 
 .theia-scm {
-  padding: 5px;
   box-sizing: border-box;
   height: 100%;
-}
-
-.theia-side-panel .theia-scm {
-  padding-left: 19px;
 }
 
 .groups-outer-container:focus {

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -718,6 +718,10 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         };
     }
 
+    protected override getDepthPadding(depth: number): number {
+        return super.getDepthPadding(depth) + 5;
+    }
+
     protected override renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
         if (SearchInWorkspaceRootFolderNode.is(node)) {
             return this.renderRootFolderNode(node);

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -23,7 +23,7 @@
 }
 
 .t-siw-search-container {
-  padding: 5px;
+  padding: 0px 1px;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -52,8 +52,7 @@
 }
 
 .t-siw-search-container .searchHeader {
-  width: 100%;
-  margin-bottom: 10px;
+  padding: 5px 5px 15px 2px;
 }
 
 .t-siw-search-container .searchHeader .controls.button-container {
@@ -206,7 +205,6 @@
 
 .t-siw-search-container .resultContainer {
   height: 100%;
-  margin-left: 13px;
 }
 
 .t-siw-search-container .result {


### PR DESCRIPTION
#### What it does
There is a display discrepancy on selected nodes between Theia and VS Code, as seen below:
##### VS Code
<img width="514" alt="VSCode" src="https://user-images.githubusercontent.com/48699277/234968664-7808e8f0-2765-47a8-ac42-4b8461925c1e.png">

##### Theia
<img width="511" alt="MasterDisplay" src="https://user-images.githubusercontent.com/48699277/234968700-e189d0b3-d545-44aa-a71b-d06d9f55e2d2.png">

This commit fixes that discrepancy in display. As seen below:
##### This Commit
<img width="505" alt="BranchDisplay" src="https://user-images.githubusercontent.com/48699277/234969068-5b6e192d-3f0f-4d27-b95a-5f22392158d5.png">

##### Notes
I have added some extra code handling to keep the current display of Theia. However, as seen in VS Code, the left margin/padding for the Search-In-Workspace and Source-Control trees is no different from the Explorer and Reference trees. As such, if the VS Code tree alignment is preferable, it would also reduce the number of lines added.

#### How to test
1. Run example Theia
2. Do a search and modify a file
3. Check that the selection (both $\textcolor{blue}{\textsf{on focus}}$  and $\textcolor{gray}{\textsf{out of focus}}$) highlights the entire row instead of leaving a space.

#### Review checklist
- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
