### PR TITLE
fix: use node ID instead of running index for menu

### DIFF
--- a/packages/core/src/electron-common/electron-api.ts
+++ b/packages/core/src/electron-common/electron-api.ts
@@ -35,7 +35,7 @@ export interface MenuDto {
 
 export type InternalMenuDto = Omit<MenuDto, 'execute' | 'submenu'> & {
     submenu?: InternalMenuDto[],
-    handlerId?: number
+    menuNodeId?: string
 };
 
 export type WindowEvent = 'maximize' | 'unmaximize' | 'focus';

--- a/packages/core/src/electron-main/electron-api-main.ts
+++ b/packages/core/src/electron-main/electron-api-main.ts
@@ -18,12 +18,11 @@ import {
     ipcMain, BrowserWindow, Menu, MenuItemConstructorOptions, webContents, WebContents, session, shell, clipboard, IpcMainEvent
 } from '@theia/electron/shared/electron';
 import * as nativeKeymap from '@theia/electron/shared/native-keymap';
-
 import { inject, injectable } from 'inversify';
 import { FrontendApplicationState, StopReason } from '../common/frontend-application-state';
 import { ElectronSecurityToken } from '../electron-common/electron-token';
 import {
-    CHANNEL_GET_SECURITY_TOKEN, CHANNEL_SET_MENU, MenuDto, CHANNEL_INVOKE_MENU, CHANNEL_FOCUS_WINDOW,
+    CHANNEL_GET_SECURITY_TOKEN, CHANNEL_SET_MENU, CHANNEL_INVOKE_MENU, CHANNEL_FOCUS_WINDOW,
     CHANNEL_ATTACH_SECURITY_TOKEN, CHANNEL_OPEN_POPUP, CHANNEL_ON_CLOSE_POPUP, CHANNEL_CLOSE_POPUP,
     CHANNEL_GET_TITLE_STYLE_AT_STARTUP,
     CHANNEL_MINIMIZE,
@@ -75,7 +74,7 @@ export class TheiaMainApi implements ElectronMainApplicationContribution {
         }));
 
         // application menu
-        ipcMain.on(CHANNEL_SET_MENU, (event, menuId: number, menu: MenuDto[]) => {
+        ipcMain.on(CHANNEL_SET_MENU, (event, menuId: number, menu: InternalMenuDto[] | undefined) => {
             let electronMenu: Menu | null;
             if (menu) {
                 electronMenu = Menu.buildFromTemplate(this.fromMenuDto(event.sender, menuId, menu));
@@ -215,7 +214,7 @@ export class TheiaMainApi implements ElectronMainApplicationContribution {
         });
     }
 
-    fromMenuDto(sender: WebContents, menuId: number, menuDto: InternalMenuDto[]): MenuItemConstructorOptions[] {
+    protected fromMenuDto(sender: WebContents, menuId: number, menuDto: InternalMenuDto[]): MenuItemConstructorOptions[] {
         return menuDto.map(dto => {
 
             const result: MenuItemConstructorOptions = {
@@ -231,9 +230,9 @@ export class TheiaMainApi implements ElectronMainApplicationContribution {
             if (dto.submenu) {
                 result.submenu = this.fromMenuDto(sender, menuId, dto.submenu);
             }
-            if (dto.handlerId) {
+            if (dto.menuNodeId) {
                 result.click = () => {
-                    sender.send(CHANNEL_INVOKE_MENU, menuId, dto.handlerId);
+                    sender.send(CHANNEL_INVOKE_MENU, menuId, dto.menuNodeId);
                 };
             }
             return result;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR switches from a running index (`number`) menu handler to the menu node's technical ID (`string`).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Start the example electron app, and once you see the `Sample Menu` popping up, click `File` > `New File` multiple times. When the app loads, the highest number of `Untitled-$NUMBER` equals the times you click on the `New File` menu during the app startup. So if you click the menu thrice, expect to see `Untitled-3`.

Closes #12493

https://user-images.githubusercontent.com/1405703/237036355-e5853350-b66f-4a81-bb3d-3549336a19d8.mp4

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
