### PR TITLE
core: refactor `manage` sidebar menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.43.0 - Unreleased
+
+<a name="breaking_changes_1.43.0">[Breaking Changes:](#breaking_changes_1.43.0)</a>
+
+- [core] removed `SETTINGS_OPEN` menupath constant - replaced by `MANAGE_GENERAL` [#12803](https://github.com/eclipse-theia/theia/pull/12803)
+- [core] removed `SETTINGS__THEME` menupath constant - replaced by `MANAGE_SETTINGS` [#12803](https://github.com/eclipse-theia/theia/pull/12803)
+
 ## v1.42.0 - 09/28/2023
 
 - [core] added `inversify` support in the frontend preload script [#12590](https://github.com/eclipse-theia/theia/pull/12590)

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -18,7 +18,7 @@
 
 import debounce = require('lodash.debounce');
 import { injectable, inject, optional } from 'inversify';
-import { MAIN_MENU_BAR, SETTINGS_MENU, MenuContribution, MenuModelRegistry, ACCOUNTS_MENU } from '../common/menu';
+import { MAIN_MENU_BAR, MANAGE_MENU, MenuContribution, MenuModelRegistry, ACCOUNTS_MENU } from '../common/menu';
 import { KeybindingContribution, KeybindingRegistry } from './keybinding';
 import { FrontendApplication, FrontendApplicationContribution, OnWillStopAction } from './frontend-application';
 import { CommandContribution, CommandRegistry, Command } from '../common/command';
@@ -100,8 +100,10 @@ export namespace CommonMenus {
     export const VIEW_LAYOUT = [...VIEW, '3_layout'];
     export const VIEW_TOGGLE = [...VIEW, '4_toggle'];
 
-    export const SETTINGS_OPEN = [...SETTINGS_MENU, '1_settings_open'];
-    export const SETTINGS__THEME = [...SETTINGS_MENU, '2_settings_theme'];
+    export const MANAGE_GENERAL = [...MANAGE_MENU, '1_manage_general'];
+    export const MANAGE_SETTINGS = [...MANAGE_MENU, '2_manage_settings'];
+    export const MANAGE_SETTINGS_THEMES = [...MANAGE_SETTINGS, '1_manage_settings_themes'];
+
     // last menu item
     export const HELP = [...MAIN_MENU_BAR, '9_help'];
 
@@ -113,6 +115,7 @@ export namespace CommonCommands {
     export const VIEW_CATEGORY = 'View';
     export const CREATE_CATEGORY = 'Create';
     export const PREFERENCES_CATEGORY = 'Preferences';
+    export const MANAGE_CATEGORY = 'Manage';
     export const FILE_CATEGORY_KEY = nls.getDefaultKey(FILE_CATEGORY);
     export const VIEW_CATEGORY_KEY = nls.getDefaultKey(VIEW_CATEGORY);
     export const PREFERENCES_CATEGORY_KEY = nls.getDefaultKey(PREFERENCES_CATEGORY);
@@ -455,16 +458,16 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         app.shell.leftPanelHandler.addBottomMenu({
             id: 'settings-menu',
             iconClass: 'codicon codicon-settings-gear',
-            title: nls.localizeByDefault(CommonCommands.PREFERENCES_CATEGORY),
-            menuPath: SETTINGS_MENU,
-            order: 0,
+            title: nls.localizeByDefault(CommonCommands.MANAGE_CATEGORY),
+            menuPath: MANAGE_MENU,
+            order: 1,
         });
         const accountsMenu = {
             id: 'accounts-menu',
             iconClass: 'codicon codicon-person',
             title: nls.localizeByDefault('Accounts'),
             menuPath: ACCOUNTS_MENU,
-            order: 1,
+            order: 0,
         };
         this.authenticationService.onDidRegisterAuthenticationProvider(() => {
             app.shell.leftPanelHandler.addBottomMenu(accountsMenu);
@@ -700,11 +703,14 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             commandId: CommonCommands.SELECT_ICON_THEME.id
         });
 
-        registry.registerMenuAction(CommonMenus.SETTINGS__THEME, {
-            commandId: CommonCommands.SELECT_COLOR_THEME.id
+        registry.registerSubmenu(CommonMenus.MANAGE_SETTINGS_THEMES, nls.localizeByDefault('Themes'), { order: 'a50' });
+        registry.registerMenuAction(CommonMenus.MANAGE_SETTINGS_THEMES, {
+            commandId: CommonCommands.SELECT_COLOR_THEME.id,
+            order: '0'
         });
-        registry.registerMenuAction(CommonMenus.SETTINGS__THEME, {
-            commandId: CommonCommands.SELECT_ICON_THEME.id
+        registry.registerMenuAction(CommonMenus.MANAGE_SETTINGS_THEMES, {
+            commandId: CommonCommands.SELECT_ICON_THEME.id,
+            order: '1'
         });
 
         registry.registerSubmenu(CommonMenus.VIEW_APPEARANCE_SUBMENU, nls.localizeByDefault('Appearance'));

--- a/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
+++ b/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
@@ -59,6 +59,11 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
             commandId: quickCommand.id,
             label: nls.localizeByDefault('Command Palette...')
         });
+        menus.registerMenuAction(CommonMenus.MANAGE_GENERAL, {
+            commandId: quickCommand.id,
+            label: nls.localizeByDefault('Command Palette...'),
+            order: '0'
+        });
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {

--- a/packages/core/src/common/menu/menu-types.ts
+++ b/packages/core/src/common/menu/menu-types.ts
@@ -19,7 +19,7 @@ import { isObject } from '../types';
 
 export type MenuPath = string[];
 export const MAIN_MENU_BAR: MenuPath = ['menubar'];
-export const SETTINGS_MENU: MenuPath = ['settings_menu'];
+export const MANAGE_MENU: MenuPath = ['manage_menu'];
 export const ACCOUNTS_MENU: MenuPath = ['accounts_menu'];
 export const ACCOUNTS_SUBMENU = [...ACCOUNTS_MENU, '1_accounts_submenu'];
 

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -94,10 +94,10 @@ export class KeymapsFrontendContribution extends AbstractViewContribution<Keybin
             label: nls.localizeByDefault('Keyboard Shortcuts'),
             order: 'a20'
         });
-        menus.registerMenuAction(CommonMenus.SETTINGS_OPEN, {
+        menus.registerMenuAction(CommonMenus.MANAGE_SETTINGS, {
             commandId: KeymapsCommands.OPEN_KEYMAPS.id,
             label: nls.localizeByDefault('Keyboard Shortcuts'),
-            order: 'a20'
+            order: 'a30'
         });
     }
 

--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -146,7 +146,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
             label: nls.localizeByDefault('Settings'),
             order: 'a10',
         });
-        menus.registerMenuAction(CommonMenus.SETTINGS_OPEN, {
+        menus.registerMenuAction(CommonMenus.MANAGE_SETTINGS, {
             commandId: CommonCommands.OPEN_PREFERENCES.id,
             label: nls.localizeByDefault('Settings'),
             order: 'a10',

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -19,7 +19,7 @@ import { ILogger, ContributionProvider, CommandContribution, Command, CommandReg
 import { QuickOpenTask, TaskTerminateQuickOpen, TaskRunningQuickOpen, TaskRestartRunningQuickOpen } from './quick-open-task';
 import {
     FrontendApplication, FrontendApplicationContribution, QuickAccessContribution,
-    KeybindingRegistry, KeybindingContribution, StorageService, StatusBar, StatusBarAlignment
+    KeybindingRegistry, KeybindingContribution, StorageService, StatusBar, StatusBarAlignment, CommonMenus
 } from '@theia/core/lib/browser';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { TaskContribution, TaskResolverRegistry, TaskProviderRegistry } from './task-contribution';
@@ -379,6 +379,12 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_CONFIG, {
             commandId: TaskCommands.TASK_CONFIGURE.id,
             order: '0'
+        });
+
+        menus.registerMenuAction(CommonMenus.MANAGE_SETTINGS, {
+            commandId: TaskCommands.TASK_OPEN_USER.id,
+            label: nls.localizeByDefault('User Tasks'),
+            order: 'a40'
         });
     }
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -17,7 +17,7 @@
 import { DateTime } from 'luxon';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import debounce = require('@theia/core/shared/lodash.debounce');
-import { CommandRegistry } from '@theia/core/lib/common/command';
+import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { VSXExtensionsViewContainer } from './vsx-extensions-view-container';
 import { VSXExtensionsModel } from './vsx-extensions-model';
@@ -27,7 +27,7 @@ import { Color } from '@theia/core/lib/common/color';
 import { FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser/frontend-application';
 import { MenuModelRegistry, MessageService, nls } from '@theia/core/lib/common';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
-import { LabelProvider, PreferenceService, QuickPickItem, QuickInputService } from '@theia/core/lib/browser';
+import { LabelProvider, PreferenceService, QuickPickItem, QuickInputService, CommonMenus } from '@theia/core/lib/browser';
 import { VscodeCommands } from '@theia/plugin-ext-vscode/lib/browser/plugin-vscode-commands-contribution';
 import { VSXExtensionsContextMenu, VSXExtension } from './vsx-extension';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
@@ -36,6 +36,12 @@ import { IGNORE_RECOMMENDATIONS_ID } from './recommended-extensions/recommended-
 import { VSXExtensionsCommands } from './vsx-extension-commands';
 import { VSXExtensionRaw, OVSXApiFilter } from '@theia/ovsx-client';
 import { OVSXClientProvider } from '../common/ovsx-client-provider';
+
+export namespace VSXCommands {
+    export const TOGGLE_EXTENSIONS: Command = {
+        id: 'vsxExtensions.toggle',
+    };
+}
 
 @injectable()
 export class VSXExtensionsContribution extends AbstractViewContribution<VSXExtensionsViewContainer> implements ColorContribution, FrontendApplicationContribution {
@@ -59,7 +65,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
                 area: 'left',
                 rank: 500
             },
-            toggleCommandId: 'vsxExtensions.toggle',
+            toggleCommandId: VSXCommands.TOGGLE_EXTENSIONS.id,
             toggleKeybinding: 'ctrlcmd+shift+x'
         });
     }
@@ -117,6 +123,11 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
 
     override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
+        menus.registerMenuAction(CommonMenus.MANAGE_SETTINGS, {
+            commandId: VSXCommands.TOGGLE_EXTENSIONS.id,
+            label: nls.localizeByDefault('Extensions'),
+            order: 'a20'
+        });
         menus.registerMenuAction(VSXExtensionsContextMenu.COPY, {
             commandId: VSXExtensionsCommands.COPY.id,
             label: nls.localizeByDefault('Copy'),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request refactors the sidebar menu (bottom settings-cog icon) to more closely align with VS Code.
The menu was refactored to `manage` and contains additional menu items in a more clear ordering.

_Before_:

![image](https://github.com/eclipse-theia/theia/assets/40359487/b7f9fd01-5469-4cd8-8bfc-c87e084b7879)

_After_:

![image](https://github.com/eclipse-theia/theia/assets/40359487/e1725e8f-45ab-4f0b-a7d1-3935268e8450)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. confirm that the sidebar menu works as expected, items are properly organized and work

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
