### PR TITLE
vscode: add `ProfileContentHandler` API stubbing

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -575,9 +575,12 @@ export function createAPIFactory(
             get tabGroups(): theia.TabGroups {
                 return tabsExt.tabGroups;
             },
-
-            // ExternalUriOpener @stubbed
+            /** @stubbed ExternalUriOpener */
             registerExternalUriOpener(id: string, opener: theia.ExternalUriOpener, metadata: theia.ExternalUriOpenerMetadata): theia.Disposable {
+                return Disposable.NULL;
+            },
+            /** @stubbed ProfileContentHandler */
+            registerProfileContentHandler(id: string, profileContentHandler: theia.ProfileContentHandler): theia.Disposable {
                 return Disposable.NULL;
             }
         };

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -706,6 +706,20 @@ export module '@theia/plugin' {
     }
 
     // #endregion
+
+    // #region ProfileContentHandler
+
+    export interface ProfileContentHandler {
+        readonly name: string;
+        saveProfile(name: string, content: string, token: CancellationToken): Thenable<Uri | null>;
+        readProfile(uri: Uri, token: CancellationToken): Thenable<string | null>;
+    }
+
+    export namespace window {
+        export function registerProfileContentHandler(id: string, profileContentHandler: ProfileContentHandler): Disposable;
+    }
+
+    // #endregion ProfileContentHandler
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: #12520.

The pull-request adds a stubbing for the proposed `ProfileContentHandler` VS Code API.
The API was necessary in order for `vscode.configuration-editing@1.77.0` to successfully activate.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- replace the `vscode.configuration-editing` builtin with `1.77,0` ([configuration-editing-1.77.0.zip](https://github.com/eclipse-theia/theia/files/11487797/configuration-editing-1.77.0.zip))
- start the application using `theia` as a workspace
- confirm that there are no activation errors on startup
- open a `.json` file - no errors should occur either

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
