### PR TITLE
Fix missing options related to 'Tasks'

### DIFF
--- a/packages/task/src/browser/provided-task-configurations.ts
+++ b/packages/task/src/browser/provided-task-configurations.ts
@@ -19,7 +19,7 @@ import { TaskProviderRegistry, TaskProvider } from './task-contribution';
 import { TaskDefinitionRegistry } from './task-definition-registry';
 import { TaskConfiguration, TaskCustomization, TaskOutputPresentation, TaskConfigurationScope, TaskScope } from '../common';
 
-const ALL_TASK_TYPES: string = '*';
+export const ALL_TASK_TYPES: string = '*';
 
 @injectable()
 export class ProvidedTaskConfigurations {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: https://github.com/eclipse-theia/theia/issues/12455

The following user options were added:

When selecting `Terminal-> Run Task...`
* Display a `+ Configure Task` entry when no tasks are configured (above contributed items)
* Add `Show All Tasks...` entry at the bottom of the list of contributed tasks.
* Improve ordering of entries (in a `multiroot`, sort by root then label)
* Add `Go back ↩` option from second level picks.

When selecting `Terminal-> Configure Tasks...`
* Add missing plugin provided entries with the scope `workspace`
* Order by scope, then by task label.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Prerequisites:
1. Install Gulp CLI (Used by the Gulp builtin extension)

> npm install gulp-cli -g

2. Install Jake CLI (Optionally, Used by the Jake builtin extension)

> npm install -g jake

3. Activate `Auto Detect` preference for `Gulp` to `on`
From the: 
Command palette -> type 'open user settings' -> click and then ->  Navigate to (Extensions -> Gulp) and change 'Auto Detect' to 'on'

4. Activate `Auto Detect` preference for `Jake` to `on`
From the: 
Command palette -> type 'open user settings' -> click and then ->  Navigate to (Extensions -> Jake) and change 'Auto Detect' to 'on' 

5. Use a clone of 'vscode' as the project to test `theia` with
>  gh repo clone microsoft/vscode
*  edit `.vscode/settings.json` to delete the line:
	"gulp.autoDetect": "off"
* edit `.vscode/tasks.json` to remove the only "gulp" task
   this to prevent early activation of gulp.
* Copy a valid Jakefile.js under the root folder.
     Example test content:

```js
desc('Default Task');
task('default', function () {
 console.log('Hello, Jake!');
});

desc('Test Task');
task('test', function () {
  console.log('This is a test task.');
});
```

Steps to test: 
1) Testing options for `Terminal-> Run Task...` , `+ Configure task`

- Using `theia`, open a project folder which does not have a `tasks.json` file
  and has a `Jakefile.js`.

- Open the `Terminal-> Run Task...` option, verity the option `+ Configure Task` is present
- When selecting the option above, provided `jake` tasks shall be available
- Select a provided `jake` task and verify it populates the `tasks.json` file with it.

2) Testing options for `Terminal -> Run Task...`, `Show All Tasks...`
Using the same project as in the previous test
- Select the option `Terminal -> Run Task...`, `Show All Tasks...`
- Validate that the plugin provided `jake` tasks are available (alphabetically ordered)
- Selecting an entry shall populate the configuration in the `tasks.json` file.

3) Testing the `Terminal-> Run Task...`, select type `gulp`, `Go back ↩`
- Validate that the `gulp` tasks are listed and alphabetically ordered 
- Validate that the last entry of the list is for the option `Go back ↩`  and that it works to go
back to display the previous level.

4) Repeat the steps 2 and 3 above using a multi-root workspace e.g. having `theia` and `vscode`

5) Test `Terminal->  Configure Tasks...`
- Using a single root workspace e.g. `vscode`, select the option `Terminal->  Configure Tasks...`
- Validate that  the plugin provided configurations are available e.g. `jake`, `gulp`, `npm`
- Validate that the entries are sorted by `scope` and then by `label`
6) Repeat the previous step but with a multi-root project e.g. `theia` and `vscode`


See test example video (`Run Task`):
https://github.com/eclipse-theia/theia/assets/76971376/bab18c32-4557-4d8f-ae0b-36fe987bbb6f

See test example video (`Configure Tasks...`)
https://github.com/eclipse-theia/theia/assets/76971376/d1340c58-b7c2-4618-a7f7-1bf8ca1fbec7


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
