### PR TITLE
Don't cover input field with file preference browse button

### DIFF
--- a/packages/preferences/src/browser/style/preference-file.css
+++ b/packages/preferences/src/browser/style/preference-file.css
@@ -26,7 +26,5 @@
 }
 
 .theia-settings-container .preference-file-button {
-  position: absolute;
-  padding: 2px 9px;
-  right: 4px;
+  margin-left: 4px;
 }

--- a/packages/preferences/src/browser/style/preference-file.css
+++ b/packages/preferences/src/browser/style/preference-file.css
@@ -27,6 +27,5 @@
 
 .theia-settings-container .preference-file-button {
   margin-left: 0px;
-  padding-bottom: 6px;
-  padding-top: 5px;
+  height: calc(var(--theia-content-line-height) + 4px);
 }

--- a/packages/preferences/src/browser/style/preference-file.css
+++ b/packages/preferences/src/browser/style/preference-file.css
@@ -26,5 +26,7 @@
 }
 
 .theia-settings-container .preference-file-button {
-  margin-left: 4px;
+  margin-left: 0px;
+  padding-bottom: 6px;
+  padding-top: 5px;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #12582. The button is now next to the input field instead of on top of it, and thus the button does not cover the end of the input field for long paths.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Enter a long path in the Windows Terminal preference in the preferences screen. It should be possible to scroll over the input field to see everything.

Before:
![image](https://github.com/eclipse-theia/theia/assets/127789813/1d10b41a-1a3c-4e19-8f4c-d1709454a57d)
After:
![image](https://github.com/eclipse-theia/theia/assets/127789813/dd3916bf-9e19-4441-b857-13285d1b2806)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

Done apart from updating the changelog since the PR that first added the browse button (#10766) didn't update it either; I'm not sure if it's needed in this case.

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
