### PR TITLE
Retire `KeybindingContext`

### DIFF
--- a/packages/console/src/browser/console-contribution.ts
+++ b/packages/console/src/browser/console-contribution.ts
@@ -18,7 +18,6 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, CommandHandler } from '@theia/core';
 import { FrontendApplicationContribution, KeybindingContribution, KeybindingRegistry, CommonCommands } from '@theia/core/lib/browser';
 import { ConsoleManager } from './console-manager';
-import { ConsoleKeybindingContexts } from './console-keybinding-contexts';
 import { ConsoleWidget } from './console-widget';
 import { ConsoleContentWidget } from './console-content-widget';
 import { nls } from '@theia/core/lib/common/nls';
@@ -70,22 +69,22 @@ export class ConsoleContribution implements FrontendApplicationContribution, Com
         keybindings.registerKeybinding({
             command: ConsoleCommands.SELECT_ALL.id,
             keybinding: 'ctrlcmd+a',
-            context: ConsoleKeybindingContexts.consoleContentFocus
+            when: 'consoleContentFocus'
         });
         keybindings.registerKeybinding({
             command: ConsoleCommands.EXECUTE.id,
             keybinding: 'enter',
-            context: ConsoleKeybindingContexts.consoleInputFocus
+            when: 'consoleInputFocus'
         });
         keybindings.registerKeybinding({
             command: ConsoleCommands.NAVIGATE_BACK.id,
             keybinding: 'up',
-            context: ConsoleKeybindingContexts.consoleNavigationBackEnabled
+            when: 'consoleInputFocus && consoleNavigationBackEnabled'
         });
         keybindings.registerKeybinding({
             command: ConsoleCommands.NAVIGATE_FORWARD.id,
             keybinding: 'down',
-            context: ConsoleKeybindingContexts.consoleNavigationForwardEnabled
+            when: 'consoleInputFocus && consoleNavigationForwardEnabled'
         });
     }
 

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -20,7 +20,7 @@ import {
 import { injectable, inject } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { MenuModelRegistry, CommandRegistry, MAIN_MENU_BAR, Command, Emitter, Mutable } from '@theia/core/lib/common';
-import { EditorKeybindingContexts, EditorManager } from '@theia/editor/lib/browser';
+import { EditorManager } from '@theia/editor/lib/browser';
 import { DebugSessionManager } from './debug-session-manager';
 import { DebugWidget } from './view/debug-widget';
 import { FunctionBreakpoint } from './breakpoint/breakpoint-marker';
@@ -36,7 +36,6 @@ import { DebugStackFrame } from './model/debug-stack-frame';
 import { DebugVariablesWidget } from './view/debug-variables-widget';
 import { DebugVariable } from './console/debug-console-items';
 import { DebugSessionWidget } from './view/debug-session-widget';
-import { DebugKeybindingContexts } from './debug-keybinding-contexts';
 import { DebugEditorModel } from './editor/debug-editor-model';
 import { DebugEditorService } from './editor/debug-editor-service';
 import { DebugConsoleContribution } from './console/debug-console-contribution';
@@ -1020,60 +1019,60 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         keybindings.registerKeybinding({
             command: DebugCommands.STOP.id,
             keybinding: 'shift+f5',
-            context: DebugKeybindingContexts.inDebugMode
+            when: 'inDebugMode'
         });
 
         keybindings.registerKeybinding({
             command: DebugCommands.RESTART.id,
             keybinding: 'shift+ctrlcmd+f5',
-            context: DebugKeybindingContexts.inDebugMode
+            when: 'inDebugMode'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.STEP_OVER.id,
             keybinding: 'f10',
-            context: DebugKeybindingContexts.inDebugMode
+            when: 'inDebugMode'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.STEP_INTO.id,
             keybinding: 'f11',
-            context: DebugKeybindingContexts.inDebugMode
+            when: 'inDebugMode'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.STEP_OUT.id,
             keybinding: 'shift+f11',
-            context: DebugKeybindingContexts.inDebugMode
+            when: 'inDebugMode'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.CONTINUE.id,
             keybinding: 'f5',
-            context: DebugKeybindingContexts.inDebugMode
+            when: 'inDebugMode'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.PAUSE.id,
             keybinding: 'f6',
-            context: DebugKeybindingContexts.inDebugMode
+            when: 'inDebugMode'
         });
 
         keybindings.registerKeybinding({
             command: DebugCommands.TOGGLE_BREAKPOINT.id,
             keybinding: 'f9',
-            context: EditorKeybindingContexts.editorTextFocus
+            when: 'editorTextFocus'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.INLINE_BREAKPOINT.id,
             keybinding: 'shift+f9',
-            context: EditorKeybindingContexts.editorTextFocus
+            when: 'editorTextFocus'
         });
 
         keybindings.registerKeybinding({
             command: DebugBreakpointWidgetCommands.ACCEPT.id,
             keybinding: 'enter',
-            context: DebugKeybindingContexts.breakpointWidgetInputFocus
+            when: 'breakpointWidgetFocus'
         });
         keybindings.registerKeybinding({
             command: DebugBreakpointWidgetCommands.CLOSE.id,
             keybinding: 'esc',
-            context: DebugKeybindingContexts.breakpointWidgetInputStrictFocus
+            when: 'isBreakpointWidgetVisible || breakpointWidgetFocus'
         });
     }
 

