### PR TITLE
[vscode] Stub onWillSaveNotebookDocument (1.78 new API)

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -633,6 +633,9 @@ export function createAPIFactory(
             onDidChangeNotebookDocument(listener, thisArg?, disposables?) {
                 return Disposable.NULL;
             },
+            onWillSaveNotebookDocument(listener, thisArg?, disposables?) {
+                return Disposable.NULL;
+            },
             onDidSaveNotebookDocument(listener, thisArg?, disposables?) {
                 return Disposable.NULL;
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7168,6 +7168,22 @@ export module '@theia/plugin' {
         export const onDidChangeNotebookDocument: Event<NotebookDocumentChangeEvent>;
 
         /**
+         * An event that is emitted when a {@link NotebookDocument notebook document} will be saved to disk.
+         *
+         * *Note 1:* Subscribers can delay saving by registering asynchronous work. For the sake of data integrity the editor
+         * might save without firing this event. For instance when shutting down with dirty files.
+         *
+         * *Note 2:* Subscribers are called sequentially and they can {@link NotebookDocumentWillSaveEvent.waitUntil delay} saving
+         * by registering asynchronous work. Protection against misbehaving listeners is implemented as such:
+         *  * there is an overall time budget that all listeners share and if that is exhausted no further listener is called
+         *  * listeners that take a long time or produce errors frequently will not be called anymore
+         *
+         * The current thresholds are 1.5 seconds as overall time budget and a listener can misbehave 3 times before being ignored.
+         * @stubbed
+         */
+        export const onWillSaveNotebookDocument: Event<NotebookDocumentWillSaveEvent>;
+
+        /**
          * An event that is emitted when files are being created.
          *
          * *Note 1:* This event is triggered by user gestures, like creating a file from the
@@ -14712,6 +14728,66 @@ export module '@theia/plugin' {
          * @stubbed
          */
         readonly cellChanges: readonly NotebookDocumentCellChange[];
+    }
+
+    /**
+     * An event that is fired when a {@link NotebookDocument notebook document} will be saved.
+     *
+     * To make modifications to the document before it is being saved, call the
+     * {@linkcode NotebookDocumentWillSaveEvent.waitUntil waitUntil}-function with a thenable
+     * that resolves to a {@link WorkspaceEdit workspace edit}.
+     */
+    export interface NotebookDocumentWillSaveEvent {
+        /**
+         * A cancellation token.
+         * @stubbed
+         */
+        readonly token: CancellationToken;
+
+        /**
+         * The {@link NotebookDocument notebook document} that will be saved.
+         * @stubbed
+         */
+        readonly notebook: NotebookDocument;
+
+        /**
+         * The reason why save was triggered.
+         * @stubbed
+         */
+        readonly reason: TextDocumentSaveReason;
+
+        /**
+         * Allows to pause the event loop and to apply {@link WorkspaceEdit workspace edit}.
+         * Edits of subsequent calls to this function will be applied in order. The
+         * edits will be *ignored* if concurrent modifications of the notebook document happened.
+         *
+         * *Note:* This function can only be called during event dispatch and not
+         * in an asynchronous manner:
+         *
+         * ```ts
+         * workspace.onWillSaveNotebookDocument(event => {
+         * // async, will *throw* an error
+         * setTimeout(() => event.waitUntil(promise));
+         *
+         * // sync, OK
+         * event.waitUntil(promise);
+         * })
+         * ```
+         *
+         * @param thenable A thenable that resolves to {@link WorkspaceEdit workspace edit}.
+         * @stubbed
+         */
+        waitUntil(thenable: Thenable<WorkspaceEdit>): void;
+
+        /**
+         * Allows to pause the event loop until the provided thenable resolved.
+         *
+         * *Note:* This function can only be called during event dispatch.
+         *
+         * @param thenable A thenable that delays saving.
+         * @stubbed
+         */
+        waitUntil(thenable: Thenable<any>): void;
     }
 
     /**


### PR DESCRIPTION
#### What it does

_Stub vscode 'Notebook' `onWillSaveNotebookDocument` & `NotebookDocumentWillSaveEvent` API_
This enables the possibility to load and start plugins which depend on the new 1.78 'Notebook' API on workspace. 

Fixes #12529 

Contributed on behalf of ST Microelectronics

#### How to test 
1. Install following extension:
-   extension: [notebook-onwillsave-extension-0.0.1.zip](https://github.com/eclipse-theia/theia/files/11724646/notebook-onwillsave-extension-0.0.1.zip)
- source: [notebook-onwillsave-extension-src.zip](https://github.com/eclipse-theia/theia/files/11724655/notebook-onwillsave-extension-src.zip)
2. Reproduce the problem in the theia instance before switching to this PR. When starting theia with the extension installed, an error will pop-up telling that _Activating extension 'notebook-onwillsave-extension' failed: o.workspace.onWillSaveNotebookDocument is not a function_
4. Update your `theia` repository to use this PR
5. Open the same workspace and make sure the message above is no longer displayed. Nothing should happen, as the API is only stubbed, not implemented.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
