### PR TITLE
tabbar: support icon-less items

### DIFF
--- a/packages/core/src/browser/label-parser.spec.ts
+++ b/packages/core/src/browser/label-parser.spec.ts
@@ -124,4 +124,42 @@ describe('StatusBarEntryUtility', () => {
         expect((iconArr[3] as LabelIcon).name).equals('icon3');
     });
 
+    it('should strip nothing from an empty string', () => {
+        text = '';
+        const stripped: string = statusBarEntryUtility.stripIcons(text);
+        expect(stripped).to.be.equal(text);
+    });
+
+    it('should strip nothing from an string containing no icons', () => {
+        // Deliberate double space to verify not concatenating these words
+        text = 'foo  bar';
+        const stripped: string = statusBarEntryUtility.stripIcons(text);
+        expect(stripped).to.be.equal(text);
+    });
+
+    it("should strip a medial '$(icon)' from a string", () => {
+        text = 'foo $(icon) bar';
+        const stripped: string = statusBarEntryUtility.stripIcons(text);
+        expect(stripped).to.be.equal('foo bar');
+    });
+
+    it("should strip a terminal '$(icon)' from a string", () => {
+        // Deliberate double space to verify not concatenating these words
+        text = 'foo  bar $(icon)';
+        const stripped: string = statusBarEntryUtility.stripIcons(text);
+        expect(stripped).to.be.equal('foo  bar');
+    });
+
+    it("should strip an initial '$(icon)' from a string", () => {
+        // Deliberate double space to verify not concatenating these words
+        text = '$(icon) foo  bar';
+        const stripped: string = statusBarEntryUtility.stripIcons(text);
+        expect(stripped).to.be.equal('foo  bar');
+    });
+
+    it("should strip multiple '$(icon)' specifiers from a string", () => {
+        text = '$(icon1) foo $(icon2)$(icon3)  bar $(icon4) $(icon5)';
+        const stripped: string = statusBarEntryUtility.stripIcons(text);
+        expect(stripped).to.be.equal('foo bar');
+    });
 });

--- a/packages/core/src/browser/label-parser.ts
+++ b/packages/core/src/browser/label-parser.ts
@@ -90,4 +90,19 @@ export class LabelParser {
         return parserArray;
     }
 
+    /**
+     * Strips icon specifiers from the given `text`, leaving only a
+     * space-separated concatenation of the non-icon segments.
+     *
+     * @param text text to be stripped of icon specifiers
+     * @returns the `text` with icon specifiers stripped out
+     */
+    stripIcons(text: string): string {
+        return this.parse(text)
+            .filter(item => !LabelIcon.is(item))
+            .map(s => (s as string).trim())
+            .filter(s => s.length)
+            .join(' ');
+    }
+
 }

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -150,7 +150,7 @@ export class TabBarToolbar extends ReactWidget {
         return <React.Fragment>
             {this.renderMore()}
             {[...this.inline.values()].map(item => TabBarToolbarItem.is(item)
-                ? (MenuToolbarItem.is(item) ? this.renderMenuItem(item) : this.renderItem(item))
+                ? (MenuToolbarItem.is(item) && !item.command ? this.renderMenuItem(item) : this.renderItem(item))
                 : item.render(this.current))}
         </React.Fragment>;
     }

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -480,6 +480,11 @@
   line-height: 18px;
 }
 
+.p-TabBar-toolbar .item > div.no-icon {
+  /* Make room for a text label instead of an icon. */
+  width: 100%;
+}
+
 .p-TabBar-toolbar .item .collapse-all {
   background: var(--theia-icon-collapse-all) no-repeat;
 }


### PR DESCRIPTION
#### What it does

VS Code renders action buttons in the tab bar for commands that do not have icons using their `"title"` text, instead. This commit does the same in Theia.

Additionally, two related minor issues are fixed:

- the `$(icon)` specifiers for icons show in the tooltip of an action, which is confusing
- the roll-over highlight shows only on action buttons for commands that use the `"icon"` property, not those that embed icon specifiers in their titles

_I am happy to extract these fixes into separate PRs if you do not feel it appropriate to join them to the primary issue at hand._

Fixes #12686

#### How to test

1. Clone the `menu_bug_1` branch of the OP's sample repository as indicated in the issue description.
2. Build the `myext` extension in that sample repository and link it into the `plugins/` directory of your Theia build.
3. Launch Theia and open a code editor on some file (e.g., a TS or JSON file from the OP's sample repository).
4. See the "Goodbye World" action presented in the toolbar next to the pencil-icon "Hello World" action as shown below, and verify that it works (showing a message toast).

![CleanShot 2023-08-07 at 08 57 50](https://github.com/eclipse-theia/theia/assets/1615558/1d6cc173-bfdc-43db-b3f7-290d1d35ab03)

Other tests that I would recommend, especially covering the ancillary issues fixed herein, include:

- append a Font Awesome icon specifier to the title of the "Goodbye World" command and see that it renders the icon and tooltip plausibly like this example using `$(cube)`:
![CleanShot 2023-08-07 at 09 34 13](https://github.com/eclipse-theia/theia/assets/1615558/dbf99b31-cfc8-4d75-80dc-b5305851aac5)
- remove the `"title"` property of the `myext.goodbyeWorld` command from the `myext` extension's `package.json` and see that at least the ID is shown for the command, which will indicate to the developer of this extension that something is amiss (otherwise there would just be a blank spot in the toolbar which could possibly be unobserved)
![CleanShot 2023-08-07 at 09 47 58](https://github.com/eclipse-theia/theia/assets/1615558/9fae59ec-3d1a-4203-8e1f-cbb7ed646ef8)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
