### PR TITLE
[vscode] support editor/linenumber/context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [debug] added support for conditional exception breakpoints [#12445](https://github.com/eclipse-theia/theia/pull/12445)
 - [vscode] Support "editor/title/run" toolbar commands [#12637](https://github.com/eclipse-theia/theia/pull/12637) - Contributed on behalf of STMicroelectronics
+- [vscode] added missing editor/lineNumber/context menu mapping [#12638](https://github.com/eclipse-theia/theia/pull/12638) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.39.0">[Breaking Changes:](#breaking_changes_1.39.0)</a>
 

--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -37,6 +37,7 @@ import { EditorVariableContribution } from './editor-variable-contribution';
 import { QuickAccessContribution } from '@theia/core/lib/browser/quick-input/quick-access';
 import { QuickEditorService } from './quick-editor-service';
 import { EditorLanguageStatusService } from './language-status/editor-language-status-service';
+import { EditorLineNumberContribution } from './editor-linenumber-contribution';
 
 export default new ContainerModule(bind => {
     bindEditorPreferences(bind);
@@ -63,6 +64,9 @@ export default new ContainerModule(bind => {
     bind(EditorContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(EditorContribution);
     bind(EditorLanguageStatusService).toSelf().inSingletonScope();
+
+    bind(EditorLineNumberContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(EditorLineNumberContribution);
 
     bind(EditorNavigationContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(EditorNavigationContribution);

--- a/packages/editor/src/browser/editor-linenumber-contribution.ts
+++ b/packages/editor/src/browser/editor-linenumber-contribution.ts
@@ -1,0 +1,88 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { EditorManager } from './editor-manager';
+import { EditorMouseEvent, MouseTargetType, Position, TextEditor } from './editor';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FrontendApplicationContribution, ContextMenuRenderer } from '@theia/core/lib/browser';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { Disposable, DisposableCollection, MenuPath } from '@theia/core';
+import { EditorWidget } from './editor-widget';
+
+export const EDITOR_LINENUMBER_CONTEXT_MENU: MenuPath = ['editor_linenumber_context_menu'];
+
+@injectable()
+export class EditorLineNumberContribution implements FrontendApplicationContribution {
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    onStart(): void {
+        this.editorManager.onCreated(editor => this.addLineNumberContextMenu(editor));
+    }
+
+    protected addLineNumberContextMenu(editorWidget: EditorWidget): void {
+        const editor = editorWidget.editor;
+        if (editor) {
+            const disposables = new DisposableCollection();
+            disposables.push(editor.onMouseDown(event => this.handleContextMenu(editor, event)));
+            const dispose = () => disposables.dispose();
+            editorWidget.disposed.connect(dispose);
+            disposables.push(Disposable.create(() => editorWidget.disposed.disconnect(dispose)));
+        }
+    }
+
+    protected handleContextMenu(editor: TextEditor, event: EditorMouseEvent): void {
+        if (event.target && event.target.type === MouseTargetType.GUTTER_LINE_NUMBERS) {
+            if (event.event.button === 2) {
+                editor.focus();
+                const lineNumber = lineNumberFromPosition(event.target.position);
+                const contextKeyService = this.contextKeyService.createOverlay([['editorLineNumber', lineNumber]]);
+                const uri = editor.getResourceUri()!;
+                const args = [{
+                    lineNumber: lineNumber,
+                    uri: uri['codeUri']
+                }];
+
+                setTimeout(() => {
+                    this.contextMenuRenderer.render({
+                        menuPath: EDITOR_LINENUMBER_CONTEXT_MENU,
+                        anchor: event.event,
+                        args,
+                        contextKeyService,
+                        onHide: () => contextKeyService.dispose()
+                    });
+                });
+            }
+        }
+    }
+
+}
+
+function lineNumberFromPosition(position: Position | undefined): number | undefined {
+    // position.line is 0-based line position, where the expected editor line number is 1-based.
+    if (position) {
+        return position.line + 1;
+    }
+    return undefined;
+}
+

--- a/packages/editor/src/browser/index.ts
+++ b/packages/editor/src/browser/index.ts
@@ -24,3 +24,4 @@ export * from './editor-keybinding-contexts';
 export * from './editor-frontend-module';
 export * from './editor-preferences';
 export * from './decorations';
+export * from './editor-linenumber-contribution';

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -30,6 +30,7 @@ import { TIMELINE_ITEM_CONTEXT_MENU } from '@theia/timeline/lib/browser/timeline
 import { COMMENT_CONTEXT, COMMENT_THREAD_CONTEXT, COMMENT_TITLE } from '../comments/comment-thread-widget';
 import { VIEW_ITEM_CONTEXT_MENU } from '../view/tree-view-widget';
 import { WebviewWidget } from '../webview/webview';
+import { EDITOR_LINENUMBER_CONTEXT_MENU } from '@theia/editor/lib/browser/editor-linenumber-contribution';
 
 export const PLUGIN_EDITOR_TITLE_MENU = ['plugin_editor/title'];
 export const PLUGIN_EDITOR_TITLE_RUN_MENU = ['plugin_editor/title/run'];
@@ -47,6 +48,7 @@ export const implementedVSCodeContributionPoints = [
     'editor/title',
     'editor/title/context',
     'editor/title/run',
+    'editor/lineNumber/context',
     'explorer/context',
     'scm/resourceFolder/context',
     'scm/resourceGroup/context',
@@ -71,6 +73,7 @@ export const codeToTheiaMappings = new Map<ContributionPoint, MenuPath[]>([
     ['editor/title', [PLUGIN_EDITOR_TITLE_MENU]],
     ['editor/title/context', [SHELL_TABBAR_CONTEXT_MENU]],
     ['editor/title/run', [PLUGIN_EDITOR_TITLE_RUN_MENU]],
+    ['editor/lineNumber/context', [EDITOR_LINENUMBER_CONTEXT_MENU]],
     ['explorer/context', [NAVIGATOR_CONTEXT_MENU]],
     ['scm/resourceFolder/context', [ScmTreeWidget.RESOURCE_FOLDER_CONTEXT_MENU]],
     ['scm/resourceGroup/context', [ScmTreeWidget.RESOURCE_GROUP_CONTEXT_MENU]],


### PR DESCRIPTION
#### What it does

_Adds a missing predefined entry in the menus_
This enables the possibility to contribute menus to editor/linenumber/context entry as defined in vscode 1.78 (see   https://code.visualstudio.com/updates/v1_78#_editorlinenumbercontext-menu)

Fixes #12560

Contributed on behalf of ST Microelectronics

#### How to test 
1. Install following extension:
-  extension: [sample-menu-extension-0.0.3.zip](https://github.com/eclipsesource/theia/files/11755214/sample-menu-extension-0.0.3.zip)
- source: [sample-menu-extension-src.0.0.3.zip](https://github.com/eclipsesource/theia/files/11755220/sample-menu-extension-src.0.0.3.zip)

2. Try to open a menu on any text file, no menu shall open when right-clicking a line number. An error shall also be displayed in the console when the extension is activated. 
3. Update your `theia` repository to use this PR
4. Any text file shall now display at least one menu on line numbers. If line selected is above 11, then a second menu shall also be displayed. This demonstrates the context key editorLineNumber is set correctly. The information displayed when selecting the action shows the current URI for the edited resource, and the line number, as expected by vscode.

5. The build-in github extension shall also start without displaying a comment on a missing menu entry for editor/linenumber/context.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
