### PR TITLE
Add a command to list installed plugins. 

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -547,8 +547,8 @@ export class ElectronMainApplication {
                 backendProcess.on('error', error => {
                     reject(error);
                 });
-                backendProcess.on('exit', () => {
-                    reject(new Error('backend process exited'));
+                backendProcess.on('exit', code => {
+                    reject(code);
                 });
                 app.on('quit', () => {
                     // Only issue a kill signal if the backend process is running.

--- a/packages/core/src/node/cli.spec.ts
+++ b/packages/core/src/node/cli.spec.ts
@@ -44,7 +44,7 @@ describe('CliManager', () => {
                 value.resolve(args['foo'] as string);
             }
         });
-        await manager.initializeCli(['-f', 'bla']);
+        await manager.initializeCli(['-f', 'bla'], () => Promise.resolve(), () => Promise.resolve());
         chai.assert.equal(await value.promise, 'bla');
     });
 
@@ -59,14 +59,14 @@ describe('CliManager', () => {
                 value.resolve(args['bar'] as string);
             }
         });
-        await manager.initializeCli(['--foo']);
+        await manager.initializeCli(['--foo'], () => Promise.resolve(), () => Promise.resolve());
         chai.assert.equal(await value.promise, 'my-default');
     });
 
     it('prints help and exits', async () =>
         assertExits(async () => {
             const manager = new TestCliManager();
-            await manager.initializeCli(['--help']);
+            await manager.initializeCli(['--help'], () => Promise.resolve(), () => Promise.resolve());
         })
     );
 });

--- a/packages/core/src/node/messaging/ipc-protocol.ts
+++ b/packages/core/src/node/messaging/ipc-protocol.ts
@@ -51,7 +51,7 @@ export function checkParentAlive(): void {
                 } catch {
                     process.exit();
                 }
-            }, 5000);
+            }, 5000).unref(); // we don't want this timeout to keep the process alive
         }
     }
 }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -428,7 +428,7 @@ export interface PluginDeployerStartContext {
 export const PluginDeployer = Symbol('PluginDeployer');
 export interface PluginDeployer {
 
-    start(): void;
+    start(): Promise<void>;
 
 }
 

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -76,6 +76,13 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         return Array.from(this.deployedBackendPlugins.keys());
     }
 
