### PR TITLE
open-editors: better styling and visible decorations

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -162,6 +162,13 @@
     justify-content: center;
 }
 
+.open-editors-node-row .theia-TreeNode .theia-TreeNodeContent .noWrapInfo > * {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline;
+}
+
 .theia-TreeNodeSegment mark {
     background-color: var(--theia-list-filterMatchBackground);
     color: var(--theia-list-inactiveSelectionForeground);

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -118,9 +118,11 @@ export class OpenEditorsWidget extends AbstractNavigatorTreeWidget {
             {this.renderExpansionToggle(node, props)}
             {isEditorNode && this.renderPrefixIcon(node)}
             {this.decorateIcon(node, this.renderIcon(node, props))}
-            {this.renderCaptionAffixes(node, props, 'captionPrefixes')}
-            {this.renderCaption(node, props)}
-            {this.renderCaptionAffixes(node, props, 'captionSuffixes')}
+            <div className='noWrapInfo theia-TreeNodeSegmentGrow'>
+                {this.renderCaptionAffixes(node, props, 'captionPrefixes')}
+                {this.renderCaption(node, props)}
+                {this.renderCaptionAffixes(node, props, 'captionSuffixes')}
+            </div>
             {this.renderTailDecorations(node, props)}
             {(this.isGroupNode(node) || this.isAreaNode(node)) && this.renderInteractables(node, props)}
         </div>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR fixes #10821 by changing the styling of the `open-editors` view  to align more closely with the styling of the `explorer` itself.  These changes include making the decorations always visible even when the view becomes too small and adding an `ellipsis` overflow to the filename and their paths.

Demo:
![open-editors styling](https://github.com/eclipse-theia/theia/assets/86936229/7594d3bc-200f-471b-9dca-bf6dcfaee664)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Start Theia application -> Go to  `Explorer View`  -> Make the `Open Editors` visible
- Open or create new files, make some changes under source control
- Resize the `Open Editors` view and observe the better styling

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
