### PR TITLE
Rename JsonRpcProxyFactory and related types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@
 - [repo] with the upgrade to Inversify 6.0, a few initialization methods were adjusted. See also [this migration guide entry](https://github.com/eclipse-theia/theia/blob/master/doc/Migration.md#inversify-60). Additionally, other changes include: [#12425](https://github.com/eclipse-theia/theia/pull/12425)
   - The type expected by the `PreferenceProxySchema` symbol has been changed from `PromiseLike<PreferenceSchema>` to `() => PromiseLike<PreferenceSchema>`
   - The symbol `OnigasmPromise` has been changed to `OnigasmProvider` and injects a function of type `() => Promise<IOnigLib>`
-  - The symbol `PreferenceTransactionPrelude` has been changed to `PreferenceTransactionPreludeProvider ` and injects a function of type `() => Promise<unknown>`
+  - The symbol `PreferenceTransactionPrelude` has been changed to `PreferenceTransactionPreludeProvider` and injects a function of type `() => Promise<unknown>`
+- [rpc] Replaced name suffixes classes and types that were still referencing the old rpc protocol. From `JsonRpc*` to `Rpc*`.
+  - Old classes and types are still available but haven been deprecated and might get removed in future releases [#12588](https://github.com/eclipse-theia/theia/pull/12588)
+  - e.g. `JsonRpcProxyFactory` is deprecated, use `RpcProxyFactory` instead.
 
 ## v1.38.0 - 05/25/2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
   - The type expected by the `PreferenceProxySchema` symbol has been changed from `PromiseLike<PreferenceSchema>` to `() => PromiseLike<PreferenceSchema>`
   - The symbol `OnigasmPromise` has been changed to `OnigasmProvider` and injects a function of type `() => Promise<IOnigLib>`
   - The symbol `PreferenceTransactionPrelude` has been changed to `PreferenceTransactionPreludeProvider` and injects a function of type `() => Promise<unknown>`
-- [rpc] Replaced name suffixes classes and types that were still referencing the old rpc protocol. From `JsonRpc*` to `Rpc*`.
-  - Old classes and types are still available but haven been deprecated and might get removed in future releases [#12588](https://github.com/eclipse-theia/theia/pull/12588)
+- [rpc] Renamed suffixes of classes and types that were still referencing the old rpc protocol. From `JsonRpc*` to `Rpc*`.
+  - Old classes and types are still available but haven been deprecated and will be removed future releases [#12588](https://github.com/eclipse-theia/theia/pull/12588)
   - e.g. `JsonRpcProxyFactory` is deprecated, use `RpcProxyFactory` instead.
 
 ## v1.38.0 - 05/25/2023

--- a/examples/api-samples/src/common/updater/sample-updater.ts
+++ b/examples/api-samples/src/common/updater/sample-updater.ts
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 
 export enum UpdateStatus {
     InProgress = 'in-progress',
@@ -23,7 +23,7 @@ export enum UpdateStatus {
 
 export const SampleUpdaterPath = '/services/sample-updater';
 export const SampleUpdater = Symbol('SampleUpdater');
-export interface SampleUpdater extends JsonRpcServer<SampleUpdaterClient> {
+export interface SampleUpdater extends RpcServer<SampleUpdaterClient> {
     checkForUpdates(): Promise<{ status: UpdateStatus }>;
     onRestartToUpdateRequested(): void;
     disconnectClient(client: SampleUpdaterClient): void;

--- a/examples/api-samples/src/electron-main/update/sample-updater-main-module.ts
+++ b/examples/api-samples/src/electron-main/update/sample-updater-main-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
 import { ElectronMainApplicationContribution } from '@theia/core/lib/electron-main/electron-main-application';
 import { ElectronConnectionHandler } from '@theia/core/lib/electron-common/messaging/electron-connection-handler';
 import { SampleUpdaterPath, SampleUpdater, SampleUpdaterClient } from '../../common/updater/sample-updater';
@@ -26,7 +26,7 @@ export default new ContainerModule(bind => {
     bind(SampleUpdater).toService(SampleUpdaterImpl);
     bind(ElectronMainApplicationContribution).toService(SampleUpdater);
     bind(ElectronConnectionHandler).toDynamicValue(context =>
-        new JsonRpcConnectionHandler<SampleUpdaterClient>(SampleUpdaterPath, client => {
+        new RpcConnectionHandler<SampleUpdaterClient>(SampleUpdaterPath, client => {
             const server = context.container.get<SampleUpdater>(SampleUpdater);
             server.setClient(client);
             client.onDidCloseConnection(() => server.disconnectClient(client));

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -15,14 +15,14 @@
 // *****************************************************************************
 
 import { injectable, interfaces, decorate, unmanaged } from 'inversify';
-import { JsonRpcProxyFactory, JsonRpcProxy, Emitter, Event, Channel } from '../../common';
+import { RpcProxyFactory, RpcProxy, Emitter, Event, Channel } from '../../common';
 import { Endpoint } from '../endpoint';
 import { AbstractConnectionProvider } from '../../common/messaging/abstract-connection-provider';
 import { io, Socket } from 'socket.io-client';
 import { IWebSocket, WebSocketChannel } from '../../common/messaging/web-socket-channel';
 
-decorate(injectable(), JsonRpcProxyFactory);
-decorate(unmanaged(), JsonRpcProxyFactory, 0);
+decorate(injectable(), RpcProxyFactory);
+decorate(unmanaged(), RpcProxyFactory, 0);
 
 export interface WebSocketOptions {
     /**
@@ -44,7 +44,7 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
         return this.onSocketDidCloseEmitter.event;
     }
 
-    static override createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
+    static override createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): RpcProxy<T> {
         return container.get(WebSocketConnectionProvider).createProxy<T>(path, arg);
     }
 

--- a/packages/core/src/common/logger-protocol.ts
+++ b/packages/core/src/common/logger-protocol.ts
@@ -15,13 +15,13 @@
 // *****************************************************************************
 
 import { injectable } from 'inversify';
-import { JsonRpcServer } from './messaging/proxy-factory';
+import { RpcServer } from './messaging/proxy-factory';
 
 export const ILoggerServer = Symbol('ILoggerServer');
 
 export const loggerPath = '/services/logger';
 
-export interface ILoggerServer extends JsonRpcServer<ILoggerClient> {
+export interface ILoggerServer extends RpcServer<ILoggerClient> {
     setLogLevel(name: string, logLevel: number): Promise<void>;
     getLogLevel(name: string): Promise<number>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/common/messaging/abstract-connection-provider.ts
+++ b/packages/core/src/common/messaging/abstract-connection-provider.ts
@@ -17,7 +17,7 @@
 import { injectable, interfaces } from 'inversify';
 import { Emitter, Event } from '../event';
 import { ConnectionHandler } from './handler';
-import { JsonRpcProxy, JsonRpcProxyFactory } from './proxy-factory';
+import { RpcProxy, RpcProxyFactory } from './proxy-factory';
 import { Channel, ChannelMultiplexer } from '../message-rpc/channel';
 
 /**
@@ -32,7 +32,7 @@ export abstract class AbstractConnectionProvider<AbstractOptions extends object>
      * Create a proxy object to remote interface of T type
      * over an electron ipc connection for the given path and proxy factory.
      */
-    static createProxy<T extends object>(container: interfaces.Container, path: string, factory: JsonRpcProxyFactory<T>): JsonRpcProxy<T>;
+    static createProxy<T extends object>(container: interfaces.Container, path: string, factory: RpcProxyFactory<T>): RpcProxy<T>;
     /**
      * Create a proxy object to remote interface of T type
      * over an electron ipc connection for the given path.
@@ -40,7 +40,7 @@ export abstract class AbstractConnectionProvider<AbstractOptions extends object>
      * An optional target can be provided to handle
      * notifications and requests from a remote side.
      */
-    static createProxy<T extends object>(container: interfaces.Container, path: string, target?: object): JsonRpcProxy<T> {
+    static createProxy<T extends object>(container: interfaces.Container, path: string, target?: object): RpcProxy<T> {
         throw new Error('abstract');
     }
 
@@ -53,7 +53,7 @@ export abstract class AbstractConnectionProvider<AbstractOptions extends object>
      * Create a proxy object to remote interface of T type
      * over a web socket connection for the given path and proxy factory.
      */
-    createProxy<T extends object>(path: string, factory: JsonRpcProxyFactory<T>): JsonRpcProxy<T>;
+    createProxy<T extends object>(path: string, factory: RpcProxyFactory<T>): RpcProxy<T>;
     /**
      * Create a proxy object to remote interface of T type
      * over a web socket connection for the given path.
@@ -61,9 +61,9 @@ export abstract class AbstractConnectionProvider<AbstractOptions extends object>
      * An optional target can be provided to handle
      * notifications and requests from a remote side.
      */
-    createProxy<T extends object>(path: string, target?: object): JsonRpcProxy<T>;
-    createProxy<T extends object>(path: string, arg?: object): JsonRpcProxy<T> {
-        const factory = arg instanceof JsonRpcProxyFactory ? arg : new JsonRpcProxyFactory<T>(arg);
+    createProxy<T extends object>(path: string, target?: object): RpcProxy<T>;
+    createProxy<T extends object>(path: string, arg?: object): RpcProxy<T> {
+        const factory = arg instanceof RpcProxyFactory ? arg : new RpcProxyFactory<T>(arg);
         this.listen({
             path,
             onConnection: c => factory.listen(c)

--- a/packages/core/src/common/messaging/proxy-factory.spec.ts
+++ b/packages/core/src/common/messaging/proxy-factory.spec.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import * as chai from 'chai';
-import { JsonRpcProxyFactory, JsonRpcProxy } from './proxy-factory';
+import { RpcProxyFactory, RpcProxy } from './proxy-factory';
 import { ChannelPipe } from '../message-rpc/channel.spec';
 
 const expect = chai.expect;
@@ -84,19 +84,19 @@ describe('Proxy-Factory', () => {
 
 function getSetup(): {
     client: TestClient;
-    clientProxy: JsonRpcProxy<TestClient>;
+    clientProxy: RpcProxy<TestClient>;
     server: TestServer;
-    serverProxy: JsonRpcProxy<TestServer>;
+    serverProxy: RpcProxy<TestServer>;
 } {
     const client = new TestClient();
     const server = new TestServer();
 
-    const serverProxyFactory = new JsonRpcProxyFactory<TestServer>(client);
+    const serverProxyFactory = new RpcProxyFactory<TestServer>(client);
     const pipe = new ChannelPipe();
     serverProxyFactory.listen(pipe.right);
     const serverProxy = serverProxyFactory.createProxy();
 
-    const clientProxyFactory = new JsonRpcProxyFactory<TestClient>(server);
+    const clientProxyFactory = new RpcProxyFactory<TestClient>(server);
     clientProxyFactory.listen(pipe.left);
     const clientProxy = clientProxyFactory.createProxy();
     return {

--- a/packages/core/src/electron-browser/messaging/electron-ipc-connection-provider.ts
+++ b/packages/core/src/electron-browser/messaging/electron-ipc-connection-provider.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable, interfaces } from 'inversify';
-import { JsonRpcProxy } from '../../common/messaging';
+import { RpcProxy } from '../../common/messaging';
 import { AbstractConnectionProvider } from '../../common/messaging/abstract-connection-provider';
 import { AbstractChannel, Channel, WriteBuffer } from '../../common';
 import { Uint8ArrayReadBuffer, Uint8ArrayWriteBuffer } from '../../common/message-rpc/uint8-array-message-buffer';
@@ -29,7 +29,7 @@ export interface ElectronIpcOptions {
 @injectable()
 export class ElectronIpcConnectionProvider extends AbstractConnectionProvider<ElectronIpcOptions> {
 
-    static override createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
+    static override createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): RpcProxy<T> {
         return container.get(ElectronIpcConnectionProvider).createProxy<T>(path, arg);
     }
 

--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -17,7 +17,7 @@
 import { ContainerModule } from 'inversify';
 import { v4 } from 'uuid';
 import { bindContributionProvider } from '../common/contribution-provider';
-import { JsonRpcConnectionHandler } from '../common/messaging/proxy-factory';
+import { RpcConnectionHandler } from '../common/messaging/proxy-factory';
 import { ElectronSecurityToken } from '../electron-common/electron-token';
 import { ElectronMainWindowService, electronMainWindowServicePath } from '../electron-common/electron-main-window-service';
 import { ElectronMainApplication, ElectronMainApplicationContribution, ElectronMainProcessArgv } from './electron-main-application';
@@ -49,7 +49,7 @@ export default new ContainerModule(bind => {
 
     bind(ElectronMainWindowService).to(ElectronMainWindowServiceImpl).inSingletonScope();
     bind(ElectronConnectionHandler).toDynamicValue(context =>
-        new JsonRpcConnectionHandler(electronMainWindowServicePath,
+        new RpcConnectionHandler(electronMainWindowServicePath,
             () => context.container.get(ElectronMainWindowService))
     ).inSingletonScope();
 

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -77,7 +77,7 @@ export interface ElectronMainExecutionParams {
  * From an `electron-main` module:
  *
  *     bind(ElectronConnectionHandler).toDynamicValue(context =>
- *          new JsonRpcConnectionHandler(electronMainWindowServicePath,
+ *          new RpcConnectionHandler(electronMainWindowServicePath,
  *          () => context.container.get(ElectronMainWindowService))
  *     ).inSingletonScope();
  *

--- a/packages/core/src/electron-node/keyboard/electron-backend-keyboard-module.ts
+++ b/packages/core/src/electron-node/keyboard/electron-backend-keyboard-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ContainerModule } from 'inversify';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '../../common/messaging';
+import { ConnectionHandler, RpcConnectionHandler } from '../../common/messaging';
 import { KeyboardLayoutProvider, keyboardPath } from '../../common/keyboard/keyboard-layout-provider';
 import { ElectronKeyboardLayoutProvider } from './electron-keyboard-layout-provider';
 
@@ -23,7 +23,7 @@ export default new ContainerModule(bind => {
     bind(ElectronKeyboardLayoutProvider).toSelf().inSingletonScope();
     bind(KeyboardLayoutProvider).toService(ElectronKeyboardLayoutProvider);
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(keyboardPath, () =>
+        new RpcConnectionHandler(keyboardPath, () =>
             ctx.container.get(KeyboardLayoutProvider)
         )
     ).inSingletonScope();

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule, decorate, injectable } from 'inversify';
 import { ApplicationPackage } from '@theia/application-package';
 import { REQUEST_SERVICE_PATH } from '@theia/request';
 import {
-    bindContributionProvider, MessageService, MessageClient, ConnectionHandler, JsonRpcConnectionHandler,
+    bindContributionProvider, MessageService, MessageClient, ConnectionHandler, RpcConnectionHandler,
     CommandService, commandServicePath, messageServicePath
 } from '../common';
 import { BackendApplication, BackendApplicationContribution, BackendApplicationCliContribution, BackendApplicationServer } from './backend-application';
@@ -86,14 +86,14 @@ export const backendApplicationModule = new ContainerModule(bind => {
     bind(ApplicationServerImpl).toSelf().inSingletonScope();
     bind(ApplicationServer).toService(ApplicationServerImpl);
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(applicationPath, () =>
+        new RpcConnectionHandler(applicationPath, () =>
             ctx.container.get(ApplicationServer)
         )
     ).inSingletonScope();
 
     bind(EnvVariablesServer).to(EnvVariablesServerImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(envVariablesPath, () => {
+        new RpcConnectionHandler(envVariablesPath, () => {
             const envVariablesServer = ctx.container.get<EnvVariablesServer>(EnvVariablesServer);
             return envVariablesServer;
         })
@@ -108,7 +108,7 @@ export const backendApplicationModule = new ContainerModule(bind => {
     bindContributionProvider(bind, WsRequestValidatorContribution);
     bind(KeytarService).to(KeytarServiceImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(keytarServicePath, () => ctx.container.get<KeytarService>(KeytarService))
+        new RpcConnectionHandler(keytarServicePath, () => ctx.container.get<KeytarService>(KeytarService))
     ).inSingletonScope();
 
     bind(ContributionFilterRegistry).to(ContributionFilterRegistryImpl).inSingletonScope();
@@ -124,7 +124,7 @@ export const backendApplicationModule = new ContainerModule(bind => {
 
     bind(BackendRequestFacade).toSelf().inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(
-        ctx => new JsonRpcConnectionHandler(REQUEST_SERVICE_PATH, () => ctx.container.get(BackendRequestFacade))
+        ctx => new RpcConnectionHandler(REQUEST_SERVICE_PATH, () => ctx.container.get(BackendRequestFacade))
     ).inSingletonScope();
 
     bindNodeStopwatch(bind);

--- a/packages/core/src/node/i18n/i18n-backend-module.ts
+++ b/packages/core/src/node/i18n/i18n-backend-module.ts
@@ -17,7 +17,7 @@
 import { ContainerModule } from 'inversify';
 import { localizationPath } from '../../common/i18n/localization';
 import { LocalizationProvider } from './localization-provider';
-import { ConnectionHandler, JsonRpcConnectionHandler, bindContributionProvider } from '../../common';
+import { ConnectionHandler, RpcConnectionHandler, bindContributionProvider } from '../../common';
 import { LocalizationRegistry, LocalizationContribution } from './localization-contribution';
 import { LocalizationBackendContribution } from './localization-backend-contribution';
 import { BackendApplicationContribution } from '../backend-application';
@@ -26,7 +26,7 @@ import { TheiaLocalizationContribution } from './theia-localization-contribution
 export default new ContainerModule(bind => {
     bind(LocalizationProvider).toSelf().inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(localizationPath, () => ctx.container.get(LocalizationProvider))
+        new RpcConnectionHandler(localizationPath, () => ctx.container.get(LocalizationProvider))
     ).inSingletonScope();
     bind(LocalizationRegistry).toSelf().inSingletonScope();
     bindContributionProvider(bind, LocalizationContribution);

--- a/packages/core/src/node/logger-backend-module.ts
+++ b/packages/core/src/node/logger-backend-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ContainerModule, Container, interfaces } from 'inversify';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '../common/messaging';
+import { ConnectionHandler, RpcConnectionHandler } from '../common/messaging';
 import { ILogger, LoggerFactory, Logger, setRootLogger, LoggerName, rootLoggerName } from '../common/logger';
 import { ILoggerServer, ILoggerClient, loggerPath, DispatchingLoggerClient } from '../common/logger-protocol';
 import { ConsoleLoggerServer } from './console-logger-server';
@@ -71,7 +71,7 @@ export const loggerBackendModule = new ContainerModule(bind => {
     });
 
     bind(ConnectionHandler).toDynamicValue(({ container }) =>
-        new JsonRpcConnectionHandler<ILoggerClient>(loggerPath, client => {
+        new RpcConnectionHandler<ILoggerClient>(loggerPath, client => {
             const dispatching = container.get(DispatchingLoggerClient);
             dispatching.clients.add(client);
             client.onDidCloseConnection(() => dispatching.clients.delete(client));

--- a/packages/core/src/node/messaging/connection-container-module.ts
+++ b/packages/core/src/node/messaging/connection-container-module.ts
@@ -17,11 +17,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { interfaces, ContainerModule } from 'inversify';
-import { JsonRpcProxyFactory, ConnectionHandler, JsonRpcConnectionHandler, JsonRpcProxy } from '../../common';
+import { RpcProxyFactory, ConnectionHandler, RpcConnectionHandler, RpcProxy } from '../../common';
 
 export type BindFrontendService = <T extends object>(path: string, serviceIdentifier: interfaces.ServiceIdentifier<T>) => interfaces.BindingWhenOnSyntax<T>;
 export type BindBackendService = <T extends object, C extends object = object>(
-    path: string, serviceIdentifier: interfaces.ServiceIdentifier<T>, onActivation?: (service: T, proxy: JsonRpcProxy<C>) => T
+    path: string, serviceIdentifier: interfaces.ServiceIdentifier<T>, onActivation?: (service: T, proxy: RpcProxy<C>) => T
 ) => void;
 export type ConnectionContainerModuleCallBack = (registry: {
     bind: interfaces.Bind
@@ -74,7 +74,7 @@ export const ConnectionContainerModule: symbol & { create(callback: ConnectionCo
     create(callback: ConnectionContainerModuleCallBack): ContainerModule {
         return new ContainerModule((bind, unbind, isBound, rebind) => {
             const bindFrontendService: BindFrontendService = (path, serviceIdentifier) => {
-                const serviceFactory = new JsonRpcProxyFactory();
+                const serviceFactory = new RpcProxyFactory();
                 const service = serviceFactory.createProxy();
                 bind<ConnectionHandler>(ConnectionHandler).toConstantValue({
                     path,
@@ -84,7 +84,7 @@ export const ConnectionContainerModule: symbol & { create(callback: ConnectionCo
             };
             const bindBackendService: BindBackendService = (path, serviceIdentifier, onActivation) => {
                 bind(ConnectionHandler).toDynamicValue(context =>
-                    new JsonRpcConnectionHandler<any>(path, proxy => {
+                    new RpcConnectionHandler<any>(path, proxy => {
                         const service = context.container.get(serviceIdentifier);
                         return onActivation ? onActivation(service, proxy) : service;
                     })

--- a/packages/core/src/node/performance/measurement-backend-bindings.ts
+++ b/packages/core/src/node/performance/measurement-backend-bindings.ts
@@ -16,7 +16,7 @@
 
 import { interfaces } from 'inversify';
 import {
-    ConnectionHandler, DefaultBackendStopwatch, BackendStopwatch, JsonRpcConnectionHandler,
+    ConnectionHandler, DefaultBackendStopwatch, BackendStopwatch, RpcConnectionHandler,
     Stopwatch, stopwatchPath
 } from '../../common';
 import { NodeStopwatch } from './node-stopwatch';
@@ -27,7 +27,7 @@ export function bindNodeStopwatch(bind: interfaces.Bind): interfaces.BindingWhen
 
 export function bindBackendStopwatchServer(bind: interfaces.Bind): interfaces.BindingWhenOnSyntax<unknown> {
     bind(ConnectionHandler).toDynamicValue(({ container }) =>
-        new JsonRpcConnectionHandler<never>(stopwatchPath, () => container.get<BackendStopwatch>(BackendStopwatch))
+        new RpcConnectionHandler<never>(stopwatchPath, () => container.get<BackendStopwatch>(BackendStopwatch))
     ).inSingletonScope();
 
     bind(DefaultBackendStopwatch).toSelf().inSingletonScope();

--- a/packages/external-terminal/src/electron-node/external-terminal-backend-module.ts
+++ b/packages/external-terminal/src/electron-node/external-terminal-backend-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common';
 import { isWindows, isOSX } from '@theia/core/lib/common/os';
 import { ExternalTerminalService, externalTerminalServicePath } from '../common/external-terminal';
 import { MacExternalTerminalService } from './mac-external-terminal-service';
@@ -29,7 +29,7 @@ export function bindExternalTerminalService(bind: interfaces.Bind): void {
     bind(ExternalTerminalService).toService(serviceProvider);
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(externalTerminalServicePath, () =>
+        new RpcConnectionHandler(externalTerminalServicePath, () =>
             ctx.container.get(ExternalTerminalService)
         )
     ).inSingletonScope();

--- a/packages/file-search/src/node/file-search-backend-module.ts
+++ b/packages/file-search/src/node/file-search-backend-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common';
 import { FileSearchServiceImpl } from './file-search-service-impl';
 import { fileSearchServicePath, FileSearchService } from '../common/file-search-service';
 
@@ -23,7 +23,7 @@ export default new ContainerModule(bind => {
 
     bind(FileSearchService).to(FileSearchServiceImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(fileSearchServicePath, () =>
+        new RpcConnectionHandler(fileSearchServicePath, () =>
             ctx.container.get(FileSearchService)
         )
     ).inSingletonScope();

--- a/packages/filesystem/src/common/filesystem-watcher-protocol.ts
+++ b/packages/filesystem/src/common/filesystem-watcher-protocol.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { JsonRpcServer } from '@theia/core';
+import { RpcServer } from '@theia/core';
 import { FileChangeType } from './files';
 export { FileChangeType };
 
@@ -24,7 +24,7 @@ export const FileSystemWatcherService = Symbol('FileSystemWatcherServer2');
  *
  * Since multiple clients all make requests to this service, we need to track those individually via a `clientId`.
  */
-export interface FileSystemWatcherService extends JsonRpcServer<FileSystemWatcherServiceClient> {
+export interface FileSystemWatcherService extends RpcServer<FileSystemWatcherServiceClient> {
     /**
      * @param clientId arbitrary id used to identify a client.
      * @param uri the path to watch.
@@ -60,7 +60,7 @@ export interface FileSystemWatcherErrorParams {
 }
 
 export const FileSystemWatcherServer = Symbol('FileSystemWatcherServer');
-export interface FileSystemWatcherServer extends JsonRpcServer<FileSystemWatcherClient> {
+export interface FileSystemWatcherServer extends RpcServer<FileSystemWatcherClient> {
     /**
      * Start file watching for the given param.
      * Resolve when watching is started.

--- a/packages/filesystem/src/common/remote-file-system-provider.ts
+++ b/packages/filesystem/src/common/remote-file-system-provider.ts
@@ -25,7 +25,7 @@ import {
     hasOpenReadWriteCloseCapability, hasFileFolderCopyCapability, hasReadWriteCapability, hasAccessCapability,
     FileSystemProviderError, FileSystemProviderErrorCode, FileUpdateOptions, hasUpdateCapability, FileUpdateResult, FileReadStreamOptions, hasFileReadStreamCapability
 } from './files';
-import { JsonRpcServer, JsonRpcProxy, JsonRpcProxyFactory } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcServer, RpcProxy, RpcProxyFactory } from '@theia/core/lib/common/messaging/proxy-factory';
 import { ApplicationError } from '@theia/core/lib/common/application-error';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import type { TextDocumentContentChangeEvent } from '@theia/core/shared/vscode-languageserver-protocol';
@@ -35,7 +35,7 @@ import { CancellationToken, cancelled } from '@theia/core/lib/common/cancellatio
 export const remoteFileSystemPath = '/services/remote-filesystem';
 
 export const RemoteFileSystemServer = Symbol('RemoteFileSystemServer');
-export interface RemoteFileSystemServer extends JsonRpcServer<RemoteFileSystemClient> {
+export interface RemoteFileSystemServer extends RpcServer<RemoteFileSystemClient> {
     getCapabilities(): Promise<FileSystemProviderCapabilities>
     stat(resource: string): Promise<Stat>;
     access(resource: string, mode?: number): Promise<void>;
@@ -79,7 +79,7 @@ export const RemoteFileSystemProviderError = ApplicationError.declare(-33005,
         ({ message, data, stack })
 );
 
-export class RemoteFileSystemProxyFactory<T extends object> extends JsonRpcProxyFactory<T> {
+export class RemoteFileSystemProxyFactory<T extends object> extends RpcProxyFactory<T> {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected override serializeError(e: any): any {
@@ -153,7 +153,7 @@ export class RemoteFileSystemProvider implements Required<FileSystemProvider>, D
      * Wrapped remote filesystem.
      */
     @inject(RemoteFileSystemServer)
-    protected readonly server: JsonRpcProxy<RemoteFileSystemServer>;
+    protected readonly server: RpcProxy<RemoteFileSystemServer>;
 
     @postConstruct()
     protected init(): void {

--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -16,7 +16,7 @@
 
 import * as path from 'path';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
-import { ConnectionHandler, JsonRpcConnectionHandler, ILogger } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler, ILogger } from '@theia/core/lib/common';
 import { FileSystemWatcherServer, FileSystemWatcherService } from '../common/filesystem-watcher-protocol';
 import { FileSystemWatcherServerClient } from './filesystem-watcher-client';
 import { NsfwFileSystemWatcherService, NsfwFileSystemWatcherServerOptions } from './nsfw-watcher/nsfw-filesystem-service';
@@ -29,7 +29,7 @@ import {
 import { FileSystemProvider } from '../common/files';
 import { EncodingService } from '@theia/core/lib/common/encoding-service';
 import { BackendApplicationContribution, IPCConnectionProvider } from '@theia/core/lib/node';
-import { JsonRpcProxyFactory, ConnectionErrorHandler } from '@theia/core';
+import { RpcProxyFactory, ConnectionErrorHandler } from '@theia/core';
 import { FileSystemWatcherServiceDispatcher } from './filesystem-watcher-dispatcher';
 
 export const NSFW_SINGLE_THREADED = process.argv.includes('--no-cluster');
@@ -54,7 +54,7 @@ export default new ContainerModule(bind => {
     bind(FileSystemProviderServer).toSelf();
     bind(RemoteFileSystemServer).toService(FileSystemProviderServer);
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler<RemoteFileSystemClient>(remoteFileSystemPath, client => {
+        new RpcConnectionHandler<RemoteFileSystemClient>(remoteFileSystemPath, client => {
             const server = ctx.container.get<RemoteFileSystemServer>(RemoteFileSystemServer);
             server.setClient(client);
             client.onDidCloseConnection(() => server.dispose());
@@ -116,7 +116,7 @@ export function spawnNsfwFileSystemWatcherServiceProcess(ctx: interfaces.Context
     const logger = ctx.container.get<ILogger>(ILogger);
     const nsfwOptions = ctx.container.get<NsfwOptions>(NsfwOptions);
     const ipcConnectionProvider = ctx.container.get<IPCConnectionProvider>(IPCConnectionProvider);
-    const proxyFactory = new JsonRpcProxyFactory<FileSystemWatcherService>();
+    const proxyFactory = new RpcProxyFactory<FileSystemWatcherService>();
     const serverProxy = proxyFactory.createProxy();
     // We need to call `.setClient` before listening, else the JSON-RPC calls won't go through.
     serverProxy.setClient(dispatcher);

--- a/packages/filesystem/src/node/nsfw-watcher/index.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/index.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import * as yargs from '@theia/core/shared/yargs';
-import { JsonRpcProxyFactory } from '@theia/core';
+import { RpcProxyFactory } from '@theia/core';
 import { FileSystemWatcherServiceClient } from '../../common/filesystem-watcher-protocol';
 import { NsfwFileSystemWatcherService } from './nsfw-filesystem-service';
 import { IPCEntryPoint } from '@theia/core/lib/node/messaging/ipc-protocol';
@@ -39,7 +39,7 @@ const options: {
 
 export default <IPCEntryPoint>(connection => {
     const server = new NsfwFileSystemWatcherService(options);
-    const factory = new JsonRpcProxyFactory<FileSystemWatcherServiceClient>(server);
+    const factory = new RpcProxyFactory<FileSystemWatcherServiceClient>(server);
     server.setClient(factory.createProxy());
     factory.listen(connection);
 });

--- a/packages/git/src/common/git-prompt.ts
+++ b/packages/git/src/common/git-prompt.ts
@@ -15,15 +15,15 @@
 // *****************************************************************************
 
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { JsonRpcProxy, JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcProxy, RpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 
 export const GitPromptServer = Symbol('GitPromptServer');
-export interface GitPromptServer extends JsonRpcServer<GitPromptClient> {
+export interface GitPromptServer extends RpcServer<GitPromptClient> {
 }
 
 export const GitPromptServerProxy = Symbol('GitPromptServerProxy');
-export interface GitPromptServerProxy extends JsonRpcProxy<GitPromptServer> {
+export interface GitPromptServerProxy extends RpcProxy<GitPromptServer> {
 }
 
 @injectable()

--- a/packages/git/src/common/git-watcher.ts
+++ b/packages/git/src/common/git-watcher.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { JsonRpcServer, JsonRpcProxy, isObject } from '@theia/core';
+import { RpcServer, RpcProxy, isObject } from '@theia/core';
 import { Repository, WorkingDirectoryStatus } from './git-model';
 import { Disposable, DisposableCollection, Emitter, Event } from '@theia/core/lib/common';
 
@@ -73,7 +73,7 @@ export const GitWatcherServer = Symbol('GitWatcherServer');
 /**
  * Service representation communicating between the backend and the frontend.
  */
-export interface GitWatcherServer extends JsonRpcServer<GitWatcherClient> {
+export interface GitWatcherServer extends RpcServer<GitWatcherClient> {
 
     /**
      * Watches status changes in the given repository.
@@ -89,7 +89,7 @@ export interface GitWatcherServer extends JsonRpcServer<GitWatcherClient> {
 }
 
 export const GitWatcherServerProxy = Symbol('GitWatcherServerProxy');
-export type GitWatcherServerProxy = JsonRpcProxy<GitWatcherServer>;
+export type GitWatcherServerProxy = RpcProxy<GitWatcherServer>;
 
 @injectable()
 export class ReconnectingGitWatcherServer implements GitWatcherServer {

--- a/packages/git/src/node/git-backend-module.ts
+++ b/packages/git/src/node/git-backend-module.ts
@@ -19,7 +19,7 @@ import { Git, GitPath } from '../common/git';
 import { GitWatcherPath, GitWatcherClient, GitWatcherServer } from '../common/git-watcher';
 import { DugiteGit, OutputParser, NameStatusParser, CommitDetailsParser, GitBlameParser } from './dugite-git';
 import { DugiteGitWatcherServer } from './dugite-git-watcher';
-import { ConnectionHandler, JsonRpcConnectionHandler, ILogger } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler, ILogger } from '@theia/core/lib/common';
 import { GitRepositoryManager } from './git-repository-manager';
 import { GitRepositoryWatcherFactory, GitRepositoryWatcherOptions, GitRepositoryWatcher } from './git-repository-watcher';
 import { GitLocator } from './git-locator/git-locator-protocol';
@@ -101,7 +101,7 @@ export default new ContainerModule(bind => {
 
     bindRepositoryWatcher(bind);
     bind(ConnectionHandler).toDynamicValue(context =>
-        new JsonRpcConnectionHandler<GitWatcherClient>(GitWatcherPath, client => {
+        new RpcConnectionHandler<GitWatcherClient>(GitWatcherPath, client => {
             const server = context.container.get<GitWatcherServer>(GitWatcherServer);
             server.setClient(client);
             client.onDidCloseConnection(() => server.dispose());
@@ -111,7 +111,7 @@ export default new ContainerModule(bind => {
 
     bindPrompt(bind);
     bind(ConnectionHandler).toDynamicValue(context =>
-        new JsonRpcConnectionHandler<GitPromptClient>(GitPrompt.WS_PATH, client => {
+        new RpcConnectionHandler<GitPromptClient>(GitPrompt.WS_PATH, client => {
             const server = context.container.get<GitPromptServer>(GitPromptServer);
             server.setClient(client);
             client.onDidCloseConnection(() => server.dispose());

--- a/packages/git/src/node/git-locator/git-locator-client.ts
+++ b/packages/git/src/node/git-locator/git-locator-client.ts
@@ -16,7 +16,7 @@
 
 import * as paths from 'path';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { JsonRpcProxyFactory, DisposableCollection } from '@theia/core';
+import { RpcProxyFactory, DisposableCollection } from '@theia/core';
 import { IPCConnectionProvider } from '@theia/core/lib/node';
 import { GitLocator, GitLocateOptions } from './git-locator-protocol';
 
@@ -38,7 +38,7 @@ export class GitLocatorClient implements GitLocator {
                 serverName: 'git-locator',
                 entryPoint: paths.join(__dirname, 'git-locator-host'),
             }, async connection => {
-                const proxyFactory = new JsonRpcProxyFactory<GitLocator>();
+                const proxyFactory = new RpcProxyFactory<GitLocator>();
                 const remote = proxyFactory.createProxy();
                 proxyFactory.listen(connection);
                 try {

--- a/packages/git/src/node/git-locator/git-locator-host.ts
+++ b/packages/git/src/node/git-locator/git-locator-host.ts
@@ -14,10 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { JsonRpcProxyFactory } from '@theia/core';
+import { RpcProxyFactory } from '@theia/core';
 import { IPCEntryPoint } from '@theia/core/lib/node/messaging/ipc-protocol';
 import { GitLocatorImpl } from './git-locator-impl';
 
 export default <IPCEntryPoint>(connection =>
-    new JsonRpcProxyFactory(new GitLocatorImpl()).listen(connection)
+    new RpcProxyFactory(new GitLocatorImpl()).listen(connection)
 );

--- a/packages/mini-browser/src/node/mini-browser-backend-module.ts
+++ b/packages/mini-browser/src/node/mini-browser-backend-module.ts
@@ -17,7 +17,7 @@
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common';
 import { MiniBrowserService, MiniBrowserServicePath } from '../common/mini-browser-service';
 import { MiniBrowserEndpoint, MiniBrowserEndpointHandler, HtmlHandler, ImageHandler, PdfHandler, SvgHandler } from './mini-browser-endpoint';
 import { WsRequestValidatorContribution } from '@theia/core/lib/node/ws-request-validators';
@@ -30,7 +30,7 @@ export default new ContainerModule(bind => {
     bind(MiniBrowserWsRequestValidator).toSelf().inSingletonScope();
     bind(WsRequestValidatorContribution).toService(MiniBrowserWsRequestValidator);
     bind(MiniBrowserService).toService(MiniBrowserEndpoint);
-    bind(ConnectionHandler).toDynamicValue(context => new JsonRpcConnectionHandler(MiniBrowserServicePath, () => context.container.get(MiniBrowserService))).inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(context => new RpcConnectionHandler(MiniBrowserServicePath, () => context.container.get(MiniBrowserService))).inSingletonScope();
     bindContributionProvider(bind, MiniBrowserEndpointHandler);
     bind(MiniBrowserEndpointHandler).to(HtmlHandler).inSingletonScope();
     bind(MiniBrowserEndpointHandler).to(ImageHandler).inSingletonScope();

--- a/packages/plugin-dev/src/common/plugin-dev-protocol.ts
+++ b/packages/plugin-dev/src/common/plugin-dev-protocol.ts
@@ -14,12 +14,12 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
 
 export const pluginDevServicePath = '/services/plugin-dev';
 export const PluginDevServer = Symbol('PluginDevServer');
-export interface PluginDevServer extends JsonRpcServer<PluginDevClient> {
+export interface PluginDevServer extends RpcServer<PluginDevClient> {
     getHostedPlugin(): Promise<PluginMetadata | undefined>;
     runHostedPluginInstance(uri: string): Promise<string>;
     runDebugHostedPluginInstance(uri: string, debugConfig: PluginDebugConfiguration): Promise<string>;

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { RPCProtocol } from './rpc-protocol';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { LogPart, KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -944,7 +944,7 @@ export interface DeployedPlugin {
 }
 
 export const HostedPluginServer = Symbol('HostedPluginServer');
-export interface HostedPluginServer extends JsonRpcServer<HostedPluginClient> {
+export interface HostedPluginServer extends RpcServer<HostedPluginClient> {
 
     getDeployedPluginIds(): Promise<PluginIdentifiers.VersionedId[]>;
 

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -33,7 +33,7 @@ import { RPCProtocol, RPCProtocolImpl } from '../../common/rpc-protocol';
 import {
     Disposable, DisposableCollection, Emitter, isCancelled,
     ILogger, ContributionProvider, CommandRegistry, WillExecuteCommandEvent,
-    CancellationTokenSource, JsonRpcProxy, ProgressService, nls
+    CancellationTokenSource, RpcProxy, ProgressService, nls
 } from '@theia/core';
 import { PreferenceServiceImpl, PreferenceProviderProvider } from '@theia/core/lib/browser/preferences';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -87,7 +87,7 @@ export class HostedPluginSupport {
     protected readonly logger: ILogger;
 
     @inject(HostedPluginServer)
-    protected readonly server: JsonRpcProxy<HostedPluginServer>;
+    protected readonly server: RpcProxy<HostedPluginServer>;
 
     @inject(HostedPluginWatcher)
     protected readonly watcher: HostedPluginWatcher;

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -36,7 +36,7 @@ import { FilePluginUriFactory } from './scanners/file-plugin-uri-factory';
 import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
 import { LanguagePackService, languagePackServicePath } from '../../common/language-pack-service';
 import { PluginLanguagePackService } from './plugin-language-pack-service';
-import { JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
 import { ConnectionHandler } from '@theia/core/lib/common/messaging/handler';
 
 const commonHostedConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService }) => {
@@ -71,7 +71,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(PluginLanguagePackService).toSelf().inSingletonScope();
     bind(LanguagePackService).toService(PluginLanguagePackService);
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(languagePackServicePath, () =>
+        new RpcConnectionHandler(languagePackServicePath, () =>
             ctx.container.get(LanguagePackService)
         )
     ).inSingletonScope();

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -30,7 +30,7 @@ import { PluginTheiaFileHandler } from './handlers/plugin-theia-file-handler';
 import { PluginTheiaDirectoryHandler } from './handlers/plugin-theia-directory-handler';
 import { GithubPluginDeployerResolver } from './plugin-github-resolver';
 import { HttpPluginDeployerResolver } from './plugin-http-resolver';
-import { ConnectionHandler, JsonRpcConnectionHandler, bindContributionProvider } from '@theia/core';
+import { ConnectionHandler, RpcConnectionHandler, bindContributionProvider } from '@theia/core';
 import { PluginPathsService, pluginPathsServicePath } from '../common/plugin-paths-protocol';
 import { PluginPathsServiceImpl } from './paths/plugin-paths-service';
 import { PluginServerHandler } from './plugin-server-handler';
@@ -71,13 +71,13 @@ export function bindMainBackend(bind: interfaces.Bind, unbind: interfaces.Unbind
 
     bind(PluginPathsService).to(PluginPathsServiceImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(pluginPathsServicePath, () =>
+        new RpcConnectionHandler(pluginPathsServicePath, () =>
             ctx.container.get(PluginPathsService)
         )
     ).inSingletonScope();
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(pluginServerJsonRpcPath, () =>
+        new RpcConnectionHandler(pluginServerJsonRpcPath, () =>
             ctx.container.get(PluginServer)
         )
     ).inSingletonScope();

--- a/packages/plugin-metrics/src/node/plugin-metrics-backend-module.ts
+++ b/packages/plugin-metrics/src/node/plugin-metrics-backend-module.ts
@@ -19,7 +19,7 @@ import { PluginMetricsContribution } from './plugin-metrics';
 import { PluginMetrics, metricsJsonRpcPath } from '../common/metrics-protocol';
 import { PluginMetricsImpl } from './plugin-metrics-impl';
 import { ConnectionHandler } from '@theia/core/lib/common/messaging/handler';
-import { JsonRpcConnectionHandler } from '@theia/core';
+import { RpcConnectionHandler } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { PluginMetricsContributor } from './metrics-contributor';
 import { PluginMetricTimeSum } from './metric-output/plugin-metrics-time-sum';
@@ -34,7 +34,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(PluginMetricsContributor).toSelf().inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx => {
         const clients = ctx.container.get(PluginMetricsContributor);
-        return new JsonRpcConnectionHandler(metricsJsonRpcPath, client => {
+        return new RpcConnectionHandler(metricsJsonRpcPath, client => {
             const pluginMetricsHandler: PluginMetrics = ctx.container.get(PluginMetrics);
             clients.clients.add(pluginMetricsHandler);
             client.onDidCloseConnection(() => {

--- a/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
+++ b/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { JsonRpcServer } from '@theia/core';
+import { RpcServer } from '@theia/core';
 
 export interface SearchInWorkspaceOptions {
     /**
@@ -134,7 +134,7 @@ export interface SearchInWorkspaceClient {
 
 export const SIW_WS_PATH = '/services/search-in-workspace';
 export const SearchInWorkspaceServer = Symbol('SearchInWorkspaceServer');
-export interface SearchInWorkspaceServer extends JsonRpcServer<SearchInWorkspaceClient> {
+export interface SearchInWorkspaceServer extends RpcServer<SearchInWorkspaceClient> {
     /**
      * Start a search for WHAT in directories ROOTURIS. Return a unique search id.
      */

--- a/packages/search-in-workspace/src/node/search-in-workspace-backend-module.ts
+++ b/packages/search-in-workspace/src/node/search-in-workspace-backend-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common';
 import { SearchInWorkspaceServer, SearchInWorkspaceClient, SIW_WS_PATH } from '../common/search-in-workspace-interface';
 import { RipgrepSearchInWorkspaceServer, RgPath } from './ripgrep-search-in-workspace-server';
 import { rgPath } from '@vscode/ripgrep';
@@ -23,7 +23,7 @@ import { rgPath } from '@vscode/ripgrep';
 export default new ContainerModule(bind => {
     bind(SearchInWorkspaceServer).to(RipgrepSearchInWorkspaceServer);
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler<SearchInWorkspaceClient>(SIW_WS_PATH, client => {
+        new RpcConnectionHandler<SearchInWorkspaceClient>(SIW_WS_PATH, client => {
             const server = ctx.container.get<SearchInWorkspaceServer>(SearchInWorkspaceServer);
             server.setClient(client);
             client.onDidCloseConnection(() => server.dispose());

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { Event } from '@theia/core';
-import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import { ProblemMatcher, ProblemMatch, WatchingMatcherContribution, ProblemMatcherContribution, ProblemPatternContribution } from './problem-matcher-protocol';
 export { WatchingMatcherContribution, ProblemMatcherContribution, ProblemPatternContribution };
@@ -203,7 +203,7 @@ export interface TaskInfo {
     readonly [key: string]: any;
 }
 
-export interface TaskServer extends JsonRpcServer<TaskClient> {
+export interface TaskServer extends RpcServer<TaskClient> {
     /** Run a task. Optionally pass a context.  */
     run(task: TaskConfiguration, ctx?: string, option?: RunTaskOption): Promise<TaskInfo>;
     /** Kill a task, by id. */

--- a/packages/task/src/node/task-backend-module.ts
+++ b/packages/task/src/node/task-backend-module.ts
@@ -16,7 +16,7 @@
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { bindContributionProvider } from '@theia/core';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common/messaging';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { bindProcessTaskRunnerModule } from './process/process-task-runner-backend-module';
 import { bindCustomTaskRunnerModule } from './custom/custom-task-runner-backend-module';
@@ -34,7 +34,7 @@ export default new ContainerModule(bind => {
 
     bind(TaskServer).to(TaskServerImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler<TaskClient>(taskPath, client => {
+        new RpcConnectionHandler<TaskClient>(taskPath, client => {
             const taskServer = ctx.container.get<TaskServer>(TaskServer);
             taskServer.setClient(client);
             // when connection closes, cleanup that client of task-server

--- a/packages/terminal/src/common/base-terminal-protocol.ts
+++ b/packages/terminal/src/common/base-terminal-protocol.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { Disposable } from '@theia/core';
 
 export interface TerminalProcessInfo {
@@ -24,7 +24,7 @@ export interface TerminalProcessInfo {
 
 export interface IBaseTerminalServerOptions { }
 
-export interface IBaseTerminalServer extends JsonRpcServer<IBaseTerminalClient> {
+export interface IBaseTerminalServer extends RpcServer<IBaseTerminalClient> {
     create(IBaseTerminalServerOptions: object): Promise<number>;
     getProcessId(id: number): Promise<number>;
     getProcessInfo(id: number): Promise<TerminalProcessInfo>;

--- a/packages/terminal/src/common/shell-terminal-protocol.ts
+++ b/packages/terminal/src/common/shell-terminal-protocol.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { JsonRpcProxy } from '@theia/core';
+import { RpcProxy } from '@theia/core';
 import { IBaseTerminalServer, IBaseTerminalServerOptions } from './base-terminal-protocol';
 import { OS } from '@theia/core/lib/common/os';
 
@@ -47,4 +47,4 @@ export interface IShellTerminalServerOptions extends IBaseTerminalServerOptions 
 }
 
 export const ShellTerminalServerProxy = Symbol('ShellTerminalServerProxy');
-export type ShellTerminalServerProxy = JsonRpcProxy<IShellTerminalServer>;
+export type ShellTerminalServerProxy = RpcProxy<IShellTerminalServer>;

--- a/packages/terminal/src/node/terminal-backend-module.ts
+++ b/packages/terminal/src/node/terminal-backend-module.ts
@@ -16,7 +16,7 @@
 
 import { ContainerModule, Container, interfaces } from '@theia/core/shared/inversify';
 import { TerminalBackendContribution } from './terminal-backend-contribution';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common/messaging';
 import { ShellProcess, ShellProcessFactory, ShellProcessOptions } from './shell-process';
 import { ITerminalServer, terminalPath } from '../common/terminal-protocol';
 import { IBaseTerminalClient, DispatchingBaseTerminalClient, IBaseTerminalServer } from '../common/base-terminal-protocol';
@@ -45,7 +45,7 @@ export function bindTerminalServer(bind: interfaces.Bind, { path, identifier, co
         return terminalServer;
     });
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler<IBaseTerminalClient>(path, client => {
+        new RpcConnectionHandler<IBaseTerminalClient>(path, client => {
             const disposable = dispatchingClient.push(client);
             client.onDidCloseConnection(() => disposable.dispose());
             return ctx.container.get(identifier);

--- a/packages/workspace/src/node/workspace-backend-module.ts
+++ b/packages/workspace/src/node/workspace-backend-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common';
 import { WorkspaceServer, workspacePath, CommonWorkspaceUtils } from '../common';
 import { DefaultWorkspaceServer, WorkspaceCliContribution } from './default-workspace-server';
 import { CliContribution } from '@theia/core/lib/node/cli';
@@ -30,7 +30,7 @@ export default new ContainerModule(bind => {
     bind(CommonWorkspaceUtils).toSelf().inSingletonScope();
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler(workspacePath, () =>
+        new RpcConnectionHandler(workspacePath, () =>
             ctx.container.get(WorkspaceServer)
         )
     ).inSingletonScope();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Rename `JsonRpcProxyFactory` and related types to `RpcProxyFactory` (Rpc*). The naming scheme was a remainder of the old vscode jsonr-rpc based protocol.
  By simply using the `Rpc` suffix the class names are less misleading and protocol agnostic.
- Keep deprecated declarations of the old `JsonRpc*` namespace. The components are heavily used by adopters so we should maintain this deprecated symbols for a while to enable graceful migration without hard API breaks.
Naturally this is open for discussion, but judging from the files I had to touch in the core framework alone I think it's definitely 
a good idea to give adopters a grace period.

Complementary website PR: https://github.com/eclipse-theia/theia-website/pull/422

Fixes #12581
Contributed on behalf of STMicroelectronics
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Nothing particular to test. Everything should work as expected
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
