### PR TITLE
Associate root folder to dynamic debug configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
 
-## v1.38.0 - 04/27/2023
+## v1.38.0 - 05/25/2023
 
 <a name="breaking_changes_1.38.0">[Breaking Changes:](#breaking_changes_1.38.0)</a>
 
 - [core] moved `ToolbarAwareTabBar.Styles` to `ScrollableTabBar.Styles` [12411](https://github.com/eclipse-theia/theia/pull/12411/)
+- [debug] Change the return type of (method) `DebugConfigurationManager.provideDynamicDebugConfigurations()` to <br>
+`Promise<Record<string, DynamicDebugConfigurationSessionOptions[]>>` [#12482](https://github.com/eclipse-theia/theia/pull/12482)
 
 ## v1.37.0 - 04/27/2023
 

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -178,8 +178,8 @@ export class DebugConfigurationManager {
 
         // Refresh a dynamic configuration from the provider.
         // This allow providers to update properties before the execution e.g. program
-        const { providerType, configuration: { name } } = this._currentOptions;
-        const configuration = await this.fetchDynamicDebugConfiguration(name, providerType);
+        const { providerType, workspaceFolderUri, configuration: { name } } = this._currentOptions;
+        const configuration = await this.fetchDynamicDebugConfiguration(name, providerType, workspaceFolderUri);
 
         if (!configuration) {
             const message = nls.localize(
@@ -188,7 +188,7 @@ export class DebugConfigurationManager {
             throw new Error(message);
         }
 
-        return { name, configuration, providerType };
+        return { name, configuration, providerType, workspaceFolderUri };
     }
 
     set current(option: DebugSessionOptions | undefined) {
@@ -215,7 +215,8 @@ export class DebugConfigurationManager {
     protected dynamicOptionsMatch(one: DynamicDebugConfigurationSessionOptions, other: DynamicDebugConfigurationSessionOptions): boolean {
         return one.providerType !== undefined
             && one.configuration.name === other.configuration.name
-            && one.providerType === other.providerType;
+            && one.providerType === other.providerType
+            && one.workspaceFolderUri === other.workspaceFolderUri;
     }
 
     get recentDynamicOptions(): readonly DynamicDebugConfigurationSessionOptions[] {
@@ -462,14 +463,40 @@ export class DebugConfigurationManager {
         await WaitUntilEvent.fire(this.onWillProvideDebugConfigurationEmitter, {});
     }
 
-    async provideDynamicDebugConfigurations(): Promise<Record<string, DebugConfiguration[]>> {
+    async provideDynamicDebugConfigurations(): Promise<Record<string, DynamicDebugConfigurationSessionOptions[]>> {
         await this.fireWillProvideDynamicDebugConfiguration();
-        return this.debug.provideDynamicDebugConfigurations!();
+        const roots = this.workspaceService.tryGetRoots();
+        const promises = roots.map(async root => {
+            const configsMap = await this.debug.provideDynamicDebugConfigurations!(root.resource.toString());
+            const optionsMap = Object.fromEntries(Object.entries(configsMap).map(([type, configs]) => {
+                const options = configs.map(config => ({
+                    name: config.name,
+                    providerType: type,
+                    configuration: config,
+                    workspaceFolderUri: root.resource.toString()
+                }));
+                return [type, options];
+            }));
+            return optionsMap;
+        });
+
+        const typesToOptionsRecords = await Promise.all(promises);
+        const consolidatedTypesToOptions: Record<string, DynamicDebugConfigurationSessionOptions[]> = {};
+
+        for (const typesToOptionsInstance of typesToOptionsRecords) {
+            for (const [providerType, configurationsOptions] of Object.entries(typesToOptionsInstance)) {
+                if (!consolidatedTypesToOptions[providerType]) {
+                    consolidatedTypesToOptions[providerType] = [];
+                }
+                consolidatedTypesToOptions[providerType].push(...configurationsOptions);
+            }
+        }
+        return consolidatedTypesToOptions;
     }
 
-    async fetchDynamicDebugConfiguration(name: string, type: string): Promise<DebugConfiguration | undefined> {
+    async fetchDynamicDebugConfiguration(name: string, type: string, folder?: string): Promise<DebugConfiguration | undefined> {
         await this.fireWillProvideDynamicDebugConfiguration();
-        return this.debug.fetchDynamicDebugConfiguration(name, type);
+        return this.debug.fetchDynamicDebugConfiguration(name, type, folder);
     }
 
     protected async fireWillProvideDynamicDebugConfiguration(): Promise<void> {

--- a/packages/debug/src/browser/view/debug-configuration-select.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-select.tsx
@@ -22,7 +22,7 @@ import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/s
 import { QuickInputService } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
 
-interface DynamicPickItem { label: string, configurationType: string, request: string, providerType: string }
+interface DynamicPickItem { label: string, configurationType: string, request: string, providerType: string, workspaceFolderUri?: string }
 
 export interface DebugConfigurationSelectProps {
     manager: DebugConfigurationManager,
@@ -130,11 +130,13 @@ export class DebugConfigurationSelect extends React.Component<DebugConfiguration
             return [];
         }
 
-        return configurationsOfProviderType.map(configuration => ({
-            label: configuration.name,
-            configurationType: configuration.type,
-            request: configuration.request,
-            providerType
+        return configurationsOfProviderType.map(options => ({
+            label: options.configuration.name,
+            configurationType: options.configuration.type,
+            request: options.configuration.request,
+            providerType: options.providerType,
+            description: this.toBaseName(options.workspaceFolderUri),
+            workspaceFolderUri: options.workspaceFolderUri
         }));
     }
 
@@ -161,15 +163,15 @@ export class DebugConfigurationSelect extends React.Component<DebugConfiguration
             type: selected.configurationType,
             request: selected.request
         };
-        this.manager.current = this.manager.find(selectedConfiguration, undefined, selected.providerType);
+        this.manager.current = this.manager.find(selectedConfiguration, selected.workspaceFolderUri, selected.providerType);
         this.refreshDebugConfigurations();
     }
 
     protected refreshDebugConfigurations = async () => {
-        const configsPerType = await this.manager.provideDynamicDebugConfigurations();
+        const configsOptionsPerType = await this.manager.provideDynamicDebugConfigurations();
         const providerTypes = [];
-        for (const [type, configurations] of Object.entries(configsPerType)) {
-            if (configurations.length > 0) {
+        for (const [type, configurationsOptions] of Object.entries(configsOptionsPerType)) {
+            if (configurationsOptions.length > 0) {
                 providerTypes.push(type);
             }
         }
@@ -251,6 +253,10 @@ export class DebugConfigurationSelect extends React.Component<DebugConfiguration
         if (!options.workspaceFolderUri || !multiRoot) {
             return name;
         }
-        return `${name} (${new URI(options.workspaceFolderUri).path.base})`;
+        return `${name} (${this.toBaseName(options.workspaceFolderUri)})`;
+    }
+
+    protected toBaseName(uri: string | undefined): string {
+        return uri ? new URI(uri).path.base : '';
     }
 }

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -80,12 +80,12 @@ export interface DebugService extends Disposable {
     /**
      * @returns A Record of debug configuration provider types and a corresponding dynamic debug configurations array
      */
-    provideDynamicDebugConfigurations?(): Promise<Record<string, DebugConfiguration[]>>;
+    provideDynamicDebugConfigurations?(folder?: string): Promise<Record<string, DebugConfiguration[]>>;
 
     /**
      * Provides a dynamic debug configuration matching the name and the provider debug type
      */
-    fetchDynamicDebugConfiguration(name: string, type: string): Promise<DebugConfiguration | undefined>;
+    fetchDynamicDebugConfiguration(name: string, type: string, folder?: string): Promise<DebugConfiguration | undefined>;
 
     /**
      * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values

--- a/packages/debug/src/node/debug-service-impl.ts
+++ b/packages/debug/src/node/debug-service-impl.ts
@@ -71,7 +71,7 @@ export class DebugServiceImpl implements DebugService {
         // TODO: Support dynamic debug configurations through Theia extensions?
         return {};
     }
-    fetchDynamicDebugConfiguration(name: string, type: string): Promise<DebugConfiguration | undefined> {
+    fetchDynamicDebugConfiguration(name: string, type: string, folder?: string): Promise<DebugConfiguration | undefined> {
         // TODO: Support dynamic debug configurations through Theia extensions?
         return Promise.resolve(undefined);
     }

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
@@ -142,7 +142,7 @@ export class PluginDebugService implements DebugService {
         return results;
     }
 
-    async fetchDynamicDebugConfiguration(name: string, providerType: string): Promise<DebugConfiguration | undefined> {
+    async fetchDynamicDebugConfiguration(name: string, providerType: string, folder?: string): Promise<DebugConfiguration | undefined> {
         const pluginProviders =
             Array.from(this.configurationProviders.values()).filter(p => (
                 p.triggerKind === DebugConfigurationProviderTriggerKind.Dynamic &&
@@ -151,7 +151,7 @@ export class PluginDebugService implements DebugService {
             ));
 
         for (const provider of pluginProviders) {
-            const configurations = await provider.provideDebugConfigurations(undefined);
+            const configurations = await provider.provideDebugConfigurations(folder);
             for (const configuration of configurations) {
                 if (configuration.name === name) {
                     return configuration;
@@ -160,7 +160,7 @@ export class PluginDebugService implements DebugService {
         }
     }
 
-    async provideDynamicDebugConfigurations(): Promise<Record<string, DebugConfiguration[]>> {
+    async provideDynamicDebugConfigurations(folder?: string): Promise<Record<string, DebugConfiguration[]>> {
         const pluginProviders =
             Array.from(this.configurationProviders.values()).filter(p => (
                 p.triggerKind === DebugConfigurationProviderTriggerKind.Dynamic &&
@@ -170,7 +170,7 @@ export class PluginDebugService implements DebugService {
         const configurationsRecord: Record<string, DebugConfiguration[]> = {};
 
         await Promise.all(pluginProviders.map(async provider => {
-            const configurations = await provider.provideDebugConfigurations(undefined);
+            const configurations = await provider.provideDebugConfigurations(folder);
             let configurationsPerType = configurationsRecord[provider.type];
             configurationsPerType = configurationsPerType ? configurationsPerType.concat(configurations) : configurations;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: https://github.com/eclipse-theia/theia/issues/12352

The methods in the `vscode` interface `DebugConfigurationProvider` specify the parameter `folder: WorksapceFolder | undefined'.

The parameter can be `undefined` in the context of a `folderless` setup, however some plugins expect it to be present always (e.g. ms-python.python). The original implementation of dynamic debug configurations did not provide this parameter.

This change associates the root folder to the contributed configurations directly after the response for the call to 'provideDebugConfigurations' and it makes sure to preserve this parameter within the pick items presented to the user.

With the above, dynamic configurations are able to execute programs located inside the same root.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1) Test that the plugin `ms-python.python` gets loaded and activated
- Using `theia`'s `Extensions` view search for `python` and install the extension with id `ms-python.python`
- Run a simple `python` program as shown below:
https://user-images.githubusercontent.com/76971376/236043099-5a3e0b1d-1425-4b06-a3b6-bc4754980dcf.mp4

2) Run programs via extension provided dynamic debug configurations within the same root folder 
[hello-multi-root-js.zip](https://github.com/eclipse-theia/theia/files/11391236/hello-multi-root-js.zip)

- Download the `zip` file above and using `theia` open the multi root workspace file included in the main folder
- There are two `root` folders named `original` and `copy`, each root have its own `src` folder with `js` files ready to run
- Follow the following recording to validate that you can  run programs via extension provided dynamic configurations as long as they are located in the same selected root folder.
- Verify that using a provided dynamic configuration to run a program in a different root folder fails.
https://user-images.githubusercontent.com/76971376/236050594-6a7f0907-6e52-40ef-a3ee-83ded4ecad80.mp4

3) Using `quick access` (e.g., typing `?` from command palette), Verify the successful execution of programs via extension provided dynamic debug configurations (follow the video clip below),
https://user-images.githubusercontent.com/76971376/236050617-59f796d5-eabf-4a9f-a01b-d31a07cec58c.mp4

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
