### PR TITLE
WIP - set initial size and position of secondary windows

### DIFF
--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -100,7 +100,43 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
     }
 
     protected doCreateSecondaryWindow(widget: ExtractableWidget, shell: ApplicationShell): Window | undefined {
-        const newWindow = window.open(DefaultSecondaryWindowService.SECONDARY_WINDOW_URL, this.nextWindowId(), 'popup') ?? undefined;
+        // const options = 'popup';
+        // const options = 'popup,width=500,height=500,left=500,top=500';
+        console.log('**** widget: ' + widget);
+        console.log('**** widget.id: ' + widget.id);
+
+        // console.log('**** widget.node.parentNode?.textContent: ' + widget.node?.parentNode?.textContent);
+
+        // const options = 'popup,width=600,height=200,left=2800,top=150';
+        // const options = 'popup,innerWidth=600,innerHeight=200,left=2800,top=150';
+        let options;
+        if (widget.node) {
+            const clientBounds = widget.node.getBoundingClientRect();
+
+            // shift a bit right and down (enough to clear the editor's preview button)
+            const offsetX = 0; // 50 + widget.node.clientWidth;
+            const offsetY = 0;
+            const offsetHeigth = 0;
+            const offsetWidth = 0;
+
+            // try to place secondary window left of the main window
+            // const offsetX = widget.node.clientWidth;
+            // const offsetY = 0;
+
+            const h = widget.node.clientHeight + offsetHeigth;
+            const w = widget.node.clientWidth + offsetWidth;
+            // window.screenLeft: horizontal offset of main window (top left corner) vs desktop
+            // window.screenTop: vertical offset of main window vs desktop
+            const l = widget.node.clientLeft + window.screenLeft + clientBounds.x + offsetX;
+            const t = widget.node.clientTop + window.screenTop + clientBounds.y + offsetY;
+
+            options = `popup=1,width=${w},height=${h},left=${l},top=${t}`;
+            // TODO: add a preference?
+            options += ',alwaysOnTop=true';
+            console.log('*** creating secondary window with options: ' + options);
+        }
+
+        const newWindow = window.open(DefaultSecondaryWindowService.SECONDARY_WINDOW_URL, this.nextWindowId(), options) ?? undefined;
         if (newWindow) {
             newWindow.addEventListener('DOMContentLoaded', () => {
                 newWindow.addEventListener('beforeunload', evt => {

--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -104,11 +104,6 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
         // const options = 'popup,width=500,height=500,left=500,top=500';
         console.log('**** widget: ' + widget);
         console.log('**** widget.id: ' + widget.id);
-
-        // console.log('**** widget.node.parentNode?.textContent: ' + widget.node?.parentNode?.textContent);
-
-        // const options = 'popup,width=600,height=200,left=2800,top=150';
-        // const options = 'popup,innerWidth=600,innerHeight=200,left=2800,top=150';
         let options;
         if (widget.node) {
             const clientBounds = widget.node.getBoundingClientRect();
@@ -116,14 +111,14 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
             // shift a bit right and down (enough to clear the editor's preview button)
             const offsetX = 0; // 50 + widget.node.clientWidth;
             const offsetY = 0;
-            const offsetHeigth = 0;
+            const offsetHeight = 0;
             const offsetWidth = 0;
 
             // try to place secondary window left of the main window
             // const offsetX = widget.node.clientWidth;
             // const offsetY = 0;
 
-            const h = widget.node.clientHeight + offsetHeigth;
+            const h = widget.node.clientHeight + offsetHeight;
             const w = widget.node.clientWidth + offsetWidth;
             // window.screenLeft: horizontal offset of main window (top left corner) vs desktop
             // window.screenTop: vertical offset of main window vs desktop

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -256,6 +256,7 @@ export class ElectronMainApplication {
      * @param options
      */
     async createWindow(asyncOptions: MaybePromise<TheiaBrowserWindowOptions> = this.getDefaultTheiaWindowOptions()): Promise<BrowserWindow> {
+        console.log('** ** ** createWindow() - ');
         let options = await asyncOptions;
         options = this.avoidOverlap(options);
         const electronWindow = this.windowFactory(options, this.config);
@@ -271,6 +272,7 @@ export class ElectronMainApplication {
     }
 
     async getLastWindowOptions(): Promise<TheiaBrowserWindowOptions> {
+        console.log('*** *** getLastWindowOptions() ');
         const previousWindowState: TheiaBrowserWindowOptions | undefined = this.electronStore.get('windowstate');
         const windowState = previousWindowState?.screenLayout === this.getCurrentScreenLayout()
             ? previousWindowState
@@ -422,23 +424,7 @@ export class ElectronMainApplication {
     }
 
     protected getDefaultTheiaSecondaryWindowBounds(): TheiaBrowserWindowOptions {
-        // const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
-        // const height = Math.round(bounds.height * (2 / 3));
-        // const width = Math.round(bounds.width * (2 / 3));
-        // const y = Math.round(bounds.y + (bounds.height - height) / 2);
-        // const x = Math.round(bounds.x + (bounds.width - width) / 2);
-        // const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
-        // const height = Math.round(bounds.height * (2 / 3));
-        // const width = Math.round(bounds.width * (2 / 3));
-        // const y = Math.round(bounds.y + (bounds.height - height) / 2);
-        // const x = Math.round(bounds.x + (bounds.width - width) / 2);
-        // console.log(`*** getDefaultTheiaSecondaryWindowBounds(): { width=${width}, height=${height}, x=${x}}, y=${y} }`);
-        return {
-            // width,
-            // height,
-            // x,
-            // y
-        };
+        return {};
     }
 
     /**
@@ -464,6 +450,7 @@ export class ElectronMainApplication {
     }
 
     protected saveWindowState(electronWindow: BrowserWindow): void {
+        console.log('*** *** saveWindowState() ');
         // In some circumstances the `electronWindow` can be `null`
         if (!electronWindow) {
             return;

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -336,13 +336,16 @@ export class ElectronMainApplication {
         electronWindow.webContents.setWindowOpenHandler(() => {
             const { minWidth, minHeight } = this.getDefaultOptions();
             const options: BrowserWindowConstructorOptions = {
-                ...this.getDefaultTheiaWindowBounds(),
+                ...this.getDefaultTheiaSecondaryWindowBounds(),
                 // We always need the native window frame for now because the secondary window does not have Theia's title bar by default.
                 // In 'custom' title bar mode this would leave the window without any window controls (close, min, max)
                 // TODO set to this.useNativeWindowFrame when secondary windows support a custom title bar.
                 frame: true,
                 minWidth,
                 minHeight
+                // ,
+                // // TODO: add a preference?
+                // alwaysOnTop: true
             };
             if (!this.useNativeWindowFrame) {
                 // If the main window does not have a native window frame, do not show  an icon in the secondary window's native title bar.
@@ -389,6 +392,7 @@ export class ElectronMainApplication {
     }
 
     protected getDefaultTheiaWindowOptions(): TheiaBrowserWindowOptions {
+        console.log('*** getDefaultTheiaWindowOptions() ');
         return {
             frame: this.useNativeWindowFrame,
             isFullScreen: false,
@@ -408,11 +412,32 @@ export class ElectronMainApplication {
         const width = Math.round(bounds.width * (2 / 3));
         const y = Math.round(bounds.y + (bounds.height - height) / 2);
         const x = Math.round(bounds.x + (bounds.width - width) / 2);
+        console.log(`*** getDefaultTheiaWindowBounds(): { width=${width}, height=${height}, x=${x}}, y=${y} }`);
         return {
             width,
             height,
             x,
             y
+        };
+    }
+
+    protected getDefaultTheiaSecondaryWindowBounds(): TheiaBrowserWindowOptions {
+        // const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+        // const height = Math.round(bounds.height * (2 / 3));
+        // const width = Math.round(bounds.width * (2 / 3));
+        // const y = Math.round(bounds.y + (bounds.height - height) / 2);
+        // const x = Math.round(bounds.x + (bounds.width - width) / 2);
+        // const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+        // const height = Math.round(bounds.height * (2 / 3));
+        // const width = Math.round(bounds.width * (2 / 3));
+        // const y = Math.round(bounds.y + (bounds.height - height) / 2);
+        // const x = Math.round(bounds.x + (bounds.width - width) / 2);
+        // console.log(`*** getDefaultTheiaSecondaryWindowBounds(): { width=${width}, height=${height}, x=${x}}, y=${y} }`);
+        return {
+            // width,
+            // height,
+            // x,
+            // y
         };
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Set the initial size and position of secondary windows. For example, sized the same as the original widget that was extracted into it's own windows and position the new window at the same place as the widget was. Alternatively, attempt to position it to the side of the current Theia app.  

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
