### PR TITLE
Properly set the value of the select component in `DebugBreakpointWidget`

### DIFF
--- a/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
@@ -92,6 +92,8 @@ export class DebugBreakpointWidget implements Disposable {
         }
     }
 
+    private readonly selectComponentRef = React.createRef<SelectComponent>();
+
     @postConstruct()
     protected init(): void {
         this.doInit();
@@ -219,6 +221,10 @@ export class DebugBreakpointWidget implements Disposable {
         if (this._input) {
             this._input.getControl().setValue(this._values[this.context] || '');
         }
+        const selectComponent = this.selectComponentRef.current;
+        if (selectComponent && selectComponent.value !== this.context) {
+            selectComponent.value = this.context;
+        }
         this.selectNodeRoot.render(<SelectComponent
             defaultValue={this.context} onChange={this.updateInput}
             options={[
@@ -226,6 +232,7 @@ export class DebugBreakpointWidget implements Disposable {
                 { value: 'hitCondition', label: nls.localizeByDefault('Hit Count') },
                 { value: 'logMessage', label: nls.localizeByDefault('Log Message') },
             ]}
+            ref={this.selectComponentRef}
         />);
     }
 


### PR DESCRIPTION
#### What it does

Fixes #12547 by ensuring that the value of the select component of the `DebugBreakpointWidget` is set to `this.context` in the `render` method.

#### How to test

Use the steps described in #12547 to verify that the issue is fixed. Check that there are no regressions.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
