### PR TITLE
Reuse markdown instance for preferences widget

### DIFF
--- a/packages/preferences/src/browser/views/components/preference-markdown-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-markdown-renderer.ts
@@ -1,0 +1,68 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PreferenceTreeModel } from '../../preference-tree-model';
+import { PreferenceTreeLabelProvider } from '../../util/preference-tree-label-provider';
+import * as markdownit from '@theia/core/shared/markdown-it';
+
+@injectable()
+export class PreferenceMarkdownRenderer {
+
+    @inject(PreferenceTreeModel) protected readonly model: PreferenceTreeModel;
+    @inject(PreferenceTreeLabelProvider) protected readonly labelProvider: PreferenceTreeLabelProvider;
+
+    protected _renderer?: markdownit;
+
+    render(text: string): string {
+        return this.getRenderer().render(text);
+    }
+
+    renderInline(text: string): string {
+        return this.getRenderer().renderInline(text);
+    }
+
+    protected getRenderer(): markdownit {
+        this._renderer ??= this.buildMarkdownRenderer();
+        return this._renderer;
+    }
+
+    protected buildMarkdownRenderer(): markdownit {
+        const engine = markdownit();
+        const inlineCode = engine.renderer.rules.code_inline;
+
+        engine.renderer.rules.code_inline = (tokens, idx, options, env, self) => {
+            const token = tokens[idx];
+            const content = token.content;
+            if (content.startsWith('#') && content.endsWith('#')) {
+                const preferenceId = content.substring(1, content.length - 1);
+                const preferenceNode = this.model.getNodeFromPreferenceId(preferenceId);
+                if (preferenceNode) {
+                    let name = this.labelProvider.getName(preferenceNode);
+                    const prefix = this.labelProvider.getPrefix(preferenceNode, true);
+                    if (prefix) {
+                        name = prefix + name;
+                    }
+                    return `<a title="${preferenceId}" href="preference:${preferenceId}">${name}</a>`;
+                } else {
+                    console.warn(`Linked preference "${preferenceId}" not found.`);
+                }
+            }
+            return inlineCode ? inlineCode(tokens, idx, options, env, self) : '';
+        };
+        return engine;
+    }
+}

--- a/packages/preferences/src/browser/views/preference-widget-bindings.ts
+++ b/packages/preferences/src/browser/views/preference-widget-bindings.ts
@@ -30,6 +30,7 @@ import {
 import { PreferenceNumberInputRenderer, PreferenceNumberInputRendererContribution } from './components/preference-number-input';
 import { PreferenceSelectInputRenderer, PreferenceSelectInputRendererContribution } from './components/preference-select-input';
 import { PreferenceStringInputRenderer, PreferenceStringInputRendererContribution } from './components/preference-string-input';
+import { PreferenceMarkdownRenderer } from './components/preference-markdown-renderer';
 import { PreferencesEditorWidget } from './preference-editor-widget';
 import { PreferencesScopeTabBar } from './preference-scope-tabbar-widget';
 import { PreferencesSearchbarWidget } from './preference-searchbar-widget';
@@ -94,6 +95,8 @@ export function createPreferencesWidgetContainer(parent: interfaces.Container): 
         const creator = registry.getPreferenceNodeRendererCreator(node);
         return creator.createRenderer(node, container);
     });
+
+    child.bind(PreferenceMarkdownRenderer).toSelf().inSingletonScope();
 
     return child;
 }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12789

The current implementation creates a new instance of `markdownit` for every preference leaf node. This is quite costly in frontend memory. The change moves the `markdownit` instance to a dedicated service that is shared across all nodes in a preference model.

In my tests, this reduces the memory consumption of the preference widget by ~165MB:

*Before (267MB)*:

![image](https://github.com/eclipse-theia/theia/assets/4377073/72bdbf1f-2eb9-4ca1-abf6-547b3b2c3a34)

*After (102MB)*:

![image](https://github.com/eclipse-theia/theia/assets/4377073/ee63b59d-5b98-4e63-ab89-06fa2a00fe3b)

#### How to test

1. Open the preference widget.
2. Assert that the memory consumption has been reduced.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
