### PR TITLE
Fix tab-bar startup error

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -1145,7 +1145,7 @@ export class SideTabBar extends ScrollableTabBar {
                 }
 
                 // Special handling if only one element is overflowing.
-                if (overflowStartIndex === n - 1) {
+                if (overflowStartIndex === n - 1 && renderData[overflowStartIndex]) {
                     if (!this.tabsOverflowData) {
                         overflowStartIndex--;
                         renderData[overflowStartIndex].visible = false;


### PR DESCRIPTION
#### What it does

After #12593, an error appears in the console when starting the application, since `renderData[overflowStartIndex]` is undefined. This is a minor fix to check that this error cannot appear.

#### How to test

Start the application and confirm that the error does not appear in the console. The original feature should behave as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
