### PR TITLE
feat: can rebind the monaco editor command handler

### DIFF
--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -153,7 +153,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(FrontendApplicationContribution).toService(MonacoStatusBarContribution);
 
     bind(MonacoCommandRegistry).toSelf().inSingletonScope();
-    bind(CommandContribution).to(MonacoEditorCommandHandlers).inSingletonScope();
+    bind(MonacoEditorCommandHandlers).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(MonacoEditorCommandHandlers);
     bind(MonacoEditorMenuContribution).toSelf().inSingletonScope();
     bind(MenuContribution).toService(MonacoEditorMenuContribution);
     bind(MonacoKeybindingContribution).toSelf().inSingletonScope();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

It binds the monaco editor command handler to self so that a downstream project can customize it. Currently, it is not possible:

```
Error: Could not unbind serviceIdentifier: MonacoEditorCommandHandlers
    at __webpack_modules__.../node_modules/inversify/lib/container/container.js.Container.unbind (container.ts:170:19)
    at __webpack_modules__.../node_modules/inversify/lib/container/container.js.Container.rebind (container.ts:161:14)
    at container.ts:310:41
    at ContainerModule.registry (arduino-ide-frontend-module.ts:1052:3)
    at __webpack_modules__.../node_modules/inversify/lib/container/container.js.Container.load (container.ts:110:27)
    at index.js:113:1
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Theia works, and basic editor commands such as find, select all, undo, and redo functional.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
