### PR TITLE
Enhance shrinking behavior in view container part headers

### DIFF
--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -96,7 +96,7 @@
 }
 
 .theia-view-container-part-header .label {
-    flex: 0;
+    overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
 }
@@ -152,6 +152,7 @@
 }
 
 .p-TabBar-toolbar.theia-view-container-part-title {
+    flex: none;
     padding: 0px;
     padding-right: calc(var(--theia-ui-padding)*2/3);
 }


### PR DESCRIPTION
#### What it does

Fixes #12541 by making labels in view container part headers shrinkable and disabling flex-shrinking for view container part title toolbars.

| Before | After |
|-------| ------|
|  <img width="167" alt="Screenshot" src="https://github.com/eclipse-theia/theia/assets/8298491/9a584f0a-df8e-45fa-bb91-8d32f33e5828"> | <img width="179" alt="Screenshot" src="https://github.com/eclipse-theia/theia/assets/8298491/dc86fc2d-ca3f-461a-b412-12527d610d39"> |
| <img width="131" alt="Screenshot 2023-05-17 at 15 23 35" src="https://github.com/eclipse-theia/theia/assets/8298491/0a10a0ab-f7bc-40ac-b702-e7451d5cf734"> | <img width="128" alt="Screenshot 2023-05-17 at 17 29 18" src="https://github.com/eclipse-theia/theia/assets/8298491/42050d5c-b964-4ab5-be4e-59c191008dc2"> |

#### How to test

Verify that enhanced shrinking in view container part headers works as expected and there are no regressions.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
