### PR TITLE
Bundle `trash` dependency helpers in backend

### DIFF
--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -91,6 +91,7 @@ export class NativeWebpackPlugin {
             }
         );
         compiler.hooks.afterEmit.tapAsync(NativeWebpackPlugin.name, async () => {
+            await this.copyTrashHelper(compiler);
             if (this.options.ripgrep) {
                 await this.copyRipgrep(compiler);
             }
@@ -123,6 +124,21 @@ export class NativeWebpackPlugin {
         } else {
             const sourceFile = require.resolve('node-pty/build/Release/spawn-helper');
             const targetFile = path.join(targetDirectory, 'spawn-helper');
+            await this.copyExecutable(sourceFile, targetFile);
+        }
+    }
+
+    protected async copyTrashHelper(compiler: Compiler): Promise<void> {
+        let sourceFile: string | undefined;
+        let targetFile: string | undefined;
+        if (process.platform === 'win32') {
+            sourceFile = require.resolve('trash/lib/windows-trash.exe');
+            targetFile = path.join(compiler.outputPath, 'windows-trash.exe');
+        } else if (process.platform === 'darwin') {
+            sourceFile = require.resolve('trash/lib/macos-trash');
+            targetFile = path.join(compiler.outputPath, 'macos-trash');
+        }
+        if (sourceFile && targetFile) {
             await this.copyExecutable(sourceFile, targetFile);
         }
     }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12780

Bundles the native executables (`macos-trash` and `windows-trash.exe`) with the backend so that the executables can actually be executed.

#### How to test

1. Start the application on Mac or Windows
2. Ensure that the `Enable Trash` setting is enabled
3. Delete a file. Assert that it has been moved to the trash and no error occurs.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