--- a/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
@@ -157,6 +157,7 @@ export class DebugBreakpointWidget implements Disposable {
             this.zone.layout(heightInLines);
             this.updatePlaceholder();
         }));
+        this._input.getControl().createContextKey<boolean>('breakpointWidgetFocus', true);
     }
 
     dispose(): void {
@@ -198,10 +199,12 @@ export class DebugBreakpointWidget implements Disposable {
         this.zone.show({ afterLineNumber, afterColumn, heightInLines, frameWidth: 1 });
         editor.setPosition(editor.getModel()!.getPositionAt(editor.getModel()!.getValueLength()));
         this._input.focus();
+        this.editor.getControl().createContextKey<boolean>('isBreakpointWidgetVisible', true);
     }
 
     hide(): void {
         this.zone.hide();
+        this.editor.getControl().createContextKey<boolean>('isBreakpointWidgetVisible', false);
         this.editor.focus();
     }
 

--- a/packages/git/src/browser/blame/blame-contribution.ts
+++ b/packages/git/src/browser/blame/blame-contribution.ts
@@ -14,14 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
 import { CommandContribution, CommandRegistry, Command, MenuContribution, MenuModelRegistry, DisposableCollection } from '@theia/core/lib/common';
 import { BlameDecorator } from './blame-decorator';
-import { EditorManager, EditorKeybindingContexts, EditorWidget, EditorTextFocusContext, StrictEditorTextFocusContext } from '@theia/editor/lib/browser';
+import { EditorManager, EditorWidget, EditorTextFocusContext, StrictEditorTextFocusContext } from '@theia/editor/lib/browser';
 import { BlameManager } from './blame-manager';
 import URI from '@theia/core/lib/common/uri';
 import { EDITOR_CONTEXT_MENU_SCM } from '@theia/scm-extra/lib/browser/scm-extra-contribution';
+import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 
 import debounce = require('@theia/core/shared/lodash.debounce');
 
@@ -47,6 +48,21 @@ export class BlameContribution implements CommandContribution, KeybindingContrib
 
     @inject(BlameManager)
     protected readonly blameManager: BlameManager;
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
+    protected _visibleBlameAnnotations: ContextKey<boolean>;
+
+    @postConstruct()
+    protected init(): void {
+        this._visibleBlameAnnotations = this.contextKeyService.createKey<boolean>('showsBlameAnnotations', this.visibleBlameAnnotations());
+        this.editorManager.onActiveEditorChanged(() => this.updateContext());
+    }
+
+    protected updateContext(): void {
+        this._visibleBlameAnnotations.set(this.visibleBlameAnnotations());
+    }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(BlameCommands.TOGGLE_GIT_ANNOTATIONS, {
@@ -100,6 +116,14 @@ export class BlameContribution implements CommandContribution, KeybindingContrib
         return this.blameManager.isBlameable(uri.toString());
     }
 
+    protected visibleBlameAnnotations(): boolean {
+        const widget = this.editorManager.activeEditor;
+        if (widget && widget.editor.isFocused() && this.showsBlameAnnotations(widget.editor.uri)) {
+            return true;
+        }
+        return false;
+    }
+
     protected appliedDecorations = new Map<string, DisposableCollection>();
 
     protected async showBlame(editorWidget: EditorWidget): Promise<void> {
@@ -128,6 +152,7 @@ export class BlameContribution implements CommandContribution, KeybindingContrib
             if (toDispose.disposed) {
                 this.appliedDecorations.delete(uri);
             };
+            this.updateContext();
         }
     }
 
@@ -136,6 +161,7 @@ export class BlameContribution implements CommandContribution, KeybindingContrib
         if (decorations) {
             this.appliedDecorations.delete(uri.toString());
             decorations.dispose();
+            this.updateContext();
         }
     }
 
