### PR TITLE
editor: add confirmation prompt when executing clear editor history

### DIFF
--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -28,6 +28,7 @@ import { NavigationLocation, RecentlyClosedEditor } from './navigation/navigatio
 import { NavigationLocationService } from './navigation/navigation-location-service';
 import { PreferenceService, PreferenceScope, addEventListener } from '@theia/core/lib/browser';
 import { ConfirmDialog, Dialog } from '@theia/core/lib/browser/dialogs';
+import { nls } from '@theia/core';
 
 @injectable()
 export class EditorNavigationContribution implements Disposable, FrontendApplicationContribution {
@@ -85,13 +86,13 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
         });
         this.commandRegistry.registerHandler(EditorCommands.CLEAR_EDITOR_HISTORY.id, {
             execute: async () => {
-                const confirmed = await new ConfirmDialog({
-                    title: 'Clear Editor History',
-                    msg: 'Are you sure you want to clear the history of recently opened editors?',
+                const shouldClear = await new ConfirmDialog({
+                    title: nls.localizeByDefault('Clear Editor History'),
+                    msg: nls.localizeByDefault('Do you want to clear the history of recently opened editors?'),
                     ok: Dialog.YES,
                     cancel: Dialog.NO
                 }).open();
-                if (confirmed) {
+                if (shouldClear) {
                     this.locationStack.clearHistory();
                 }
             },

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -27,6 +27,7 @@ import { TextEditor, Position, Range, TextDocumentChangeEvent } from './editor';
 import { NavigationLocation, RecentlyClosedEditor } from './navigation/navigation-location';
 import { NavigationLocationService } from './navigation/navigation-location-service';
 import { PreferenceService, PreferenceScope, addEventListener } from '@theia/core/lib/browser';
+import { ConfirmDialog, Dialog } from '@theia/core/lib/browser/dialogs';
 
 @injectable()
 export class EditorNavigationContribution implements Disposable, FrontendApplicationContribution {
@@ -83,7 +84,17 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             isEnabled: () => !!this.locationStack.lastEditLocation()
         });
         this.commandRegistry.registerHandler(EditorCommands.CLEAR_EDITOR_HISTORY.id, {
-            execute: () => this.locationStack.clearHistory(),
+            execute: async () => {
+                const confirmed = await new ConfirmDialog({
+                    title: 'Clear Editor History',
+                    msg: 'Are you sure you want to clear the history of recently opened editors?',
+                    ok: Dialog.YES,
+                    cancel: Dialog.NO
+                }).open();
+                if (confirmed) {
+                    this.locationStack.clearHistory();
+                }
+            },
             isEnabled: () => this.locationStack.locations().length > 0
         });
         this.commandRegistry.registerHandler(EditorCommands.TOGGLE_MINIMAP.id, {


### PR DESCRIPTION

#### What it does
It adds a confirmation prompt when executing clear editor history 
fixes #12496

![Recording](https://github.com/eclipse-theia/theia/assets/37548139/8362469c-e662-4af5-a375-e36d646ed321)

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
