### PR TITLE
Show "Collapse All" command in tree view toolbar. 

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -77,6 +77,20 @@ export namespace BadgeWidget {
 }
 
 /**
+ * A widget that may change it's internal structure dynamically. Current use is for
+ * updating the toolbar when a contributed view is contructed "lazily"
+ */
+export interface DynamicWidget {
+    onChanged: CommonEvent<void>;
+}
+
+export namespace DynamicWidget {
+    export function is(arg: unknown): arg is DynamicWidget {
+        return isObject(arg) && 'onChanged' in arg;
+    }
+}
+
+/**
  * A view container holds an arbitrary number of widgets inside a split panel.
  * Each widget is wrapped in a _part_ that displays the widget title and toolbar
  * and allows to collapse / expand the widget content.
@@ -968,6 +982,10 @@ export class ViewContainerPart extends BaseWidget {
         if (BadgeWidget.is(this.wrapped)) {
             this.wrapped.onDidChangeBadge(() => this.onDidChangeBadgeEmitter.fire(), undefined, this.toDispose);
             this.wrapped.onDidChangeBadgeTooltip(() => this.onDidChangeBadgeTooltipEmitter.fire(), undefined, this.toDispose);
+        }
+
+        if (DynamicWidget.is(this.wrapped)) {
+            this.wrapped.onChanged(() => this.toolbar.updateTarget(this.wrapped));
         }
 
         const { header, body, disposable } = this.createContent();

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -80,13 +80,13 @@ export namespace BadgeWidget {
  * A widget that may change it's internal structure dynamically. Current use is for
  * updating the toolbar when a contributed view is contructed "lazily"
  */
