### PR TITLE
[vscode] Add proposed documentPaste API

### DIFF
--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -3499,11 +3499,16 @@ export class InteractiveWindowInput {
 // #region DocumentPaste
 @es5ClassCompat
 export class DocumentPasteEdit {
-    constructor(insertText: string | SnippetString) {
+    constructor(insertText: string | SnippetString, id: string, label: string) {
         this.insertText = insertText;
+        this.id = id;
+        this.label = label;
     }
     insertText: string | SnippetString;
     additionalEdit?: WorkspaceEdit;
+    id: string;
+    label: string;
+    priority?: number;
 }
 // #endregion
 

--- a/packages/plugin/src/theia.proposed.documentPaste.d.ts
+++ b/packages/plugin/src/theia.proposed.documentPaste.d.ts
@@ -18,7 +18,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-// code copied and modified from https://github.com/microsoft/vscode/blob/1.77.0/src/vscode-dts/vscode.proposed.documentPaste.d.ts
+// code copied and modified from https://github.com/microsoft/vscode/blob/1.79.0/src/vscode-dts/vscode.proposed.documentPaste.d.ts
 
 export module '@theia/plugin' {
 
@@ -52,13 +52,32 @@ export module '@theia/plugin' {
          *
          * @return Optional workspace edit that applies the paste. Return undefined to use standard pasting.
          */
-        provideDocumentPasteEdits(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentPasteEdit>;
+        provideDocumentPasteEdits?(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentPasteEdit>;
     }
 
     /**
      * An operation applied on paste
      */
     class DocumentPasteEdit {
+        /**
+         * Identifies the type of edit.
+         *
+         * This id should be unique within the extension but does not need to be unique across extensions.
+         */
+        id: string;
+
+        /**
+         * Human readable label that describes the edit.
+         */
+        label: string;
+
+        /**
+         * The relative priority of this edit. Higher priority items are shown first in the UI.
+         *
+         * Defaults to `0`.
+         */
+        priority?: number;
+
         /**
          * The text or snippet to insert at the pasted locations.
          */
@@ -71,17 +90,30 @@ export module '@theia/plugin' {
 
         /**
          * @param insertText The text or snippet to insert at the pasted locations.
+         *
+         * TODO: Reverse args, but this will break existing consumers :(
          */
-        constructor(insertText: string | SnippetString);
+        constructor(insertText: string | SnippetString, id: string, label: string);
     }
 
     interface DocumentPasteProviderMetadata {
         /**
-         * Mime types that `provideDocumentPasteEdits` should be invoked for.
-         *
-         * Use the special `files` mimetype to indicate the provider should be invoked if any files are present in the `DataTransfer`.
+         * Mime types that {@link DocumentPasteEditProvider.prepareDocumentPaste provideDocumentPasteEdits} may add on copy.
          */
-        readonly pasteMimeTypes: readonly string[];
+        readonly copyMimeTypes?: readonly string[];
+
+        /**
+         * Mime types that {@link DocumentPasteEditProvider.provideDocumentPasteEdits provideDocumentPasteEdits} should be invoked for.
+         *
+         * This can either be an exact mime type such as `image/png`, or a wildcard pattern such as `image/*`.
+         *
+         * Use `text/uri-list` for resources dropped from the explorer or other tree views in the workbench.
+         *
+         * Use `files` to indicate that the provider should be invoked if any {@link DataTransferFile files} are present in the {@link DataTransfer}.
+         * Note that {@link DataTransferFile} entries are only created when dropping content from outside the editor, such as
+         * from the operating system.
+         */
+        readonly pasteMimeTypes?: readonly string[];
     }
 
     namespace languages {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12633

Updates our `theia.proposed.documentPaste.d.ts` file to vscode 1.79.0 and ensures that the values from the constructor calls are stored as expected on the `DocumentPasteEdit` class. Since we don't have any implementation for this vscode API right now, no behavior has changed.

#### How to test

Nothing to test, no behavior has changed. CI should be green though.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
