### PR TITLE
Fix TreeView.reveal() behavior. 

### DIFF
--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -247,14 +247,14 @@ class TreeViewExtImpl<T> implements Disposable {
 
     async reveal(element: T, options?: Partial<TreeViewRevealOptions>): Promise<void> {
         await this.pendingRefresh;
-        const select = !(options?.select === false); // default to true
+        const select = options?.select !== false; // default to true
         const focus = !!options?.focus;
-        const expand = typeof options?.expand === 'undefined' ? false : options!.expand!;
+        const expand = typeof options?.expand === 'undefined' ? false : options!.expand;
 
         const elementParentChain = await this.calculateRevealParentChain(element);
         if (elementParentChain) {
             return this.proxy.$reveal(this.treeViewId, elementParentChain, {
-                select: select, focus: focus, expand: expand, ...options
+                select, focus, expand, ...options
             });
         }
     }


### PR DESCRIPTION

#### What it does
Fixes the `TreeView.reveal` behavior. The behavior was broken when we moved to a new scheme for generating `TreeNode` ids from `TreeItem`s, In addition, the reveal flags (select, focus, reveal) were not passed to the front end.

Fixes #12488

Contributed on behalf of STMicroelectronics
#### How to test
Make sure the failure case from the related issue now works. In addition, I used the procedure from https://github.com/eclipse-theia/theia/pull/8783 to guard against regressions.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
