### PR TITLE
A VS Code extension configurationDefault does not work #12713

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -27,7 +27,7 @@ import {
     LabelProviderContribution,
     PreferenceSchemaProvider
 } from '@theia/core/lib/browser';
-import { PreferenceLanguageOverrideService, PreferenceSchema, PreferenceSchemaProperties } from '@theia/core/lib/browser/preferences';
+import { DefaultOverridesPreferenceSchemaId, PreferenceLanguageOverrideService, PreferenceSchema, PreferenceSchemaProperties } from '@theia/core/lib/browser/preferences';
 import { KeybindingsContributionPointHandler } from './keybindings/keybindings-contribution-handler';
 import { MonacoSnippetSuggestProvider } from '@theia/monaco/lib/browser/monaco-snippet-suggest-provider';
 import { PluginSharedStyle } from './plugin-shared-style';
@@ -487,7 +487,7 @@ export class PluginContributionHandler {
 
     protected updateDefaultOverridesSchema(configurationDefaults: PreferenceSchemaProperties): Disposable {
         const defaultOverrides: PreferenceSchema = {
-            id: 'defaultOverrides',
+            id: DefaultOverridesPreferenceSchemaId,
             title: 'Default Configuration Overrides',
             properties: {}
         };
@@ -495,10 +495,17 @@ export class PluginContributionHandler {
         for (const key in configurationDefaults) {
             const defaultValue = configurationDefaults[key];
             if (this.preferenceOverrideService.testOverrideValue(key, defaultValue)) {
+                // language specific override
                 defaultOverrides.properties[key] = {
                     type: 'object',
                     default: defaultValue,
                     description: `Configure editor settings to be overridden for ${key} language.`
+                };
+            } else {
+                // regular configuration override
+                defaultOverrides.properties[key] = {
+                    default: defaultValue,
+                    description: `Configure default setting for ${key}.`
                 };
             }
         }

--- a/packages/preferences/src/browser/views/components/preference-select-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-select-input.ts
@@ -29,14 +29,15 @@ import { escapeInvisibleChars } from '@theia/core/lib/common/strings';
 export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JSONValue, HTMLDivElement> {
 
     protected readonly selectComponent = React.createRef<SelectComponent>();
-    protected readonly selectOptions: SelectOption[] = [];
+
+    protected selectOptions: SelectOption[] = [];
 
     protected get enumValues(): JSONValue[] {
         return this.preferenceNode.preference.data.enum!;
     }
 
     protected updateSelectOptions(): void {
-        this.selectOptions.splice(0);
+        const updatedSelectOptions: SelectOption[] = [];
         const values = this.enumValues;
         const preferenceData = this.preferenceNode.preference.data;
         const defaultValue = preferenceData.default;
@@ -52,7 +53,7 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
                 enumDescription = this.markdownRenderer.renderInline(markdownEnumDescription);
                 markdown = true;
             }
-            this.selectOptions.push({
+            updatedSelectOptions.push({
                 label,
                 value: stringValue,
                 detail,
@@ -60,6 +61,7 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
                 markdown
             });
         }
+        this.selectOptions = updatedSelectOptions;
     }
 
     protected createInteractable(parent: HTMLElement): void {

--- a/packages/preferences/src/browser/views/components/preference-select-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-select-input.ts
@@ -29,13 +29,14 @@ import { escapeInvisibleChars } from '@theia/core/lib/common/strings';
 export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JSONValue, HTMLDivElement> {
 
     protected readonly selectComponent = React.createRef<SelectComponent>();
+    protected readonly selectOptions: SelectOption[] = [];
 
     protected get enumValues(): JSONValue[] {
         return this.preferenceNode.preference.data.enum!;
     }
 
-    protected get selectOptions(): SelectOption[] {
-        const items: SelectOption[] = [];
+    protected updateSelectOptions(): void {
+        this.selectOptions.splice(0);
         const values = this.enumValues;
         const preferenceData = this.preferenceNode.preference.data;
         const defaultValue = preferenceData.default;
@@ -51,7 +52,7 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
                 enumDescription = this.markdownRenderer.renderInline(markdownEnumDescription);
                 markdown = true;
             }
-            items.push({
+            this.selectOptions.push({
                 label,
                 value: stringValue,
                 detail,
@@ -59,10 +60,10 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
                 markdown
             });
         }
-        return items;
     }
 
     protected createInteractable(parent: HTMLElement): void {
+        this.updateSelectOptions();
         const interactable = document.createElement('div');
         const selectComponent = React.createElement(SelectComponent, {
             options: this.selectOptions,
@@ -86,6 +87,7 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
 
     protected doHandleValueChange(): void {
         this.updateInspection();
+        this.updateSelectOptions();
         const newValue = this.getDataValue();
         this.updateModificationStatus(this.getValue());
         if (document.activeElement !== this.interactable && this.selectComponent.current) {


### PR DESCRIPTION
#### What it does

Fixes: #12713

* plugin contribution handler will now also register configurationDefault for non language related configuration changes
* extend preference-contribution#doSetSchema to allow modifying default values for existing schemas when contributed via a special schema id
* also update select options in preference-select-input, since the default value may change now, which requires the SelectOptions to recreate

The solution is based on the existing implementation for providing language specific editor settings:
https://github.com/eclipse-theia/theia/issues/3540
https://github.com/eclipse-theia/theia/pull/4296
In the existing solution we are using a special `defaultOverrides` PreferenceSchema that gets registered. I've adapted the registration code to also work for existing preference keys when provided via this special schema. 

I am open for suggestions to implement this in a different way, however we should probably refactor the language specific editor overrides then as well. 

#### How to test
See the bug report for a reproducer: https://github.com/eclipse-theia/theia/issues/12713
Check the preference's (default) value when installing/uninstalling the extension. 
Check the preference UI (default highlight in drop down) and test resetting to the default value

Please be aware of this bug during testing with the vsix from the reproducer: https://github.com/eclipse-theia/theia/issues/10812

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
