### PR TITLE
Implement CanonicalUriProvider API. Fixes #12735

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -694,6 +694,9 @@ export interface WorkspaceMain {
     $getWorkspace(): Promise<files.FileStat | undefined>;
     $requestWorkspaceTrust(options?: theia.WorkspaceTrustRequestOptions): Promise<boolean | undefined>;
     $resolveProxy(url: string): Promise<string | undefined>;
+    $registerCanonicalUriProvider(scheme: string): Promise<void | undefined>;
+    $unregisterCanonicalUriProvider(scheme: string): void;
+    $getCanonicalUri(uri: string, targetScheme: string, token: theia.CancellationToken): Promise<string | undefined>;
 }
 
 export interface WorkspaceExt {
@@ -703,6 +706,10 @@ export interface WorkspaceExt {
     $onTextSearchResult(searchRequestId: number, done: boolean, result?: SearchInWorkspaceResult): void;
     $onWorkspaceTrustChanged(trust: boolean | undefined): void;
     $registerEditSessionIdentityProvider(scheme: string, provider: theia.EditSessionIdentityProvider): theia.Disposable;
+    registerCanonicalUriProvider(scheme: string, provider: theia.CanonicalUriProvider): theia.Disposable;
+    $disposeCanonicalUriProvider(scheme: string): void;
+    getCanonicalUri(uri: theia.Uri, options: theia.CanonicalUriRequestOptions, token: CancellationToken): theia.ProviderResult<theia.Uri>;
+    $provideCanonicalUri(uri: string, targetScheme: string, token: CancellationToken): Promise<string | undefined>;
 }
 
 export interface TimelineExt {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -747,6 +747,12 @@ export function createAPIFactory(
              * that currently use this proposed API.
              */
             onWillCreateEditSessionIdentity: () => Disposable.NULL,
+            registerCanonicalUriProvider(scheme: string, provider: theia.CanonicalUriProvider): theia.Disposable {
+                return workspaceExt.registerCanonicalUriProvider(scheme, provider);
+            },
+            getCanonicalUri(uri: theia.Uri, options: theia.CanonicalUriRequestOptions, token: CancellationToken): theia.ProviderResult<theia.Uri> {
+                return workspaceExt.getCanonicalUri(uri, options, token);
+            }
         };
 
         const onDidChangeLogLevel = new Emitter<theia.LogLevel>();

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -403,6 +403,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         if (typeof pluginMain[plugin.lifecycle.startMethod] === 'function') {
             await this.localization.initializeLocalizedMessages(plugin, this.envExt.language);
             const pluginExport = await pluginMain[plugin.lifecycle.startMethod].apply(getGlobal(), [pluginContext]);
+            console.log(`calling activation function on ${id}`);
             this.activatedPlugins.set(plugin.model.id, new ActivatedPlugin(pluginContext, pluginExport, stopFn));
         } else {
             // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/workbench/api/common/extHostExtensionService.ts#L400-L401

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -22,6 +22,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './theia-extra';
+import './theia.proposed.canonicalUriProvider';
 import './theia.proposed.customEditorMove';
 import './theia.proposed.diffCommand';
 import './theia.proposed.documentPaste';

--- a/packages/plugin/src/theia.proposed.canonicalUriProvider.d.ts
+++ b/packages/plugin/src/theia.proposed.canonicalUriProvider.d.ts
@@ -1,0 +1,64 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// code copied and modified from https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.canonicalUriProvider.d.ts
+
+export module '@theia/plugin' {
+
+    // https://github.com/microsoft/vscode/issues/180582
+
+    export namespace workspace {
+        /**
+         *
+         * @param scheme The URI scheme that this provider can provide canonical URIs for.
+         * A canonical URI represents the conversion of a resource's alias into a source of truth URI.
+         * Multiple aliases may convert to the same source of truth URI.
+         * @param provider A provider which can convert URIs of scheme @param scheme to
+         * a canonical URI which is stable across machines.
+         */
+        export function registerCanonicalUriProvider(scheme: string, provider: CanonicalUriProvider): Disposable;
+
+        /**
+         *
+         * @param uri The URI to provide a canonical URI for.
+         * @param token A cancellation token for the request.
+         */
+        export function getCanonicalUri(uri: Uri, options: CanonicalUriRequestOptions, token: CancellationToken): ProviderResult<Uri>;
+    }
+
+    export interface CanonicalUriProvider {
+        /**
+         *
+         * @param uri The URI to provide a canonical URI for.
+         * @param options Options that the provider should honor in the URI it returns.
+         * @param token A cancellation token for the request.
+         * @returns The canonical URI for the requested URI or undefined if no canonical URI can be provided.
+         */
+        provideCanonicalUri(uri: Uri, options: CanonicalUriRequestOptions, token: CancellationToken): ProviderResult<Uri>;
+    }
+
+    export interface CanonicalUriRequestOptions {
+        /**
+         *
+         * The desired scheme of the canonical URI.
+         */
+        targetScheme: string;
+    }
+}

--- a/packages/workspace/src/browser/canonical-uri-service.ts
+++ b/packages/workspace/src/browser/canonical-uri-service.ts
@@ -1,0 +1,57 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { CancellationToken, URI } from '@theia/core/lib/common';
+import { injectable } from '@theia/core/shared/inversify';
+import { Disposable } from '@theia/core/shared/vscode-languageserver-protocol';
+
+export interface CanonicalUriProvider extends Disposable {
+    provideCanonicalUri(uri: URI, targetScheme: string, token: CancellationToken): Promise<URI | undefined>;
+}
+
+@injectable()
+export class CanonicalUriService {
+    private providers = new Map<string, CanonicalUriProvider>();
+
+    registerCanonicalUriProvider(scheme: string, provider: CanonicalUriProvider): Disposable {
+        if (this.providers.has(scheme)) {
+            throw new Error(`Canonical URI provider for scheme: '${scheme}' already exists`);
+        }
+
+        this.providers.set(scheme, provider);
+        return Disposable.create(() => { this.removeCanonicalUriProvider(scheme); });
+    }
+
+    private removeCanonicalUriProvider(scheme: string): void {
+        const provider = this.providers.get(scheme);
+        if (!provider) {
+            throw new Error(`No Canonical URI provider for scheme: '${scheme}' exists`);
+        }
+
+        this.providers.delete(scheme);
+        provider.dispose();
+    }
+
+    async provideCanonicalUri(uri: URI, targetScheme: string, token: CancellationToken = CancellationToken.None): Promise<URI | undefined> {
+        const provider = this.providers.get(uri.scheme);
+        if (!provider) {
+            console.warn(`No Canonical URI provider for scheme: '${uri.scheme}' exists`);
+            return undefined;
+        }
+
+        return provider.provideCanonicalUri(uri, targetScheme, token);
+    }
+}

--- a/packages/workspace/src/browser/index.ts
+++ b/packages/workspace/src/browser/index.ts
@@ -16,6 +16,7 @@
 
 export * from './workspace-commands';
 export * from './workspace-service';
+export * from './canonical-uri-service';
 export * from './workspace-frontend-contribution';
 export * from './workspace-frontend-module';
 export * from './workspace-preferences';

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -54,6 +54,7 @@ import { UserWorkingDirectoryProvider } from '@theia/core/lib/browser/user-worki
 import { WorkspaceUserWorkingDirectoryProvider } from './workspace-user-working-directory-provider';
 import { WindowTitleUpdater } from '@theia/core/lib/browser/window/window-title-updater';
 import { WorkspaceWindowTitleUpdater } from './workspace-window-title-updater';
+import { CanonicalUriService } from './canonical-uri-service';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
@@ -61,6 +62,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
 
     bind(WorkspaceService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(WorkspaceService);
+    bind(CanonicalUriService).toSelf().inSingletonScope();
     bind(WorkspaceServer).toDynamicValue(ctx => {
         const provider = ctx.container.get(WebSocketConnectionProvider);
         return provider.createProxy<WorkspaceServer>(workspacePath);


### PR DESCRIPTION
#### What it does
The implementation follows the usual pattern of having a Theia service for canonicla URI's with the VS Code implementation being a special case of the Theia service contributions.
The API is proposed in VS Code, but used in built-in extensions in versions >= 1.80.0

Contributed on behalf of STMicroelectronics

#### How to test
Add the attached extension to the plugins folder. It provides two commands: one to "Register Canoniccal URI Provider" and one to "Convert to Canonical URI". The first one registers a provider we can test with the second command. To test, invoke the command, then

1. Select a target scheme ('uppercase/lowercase/https')
2. Enter a uri
3. The provider converts the uri either to upper/lower case depending on the chosen target scheme. It returns undefined if the targets scheme is https.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
