### PR TITLE
Show command shortcuts in toolbar item tooltips.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.40.0 - 
+
+-  Show command shortcuts in toolbar item tooltips. #12660 (https://github.com/eclipse-theia/theia/pull/12660) - Contributed on behalf of STMicroelectronics
+
+<a name="breaking_changes_1.40.0">[Breaking Changes:](#breaking_changes_1.40.0)</a>
+
+
 ## v1.39.0 - 06/29/2023
 
 - [application-manager] added support for backend bundling [#12412](https://github.com/eclipse-theia/theia/pull/12412)

--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -51,7 +51,8 @@ export class ToolbarImpl extends TabBarToolbar {
     protected isBusyDeferred = new Deferred<void>();
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
+        super.init();
         this.doInit();
     }
 
@@ -310,20 +311,6 @@ export class ToolbarImpl extends TabBarToolbar {
                 title={itemTooltip}
             />
         );
-    }
-
-    protected resolveKeybindingForCommand(commandID: string | undefined): string {
-        if (!commandID) {
-            return '';
-        }
-        const keybindings = this.keybindingRegistry.getKeybindingsForCommand(commandID);
-        if (keybindings.length > 0) {
-            const binding = keybindings[0];
-            const bindingKeySequence = this.keybindingRegistry.resolveKeybinding(binding);
-            const keyCode = bindingKeySequence[0];
-            return ` (${this.keybindingRegistry.acceleratorForKeyCode(keyCode, '+')})`;
-        }
-        return '';
     }
 
     protected handleOnDragStart = (e: React.DragEvent<HTMLDivElement>): void => this.doHandleOnDragStart(e);


### PR DESCRIPTION
#### What it does
Shows the active shortcuts for commands in view toolbars, etc. and on rows in contributed tree views. The linked issue has more discussion about the limitations of the implementation here: https://github.com/eclipse-theia/theia/issues/12656#issuecomment-1611113932

Fixes #12656

Contributed on behalf of STMicroelectronics

#### How to test
The attached plugin contributes a view "Test View  Drag and Drop" with a "Print Selection" command in both the view toolbar and on each tree item. There is also a "Toggle enablement" command that toggles the `enablePrintSelection` context key on and off. While toggling enablement on and off, make sure the correct shortcut is shown 1. in the view toolbar 2. in the global toolbar (you'll have to add the "Print Selection" command manually) and on the individual tree items in the view. You can play with the keybindings in the keymaps.json file (open via the keybindings preference page). For example like so:
```
{
    "command": "treeViewDnD.printSelection",
    "keybinding": "ctrl+h",
    "when": "!enablePrintSelection"
},
{
    "command": "-treeViewDnD.printSelection",
    "keybinding": "ctrl+o",
    "when": "enablePrintSelection"
}
```



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
