### PR TITLE
Fix for #12605: Edits made to watch expressions are not immediately shown when there is no debug session

### DIFF
--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -42,11 +42,10 @@ export class DebugWatchExpression extends ExpressionItem {
     }
 
     protected override setResult(body?: DebugProtocol.EvaluateResponse['body'], error?: string): void {
-        if (!this.options.session()) {
-            return;
+        if (this.options.session()) {
+            super.setResult(body, error);
+            this.isError = !!error;
         }
-        super.setResult(body, error);
-        this.isError = !!error;
         this.options.onDidChange();
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #12605. When no debug session is active and user edits a watch expression, the updated expression is not shown until Debug view is reopened or user clicks on the expression. 

In the current code, the watch expression change event is not fired when there is no debug session, so I updated the logic to trigger it regardless of whether or not there is a debug session.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Make sure you don't have a debug session running.
2. Add a watch expression.
3. Edit that watch expression.
4. Make sure that the updated expression is now shown. It should have replaced the old expression.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
