### PR TITLE
getting-started: add welcome page checkbox preference

### DIFF
--- a/packages/getting-started/src/browser/getting-started-contribution.ts
+++ b/packages/getting-started/src/browser/getting-started-contribution.ts
@@ -16,10 +16,8 @@
 
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { CommandRegistry, MenuModelRegistry } from '@theia/core/lib/common';
-import { CommonMenus, AbstractViewContribution, FrontendApplicationContribution, FrontendApplication, PreferenceService } from '@theia/core/lib/browser';
-import { EditorManager } from '../../../editor/lib/browser';
+import { CommonMenus, AbstractViewContribution, FrontendApplicationContribution, FrontendApplication, NavigatableWidget, PreferenceService } from '@theia/core/lib/browser';
 import { GettingStartedWidget } from './getting-started-widget';
-import { GettingStartedPreferences } from './getting-started-preferences';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 
@@ -40,9 +38,6 @@ export class GettingStartedContribution extends AbstractViewContribution<Getting
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
-    @inject(EditorManager)
-    protected readonly editorManager: EditorManager;
-
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
 
@@ -58,10 +53,10 @@ export class GettingStartedContribution extends AbstractViewContribution<Getting
 
     async onStart(app: FrontendApplication): Promise<void> {
         this.stateService.reachedState('ready').then(() => {
-            const lastOpenedEditors = this.editorManager.all;
-            if (lastOpenedEditors.length === 0) {
+            const editors = this.shell.widgets.filter((widget): widget is NavigatableWidget => NavigatableWidget.is(widget));
+            if (editors.length === 0) {
                 this.preferenceService.ready.then(() => {
-                    const showWelcomePage: boolean = this.preferenceService.get(GettingStartedPreferences.alwaysShowWelcomePage, true);
+                    const showWelcomePage: boolean = this.preferenceService.get('welcome.alwaysShowWelcomePage', true);
                     if (showWelcomePage) {
                         this.openView({ reveal: true, activate: true });
                     }

--- a/packages/getting-started/src/browser/getting-started-frontend-module.ts
+++ b/packages/getting-started/src/browser/getting-started-frontend-module.ts
@@ -18,7 +18,7 @@ import { GettingStartedContribution } from './getting-started-contribution';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { GettingStartedWidget } from './getting-started-widget';
 import { WidgetFactory, FrontendApplicationContribution, bindViewContribution } from '@theia/core/lib/browser';
-import { bindWelcomePreference } from './getting-started-preferences';
+import { bindGettingStartedPreferences } from './getting-started-preferences';
 import '../../src/browser/style/index.css';
 
 export default new ContainerModule((bind: interfaces.Bind) => {
@@ -29,5 +29,5 @@ export default new ContainerModule((bind: interfaces.Bind) => {
         id: GettingStartedWidget.ID,
         createWidget: () => context.container.get<GettingStartedWidget>(GettingStartedWidget),
     })).inSingletonScope();
-    bindWelcomePreference(bind);
+    bindGettingStartedPreferences(bind);
 });

--- a/packages/getting-started/src/browser/getting-started-preferences.ts
+++ b/packages/getting-started/src/browser/getting-started-preferences.ts
@@ -15,17 +15,18 @@
 // *****************************************************************************
 
 import { interfaces } from '@theia/core/shared/inversify';
+import {
+    createPreferenceProxy,
+    PreferenceProxy,
+    PreferenceService,
+    PreferenceSchema,
+    PreferenceContribution
+} from '@theia/core/lib/browser/preferences';
 import { nls } from '@theia/core/lib/common/nls';
-import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
-import { PreferenceContribution } from '@theia/core/lib/browser';
 
-export namespace GettingStartedPreferences {
-    export const alwaysShowWelcomePage = 'welcome.alwaysShowWelcomePage';
-}
-
-export const welcomePreferenceSchema: PreferenceSchema = {
+export const GettingStartedPreferenceSchema: PreferenceSchema = {
     'type': 'object',
-    'properties': {
+    properties: {
         'welcome.alwaysShowWelcomePage': {
             type: 'boolean',
             description: nls.localizeByDefault('Show welcome page on startup'),
@@ -34,6 +35,24 @@ export const welcomePreferenceSchema: PreferenceSchema = {
     }
 };
 
-export function bindWelcomePreference(bind: interfaces.Bind): void {
-    bind(PreferenceContribution).toConstantValue({ schema: welcomePreferenceSchema });
+export interface GettingStartedConfiguration {
+    'welcome.alwaysShowWelcomePage': boolean;
+}
+
+export const GettingStartedPreferenceContribution = Symbol('GettingStartedPreferenceContribution');
+export const GettingStartedPreferences = Symbol('GettingStartedPreferences');
+export type GettingStartedPreferences = PreferenceProxy<GettingStartedConfiguration>;
+
+export function createGettingStartedPreferences(preferences: PreferenceService, schema: PreferenceSchema = GettingStartedPreferenceSchema): GettingStartedPreferences {
+    return createPreferenceProxy(preferences, schema);
+}
+
+export function bindGettingStartedPreferences(bind: interfaces.Bind): void {
+    bind(GettingStartedPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        const contribution = ctx.container.get<PreferenceContribution>(GettingStartedPreferenceContribution);
+        return createGettingStartedPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(GettingStartedPreferenceContribution).toConstantValue({ schema: GettingStartedPreferenceSchema });
+    bind(PreferenceContribution).toService(GettingStartedPreferenceContribution);
 }

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -26,7 +26,6 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { nls } from '@theia/core/lib/common/nls';
-import { GettingStartedPreferences } from './getting-started-preferences';
 
 /**
  * Default implementation of the `GettingStartedWidget`.
@@ -498,11 +497,11 @@ export interface PreferencesProps {
 
 function WelcomePreferences(props: PreferencesProps): JSX.Element {
     const [alwaysShowWelcomePage, setAlwaysShowWelcomePage] = React.useState<boolean>(
-        props.preferenceService.get(GettingStartedPreferences.alwaysShowWelcomePage, true)
+        props.preferenceService.get('welcome.alwaysShowWelcomePage', true)
     );
     React.useEffect(() => {
         const prefListener = props.preferenceService.onPreferenceChanged(change => {
-            if (change.preferenceName === GettingStartedPreferences.alwaysShowWelcomePage) {
+            if (change.preferenceName === 'welcome.alwaysShowWelcomePage') {
                 const prefValue = change.newValue;
                 setAlwaysShowWelcomePage(prefValue);
             }
@@ -511,7 +510,7 @@ function WelcomePreferences(props: PreferencesProps): JSX.Element {
     }, [props.preferenceService]);
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const newChecked = e.target.checked;
-        props.preferenceService.updateValue(GettingStartedPreferences.alwaysShowWelcomePage, newChecked);
+        props.preferenceService.updateValue('welcome.alwaysShowWelcomePage', newChecked);
     };
     return (
         <div className='gs-preference'>

--- a/packages/getting-started/src/browser/style/index.css
+++ b/packages/getting-started/src/browser/style/index.css
@@ -97,6 +97,7 @@ body {
   width: 100%;
   justify-content: center;
 }
+
 .gs-preference {
   margin-top: 20px;
   margin-bottom: 20px;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: https://github.com/eclipse-theia/theia-blueprint/issues/286 and partially https://github.com/eclipse-theia/theia-blueprint/issues/280

This PR adds a preference `Show Welcome Page after every start of the application` to the welcome page as a checkbox. It also addresses a few points from this issue: https://github.com/eclipse-theia/theia-blueprint/issues/280, by calling it `Welcome` instead of `Get Started` and by making the preference section's UI standout.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start browser or electron example
2. Welcome page should appear
3. Uncheck the preference `Show Welcome page after every start of the application` and close the welcome page editor
4. Close the application
5. Reopen it
6. The welcome page should not reappear

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
