### PR TITLE
Ensure we keep task type and properly support custom execution

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2175,8 +2175,8 @@ export const MAIN_RPC_CONTEXT = {
 
 export interface TasksExt {
     $initLoadedTasks(executions: TaskExecutionDto[]): Promise<void>;
-    $provideTasks(handle: number): Promise<TaskDto[] | undefined>;
-    $resolveTask(handle: number, task: TaskDto, token?: CancellationToken): Promise<TaskDto | undefined>;
+    $provideTasks(handle: number): Promise<TaskDto[]>;
+    $resolveTask(handle: number, task: TaskDto, token?: CancellationToken): Promise<TaskDto>;
     $onDidStartTask(execution: TaskExecutionDto, terminalId: number): void;
     $onDidEndTask(id: number): void;
     $onDidStartTaskProcess(processId: number | undefined, execution: TaskExecutionDto): void;

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -184,8 +184,8 @@ export class TasksMainImpl implements TasksMain, Disposable {
     protected createTaskProvider(handle: number): TaskProvider {
         return {
             provideTasks: () =>
-                this.proxy.$provideTasks(handle).then(v =>
-                    v!.map(taskDto =>
+                this.proxy.$provideTasks(handle).then(tasks =>
+                    tasks.map(taskDto =>
                         this.toTaskConfiguration(taskDto)
                     )
                 )
@@ -195,8 +195,8 @@ export class TasksMainImpl implements TasksMain, Disposable {
     protected createTaskResolver(handle: number): TaskResolver {
         return {
             resolveTask: taskConfig =>
-                this.proxy.$resolveTask(handle, this.fromTaskConfiguration(taskConfig)).then(v =>
-                    this.toTaskConfiguration(v!)
+                this.proxy.$resolveTask(handle, this.fromTaskConfiguration(taskConfig)).then(task =>
+                    this.toTaskConfiguration(task)
                 )
         };
     }

--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -158,37 +158,42 @@ export class TasksExtImpl implements TasksExt {
         throw new Error('Task was not successfully transformed into a task config');
     }
 
-    $provideTasks(handle: number): Promise<TaskDto[] | undefined> {
+    async $provideTasks(handle: number): Promise<TaskDto[]> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {
             return adapter.provideTasks(CancellationToken.None).then(tasks => {
-                if (tasks) {
-                    for (const task of tasks) {
-                        if (task.taskType === 'customExecution') {
-                            task.executionId = this.addCustomExecution(task.callback);
-                            task.callback = undefined;
-                        }
+                for (const task of tasks) {
+                    if (task.taskType === 'customExecution') {
+                        this.applyCustomExecution(task);
                     }
                 }
                 return tasks;
             });
         } else {
-            return Promise.reject(new Error('No adapter found to provide tasks'));
+            throw new Error('No adapter found to provide tasks');
         }
     }
 
-    $resolveTask(handle: number, task: TaskDto, token: theia.CancellationToken): Promise<TaskDto | undefined> {
+    async $resolveTask(handle: number, task: TaskDto, token: theia.CancellationToken): Promise<TaskDto> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {
             return adapter.resolveTask(task, token).then(resolvedTask => {
-                if (resolvedTask && resolvedTask.taskType === 'customExecution') {
-                    resolvedTask.executionId = this.addCustomExecution(resolvedTask.callback);
-                    resolvedTask.callback = undefined;
+                // ensure we do not lose task type and execution id during resolution as we need it for custom execution
+                resolvedTask.taskType = resolvedTask.taskType ?? task.taskType;
+                if (resolvedTask.taskType === 'customExecution') {
+                    this.applyCustomExecution(resolvedTask);
                 }
                 return resolvedTask;
             });
         } else {
-            return Promise.reject(new Error('No adapter found to resolve task'));
+            throw new Error('No adapter found to resolve task');
+        }
+    }
+
+    private applyCustomExecution(task: TaskDto): void {
+        if (task.callback) {
+            task.executionId = this.addCustomExecution(task.callback);
+            task.callback = undefined;
         }
     }
 

--- a/packages/task/src/browser/task-definition-registry.ts
+++ b/packages/task/src/browser/task-definition-registry.ts
@@ -113,6 +113,9 @@ export class TaskDefinitionRegistry {
         if (oneType !== otherType) {
             return false;
         }
+        if (one['taskType'] !== other['taskType']) {
+            return false;
+        }
         const def = this.getDefinition(one);
         if (def) {
             // scope is either a string or an enum value. Anyway...they must exactly match


### PR DESCRIPTION
#### What it does
- Make TaskProviderAdapter more resilient against undefined
- Ensure task type is not lost during conversion (used for custom exec)
- Ensure task type is considered during comparison

Fixes https://github.com/eclipse-theia/theia/issues/12721

#### How to test
- Checkout https://github.com/eclipse-theia/theia/tree/martin-fleck-at/12721-test which adds some example tasks to Theia
- Launch the application using launch configuration 'Launch Electron Backend' (as it sets the plugin directory correctly)
- F1 > Hello from plugin-a (activates plugin)
- F1 > Run Task... > mytasktype
- Execute the shell, process and custom task to see if they are working as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
