### PR TITLE
Fix erroneous header info after recent merge

### DIFF
--- a/packages/filesystem/src/node/disk-file-system-provider.spec.ts
+++ b/packages/filesystem/src/node/disk-file-system-provider.spec.ts
@@ -11,7 +11,7 @@
 // with the GNU Classpath Exception which is available at
 // https://www.gnu.org/software/classpath/license.html.
 //
-// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';


### PR DESCRIPTION
#### What it does

Fixes an error in our linter CI that appeared after a recent PR merge https://github.com/eclipse-theia/theia/pull/12354.

#### How to test

Lint CI is supposed to be green

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
