### PR TITLE
Add support for "enablement" property in plugin command contributions

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -172,7 +172,11 @@ export class TabBarToolbar extends ReactWidget {
     }
 
     protected isEnabled(item: AnyToolbarItem): boolean {
-        return (!!item.command && this.commandIsEnabled(item.command) && this.evaluateWhenClause(item.when)) || (!!item.menuPath && !item.command);
+        if (!!item.command) {
+            return this.commandIsEnabled(item.command) && this.evaluateWhenClause(item.when);
+        } else {
+            return !!item.menuPath;
+        }
     }
 
     protected getToolbarItemClassNames(item: AnyToolbarItem): string[] {

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -43,6 +43,7 @@ export class TabBarToolbar extends ReactWidget {
     protected more = new Map<string, TabBarToolbarItem>();
 
     protected contextKeyListener: Disposable | undefined;
+    protected toDisposeOnUpdateItems: DisposableCollection = new DisposableCollection();
 
     @inject(CommandRegistry) protected readonly commands: CommandRegistry;
     @inject(LabelParser) protected readonly labelParser: LabelParser;
@@ -59,11 +60,20 @@ export class TabBarToolbar extends ReactWidget {
     }
 
     updateItems(items: Array<TabBarToolbarItem | ReactTabBarToolbarItem>, current: Widget | undefined): void {
+        this.toDisposeOnUpdateItems.dispose();
+        this.toDisposeOnUpdateItems = new DisposableCollection();
         this.inline.clear();
         this.more.clear();
 
         const contextKeys = new Set<string>();
         for (const item of items.sort(TabBarToolbarItem.PRIORITY_COMPARATOR).reverse()) {
+            if ('command' in item) {
+                this.commands.getAllHandlers(item.command).forEach(handler => {
+                    if (handler.onDidChangeEnabled) {
+                        this.toDisposeOnUpdateItems.push(handler.onDidChangeEnabled(() => this.update()));
+                    }
+                });
+            }
             if ('render' in item || item.group === undefined || item.group === 'navigation') {
                 this.inline.set(item.id, item);
             } else {
@@ -149,7 +159,6 @@ export class TabBarToolbar extends ReactWidget {
         const tooltip = item.tooltip || (command && command.label);
 
         const toolbarItemClassNames = this.getToolbarItemClassNames(item);
-        if (item.menuPath && !item.command) { toolbarItemClassNames.push('enabled'); }
         return <div key={item.id}
             className={toolbarItemClassNames.join(' ')}
             onMouseDown={this.onMouseDownEvent}
@@ -162,10 +171,14 @@ export class TabBarToolbar extends ReactWidget {
         </div>;
     }
 
+    protected isEnabled(item: AnyToolbarItem): boolean {
+        return (!!item.command && this.commandIsEnabled(item.command) && this.evaluateWhenClause(item.when)) || (!!item.menuPath && !item.command);
+    }
+
     protected getToolbarItemClassNames(item: AnyToolbarItem): string[] {
         const classNames = [TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM];
         if (item.command) {
-            if (this.commandIsEnabled(item.command) && this.evaluateWhenClause(item.when)) {
+            if (this.isEnabled(item)) {
                 classNames.push('enabled');
             }
             if (this.commandIsToggled(item.command)) {
@@ -254,15 +267,15 @@ export class TabBarToolbar extends ReactWidget {
 
         const item: AnyToolbarItem | undefined = this.inline.get(e.currentTarget.id);
 
-        if (!this.evaluateWhenClause(item?.when)) {
+        if (!item || !this.isEnabled(item)) {
             return;
         }
 
-        if (item?.command && item.menuPath) {
+        if (item.command && item.menuPath) {
             this.menuCommandExecutor.executeCommand(item.menuPath, item.command, this.current);
-        } else if (item?.command) {
+        } else if (item.command) {
             this.commands.executeCommand(item.command, this.current);
-        } else if (item?.menuPath) {
+        } else if (item.menuPath) {
             this.renderMoreContextMenu(this.toAnchor(e), item.menuPath);
         }
         this.update();

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -122,6 +122,7 @@ export interface CommandHandler {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     isEnabled?(...args: any[]): boolean;
+    onDidChangeEnabled?: Event<void>;
     /**
      * Test whether menu items for this handler should be visible.
      */

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -35,6 +35,12 @@ export interface ElectronMenuOptions {
      * Defaults to `true`.
      */
     readonly showDisabled?: boolean;
+
+    /**
+     * Controls whether to render disabled items as disabled
+     * Defaults to `true`
+     */
+    readonly honorDisabled?: boolean;
     /**
      * A DOM context to use when evaluating any `when` clauses
      * of menu items registered for this item.
@@ -108,7 +114,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
         const maxWidget = document.getElementsByClassName(MAXIMIZED_CLASS);
         if (preference === 'visible' || (preference === 'classic' && maxWidget.length === 0)) {
             const menuModel = this.menuProvider.getMenu(MAIN_MENU_BAR);
-            this._menu = this.fillMenuTemplate([], menuModel, [], { rootMenuPath: MAIN_MENU_BAR });
+            this._menu = this.fillMenuTemplate([], menuModel, [], { honorDisabled: false, rootMenuPath: MAIN_MENU_BAR });
             if (isOSX) {
                 this._menu.unshift(this.createOSXMenu());
             }
@@ -121,7 +127,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
 
     createElectronContextMenu(menuPath: MenuPath, args?: any[], context?: HTMLElement, contextKeyService?: ContextMatcher): MenuDto[] {
         const menuModel = this.menuProvider.getMenu(menuPath);
-        return this.fillMenuTemplate([], menuModel, args, { showDisabled: false, context, rootMenuPath: menuPath, contextKeyService });
+        return this.fillMenuTemplate([], menuModel, args, { showDisabled: true, context, rootMenuPath: menuPath, contextKeyService });
     }
 
     protected fillMenuTemplate(parentItems: MenuDto[],
@@ -130,6 +136,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
         options: ElectronMenuOptions
     ): MenuDto[] {
         const showDisabled = options?.showDisabled !== false;
+        const honorDisabled = options?.honorDisabled !== false;
 
         if (CompoundMenuNode.is(menu) && menu.children.length && this.undefinedOrMatch(options.contextKeyService ?? this.contextKeyService, menu.when, options.context)) {
             const role = CompoundMenuNode.getRole(menu);
@@ -181,7 +188,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
                 label: node.label,
                 type: this.commandRegistry.getToggledHandler(commandId, ...args) ? 'checkbox' : 'normal',
                 checked: this.commandRegistry.isToggled(commandId, ...args),
-                enabled: true, // https://github.com/eclipse-theia/theia/issues/446
+                enabled: !honorDisabled || this.commandRegistry.isEnabled(commandId, args), // see https://github.com/eclipse-theia/theia/issues/446
                 visible: true,
                 accelerator,
                 execute: () => this.execute(commandId, args, options.rootMenuPath)

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -47,6 +47,7 @@ import { ContributedTerminalProfileStore, TerminalProfileStore } from '@theia/te
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { PluginTerminalRegistry } from './plugin-terminal-registry';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 
 @injectable()
 export class PluginContributionHandler {
@@ -121,6 +122,9 @@ export class PluginContributionHandler {
 
     @inject(ContributionProvider) @named(LabelProviderContribution)
     protected readonly contributionProvider: ContributionProvider<LabelProviderContribution>;
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
 
     protected readonly commandHandlers = new Map<string, CommandHandler['execute'] | undefined>();
 
@@ -399,7 +403,7 @@ export class PluginContributionHandler {
             return Disposable.NULL;
         }
         const toDispose = new DisposableCollection();
-        for (const { iconUrl, themeIcon, command, category, title, originalTitle } of contribution.commands) {
+        for (const { iconUrl, themeIcon, command, category, title, originalTitle, enablement } of contribution.commands) {
             const reference = iconUrl && this.style.toIconClass(iconUrl);
             const icon = themeIcon && ThemeIcon.fromString(themeIcon);
             let iconClass;
@@ -409,12 +413,12 @@ export class PluginContributionHandler {
             } else if (icon) {
                 iconClass = ThemeIcon.asClassName(icon);
             }
-            toDispose.push(this.registerCommand({ id: command, category, label: title, originalLabel: originalTitle, iconClass }));
+            toDispose.push(this.registerCommand({ id: command, category, label: title, originalLabel: originalTitle, iconClass }, enablement));
         }
         return toDispose;
     }
 
-    registerCommand(command: Command): Disposable {
+    registerCommand(command: Command, enablement?: string): Disposable {
         if (this.hasCommand(command.id)) {
             console.warn(`command '${command.id}' already registered`);
             return Disposable.NULL;
@@ -429,10 +433,26 @@ export class PluginContributionHandler {
                 return handler(...args);
             },
             // Always enabled - a command can be executed programmatically or via the commands palette.
-            isEnabled(): boolean { return true; },
+            isEnabled: () => {
+                if (enablement) {
+                    return this.contextKeyService.match(enablement);
+                }
+                return true;
+            },
             // Visibility rules are defined via the `menus` contribution point.
             isVisible(): boolean { return true; }
         };
+
+        if (enablement) {
+            const contextKeys = this.contextKeyService.parseKeys(enablement);
+            if (contextKeys && contextKeys.size > 0) {
+                commandHandler.onDidChangeEnabled = (listener: () => void) => this.contextKeyService.onDidChange(e => {
+                    if (e.affects(contextKeys)) {
+                        listener();
+                    }
+                });
+            }
+        }
 
         const toDispose = new DisposableCollection();
         if (this.commands.getCommand(command.id)) {
@@ -608,5 +628,4 @@ export class PluginContributionHandler {
         }
         return { indentAction, appendText: action.appendText, removeText: action.removeText };
     }
-
 }


### PR DESCRIPTION
#### What it does
Reads the `enablement` property for commands contributed in a plugin `package.json` and updates toolbar items when necessary.

Fixes #12426

Contributed on behalf of STMicroelectronics

#### How to test
1. Install the attached plugin
2. Open the view "Test View Drag And Drop"
3. There are two toolbar actions: the left one prints the selction to the console and the right one changes the enablement of the other action
4. Click on the second action
5. Observe: the toolbar item becomes grayed-out/normal
6. Observe: you cannot execute the action if the item appears disabled and vice-versa.
7. Click on the "more" menu in the view and make the enablement in the menu is correct
8. Open the context menu on an item in the view and make sure the enablement is correct
9. Repeat the above tests in electron-native and electron-custom mode
10. Repeat the above tests in browser mode
11. Check main-menu behavior: in electron-custom and browser mode, enablement/disablement should work, in electron-native mode, main menu items should always be enabled (see  https://github.com/eclipse-theia/theia/issues/446). The "Selection" menu is a good candidate to check the behavior.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