-export interface DynamicWidget {
-    onChanged: CommonEvent<void>;
+export interface DynamicToolbarWidget {
+    onDidChangeToolbarItems: CommonEvent<void>;
 }
 
-export namespace DynamicWidget {
-    export function is(arg: unknown): arg is DynamicWidget {
-        return isObject(arg) && 'onChanged' in arg;
+export namespace DynamicToolbarWidget {
+    export function is(arg: unknown): arg is DynamicToolbarWidget {
+        return isObject(arg) && 'onDidChangeToolbarItems' in arg;
     }
 }
 
@@ -984,8 +984,11 @@ export class ViewContainerPart extends BaseWidget {
             this.wrapped.onDidChangeBadgeTooltip(() => this.onDidChangeBadgeTooltipEmitter.fire(), undefined, this.toDispose);
         }
 
-        if (DynamicWidget.is(this.wrapped)) {
-            this.wrapped.onChanged(() => this.toolbar.updateTarget(this.wrapped));
+        if (DynamicToolbarWidget.is(this.wrapped)) {
+            this.wrapped.onDidChangeToolbarItems(() => {
+                this.toolbar.updateTarget(this.wrapped);
+                this.viewContainer?.update();
+            });
         }
 
         const { header, body, disposable } = this.createContent();

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -728,6 +728,7 @@ export interface DialogsMain {
 }
 
 export interface RegisterTreeDataProviderOptions {
+    showCollapseAll?: boolean
     canSelectMany?: boolean
     dragMimeTypes?: string[]
     dropMimeTypes?: string[]

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -84,6 +84,7 @@ import { PluginTerminalRegistry } from './plugin-terminal-registry';
 import { DnDFileContentStore } from './view/dnd-file-content-store';
 import { WebviewContextKeys } from './webview/webview-context-keys';
 import { LanguagePackService, languagePackServicePath } from '../../common/language-pack-service';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
@@ -110,6 +111,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(OpenUriCommandHandler).toSelf().inSingletonScope();
     bind(PluginApiFrontendContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(PluginApiFrontendContribution);
+    bind(TabBarToolbarContribution).toService(PluginApiFrontendContribution);
 
     bind(EditorModelService).toSelf().inSingletonScope();
 

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
@@ -15,21 +15,56 @@
 // *****************************************************************************
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
+import { CommandRegistry, CommandContribution, Command } from '@theia/core/lib/common';
 import { OpenUriCommandHandler } from './commands';
 import URI from '@theia/core/lib/common/uri';
+import { TreeViewWidget } from './view/tree-view-widget';
+import { CompositeTreeNode, Widget, codicon } from '@theia/core/lib/browser';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { PluginViewWidget } from './view/plugin-view-widget';
 
 @injectable()
-export class PluginApiFrontendContribution implements CommandContribution {
+export class PluginApiFrontendContribution implements CommandContribution, TabBarToolbarContribution {
 
     @inject(OpenUriCommandHandler)
     protected readonly openUriCommandHandler: OpenUriCommandHandler;
+
+    static readonly COLLAPSE_ALL_COMMAND = Command.toDefaultLocalizedCommand({
+        id: 'treeviews.collapseAll',
+        iconClass: codicon('collapse-all')
+    });
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(OpenUriCommandHandler.COMMAND_METADATA, {
             execute: (arg: URI) => this.openUriCommandHandler.execute(arg),
             isVisible: () => false
         });
+        commands.registerCommand(PluginApiFrontendContribution.COLLAPSE_ALL_COMMAND, {
+            execute: (widget: Widget) => {
+                if (widget instanceof PluginViewWidget && widget.widgets[0] instanceof TreeViewWidget) {
+                    const model = widget.widgets[0].model;
+                    if (CompositeTreeNode.is(model.root)) {
+                        for (const child of model.root.children) {
+                            if (CompositeTreeNode.is(child)) {
+                                model.collapseAll(child);
+                            }
+                        }
+                    }
+                }
+            },
+            isVisible: (widget: Widget) => widget instanceof PluginViewWidget && widget.widgets[0] instanceof TreeViewWidget && widget.widgets[0].showCollapseAll
+        });
+
     }
 
+    registerToolbarItems(registry: TabBarToolbarRegistry): void {
+
+        registry.registerItem({
+            id: PluginApiFrontendContribution.COLLAPSE_ALL_COMMAND.id,
+            command: PluginApiFrontendContribution.COLLAPSE_ALL_COMMAND.id,
+            tooltip: PluginApiFrontendContribution.COLLAPSE_ALL_COMMAND.label,
+            icon: PluginApiFrontendContribution.COLLAPSE_ALL_COMMAND.iconClass,
+            priority: 1000
+        });
+    }
 }

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
@@ -31,7 +31,8 @@ export class PluginApiFrontendContribution implements CommandContribution, TabBa
 
     static readonly COLLAPSE_ALL_COMMAND = Command.toDefaultLocalizedCommand({
         id: 'treeviews.collapseAll',
-        iconClass: codicon('collapse-all')
+        iconClass: codicon('collapse-all'),
+        label: 'Collapse All'
     });
 
     registerCommands(commands: CommandRegistry): void {
@@ -58,7 +59,6 @@ export class PluginApiFrontendContribution implements CommandContribution, TabBa
     }
 
     registerToolbarItems(registry: TabBarToolbarRegistry): void {
-
         registry.registerItem({
             id: PluginApiFrontendContribution.COLLAPSE_ALL_COMMAND.id,
             command: PluginApiFrontendContribution.COLLAPSE_ALL_COMMAND.id,

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
@@ -21,7 +21,7 @@ import { CommandRegistry } from '@theia/core/lib/common/command';
 import { StatefulWidget } from '@theia/core/lib/browser/shell/shell-layout-restorer';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
 import { TreeViewWidget } from './tree-view-widget';
-import { BadgeWidget, DescriptionWidget } from '@theia/core/lib/browser/view-container';
+import { BadgeWidget, DescriptionWidget, DynamicWidget } from '@theia/core/lib/browser/view-container';
 import { DisposableCollection, Emitter, Event } from '@theia/core/lib/common';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 
@@ -32,7 +32,7 @@ export class PluginViewWidgetIdentifier {
 }
 
 @injectable()
-export class PluginViewWidget extends Panel implements StatefulWidget, DescriptionWidget, BadgeWidget {
+export class PluginViewWidget extends Panel implements StatefulWidget, DescriptionWidget, BadgeWidget, DynamicWidget {
 
     currentViewContainerId?: string;
 
@@ -46,6 +46,11 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
     protected onDidChangeBadgeEmitter = new Emitter<void>();
     protected onDidChangeBadgeTooltipEmitter = new Emitter<void>();
     protected toDispose = new DisposableCollection(this.onDidChangeDescriptionEmitter, this.onDidChangeBadgeEmitter, this.onDidChangeBadgeTooltipEmitter);
+    protected readonly onChangedEmitter = new Emitter<void>();
+
+    get onChanged(): Event<void> {
+        return this.onChangedEmitter.event;
+    }
 
     @inject(MenuModelRegistry)
     protected readonly menus: MenuModelRegistry;
@@ -192,11 +197,13 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
             widget.onDidChangeBadgeTooltip(() => this.onDidChangeBadgeTooltipEmitter.fire());
         }
         this.updateWidgetMessage();
+        this.onChangedEmitter.fire();
     }
 
     override insertWidget(index: number, widget: Widget): void {
         super.insertWidget(index, widget);
         this.updateWidgetMessage();
+        this.onChangedEmitter.fire();
     }
 
     override dispose(): void {

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
@@ -21,7 +21,7 @@ import { CommandRegistry } from '@theia/core/lib/common/command';
 import { StatefulWidget } from '@theia/core/lib/browser/shell/shell-layout-restorer';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
 import { TreeViewWidget } from './tree-view-widget';
-import { BadgeWidget, DescriptionWidget, DynamicWidget } from '@theia/core/lib/browser/view-container';
+import { BadgeWidget, DescriptionWidget, DynamicToolbarWidget } from '@theia/core/lib/browser/view-container';
 import { DisposableCollection, Emitter, Event } from '@theia/core/lib/common';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 
@@ -32,7 +32,7 @@ export class PluginViewWidgetIdentifier {
 }
 
 @injectable()
-export class PluginViewWidget extends Panel implements StatefulWidget, DescriptionWidget, BadgeWidget, DynamicWidget {
+export class PluginViewWidget extends Panel implements StatefulWidget, DescriptionWidget, BadgeWidget, DynamicToolbarWidget {
 
     currentViewContainerId?: string;
 
@@ -46,10 +46,10 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
     protected onDidChangeBadgeEmitter = new Emitter<void>();
     protected onDidChangeBadgeTooltipEmitter = new Emitter<void>();
     protected toDispose = new DisposableCollection(this.onDidChangeDescriptionEmitter, this.onDidChangeBadgeEmitter, this.onDidChangeBadgeTooltipEmitter);
-    protected readonly onChangedEmitter = new Emitter<void>();
+    protected readonly onDidChangeToolbarItemsEmitter = new Emitter<void>();
 
-    get onChanged(): Event<void> {
-        return this.onChangedEmitter.event;
+    get onDidChangeToolbarItems(): Event<void> {
+        return this.onDidChangeToolbarItemsEmitter.event;
     }
 
     @inject(MenuModelRegistry)
@@ -197,13 +197,13 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
             widget.onDidChangeBadgeTooltip(() => this.onDidChangeBadgeTooltipEmitter.fire());
         }
         this.updateWidgetMessage();
-        this.onChangedEmitter.fire();
+        this.onDidChangeToolbarItemsEmitter.fire();
     }
 
     override insertWidget(index: number, widget: Widget): void {
         super.insertWidget(index, widget);
         this.updateWidgetMessage();
-        this.onChangedEmitter.fire();
+        this.onDidChangeToolbarItemsEmitter.fire();
     }
 
     override dispose(): void {

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -164,6 +164,7 @@ export namespace CompositeTreeViewNode {
 @injectable()
 export class TreeViewWidgetOptions {
     id: string;
+    showCollapseAll: boolean | undefined;
     multiSelect: boolean | undefined;
     dragMimeTypes: string[] | undefined;
     dropMimeTypes: string[] | undefined;
@@ -441,6 +442,10 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         this.toDispose.push(this.onDidChangeVisibilityEmitter);
         this.toDispose.push(this.contextKeyService.onDidChange(() => this.update()));
         this.treeDragType = `application/vnd.code.tree.${this.id.toLowerCase()}`;
+    }
+
+    get showCollapseAll(): boolean {
+        return this.options.showCollapseAll || false;
     }
 
     protected override renderIcon(node: TreeNode, props: NodeProps): React.ReactNode {

--- a/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
@@ -63,6 +63,7 @@ export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
         this.treeViewProviders.set(treeViewId, this.viewRegistry.registerViewDataProvider(treeViewId, async ({ state, viewInfo }) => {
             const options: TreeViewWidgetOptions = {
                 id: treeViewId,
+                showCollapseAll: $options.showCollapseAll,
                 multiSelect: $options.canSelectMany,
                 dragMimeTypes: $options.dragMimeTypes,
                 dropMimeTypes: $options.dropMimeTypes

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -234,7 +234,7 @@ class TreeViewExtImpl<T> implements Disposable {
         // make copies of optionally provided MIME types:
         const dragMimeTypes = options.dragAndDropController?.dragMimeTypes?.slice();
         const dropMimeTypes = options.dragAndDropController?.dropMimeTypes?.slice();
-        proxy.$registerTreeDataProvider(treeViewId, { canSelectMany: options.canSelectMany, dragMimeTypes, dropMimeTypes });
+        proxy.$registerTreeDataProvider(treeViewId, { showCollapseAll: options.showCollapseAll, canSelectMany: options.canSelectMany, dragMimeTypes, dropMimeTypes });
         this.toDispose.push(Disposable.create(() => this.proxy.$unregisterTreeDataProvider(treeViewId)));
         options.treeDataProvider.onDidChangeTreeData?.(() => {
             this.pendingRefresh = proxy.$refresh(treeViewId);


### PR DESCRIPTION
Contributed on behalf of STMicroelectronics

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12513.

Adds a "Collapse All" toolbar item in tree views contributed by plugins if the plugin requests it in the options (`showCollapseAll`). This PR introduces the concept of `DynamicWidget`. It allows to update the toolbar after the contents of a view widget has been create lazily.

#### How to test
Use the procedure from the related issue and make sure the icon appears. You can also use the built-in "NPM SCRIPTS" view as a second test case.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
