### PR TITLE
Fix ignored resource in backend bundling

### DIFF
--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -375,6 +375,7 @@ const ignoredResources = new Set();
 
 if (process.platform !== 'win32') {
     ignoredResources.add('@vscode/windows-ca-certs');
+    ignoredResources.add('@vscode/windows-ca-certs/build/Release/crypt32.node');
 }
 
 const nativePlugin = new NativeWebpackPlugin({

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -67,7 +67,7 @@
     "coverage:clean": "rimraf .nyc_output && rimraf coverage",
     "coverage:report": "nyc report --reporter=html",
     "rebuild": "theia rebuild:browser --cacheRoot ../..",
-    "start": "yarn -s rebuild && theia start --plugins=local-dir:../../plugins --ovsx-router-config=../ovsx-router-config.json",
+    "start": "theia start --plugins=local-dir:../../plugins --ovsx-router-config=../ovsx-router-config.json",
     "start:debug": "yarn -s start --log-level=debug",
     "start:watch": "concurrently --kill-others -n tsc,bundle,run -c red,yellow,green \"tsc -b -w --preserveWatchOutput\" \"yarn -s watch:bundle\" \"yarn -s start\"",
     "test": "theia test . --plugins=local-dir:../../plugins --test-spec=../api-tests/**/*.spec.js",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -66,7 +66,7 @@
     "compile": "tsc -b",
     "lint": "theiaext lint",
     "rebuild": "theia rebuild:electron --cacheRoot ../..",
-    "start": "yarn -s rebuild && theia start --plugins=local-dir:../../plugins --ovsx-router-config=../ovsx-router-config.json",
+    "start": "theia start --plugins=local-dir:../../plugins --ovsx-router-config=../ovsx-router-config.json",
     "start:debug": "yarn -s start --log-level=debug --remote-debugging-port=9222",
     "start:watch": "concurrently --kill-others -n tsc,bundle,run -c red,yellow,green \"tsc -b -w --preserveWatchOutput\" \"yarn -s watch:bundle\" \"yarn -s start\"",
     "test": "electron-mocha --timeout 60000 \"./lib/test/**/*.espec.js\"",

--- a/scripts/performance/base-package.json
+++ b/scripts/performance/base-package.json
@@ -29,7 +29,7 @@
     "bundle": "theia build --mode development",
     "compile": "tsc -b",
     "rebuild": "theia rebuild:{{app}} --cacheRoot ../..",
-    "start": "yarn -s rebuild && THEIA_CONFIG_DIR=./theia-config-dir theia start --plugins=local-dir:../../noPlugins --log-level=fatal"
+    "start": "THEIA_CONFIG_DIR=./theia-config-dir theia start --plugins=local-dir:../../noPlugins --log-level=fatal"
   },
   "devDependencies": {
     "@theia/cli": "{{version}}"


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12680

Related to an issue we've also encountered in Theia Blueprint, https://github.com/eclipse-theia/theia-blueprint/pull/275.

For some reason, webpack finds a direct reference between `@vscode/proxy-agent` and `@vscode/windows-ca-certs/build/Release/crypt32.node` in some adopter projects - even though there is none. This change ensures that the dependency is correctly skipped on non-Windows systems, as the dependency is only installed/needed on Windows.

Also removes a few unnecessary `yarn rebuild` calls.

#### How to test

Confirm that the set of `ignoredResources` is the same as in the blueprint PR https://github.com/eclipse-theia/theia-blueprint/pull/275.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
