### PR TITLE
ui/ux: fix flickering icons when resizing explorer

### DIFF
--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -188,3 +188,7 @@
   .theia-view-container-part-title {
   display: flex;
 }
+
+.no-pointer-events {
+  pointer-events: none;
+}

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -946,8 +946,6 @@ export class ViewContainerPart extends BaseWidget {
     protected readonly onDidChangeBadgeTooltipEmitter = new Emitter<void>();
     readonly onDidChangeBadgeTooltip = this.onDidChangeBadgeTooltipEmitter.event;
 
-    protected readonly onResizeEvent = new Event('onResizeEvent');
-
     protected readonly toolbar: TabBarToolbar;
 
     protected _collapsed: boolean;
@@ -1242,7 +1240,7 @@ export class ViewContainerPart extends BaseWidget {
             setTimeout(() => {
                 this.node?.classList.remove('no-pointer-events');
                 this.node?.removeEventListener('mouseenter', handleMouseEnter);
-            }, 1000);
+            }, 100);
         };
         this.node?.addEventListener('mouseenter', handleMouseEnter);
     }

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -1024,18 +1024,6 @@ export class ViewContainerPart extends BaseWidget {
         if (options.initiallyHidden && this.canHide) {
             this.hide();
         }
-
-        const handleResize = () => {
-            const handleMouseEnter = () => {
-                this.node?.classList.add('no-pointer-events');
-                setTimeout(() => {
-                    this.node?.classList.remove('no-pointer-events');
-                    this.node?.removeEventListener('mouseenter', handleMouseEnter);
-                }, 1000);
-            };
-            this.node.addEventListener('mouseenter', handleMouseEnter);
-        };
-        this.node.addEventListener('onResizeEvent', handleResize);
     }
 
     get viewContainer(): ViewContainer | undefined {
@@ -1248,8 +1236,19 @@ export class ViewContainerPart extends BaseWidget {
         };
     }
 
+    protected handleResize(): void {
+        const handleMouseEnter = () => {
+            this.node?.classList.add('no-pointer-events');
+            setTimeout(() => {
+                this.node?.classList.remove('no-pointer-events');
+                this.node?.removeEventListener('mouseenter', handleMouseEnter);
+            }, 1000);
+        };
+        this.node?.addEventListener('mouseenter', handleMouseEnter);
+    }
+
     protected override onResize(msg: Widget.ResizeMessage): void {
-        this.node.dispatchEvent(this.onResizeEvent);
+        this.handleResize();
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, Widget.ResizeMessage.UnknownSize);
         }

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -946,6 +946,8 @@ export class ViewContainerPart extends BaseWidget {
     protected readonly onDidChangeBadgeTooltipEmitter = new Emitter<void>();
     readonly onDidChangeBadgeTooltip = this.onDidChangeBadgeTooltipEmitter.event;
 
+    protected readonly onResizeEvent = new Event('onResizeEvent');
+
     protected readonly toolbar: TabBarToolbar;
 
     protected _collapsed: boolean;
@@ -1022,6 +1024,18 @@ export class ViewContainerPart extends BaseWidget {
         if (options.initiallyHidden && this.canHide) {
             this.hide();
         }
+
+        const handleResize = () => {
+            const handleMouseEnter = () => {
+                this.node?.classList.add('no-pointer-events');
+                setTimeout(() => {
+                    this.node?.classList.remove('no-pointer-events');
+                    this.node?.removeEventListener('mouseenter', handleMouseEnter);
+                }, 1000);
+            };
+            this.node.addEventListener('mouseenter', handleMouseEnter);
+        };
+        this.node.addEventListener('onResizeEvent', handleResize);
     }
 
     get viewContainer(): ViewContainer | undefined {
@@ -1234,20 +1248,8 @@ export class ViewContainerPart extends BaseWidget {
         };
     }
 
-    protected noPointerOnHover(): void {
-        const explorer = document.querySelector('#explorer-view-container--files');
-        const handleMouseEnter = () => {
-            explorer?.classList.add('no-pointer-events');
-            setTimeout(() => {
-                explorer?.classList.remove('no-pointer-events');
-                explorer?.removeEventListener('mouseenter', handleMouseEnter);
-            }, 500);
-        };
-        explorer?.addEventListener('mouseenter', handleMouseEnter);
-    }
-
     protected override onResize(msg: Widget.ResizeMessage): void {
-        this.noPointerOnHover();
+        this.node.dispatchEvent(this.onResizeEvent);
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, Widget.ResizeMessage.UnknownSize);
         }

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -1234,7 +1234,20 @@ export class ViewContainerPart extends BaseWidget {
         };
     }
 
+    protected noPointerOnHover(): void {
+        const explorer = document.querySelector('#explorer-view-container--files');
+        const handleMouseEnter = () => {
+            explorer?.classList.add('no-pointer-events');
+            setTimeout(() => {
+                explorer?.classList.remove('no-pointer-events');
+                explorer?.removeEventListener('mouseenter', handleMouseEnter);
+            }, 500);
+        };
+        explorer?.addEventListener('mouseenter', handleMouseEnter);
+    }
+
     protected override onResize(msg: Widget.ResizeMessage): void {
+        this.noPointerOnHover();
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, Widget.ResizeMessage.UnknownSize);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR closes #12615 by fixing the flickering of the toolbar icons when resizing the navigator. The issue was resolved by adding a new method called `noPointerOnHover`. This method temporarily disables pointer events on the explorer view when the mouse enters it which prevents the flickering behavior and leads to a better user experience.

Demo:
![Fix Demo](https://github.com/eclipse-theia/theia/assets/86936229/737b3c17-67b0-46cd-8525-91f0f548b30a)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open Theia application
2. Go in the `Explorer` view and open a folder if none are open (`File` -> `Open Folder`)
3. Click somewhere outside the `Explorer` view to make sure that it is not focused
4. Resize the view and notice that the toolbar icons stay hidden until you stop resizing the view

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
