### PR TITLE
Search result navigation with next and previous focus

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -108,6 +108,16 @@ export namespace SearchInWorkspaceCommands {
     export const REPLACE_ALL_RESULTS = Command.toDefaultLocalizedCommand({
         id: 'search.action.replaceAll'
     });
+    export const NEXT_MATCH = Command.toDefaultLocalizedCommand({
+        id: 'search.action.nextMatchFindAction',
+        category: SEARCH_CATEGORY,
+        label: 'Focus Next Search Result',
+    });
+    export const PREVIOUS_MATCH = Command.toDefaultLocalizedCommand({
+        id: 'search.action.previousMatchFindAction',
+        category: SEARCH_CATEGORY,
+        label: 'Focus Previous Search Result',
+    });
 }
 
 @injectable()
@@ -262,6 +272,16 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
                 }
             }),
         });
+        commands.registerCommand(SearchInWorkspaceCommands.NEXT_MATCH, {
+            isEnabled: () => this.withWidget(undefined, widget => widget.hasResultList()),
+            isVisible: () => this.withWidget(undefined, widget => widget.hasResultList()),
+            execute: () => this.withWidget(undefined, widget => widget.resultTreeWidget.focusNextResult())
+        });
+        commands.registerCommand(SearchInWorkspaceCommands.PREVIOUS_MATCH, {
+            isEnabled: () => this.withWidget(undefined, widget => widget.hasResultList()),
+            isVisible: () => this.withWidget(undefined, widget => widget.hasResultList()),
+            execute: () => this.withWidget(undefined, widget => widget.resultTreeWidget.focusPreviousResult())
+        });
         commands.registerCommand(SearchInWorkspaceCommands.COPY_ONE, {
             isEnabled: () => this.withWidget(undefined, widget => {
                 const { selection } = this.selectionService;
@@ -342,6 +362,15 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             command: SearchInWorkspaceCommands.FIND_IN_FOLDER.id,
             keybinding: 'shift+alt+f',
             when: 'explorerResourceIsFolder'
+        });
+        keybindings.registerKeybindings({
+            command: SearchInWorkspaceCommands.NEXT_MATCH.id,
+            keybinding: 'f4',
+            when: 'searchViewletFocus'
+        });
+        keybindings.registerKeybinding({
+            command: SearchInWorkspaceCommands.PREVIOUS_MATCH.id,
+            keybinding: 'shift+f4',
         });
         keybindings.registerKeybinding({
             command: SearchInWorkspaceCommands.DISMISS_RESULT.id,

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -371,6 +371,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         keybindings.registerKeybinding({
             command: SearchInWorkspaceCommands.PREVIOUS_MATCH.id,
             keybinding: 'shift+f4',
+            when: 'searchViewletFocus'
         });
         keybindings.registerKeybinding({
             command: SearchInWorkspaceCommands.DISMISS_RESULT.id,

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -847,11 +847,11 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     protected renderReplaceButton(node: TreeNode): React.ReactNode {
         const isResultLineNode = SearchInWorkspaceResultLineNode.is(node);
         return <span className={isResultLineNode ? codicon('replace') : codicon('replace-all')}
-                     onClick={e => this.doReplace(node, e)}
-                     title={isResultLineNode
-                         ? nls.localizeByDefault('Replace')
-                         : nls.localizeByDefault('Replace All')
-                     }></span>;
+             onClick={e => this.doReplace(node, e)}
+             title={isResultLineNode
+                 ? nls.localizeByDefault('Replace')
+                 : nls.localizeByDefault('Replace All')
+             }></span>;
     }
 
     protected getFileCount(node: TreeNode): number {
@@ -1082,7 +1082,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         return <div className='result'>
             <div className='result-head'>
                 <div className={`result-head-info noWrapInfo noselect ${node.selected ? 'selected' : ''}`}
-                     title={new URI(node.fileUri).path.fsPath()}>
+                    title={new URI(node.fileUri).path.fsPath()}>
                     <span className={`file-icon ${this.toNodeIcon(node)}`}></span>
                     <div className='noWrapInfo'>
                         <span className={'file-name'}>

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -847,11 +847,11 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     protected renderReplaceButton(node: TreeNode): React.ReactNode {
         const isResultLineNode = SearchInWorkspaceResultLineNode.is(node);
         return <span className={isResultLineNode ? codicon('replace') : codicon('replace-all')}
-             onClick={e => this.doReplace(node, e)}
-             title={isResultLineNode
-                 ? nls.localizeByDefault('Replace')
-                 : nls.localizeByDefault('Replace All')
-             }></span>;
+            onClick={e => this.doReplace(node, e)}
+            title={isResultLineNode
+                ? nls.localizeByDefault('Replace')
+                : nls.localizeByDefault('Replace All')
+            }></span>;
     }
 
     protected getFileCount(node: TreeNode): number {


### PR DESCRIPTION
#### What it does
Implementation for issue: https://github.com/eclipse-theia/theia/issues/12692

Added commands for `Search: Focus Next Search Result` and `Search: Focus Previous Search Result`, similar to their VSCode counterparts, along with the corresponding keybinds.

#### How to test
1. Run Theia.
2. Search using terms which return multiple results.
3. Use the command palette (`Ctrl+Shift+P`) and enter `Search: Focus Next Search Result` (or its `Previous` counterpart) or using the `F4` / `Shift+F4` keybinds.
4. Notice how the results are focused correspondingly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
