### PR TITLE
Fixed #12475: Debug toobar not showing current launch configuration on startup

### DIFF
--- a/packages/debug/src/browser/view/debug-configuration-select.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-select.tsx
@@ -59,6 +59,13 @@ export class DebugConfigurationSelect extends React.Component<DebugConfiguration
         });
     }
 
+    override componentDidUpdate(): void {
+        // synchronize the currentValue with the selectComponent value
+        if (this.selectRef.current?.value !== this.currentValue) {
+            this.refreshDebugConfigurations();
+        }
+    }
+
     override componentDidMount(): void {
         this.refreshDebugConfigurations();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Closes: #12475

The pull-request fixes an issue where the last debug launch configuration was not reflected in the UI on startup, and instead would always show the first configuration in the list. With this update, the debug launch configuration is persisted similarly to VS Code.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. start the application
2. select a debug launch configuration in the debug-view other than the first configuration
3. reload the application
4. confirm that the launch configuration is persisted

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
