### PR TITLE
Implement "secondary window" support for Electron

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -48,6 +48,7 @@
     "@theia/scm": "1.38.0",
     "@theia/scm-extra": "1.38.0",
     "@theia/search-in-workspace": "1.38.0",
+    "@theia/secondary-window": "1.38.0",
     "@theia/task": "1.38.0",
     "@theia/terminal": "1.38.0",
     "@theia/timeline": "1.38.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -108,6 +108,9 @@
       "path": "../../packages/search-in-workspace"
     },
     {
+      "path": "../../packages/secondary-window"
+    },
+    {
       "path": "../../packages/task"
     },
     {

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -287,9 +287,11 @@ export class ShouldSaveDialog extends AbstractDialog<boolean> {
     constructor(widget: Widget) {
         super({
             title: nls.localizeByDefault('Do you want to save the changes you made to {0}?', widget.title.label || widget.title.caption)
+        }, {
+            node: widget.node.ownerDocument.createElement('div')
         });
 
-        const messageNode = document.createElement('div');
+        const messageNode = this.node.ownerDocument.createElement('div');
         messageNode.textContent = nls.localizeByDefault("Your changes will be lost if you don't save them.");
         messageNode.setAttribute('style', 'flex: 1 100%; padding-bottom: calc(var(--theia-ui-padding)*3);');
         this.contentNode.appendChild(messageNode);

--- a/packages/core/src/browser/styling-service.ts
+++ b/packages/core/src/browser/styling-service.ts
@@ -65,9 +65,7 @@ export class StylingService implements FrontendApplicationContribution {
     }
 
     protected applyStylingToWindows(theme: Theme): void {
-        this.cssElements.forEach((cssElement, win) => {
-            this.applyStyling(theme, cssElement);
-        });
+        this.cssElements.forEach(cssElement => this.applyStyling(theme, cssElement));
     }
 
     protected applyStyling(theme: Theme, cssElement: HTMLStyleElement): void {

--- a/packages/core/src/browser/styling-service.ts
+++ b/packages/core/src/browser/styling-service.ts
@@ -21,6 +21,7 @@ import { ColorRegistry } from './color-registry';
 import { DecorationStyle } from './decoration-style';
 import { FrontendApplicationContribution } from './frontend-application';
 import { ThemeService } from './theming';
+import { Disposable } from '../common';
 
 export const StylingParticipant = Symbol('StylingParticipant');
 
@@ -40,8 +41,7 @@ export interface CssStyleCollector {
 
 @injectable()
 export class StylingService implements FrontendApplicationContribution {
-
-    protected cssElement = DecorationStyle.createStyleElement('contributedColorTheme');
+    protected cssElements = new Map<Window, HTMLStyleElement>();
 
     @inject(ThemeService)
     protected readonly themeService: ThemeService;
@@ -53,11 +53,24 @@ export class StylingService implements FrontendApplicationContribution {
     protected readonly themingParticipants: ContributionProvider<StylingParticipant>;
 
     onStart(): void {
-        this.applyStyling(this.themeService.getCurrentTheme());
-        this.themeService.onDidColorThemeChange(e => this.applyStyling(e.newTheme));
+        this.registerWindow(window);
+        this.themeService.onDidColorThemeChange(e => this.applyStylingToWindows(e.newTheme));
     }
 
-    protected applyStyling(theme: Theme): void {
+    registerWindow(win: Window): Disposable {
+        const cssElement = DecorationStyle.createStyleElement('contributedColorTheme', win.document.head);
+        this.cssElements.set(win, cssElement);
+        this.applyStyling(this.themeService.getCurrentTheme(), cssElement);
+        return Disposable.create(() => this.cssElements.delete(win));
+    }
+
+    protected applyStylingToWindows(theme: Theme): void {
+        this.cssElements.forEach((cssElement, win) => {
+            this.applyStyling(theme, cssElement);
+        });
+    }
+
+    protected applyStyling(theme: Theme, cssElement: HTMLStyleElement): void {
         const rules: string[] = [];
         const colorTheme: ColorTheme = {
             type: theme.type,
@@ -71,6 +84,6 @@ export class StylingService implements FrontendApplicationContribution {
             themingParticipant.registerThemeStyle(colorTheme, styleCollector);
         }
         const fullCss = rules.join('\n');
-        this.cssElement.innerText = fullCss;
+        cssElement.innerText = fullCss;
     }
 }

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -115,6 +115,10 @@ export class BaseWidget extends Widget {
     protected scrollBar?: PerfectScrollbar;
     protected scrollOptions?: PerfectScrollbar.Options;
 
+    constructor(options?: Widget.IOptions) {
+        super(options);
+    }
+
     override dispose(): void {
         if (this.isDisposed) {
             return;

--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -16,6 +16,9 @@
 import { inject, injectable, postConstruct } from 'inversify';
 import { SecondaryWindowService } from './secondary-window-service';
 import { WindowService } from './window-service';
+import { ExtractableWidget } from '../widgets';
+import { ApplicationShell } from '../shell';
+import { Saveable } from '../saveable';
 
 @injectable()
 export class DefaultSecondaryWindowService implements SecondaryWindowService {
@@ -37,6 +40,33 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
 
     @postConstruct()
     init(): void {
+        // Set up messaging with secondary windows
+        window.addEventListener('message', (event: MessageEvent) => {
+            console.trace('Message on main window', event);
+            if (event.data.fromSecondary) {
+                console.trace('Message comes from secondary window');
+                return;
+            }
+            if (event.data.fromMain) {
+                console.trace('Message has mainWindow marker, therefore ignore it');
+                return;
+            }
+
+            // Filter setImmediate messages. Do not forward because these come in with very high frequency.
+            // They are not needed in secondary windows because these messages are just a work around
+            // to make setImmediate work in the main window: https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate
+            if (typeof event.data === 'string' && event.data.startsWith('setImmediate')) {
+                return;
+            }
+
+            console.trace('Delegate main window message to secondary windows', event);
+            this.secondaryWindows.forEach(secondaryWindow => {
+                if (!secondaryWindow.window.closed) {
+                    secondaryWindow.window.postMessage({ ...event.data, fromMain: true }, '*');
+                }
+            });
+        });
+
         // Close all open windows when the main window is closed.
         this.windowService.onUnload(() => {
             // Iterate backwards because calling window.close might remove the window from the array
@@ -46,33 +76,52 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
         });
     }
 
-    createSecondaryWindow(onClose?: (closedWin: Window) => void): Window | undefined {
-        const win = this.doCreateSecondaryWindow(onClose);
+    createSecondaryWindow(widget: ExtractableWidget, shell: ApplicationShell): Window | undefined {
+        const win = this.doCreateSecondaryWindow(widget, shell);
         if (win) {
             this.secondaryWindows.push(win);
+            win.addEventListener('close', () => {
+                const extIndex = this.secondaryWindows.indexOf(win);
+                if (extIndex > -1) {
+                    this.secondaryWindows.splice(extIndex, 1);
+                };
+            });
         }
         return win;
     }
 
-    protected doCreateSecondaryWindow(onClose?: (closedWin: Window) => void): Window | undefined {
-        const win = window.open(DefaultSecondaryWindowService.SECONDARY_WINDOW_URL, this.nextWindowId(), 'popup');
-        if (win) {
-            // Add the unload listener after the dom content was loaded because otherwise the unload listener is called already on open in some browsers (e.g. Chrome).
-            win.addEventListener('DOMContentLoaded', () => {
-                win.addEventListener('unload', () => {
-                    this.handleWindowClosed(win, onClose);
+    protected findWindow<T>(windowName: string): Window | undefined {
+        for (const w of this.secondaryWindows) {
+            if (w.name === windowName) {
+                return w;
+            }
+        }
+        return undefined;
+    }
+
+    protected doCreateSecondaryWindow(widget: ExtractableWidget, shell: ApplicationShell): Window | undefined {
+        const newWindow = window.open(DefaultSecondaryWindowService.SECONDARY_WINDOW_URL, this.nextWindowId(), 'popup') ?? undefined;
+        if (newWindow) {
+            newWindow.addEventListener('DOMContentLoaded', () => {
+                newWindow.addEventListener('beforeunload', evt => {
+                    const saveable = Saveable.get(widget);
+                    const wouldLoseState = !!saveable && saveable.dirty && saveable.autoSave === 'off';
+                    if (wouldLoseState) {
+                        evt.returnValue = '';
+                        evt.preventDefault();
+                        return 'non-empty';
+                    }
+                }, { capture: true });
+
+                newWindow.addEventListener('close', () => {
+                    const saveable = Saveable.get(widget);
+                    shell.closeWidget(widget.id, {
+                        save: !!saveable && saveable.dirty && saveable.autoSave !== 'off'
+                    });
                 });
             });
         }
-        return win ?? undefined;
-    }
-
-    protected handleWindowClosed(win: Window, onClose?: (closedWin: Window) => void): void {
-        const extIndex = this.secondaryWindows.indexOf(win);
-        if (extIndex > -1) {
-            this.secondaryWindows.splice(extIndex, 1);
-        };
-        onClose?.(win);
+        return newWindow;
     }
 
     focus(win: Window): void {

--- a/packages/core/src/browser/window/secondary-window-service.ts
+++ b/packages/core/src/browser/window/secondary-window-service.ts
@@ -14,6 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { ApplicationShell } from '../shell';
+import { ExtractableWidget } from '../widgets';
+
 export const SecondaryWindowService = Symbol('SecondaryWindowService');
 
 /**
@@ -29,7 +32,7 @@ export interface SecondaryWindowService {
      * @param onClose optional callback that is invoked when the secondary window is closed
      * @returns the created window or `undefined` if it could not be created
      */
-    createSecondaryWindow(onClose?: (win: Window) => void): Window | undefined;
+    createSecondaryWindow(widget: ExtractableWidget, shell: ApplicationShell): Window | undefined;
 
     /** Handles focussing the given secondary window in the browser and on Electron. */
     focus(win: Window): void;

--- a/packages/core/src/electron-browser/preload.ts
+++ b/packages/core/src/electron-browser/preload.ts
@@ -13,6 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 //
+import { IpcRendererEvent } from '@theia/electron/shared/electron';
 import { Disposable } from '../common/disposable';
 import { StopReason } from '../common/frontend-application-state';
 import { NativeKeyboardLayout } from '../common/keyboard/keyboard-layout-provider';
@@ -24,7 +25,7 @@ import {
     CHANNEL_ON_WINDOW_EVENT, CHANNEL_GET_ZOOM_LEVEL, CHANNEL_SET_ZOOM_LEVEL, CHANNEL_IS_FULL_SCREENABLE, CHANNEL_TOGGLE_FULL_SCREEN,
     CHANNEL_IS_FULL_SCREEN, CHANNEL_SET_MENU_BAR_VISIBLE, CHANNEL_REQUEST_CLOSE, CHANNEL_SET_TITLE_STYLE, CHANNEL_RESTART,
     CHANNEL_REQUEST_RELOAD, CHANNEL_APP_STATE_CHANGED, CHANNEL_SHOW_ITEM_IN_FOLDER, CHANNEL_READ_CLIPBOARD, CHANNEL_WRITE_CLIPBOARD,
-    CHANNEL_KEYBOARD_LAYOUT_CHANGED, CHANNEL_IPC_CONNECTION, InternalMenuDto
+    CHANNEL_KEYBOARD_LAYOUT_CHANGED, CHANNEL_IPC_CONNECTION, InternalMenuDto, CHANNEL_REQUEST_SECONDARY_CLOSE
 } from '../electron-common/electron-api';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -136,6 +137,25 @@ const api: TheiaCoreAPI = {
             }
             event.sender.send(cancelChannel);
         });
+    },
+
+    setSecondaryWindowCloseRequestHandler(windowName: string, handler: () => Promise<boolean>): void {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const listener: (event: IpcRendererEvent, ...args: any[]) => void = async (event, name, confirmChannel, cancelChannel) => {
+            if (name === windowName) {
+                try {
+                    if (await handler()) {
+                        event.sender.send(confirmChannel);
+                        ipcRenderer.removeListener(CHANNEL_REQUEST_SECONDARY_CLOSE, listener);
+                        return;
+                    };
+                } catch (e) {
+                    console.warn('exception in close handler ', e);
+                }
+                event.sender.send(cancelChannel);
+            }
+        };
+        ipcRenderer.on(CHANNEL_REQUEST_SECONDARY_CLOSE, listener);
     },
 
     toggleDevTools: function (): void {

--- a/packages/core/src/electron-browser/window/electron-secondary-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-secondary-window-service.ts
@@ -16,6 +16,7 @@
 
 import { injectable } from 'inversify';
 import { DefaultSecondaryWindowService } from '../../browser/window/default-secondary-window-service';
+import { ApplicationShell, ExtractableWidget } from 'src/browser';
 
 @injectable()
 export class ElectronSecondaryWindowService extends DefaultSecondaryWindowService {
@@ -23,11 +24,16 @@ export class ElectronSecondaryWindowService extends DefaultSecondaryWindowServic
         window.electronTheiaCore.focusWindow(win.name);
     }
 
-    protected override doCreateSecondaryWindow(onClose?: (closedWin: Window) => void): Window | undefined {
-        const w = super.doCreateSecondaryWindow(onClose);
+    protected override doCreateSecondaryWindow(widget: ExtractableWidget, shell: ApplicationShell): Window | undefined {
+        const w = super.doCreateSecondaryWindow(widget, shell);
         if (w) {
             window.electronTheiaCore.setMenuBarVisible(false, w.name);
+            window.electronTheiaCore.setSecondaryWindowCloseRequestHandler(w.name, () => this.canClose(widget, shell));
         }
         return w;
+    }
+    private async canClose(widget: ExtractableWidget, shell: ApplicationShell): Promise<boolean> {
+        await shell.closeWidget(widget.id, undefined);
+        return widget.isDisposed;
     }
 }

--- a/packages/core/src/electron-common/electron-api.ts
+++ b/packages/core/src/electron-common/electron-api.ts
@@ -64,6 +64,8 @@ export interface TheiaCoreAPI {
     onWindowEvent(event: WindowEvent, handler: () => void): Disposable;
     setCloseRequestHandler(handler: (reason: StopReason) => Promise<boolean>): void;
 
+    setSecondaryWindowCloseRequestHandler(windowName: string, handler: () => Promise<boolean>): void;
+
     toggleDevTools(): void;
     getZoomLevel(): Promise<number>;
     setZoomLevel(desired: number): void;
@@ -120,6 +122,8 @@ export const CHANNEL_SET_ZOOM_LEVEL = 'SetZoomLevel';
 export const CHANNEL_IS_FULL_SCREENABLE = 'IsFullScreenable';
 export const CHANNEL_IS_FULL_SCREEN = 'IsFullScreen';
 export const CHANNEL_TOGGLE_FULL_SCREEN = 'ToggleFullScreen';
+
+export const CHANNEL_REQUEST_SECONDARY_CLOSE = 'RequestSecondaryClose';
 
 export const CHANNEL_REQUEST_CLOSE = 'RequestClose';
 export const CHANNEL_REQUEST_RELOAD = 'RequestReload';

--- a/packages/core/src/electron-main/theia-electron-window.ts
+++ b/packages/core/src/electron-main/theia-electron-window.ts
@@ -44,6 +44,12 @@ export const TheiaBrowserWindowOptions = Symbol('TheiaBrowserWindowOptions');
 export const WindowApplicationConfig = Symbol('WindowApplicationConfig');
 export type WindowApplicationConfig = FrontendApplicationConfig;
 
+enum ClosingState {
+    initial,
+    inProgress,
+    readyToClose
+}
+
 @injectable()
 export class TheiaElectronWindow {
     @inject(TheiaBrowserWindowOptions) protected readonly options: TheiaBrowserWindowOptions;
@@ -75,8 +81,32 @@ export class TheiaElectronWindow {
         this.attachCloseListeners();
         this.trackApplicationState();
         this.attachReloadListener();
+        this.attachSecondaryWindowListener();
     }
 
+    protected attachSecondaryWindowListener(): void {
+        createDisposableListener(this._window.webContents, 'did-create-window', (newWindow: BrowserWindow) => {
+            let closingState = ClosingState.initial;
+            newWindow.on('close', event => {
+                if (closingState === ClosingState.initial) {
+                    closingState = ClosingState.inProgress;
+                    event.preventDefault();
+                    TheiaRendererAPI.requestSecondaryClose(this._window.webContents, newWindow.webContents).then(shouldClose => {
+                        if (shouldClose) {
+                            closingState = ClosingState.readyToClose;
+                            newWindow.close();
+                        } else {
+                            closingState = ClosingState.initial;
+                        }
+                    });
+                } else if (closingState === ClosingState.inProgress) {
+                    // When the extracted widget is disposed programmatically, a dispose listener on it will try to close the window.
+                    // if we dispose the widget because of closing the window, we'll get a recursive call to window.close()
+                    event.preventDefault();
+                }
+            });
+        });
+    }
     /**
      * Only show the window when the content is ready.
      */


### PR DESCRIPTION
#### What it does
Fixes #11642

The main change is to prevent the secondary window from closing until the extracted widget is removed from the window. This includes waiting until any close handling (including dialogs) are finished.

To enable this properly, dialog support has been extended to work with secondary windows, including support for the StylingService in secondary windows.

Contributed on behalf of STMicroelectronics

#### How to test
The test scenarios from https://github.com/eclipse-theia/theia/pull/11048 apply, but run them in electron

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
