### PR TITLE
plugin-ext: default the folderExpanded icon

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-icon-theme-service.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-icon-theme-service.ts
@@ -390,6 +390,12 @@ export class PluginIconTheme extends PluginIconThemeDefinition implements IconTh
     ): void {
         if (associations.folder) {
             accept(associations.folder, this.folderIcon);
+            if (associations.folderExpanded === undefined) {
+                // Use the same icon for expanded state (issue #12727). Check for
+                // undefined folderExpanded property to allow for
+                // "folderExpanded": null in case a developer really wants that
+                accept(associations.folder, this.folderExpandedIcon);
+            }
             this.hasFolderIcons = true;
         }
         if (associations.folderExpanded) {


### PR DESCRIPTION
#### What it does

In file icon themes, VS Code will use the `"folder"` icon also for expanded folders in the case that the theme omits the `"folderExpanded"` entry.

This PR implements the same fall-back in Theia for consistency.

Fixes #12727

#### How to test

1. Follow the OP's directions in #12727 to clone and build a same `myext` extension with a custom file icon theme.
2. Link the `myext` extension package into your `plugins/` folder.
3. As directed in the issue description, launch Theia and select the "My File Icon Theme" file icon theme.
4. See that the custom folder icon is shown in both expanded and collapsed states.

Furthermore, edit the file icon theme in the `myext` to

- set a different icon (the extension `resources/` conveniently includes additional icons) as the `"folderExpanded"` and see that it works as expected, showing that icon in expanded state and the other in collapsed state
- set `"folderExpanded": null` or `"folderExpanded": ""` to explicitly ask for no icon for expanded state and see that this also works

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
