### PR TITLE
Fix bug in `TheiaDialog` page object

### DIFF
--- a/examples/playwright/src/theia-dialog.ts
+++ b/examples/playwright/src/theia-dialog.ts
@@ -105,10 +105,10 @@ export class TheiaDialog extends TheiaPageObject {
     }
 
     async waitUntilMainButtonIsEnabled(): Promise<void> {
-        await this.page.waitForFunction(() => {
-            const button = document.querySelector<HTMLButtonElement>(`${this.controlSelector} > button.theia-button.main`);
+        await this.page.waitForFunction(predicate => {
+            const button = document.querySelector<HTMLButtonElement>(predicate.buttonSelector);
             return !!button && !button.disabled;
-        });
+        }, { buttonSelector: `${this.controlSelector} > button.theia-button.main` });
     }
 
 }

--- a/examples/playwright/src/theia-explorer-view.ts
+++ b/examples/playwright/src/theia-explorer-view.ts
@@ -265,6 +265,7 @@ export class TheiaExplorerView extends TheiaView {
         const renameDialog = new TheiaRenameDialog(this.app);
         await renameDialog.waitForVisible();
         await renameDialog.enterNewName(newName);
+        await renameDialog.waitUntilMainButtonIsEnabled();
         confirm ? await renameDialog.confirm() : await renameDialog.close();
         await renameDialog.waitForClosed();
         await this.refresh();


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes a  bug with the `TheiaDialog.waitUntilMainButtonIsEnabled` method not working as expected. 
Calling the method resulted in an infinite timeout because `this` was used inside of the `pageFunction`. The `pageFunction` is executed inside the browser where  the `TheiaDialog` page objectis not available and therefore it was `undefined`.
Call `waitUntilMainButtonIsEnabled` in `TheiaExplorView.renameNode` to ensure that the method is covered by the test case execution.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
This change is directly tested by the playwright test suite.
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
