### PR TITLE
Update broken link in `@theia/keymaps` package docs

### DIFF
--- a/packages/keymaps/README.md
+++ b/packages/keymaps/README.md
@@ -37,7 +37,7 @@ You can use `shift`, `ctrl`, `alt`, `meta`, `option` (`alt`), `command` (`meta`)
 
 You can also use the following strings for special keys: `backspace`, `tab`, `enter`, `return`, `capslock`, `esc`, `escape`, `space`, `pageup`, `pagedown`, `end`, `home`, `left`, `up`, `right`, `down`, `ins`, `del` and `plus`.
 
-If unsure you can always look at the framework's [supported keys](https://eclipse-theia.github.io/theia/docs/next/modules/core.key-2.html)
+If unsure you can always look at the framework's [supported keys](https://eclipse-theia.github.io/theia/docs/next/modules/core.Key-4.html)
 
 ## Key Sequences
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Update the URL targeted by a reference link in the `@theia/keymaps` package's README.

#### How to test

1. Click the "supported keys" link [in the "**Supported Keys**" section of the current readme](https://github.com/eclipse-theia/theia/tree/master/packages/keymaps#supported-keys).
   🐛 The link leads to a 404 response page.
1. Click the "supported keys" link [in the "**Supported Keys**" of the version of the readme from this PR](https://github.com/per1234/theia/blob/fix-link/packages/keymaps/README.md#supported-keys).
   🙂 The link is functional.
1. Open the page for the previous URL as archived near the time of its addition to the readme (https://github.com/eclipse-theia/theia/commit/a6422c39d6c09095f2bdc8cb4af4427e6bc78082):
   https://web.archive.org/web/20210925095416/https://eclipse-theia.github.io/theia/docs/next/modules/core.key-2.html
1. Compare the archived page to the one targeted by the updated link from this PR.
   🙂 The updated link targets equivalent documentation content.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
