### PR TITLE
Update ripgrep arguments for file search

### DIFF
--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -129,7 +129,7 @@ export class FileSearchServiceImpl implements FileSearchService {
         return [...exactMatches, ...fuzzyMatches].slice(0, opts.limit);
     }
 
-    private doFind(rootUri: URI, options: FileSearchService.BaseOptions, accept: (fileUri: string) => void, token: CancellationToken): Promise<void> {
+    protected doFind(rootUri: URI, options: FileSearchService.BaseOptions, accept: (fileUri: string) => void, token: CancellationToken): Promise<void> {
         return new Promise((resolve, reject) => {
             const cwd = FileUri.fsPath(rootUri);
             const args = this.getSearchArgs(options);
@@ -159,7 +159,7 @@ export class FileSearchServiceImpl implements FileSearchService {
         });
     }
 
-    private getSearchArgs(options: FileSearchService.BaseOptions): string[] {
+    protected getSearchArgs(options: FileSearchService.BaseOptions): string[] {
         const args = ['--files', '--hidden', '--case-sensitive', '--no-require-git', '--no-config'];
         if (options.includePatterns) {
             for (const includePattern of options.includePatterns) {

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -133,7 +133,7 @@ export class FileSearchServiceImpl implements FileSearchService {
         return new Promise((resolve, reject) => {
             const cwd = FileUri.fsPath(rootUri);
             const args = this.getSearchArgs(options);
-            const ripgrep = cp.spawn(rgPath, args, { cwd, stdio: ['pipe', 'pipe', 'inherit'] });
+            const ripgrep = cp.spawn(rgPath, args, { cwd });
             ripgrep.on('error', reject);
             ripgrep.on('exit', (code, signal) => {
                 if (typeof code === 'number' && code !== 0) {
@@ -160,7 +160,7 @@ export class FileSearchServiceImpl implements FileSearchService {
     }
 
     private getSearchArgs(options: FileSearchService.BaseOptions): string[] {
-        const args = ['--files', '--hidden'];
+        const args = ['--files', '--hidden', '--case-sensitive', '--no-require-git', '--no-config'];
         if (options.includePatterns) {
             for (const includePattern of options.includePatterns) {
                 if (includePattern) {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12607

Updates our used arguments and child process spawn options to be aligned with [vscode](https://github.com/eclipse-theia/theia/issues/12607). In particular, the issue exhibited in #12607 was the result of the added `stdio` options property.

Removing the `stdio` field from the options fixed #12607 locally. Also updates the `private` methods to be `protected`.

#### How to test

1. Build the applications for different OS for Browser and Electron.
2. Perform file search, it should work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
