### PR TITLE
Rework sidepanel behavior on tab overflow

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -136,6 +136,7 @@ import { MarkdownRenderer, MarkdownRendererFactory, MarkdownRendererImpl } from 
 import { StylingParticipant, StylingService } from './styling-service';
 import { bindCommonStylingParticipants } from './common-styling-participants';
 import { HoverService } from './hover-service';
+import { AdditionalViewsMenuWidget, AdditionalViewsMenuWidgetFactory } from './shell/additional-views-menu-widget';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -167,6 +168,12 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(SidebarMenuWidget).toSelf();
     bind(SidebarBottomMenuWidget).toSelf();
     bind(SidebarBottomMenuWidgetFactory).toAutoFactory(SidebarBottomMenuWidget);
+    bind(AdditionalViewsMenuWidget).toSelf();
+    bind(AdditionalViewsMenuWidgetFactory).toFactory(ctx => (side: 'left' | 'right') => {
+        const widget = ctx.container.resolve(AdditionalViewsMenuWidget);
+        widget.side = side;
+        return widget;
+    });
     bind(SplitPositionHandler).toSelf().inSingletonScope();
 
     bindContributionProvider(bind, TabBarToolbarContribution);

--- a/packages/core/src/browser/shell/additional-views-menu-widget.tsx
+++ b/packages/core/src/browser/shell/additional-views-menu-widget.tsx
@@ -11,7 +11,7 @@
 // with the GNU Classpath Exception which is available at
 // https://www.gnu.org/software/classpath/license.html.
 //
-// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
 import { inject, injectable } from '../../../shared/inversify';

