### PR TITLE
workspace: fix untitled file-saving

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -36,7 +36,7 @@ import { OS, isOSX, isWindows, EOL } from '../common/os';
 import { ResourceContextKey } from './resource-context-key';
 import { UriSelection } from '../common/selection';
 import { StorageService } from './storage-service';
-import { Navigatable } from './navigatable';
+import { Navigatable, NavigatableWidget } from './navigatable';
 import { QuickViewService } from './quick-input/quick-view-service';
 import { environment } from '@theia/application-package/lib/environment';
 import { IconTheme, IconThemeService } from './icon-theme-service';
@@ -63,7 +63,7 @@ import { DecorationStyle } from './decoration-style';
 import { isPinned, Title, togglePinned, Widget } from './widgets';
 import { SaveResourceService } from './save-resource-service';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
-import { UntitledResourceResolver } from '../common';
+import { UNTITLED_SCHEME, UntitledResourceResolver } from '../common';
 import { LanguageQuickPickService } from './i18n/language-quick-pick-service';
 
 export namespace CommonMenus {
@@ -1173,9 +1173,18 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     onWillStop(): OnWillStopAction | undefined {
         try {
             if (this.shouldPreventClose || this.shell.canSaveAll()) {
-                const captionsToSave = this.unsavedTabsCaptions();
-
-                return { reason: 'Dirty editors present', action: async () => confirmExitWithOrWithoutSaving(captionsToSave, async () => this.shell.saveAll()) };
+                return {
+                    reason: 'Dirty editors present',
+                    action: async () => {
+                        const captionsToSave = this.unsavedTabsCaptions();
+                        const untitledCaptionsToSave = this.unsavedUntitledTabsCaptions();
+                        const result = await confirmExitWithOrWithoutSaving(captionsToSave, async () => {
+                            await this.saveDirty(untitledCaptionsToSave);
+                            await this.shell.saveAll();
+                        });
+                        return result;
+                    }
+                };
             }
         } finally {
             this.shouldPreventClose = false;
@@ -1185,6 +1194,11 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         return this.shell.widgets
             .filter(widget => this.saveResourceService.canSave(widget))
             .map(widget => widget.title.label);
+    }
+    protected unsavedUntitledTabsCaptions(): Widget[] {
+        return this.shell.widgets.filter(widget =>
+            NavigatableWidget.getUri(widget)?.scheme === UNTITLED_SCHEME && this.saveResourceService.canSaveAs(widget)
+        );
     }
     protected async configureDisplayLanguage(): Promise<void> {
         const languageInfo = await this.languageQuickPickService.pickDisplayLanguage();
@@ -1196,7 +1210,14 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             this.windowService.reload();
         }
     }
-
+    protected async saveDirty(toSave: Widget[]): Promise<void> {
+        for (const widget of toSave) {
+            const saveable = Saveable.get(widget);
+            if (saveable?.dirty) {
+                await this.saveResourceService.save(widget);
+            }
+        }
+    }
     protected toggleBreadcrumbs(): void {
         const value: boolean | undefined = this.preferenceService.get('breadcrumbs.enabled');
         this.preferenceService.set('breadcrumbs.enabled', !value, PreferenceScope.User);

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1171,23 +1171,26 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     }
 
     onWillStop(): OnWillStopAction | undefined {
-        try {
-            if (this.shouldPreventClose || this.shell.canSaveAll()) {
-                return {
-                    reason: 'Dirty editors present',
-                    action: async () => {
-                        const captionsToSave = this.unsavedTabsCaptions();
-                        const untitledCaptionsToSave = this.unsavedUntitledTabsCaptions();
-                        const result = await confirmExitWithOrWithoutSaving(captionsToSave, async () => {
-                            await this.saveDirty(untitledCaptionsToSave);
-                            await this.shell.saveAll();
-                        });
+        if (this.shouldPreventClose || this.shell.canSaveAll()) {
+            return {
+                reason: 'Dirty editors present',
+                action: async () => {
+                    const captionsToSave = this.unsavedTabsCaptions();
+                    const untitledCaptionsToSave = this.unsavedUntitledTabsCaptions();
+                    const result = await confirmExitWithOrWithoutSaving(captionsToSave, async () => {
+                        await this.saveDirty(untitledCaptionsToSave);
+                        await this.shell.saveAll();
+                    });
+                    if (this.shell.canSaveAll()) {
+                        this.shouldPreventClose = true;
+                        return false;
+                    } else {
+                        this.shouldPreventClose = false;
                         return result;
                     }
-                };
-            }
-        } finally {
-            this.shouldPreventClose = false;
+
+                }
+            };
         }
     }
     protected unsavedTabsCaptions(): string[] {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR fixes #12557 by fixing the untitled file saving behavior when closing the `Workspace`. The user should now be prompted to select a location to save the untitled file before closing the `Workspace`. The file should be saved at the chosen location, and the `Workspace` should reload successfully, preserving the newly created file.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Remove AutoSave: `File` -> `AutoSave`
2. Create new file from header: `File` -> `New File` or `Alt+N`
3. Enter random content inside this new file which is unsaved
4. Close the workspace: `File` -> `Close Workspace`
5. The user should now be prompted with a dialog to save the untitled file
6. Select `Save` and choose a location to save the file
7. Reopen the `Workspace` and the newly created file should be saved successfully

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
