### PR TITLE
[vscode] Add proposed dropMetadata API

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -329,6 +329,10 @@ export interface DocumentDropEdit {
     additionalEdit?: WorkspaceEdit;
 }
 
+export interface DocumentDropEditProviderMetadata {
+    readonly dropMimeTypes: readonly string[];
+}
+
 export interface DataTransferFileDTO {
     readonly name: string;
     readonly uri?: UriComponents;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -87,7 +87,8 @@ import {
     InlineCompletions,
     InlineCompletionContext,
     DocumentDropEdit,
-    DataTransferDTO
+    DataTransferDTO,
+    DocumentDropEditProviderMetadata
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -1657,7 +1658,7 @@ export interface LanguagesMain {
     $clearDiagnostics(id: string): void;
     $changeDiagnostics(id: string, delta: [string, MarkerData[]][]): void;
     $registerDocumentFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
-    $registerDocumentDropEditProvider(handle: number, selector: SerializedDocumentFilter[]): void
+    $registerDocumentDropEditProvider(handle: number, selector: SerializedDocumentFilter[], metadata?: DocumentDropEditProviderMetadata): void
     $registerRangeFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerOnTypeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void;
     $registerDocumentLinkProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -40,7 +40,8 @@ import {
 import { injectable, inject } from '@theia/core/shared/inversify';
 import {
     SerializedDocumentFilter, MarkerData, Range, RelatedInformation,
-    MarkerSeverity, DocumentLink, WorkspaceSymbolParams, CodeAction, CompletionDto, CodeActionProviderDocumentation, InlayHint, InlayHintLabelPart, CodeActionContext
+    MarkerSeverity, DocumentLink, WorkspaceSymbolParams, CodeAction, CompletionDto,
+    CodeActionProviderDocumentation, InlayHint, InlayHintLabelPart, CodeActionContext, DocumentDropEditProviderMetadata
 } from '../../common/plugin-api-rpc-model';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { MonacoLanguages, WorkspaceSymbolProvider } from '@theia/monaco/lib/browser/monaco-languages';
@@ -726,12 +727,20 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$provideOnTypeFormattingEdits(handle, model.uri, position, ch, options, token);
     }
 
-    $registerDocumentDropEditProvider(handle: number, selector: SerializedDocumentFilter[]): void {
-        this.register(handle, (StandaloneServices.get(ILanguageFeaturesService).documentOnDropEditProvider.register(selector, this.createDocumentDropEditProvider(handle))));
+    $registerDocumentDropEditProvider(handle: number, selector: SerializedDocumentFilter[], metadata?: DocumentDropEditProviderMetadata): void {
+        this.register(
+            handle,
+            StandaloneServices
+                .get(ILanguageFeaturesService)
+                .documentOnDropEditProvider
+                .register(selector, this.createDocumentDropEditProvider(handle, metadata))
+        );
     }
 
-    createDocumentDropEditProvider(handle: number): DocumentOnDropEditProvider {
+    createDocumentDropEditProvider(handle: number, _metadata?: DocumentDropEditProviderMetadata): DocumentOnDropEditProvider {
         return {
+            // @monaco-uplift dropMimeTypes should be supported by the monaco drop editor provider after 1.79.0
+            // dropMimeTypes: metadata?.dropMimeTypes ?? ['*/*'],
             provideDocumentOnDropEdits: async (model, position, dataTransfer, token) => this.provideDocumentDropEdits(handle, model, position, dataTransfer, token)
         };
     }
@@ -742,6 +751,10 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         const edit = await this.proxy.$provideDocumentDropEdits(handle, model.uri, position, await DataTransfer.toDataTransferDTO(dataTransfer), token);
         if (edit) {
             return {
+                // @monaco-uplift id, priority and label should be supported by monaco after 1.79.0. The implementation relies on a copy of the plugin data
+                // id: edit.id ? plugin.identifier.value + '.' + edit.id : plugin.identifier.value,
+                // label: edit.label ?? nls.localizeByDefault("Drop using '{0}' extension", plugin.displayName || plugin.name),
+                // priority: edit.priority ?? 0,
                 insertText: edit.insertText instanceof SnippetString ? { snippet: edit.insertText.value } : edit.insertText,
                 additionalEdit: toMonacoWorkspaceEdit(edit?.additionalEdit)
             };

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -494,9 +494,13 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, DocumentDropEditAdapter, adapter => adapter.provideDocumentDropEdits(URI.revive(resource), position, dataTransfer, token), undefined);
     }
 
-    registerDocumentDropEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentDropEditProvider): theia.Disposable {
+    registerDocumentDropEditProvider(
+        selector: theia.DocumentSelector,
+        provider: theia.DocumentDropEditProvider,
+        metadata?: theia.DocumentDropEditProviderMetadata
+    ): theia.Disposable {
         const callId = this.addNewAdapter(new DocumentDropEditAdapter(provider, this.documents, this.filesSystem));
-        this.proxy.$registerDocumentDropEditProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerDocumentDropEditProvider(callId, this.transformDocumentSelector(selector), metadata);
         return this.createDisposable(callId);
     }
     // ### Drop Edit Provider end

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -900,8 +900,8 @@ export function createAPIFactory(
             ): theia.Disposable {
                 return languagesExt.registerOnTypeFormattingEditProvider(selector, provider, [firstTriggerCharacter].concat(moreTriggerCharacters), pluginToPluginInfo(plugin));
             },
-            registerDocumentDropEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentDropEditProvider) {
-                return languagesExt.registerDocumentDropEditProvider(selector, provider);
+            registerDocumentDropEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentDropEditProvider, metadata?: theia.DocumentDropEditProviderMetadata) {
+                return languagesExt.registerDocumentDropEditProvider(selector, provider, metadata);
             },
             registerDocumentLinkProvider(selector: theia.DocumentSelector, provider: theia.DocumentLinkProvider): theia.Disposable {
                 return languagesExt.registerDocumentLinkProvider(selector, provider, pluginToPluginInfo(plugin));

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1542,6 +1542,13 @@ export class DocumentLink {
 
 @es5ClassCompat
 export class DocumentDropEdit {
+
+    id?: string;
+
+    priority?: number;
+
+    label?: string;
+
     insertText: string | SnippetString;
 
     additionalEdit?: WorkspaceEdit;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -25,6 +25,7 @@ import './theia-extra';
 import './theia.proposed.customEditorMove';
 import './theia.proposed.diffCommand';
 import './theia.proposed.documentPaste';
+import './theia.proposed.dropMetadata';
 import './theia.proposed.editSessionIdentityProvider';
 import './theia.proposed.extensionsAny';
 import './theia.proposed.externalUriOpener';

--- a/packages/plugin/src/theia.proposed.dropMetadata.d.ts
+++ b/packages/plugin/src/theia.proposed.dropMetadata.d.ts
@@ -20,7 +20,7 @@
  *--------------------------------------------------------------------------------------------*/
 // code copied and modified from https://github.com/microsoft/vscode/blob/1.79.0/src/vscode-dts/vscode.proposed.dropMetadata.d.ts
 
-declare module '@theia/plugin' {
+export module '@theia/plugin' {
 
     // https://github.com/microsoft/vscode/issues/179430
 

--- a/packages/plugin/src/theia.proposed.dropMetadata.d.ts
+++ b/packages/plugin/src/theia.proposed.dropMetadata.d.ts
@@ -1,0 +1,66 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// code copied and modified from https://github.com/microsoft/vscode/blob/1.79.0/src/vscode-dts/vscode.proposed.dropMetadata.d.ts
+
+declare module '@theia/plugin' {
+
+    // https://github.com/microsoft/vscode/issues/179430
+
+    export interface DocumentDropEdit {
+        /**
+         * Identifies the type of edit.
+         *
+         * This id should be unique within the extension but does not need to be unique across extensions.
+         */
+        id?: string;
+
+        /**
+         * The relative priority of this edit. Higher priority items are shown first in the UI.
+         *
+         * Defaults to `0`.
+         */
+        priority?: number;
+
+        /**
+         * Human readable label that describes the edit.
+         */
+        label?: string;
+    }
+
+    export interface DocumentDropEditProviderMetadata {
+        /**
+         * List of data transfer types that the provider supports.
+         *
+         * This can either be an exact mime type such as `image/png`, or a wildcard pattern such as `image/*`.
+         *
+         * Use `text/uri-list` for resources dropped from the explorer or other tree views in the workbench.
+         *
+         * Use `files` to indicate that the provider should be invoked if any {@link DataTransferFile files} are present in the {@link DataTransfer}.
+         * Note that {@link DataTransferFile} entries are only created when dropping content from outside the editor, such as
+         * from the operating system.
+         */
+        readonly dropMimeTypes: readonly string[];
+    }
+
+    export namespace languages {
+        export function registerDocumentDropEditProvider(selector: DocumentSelector, provider: DocumentDropEditProvider, metadata?: DocumentDropEditProviderMetadata): Disposable;
+    }
+}


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12632

This PR adds the groundworks for supporting the proposed API. Note that while the API is supported on a type level, our current monaco version isn't able to actually make use of the changes. I've annotated all places in the code with `@monaco-uplift` so that any contributor can improve on this behavior once we have performed the uplift to `^1.79.0`.

#### How to test

There isn't really anything to test, no behavior should have changed. Confirm that the changes in https://github.com/eclipse-theia/theia/pull/12125 still work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
