### PR TITLE
vscode: fix `MarkdownString` for `documentation`

### DIFF
--- a/packages/plugin-ext/src/plugin/languages/completion.ts
+++ b/packages/plugin-ext/src/plugin/languages/completion.ts
@@ -153,13 +153,17 @@ export class CompletionAdapter {
             ? [CompletionItemTag.Deprecated]
             : undefined;
 
+        const documentation = typeof item.documentation !== 'undefined'
+            ? Converter.fromMarkdown(item.documentation)
+            : undefined;
+
         return {
             id,
             parentId,
             label: item.label,
             kind: Converter.fromCompletionItemKind(item.kind),
             detail: item.detail,
-            documentation: item.documentation,
+            documentation,
             filterText: item.filterText,
             sortText: item.sortText,
             preselect: item.preselect,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/12684.

The pull-request fixes an issue where `CompletionItem`s using `MarkdownString` for `documentation` were not being rendered previously. The change makes sure to properly convert the object.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with the [test plugin](https://github.com/eclipse-theia/theia/files/11968464/completions-sample-0.0.2.zip)
2. open or create a `.txt` file
3. trigger completion items (ex: <kbd>ctrl</kbd>+<kbd>space</kbd>) - press again to show to documentation
4. confirm the documentation is rendered

https://github.com/eclipse-theia/theia/assets/40359487/87bc19c8-93a0-4152-bc5a-57e8e9b35961

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
