### PR TITLE
fix: handle exception in WorkspaceDeleteHandler

### DIFF
--- a/packages/workspace/src/browser/workspace-delete-handler.ts
+++ b/packages/workspace/src/browser/workspace-delete-handler.ts
@@ -167,7 +167,7 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
 
     protected async moveFileToTrash(uri: URI, options: FileDeleteOptions): Promise<void> {
         try {
-            this.fileService.delete(uri, { ...options, useTrash: true });
+            await this.fileService.delete(uri, { ...options, useTrash: true });
         } catch (error) {
             console.error('Error deleting with trash:', error);
             if (await this.confirmDeletePermanently(uri)) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes:  https://github.com/eclipse-theia/theia/issues/11908

This PR addresses issue #11908 where the method moveFileToTrash in the WorkspaceDeleteHandler class was not handling promise rejections correctly. The method has been updated to use await when calling fileService.delete(...) to ensure that rejections are caught properly.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Try deleting a file within the workspace. The file should move to trash successfully. Errors during deletion will display appropriate console error messages.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
