### PR TITLE
terminal: fix `split-terminal` visibility

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -32,7 +32,7 @@ import {
 import {
     ApplicationShell, KeybindingContribution, KeyCode, Key, WidgetManager, PreferenceService,
     KeybindingRegistry, LabelProvider, WidgetOpenerOptions, StorageService, QuickInputService,
-    codicon, CommonCommands, FrontendApplicationContribution, OnWillStopAction, Dialog, ConfirmDialog, FrontendApplication, PreferenceScope
+    codicon, CommonCommands, FrontendApplicationContribution, OnWillStopAction, Dialog, ConfirmDialog, FrontendApplication, PreferenceScope, Widget
 } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions, TerminalWidgetImpl } from './terminal-widget-impl';
@@ -543,8 +543,8 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
         });
         commands.registerCommand(TerminalCommands.SPLIT, {
             execute: () => this.splitTerminal(),
-            isEnabled: () => this.shell.currentWidget instanceof TerminalWidget,
-            isVisible: () => this.shell.currentWidget instanceof TerminalWidget,
+            isEnabled: w => this.withWidget(w, () => true),
+            isVisible: w => this.withWidget(w, () => true),
         });
         commands.registerCommand(TerminalCommands.TERMINAL_CLEAR);
         commands.registerHandler(TerminalCommands.TERMINAL_CLEAR.id, {
@@ -1020,6 +1020,13 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
         const termWidget = await this.newTerminal({});
         termWidget.start();
         this.open(termWidget, { widgetOptions: options });
+    }
+
+    protected withWidget<T>(widget: Widget | undefined, fn: (widget: TerminalWidget) => T): T | false {
+        if (widget instanceof TerminalWidget) {
+            return fn(widget);
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit fixes #12357 which caused the `split-terminal` toolbar item from leaking to other views incorrectly when a terminal was currently visible. 

Related https://github.com/eclipse-theia/theia/pull/12358.

<details>

<summary>Screenshots</summary>

<br/>

_Before_:

![Screen Shot 2023-06-15 at 1 17 15 PM](https://github.com/eclipse-theia/theia/assets/40359487/bbf2606a-8957-4f7b-9a86-d364457c9d65)

_After_:

![Screen Shot 2023-06-15 at 1 14 43 PM](https://github.com/eclipse-theia/theia/assets/40359487/dae705ac-a9eb-4bb2-98af-ad890b42880d)

</details>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open a terminal - confirm the `split-terminal` toolbar item is present and works
3. confirm the `split-terminal` toolbar item is not present in other views when a terminal is visible
4. confirm the `split-terminal` toolbar item is present for subsequent terminals

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
