### PR TITLE
Quit Electron app when back end fails to start. Fixes #12769

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## History
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
+## v1.41.0 -
+- [application-package] Quit Electron app when back end fails to start [#12778](https://github.com/eclipse-theia/theia/pull/12778) - Contributed on behalf of STMicroelectronics.
 
 ## v1.40.0 - 07/27/2023
 

--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -90,6 +90,7 @@ module.exports = Promise.resolve()${this.compileElectronMainModuleImports(electr
         if (reason) {
             console.error(reason);
         }
+        app.quit();
     });
 `;
     }

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -507,6 +507,9 @@ export class ElectronMainApplication {
                 backendProcess.on('error', error => {
                     reject(error);
                 });
+                backendProcess.on('exit', () => {
+                    reject(new Error('backend process exited'));
+                })
                 app.on('quit', () => {
                     // Only issue a kill signal if the backend process is running.
                     // eslint-disable-next-line no-null/no-null

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -509,7 +509,7 @@ export class ElectronMainApplication {
                 });
                 backendProcess.on('exit', () => {
                     reject(new Error('backend process exited'));
-                })
+                });
                 app.on('quit', () => {
                     // Only issue a kill signal if the backend process is running.
                     // eslint-disable-next-line no-null/no-null


### PR DESCRIPTION


#### What it does
When the back end process fails to start for some reason, the Electron process hangs with no Windows visible. This PR does an `app.quit` in electron if the back end process fails to start.
 
Fixes #12769

Contributed on behalf of STMicroelectronics

#### How to test
Start the electron version with a bogus parameter, for example `yarn electron start --log-level=Gurkensalat`. Make sure you get back to the command prompt. Make sure the same command line works for correct cmd line argments.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
