### PR TITLE
[vscode] Stub for proposed API: EditSessionIdentityProvider

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -702,6 +702,7 @@ export interface WorkspaceExt {
     $provideTextDocumentContent(uri: string): Promise<string | undefined | null>;
     $onTextSearchResult(searchRequestId: number, done: boolean, result?: SearchInWorkspaceResult): void;
     $onWorkspaceTrustChanged(trust: boolean | undefined): void;
+    $registerEditSessionIdentityProvider(scheme: string, provider: theia.EditSessionIdentityProvider): theia.Disposable
 }
 
 export interface TimelineExt {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -714,6 +714,9 @@ export function createAPIFactory(
             },
             get onDidGrantWorkspaceTrust(): theia.Event<void> {
                 return workspaceExt.onDidGrantWorkspaceTrust;
+            },
+            registerEditSessionIdentityProvider(scheme: string, provider: theia.EditSessionIdentityProvider) {
+                return workspaceExt.$registerEditSessionIdentityProvider(scheme, provider);
             }
         };
 

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -449,7 +449,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         }
     }
 
-    // stub
+    /** @stubbed */
     $registerEditSessionIdentityProvider(scheme: string, provider: theia.EditSessionIdentityProvider): theia.Disposable {
         return Disposable.NULL;
     }

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -34,7 +34,7 @@ import { Path } from '@theia/core/lib/common/path';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { WorkspaceRootsChangeEvent, SearchInWorkspaceResult, Range } from '../common/plugin-api-rpc-model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
-import { URI } from './types-impl';
+import { Disposable, URI } from './types-impl';
 import { normalize } from '@theia/core/lib/common/paths';
 import { relative } from '../common/paths-util';
 import { Schemes } from '../common/uri-components';
@@ -447,6 +447,11 @@ export class WorkspaceExtImpl implements WorkspaceExt {
             this._trusted = trust;
             this.didGrantWorkspaceTrustEmitter.fire();
         }
+    }
+
+    // stub
+    $registerEditSessionIdentityProvider(scheme: string, provider: theia.EditSessionIdentityProvider): theia.Disposable {
+        return Disposable.NULL;
     }
 
 }

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -614,6 +614,29 @@ export module '@theia/plugin' {
     }
 
     // #endregion
+
+    // #region SessionIdentityProvider
+    export namespace workspace {
+        /**
+         *
+         * @param scheme The URI scheme that this provider can provide edit session identities for.
+         * @param provider A provider which can convert URIs for workspace folders of scheme @param scheme to
+         * an edit session identifier which is stable across machines. This enables edit sessions to be resolved.
+         */
+        export function registerEditSessionIdentityProvider(scheme: string, provider: EditSessionIdentityProvider): Disposable;
+    }
+
+    export interface EditSessionIdentityProvider {
+        /**
+         *
+         * @param workspaceFolder The workspace folder to provide an edit session identity for.
+         * @param token A cancellation token for the request.
+         * @returns An string representing the edit session identity for the requested workspace folder.
+         */
+        provideEditSessionIdentity(workspaceFolder: WorkspaceFolder, token: CancellationToken): ProviderResult<string>;
+    }
+
+    // #endregion
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
EditSessionIdentityProvider is a new proposed API. As of 1.72.2 it's only used 
in built-in git (vscode.git).
    
This commit adds a stub implementation, sufficient to use vscode.git 1.72.2 and 
hopefully later versions, if we need it to. The eventual goal is to implement this 
API with a working implementation.

~~Temporary test commit:~~
~~To make it easier to  test the stub implementation, a temporary commit as added 
to the PR, to be removed before merging.~~

Change of plans: replacing @theia/git will definately interfere with some of our tests. 
Instead here's the git diff of the commit, that can guide a reviewer how to modify locally 
the example app, so it uses `vscode.git@1.72.2` instead of `@theia/git`.  This will be 
useful to test locally this PR: (unzip locally - contains a single text file: `git-diff.txt`)

[git-diff.zip](https://github.com/eclipse-theia/theia/files/11436021/git-diff.zip)
    
Fixes #12437

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Do the changes suggested above so that the example app uses vscode built-in git instead of 
@theia/git. Unzip the file below to an empty "plugins" folder at the root of the theia repo (a few 
built-ins v1.72.2, not published yet). You may remove the markdown extension for now and keep 
the two git extensions : 

[builtins-extensions-for-tests.zip](https://github.com/eclipse-theia/theia/files/11435831/builtins-extensions-for-tests.zip)

Do not run `yarn download:plugins` after adding the vscode git extensions v1.72.2, 
since the command might install another version along, which  might interfere with 
the tests.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
