### PR TITLE
navigator: handle middle-click behavior

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -29,7 +29,7 @@ import { ExpandableTreeNode } from './tree-expansion';
 import { SelectableTreeNode, TreeSelection } from './tree-selection';
 import { TreeDecoratorService, TreeDecoration, DecoratedTreeNode } from './tree-decorator';
 import { notEmpty } from '../../common/objects';
-import { isOSX, isWindows } from '../../common/os';
+import { isOSX } from '../../common/os';
 import { ReactWidget } from '../widgets/react-widget';
 import * as React from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1256,10 +1256,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     /**
-     * Prevents auto-scrolling behavior when middle-clicking.
+     * Handle the middle-click mouse event.
      * @param event the middle-click mouse event.
      */
     protected handleMiddleClickEvent(event: MouseEvent): void {
+        // Prevents auto-scrolling behavior when middle-clicking.
         if (event.button === 1) {
             event.preventDefault();
         }

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -245,6 +245,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         }
         this.node.addEventListener('mousedown', this.handleMiddleClickEvent.bind(this));
         this.node.addEventListener('mouseup', this.handleMiddleClickEvent.bind(this));
+        this.node.addEventListener('auxclick', this.handleMiddleClickEvent.bind(this));
         this.toDispose.pushAll([
             this.model,
             this.model.onChanged(() => this.updateRows()),

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -243,6 +243,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 }),
             ]);
         }
+        this.node.addEventListener('mousedown', (event: MouseEvent) => {
+            if (event.button === 1) {
+                event.preventDefault();
+            }
+        });
         this.toDispose.pushAll([
             this.model,
             this.model.onChanged(() => this.updateRows()),
@@ -924,6 +929,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             style,
             onClick: event => this.handleClickEvent(node, event),
             onDoubleClick: event => this.handleDblClickEvent(node, event),
+            onAuxClick: event => this.handleAuxClickEvent(node, event),
             onContextMenu: event => this.handleContextMenuEvent(node, event),
         };
     }
@@ -1235,6 +1241,17 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
      */
     protected handleDblClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         this.model.openNode(node);
+        event.stopPropagation();
+    }
+
+    /**
+     * Handle the middle-click mouse event.
+     * @param node the tree node if available.
+     * @param event the middle-click mouse event.
+     */
+    protected handleAuxClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        this.model.openNode(node);
+        this.tapNode(node);
         event.stopPropagation();
     }
 

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -243,6 +243,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 }),
             ]);
         }
+        this.node.addEventListener('mousedown', this.handleMiddleClickEvent.bind(this));
+        this.node.addEventListener('mouseup', this.handleMiddleClickEvent.bind(this));
         this.toDispose.pushAll([
             this.model,
             this.model.onChanged(() => this.updateRows()),
@@ -1250,6 +1252,16 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             this.model.selectNode(node);
         }
         event.stopPropagation();
+    }
+
+    /**
+     * Handle the middle-click mouse event.
+     * @param event the middle-click mouse event.
+     */
+    protected handleMiddleClickEvent(event: MouseEvent): void {
+        if (event.button === 1) {
+            event.preventDefault();
+        }
     }
 
     /**

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1256,7 +1256,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     /**
-     * Handle the middle-click mouse event.
+     * Prevents auto-scrolling behavior when middle-clicking.
      * @param event the middle-click mouse event.
      */
     protected handleMiddleClickEvent(event: MouseEvent): void {

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1251,7 +1251,9 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
      */
     protected handleAuxClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         this.model.openNode(node);
-        this.tapNode(node);
+        if (SelectableTreeNode.is(node)) {
+            this.model.selectNode(node);
+        }
         event.stopPropagation();
     }
 

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -29,7 +29,7 @@ import { ExpandableTreeNode } from './tree-expansion';
 import { SelectableTreeNode, TreeSelection } from './tree-selection';
 import { TreeDecoratorService, TreeDecoration, DecoratedTreeNode } from './tree-decorator';
 import { notEmpty } from '../../common/objects';
-import { isOSX } from '../../common/os';
+import { isOSX, isWindows } from '../../common/os';
 import { ReactWidget } from '../widgets/react-widget';
 import * as React from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
@@ -243,11 +243,13 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 }),
             ]);
         }
-        this.node.addEventListener('mousedown', (event: MouseEvent) => {
-            if (event.button === 1) {
-                event.preventDefault();
-            }
-        });
+        if (isWindows) {
+            this.node.addEventListener('mousedown', (event: MouseEvent) => {
+                if (event.button === 1) {
+                    event.preventDefault();
+                }
+            });
+        }
         this.toDispose.pushAll([
             this.model,
             this.model.onChanged(() => this.updateRows()),

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -243,13 +243,6 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 }),
             ]);
         }
-        if (isWindows) {
-            this.node.addEventListener('mousedown', (event: MouseEvent) => {
-                if (event.button === 1) {
-                    event.preventDefault();
-                }
-            });
-        }
         this.toDispose.pushAll([
             this.model,
             this.model.onChanged(() => this.updateRows()),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: #12762 
Fixes: #12788 

This PR handles the middle-click button behavior in various tree-widgets, such as the `explorer`, `search-in-workspace`, `references` ... Like in VS Code, selecting a file using the middle-button will open that file as an open-editor instead of simply selecting it. This achieves the same functionality as double-clicking on a file, but it is faster.

Demo:
![middle-click demo](https://github.com/eclipse-theia/theia/assets/86936229/48772f75-7ec3-41ac-a944-c14f87d9501f)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start Theia
2. Open a Workspace / Folder
3. Go to the `Explorer` / `Search-in-workspace` / `SCM` /... views
4. Select a file by pressing the mouse's middle button (scroll wheel)
5. The file should be selected and added as an open-editor

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
