### PR TITLE
Submenu contribution to editor/title and view/title not working #12706

### DIFF
--- a/packages/core/src/browser/context-menu-renderer.ts
+++ b/packages/core/src/browser/context-menu-renderer.ts
@@ -120,4 +120,9 @@ export interface RenderContextMenuOptions {
     context?: HTMLElement;
     contextKeyService?: ContextMatcher;
     onHide?: () => void;
+    /**
+     * If true a single submenu in the context menu is not rendered but its children are rendered on the top level.
+     * Default is `false`.
+     */
+    skipSingleRootNode?: boolean;
 }

--- a/packages/core/src/browser/menu/browser-context-menu-renderer.ts
+++ b/packages/core/src/browser/menu/browser-context-menu-renderer.ts
@@ -34,8 +34,8 @@ export class BrowserContextMenuRenderer extends ContextMenuRenderer {
         super();
     }
 
-    protected doRender({ menuPath, anchor, args, onHide, context, contextKeyService }: RenderContextMenuOptions): ContextMenuAccess {
-        const contextMenu = this.menuFactory.createContextMenu(menuPath, args, context, contextKeyService);
+    protected doRender({ menuPath, anchor, args, onHide, context, contextKeyService, skipSingleRootNode }: RenderContextMenuOptions): ContextMenuAccess {
+        const contextMenu = this.menuFactory.createContextMenu(menuPath, args, context, contextKeyService, skipSingleRootNode);
         const { x, y } = coordinateFromAnchor(anchor);
         if (onHide) {
             contextMenu.aboutToClose.connect(() => onHide!());

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -108,8 +108,8 @@ export class BrowserMainMenuFactory implements MenuWidgetFactory {
         }
     }
 
-    createContextMenu(path: MenuPath, args?: unknown[], context?: HTMLElement, contextKeyService?: ContextMatcher): MenuWidget {
-        const menuModel = this.menuProvider.getMenu(path);
+    createContextMenu(path: MenuPath, args?: unknown[], context?: HTMLElement, contextKeyService?: ContextMatcher, skipSingleRootNode?: boolean): MenuWidget {
+        const menuModel = skipSingleRootNode ? this.menuProvider.removeSingleRootNode(this.menuProvider.getMenu(path), path) : this.menuProvider.getMenu(path);
         const menuCommandRegistry = this.createMenuCommandRegistry(menuModel, args).snapshot(path);
         const contextMenu = this.createMenuWidget(menuModel, { commands: menuCommandRegistry, context, rootMenuPath: path, contextKeyService });
         return contextMenu;

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -281,7 +281,8 @@ export class TabBarToolbar extends ReactWidget {
             args: [this.current],
             anchor,
             context: this.current?.node,
-            onHide: () => toDisposeOnHide.dispose()
+            onHide: () => toDisposeOnHide.dispose(),
+            skipSingleRootNode: true,
         });
     }
 

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -224,6 +224,10 @@ export class TabBarToolbar extends ReactWidget {
             if (this.commandIsToggled(item.command)) {
                 classNames.push('toggled');
             }
+        } else {
+            if (this.isEnabled(item)) {
+                classNames.push('enabled');
+            }
         }
         return classNames;
     }

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -459,6 +459,10 @@
   cursor: pointer;
 }
 
