### PR TITLE
fix: propagate log-config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v1.42.0
 
+- [core] fixed logger level propagation when log config file changes at runtime [#12566](https://github.com/eclipse-theia/theia/pull/12566) - Contributed on behalf of STMicroelectronics
 - [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics
 
 ## v1.41.0 - 08/31/2023

--- a/packages/core/src/common/logger-protocol.ts
+++ b/packages/core/src/common/logger-protocol.ts
@@ -38,6 +38,7 @@ export interface ILogLevelChangedEvent {
 
 export interface ILoggerClient {
     onLogLevelChanged(event: ILogLevelChangedEvent): void;
+    onLogConfigChanged(): void;
 }
 
 @injectable()
@@ -49,6 +50,9 @@ export class DispatchingLoggerClient implements ILoggerClient {
         this.clients.forEach(client => client.onLogLevelChanged(event));
     }
 
+    onLogConfigChanged(): void {
+        this.clients.forEach(client => client.onLogConfigChanged());
+    }
 }
 
 export const rootLoggerName = 'root';

--- a/packages/core/src/common/logger-watcher.ts
+++ b/packages/core/src/common/logger-watcher.ts
@@ -22,22 +22,27 @@ import { ILoggerClient, ILogLevelChangedEvent } from './logger-protocol';
 export class LoggerWatcher {
 
     getLoggerClient(): ILoggerClient {
-        const emitter = this.onLogLevelChangedEmitter;
+        const logLevelEmitter = this.onLogLevelChangedEmitter;
+        const logConfigEmitter = this.onLogConfigChangedEmitter;
         return {
             onLogLevelChanged(event: ILogLevelChangedEvent): void {
-                emitter.fire(event);
-            }
+                logLevelEmitter.fire(event);
+            },
+            onLogConfigChanged(): void {
+                logConfigEmitter.fire();
+            },
         };
     }
 
-    private onLogLevelChangedEmitter = new Emitter<ILogLevelChangedEvent>();
+    protected onLogLevelChangedEmitter = new Emitter<ILogLevelChangedEvent>();
 
     get onLogLevelChanged(): Event<ILogLevelChangedEvent> {
         return this.onLogLevelChangedEmitter.event;
     }
 
-    // FIXME: get rid of it, backend services should as well set a client on the server
-    fireLogLevelChanged(event: ILogLevelChangedEvent): void {
-        this.onLogLevelChangedEmitter.fire(event);
+    protected onLogConfigChangedEmitter = new Emitter<void>();
+
+    get onLogConfigChanged(): Event<void> {
+        return this.onLogConfigChangedEmitter.event;
     }
 }

--- a/packages/core/src/common/logger.ts
+++ b/packages/core/src/common/logger.ts
@@ -261,6 +261,11 @@ export class Logger implements ILogger {
                 }
             });
         });
+
+        /* Refetch log level if overall config in backend changed. */
+        this.loggerWatcher.onLogConfigChanged(() => {
+            this._logLevel = this.created.then(_ => this.server.getLogLevel(this.name));
+        });
     }
 
     setLogLevel(logLevel: number): Promise<void> {

--- a/packages/core/src/node/console-logger-server.ts
+++ b/packages/core/src/node/console-logger-server.ts
@@ -17,7 +17,7 @@
 import { inject, injectable, postConstruct } from 'inversify';
 import { LoggerWatcher } from '../common/logger-watcher';
 import { LogLevelCliContribution } from './logger-cli-contribution';
-import { ILoggerServer, ILoggerClient, ConsoleLogger } from '../common/logger-protocol';
+import { ILoggerServer, ILoggerClient, ConsoleLogger, rootLoggerName } from '../common/logger-protocol';
 
 @injectable()
 export class ConsoleLoggerServer implements ILoggerServer {
@@ -32,9 +32,13 @@ export class ConsoleLoggerServer implements ILoggerServer {
 
     @postConstruct()
     protected init(): void {
+        this.setLogLevel(rootLoggerName, this.cli.defaultLogLevel);
         for (const name of Object.keys(this.cli.logLevels)) {
             this.setLogLevel(name, this.cli.logLevels[name]);
         }
+        this.cli.onLogConfigChanged(() => {
+            this.client?.onLogConfigChanged();
+        });
     }
 
     async setLogLevel(name: string, newLogLevel: number): Promise<void> {
@@ -45,7 +49,6 @@ export class ConsoleLoggerServer implements ILoggerServer {
         if (this.client !== undefined) {
             this.client.onLogLevelChanged(event);
         }
-        this.watcher.fireLogLevelChanged(event);
     }
 
     async getLogLevel(name: string): Promise<number> {

--- a/packages/core/src/node/logger-backend-module.ts
+++ b/packages/core/src/node/logger-backend-module.ts
@@ -63,7 +63,14 @@ export const loggerBackendModule = new ContainerModule(bind => {
     bind(DispatchingLoggerClient).toSelf().inSingletonScope();
     bindLogger(bind, {
         onLoggerServerActivation: ({ container }, server) => {
-            server.setClient(container.get(DispatchingLoggerClient));
+            const dispatchingLoggerClient = container.get(DispatchingLoggerClient);
+            server.setClient(dispatchingLoggerClient);
+
+            // register backend logger watcher as a client
+            const loggerWatcher = container.get(LoggerWatcher);
+            dispatchingLoggerClient.clients.add(loggerWatcher.getLoggerClient());
+
+            // make sure dispatching logger client is the only client
             server.setClient = () => {
                 throw new Error('use DispatchingLoggerClient');
             };


### PR DESCRIPTION
If Theia is started with the "--log-config" option the 'LogLevelCliContribution' watches for file changes and fires a 'logConfigChangedEvent'. This event was not listened to. Therefore already existing 'ILogger' levels were not updated. This is now fixed.

Contributed on behalf of STMicroelectronics

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Installs a listener in the `console-logger-server` to update log levels when the log config file changes

#### How to test
Create a log config file and start Theia with the `--log-config` option, e.g. `theia start --log-config=logConfig.json`.

Example log config:
```json
{
    "defaultLevel": "info",
    "levels": {
        "task": "warn"
    }
}
```

While Theia is running modify the handed over log config file (e.g. change the `defaultLevel` to `warn` or `fatal`) and observe that from then on the log messages are filtered accordingly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
