### PR TITLE
fix for windows execute command in terminal

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -32,7 +32,7 @@ import { AboutDialog } from './about-dialog';
 import * as browser from './browser';
 import URI from '../common/uri';
 import { ContextKey, ContextKeyService } from './context-key-service';
-import { OS, isOSX, isWindows } from '../common/os';
+import { OS, isOSX, isWindows, EOL } from '../common/os';
 import { ResourceContextKey } from './resource-context-key';
 import { UriSelection } from '../common/selection';
 import { StorageService } from './storage-service';
@@ -65,7 +65,6 @@ import { SaveResourceService } from './save-resource-service';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
 import { UntitledResourceResolver } from '../common';
 import { LanguageQuickPickService } from './i18n/language-quick-pick-service';
-import { EOL } from 'os';
 
 export namespace CommonMenus {
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -65,6 +65,7 @@ import { SaveResourceService } from './save-resource-service';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
 import { UntitledResourceResolver } from '../common';
 import { LanguageQuickPickService } from './i18n/language-quick-pick-service';
+import { EOL } from 'os';
 
 export namespace CommonMenus {
 
@@ -736,7 +737,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             isEnabled: uris => Array.isArray(uris) && uris.some(uri => uri instanceof URI),
             execute: async uris => {
                 if (uris.length) {
-                    const lineDelimiter = isWindows ? '\r\n' : '\n';
+                    const lineDelimiter = EOL;
                     const text = uris.map(resource => resource.path.fsPath()).join(lineDelimiter);
                     await this.clipboardService.writeText(text);
                 } else {

--- a/packages/core/src/browser/preloader.ts
+++ b/packages/core/src/browser/preloader.ts
@@ -55,6 +55,7 @@ async function loadBackendOS(): Promise<void> {
     OS.backend.isOSX = isOSX;
     OS.backend.isWindows = isWindows;
     OS.backend.type = () => osType;
+    OS.backend.EOL = isWindows ? '\r\n' : '\n';
 }
 
 function initBackground(): void {

--- a/packages/core/src/common/os.ts
+++ b/packages/core/src/common/os.ts
@@ -29,6 +29,8 @@ function is(userAgent: string, platform: string): boolean {
 export const isWindows = is('Windows', 'win32');
 export const isOSX = is('Mac', 'darwin');
 
+export const EOL = isWindows ? '\r\n' : '\n';
+
 export type CMD = [string, string[]];
 export function cmd(command: string, ...args: string[]): CMD {
     return [
@@ -65,7 +67,8 @@ export namespace OS {
     export const backend = {
         type,
         isWindows,
-        isOSX
+        isOSX,
+        EOL
     };
 
 }

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -88,7 +88,7 @@ export class MonacoTextModelService implements ITextModelService {
                 if (eol && eol !== 'auto') {
                     return eol;
                 }
-                return OS.backend.isWindows ? '\r\n' : '\n';
+                return OS.backend.EOL;
             };
         }
     }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -33,7 +33,7 @@ import {
     codicon,
     TopDownTreeIterator
 } from '@theia/core/lib/browser';
-import { CancellationTokenSource, Emitter, Event, isWindows, ProgressService } from '@theia/core';
+import { CancellationTokenSource, Emitter, EOL, Event, ProgressService } from '@theia/core';
 import {
     EditorManager, EditorDecoration, TrackedRangeStickiness, OverviewRulerLane,
     EditorWidget, EditorOpenerOptions, FindMatch
@@ -1210,7 +1210,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                 strings.push(string);
             }
         }
-        return strings.join(isWindows ? '\r\n' : '\n');
+        return strings.join(EOL);
     }
 }
 

--- a/packages/task/src/node/task-abstract-line-matcher.ts
+++ b/packages/task/src/node/task-abstract-line-matcher.ts
@@ -19,7 +19,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isWindows } from '@theia/core/lib/common/os';
+import { EOL } from '@theia/core/lib/common/os';
 import { Diagnostic, DiagnosticSeverity, Range } from '@theia/core/shared/vscode-languageserver-protocol';
 import {
     FileLocationKind, ProblemMatcher, ProblemPattern,
@@ -31,7 +31,7 @@ import { URI as vscodeURI } from '@theia/core/shared/vscode-uri';
 import { Severity } from '@theia/core/lib/common/severity';
 import { MAX_SAFE_INTEGER } from '@theia/core/lib/common/numbers';
 
-const endOfLine: string = isWindows ? '\r\n' : '\n';
+const endOfLine: string = EOL;
 
 export interface ProblemData {
     kind?: ProblemLocationKind;

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -706,7 +706,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     }
 
     async executeCommand(commandOptions: CommandLineOptions): Promise<void> {
-        this.sendText(this.shellCommandBuilder.buildCommand(await this.processInfo, commandOptions) + '\n');
+        this.sendText(this.shellCommandBuilder.buildCommand(await this.processInfo, commandOptions) + (OS.backend.isWindows ? '\r\n' : '\n'));
     }
 
     scrollLineUp(): void {

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -706,7 +706,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     }
 
     async executeCommand(commandOptions: CommandLineOptions): Promise<void> {
-        this.sendText(this.shellCommandBuilder.buildCommand(await this.processInfo, commandOptions) + (OS.backend.isWindows ? '\r\n' : '\n'));
+        this.sendText(this.shellCommandBuilder.buildCommand(await this.processInfo, commandOptions) + OS.backend.EOL);
     }
 
     scrollLineUp(): void {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -34,11 +34,12 @@ import { WorkspaceCompareHandler } from './workspace-compare-handler';
 import { FileDownloadCommands } from '@theia/filesystem/lib/browser/download/file-download-command-contribution';
 import { FileSystemCommands } from '@theia/filesystem/lib/browser/filesystem-frontend-contribution';
 import { WorkspaceInputDialog } from './workspace-input-dialog';
-import { Emitter, Event, isWindows, OS } from '@theia/core/lib/common';
+import { Emitter, Event, OS } from '@theia/core/lib/common';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { nls } from '@theia/core/lib/common/nls';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
+import { EOL } from 'os';
 
 const validFilename: (arg: string) => boolean = require('valid-filename');
 
@@ -313,7 +314,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
             isEnabled: uris => !!uris.length,
             isVisible: uris => !!uris.length,
             execute: async uris => {
-                const lineDelimiter = isWindows ? '\r\n' : '\n';
+                const lineDelimiter = EOL;
                 const text = uris.map((uri: URI) => {
                     const workspaceRoot = this.workspaceService.getWorkspaceRootUri(uri);
                     if (workspaceRoot) {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -34,12 +34,11 @@ import { WorkspaceCompareHandler } from './workspace-compare-handler';
 import { FileDownloadCommands } from '@theia/filesystem/lib/browser/download/file-download-command-contribution';
 import { FileSystemCommands } from '@theia/filesystem/lib/browser/filesystem-frontend-contribution';
 import { WorkspaceInputDialog } from './workspace-input-dialog';
-import { Emitter, Event, OS } from '@theia/core/lib/common';
+import { Emitter, EOL, Event, OS } from '@theia/core/lib/common';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { nls } from '@theia/core/lib/common/nls';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
-import { EOL } from 'os';
 
 const validFilename: (arg: string) => boolean = require('valid-filename');
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This fixes an issue that on windows commands where only pasted in the terminal and needed the user to press Enter again instead of being exeuted directly like in other Operating Systems

#### How to test
I tested it with the [codeLLDB](https://open-vsx.org/extension/vadimcn/vscode-lldb) extension:
1. Create a basic rust or c/c++ project
2. create a codeLLDB debug configuration for launching the project.
3. run the debug configuration.
4. Debugging should start directly instead of displaying the terminal with the command pasted in there.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
