### PR TITLE
plugins: view/title menus in all dock panel views

### DIFF
--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -22,7 +22,6 @@ import { MenuModelRegistry } from '@theia/core/lib/common';
 import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { DeployedPlugin, IconUrl, Menu } from '../../../common';
 import { ScmWidget } from '@theia/scm/lib/browser/scm-widget';
-import { PluginViewWidget } from '../view/plugin-view-widget';
 import { QuickCommandService } from '@theia/core/lib/browser';
 import {
     CodeEditorWidgetUtil, codeToTheiaMappings, ContributionPoint,
@@ -58,7 +57,7 @@ export class MenusContributionPointHandler {
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_EDITOR_TITLE_MENU, widget => this.codeEditorWidgetUtil.is(widget));
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_EDITOR_TITLE_RUN_MENU, widget => this.codeEditorWidgetUtil.is(widget));
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_SCM_TITLE_MENU, widget => widget instanceof ScmWidget);
-        this.tabBarToolbar.registerMenuDelegate(PLUGIN_VIEW_TITLE_MENU, widget => widget instanceof PluginViewWidget);
+        this.tabBarToolbar.registerMenuDelegate(PLUGIN_VIEW_TITLE_MENU, widget => !this.codeEditorWidgetUtil.is(widget));
         this.tabBarToolbar.registerItem({ id: 'plugin-menu-contribution-title-contribution', command: '_never_', onDidChange: this.onDidChangeTitleContributionEmitter.event });
         this.contextKeyService.onDidChange(event => {
             if (event.affects(this.titleContributionContextKeys)) {


### PR DESCRIPTION
#### What it does

In VS Code, contributions of menus to the `"view/title"` contribution point are supposed to be included in all views in the dock panels, so long as the `"when"` condition (if any) is satisfied. So the contribution handler is updated to register the menu delegate for all non-editor views.

Fixes #12705

#### How to test

Per the directions in the description of #12705:

1. Check out the `menu_bug_4` branch of the OP's sample repository and build the `myext` extension.
2. Link the extension into your `plugins/` directory and launch Theia.
3. See that the "Hello World" menu action is contributed with a pencil icon in all of the views in the dock panels as shown in the following graphic:

![CleanShot 2023-08-07 at 12 29 58](https://github.com/eclipse-theia/theia/assets/1615558/d8de3c2c-b7c3-4b6d-ae33-f65411fb58bb)


where

- at ① you can see, for example, that it appears in the Explorer view
- at ② you can see that views such as the Problems view that are in the bottom panel also show the contribution
- at ③ likewise views in the secondary panel
- but at ④ you can see that editor widgets do not get the contribution

Subsequently, verify that by use of the `"when"` condition on the contribution this action can be restricted to selected views. For example:

1. Add a when condition restricting the menu contribution to the "Hello World" view, only, as shown in the screen grab below
2. Rebuild the extension and launch Theia again to verify that the action now only shows in the toolbar of the Hello World view.

<img width="359" alt="CleanShot 2023-07-26 at 16 09 36@2x" src="https://github.com/eclipse-theia/theia/assets/1615558/09b22a2d-d97e-4d92-a9cd-5b11856a8ead">


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
