### PR TITLE
Fix plugin menu icon background on hover

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
@@ -110,7 +110,8 @@ export class PluginSharedStyle {
         const lightIconUrl = PluginSharedStyle.toExternalIconUrl(`${typeof iconUrl === 'object' ? iconUrl.light : iconUrl}`);
         const iconClass = 'plugin-icon-' + this.iconSequence++;
         const toDispose = new DisposableCollection();
-        toDispose.push(this.insertRule('.' + iconClass, theme => `
+        toDispose.push(this.insertRule('.' + iconClass + '::before', theme => `
+                content: "";
                 background-position: 2px;
                 width: ${size}px;
                 height: ${size}px;


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12826

Replaces the css rule on the icon element with a `::before` element that emulates the same behavior. That leaves the background attribute on the icon element free to use ourselves.

#### How to test

Follow the instructions in https://github.com/eclipse-theia/theia/issues/12826 to ensure that the behavior has been fixed.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
