### PR TITLE
vscode: support  editor/title/run predefined entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.39.0 - 06/29/2023
 
 - [debug] added support for conditional exception breakpoints [#12445](https://github.com/eclipse-theia/theia/pull/12445)
+- [vscode] Support "editor/title/run" toolbar commands [#12637](https://github.com/eclipse-theia/theia/pull/12637) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.39.0">[Breaking Changes:](#breaking_changes_1.39.0)</a>
 

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -26,7 +26,7 @@ import { PluginViewWidget } from '../view/plugin-view-widget';
 import { QuickCommandService } from '@theia/core/lib/browser';
 import {
     CodeEditorWidgetUtil, codeToTheiaMappings, ContributionPoint,
-    PLUGIN_EDITOR_TITLE_MENU, PLUGIN_SCM_TITLE_MENU, PLUGIN_VIEW_TITLE_MENU
+    PLUGIN_EDITOR_TITLE_MENU, PLUGIN_EDITOR_TITLE_RUN_MENU, PLUGIN_SCM_TITLE_MENU, PLUGIN_VIEW_TITLE_MENU
 } from './vscode-theia-menu-mappings';
 import { PluginMenuCommandAdapter, ReferenceCountingSet } from './plugin-menu-command-adapter';
 import { ContextKeyExpr } from '@theia/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
@@ -56,6 +56,7 @@ export class MenusContributionPointHandler {
         this.initialized = true;
         this.commandAdapterRegistry.registerAdapter(this.commandAdapter);
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_EDITOR_TITLE_MENU, widget => this.codeEditorWidgetUtil.is(widget));
+        this.tabBarToolbar.registerMenuDelegate(PLUGIN_EDITOR_TITLE_RUN_MENU, widget => this.codeEditorWidgetUtil.is(widget));
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_SCM_TITLE_MENU, widget => widget instanceof ScmWidget);
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_VIEW_TITLE_MENU, widget => widget instanceof PluginViewWidget);
         this.tabBarToolbar.registerItem({ id: 'plugin-menu-contribution-title-contribution', command: '_never_', onDidChange: this.onDidChangeTitleContributionEmitter.event });

--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -94,6 +94,7 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
             ['editor/context', selectedResource],
             ['editor/title', widgetURI],
             ['editor/title/context', selectedResource],
+            ['editor/title/run', widgetURI],
             ['explorer/context', selectedResource],
             ['scm/resourceFolder/context', toScmArgs],
             ['scm/resourceGroup/context', toScmArgs],

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -32,6 +32,7 @@ import { VIEW_ITEM_CONTEXT_MENU } from '../view/tree-view-widget';
 import { WebviewWidget } from '../webview/webview';
 
 export const PLUGIN_EDITOR_TITLE_MENU = ['plugin_editor/title'];
+export const PLUGIN_EDITOR_TITLE_RUN_MENU = ['plugin_editor/title/run'];
 export const PLUGIN_SCM_TITLE_MENU = ['plugin_scm/title'];
 export const PLUGIN_VIEW_TITLE_MENU = ['plugin_view/title'];
 
@@ -45,6 +46,7 @@ export const implementedVSCodeContributionPoints = [
     'editor/context',
     'editor/title',
     'editor/title/context',
+    'editor/title/run',
     'explorer/context',
     'scm/resourceFolder/context',
     'scm/resourceGroup/context',
@@ -68,6 +70,7 @@ export const codeToTheiaMappings = new Map<ContributionPoint, MenuPath[]>([
     ['editor/context', [EDITOR_CONTEXT_MENU]],
     ['editor/title', [PLUGIN_EDITOR_TITLE_MENU]],
     ['editor/title/context', [SHELL_TABBAR_CONTEXT_MENU]],
+    ['editor/title/run', [PLUGIN_EDITOR_TITLE_RUN_MENU]],
     ['explorer/context', [NAVIGATOR_CONTEXT_MENU]],
     ['scm/resourceFolder/context', [ScmTreeWidget.RESOURCE_FOLDER_CONTEXT_MENU]],
     ['scm/resourceGroup/context', [ScmTreeWidget.RESOURCE_GROUP_CONTEXT_MENU]],


### PR DESCRIPTION
#### What it does

_Adds a missing predefined entry in the menus_
This enables the possibility to contribute menus to editor/title/run entry as defined in vscode.  

Fixes #9387

Contributed on behalf of ST Microelectronics

#### How to test 
1. Install following extension:
-   extension: [editor-title-run-menu-0.0.1.zip](https://github.com/eclipse-theia/theia/files/11832915/editor-title-run-menu-0.0.1.zip)
- source: [editor-title-run-menu-0.0.1-src.zip](https://github.com/eclipse-theia/theia/files/11832916/editor-title-run-menu-0.0.1-src.zip)

2. Try to open a menu on any file except md file, one menu should be contributed by the extension. A second one will pop-up on any md file if the basic markdown extension is installed. 
![before-addeMenu](https://github.com/eclipsesource/theia/assets/3964263/42893ebc-2a0a-42fc-b3ab-3909faafed40)

3. Update your `theia` repository to use this PR
4. Any file should now also have an additional run menu entry, and the md files shall display a total of 2 o 4 menus with this extension depending if markdown extension is installed or not.
![after-addeMenu](https://github.com/eclipsesource/theia/assets/3964263/6e6e17f4-5dbf-462e-9ad8-4bc482384ccb)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)