@@ -148,12 +174,12 @@ export class BlameContribution implements CommandContribution, KeybindingContrib
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: BlameCommands.TOGGLE_GIT_ANNOTATIONS.id,
-            context: EditorKeybindingContexts.editorTextFocus,
+            when: 'editorTextFocus',
             keybinding: 'alt+b'
         });
         keybindings.registerKeybinding({
             command: BlameCommands.CLEAR_GIT_ANNOTATIONS.id,
-            context: BlameAnnotationsKeybindingContext.showsBlameAnnotations,
+            when: 'showsBlameAnnotations',
             keybinding: 'esc'
         });
     }

--- a/packages/messages/src/browser/notifications-contribution.ts
+++ b/packages/messages/src/browser/notifications-contribution.ts
@@ -98,7 +98,7 @@ export class NotificationsContribution implements FrontendApplicationContributio
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: NotificationsCommands.HIDE.id,
-            context: NotificationsKeybindingContext.notificationsVisible,
+            when: 'notificationsVisible',
             keybinding: 'esc'
         });
     }

--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -82,6 +82,7 @@ export class NotificationManager extends MessageClient {
 
     protected notificationToastsVisibleKey: ContextKey<boolean>;
     protected notificationCenterVisibleKey: ContextKey<boolean>;
+    protected notificationsVisible: ContextKey<boolean>;
 
     @postConstruct()
     protected init(): void {
@@ -91,11 +92,13 @@ export class NotificationManager extends MessageClient {
     protected async doInit(): Promise<void> {
         this.notificationToastsVisibleKey = this.contextKeyService.createKey<boolean>('notificationToastsVisible', false);
         this.notificationCenterVisibleKey = this.contextKeyService.createKey<boolean>('notificationCenterVisible', false);
+        this.notificationsVisible = this.contextKeyService.createKey<boolean>('notificationsVisible', false);
     }
 
     protected updateContextKeys(): void {
         this.notificationToastsVisibleKey.set(this.toastsVisible);
         this.notificationCenterVisibleKey.set(this.centerVisible);
+        this.notificationsVisible.set(this.toastsVisible || this.centerVisible);
     }
 
     get toastsVisible(): boolean {

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -51,7 +51,6 @@ import {
 import { EXPLORER_VIEW_CONTAINER_ID, EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS } from './navigator-widget-factory';
 import { FILE_NAVIGATOR_ID, FileNavigatorWidget } from './navigator-widget';
 import { FileNavigatorPreferences } from './navigator-preferences';
-import { NavigatorKeybindingContexts } from './navigator-keybinding-context';
 import { FileNavigatorFilter } from './navigator-filter';
 import { WorkspaceNode } from './navigator-tree';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
@@ -507,19 +506,19 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         registry.registerKeybinding({
             command: WorkspaceCommands.FILE_DELETE.id,
             keybinding: isOSX ? 'cmd+backspace' : 'del',
-            context: NavigatorKeybindingContexts.navigatorActive
+            when: 'filesExplorerFocus'
         });
 
         registry.registerKeybinding({
             command: WorkspaceCommands.FILE_RENAME.id,
             keybinding: 'f2',
-            context: NavigatorKeybindingContexts.navigatorActive
+            when: 'filesExplorerFocus'
         });
 
         registry.registerKeybinding({
             command: FileNavigatorCommands.TOGGLE_HIDDEN_FILES.id,
             keybinding: 'ctrlcmd+i',
-            context: NavigatorKeybindingContexts.navigatorActive
+            when: 'filesExplorerFocus'
         });
     }
 


### PR DESCRIPTION
Retiring the use of `context` in keybindings

This is still a draft.
Needs some review to streamline

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
