### PR TITLE
docs: add `msgpackr` resolution note

### DIFF
--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -9,6 +9,30 @@ Please see the latest version (`master`) for the most up-to-date information. Pl
 
 ### General
 
+_msgpackr_:
+
+If you're experiencing [`maximum callstack exceeded`](https://github.com/eclipse-theia/theia/issues/12499) errors you may need to downgrade the version of `msgpackr` pulled using a [yarn resolution](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).
+
+```
+rpc-message-encoder.ts:151 Uncaught (in promise) Error: Error during encoding: 'Maximum call stack size exceeded'
+    at MsgPackMessageEncoder.encode (rpc-message-encoder.ts:151:23)
+    at MsgPackMessageEncoder.request (rpc-message-encoder.ts:137:14)
+    at RpcProtocol.sendRequest (rpc-protocol.ts:161:22)
+    at proxy-handler.ts:74:45
+```
+
+For the best results follow the version used and tested by the framework.
+
+For example:
+
+```json
+"resolutions": {
+    "**/msgpackr": "1.8.3"
+}
+```
+
+_socket.io-parser_:
+
 Prior to [`v1.31.1`](https://github.com/eclipse-theia/theia/releases/tag/v1.31.1), a [resolution](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) might be necessary to work-around a recently discovered [critical vulnerability](https://security.snyk.io/vuln/SNYK-JS-SOCKETIOPARSER-3091012) in one of our runtime dependencies [socket.io-parser](https://github.com/socketio/socket.io-parser).
 
 For example:


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Related: https://github.com/eclipse-theia/theia/issues/12499.

The commit adds a `yarn resolution` note in our migration documentation for `msgpackr` as recent versions cause `maximum callstack exceeded` errors.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- confirm the content of the documentation
- if you want to test the bug follow the [guide](https://theia-ide.org/docs/composing_applications/#consuming-vs-code-extensions) on our website with and without the resolution - without the resolution plugins will fail to work and the error will be thrown in the dev-console

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
