### PR TITLE
dialog: adding maxWidth to `SingleTextInputDialog`

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -166,8 +166,10 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         container.classList.add('dialogBlock');
         if (props.maxWidth === undefined) {
             container.setAttribute('style', 'max-width: none');
-        } else {
+        } else if (props.maxWidth < 400) {
             container.setAttribute('style', `max-width: ${props.maxWidth}px; min-width: 0px`);
+        } else {
+            container.setAttribute('style', `max-width: ${props.maxWidth}px`);
         }
         this.node.appendChild(container);
 

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -577,6 +577,7 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
         const oldKeybinding = item.keybinding;
         const dialog = new EditKeybindingDialog({
             title: nls.localize('theia/keymaps/editKeybindingTitle', 'Edit Keybinding for {0}', command),
+            maxWidth: 400,
             initialValue: oldKeybinding?.keybinding,
             validate: newKeybinding => this.validateKeybinding(command, oldKeybinding?.keybinding, newKeybinding),
         }, this.keymapsService, item);

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -235,6 +235,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
 
                     const dialog = new WorkspaceInputDialog({
                         title: nls.localizeByDefault('New File...'),
+                        maxWidth: 400,
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
                         placeholder: nls.localize('theia/workspace/newFilePlaceholder', 'File Name'),
@@ -260,6 +261,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parent, targetUri, true);
                     const dialog = new WorkspaceInputDialog({
                         title: nls.localizeByDefault('New Folder...'),
+                        maxWidth: 400,
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
                         placeholder: nls.localize('theia/workspace/newFolderPlaceholder', 'Folder Name'),
@@ -285,6 +287,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const oldName = uri.path.base;
                     const dialog = new SingleTextInputDialog({
                         title: nls.localizeByDefault('Rename'),
+                        maxWidth: 400,
                         initialValue: oldName,
                         initialSelectionRange: {
                             start: 0,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR adds a maxWidth attribute to `SingleTextInputDialogs`  in order to fix a styling issue that would occur when the input validation error message would get too long. This would cause the dialog to extend indefinitely. This fix adds a max-width of 400 px to the dialogs to make their styling more user-friendly. The modified dialogs include: `New File`, `New Folder`, `Rename` and `EditKeybinding` dialogs.

Before:
![no maxwidth](https://github.com/eclipse-theia/theia/assets/86936229/395f2bf5-c2e7-4e9c-821d-8481c01b62f0)

After:
![maxwidth](https://github.com/eclipse-theia/theia/assets/86936229/c6e1ea35-79b8-4465-8642-76f3e9cd6c61)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open Theia application
2. Try causing errors while renaming files, creating new files/folders, modifying keybindings
3. The dialog should have a `max-width: 400px` css style
4. Long error messages should not extend the dialog indefinitely

Easy errors to test include: creating a file/folder with no name or a duplicate name, 
renaming a file to the same name, creating empty key bindings ...

Should be merged after #12585 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)