### PR TITLE
move preload bits under Electron only

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -21,16 +21,14 @@ import { existsSync, readFileSync } from 'fs';
 
 export class FrontendGenerator extends AbstractGenerator {
 
-    async generate(options: GeneratorOptions = {}): Promise<void> {
-        const frontendModules = this.pck.targetFrontendModules;
-        await this.write(this.pck.frontend('index.html'), this.compileIndexHtml(frontendModules));
-        await this.write(this.pck.frontend('index.js'), this.compileIndexJs(frontendModules));
-        await this.write(this.pck.frontend('preload.js'), this.compilePreloadJs());
+    async generate(options?: GeneratorOptions): Promise<void> {
+        await this.write(this.pck.frontend('index.html'), this.compileIndexHtml(this.pck.targetFrontendModules));
+        await this.write(this.pck.frontend('index.js'), this.compileIndexJs(this.pck.targetFrontendModules));
         await this.write(this.pck.frontend('secondary-window.html'), this.compileSecondaryWindowHtml());
         await this.write(this.pck.frontend('secondary-index.js'), this.compileSecondaryIndexJs(this.pck.secondaryWindowModules));
         if (this.pck.isElectron()) {
-            const electronMainModules = this.pck.targetElectronMainModules;
-            await this.write(this.pck.frontend('electron-main.js'), this.compileElectronMain(electronMainModules));
+            await this.write(this.pck.frontend('electron-main.js'), this.compileElectronMain(this.pck.targetElectronMainModules));
+            await this.write(this.pck.frontend('preload.js'), this.compilePreloadJs());
         }
     }
 
@@ -90,8 +88,7 @@ self.MonacoEnvironment = {
     getWorkerUrl: function (moduleId, label) {
         return './editor.worker.js';
     }
-}
-`)}
+}`)}
 
 const preloader = require('@theia/core/lib/browser/preloader');
 

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -278,7 +278,7 @@ module.exports = [{
         warnings: true,
         children: true
     }
-}, {
+}${this.ifElectron(`, {
     mode,
     devtool: 'source-map',
     entry: {
@@ -296,7 +296,7 @@ module.exports = [{
         warnings: true,
         children: true
     }
-}];`;
+}`)}];`;
     }
 
     protected compileUserWebpackConfig(): string {


### PR DESCRIPTION
The `preload.js` generated script is included in browser builds, this will cause issues for anyone trying to build a browser app.

This commit makes sure the Electron bits aren't used when building a browser app.

Closes https://github.com/eclipse-theia/theia/issues/12490

#### How to test

There should be no mention of `preload.js` in the generated files for the browser (`src-gen/*` and `gen-webpack.config.js`).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
