### PR TITLE
Fix terminal widget flickering on resize

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -42,6 +42,7 @@ import { CommandLineOptions, ShellCommandBuilder } from '@theia/process/lib/comm
 import { Key } from '@theia/core/lib/browser/keys';
 import { nls } from '@theia/core/lib/common/nls';
 import { TerminalMenus } from './terminal-frontend-contribution';
+import debounce = require('p-debounce');
 
 export const TERMINAL_WIDGET_FACTORY_ID = 'terminal';
 
@@ -758,7 +759,12 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         super.dispose();
     }
 
-    protected resizeTerminal(): void {
+    protected resizeTerminal = debounce(() => this.doResizeTerminal(), 50);
+
+    protected doResizeTerminal(): void {
+        if (this.isDisposed) {
+            return;
+        }
         const geo = this.fitAddon.proposeDimensions();
         const cols = geo.cols;
         const rows = geo.rows - 1; // subtract one row for margin


### PR DESCRIPTION

#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12280
Closes https://github.com/eclipse-theia/theia/pull/12320

Debounces the terminal resize call in order to prevent unnecessary resizing which causes flickering.

#### How to test

See https://github.com/eclipse-theia/theia/issues/12280 and observe that the flickering isn't exhibited any longer.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
