### PR TITLE
Remove erroneous dialog min-height styling

### DIFF
--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -33,7 +33,6 @@
   display: flex;
   flex-direction: column;
   min-width: 400px;
-  min-height: 150px;
   color: var(--theia-editorWidget-foreground);
   background-color: var(--theia-editorWidget-background);
   border: 1px solid var(--theia-contrastBorder);


### PR DESCRIPTION
#### What it does

During https://github.com/eclipse-theia/theia/pull/12252 I accidentally added a styling rule while resolving a merge conflict that makes some dialogs unexpectedly large and weird looking. See:

![image](https://github.com/eclipse-theia/theia/assets/4377073/0f3254d9-80bc-4814-9368-b3396d492345)


#### How to test

Open a dialog, confirm that the height is calculated as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
