### PR TITLE
plugin-ext: stop reading before writing stores

### DIFF
--- a/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
+++ b/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
@@ -14,7 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { deepmerge } from '@theia/core/shared/@theia/application-package';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { FileSystemLocking } from '@theia/core/lib/node';
 import * as fs from '@theia/core/shared/fs-extra';
@@ -111,11 +110,9 @@ export class PluginsKeyValueStorage {
 
     private syncStores(): void {
         this.syncStoresTimeout = setTimeout(async () => {
-            await Promise.all(Array.from(this.storesToSync, async store => {
-                await this.fsLocking.lockPath(store.fsPath, async storePath => {
-                    const valuesOnDisk = await this.readFromFile(storePath);
-                    store.values = deepmerge(valuesOnDisk, store.values);
-                    await this.writeToFile(storePath, store.values);
+            await Promise.all(Array.from(this.storesToSync, async ({ fsPath, values }) => {
+                await this.fsLocking.lockPath(fsPath, async storePath => {
+                    await this.writeToFile(storePath, values);
                 });
             }));
             this.storesToSync.clear();


### PR DESCRIPTION
The merging of on disk values using `deepmerge` is bogus.

Instead we'll completely overwrite the file. This should be fine as the `PluginsKeyValueStorage` singleton is shared across all plugin host processes, meaning there shouldn't be a risk for a race condition to corrupt the file being written on disk.

Note that there is still a race condition risk when multiple Theia backends are running on the same host, but odds should be low.

#### How to test

Help needed

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
