### PR TITLE
[vscode] support TaskPresentationOptions close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 ## v1.40.0 - 
 
-- [workspace] Implement CanonicalUriProvider API #12743 (https://github.com/eclipse-theia/theia/pull/12743 - Contributed on behalf of STMicroelectronics
-- Show command shortcuts in toolbar item tooltips. #12660 (https://github.com/eclipse-theia/theia/pull/12660) - Contributed on behalf of STMicroelectronics
+- [workspace] Implement CanonicalUriProvider API [#12743](https://github.com/eclipse-theia/theia/pull/12743) - Contributed on behalf of STMicroelectronics
+- Show command shortcuts in toolbar item tooltips. [#12660](https://github.com/eclipse-theia/theia/pull/12660) - Contributed on behalf of STMicroelectronics
 - [cli] added `check:theia-extensions` which checks the uniqueness of Theia extension versions [#12596](https://github.com/eclipse-theia/theia/pull/12596) - Contributed on behalf of STMicroelectronics
+- [vscode] Add support for the TaskPresentationOptions close property [#12749](https://github.com/eclipse-theia/theia/pull/12749) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.40.0">[Breaking Changes:](#breaking_changes_1.40.0)</a>
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1517,6 +1517,7 @@ export interface TaskPresentationOptionsDTO {
     panel?: number;
     showReuseMessage?: boolean;
     clear?: boolean;
+    close?: boolean;
 }
 
 export interface TaskExecutionDto {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12628,6 +12628,9 @@ export module '@theia/plugin' {
 
         /** Controls whether the terminal is cleared before executing the task. */
         clear?: boolean;
+
+        /** Controls whether the terminal is closed after executing the task. */
+        close?: boolean;
     }
 
     /**

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -48,6 +48,7 @@ export interface TaskOutputPresentation {
     panel?: PanelKind;
     showReuseMessage?: boolean;
     clear?: boolean;
+    close?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [name: string]: any;
 }
@@ -59,7 +60,8 @@ export namespace TaskOutputPresentation {
             focus: false,
             panel: PanelKind.Shared,
             showReuseMessage: true,
-            clear: false
+            clear: false,
+            close: false
         };
     }
 
@@ -90,7 +92,8 @@ export namespace TaskOutputPresentation {
                 echo: task.presentation.echo === undefined || task.presentation.echo,
                 focus: shouldSetFocusToTerminal(task),
                 showReuseMessage: shouldShowReuseMessage(task),
-                clear: shouldClearTerminalBeforeRun(task)
+                clear: shouldClearTerminalBeforeRun(task),
+                close: shouldCloseTerminalOnFinish(task)
             };
         }
         return outputPresentation;
@@ -106,6 +109,10 @@ export namespace TaskOutputPresentation {
 
     export function shouldClearTerminalBeforeRun(task: TaskCustomization): boolean {
         return !!task.presentation && !!task.presentation.clear;
+    }
+
+    export function shouldCloseTerminalOnFinish(task: TaskCustomization): boolean {
+        return !!task.presentation && !!task.presentation.close;
     }
 
     export function shouldShowReuseMessage(task: TaskCustomization): boolean {


### PR DESCRIPTION
#### What it does

_Adds the close property to TaskPresentationOptions_
This enables the possibility to close the terminal once the task is finished.

Fixes #12611

Contributed on behalf of ST Microelectronics

#### How to test 
1. Install following extension:
-  extension: [task-provider-samples-0.0.3.zip](https://github.com/eclipsesource/theia/files/11800018/task-provider-samples-0.0.3.zip)
- source: [task-provider-sample-0.0.3-src.zip](https://github.com/eclipsesource/theia/files/11800019/task-provider-sample-0.0.3-src.zip)

2. Copy the content of this archive at the root of your workspace: 
[workspace-test.zip](https://github.com/eclipsesource/theia/files/12104301/workspace-test.zip). It contains several tasks that can be identified by the sample extension. In the extension, the build tasks are supposed to close the terminal after the task is finished (`close` set to `true`) whereas the terminal should remain on completion for other tasks like test tasks.

3. On `master` theia, the terminal always remain after the tasks are finished (this is also the default behavior after the patch when `close` is not defined.). The extension is written so the tasks are configured differently if they are build tasks or any other kind of tasks. This does not do any difference on `master`, as the close property is not known.
![12611-before](https://github.com/eclipsesource/theia/assets/3964263/bd3fe826-7e50-4d02-87f5-9fd1e347ecd3)

4. Switch to this PR and run the same tests. The terminal will close for the build tasks, and remain open for reuse for the other tasks like test tasks. 
![12611-after](https://github.com/eclipsesource/theia/assets/3964263/25b6a4d6-50c8-49b9-b8ae-156bb079afa3)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
