### PR TITLE
Style: close icon highlights on tab hover

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -254,8 +254,8 @@
 }
 
 .p-TabBar.theia-app-centers
-  .p-TabBar-tab:hover.p-mod-closable
-  > .p-TabBar-tabCloseIcon {
+  .p-TabBar-tab.p-mod-closable
+  > .p-TabBar-tabCloseIcon:hover {
   border-radius: 5px;
   background-color: rgba(50%, 50%, 50%, 0.2);
 }


### PR DESCRIPTION
#### What it does
This commit brings the mouse onHover behavior on tabs closer to VS Code behavior.
Currently:
![OnHoverSmallIssue](https://github.com/eclipse-theia/theia/assets/48699277/85e3fb55-761c-427c-bdb8-e8eb825bd619)

On VS Code:
![OnHoverSmallIssueVSCODE](https://github.com/eclipse-theia/theia/assets/48699277/2869b0e7-db45-4a91-8179-5b71627c137d)

This request:
![OnHoverSmallIssueFixed](https://github.com/eclipse-theia/theia/assets/48699277/aa045b76-f333-401f-9c31-9b69bf5d321a)

I have kept the lines in `tabs.css` despite them seemingly being obsolete. The function of the style implemented in lines 256-261 seems to be redundant as eliminating them caused no visible change in the styling.

#### How to test
1. Open Theia
2. Hover over open tabs

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
