### PR TITLE
feat: remove sync `fs` calls from backend+plugin code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
     - `visual`: Display a visual preview of the tab. (The preview support was added with this PR)
 - [repo] updated GitHub workflow to stop publishing `next` versions [#12699](https://github.com/eclipse-theia/theia/pull/12699)
 - [workspace] split `CommonWorkspaceUtils` into `WorkspaceFileService` and `UntitledWorkspaceService` [#12420](https://github.com/eclipse-theia/theia/pull/12420)
+- [plugin] Removed synchronous `fs` calls from the backend application and plugins. The plugin scanner, directory and file handlers, and the plugin deploy entry has async API now. Internal `protected` APIs have been affected. [#12798](https://github.com/eclipse-theia/theia/pull/12798)
 
 ## v1.39.0 - 06/29/2023
 

--- a/packages/core/src/common/promise-util.spec.ts
+++ b/packages/core/src/common/promise-util.spec.ts
@@ -13,28 +13,59 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import * as assert from 'assert';
-import { waitForEvent } from './promise-util';
+import * as assert from 'assert/strict';
+import { firstTrue, waitForEvent } from './promise-util';
 import { Emitter } from './event';
+import { CancellationError } from './cancellation';
 
 describe('promise-util', () => {
-    it('should time out', async () => {
-        const emitter = new Emitter<string>();
-        try {
-            await waitForEvent(emitter.event, 1000);
-            assert.fail('did not time out');
-        } catch (e) {
-            // OK
-        }
-    });
 
-    describe('promise-util', () => {
+    describe('waitForEvent', () => {
+        it('should time out', async () => {
+            const emitter = new Emitter<string>();
+            await assert.rejects(waitForEvent(emitter.event, 1000), reason => reason instanceof CancellationError);
+        });
+
         it('should get event', async () => {
             const emitter = new Emitter<string>();
             setTimeout(() => {
                 emitter.fire('abcd');
             }, 500);
             assert.strictEqual(await waitForEvent(emitter.event, 1000), 'abcd');
+        });
+    });
+
+    describe('firstTrue', () => {
+        it('should resolve to false when the promises arg is empty', async () => {
+            const actual = await firstTrue();
+            assert.strictEqual(actual, false);
+        });
+
+        it('should resolve to true when the first promise resolves to true', async () => {
+            const signals: string[] = [];
+            const createPromise = (signal: string, timeout: number, result: boolean) =>
+                new Promise<boolean>(resolve => setTimeout(() => {
+                    signals.push(signal);
+                    resolve(result);
+                }, timeout));
+            const actual = await firstTrue(
+                createPromise('a', 10, false),
+                createPromise('b', 20, false),
+                createPromise('c', 30, true),
+                createPromise('d', 40, false),
+                createPromise('e', 50, true)
+            );
+            assert.strictEqual(actual, true);
+            assert.deepStrictEqual(signals, ['a', 'b', 'c']);
+        });
+
+        it('should reject when one of the promises rejects', async () => {
+            await assert.rejects(firstTrue(
+                new Promise<boolean>(resolve => setTimeout(() => resolve(false), 10)),
+                new Promise<boolean>(resolve => setTimeout(() => resolve(false), 20)),
+                new Promise<boolean>((_, reject) => setTimeout(() => reject(new Error('my test error')), 30)),
+                new Promise<boolean>(resolve => setTimeout(() => resolve(true), 40)),
+            ), /Error: my test error/);
         });
     });
 

--- a/packages/core/src/common/promise-util.ts
+++ b/packages/core/src/common/promise-util.ts
@@ -129,3 +129,15 @@ export function waitForEvent<T>(event: Event<T>, ms: number, thisArg?: any, disp
 export function isThenable<T>(obj: unknown): obj is Promise<T> {
     return isObject<Promise<unknown>>(obj) && isFunction(obj.then);
 }
+
+/**
+ * Returns with a promise that waits until the first promise resolves to `true`.
+ */
+// Based on https://stackoverflow.com/a/51160727/5529090
+export function firstTrue(...promises: readonly Promise<boolean>[]): Promise<boolean> {
+    const newPromises = promises.map(promise => new Promise<boolean>(
+        (resolve, reject) => promise.then(result => result && resolve(true), reject)
+    ));
+    newPromises.push(Promise.all(promises).then(() => false));
+    return Promise.race(newPromises);
+}

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -766,7 +766,8 @@ export class DugiteGit implements Git {
         const out = result.stdout;
         if (out && out.length !== 0) {
             try {
-                return fs.realpathSync(out.trim());
+                const realpath = await fs.realpath(out.trim());
+                return realpath;
             } catch (e) {
                 this.logger.error(e);
                 return undefined;

--- a/packages/git/src/node/git-locator/git-locator-impl.ts
+++ b/packages/git/src/node/git-locator/git-locator-impl.ts
@@ -59,7 +59,7 @@ export class GitLocatorImpl implements GitLocator {
     }
 
     protected async doLocate(basePath: string, context: GitLocateContext): Promise<string[]> {
-        const realBasePath = fs.realpathSync(basePath);
+        const realBasePath = await fs.realpath(basePath);
         if (context.visited.has(realBasePath)) {
             return [];
         }
@@ -77,9 +77,9 @@ export class GitLocatorImpl implements GitLocator {
                 }
             });
             if (context.maxCount >= 0 && paths.length >= context.maxCount) {
-                return paths.slice(0, context.maxCount).map(GitLocatorImpl.map);
+                return Promise.all(paths.slice(0, context.maxCount).map(GitLocatorImpl.map));
             }
-            const repositoryPaths = paths.map(GitLocatorImpl.map);
+            const repositoryPaths = await Promise.all(paths.map(GitLocatorImpl.map));
             return this.locateFrom(
                 newContext => this.generateNested(repositoryPaths, newContext),
                 context,
@@ -145,8 +145,8 @@ export class GitLocatorImpl implements GitLocator {
         return result;
     }
 
-    static map(repository: string): string {
-        return fs.realpathSync(path.dirname(repository));
+    static async map(repository: string): Promise<string> {
+        return fs.realpath(path.dirname(repository));
     }
 
 }

--- a/packages/git/src/node/git-locator/git-locator-impl.ts
+++ b/packages/git/src/node/git-locator/git-locator-impl.ts
@@ -77,7 +77,7 @@ export class GitLocatorImpl implements GitLocator {
                 }
             });
             if (context.maxCount >= 0 && paths.length >= context.maxCount) {
-                return Promise.all(paths.slice(0, context.maxCount).map(GitLocatorImpl.map));
+                return await Promise.all(paths.slice(0, context.maxCount).map(GitLocatorImpl.map));
             }
             const repositoryPaths = await Promise.all(paths.map(GitLocatorImpl.map));
             return this.locateFrom(

--- a/packages/plugin-dev/src/node/hosted-plugins-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-plugins-manager.ts
@@ -131,15 +131,15 @@ export class HostedPluginsManagerImpl implements HostedPluginsManager {
      *
      * @param pluginPath path to plugin's root directory
      */
-    protected checkWatchScript(pluginPath: string): boolean {
+    protected async checkWatchScript(pluginPath: string): Promise<boolean> {
         const pluginPackageJsonPath = path.join(pluginPath, 'package.json');
-        if (fs.existsSync(pluginPackageJsonPath)) {
-            const packageJson = fs.readJSONSync(pluginPackageJsonPath);
+        try {
+            const packageJson = await fs.readJSON(pluginPackageJsonPath);
             const scripts = packageJson['scripts'];
             if (scripts && scripts['watch']) {
                 return true;
             }
-        }
+        } catch { }
         return false;
     }
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
@@ -19,7 +19,7 @@ import * as filenamify from 'filenamify';
 import * as fs from '@theia/core/shared/fs-extra';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import type { RecursivePartial, URI } from '@theia/core';
-import { Deferred } from '@theia/core/lib/common/promise-util';
+import { Deferred, firstTrue } from '@theia/core/lib/common/promise-util';
 import { getTempDirPathAsync } from '@theia/plugin-ext/lib/main/node/temp-dir-util';
 import {
     PluginDeployerDirectoryHandler, PluginDeployerEntry, PluginDeployerDirectoryHandlerContext,
@@ -54,10 +54,10 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
     }
 
     protected async deriveMetadata(plugin: PluginDeployerEntry): Promise<boolean> {
-        return (
-            (await this.resolveFromSources(plugin)) ||
-            (await this.resolveFromVSIX(plugin)) ||
-            (this.resolveFromNpmTarball(plugin))
+        return firstTrue(
+            this.resolveFromSources(plugin),
+            this.resolveFromVSIX(plugin),
+            this.resolveFromNpmTarball(plugin)
         );
     }
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
@@ -18,33 +18,47 @@ import * as path from 'path';
 import * as filenamify from 'filenamify';
 import * as fs from '@theia/core/shared/fs-extra';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { RecursivePartial } from '@theia/core';
+import type { RecursivePartial, URI } from '@theia/core';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { getTempDirPathAsync } from '@theia/plugin-ext/lib/main/node/temp-dir-util';
 import {
     PluginDeployerDirectoryHandler, PluginDeployerEntry, PluginDeployerDirectoryHandlerContext,
     PluginDeployerEntryType, PluginPackage, PluginType, PluginIdentifiers
 } from '@theia/plugin-ext';
 import { FileUri } from '@theia/core/lib/node';
-import { getTempDir } from '@theia/plugin-ext/lib/main/node/temp-dir-util';
 import { PluginCliContribution } from '@theia/plugin-ext/lib/main/node/plugin-cli-contribution';
 
 @injectable()
 export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHandler {
 
-    protected readonly deploymentDirectory = FileUri.create(getTempDir('vscode-copied'));
+    protected readonly deploymentDirectory: Deferred<URI>;
 
     @inject(PluginCliContribution) protected readonly pluginCli: PluginCliContribution;
 
-    accept(plugin: PluginDeployerEntry): boolean {
+    constructor() {
+        this.deploymentDirectory = new Deferred();
+        getTempDirPathAsync('vscode-copied')
+            .then(deploymentDirectoryPath => this.deploymentDirectory.resolve(FileUri.create(deploymentDirectoryPath)));
+    }
+
+    async accept(plugin: PluginDeployerEntry): Promise<boolean> {
         console.debug(`Resolving "${plugin.id()}" as a VS Code extension...`);
         return this.attemptResolution(plugin);
     }
 
-    protected attemptResolution(plugin: PluginDeployerEntry): boolean {
-        return this.resolvePackage(plugin) || this.deriveMetadata(plugin);
+    protected async attemptResolution(plugin: PluginDeployerEntry): Promise<boolean> {
+        if (this.resolvePackage(plugin)) {
+            return true;
+        }
+        return this.deriveMetadata(plugin);
     }
 
-    protected deriveMetadata(plugin: PluginDeployerEntry): boolean {
-        return this.resolveFromSources(plugin) || this.resolveFromVSIX(plugin) || this.resolveFromNpmTarball(plugin);
+    protected async deriveMetadata(plugin: PluginDeployerEntry): Promise<boolean> {
+        return (
+            (await this.resolveFromSources(plugin)) ||
+            (await this.resolveFromVSIX(plugin)) ||
+            (this.resolveFromNpmTarball(plugin))
+        );
     }
 
     async handle(context: PluginDeployerDirectoryHandlerContext): Promise<void> {
@@ -68,11 +82,12 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
             const origin = entry.originalPath();
             const targetDir = await this.getExtensionDir(context);
             try {
-                if (fs.existsSync(targetDir) || !entry.path().startsWith(origin)) {
+                if (await fs.pathExists(targetDir) || !entry.path().startsWith(origin)) {
                     console.log(`[${id}]: already copied.`);
                 } else {
                     console.log(`[${id}]: copying to "${targetDir}"`);
-                    await fs.mkdirp(FileUri.fsPath(this.deploymentDirectory));
+                    const deploymentDirectory = await this.deploymentDirectory.promise;
+                    await fs.mkdirp(FileUri.fsPath(deploymentDirectory));
                     await context.copy(origin, targetDir);
                     entry.updatePath(targetDir);
                     if (!this.deriveMetadata(entry)) {
@@ -86,22 +101,25 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
         }
     }
 
-    protected resolveFromSources(plugin: PluginDeployerEntry): boolean {
+    protected async resolveFromSources(plugin: PluginDeployerEntry): Promise<boolean> {
         const pluginPath = plugin.path();
-        return this.resolvePackage(plugin, { pluginPath, pck: this.requirePackage(pluginPath) });
+        const pck = await this.requirePackage(pluginPath);
+        return this.resolvePackage(plugin, { pluginPath, pck });
     }
 
-    protected resolveFromVSIX(plugin: PluginDeployerEntry): boolean {
-        if (!fs.existsSync(path.join(plugin.path(), 'extension.vsixmanifest'))) {
+    protected async resolveFromVSIX(plugin: PluginDeployerEntry): Promise<boolean> {
+        if (!(await fs.pathExists(path.join(plugin.path(), 'extension.vsixmanifest')))) {
             return false;
         }
         const pluginPath = path.join(plugin.path(), 'extension');
-        return this.resolvePackage(plugin, { pluginPath, pck: this.requirePackage(pluginPath) });
+        const pck = await this.requirePackage(pluginPath);
+        return this.resolvePackage(plugin, { pluginPath, pck });
     }
 
-    protected resolveFromNpmTarball(plugin: PluginDeployerEntry): boolean {
+    protected async resolveFromNpmTarball(plugin: PluginDeployerEntry): Promise<boolean> {
         const pluginPath = path.join(plugin.path(), 'package');
-        return this.resolvePackage(plugin, { pluginPath, pck: this.requirePackage(pluginPath) });
+        const pck = await this.requirePackage(pluginPath);
+        return this.resolvePackage(plugin, { pluginPath, pck });
     }
 
     protected resolvePackage(plugin: PluginDeployerEntry, options?: {
@@ -125,9 +143,9 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
         return true;
     }
 
-    protected requirePackage(pluginPath: string): PluginPackage | undefined {
+    protected async requirePackage(pluginPath: string): Promise<PluginPackage | undefined> {
         try {
-            const plugin = fs.readJSONSync(path.join(pluginPath, 'package.json')) as PluginPackage;
+            const plugin: PluginPackage = await fs.readJSON(path.join(pluginPath, 'package.json'));
             plugin.publisher ??= PluginIdentifiers.UNPUBLISHED;
             return plugin;
         } catch {
@@ -136,6 +154,7 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
     }
 
     protected async getExtensionDir(context: PluginDeployerDirectoryHandlerContext): Promise<string> {
-        return FileUri.fsPath(this.deploymentDirectory.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
+        const deploymentDirectory = await this.deploymentDirectory.promise;
+        return FileUri.fsPath(deploymentDirectory.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 }

--- a/packages/plugin-ext/src/common/errors.ts
+++ b/packages/plugin-ext/src/common/errors.ts
@@ -14,6 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { isObject } from '@theia/core/lib/common/types';
+
 export function illegalArgument(message?: string): Error {
     if (message) {
         return new Error(`Illegal argument: ${message}`);
@@ -34,4 +36,28 @@ export function disposed(what: string): Error {
     const result = new Error(`${what} has been disposed`);
     result.name = 'DISPOSED';
     return result;
+}
+
+interface Errno {
+    readonly code: string;
+    readonly errno: number
+}
+const ENOENT = 'ENOENT' as const;
+
+type ErrnoException = Error & Errno;
+function isErrnoException(arg: unknown): arg is ErrnoException {
+    return arg instanceof Error
+        && isObject<Partial<Errno>>(arg)
+        && typeof arg.code === 'string'
+        && typeof arg.errno === 'number';
+}
+
+/**
+ * _(No such file or directory)_: Commonly raised by `fs` operations to indicate that a component of the specified pathname does not exist — no entity (file or directory) could be
+ * found by the given path.
+ */
+export function isENOENT(
+    arg: unknown
+): arg is ErrnoException & Readonly<{ code: typeof ENOENT }> {
+    return isErrnoException(arg) && arg.code === ENOENT;
 }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -348,7 +348,7 @@ export interface PluginScanner {
      */
     getLifecycle(plugin: PluginPackage): PluginLifecycle;
 
-    getContribution(plugin: PluginPackage): PluginContribution | undefined;
+    getContribution(plugin: PluginPackage): Promise<PluginContribution | undefined>;
 
     /**
      * A mapping between a dependency as its defined in package.json
@@ -376,7 +376,7 @@ export interface PluginDeployerResolver {
 
 export const PluginDeployerDirectoryHandler = Symbol('PluginDeployerDirectoryHandler');
 export interface PluginDeployerDirectoryHandler {
-    accept(pluginDeployerEntry: PluginDeployerEntry): boolean;
+    accept(pluginDeployerEntry: PluginDeployerEntry): Promise<boolean>;
 
     handle(context: PluginDeployerDirectoryHandlerContext): Promise<void>;
 }
@@ -384,7 +384,7 @@ export interface PluginDeployerDirectoryHandler {
 export const PluginDeployerFileHandler = Symbol('PluginDeployerFileHandler');
 export interface PluginDeployerFileHandler {
 
-    accept(pluginDeployerEntry: PluginDeployerEntry): boolean;
+    accept(pluginDeployerEntry: PluginDeployerEntry): Promise<boolean>;
 
     handle(context: PluginDeployerFileHandlerContext): Promise<void>;
 }
@@ -477,9 +477,9 @@ export interface PluginDeployerEntry {
 
     getChanges(): string[];
 
-    isFile(): boolean;
+    isFile(): Promise<boolean>;
 
-    isDirectory(): boolean;
+    isDirectory(): Promise<boolean>;
 
     /**
      * Resolved if a resolver has handle this plugin

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -173,7 +173,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
 
             const { type } = entry;
             const deployed: DeployedPlugin = { metadata, type };
-            deployed.contributes = this.reader.readContribution(manifest);
+            deployed.contributes = await this.reader.readContribution(manifest);
             await this.localizationService.deployLocalizations(deployed);
             deployedPlugins.set(id, deployed);
             deployPlugin.debug(`Deployed ${entryPoint} plugin "${id}" from "${metadata.model.entryPoint[entryPoint] || pluginPath}"`);

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -118,7 +118,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
         return pluginMetadata;
     }
 
-    readContribution(plugin: PluginPackage): PluginContribution | undefined {
+    async readContribution(plugin: PluginPackage): Promise<PluginContribution | undefined> {
         const scanner = this.scanner.getScanner(plugin);
         return scanner.getContribution(plugin);
     }

--- a/packages/plugin-ext/src/hosted/node/scanners/grammars-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/grammars-reader.ts
@@ -22,10 +22,10 @@ import * as fs from '@theia/core/shared/fs-extra';
 @injectable()
 export class GrammarsReader {
 
-    readGrammars(rawGrammars: PluginPackageGrammarsContribution[], pluginPath: string): GrammarsContribution[] {
+    async readGrammars(rawGrammars: PluginPackageGrammarsContribution[], pluginPath: string): Promise<GrammarsContribution[]> {
         const result = new Array<GrammarsContribution>();
         for (const rawGrammar of rawGrammars) {
-            const grammar = this.readGrammar(rawGrammar, pluginPath);
+            const grammar = await this.readGrammar(rawGrammar, pluginPath);
             if (grammar) {
                 result.push(grammar);
             }
@@ -34,13 +34,14 @@ export class GrammarsReader {
         return result;
     }
 
-    private readGrammar(rawGrammar: PluginPackageGrammarsContribution, pluginPath: string): GrammarsContribution | undefined {
+    private async readGrammar(rawGrammar: PluginPackageGrammarsContribution, pluginPath: string): Promise<GrammarsContribution | undefined> {
         // TODO: validate inputs
         let grammar: string | object;
+
         if (rawGrammar.path.endsWith('json')) {
-            grammar = fs.readJSONSync(path.resolve(pluginPath, rawGrammar.path));
+            grammar = await fs.readJSON(path.resolve(pluginPath, rawGrammar.path));
         } else {
-            grammar = fs.readFileSync(path.resolve(pluginPath, rawGrammar.path), 'utf8');
+            grammar = await fs.readFile(path.resolve(pluginPath, rawGrammar.path), 'utf8');
         }
         return {
             language: rawGrammar.language,

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-directory-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-directory-handler.ts
@@ -17,27 +17,35 @@
 import * as path from 'path';
 import * as filenamify from 'filenamify';
 import * as fs from '@theia/core/shared/fs-extra';
+import type { URI } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
+import { Deferred } from '@theia/core/lib/common/promise-util';
 import { FileUri } from '@theia/core/lib/node';
 import {
     PluginDeployerDirectoryHandler, PluginDeployerEntry, PluginPackage, PluginDeployerDirectoryHandlerContext, PluginDeployerEntryType, PluginType, PluginIdentifiers
 } from '../../../common/plugin-protocol';
 import { PluginCliContribution } from '../plugin-cli-contribution';
-import { getTempDir } from '../temp-dir-util';
+import { getTempDirPathAsync } from '../temp-dir-util';
 
 @injectable()
 export class PluginTheiaDirectoryHandler implements PluginDeployerDirectoryHandler {
 
-    protected readonly deploymentDirectory = FileUri.create(getTempDir('theia-copied'));
+    protected readonly deploymentDirectory: Deferred<URI>;
 
     @inject(PluginCliContribution) protected readonly pluginCli: PluginCliContribution;
 
-    accept(resolvedPlugin: PluginDeployerEntry): boolean {
+    constructor() {
+        this.deploymentDirectory = new Deferred();
+        getTempDirPathAsync('theia-copied')
+            .then(deploymentDirectory => this.deploymentDirectory.resolve(FileUri.create(deploymentDirectory)));
+    }
+
+    async accept(resolvedPlugin: PluginDeployerEntry): Promise<boolean> {
 
         console.debug('PluginTheiaDirectoryHandler: accepting plugin with path', resolvedPlugin.path());
 
         // handle only directories
-        if (resolvedPlugin.isFile()) {
+        if (await resolvedPlugin.isFile()) {
             return false;
         }
 
@@ -47,7 +55,7 @@ export class PluginTheiaDirectoryHandler implements PluginDeployerDirectoryHandl
         try {
             let packageJson = resolvedPlugin.getValue<PluginPackage>('package.json');
             if (!packageJson) {
-                packageJson = fs.readJSONSync(packageJsonPath);
+                packageJson = await fs.readJSON(packageJsonPath);
                 packageJson.publisher ??= PluginIdentifiers.UNPUBLISHED;
                 resolvedPlugin.storeValue('package.json', packageJson);
             }
@@ -81,11 +89,12 @@ export class PluginTheiaDirectoryHandler implements PluginDeployerDirectoryHandl
             const origin = entry.originalPath();
             const targetDir = await this.getExtensionDir(context);
             try {
-                if (fs.existsSync(targetDir) || !entry.path().startsWith(origin)) {
+                if (await fs.pathExists(targetDir) || !entry.path().startsWith(origin)) {
                     console.log(`[${id}]: already copied.`);
                 } else {
                     console.log(`[${id}]: copying to "${targetDir}"`);
-                    await fs.mkdirp(FileUri.fsPath(this.deploymentDirectory));
+                    const deploymentDirectory = await this.deploymentDirectory.promise;
+                    await fs.mkdirp(FileUri.fsPath(deploymentDirectory));
                     await context.copy(origin, targetDir);
                     entry.updatePath(targetDir);
                     if (!this.accept(entry)) {
@@ -100,6 +109,7 @@ export class PluginTheiaDirectoryHandler implements PluginDeployerDirectoryHandl
     }
 
     protected async getExtensionDir(context: PluginDeployerDirectoryHandlerContext): Promise<string> {
-        return FileUri.fsPath(this.deploymentDirectory.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
+        const deploymentDirectory = await this.deploymentDirectory.promise;
+        return FileUri.fsPath(deploymentDirectory.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 }

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
@@ -15,8 +15,10 @@
 // *****************************************************************************
 
 import { PluginDeployerFileHandler, PluginDeployerEntry, PluginDeployerFileHandlerContext, PluginType } from '../../../common/plugin-protocol';
-import { injectable, inject } from '@theia/core/shared/inversify';
-import { getTempDir } from '../temp-dir-util';
+import type { URI } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { getTempDirPathAsync } from '../temp-dir-util';
 import * as fs from '@theia/core/shared/fs-extra';
 import * as filenamify from 'filenamify';
 import { FileUri } from '@theia/core/lib/node/file-uri';
@@ -25,13 +27,22 @@ import { PluginTheiaEnvironment } from '../../common/plugin-theia-environment';
 @injectable()
 export class PluginTheiaFileHandler implements PluginDeployerFileHandler {
 
-    private readonly systemPluginsDirUri = FileUri.create(getTempDir('theia-unpacked'));
+    private readonly systemPluginsDirUri: Deferred<URI>;
 
     @inject(PluginTheiaEnvironment)
     protected readonly environment: PluginTheiaEnvironment;
 
-    accept(resolvedPlugin: PluginDeployerEntry): boolean {
-        return resolvedPlugin.isFile() && resolvedPlugin.path() !== null && resolvedPlugin.path().endsWith('.theia');
+    constructor() {
+        this.systemPluginsDirUri = new Deferred();
+        getTempDirPathAsync('theia-unpacked')
+            .then(systemPluginsDirPath => this.systemPluginsDirUri.resolve(FileUri.create(systemPluginsDirPath)));
+    }
+
+    async accept(resolvedPlugin: PluginDeployerEntry): Promise<boolean> {
+        if (resolvedPlugin.path() !== null && resolvedPlugin.path().endsWith('.theia')) {
+            return resolvedPlugin.isFile();
+        }
+        return false;
     }
 
     async handle(context: PluginDeployerFileHandlerContext): Promise<void> {
@@ -49,6 +60,7 @@ export class PluginTheiaFileHandler implements PluginDeployerFileHandler {
     }
 
     protected async getPluginDir(context: PluginDeployerFileHandlerContext): Promise<string> {
-        return FileUri.fsPath(this.systemPluginsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
+        const systemPluginsDirUri = await this.systemPluginsDirUri.promise;
+        return FileUri.fsPath(systemPluginsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 }

--- a/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
+++ b/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
@@ -140,9 +140,9 @@ export class PluginPathsServiceImpl implements PluginPathsService {
     }
 
     private async cleanupOldLogs(parentLogsDir: string): Promise<void> {
-        const dirEntries = await readdir(parentLogsDir, { withFileTypes: true }) as fs.Dirent[];
-        const subDirEntries = dirEntries.filter((dirent: fs.Dirent) => dirent.isDirectory());
-        const subDirNames = subDirEntries.map((dirent: fs.Dirent) => dirent.name);
+        const dirEntries = await readdir(parentLogsDir, { withFileTypes: true });
+        const subDirEntries = dirEntries.filter(dirent => dirent.isDirectory());
+        const subDirNames = subDirEntries.map(dirent => dirent.name);
         // We never clean a folder that is not a Theia logs session folder.
         // Even if it does appears under the `parentLogsDir`...
         const sessionSubDirNames = subDirNames.filter((dirName: string) => SESSION_TIMESTAMP_PATTERN.test(dirName));

--- a/packages/plugin-ext/src/main/node/plugin-deployer-directory-handler-context-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-directory-handler-context-impl.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import * as path from 'path';
-import * as fs from '@theia/core/shared/fs-extra';
+import { promises as fs } from 'fs';
 import { PluginDeployerEntry, PluginDeployerDirectoryHandlerContext } from '../../common/plugin-protocol';
 
 export class PluginDeployerDirectoryHandlerContextImpl implements PluginDeployerDirectoryHandlerContext {
@@ -23,17 +23,17 @@ export class PluginDeployerDirectoryHandlerContextImpl implements PluginDeployer
     constructor(private readonly pluginDeployerEntry: PluginDeployerEntry) { }
 
     async copy(origin: string, target: string): Promise<void> {
-        const contents = await fs.readdir(origin);
-        await fs.mkdirp(target);
-        await Promise.all(contents.map(async item => {
+        const entries = await fs.readdir(origin, { withFileTypes: true });
+        await fs.mkdir(target, { recursive: true });
+        await Promise.all(entries.map(async entry => {
+            const item = entry.name;
             const itemPath = path.resolve(origin, item);
             const targetPath = path.resolve(target, item);
-            const stat = await fs.stat(itemPath);
-            if (stat.isDirectory()) {
+            if (entry.isDirectory()) {
                 return this.copy(itemPath, targetPath);
             }
-            if (stat.isFile()) {
-                return new Promise<void>((resolve, reject) => fs.copyFile(itemPath, targetPath, e => e === null ? resolve() : reject(e)));
+            if (entry.isFile()) {
+                return fs.copyFile(itemPath, targetPath);
             }
         }));
     }

--- a/packages/plugin-ext/src/main/node/plugin-deployer-entry-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-entry-impl.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { PluginDeployerEntry, PluginDeployerEntryType, PluginType } from '../../common/plugin-protocol';
-import * as fs from 'fs';
+import { promises as fs } from 'fs';
 
 export class PluginDeployerEntryImpl implements PluginDeployerEntry {
 
@@ -73,17 +73,19 @@ export class PluginDeployerEntryImpl implements PluginDeployerEntry {
     getChanges(): string[] {
         return this.changes;
     }
-    isFile(): boolean {
+    async isFile(): Promise<boolean> {
         try {
-            return fs.statSync(this.currentPath).isFile();
-        } catch (e) {
+            const stat = await fs.stat(this.currentPath);
+            return stat.isFile();
+        } catch {
             return false;
         }
     }
-    isDirectory(): boolean {
+    async isDirectory(): Promise<boolean> {
         try {
-            return fs.statSync(this.currentPath).isDirectory();
-        } catch (e) {
+            const stat = await fs.stat(this.currentPath);
+            return stat.isDirectory();
+        } catch {
             return false;
         }
     }

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -305,7 +305,7 @@ export class PluginDeployerImpl implements PluginDeployer {
                 }
             })
         );
-        return Promise.all(waitPromises) as Promise<unknown> as Promise<void>;
+        await Promise.all(waitPromises);
     }
 
     /**

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -21,8 +21,8 @@ import * as semver from 'semver';
 import {
     PluginDeployerResolver, PluginDeployerFileHandler, PluginDeployerDirectoryHandler,
     PluginDeployerEntry, PluginDeployer, PluginDeployerParticipant, PluginDeployerStartContext,
-    PluginDeployerResolverInit, PluginDeployerFileHandlerContext,
-    PluginDeployerDirectoryHandlerContext, PluginDeployerEntryType, PluginDeployerHandler, PluginType, UnresolvedPluginEntry, PluginIdentifiers, PluginDeployOptions
+    PluginDeployerResolverInit,
+    PluginDeployerEntryType, PluginDeployerHandler, PluginType, UnresolvedPluginEntry, PluginIdentifiers, PluginDeployOptions
 } from '../../common/plugin-protocol';
 import { PluginDeployerEntryImpl } from './plugin-deployer-entry-impl';
 import {
@@ -296,40 +296,38 @@ export class PluginDeployerImpl implements PluginDeployer {
      * If there are some single files, try to see if we can work on these files (like unpacking it, etc)
      */
     public async applyFileHandlers(pluginDeployerEntries: PluginDeployerEntry[]): Promise<any> {
-        const waitPromises: Array<Promise<any>> = [];
-
-        pluginDeployerEntries.filter(pluginDeployerEntry => pluginDeployerEntry.isResolved()).map(pluginDeployerEntry => {
-            this.pluginDeployerFileHandlers.map(pluginFileHandler => {
+        const waitPromises = pluginDeployerEntries.filter(pluginDeployerEntry => pluginDeployerEntry.isResolved()).map(pluginDeployerEntry =>
+            this.pluginDeployerFileHandlers.reduce((acc, pluginFileHandler) => {
                 const proxyPluginDeployerEntry = new ProxyPluginDeployerEntry(pluginFileHandler, (pluginDeployerEntry) as PluginDeployerEntryImpl);
-                if (pluginFileHandler.accept(proxyPluginDeployerEntry)) {
-                    const pluginDeployerFileHandlerContext: PluginDeployerFileHandlerContext = new PluginDeployerFileHandlerContextImpl(proxyPluginDeployerEntry);
-                    const promise: Promise<void> = pluginFileHandler.handle(pluginDeployerFileHandlerContext);
-                    waitPromises.push(promise);
-                }
-            });
-
-        });
-        return Promise.all(waitPromises);
+                acc.push(async () => {
+                    if (await pluginFileHandler.accept(proxyPluginDeployerEntry)) {
+                        const pluginDeployerFileHandlerContext = new PluginDeployerFileHandlerContextImpl(proxyPluginDeployerEntry);
+                        await pluginFileHandler.handle(pluginDeployerFileHandlerContext);
+                    }
+                });
+                return acc;
+            }, [] as (() => Promise<void>)[])
+        ).reduce((left, right) => left.concat(right), []);
+        return Promise.all(waitPromises.map(promise => promise()));
     }
 
     /**
      * Check for all registered directories to see if there are some plugins that can be accepted to be deployed.
      */
     public async applyDirectoryFileHandlers(pluginDeployerEntries: PluginDeployerEntry[]): Promise<any> {
-        const waitPromises: Array<Promise<any>> = [];
-
-        pluginDeployerEntries.filter(pluginDeployerEntry => pluginDeployerEntry.isResolved()).map(pluginDeployerEntry => {
-            this.pluginDeployerDirectoryHandlers.map(pluginDirectoryHandler => {
+        const waitPromises = pluginDeployerEntries.filter(pluginDeployerEntry => pluginDeployerEntry.isResolved()).map(pluginDeployerEntry =>
+            this.pluginDeployerDirectoryHandlers.reduce((acc, pluginDirectoryHandler) => {
                 const proxyPluginDeployerEntry = new ProxyPluginDeployerEntry(pluginDirectoryHandler, (pluginDeployerEntry) as PluginDeployerEntryImpl);
-                if (pluginDirectoryHandler.accept(proxyPluginDeployerEntry)) {
-                    const pluginDeployerDirectoryHandlerContext: PluginDeployerDirectoryHandlerContext = new PluginDeployerDirectoryHandlerContextImpl(proxyPluginDeployerEntry);
-                    const promise: Promise<void> = pluginDirectoryHandler.handle(pluginDeployerDirectoryHandlerContext);
-                    waitPromises.push(promise);
-                }
-            });
-
-        });
-        return Promise.all(waitPromises);
+                acc.push(async () => {
+                    if (await pluginDirectoryHandler.accept(proxyPluginDeployerEntry)) {
+                        const pluginDeployerDirectoryHandlerContext = new PluginDeployerDirectoryHandlerContextImpl(proxyPluginDeployerEntry);
+                        await pluginDirectoryHandler.handle(pluginDeployerDirectoryHandlerContext);
+                    }
+                });
+                return acc;
+            }, [] as (() => Promise<void>)[])
+        ).reduce((left, right) => left.concat(right), []);
+        return Promise.all(waitPromises.map(promise => promise()));
     }
 
     /**

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -321,7 +321,7 @@ export class PluginDeployerImpl implements PluginDeployer {
                 }
             })
         );
-        return Promise.all(waitPromises) as Promise<unknown> as Promise<void>;
+        await Promise.all(waitPromises);
     }
 
     /**

--- a/packages/plugin-ext/src/main/node/plugin-deployer-proxy-entry-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-proxy-entry-impl.ts
@@ -54,11 +54,11 @@ export class ProxyPluginDeployerEntry<T> implements PluginDeployerEntry {
         return this.delegate.getChanges();
     }
 
-    isFile(): boolean {
+    isFile(): Promise<boolean> {
         return this.delegate.isFile();
     }
 
-    isDirectory(): boolean {
+    isDirectory(): Promise<boolean> {
         return this.delegate.isDirectory();
     }
     isResolved(): boolean {

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -957,10 +957,10 @@ describe('ripgrep-search-in-workspace-server', function (): void {
 
 describe('#extractSearchPathsFromIncludes', function (): void {
     this.timeout(10000);
-    it('should not resolve paths from a not absolute / relative pattern', function (): void {
+    it('should not resolve paths from a not absolute / relative pattern', async () => {
         const pattern = 'carrots';
         const options = { include: [pattern] };
-        const searchPaths = ripgrepServer['extractSearchPathsFromIncludes']([rootDirA], options);
+        const searchPaths = await ripgrepServer['extractSearchPathsFromIncludes']([rootDirA], options);
         // Same root directory
         expect(searchPaths.length).equal(1);
         expect(searchPaths[0]).equal(rootDirA);
@@ -970,21 +970,21 @@ describe('#extractSearchPathsFromIncludes', function (): void {
         expect(options.include[0]).equals(pattern);
     });
 
-    it('should resolve pattern to path for relative filename', function (): void {
+    it('should resolve pattern to path for relative filename', async () => {
         const filename = 'carrots';
         const pattern = `./${filename}`;
-        checkResolvedPathForPattern(pattern, path.join(rootDirA, filename));
+        await checkResolvedPathForPattern(pattern, path.join(rootDirA, filename));
     });
 
-    it('should resolve relative pattern with sub-folders glob', function (): void {
+    it('should resolve relative pattern with sub-folders glob', async () => {
         const filename = 'carrots';
         const pattern = `./${filename}/**`;
-        checkResolvedPathForPattern(pattern, path.join(rootDirA, filename));
+        await checkResolvedPathForPattern(pattern, path.join(rootDirA, filename));
     });
 
-    it('should resolve absolute path pattern', function (): void {
+    it('should resolve absolute path pattern', async () => {
         const pattern = `${rootDirA}/carrots`;
-        checkResolvedPathForPattern(pattern, pattern);
+        await checkResolvedPathForPattern(pattern, pattern);
     });
 });
 
@@ -1064,9 +1064,9 @@ describe('#addGlobArgs', function (): void {
     });
 });
 
-function checkResolvedPathForPattern(pattern: string, expectedPath: string): void {
+async function checkResolvedPathForPattern(pattern: string, expectedPath: string): Promise<void> {
     const options = { include: [pattern] };
-    const searchPaths = ripgrepServer['extractSearchPathsFromIncludes']([rootDirA], options);
+    const searchPaths = await ripgrepServer['extractSearchPathsFromIncludes']([rootDirA], options);
     expect(searchPaths.length).equal(1, 'searchPath result should contain exactly one element');
     expect(options.include.length).equals(0, 'options.include should be empty');
     expect(searchPaths[0]).equal(path.normalize(expectedPath));

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
@@ -216,7 +216,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
         const rootPaths = rootUris.map(root => FileUri.fsPath(root));
         // If there are absolute paths in `include` we will remove them and use
         // those as paths to search from.
-        const searchPaths = this.extractSearchPathsFromIncludes(rootPaths, options);
+        const searchPaths = await this.extractSearchPathsFromIncludes(rootPaths, options);
         options.include = this.replaceRelativeToAbsolute(searchPaths, options.include);
         options.exclude = this.replaceRelativeToAbsolute(searchPaths, options.exclude);
         const rgArgs = this.getArgs(options);
@@ -388,23 +388,27 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
      * Any pattern that resulted in a valid search path will be removed from the 'include' list as it is
      * provided as an equivalent search path instead.
      */
-    protected extractSearchPathsFromIncludes(rootPaths: string[], options: SearchInWorkspaceOptions): string[] {
+    protected async extractSearchPathsFromIncludes(rootPaths: string[], options: SearchInWorkspaceOptions): Promise<string[]> {
         if (!options.include) {
             return rootPaths;
         }
         const resolvedPaths = new Set<string>();
-        options.include = options.include.filter(pattern => {
+        const include: string[] = [];
+        for (const pattern of options.include) {
             let keep = true;
             for (const root of rootPaths) {
-                const absolutePath = this.getAbsolutePathFromPattern(root, pattern);
+                const absolutePath = await this.getAbsolutePathFromPattern(root, pattern);
                 // undefined means the pattern cannot be converted into an absolute path
                 if (absolutePath) {
                     resolvedPaths.add(absolutePath);
                     keep = false;
                 }
             }
-            return keep;
-        });
+            if (keep) {
+                include.push(pattern);
+            }
+        }
+        options.include = include;
         return resolvedPaths.size > 0
             ? Array.from(resolvedPaths)
             : rootPaths;
@@ -417,7 +421,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
      *
      * @returns undefined if the pattern cannot be converted into an absolute path.
      */
-    protected getAbsolutePathFromPattern(root: string, pattern: string): string | undefined {
+    protected async getAbsolutePathFromPattern(root: string, pattern: string): Promise<string | undefined> {
         pattern = pattern.replace(/\\/g, '/');
         // The pattern is not referring to a single file or folder, i.e. not to be converted
         if (!path.isAbsolute(pattern) && !pattern.startsWith('./')) {
@@ -429,7 +433,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
         }
         // if `pattern` is absolute then `root` will be ignored by `path.resolve()`
         const targetPath = path.resolve(root, pattern);
-        if (fs.existsSync(targetPath)) {
+        if (await fs.pathExists(targetPath)) {
             return targetPath;
         }
         return undefined;

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -153,12 +153,8 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
     async getRecentWorkspaces(): Promise<string[]> {
         const data = await this.readRecentWorkspacePathsFromUserHome();
         if (data && data.recentRoots) {
-            const allRootUris = await Promise.all(data.recentRoots.map(element => new Promise<string | undefined>(async resolve => {
-                if (element && await this.workspaceStillExist(element)) {
-                    resolve(element);
-                }
-                resolve(undefined);
-            })));
+            const allRootUris = await Promise.all(data.recentRoots.map(async element =>
+                element && await this.workspaceStillExist(element) ? element : undefined));
             return allRootUris.filter(notEmpty);
         }
         return [];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Read plugin contributions asynchronously to avoid blocking and improve backend application startup.

Changed `PluginScanner#getContribution` from sync to async. The `protected` Theia and grammar scanner APIs were affected: they have been adjusted to async.

I have noticed loading all the translations and contributions takes half a second in a downstream project:

This PR removes all sync `fs` calls in `git`, `siw`, and `workspace` extensions.

<img width="1385" alt="Screenshot 2023-08-03 at 18 01 13" src="https://github.com/eclipse-theia/theia/assets/1405703/bc07e052-a29e-4e15-b076-a1e4e2862c86">


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

VS Code extensions still load, and all works fine.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