--- a/packages/core/src/browser/shell/additional-views-menu-widget.tsx
+++ b/packages/core/src/browser/shell/additional-views-menu-widget.tsx
@@ -1,0 +1,71 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '../../../shared/inversify';
+import { Command, CommandRegistry, Disposable, MenuModelRegistry, MenuPath, nls } from '../../common';
+import { Title, Widget, codicon } from '../widgets';
+import { SidebarMenuWidget } from './sidebar-menu-widget';
+import { SideTabBar } from './tab-bars';
+
+export const AdditionalViewsMenuWidgetFactory = Symbol('AdditionalViewsMenuWidgetFactory');
+export type AdditionalViewsMenuWidgetFactory = (side: 'left' | 'right') => AdditionalViewsMenuWidget;
+
+export const ADDITIONAL_VIEWS_MENU_PATH: MenuPath = ['additional_views_menu'];
+
+@injectable()
+export class AdditionalViewsMenuWidget extends SidebarMenuWidget {
+    static readonly ID = 'sidebar.additional.views';
+
+    side: 'left' | 'right';
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    @inject(MenuModelRegistry)
+    protected readonly menuModelRegistry: MenuModelRegistry;
+
+    protected menuDisposables: Disposable[] = [];
+
+    updateAdditionalViews(sender: SideTabBar, event: { titles: Title<Widget>[], startIndex: number }): void {
+        if (event.startIndex === -1) {
+            this.removeMenu(AdditionalViewsMenuWidget.ID);
+        } else {
+            this.addMenu({
+                title: nls.localizeByDefault('Additional Views'),
+                iconClass: codicon('ellipsis'),
+                id: AdditionalViewsMenuWidget.ID,
+                menuPath: ADDITIONAL_VIEWS_MENU_PATH,
+                order: 0
+            });
+        }
+
+        this.menuDisposables.forEach(disposable => disposable.dispose());
+        this.menuDisposables = [];
+        event.titles.forEach((title, i) => this.registerMenuAction(sender, title, i));
+    }
+
+    protected registerMenuAction(sender: SideTabBar, title: Title<Widget>, index: number): void {
+        const command: Command = { id: `reveal.${title.label}.${index}`, label: title.label };
+        this.menuDisposables.push(this.commandRegistry.registerCommand(command, {
+            execute: () => {
+                window.requestAnimationFrame(() => {
+                    sender.currentIndex = sender.titles.indexOf(title);
+                });
+            }
+        }));
+        this.menuDisposables.push(this.menuModelRegistry.registerMenuAction(ADDITIONAL_VIEWS_MENU_PATH, { commandId: command.id, order: index.toString() }));
+    }
+}

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -348,7 +348,7 @@ export class TabBarRenderer extends TabBar.Renderer {
      * @param {string | string[]} iconName The name of the icon.
      * @param {string[]} additionalClasses Additional classes of the icon.
      */
-    private getIconClass(iconName: string | string[], additionalClasses: string[] = []): string {
+    protected getIconClass(iconName: string | string[], additionalClasses: string[] = []): string {
         const iconClass = (typeof iconName === 'string') ? ['a', 'fa', `fa-${iconName}`] : ['a'].concat(iconName);
         return iconClass.concat(additionalClasses).join(' ');
     }
@@ -594,12 +594,12 @@ export class ScrollableTabBar extends TabBar<Widget> {
 
     protected scrollBar?: PerfectScrollbar;
 
-    private scrollBarFactory: () => PerfectScrollbar;
+    protected scrollBarFactory: () => PerfectScrollbar;
     protected pendingReveal?: Promise<void>;
-    private isMouseOver = false;
+    protected isMouseOver = false;
     protected needsRecompute = false;
     protected tabSize = 0;
-    private _dynamicTabOptions?: ScrollableTabBar.Options;
+    protected _dynamicTabOptions?: ScrollableTabBar.Options;
     protected contentContainer: HTMLElement;
     protected topRow: HTMLElement;
 
@@ -638,7 +638,7 @@ export class ScrollableTabBar extends TabBar<Widget> {
      * Instead of this structure, we add a container for the `this.contentNode` and for the toolbar.
      * The scrollbar will only work for the `ul` part but it does not affect the toolbar, so it can be on the right hand-side.
      */
-    private rewireDOM(): void {
+    protected rewireDOM(): void {
         const contentNode = this.node.getElementsByClassName(ScrollableTabBar.Styles.TAB_BAR_CONTENT)[0];
         if (!contentNode) {
             throw new Error("'this.node' does not have the content as a direct child with class name 'p-TabBar-content'.");
@@ -933,7 +933,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
         super.handleEvent(event);
     }
 
-    private isOver(event: Event, element: Element): boolean {
+    protected isOver(event: Event, element: Element): boolean {
         return element && event.target instanceof Element && element.contains(event.target);
     }
 
@@ -944,7 +944,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
      * Instead of this structure, we add a container for the `this.contentNode` and for the toolbar.
      * The scrollbar will only work for the `ul` part but it does not affect the toolbar, so it can be on the right hand-side.
      */
-    private addBreadcrumbs(): void {
+    protected addBreadcrumbs(): void {
         this.breadcrumbsContainer = document.createElement('div');
         this.breadcrumbsContainer.classList.add('theia-tabBar-breadcrumb-row');
         this.breadcrumbsContainer.appendChild(this.breadcrumbsRenderer.host);
@@ -957,7 +957,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
  */
 export class SideTabBar extends ScrollableTabBar {
 
-    private static readonly DRAG_THRESHOLD = 5;
+    protected static readonly DRAG_THRESHOLD = 5;
 
     /**
      * Emitted when a tab is added to the tab bar.
@@ -974,18 +974,18 @@ export class SideTabBar extends ScrollableTabBar {
      */
     readonly tabsOverflowChanged = new Signal<this, { titles: Title<Widget>[], startIndex: number }>(this);
 
-    private mouseData?: {
+    protected mouseData?: {
         pressX: number,
         pressY: number,
         mouseDownTabIndex: number
     };
 
-    private tabsOverflowData?: {
+    protected tabsOverflowData?: {
         titles: Title<Widget>[],
         startIndex: number
     };
 
-    private _rowGap: number;
+    protected _rowGap: number;
 
     constructor(options?: TabBar.IOptions<Widget> & PerfectScrollbar.Options) {
         super(options);
@@ -1108,7 +1108,7 @@ export class SideTabBar extends ScrollableTabBar {
                 const hiddenContent = this.hiddenContentNode;
                 const n = hiddenContent.children.length;
                 const renderData = new Array<Partial<SideBarRenderData>>(n);
-                const availableWidth = this.node.clientHeight;
+                const availableWidth = this.node.clientHeight - this.tabRowGap;
                 let actualWidth = 0;
                 let overflowStartIndex = -1;
                 for (let i = 0; i < n; i++) {
@@ -1143,6 +1143,17 @@ export class SideTabBar extends ScrollableTabBar {
                         renderData[i] = rd;
                     }
                 }
+
+                // Special handling if only one element is overflowing.
+                if (overflowStartIndex === n - 1) {
+                    if (!this.tabsOverflowData) {
+                        overflowStartIndex--;
+                        renderData[overflowStartIndex].visible = false;
+                    } else {
+                        renderData[overflowStartIndex].visible = true;
+                        overflowStartIndex = -1;
+                    }
+                }
                 // Render into the visible node
                 this.renderTabs(this.contentNode, renderData);
                 this.computeOverflowingTabsData(overflowStartIndex);
@@ -1150,7 +1161,7 @@ export class SideTabBar extends ScrollableTabBar {
         }
     }
 
-    private computeOverflowingTabsData(startIndex: number): void {
+    protected computeOverflowingTabsData(startIndex: number): void {
         // ensure that render tabs has completed
         window.requestAnimationFrame(() => {
             if (startIndex === -1) {
@@ -1238,7 +1249,7 @@ export class SideTabBar extends ScrollableTabBar {
         }
     }
 
-    private onMouseDown(event: MouseEvent): void {
+    protected onMouseDown(event: MouseEvent): void {
         // Check for left mouse button and current mouse status
         if (event.button !== 0 || this.mouseData) {
             return;
@@ -1264,7 +1275,7 @@ export class SideTabBar extends ScrollableTabBar {
         };
     }
 
-    private onMouseUp(event: MouseEvent): void {
+    protected onMouseUp(event: MouseEvent): void {
         // Check for left mouse button and current mouse status
         if (event.button !== 0 || !this.mouseData) {
             return;
@@ -1283,7 +1294,7 @@ export class SideTabBar extends ScrollableTabBar {
         this.collapseRequested.emit(this.titles[index]);
     }
 
-    private onMouseMove(event: MouseEvent): void {
+    protected onMouseMove(event: MouseEvent): void {
         // Check for left mouse button and current mouse status
         if (event.button !== 0 || !this.mouseData) {
             return;

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -302,6 +302,7 @@
   display: flex;
   position: absolute;
   visibility: hidden;
+  padding-inline-start: 0px;
 }
 
 .p-TabBar.theia-app-sides > .theia-TabBar-hidden-content .p-TabBar-tab {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -195,6 +195,10 @@
     height: inherit;
 }
 
+.p-TabBar[data-orientation='vertical'] .p-TabBar-tab.p-mod-invisible {
+    visibility: hidden;
+}
+
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon,
 .p-TabBar.theia-app-centers .p-TabBar-tab.theia-mod-pinned > .p-TabBar-tabCloseIcon {
   padding: 2px;
@@ -322,6 +326,10 @@
 .p-TabBar[data-orientation='vertical'] .p-TabBar-content-container > .ps__rail-y  > .ps__thumb-y {
   width: var(--theia-private-horizontal-tab-scrollbar-height) !important;
   right: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
+}
+
+.p-TabBar[data-orientation='vertical'] .p-TabBar-content-container {
+  display: block;
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Reworks the behavior of the sidepanels if there are  more tabs than they can fit (overflow). Instead of the counter intuitive on-hover scroll bar we introduce behavior similar to VS Code: 
Overflowing tabs will simply be hidden or 'merged' into one menu button at the end of the tabBar. Clicking the button allows revealing of a currently hidden view. Special handling is implemented to ensure that the currently selected view never gets hidden away. When a view that is currently hidden is revelead (i.e. by opening via command) it will be moved to the visible part of the tabbar.

As outline in #12416 this feature is currently intended to become the default behavior and should replace the scroll approach. If there are any objects we could also make in an opt-in feature (toggleable via settings).

Fixes #12416
Contributed on behalf of STMicroelectronics

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Feature can be tested by populating the sidebars with a lot of views and/or resizing the window. Following cases should be tested:
- If a view/tab no longer fits, the additional view menu appears. Clicking on the view menu opens up a context menu with commands to reveal the hidden views.
- Clicking an entry of the "addtional views" menu properly reveals the corresponding view and the context menu is updated accordingly after wards
- Closing a view should reorder the tabbar and bring back one of the hidden tabs
- Resizing the window should properly add/remove tabs from the bar and add them to the view menu accordingly
- The currently selected tab should never get hidden when resizing.
- Revealing a hidden view (e.g. via command) properly moves the view in question to the visible part of the bar
- Drag & drop behavior should work as before

And probably a lot of other corner cases that I didn't think about 😉 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
