### PR TITLE
cli: use `includeAllVersions` when resolving packs

### DIFF
--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -129,7 +129,7 @@ export default async function downloadPlugins(ovsxClient: OVSXClient, requestSer
             await parallelOrSequence(Array.from(ids, id => async () => {
                 try {
                     await rateLimiter.removeTokens(1);
-                    const { extensions } = await ovsxClient.query({ extensionId: id });
+                    const { extensions } = await ovsxClient.query({ extensionId: id, includeAllVersions: true });
                     const extension = apiFilter.getLatestCompatibleExtension(extensions);
                     const version = extension?.version;
                     const downloadUrl = extension?.files.download;

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -315,7 +315,7 @@ export class VSXExtensionsModel {
             const client = await this.clientProvider();
             let data: VSXExtensionRaw | undefined;
             if (version === undefined) {
-                const { extensions } = await client.query({ extensionId: id });
+                const { extensions } = await client.query({ extensionId: id, includeAllVersions: true });
                 if (extensions?.length) {
                     data = this.vsxApiFilter.getLatestCompatibleExtension(extensions);
                 }

--- a/packages/vsx-registry/src/node/vsx-extension-resolver.ts
+++ b/packages/vsx-registry/src/node/vsx-extension-resolver.ts
@@ -54,7 +54,7 @@ export class VSXExtensionResolver implements PluginDeployerResolver {
             extension = extensions[0];
         } else {
             console.log(`[${id}]: trying to resolve latest version...`);
-            const { extensions } = await client.query({ extensionId: id });
+            const { extensions } = await client.query({ extensionId: id, includeAllVersions: true });
             extension = this.vsxApiFilter.getLatestCompatibleExtension(extensions);
         }
         if (!extension) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit re-introduces the `includeAllVersions` flag when querying for extension-packs in order to find a compatible version of a declared plugin. Before the change we were not properly iterating the versions of a plugin which resulted in a plugin failing to download if the latest version was not compatible to our version range (ex: `ms-vscode.js-debug`). 

The change means that we we will properly iterate the versions of a plugin until we hit a version which is compatible with the framework (with respect to our declared supported API range).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. confirm that CI for the `yarn download:plugins` script is successful

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