+    async getDeployedBackendPlugins(): Promise<DeployedPlugin[]> {
+        // await first deploy
+        await this.backendPluginsMetadataDeferred.promise;
+        // fetch the last deployed state
+        return Array.from(this.deployedBackendPlugins.values());
+    }
+
     getDeployedPluginsById(pluginId: string): DeployedPlugin[] {
         const matches: DeployedPlugin[] = [];
         const handle = (plugins: Iterable<DeployedPlugin>): void => {

--- a/packages/plugin-ext/src/main/node/plugin-deployer-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-contribution.ts
@@ -28,7 +28,7 @@ export class PluginDeployerContribution implements BackendApplicationContributio
     @inject(PluginDeployer)
     protected pluginDeployer: PluginDeployer;
 
-    initialize(): void {
-        this.pluginDeployer.start();
+    initialize(): Promise<void> {
+        return this.pluginDeployer.start();
     }
 }

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -75,9 +75,9 @@ export class PluginDeployerImpl implements PluginDeployer {
     @inject(ContributionProvider) @named(PluginDeployerParticipant)
     protected readonly participants: ContributionProvider<PluginDeployerParticipant>;
 
-    public start(): void {
+    public start(): Promise<void> {
         this.logger.debug('Starting the deployer with the list of resolvers', this.pluginResolvers);
-        this.doStart();
+        return this.doStart();
     }
 
     public async initResolvers(): Promise<Array<void>> {

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -41,6 +41,7 @@ import { WebviewBackendSecurityWarnings } from './webview-backend-security-warni
 import { PluginUninstallationManager } from './plugin-uninstallation-manager';
 import { LocalizationServerImpl } from '@theia/core/lib/node/i18n/localization-server';
 import { PluginLocalizationServer } from './plugin-localization-server';
+import { PluginMgmtCliContribution } from './plugin-mgmt-cli-contribution';
 
 export function bindMainBackend(bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
@@ -84,6 +85,9 @@ export function bindMainBackend(bind: interfaces.Bind, unbind: interfaces.Unbind
 
     bind(PluginCliContribution).toSelf().inSingletonScope();
     bind(CliContribution).toService(PluginCliContribution);
+
+    bind(PluginMgmtCliContribution).toSelf().inSingletonScope();
+    bind(CliContribution).toService(PluginMgmtCliContribution);
 
     bind(WebviewBackendSecurityWarnings).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(WebviewBackendSecurityWarnings);

--- a/packages/plugin-ext/src/main/node/plugin-mgmt-cli-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-mgmt-cli-contribution.ts
@@ -1,0 +1,64 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { Argv, Arguments } from '@theia/core/shared/yargs';
+import { CliContribution } from '@theia/core/lib/node/cli';
+import { HostedPluginDeployerHandler } from '../../hosted/node/hosted-plugin-deployer-handler';
+import { PluginType } from '../../common';
+
+@injectable()
+export class PluginMgmtCliContribution implements CliContribution {
+
+    static LIST_PLUGINS = 'list-plugins';
+    static SHOW_VERSIONS = '--show-versions';
+    static SHOW_BUILTINS = '--show-builtins';
+
+    @inject(HostedPluginDeployerHandler)
+    protected deployerHandler: HostedPluginDeployerHandler;
+
+    configure(conf: Argv): void {
+        conf.command([PluginMgmtCliContribution.LIST_PLUGINS, 'list-extensions'],
+            'List the installed plugins',
+            yargs => yargs.option(PluginMgmtCliContribution.SHOW_VERSIONS, {
+                description: 'List the versions of the installed plugins',
+                type: 'boolean',
+                default: false,
+            }).option(PluginMgmtCliContribution.SHOW_BUILTINS, {
+                description: 'List the built-in plugins',
+                type: 'boolean',
+                default: false,
+            }),
+
+            async yargs => {
+                const showVersions = yargs[PluginMgmtCliContribution.SHOW_VERSIONS];
+                const deployedIds = await this.deployerHandler.getDeployedBackendPlugins();
+                const pluginType = yargs[PluginMgmtCliContribution.SHOW_BUILTINS] ? PluginType.System : PluginType.User;
+                process.stdout.write('installed plugins:\n');
+                deployedIds.filter(plugin => plugin.type === pluginType).forEach(plugin => {
+                    if (showVersions) {
+                        process.stdout.write(`${plugin.metadata.model.id}@${plugin.metadata.model.version}\n`);
+                    } else {
+                        process.stdout.write(`${plugin.metadata.model.id}\n`);
+                    }
+                });
+            }
+        );
+    }
+
+    setArguments(args: Arguments): void {
+    }
+}

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -43,7 +43,7 @@ export class WorkspaceCliContribution implements CliContribution {
     }
 
     async setArguments(args: yargs.Arguments): Promise<void> {
-        const workspaceArguments = args._.slice(2).map(probablyAlreadyString => String(probablyAlreadyString));
+        const workspaceArguments = args._.map(probablyAlreadyString => String(probablyAlreadyString));
         if (workspaceArguments.length === 0 && args['root-dir']) {
             workspaceArguments.push(String(args['root-dir']));
         }


### PR DESCRIPTION
Contributed on behalf of STMicroelectronics

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Allows cli-contributions to add commands to the `yargs` instance as well as options. The change required a couple of adjustments, for example: 
- the mock vsx server BackendApplicatinContribution relied on the back-end app to be started in order to finish it's configuration
- The BackendApplicatinContribution init and configure methods are now called in parallel for all contributions instead of sequentially.

The new command is called `list-plugins` with the alias `list-extensions`. `yargs` does not allow for commands that start with `--`, so we can't do it just the same as in VS Code. There are two options for the new command: 
- `--show-builtins` shows the built-ins instead of installed plugins
- `--show-versions` shows the versions that are installed.

Fixes #12298

#### How to test
Make sure the --list-plugins works as described above with various other options like `--no-cluster` and via `yarn` as well as `npx theia`, or when debugging the browser and electron back ends.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
