### PR TITLE
cli: Add `check:theia-extensions` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.40.0 - 
 
 -  Show command shortcuts in toolbar item tooltips. #12660 (https://github.com/eclipse-theia/theia/pull/12660) - Contributed on behalf of STMicroelectronics
+- [cli] added `check:theia-extensions` which checks the uniqueness of Theia extension versions [#12596](https://github.com/eclipse-theia/theia/pull/12596) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.40.0">[Breaking Changes:](#breaking_changes_1.40.0)</a>
 

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -201,6 +201,7 @@ async function theiaCli(): Promise<void> {
                     skipHoisted: false,
                     skipUniqueness: true,
                     skipSingleTheiaVersion: true,
+                    onlyTheiaExtensions: false,
                     suppress
                 });
             }
@@ -226,6 +227,33 @@ async function theiaCli(): Promise<void> {
                     skipHoisted: true,
                     skipUniqueness: false,
                     skipSingleTheiaVersion: false,
+                    onlyTheiaExtensions: false,
+                    suppress
+                });
+            }
+        })
+        .command<{
+            suppress: boolean
+        }>({
+            command: 'check:theia-extensions',
+            describe: 'Check uniqueness of Theia extension versions or whether they are hoisted',
+            builder: {
+                'suppress': {
+                    alias: 's',
+                    describe: 'Suppress exiting with failure code',
+                    boolean: true,
+                    default: false
+                }
+            },
+            handler: ({ suppress }) => {
+                checkDependencies({
+                    workspaces: undefined,
+                    include: ['**'],
+                    exclude: [],
+                    skipHoisted: true,
+                    skipUniqueness: false,
+                    skipSingleTheiaVersion: true,
+                    onlyTheiaExtensions: true,
                     suppress
                 });
             }
@@ -237,6 +265,7 @@ async function theiaCli(): Promise<void> {
             skipHoisted: boolean,
             skipUniqueness: boolean,
             skipSingleTheiaVersion: boolean,
+            onlyTheiaExtensions: boolean,
             suppress: boolean
         }>({
             command: 'check:dependencies',
@@ -280,6 +309,12 @@ async function theiaCli(): Promise<void> {
                     boolean: true,
                     default: false
                 },
+                'only-theia-extensions': {
+                    alias: 'o',
+                    describe: 'Only check dependencies which are Theia extensions',
+                    boolean: true,
+                    default: false
+                },
                 'suppress': {
                     alias: 's',
                     describe: 'Suppress exiting with failure code',
@@ -294,6 +329,7 @@ async function theiaCli(): Promise<void> {
                 skipHoisted,
                 skipUniqueness,
                 skipSingleTheiaVersion,
+                onlyTheiaExtensions,
                 suppress
             }) => {
                 checkDependencies({
@@ -303,6 +339,7 @@ async function theiaCli(): Promise<void> {
                     skipHoisted,
                     skipUniqueness,
                     skipSingleTheiaVersion,
+                    onlyTheiaExtensions,
                     suppress
                 });
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The goal of this PR is to improve the existing `theia check:dependencies` script introduced in [this PR](https://github.com/eclipse-theia/theia/pull/11483). The existing script returns a list of all mismatching version numbers for all dependencies. While introducing two versions of the same dependency can always possibly introduce issues, this will be much more common for Theia extensions, than for other dependencies like `loadash` or `rimraf`. Thats why:

This allows to check for duplicate versions of theia extensions only. 
Added the option `only-theia-extensions` to `theia check:dependencies`. 
Theia extensions are identified via their `theiaExtensions` field in the `package.json`. 
The check is running recursively as long as it finds Theia extensions.
The recursion was added to also display cases where more than 2 versions of a dependency might extist.
The advantage of this approach is that a shorter, but more important, list is returned.

Fixes #12572.

Contributed on behalf of STMicroelectronics
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Check out this PR and build with `yarn`
- Go to `dev-packages/cli` and run `yarn link`
- Checkout [this example](https://github.com/eclipsesource/theia/tree/cliExampleApplication) (or create any other example you would like) and run `yarn link "@theia/cli"` in its root
- Run `yarn` to see the output (this will run `theia check:theia-extensions` on postinstall)

The provided example has a few issues built-in:
- The `test-extension` requires a `@theia/core` version of `1.37.2` while the application depends on `1.38.0`
- To test nested (and 3rd-party)  dependencies the following dependencies where added
    - `test-extension` > `test-extension-3` > `@eclipse-emfcloud/modelserver-theia:0.8.0-theia-cr03`
    - `test-extension2` > `test-extension-4` > `@eclipse-emfcloud/modelserver-theia:0.8.0-theia-cr01`
    - `@eclipse-emfcloud/modelserver-theia:0.8.0-theia-cr01` depends on version `1.37.2` of `@theia/(core|filesystem|process|variable-resolver|workpace)`

So the result of `theia check:theia-extensions` should find the following issues:
- Different versions for `@theia/(filesystem|process|variable-resolver|workpace)` from the application and `@eclipse-emfcloud/modelserver-theia`
- Different versions for `@theia/core` from the application, `@eclipse-emfcloud/modelserver-theia` and `test-extension`
- Different versions for `@eclipse-emfcloud/modelserver-theia` from `test-extension-3` and `test-extension-4`

Note that one of the versions will always be hoisted to the root `node_modules` version

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
