### PR TITLE
add handling of extension visibility

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -136,11 +136,18 @@ export interface PluginPackageTranslation {
     path: string;
 }
 
+export enum InitialVisibility {
+    Visible = 'visible',
+    Hidden = 'hidden',
+    Collapsed = 'collapsed'
+}
+
 export interface PluginPackageCustomEditor {
     viewType: string;
     displayName: string;
     selector?: CustomEditorSelector[];
     priority?: CustomEditorPriority;
+    visibility?: InitialVisibility;
 }
 
 export interface CustomEditorSelector {
@@ -169,12 +176,14 @@ export interface PluginPackageView {
     name: string;
     when?: string;
     type?: string;
+    visibility?: InitialVisibility;
 }
 
 export interface PluginPackageViewWelcome {
     view: string;
     contents: string;
     when?: string;
+    visibility?: InitialVisibility;
 }
 
 export interface PluginPackageCommand {
@@ -774,6 +783,7 @@ export interface View {
     name: string;
     when?: string;
     type?: string;
+    visibility?: InitialVisibility;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -596,7 +596,8 @@ export class TheiaPluginScanner implements PluginScanner {
             id: rawView.id,
             name: rawView.name,
             when: rawView.when,
-            type: rawView.type
+            type: rawView.type,
+            visibility: rawView.visibility,
         };
 
         return result;

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -20,7 +20,7 @@ import {
     ViewContainerIdentifier, ViewContainerTitleOptions, Widget, FrontendApplicationContribution,
     StatefulWidget, CommonMenus, TreeViewWelcomeWidget, codicon, ViewContainerPart, BaseWidget
 } from '@theia/core/lib/browser';
-import { ViewContainer, View, ViewWelcome, PluginViewType } from '../../../common';
+import { ViewContainer, View, ViewWelcome, PluginViewType, InitialVisibility } from '../../../common';
 import { PluginSharedStyle } from '../plugin-shared-style';
 import { DebugWidget } from '@theia/debug/lib/browser/view/debug-widget';
 import { PluginViewWidget, PluginViewWidgetIdentifier } from './plugin-view-widget';
@@ -608,9 +608,15 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             }
             const widget = await this.widgetManager.getOrCreateWidget<PluginViewWidget>(PLUGIN_VIEW_FACTORY_ID, identifier);
             if (containerWidget.getTrackableWidgets().indexOf(widget) === -1) {
+                const viewInfo = this.views.get(viewId);
+                const initialVisibility = viewInfo?.[1].visibility;
+                const isInitiallyVisible = initialVisibility === InitialVisibility.Visible;
+                const isinitiallyHidden = initialVisibility === InitialVisibility.Hidden;
+                const isInitiallyCollapsed = initialVisibility === InitialVisibility.Collapsed;
+
                 containerWidget.addWidget(widget, {
-                    initiallyCollapsed: !!containerWidget.getParts().length,
-                    initiallyHidden: !this.isViewVisible(viewId)
+                    initiallyCollapsed: !!containerWidget.getParts().length && (!isInitiallyVisible || isInitiallyCollapsed),
+                    initiallyHidden: (!this.isViewVisible(viewId) || isinitiallyHidden) && !isInitiallyVisible,
                 });
             }
             this.registerWidgetPartEvents(widget, containerWidget);


### PR DESCRIPTION
#### What it does
Adds support for initial visibility of view contributions in extension as implemented by vscode (see https://github.com/microsoft/vscode/pull/102002)

#### How to test
Install a plugin that with view contributions where the "visibility" property set to either "hidden", "visible" or "collapsed"

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
