### PR TITLE
core: enable portable-mode

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -19,7 +19,7 @@ import { screen, app, BrowserWindow, WebContents, Event as ElectronEvent, Browse
 import * as path from 'path';
 import { Argv } from 'yargs';
 import { AddressInfo } from 'net';
-import { promises as fs } from 'fs';
+import { promises as fs, existsSync, mkdirSync } from 'fs';
 import { fork, ForkOptions } from 'child_process';
 import { DefaultTheme, FrontendApplicationConfig } from '@theia/application-package/lib/application-props';
 import URI from '../common/uri';
@@ -171,6 +171,8 @@ export class ElectronMainApplication {
     @inject(TheiaElectronWindowFactory)
     protected readonly windowFactory: TheiaElectronWindowFactory;
 
+    protected isPortable = this.makePortable();
+
     protected readonly electronStore = new Storage<{
         windowstate?: TheiaBrowserWindowOptions
     }>();
@@ -192,6 +194,19 @@ export class ElectronMainApplication {
             throw new Error('You have to start the application first.');
         }
         return this._config;
+    }
+
+    protected makePortable(): boolean {
+        const dataFolderPath = path.join(process.cwd(), 'data');
+        const appDataPath = path.join(dataFolderPath, 'app-data');
+        if (existsSync(dataFolderPath)) {
+            if (!existsSync(appDataPath)) {
+                mkdirSync(appDataPath);
+            }
+            app.setPath('userData', appDataPath);
+            return true;
+        }
+        return false;
     }
 
     async start(config: FrontendApplicationConfig): Promise<void> {

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -50,11 +50,9 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
         if (existsSync(dataFolderPath)) {
             if (existsSync(userDataPath)) {
                 process.env.THEIA_CONFIG_DIR = userDataPath;
-                return FileUri.create(userDataPath).toString();
             } else {
                 mkdirSync(userDataPath);
                 process.env.THEIA_CONFIG_DIR = userDataPath;
-                return FileUri.create(userDataPath).toString();
             }
         } else {
             process.env.THEIA_CONFIG_DIR = join(homedir(), '.theia');

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { existsSync, mkdirSync } from 'node:fs';
+import { pathExists, mkdir } from 'fs-extra';
 import { join } from 'path';
 import { homedir } from 'os';
 import { injectable } from 'inversify';
@@ -29,6 +29,7 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
     protected readonly envs: { [key: string]: EnvVariable } = {};
     protected readonly homeDirUri = FileUri.create(homedir()).toString();
     protected readonly configDirUri: Promise<string>;
+    protected cachedConfigDirUri: string | undefined = undefined;
 
     constructor() {
         this.configDirUri = this.createConfigDirUri();
@@ -44,20 +45,28 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
     }
 
     protected async createConfigDirUri(): Promise<string> {
-        const dataFolderPath = join(process.cwd(), 'data');
+        if (this.cachedConfigDirUri) {
+            return this.cachedConfigDirUri;
+        }
+        let dataFolderPath: string = '';
+        if (process.env.THEIA_APP_PROJECT_PATH) {
+            dataFolderPath = join(process.env.THEIA_APP_PROJECT_PATH, 'data');
+        }
         const userDataPath = join(dataFolderPath, 'user-data');
         // Check if data folder exists for portable mode
-        if (existsSync(dataFolderPath)) {
-            if (existsSync(userDataPath)) {
+        if (await pathExists(dataFolderPath)) {
+            if (await pathExists(userDataPath)) {
                 process.env.THEIA_CONFIG_DIR = userDataPath;
             } else {
-                mkdirSync(userDataPath);
+                await mkdir(userDataPath);
                 process.env.THEIA_CONFIG_DIR = userDataPath;
             }
         } else {
             process.env.THEIA_CONFIG_DIR = join(homedir(), '.theia');
         }
-        return FileUri.create(process.env.THEIA_CONFIG_DIR).toString();
+        const newConfigDirUri = FileUri.create(process.env.THEIA_CONFIG_DIR).toString();
+        this.cachedConfigDirUri = newConfigDirUri;
+        return newConfigDirUri;
     }
 
     async getExecPath(): Promise<string> {

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -43,6 +43,7 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
     }
 
     protected async createConfigDirUri(): Promise<string> {
+        process.env.THEIA_CONFIG_DIR = join(homedir(), 'data');
         return FileUri.create(process.env.THEIA_CONFIG_DIR || join(homedir(), '.theia')).toString();
     }
 

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -62,7 +62,6 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
             }
         } else {
             process.env.THEIA_CONFIG_DIR = join(homedir(), '.theia');
-            this.pathExistenceCache[process.env.THEIA_CONFIG_DIR] = true;
         }
         return FileUri.create(process.env.THEIA_CONFIG_DIR).toString();
     }


### PR DESCRIPTION
## Portable Mode in Theia

Creating a `data` folder at the root of a Theia application will make it portable. So all of the app data and user data will get written to the `data` folder instead of their default locations.

The `.theia`folder is moved from the user’s home directory (`%userprofile%` or `~/`) to a folder called `user-data` inside the `data` folder. `user-data` contains all of the settings, preferences and extensions.

In addition, all of the application data which is stored by default inside a `Theia App Name (Theia Electron Example)`folder in (`%appdata%` or `~/.config` ) is moved to a folder called `app-data` inside the `data` folder. `app-data` contains all of the application’s cache and layout information.

Please refer to the following PR to further understand how the Portable mode is implemented in Theia Blueprint:
https://github.com/eclipse-theia/theia-blueprint/pull/276

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The following changes should make the `user-data` portable (settings, preferences, recent workspace ...).
It also makes the `app-data` portable so all of the electron cache and layout information will be stored in `data/app-data` instead of the default location.

You can test that the portable mode is functional using the Electron Example Application. 

- Run `yarn` and `yarn electron build` 
- Create a `data` folder inside `/theia/examples/electron`. 
- Run `yarn electron start`.

All of the `user-data` which is stored by default inside the user's directory will be stored inside of `/theia/examples/electron/data/user-data`. In addition, all of the `app-data` which is stored by default in `~/.config/Theia Electron Example or %appdata%/Theia Electron Example` will be stored inside of `/theia/examples/electron/data/app-data`.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
