### PR TITLE
Fix background rendering for menu icons

### DIFF
--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -121,7 +121,11 @@
   min-height: var(--theia-private-menu-item-height);
   max-height: var(--theia-private-menu-item-height);
   padding: 0px;
-  line-height: var(--theia-private-menu-item-height);
+  /** 
+   * FireFox adds 0.5px to all menu items for some reason
+   * Subtracting that amount fixes the behavior on FireFox and doesn't introduce issues on Chromium
+   */
+  line-height: calc(var(--theia-private-menu-item-height) - 0.5px);
   overflow: hidden;
 }
 
@@ -158,7 +162,7 @@
 .p-Menu-itemIcon {
   width: 21px;
   padding: 0px 2px 0px 4px;
-  margin-top: -2px;
+  height: var(--theia-private-menu-item-height);
 }
 
 .p-Menu-itemLabel {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12738

The icon that received a background in https://github.com/eclipse-theia/theia/pull/12252 hasn't been sized correctly. This PR changes the size of the icon so that the background is uniform across all horizontal elements within a menu entry.

#### How to test

1. Open the `Run` menu.
2. Assert that the background color across all horizontal html elements appears consistent.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
