### PR TITLE
terminal: Windows .exe compatibility for VSCode

### DIFF
--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -48,6 +48,23 @@ describe('TerminalProcess', function (): void {
         expect(error.code).eq('ENOENT');
     });
 
+    it('test implicit .exe (Windows only)', async function (): Promise<void> {
+        const match = /^(.+)\.exe$/.exec(process.execPath);
+        if (!isWindows || !match) {
+            this.skip();
+        }
+
+        const command = match[1];
+        const args = ['--version'];
+        const terminal = await new Promise<IProcessExitEvent>((resolve, reject) => {
+            const proc = terminalProcessFactory({ command, args });
+            proc.onExit(resolve);
+            proc.onError(reject);
+        });
+
+        expect(terminal.code).to.exist;
+    });
+
     it('test error on trying to execute a directory', async function (): Promise<void> {
         const error = await new Promise<ProcessErrorEvent>((resolve, reject) => {
             const proc = terminalProcessFactory({ command: __dirname });


### PR DESCRIPTION
#### What it does

On Windows platform, support implicit file '.exe' extension on the shell command in terminal profiles as in VS Code.

VS Code allows a terminal profile to omit the `'.exe'` extension of the executable file and will find and run it anyways. So this PR enhances the `TerminalProcess` initialization, in the case that the program launch fails by reason of not being found and the host platform is Windows and the command did not end with `'.exe'`, to try again with `'.exe'` appended to the program.

Fixes #12734

#### How to test

Per the description of #12734:

1. Clone the OP's referenced sample repository
2. Check out the `terminal` branch. This provides a `myext` VS Code extension that you can link into your `plugins/` directory to obtain a "Profile from my extension" terminal profile. This is configured simply with `'cmd'` as the command to run, not `'cmd.exe'`.
3. Launch Theia and start a new terminal using the "Profile from my extension" profile in the Terminal menu.
4. See that the terminal starts (you may observe other unrelated issues as described in other bugs filed by the OP).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
