### PR TITLE
ui/ux: styling vsx and source control input fields

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -112,10 +112,16 @@ blockquote {
     font-size: var(--theia-ui-font-size1);
     line-height: var(--theia-content-line-height);
     padding-left: 5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .theia-input::placeholder {
     color: var(--theia-input-placeholderForeground);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .theia-maximized {

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -39,6 +39,9 @@
     flex: 1;
     padding-top: calc(var(--theia-ui-padding)/2);
     padding-bottom: calc(var(--theia-ui-padding)/2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .theia-vsx-extension {
@@ -351,4 +354,3 @@
 .theia-vsx-extension-action-bar .action.prominent:hover {
     background-color: var(--theia-extensionButton-prominentHoverBackground);
 }
-

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -39,9 +39,6 @@
     flex: 1;
     padding-top: calc(var(--theia-ui-padding)/2);
     padding-bottom: calc(var(--theia-ui-padding)/2);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .theia-vsx-extension {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Closes: #10855 
This PR provides better styling for various input fields when the view is limited. This includes the vsx-registry and the source control views. These changes allow the placeholder overflow to be `hidden` and replaced by an `ellipsis` to make the styling cleaner and more consistent.

Demo:
![VSX Styling Demo](https://github.com/eclipse-theia/theia/assets/86936229/17033aec-449c-4c9b-ac9d-029414d73496)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Start Theia, open the `Extensions` or the `Source Control` views
- Resize the view, making it smaller
- The input field should be responsive, with the text overflow hidden by an ellipsis

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
