### PR TITLE
vscode: add `TerminalQuickFixProvider` API stubbing

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -160,6 +160,7 @@ import {
     TerminalLocation,
     TerminalExitReason,
     TerminalProfile,
+    TerminalQuickFixType,
     InlayHint,
     InlayHintKind,
     InlayHintLabelPart,
@@ -582,6 +583,10 @@ export function createAPIFactory(
             /** @stubbed ProfileContentHandler */
             registerProfileContentHandler(id: string, profileContentHandler: theia.ProfileContentHandler): theia.Disposable {
                 return Disposable.NULL;
+            },
+            /** @stubbed TerminalQuickFixProvider */
+            registerTerminalQuickFixProvider(id: string, provider: theia.TerminalQuickFixProvider): theia.Disposable {
+                return terminalExt.registerTerminalQuickFixProvider(id, provider);
             }
         };
 
@@ -1363,7 +1368,8 @@ export function createAPIFactory(
             TerminalLocation,
             TerminalExitReason,
             DocumentPasteEdit,
-            ExternalUriOpenerPriority
+            ExternalUriOpenerPriority,
+            TerminalQuickFixType
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -246,6 +246,11 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         });
     }
 
+    /** @stubbed */
+    registerTerminalQuickFixProvider(id: string, provider: theia.TerminalQuickFixProvider): theia.Disposable {
+        return Disposable.NULL;
+    }
+
     protected isExtensionTerminalOptions(options: theia.TerminalOptions | theia.ExtensionTerminalOptions): options is theia.ExtensionTerminalOptions {
         return 'pty' in options;
     }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2066,6 +2066,11 @@ export enum TerminalExitReason {
     Extension = 4,
 }
 
+export enum TerminalQuickFixType {
+    command = 'command',
+    opener = 'opener'
+}
+
 @es5ClassCompat
 export class FileDecoration {
 

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -720,6 +720,46 @@ export module '@theia/plugin' {
     }
 
     // #endregion ProfileContentHandler
+
+    // #region TerminalQuickFixProvider
+
+    export namespace window {
+        /**
+         * @param provider A terminal quick fix provider
+         * @return A {@link Disposable} that un-registers the provider when being disposed
+         */
+        export function registerTerminalQuickFixProvider(id: string, provider: TerminalQuickFixProvider): Disposable;
+    }
+
+    export interface TerminalQuickFixProvider {
+        /**
+         * Provides terminal quick fixes
+         * @param commandMatchResult The command match result for which to provide quick fixes
+         * @param token A cancellation token indicating the result is no longer needed
+         * @return Terminal quick fix(es) if any
+         */
+        provideTerminalQuickFixes(commandMatchResult: TerminalCommandMatchResult, token: CancellationToken): TerminalQuickFix[] | TerminalQuickFix | undefined;
+    }
+
+    export interface TerminalCommandMatchResult {
+        commandLine: string;
+        commandLineMatch: RegExpMatchArray;
+        outputMatch?: {
+            regexMatch: RegExpMatchArray;
+            outputLines?: string[];
+        };
+    }
+
+    interface TerminalQuickFix {
+        type: TerminalQuickFixType;
+    }
+
+    enum TerminalQuickFixType {
+        command = 'command',
+        opener = 'opener'
+    }
+
+    // #endRegion TerminalQuickFixProvider
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: https://github.com/eclipse-theia/theia/issues/12522.

The pull-request adds stubbing for the proposed `TerminalQuickFixProvider`  VS Code API.
The API was necessary in order for `vscode.npm@1.77.0` to successfully activate.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- replace the `vscode.npm` builtin with `1.77.0` ([npm-1.77.0.zip](https://github.com/eclipse-theia/theia/files/11480949/npm-1.77.0.zip))
- start the application using `theia` as a workspace
- confirm that there are no activation errors on startup
- confirm that `npm scripts` in the explorer is correctly populated (functionality like running a script should work)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
