### PR TITLE
debug: improve debug configuration behavior for multi-root workspaces

### DIFF
--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -105,6 +105,7 @@ export class DebugConfigurationManager {
     protected async doInit(): Promise<void> {
         this.debugConfigurationTypeKey = this.contextKeyService.createKey<string>('debugConfigurationType', undefined);
         this.initialized = this.preferences.ready.then(() => {
+            this.workspaceService.onWorkspaceChanged(this.updateModels);
             this.preferences.onPreferenceChanged(e => {
                 if (e.preferenceName === 'launch') {
                     this.updateModels();
@@ -312,7 +313,8 @@ export class DebugConfigurationManager {
     }
 
     async openConfiguration(): Promise<void> {
-        const model = this.getModel();
+        const currentUri = new URI(this.current?.workspaceFolderUri);
+        const model = this.getModel(currentUri);
         if (model) {
             await this.doOpen(model);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR fixes #12663 and introduces improvements to the theia debug widget:
- debug configuration dropdown now listen to changes in workspace root. If a root is added or removed for a multi-root project, the debug widget will refresh to reflect the change.
- the open launch.json button now opens the configuration selected in the drop down menu instead of the first root folder configuration.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Open a multi-root work space. Verify that launch configuration for each root show up in the debug dropdown
- Remove one of the root folder by right click -> remove folder from workspace
- Verify that the associated launch configuration disappears
- Verify that open launch.json button opens the configuration selected in the drop down menu
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
