### PR TITLE
editor: combine left gutter context menus

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -19,8 +19,8 @@ import {
 } from '@theia/core/lib/browser';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
-import { MenuModelRegistry, CommandRegistry, MAIN_MENU_BAR, Command, Emitter, Mutable } from '@theia/core/lib/common';
-import { EditorKeybindingContexts, EditorManager } from '@theia/editor/lib/browser';
+import { MenuModelRegistry, CommandRegistry, MAIN_MENU_BAR, Command, Emitter, Mutable, CompoundMenuNodeRole } from '@theia/core/lib/common';
+import { EDITOR_LINENUMBER_CONTEXT_MENU, EditorKeybindingContexts, EditorManager } from '@theia/editor/lib/browser';
 import { DebugSessionManager } from './debug-session-manager';
 import { DebugWidget } from './view/debug-widget';
 import { FunctionBreakpoint } from './breakpoint/breakpoint-marker';
@@ -627,6 +627,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             { ...DebugEditorContextCommands.ENABLE_LOGPOINT, label: nlsEnableBreakpoint('Logpoint') },
             { ...DebugEditorContextCommands.DISABLE_LOGPOINT, label: nlsDisableBreakpoint('Logpoint') }
         );
+        menus.linkSubmenu(EDITOR_LINENUMBER_CONTEXT_MENU, DebugEditorModel.CONTEXT_MENU, { role: CompoundMenuNodeRole.Group });
     }
 
     override registerCommands(registry: CommandRegistry): void {
@@ -882,59 +883,59 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
         // Debug context menu commands
         registry.registerCommand(DebugEditorContextCommands.ADD_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(position),
-            isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(position),
-            isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(position)
+            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(this.asPosition(position)),
+            isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(this.asPosition(position))
         });
         registry.registerCommand(DebugEditorContextCommands.ADD_CONDITIONAL_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.addBreakpoint('condition', position),
-            isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(position),
-            isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(position)
+            execute: position => this.isPosition(position) && this.editors.addBreakpoint('condition', this.asPosition(position)),
+            isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(this.asPosition(position))
         });
         registry.registerCommand(DebugEditorContextCommands.ADD_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.addBreakpoint('logMessage', position),
-            isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(position),
-            isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(position)
+            execute: position => this.isPosition(position) && this.editors.addBreakpoint('logMessage', this.asPosition(position)),
+            isEnabled: position => this.isPosition(position) && !this.editors.anyBreakpoint(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !this.editors.anyBreakpoint(this.asPosition(position))
         });
         registry.registerCommand(DebugEditorContextCommands.REMOVE_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(position),
-            isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpoint(position),
-            isVisible: position => this.isPosition(position) && !!this.editors.getBreakpoint(position)
+            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(this.asPosition(position)),
+            isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpoint(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !!this.editors.getBreakpoint(this.asPosition(position))
         });
         registry.registerCommand(DebugEditorContextCommands.EDIT_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.editBreakpoint(position),
-            isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpoint(position),
-            isVisible: position => this.isPosition(position) && !!this.editors.getBreakpoint(position)
+            execute: position => this.isPosition(position) && this.editors.editBreakpoint(this.asPosition(position)),
+            isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpoint(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !!this.editors.getBreakpoint(this.asPosition(position))
         });
         registry.registerCommand(DebugEditorContextCommands.ENABLE_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(position, true),
-            isEnabled: position => this.isPosition(position) && this.editors.getBreakpointEnabled(position) === false,
-            isVisible: position => this.isPosition(position) && this.editors.getBreakpointEnabled(position) === false
+            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(this.asPosition(position), true),
+            isEnabled: position => this.isPosition(position) && this.editors.getBreakpointEnabled(this.asPosition(position)) === false,
+            isVisible: position => this.isPosition(position) && this.editors.getBreakpointEnabled(this.asPosition(position)) === false
         });
         registry.registerCommand(DebugEditorContextCommands.DISABLE_BREAKPOINT, {
-            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(position, false),
-            isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpointEnabled(position),
-            isVisible: position => this.isPosition(position) && !!this.editors.getBreakpointEnabled(position)
+            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(this.asPosition(position), false),
+            isEnabled: position => this.isPosition(position) && !!this.editors.getBreakpointEnabled(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !!this.editors.getBreakpointEnabled(this.asPosition(position))
         });
         registry.registerCommand(DebugEditorContextCommands.REMOVE_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(position),
-            isEnabled: position => this.isPosition(position) && !!this.editors.getLogpoint(position),
-            isVisible: position => this.isPosition(position) && !!this.editors.getLogpoint(position)
+            execute: position => this.isPosition(position) && this.editors.toggleBreakpoint(this.asPosition(position)),
+            isEnabled: position => this.isPosition(position) && !!this.editors.getLogpoint(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !!this.editors.getLogpoint(this.asPosition(position))
         });
         registry.registerCommand(DebugEditorContextCommands.EDIT_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.editBreakpoint(position),
-            isEnabled: position => this.isPosition(position) && !!this.editors.getLogpoint(position),
-            isVisible: position => this.isPosition(position) && !!this.editors.getLogpoint(position)
+            execute: position => this.isPosition(position) && this.editors.editBreakpoint(this.asPosition(position)),
+            isEnabled: position => this.isPosition(position) && !!this.editors.getLogpoint(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !!this.editors.getLogpoint(this.asPosition(position))
         });
         registry.registerCommand(DebugEditorContextCommands.ENABLE_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(position, true),
-            isEnabled: position => this.isPosition(position) && this.editors.getLogpointEnabled(position) === false,
-            isVisible: position => this.isPosition(position) && this.editors.getLogpointEnabled(position) === false
+            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(this.asPosition(position), true),
+            isEnabled: position => this.isPosition(position) && this.editors.getLogpointEnabled(this.asPosition(position)) === false,
+            isVisible: position => this.isPosition(position) && this.editors.getLogpointEnabled(this.asPosition(position)) === false
         });
         registry.registerCommand(DebugEditorContextCommands.DISABLE_LOGPOINT, {
-            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(position, false),
-            isEnabled: position => this.isPosition(position) && !!this.editors.getLogpointEnabled(position),
-            isVisible: position => this.isPosition(position) && !!this.editors.getLogpointEnabled(position)
+            execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(this.asPosition(position), false),
+            isEnabled: position => this.isPosition(position) && !!this.editors.getLogpointEnabled(this.asPosition(position)),
+            isVisible: position => this.isPosition(position) && !!this.editors.getLogpointEnabled(this.asPosition(position))
         });
 
         registry.registerCommand(DebugBreakpointWidgetCommands.ACCEPT, {
@@ -1263,8 +1264,12 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         return watch && watch.selectedElement instanceof DebugWatchExpression && watch.selectedElement || undefined;
     }
 
-    protected isPosition(position: monaco.Position): boolean {
-        return (position instanceof monaco.Position);
+    protected isPosition(position: unknown): boolean {
+        return monaco.Position.isIPosition(position);
+    }
+
+    protected asPosition(position: monaco.IPosition): monaco.Position {
+        return monaco.Position.lift(position);
     }
 
     registerColors(colors: ColorRegistry): void {

--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -407,16 +407,7 @@ export class DebugEditorModel implements Disposable {
 
     protected handleMouseDown(event: monaco.editor.IEditorMouseEvent): void {
         if (event.target && event.target.type === monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN) {
-            if (event.event.rightButton) {
-                this.editor.focus();
-                setTimeout(() => {
-                    this.contextMenu.render({
-                        menuPath: DebugEditorModel.CONTEXT_MENU,
-                        anchor: event.event.browserEvent,
-                        args: [event.target.position!]
-                    });
-                });
-            } else {
+            if (!event.event.rightButton) {
                 this.toggleBreakpoint(event.target.position!);
             }
         }

--- a/packages/editor/src/browser/editor-linenumber-contribution.ts
+++ b/packages/editor/src/browser/editor-linenumber-contribution.ts
@@ -52,7 +52,7 @@ export class EditorLineNumberContribution implements FrontendApplicationContribu
     }
 
     protected handleContextMenu(editor: TextEditor, event: EditorMouseEvent): void {
-        if (event.target && event.target.type === MouseTargetType.GUTTER_LINE_NUMBERS) {
+        if (event.target && (event.target.type === MouseTargetType.GUTTER_LINE_NUMBERS || event.target.type === MouseTargetType.GUTTER_GLYPH_MARGIN)) {
             if (event.event.button === 2) {
                 editor.focus();
                 const lineNumber = lineNumberFromPosition(event.target.position);
@@ -60,7 +60,8 @@ export class EditorLineNumberContribution implements FrontendApplicationContribu
                 const uri = editor.getResourceUri()!;
                 const args = [{
                     lineNumber: lineNumber,
-                    uri: uri['codeUri']
+                    column: 1, // Compatible with Monaco editor IPosition API
+                    uri: uri['codeUri'],
                 }];
 
                 setTimeout(() => {


### PR DESCRIPTION
#### What it does

For compatibility with the VS Code behaviour of the `"editor/lineNumber/context"` menu contribution point, combines the context menus created by

  - `debug` extension in the area to the left of the line numbers and
  - `editor` extension in the line numbers, themselves

into one context menu, managed by the `editor` extension, opened either from the line numbers or from the gutter area to their left.

Fixes #12688

#### How to test

1. Clone the `menu_bug_3` branch of the sample repository provided by the OP of #12688 as described in that issue and build it.
2. Link the `myext`  extension from step 1 into your `plugins/` directory.
3. Launch Theia.
4. Open a code editor on some TS file or something and right click anywhere in the left gutter of the editor where there is some line of text. You should see something like this:
  ![CleanShot 2023-08-01 at 14 11 21](https://github.com/eclipse-theia/theia/assets/1615558/c08f3c0f-ec2b-4775-8e99-eb7ac848c6a2)
5. Observe that the "Hello, World!" action shows the message toast as expected.
6. Verify also that the menu actions to create and remove breakpoints work as expected whether the context menu was summoned by right-clicking on an actual line number or to the left of it.
7. Verify further that simply clicking in the gutter area to the left of a line number, without summoning the context menu, still toggles line breakpoints.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
