### PR TITLE
Properly re-render problem widget and fix problem matching

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -21,7 +21,7 @@ import { ProblemTreeModel } from './problem-tree-model';
 import { MarkerInfoNode, MarkerNode, MarkerRootNode } from '../marker-tree';
 import {
     TreeWidget, TreeProps, ContextMenuRenderer, TreeNode, NodeProps, TreeModel,
-    ApplicationShell, Navigatable, ExpandableTreeNode, SelectableTreeNode, TREE_NODE_INFO_CLASS, codicon
+    ApplicationShell, Navigatable, ExpandableTreeNode, SelectableTreeNode, TREE_NODE_INFO_CLASS, codicon, Message
 } from '@theia/core/lib/browser';
 import { DiagnosticSeverity } from '@theia/core/shared/vscode-languageserver-protocol';
 import * as React from '@theia/core/shared/react';
@@ -71,6 +71,11 @@ export class ProblemWidget extends TreeWidget {
                 this.updateFollowActiveEditor();
             }
         }));
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this.update();
     }
 
     protected updateFollowActiveEditor(): void {

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -249,7 +249,7 @@ export class TaskService implements TaskConfigurationClient {
                                 }
                             }
                         }
-                        const uri = new URI(problem.resource.path).withScheme(problem.resource.scheme);
+                        const uri = problem.resource.withScheme(problem.resource.scheme);
                         const document = this.monacoWorkspace.getTextDocument(uri.toString());
                         if (problem.description.applyTo === ApplyToKind.openDocuments && !!document ||
                             problem.description.applyTo === ApplyToKind.closedDocuments && !document ||

--- a/packages/task/src/common/problem-matcher-protocol.ts
+++ b/packages/task/src/common/problem-matcher-protocol.ts
@@ -21,10 +21,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { URI } from '@theia/core';
 import { Severity } from '@theia/core/lib/common/severity';
 import { Diagnostic } from '@theia/core/shared/vscode-languageserver-protocol';
-// TODO use URI from `@theia/core` instead
-import { URI } from '@theia/core/shared/vscode-uri';
 
 export enum ApplyToKind {
     allDocuments,

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -27,21 +27,18 @@ import { TaskManager } from '../task-manager';
 import { ProcessType, ProcessTaskInfo } from '../../common/process/task-protocol';
 import { TaskExitedEvent } from '../../common/task-protocol';
 
-// copied from https://github.com/Microsoft/vscode/blob/1.33.1/src/vs/base/common/strings.ts
-// Escape codes
-// http://en.wikipedia.org/wiki/ANSI_escape_code
-const EL = /\x1B\x5B[12]?K/g; // Erase in line
-const COLOR_START = /\x1b\[\d+(;\d+)*m/g; // Color
-const COLOR_END = /\x1b\[0?m/g; // Color
+// copied from https://github.com/microsoft/vscode/blob/1.79.0/src/vs/base/common/strings.ts#L736
+const CSI_SEQUENCE = /(:?\x1b\[|\x9B)[=?>!]?[\d;:]*["$#'* ]?[a-zA-Z@^`{}|~]/g;
+
+// Plus additional markers for custom `\x1b]...\x07` instructions.
+const CSI_CUSTOM_SEQUENCE = /\x1b\].*?\x07/g;
 
 export function removeAnsiEscapeCodes(str: string): string {
     if (str) {
-        str = str.replace(EL, '');
-        str = str.replace(COLOR_START, '');
-        str = str.replace(COLOR_END, '');
+        str = str.replace(CSI_SEQUENCE, '').replace(CSI_CUSTOM_SEQUENCE, '');
     }
 
-    return str.trimRight();
+    return str.trimEnd();
 }
 
 export const TaskProcessOptions = Symbol('TaskProcessOptions');

--- a/packages/task/src/node/task-abstract-line-matcher.ts
+++ b/packages/task/src/node/task-abstract-line-matcher.ts
@@ -26,10 +26,9 @@ import {
     ProblemMatch, ProblemMatchData, ProblemLocationKind
 } from '../common/problem-matcher-protocol';
 import URI from '@theia/core/lib/common/uri';
-// TODO use only URI from '@theia/core'
-import { URI as vscodeURI } from '@theia/core/shared/vscode-uri';
 import { Severity } from '@theia/core/lib/common/severity';
 import { MAX_SAFE_INTEGER } from '@theia/core/lib/common/numbers';
+import { join } from 'path';
 
 const endOfLine: string = EOL;
 
@@ -247,7 +246,7 @@ export abstract class AbstractLineMatcher {
         return Severity.toDiagnosticSeverity(result);
     }
 
-    private getResource(filename: string, matcher: ProblemMatcher): vscodeURI {
+    private getResource(filename: string, matcher: ProblemMatcher): URI {
         const kind = matcher.fileLocation;
         let fullPath: string | undefined;
         if (kind === FileLocationKind.Absolute) {
@@ -257,19 +256,15 @@ export abstract class AbstractLineMatcher {
             if (relativeFileName.startsWith('./')) {
                 relativeFileName = relativeFileName.slice(2);
             }
-            fullPath = new URI(matcher.filePrefix).resolve(relativeFileName).path.toString();
+            fullPath = join(matcher.filePrefix, relativeFileName);
         }
         if (fullPath === undefined) {
             throw new Error('FileLocationKind is not actionable. Does the matcher have a filePrefix? This should never happen.');
         }
-        fullPath = fullPath.replace(/\\/g, '/');
-        if (fullPath[0] !== '/') {
-            fullPath = '/' + fullPath;
-        }
         if (matcher.uriProvider !== undefined) {
             return matcher.uriProvider(fullPath);
         } else {
-            return vscodeURI.file(fullPath);
+            return URI.fromFilePath(fullPath);
         }
     }
 

--- a/packages/task/src/node/task-problem-collector.spec.ts
+++ b/packages/task/src/node/task-problem-collector.spec.ts
@@ -14,11 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { expect } from 'chai';
-import { DiagnosticSeverity } from '@theia/core/shared/vscode-languageserver-protocol';
-import { ProblemCollector } from './task-problem-collector';
-import { ApplyToKind, FileLocationKind, ProblemLocationKind, ProblemMatch, ProblemMatchData, ProblemMatcher } from '../common/problem-matcher-protocol';
 import { Severity } from '@theia/core/lib/common/severity';
+import { DiagnosticSeverity } from '@theia/core/shared/vscode-languageserver-protocol';
+import { expect } from 'chai';
+import { ApplyToKind, FileLocationKind, ProblemLocationKind, ProblemMatch, ProblemMatchData, ProblemMatcher } from '../common/problem-matcher-protocol';
+import { ProblemCollector } from './task-problem-collector';
 
 const startStopMatcher1: ProblemMatcher = {
     owner: 'test1',
@@ -130,7 +130,7 @@ describe('ProblemCollector', () => {
 
         expect(allMatches.length).to.eq(3);
 
-        expect((allMatches[0] as ProblemMatchData).resource!.path).eq('/home/test/hello.go');
+        expect((allMatches[0] as ProblemMatchData).resource!.path.toString()).eq('/home/test/hello.go');
         expect((allMatches[0] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 8, character: 1 }, end: { line: 8, character: 1 } },
             severity: DiagnosticSeverity.Error,
@@ -138,7 +138,7 @@ describe('ProblemCollector', () => {
             message: 'undefined: fmt.Pntln'
         });
 
-        expect((allMatches[1] as ProblemMatchData).resource!.path).eq('/home/test/hello.go');
+        expect((allMatches[1] as ProblemMatchData).resource!.path.toString()).eq('/home/test/hello.go');
         expect((allMatches[1] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 9, character: 5 }, end: { line: 9, character: 5 } },
             severity: DiagnosticSeverity.Error,
@@ -146,7 +146,7 @@ describe('ProblemCollector', () => {
             message: 'undefined: numb'
         });
 
-        expect((allMatches[2] as ProblemMatchData).resource!.path).eq('/home/test/hello.go');
+        expect((allMatches[2] as ProblemMatchData).resource!.path.toString()).eq('/home/test/hello.go');
         expect((allMatches[2] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 14, character: 8 }, end: { line: 14, character: 8 } },
             severity: DiagnosticSeverity.Error,
@@ -176,7 +176,7 @@ describe('ProblemCollector', () => {
 
         expect(allMatches.length).to.eq(4);
 
-        expect((allMatches[0] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[0] as ProblemMatchData).resource!.path.toString()).eq('/home/test/test-dir.js');
         expect((allMatches[0] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 13, character: 20 }, end: { line: 13, character: 20 } },
             severity: DiagnosticSeverity.Warning,
@@ -185,7 +185,7 @@ describe('ProblemCollector', () => {
             code: 'semi'
         });
 
-        expect((allMatches[1] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[1] as ProblemMatchData).resource!.path.toString()).eq('/home/test/test-dir.js');
         expect((allMatches[1] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 14, character: 22 }, end: { line: 14, character: 22 } },
             severity: DiagnosticSeverity.Warning,
@@ -194,7 +194,7 @@ describe('ProblemCollector', () => {
             code: 'semi'
         });
 
-        expect((allMatches[2] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[2] as ProblemMatchData).resource!.path.toString()).eq('/home/test/test-dir.js');
         expect((allMatches[2] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 102, character: 8 }, end: { line: 102, character: 8 } },
             severity: DiagnosticSeverity.Error,
@@ -202,7 +202,7 @@ describe('ProblemCollector', () => {
             message: 'Parsing error: Unexpected token inte'
         });
 
-        expect((allMatches[3] as ProblemMatchData).resource!.path).eq('/home/test/more-test.js');
+        expect((allMatches[3] as ProblemMatchData).resource!.path.toString()).eq('/home/test/more-test.js');
         expect((allMatches[3] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 12, character: 8 }, end: { line: 12, character: 8 } },
             severity: DiagnosticSeverity.Error,
@@ -232,7 +232,7 @@ describe('ProblemCollector', () => {
 
         expect(allMatches.length).to.eq(4);
 
-        expect((allMatches[0] as ProblemMatchData).resource?.path).eq('/home/test/test-dir.js');
+        expect((allMatches[0] as ProblemMatchData).resource?.path.toString()).eq('/home/test/test-dir.js');
         expect((allMatches[0] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Warning,
@@ -241,7 +241,7 @@ describe('ProblemCollector', () => {
             code: 'semi'
         });
 
-        expect((allMatches[1] as ProblemMatchData).resource?.path).eq('/home/test/test-dir.js');
+        expect((allMatches[1] as ProblemMatchData).resource?.path.toString()).eq('/home/test/test-dir.js');
         expect((allMatches[1] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Warning,
@@ -250,7 +250,7 @@ describe('ProblemCollector', () => {
             code: 'semi'
         });
 
-        expect((allMatches[2] as ProblemMatchData).resource?.path).eq('/home/test/test-dir.js');
+        expect((allMatches[2] as ProblemMatchData).resource?.path.toString()).eq('/home/test/test-dir.js');
         expect((allMatches[2] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Error,
@@ -258,7 +258,7 @@ describe('ProblemCollector', () => {
             message: 'Parsing error: Unexpected token inte'
         });
 
-        expect((allMatches[3] as ProblemMatchData).resource?.path).eq('/home/test/more-test.js');
+        expect((allMatches[3] as ProblemMatchData).resource?.path.toString()).eq('/home/test/more-test.js');
         expect((allMatches[3] as ProblemMatchData).marker).deep.equal({
             range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
             severity: DiagnosticSeverity.Error,

--- a/packages/terminal/src/common/base-terminal-protocol.ts
+++ b/packages/terminal/src/common/base-terminal-protocol.ts
@@ -67,6 +67,8 @@ export interface IBaseTerminalExitEvent {
     code?: number;
     reason?: TerminalExitReason;
     signal?: string;
+
+    attached?: boolean;
 }
 
 export enum TerminalExitReason {
@@ -79,7 +81,8 @@ export enum TerminalExitReason {
 
 export interface IBaseTerminalErrorEvent {
     terminalId: number;
-    error: Error
+    error: Error;
+    attached?: boolean;
 }
 
 export interface IBaseTerminalClient {


### PR DESCRIPTION
#### What it does
- Ensure we re-render the tree model if the problem widget is activated
- Update Ansi stripping to catch Windows 'clear screen' and other codes
- Consistently use Theia URI in problem matcher protocol

Fixes https://github.com/eclipse-theia/theia/issues/12724

#### How to test
- Follow instructions in bug report or checkout https://github.com/eclipse-theia/theia/tree/martin-fleck-at/issue-12724-test
- Run Electron App (either through launch config or command line)
- Create a task in a workspace with the following content:
```
{
   "version": "2.0.0",
   "tasks": [
      {
         "label": "echo",
         "type": "shell",
         "command": "@echo somefile.abc:1:4: warning: the roof is on fire ",
         "problemMatcher" : ["$myproblemmatcher"]
      }
   ]
}
```
- Run Task 'echo' and check the Problems view:

![image](https://github.com/eclipse-theia/theia/assets/19170971/80b12e1b-0ab8-4306-a4b6-d6671555f1cf)
(Windows)

![image](https://github.com/eclipse-theia/theia/assets/19170971/0cbd5b82-b2f7-4bb0-9eb9-e1d3410d2450)
(File path on Hover)

![image](https://github.com/eclipse-theia/theia/assets/19170971/90a37402-898f-434e-ad1c-1205d4a4cee3)
(Linux)



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
