### PR TITLE
getting-started: fix checkbox overlapping with other content for small viewports

### DIFF
--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -129,8 +129,8 @@ export class GettingStartedWidget extends ReactWidget {
      * Render the content of the widget.
      */
     protected render(): React.ReactNode {
-        return <div>
-            <div className='gs-container'>
+        return <div className='gs-container'>
+            <div className='gs-content-container'>
                 {this.renderHeader()}
                 <hr className='gs-hr' />
                 <div className='flex-grid'>

--- a/packages/getting-started/src/browser/style/index.css
+++ b/packages/getting-started/src/browser/style/index.css
@@ -39,10 +39,17 @@ body {
 }
 
 .gs-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.gs-content-container {
   padding: 20px;
 }
 
-.gs-container a {
+.gs-content-container a {
   cursor: pointer;
 }
 
@@ -92,14 +99,10 @@ body {
 
 .gs-preference-container {
   display: flex;
-  position: absolute;
-  bottom: 0;
-  width: 100%;
   justify-content: center;
 }
 
 .gs-preference {
-  margin-top: 20px;
   margin-bottom: 20px;
   display: flex;
   align-items: center;


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: https://github.com/eclipse-theia/theia/issues/12822

This PR fixes the issue with the getting-started preference checkbox overlapping with other content for small viewports. It achieves this by adding styling to the main getting-started container which includes: `justify-content: space-between`. 

Before:
![checkbox styling error](https://github.com/eclipse-theia/theia/assets/86936229/09844df2-0eb9-4297-9eea-87d848d8ffd7)

After:
![checkbox styling fix](https://github.com/eclipse-theia/theia/assets/86936229/eaeb9b92-7f0f-498d-8dae-fe4afbfbe232)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open Theia.
2. If welcome page is not opened, open the command palette (`Ctrl`+`Shift`+`p`) and search for `welcome`.
3. Resize the application, reducing its view.
4. The preference checkbox should not overlap with other content.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