+.p-TabBar-toolbar .item.enabled .action-label::before {
+  display: flex;
+}
+
 .p-TabBar-toolbar :not(.item.enabled) .action-label {
   background: transparent;
   cursor: default;

--- a/packages/core/src/common/menu/menu-model-registry.ts
+++ b/packages/core/src/common/menu/menu-model-registry.ts
@@ -269,7 +269,7 @@ export class MenuModelRegistry {
         }
         let nonEmptyNode = undefined;
         for (const child of fullMenuModel.children) {
-            if (!this.isEmpty(child.children!)) {
+            if (!this.isEmpty(child.children || [])) {
                 if (nonEmptyNode === undefined) {
                     nonEmptyNode = child;
                 } else {
@@ -285,16 +285,11 @@ export class MenuModelRegistry {
         return CompoundMenuNode.is(nonEmptyNode) ? nonEmptyNode : fullMenuModel;
     }
 
-    private allChildrenCompound(children: ReadonlyArray<MenuNode>): boolean {
-        for (const child of children) {
-            if (!CompoundMenuNode.is(child)) {
-                return false;
-            }
-        }
-        return true;
+    protected allChildrenCompound(children: ReadonlyArray<MenuNode>): boolean {
+        return children.every(CompoundMenuNode.is);
     }
 
-    private isEmpty(children: ReadonlyArray<MenuNode>): boolean {
+    protected isEmpty(children: ReadonlyArray<MenuNode>): boolean {
         if (children.length === 0) {
             return true;
         }
@@ -302,7 +297,7 @@ export class MenuModelRegistry {
             return false;
         }
         for (const child of children) {
-            if (!this.isEmpty(child.children!)) {
+            if (!this.isEmpty(child.children || [])) {
                 return false;
             }
         }

--- a/packages/core/src/common/menu/menu-model-registry.ts
+++ b/packages/core/src/common/menu/menu-model-registry.ts
@@ -278,6 +278,10 @@ export class MenuModelRegistry {
             }
         }
 
+        if (CompoundMenuNode.is(nonEmptyNode) && nonEmptyNode.children.length === 1 && CompoundMenuNode.is(nonEmptyNode.children[0])) {
+            nonEmptyNode = nonEmptyNode.children[0];
+        }
+
         return CompoundMenuNode.is(nonEmptyNode) ? nonEmptyNode : fullMenuModel;
     }
 

--- a/packages/core/src/common/menu/menu-model-registry.ts
+++ b/packages/core/src/common/menu/menu-model-registry.ts
@@ -255,6 +255,57 @@ export class MenuModelRegistry {
     }
 
     /**
+     * Checks the given menu model whether it will show a menu with a single submenu.
+     *
+     * @param fullMenuModel the menu model to analyze
+     * @param menuPath the menu's path
+     * @returns if the menu will show a single submenu this returns a menu that will show the child elements of the submenu,
+     * otherwise the given `fullMenuModel` is return
+     */
+    removeSingleRootNode(fullMenuModel: MutableCompoundMenuNode, menuPath: MenuPath): CompoundMenuNode {
+        // check whether all children are compound menus and that there is only one child that has further children
+        if (!this.allChildrenCompound(fullMenuModel.children)) {
+            return fullMenuModel;
+        }
+        let nonEmptyNode = undefined;
+        for (const child of fullMenuModel.children) {
+            if (!this.isEmpty(child.children!)) {
+                if (nonEmptyNode === undefined) {
+                    nonEmptyNode = child;
+                } else {
+                    return fullMenuModel;
+                }
+            }
+        }
+
+        return CompoundMenuNode.is(nonEmptyNode) ? nonEmptyNode : fullMenuModel;
+    }
+
+    private allChildrenCompound(children: ReadonlyArray<MenuNode>): boolean {
+        for (const child of children) {
+            if (!CompoundMenuNode.is(child)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private isEmpty(children: ReadonlyArray<MenuNode>): boolean {
+        if (children.length === 0) {
+            return true;
+        }
+        if (!this.allChildrenCompound(children)) {
+            return false;
+        }
+        for (const child of children) {
+            if (!this.isEmpty(child.children!)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Returns the {@link MenuPath path} at which a given menu node can be accessed from this registry, if it can be determined.
      * Returns `undefined` if the `parent` of any node in the chain is unknown.
      */

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -100,8 +100,8 @@ export class ElectronContextMenuRenderer extends BrowserContextMenuRenderer {
 
     protected override doRender(options: RenderContextMenuOptions): ContextMenuAccess {
         if (this.useNativeStyle) {
-            const { menuPath, anchor, args, onHide, context, contextKeyService } = options;
-            const menu = this.electronMenuFactory.createElectronContextMenu(menuPath, args, context, contextKeyService);
+            const { menuPath, anchor, args, onHide, context, contextKeyService, skipSingleRootNode } = options;
+            const menu = this.electronMenuFactory.createElectronContextMenu(menuPath, args, context, contextKeyService, skipSingleRootNode);
             const { x, y } = coordinateFromAnchor(anchor);
 
             const menuHandle = window.electronTheiaCore.popup(menu, x, y, () => {

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -125,8 +125,8 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
         return undefined;
     }
 
-    createElectronContextMenu(menuPath: MenuPath, args?: any[], context?: HTMLElement, contextKeyService?: ContextMatcher): MenuDto[] {
-        const menuModel = this.menuProvider.getMenu(menuPath);
+    createElectronContextMenu(menuPath: MenuPath, args?: any[], context?: HTMLElement, contextKeyService?: ContextMatcher, skipSingleRootNode?: boolean): MenuDto[] {
+        const menuModel = skipSingleRootNode ? this.menuProvider.removeSingleRootNode(this.menuProvider.getMenu(menuPath), menuPath) : this.menuProvider.getMenu(menuPath);
         return this.fillMenuTemplate([], menuModel, args, { showDisabled: true, context, rootMenuPath: menuPath, contextKeyService });
     }
 


### PR DESCRIPTION
#### What it does

The menu registered at the registry is correctly registered (Context menu > Sub Menu > Child Entries). 

In this case the renderer should skip rendering the sub menu however. 
The sub menu is represented by the toolbar button and its tooltip already. 
So we just want to see the child entries in the context menu. 

This PR introduces a helper method to adjust an existing menu-model to be rendered without a single root-submenu. Renderers may use this helper as required.  

* introduce option in RenderContextMenuOptions to ask renderer to not render a menu with single submenu. Instead render only the children
* add helper method to menu-model-registry to remove the parent nodes from a menu node as described above
* adjust renderers and callers accordingly
* fix icons in toolbar

fixes #12706

![Peek 2023-08-08 15-31](https://github.com/eclipse-theia/theia/assets/5889696/4218bdf1-e894-4740-a176-67e4f7468f54)


#### How to test
See the reproducer on #12706

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
