### PR TITLE
Spread the parameters when calling "isEnabled"

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -188,7 +188,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
                 label: node.label,
                 type: this.commandRegistry.getToggledHandler(commandId, ...args) ? 'checkbox' : 'normal',
                 checked: this.commandRegistry.isToggled(commandId, ...args),
-                enabled: !honorDisabled || this.commandRegistry.isEnabled(commandId, args), // see https://github.com/eclipse-theia/theia/issues/446
+                enabled: !honorDisabled || this.commandRegistry.isEnabled(commandId, ...args), // see https://github.com/eclipse-theia/theia/issues/446
                 visible: true,
                 accelerator,
                 execute: () => this.execute(commandId, args, options.rootMenuPath)


### PR DESCRIPTION
#### What it does
Correctly spread the command arguments when computing command enablement for Electron context menus.

Fixes #12548

Contributed on behalf of STMicroelectronics

#### How to test
Make sure the command enablement scenarios from the related issue work. The "general" context menu on Typescript editors als has some disabled items.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
