### PR TITLE
repo: add `js-debug` and `js-debug-companion` builtins

### DIFF
--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -9,6 +9,21 @@ Please see the latest version (`master`) for the most up-to-date information. Pl
 
 ### General
 
+_Builtin Extension Pack_:
+
+If you are using the [`eclipse-theia.builtin-extension-pack@1.79.0`](https://open-vsx.org/extension/eclipse-theia/builtin-extension-pack) extension pack you may need to include the [`ms-vscode.js-debug`](https://open-vsx.org/extension/ms-vscode/js-debug) and [`ms-vscode.js-debug-companion`](https://open-vsx.org/extension/ms-vscode/js-debug-companion) plugins for JavaScript debug support.
+There was an issue when the publishing of the pack which excluded these necessary builtins.
+
+For example, in your application's `package.json`:
+
+```json
+"theiaPlugins": {
+  "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.79.0/file/eclipse-theia.builtin-extension-pack-1.79.0.vsix",
+  "ms-vscode.js-debug": "https://open-vsx.org/api/ms-vscode/js-debug/1.78.0/file/ms-vscode.js-debug-1.78.0.vsix",
+  "ms-vscode.js-debug-companion": "https://open-vsx.org/api/ms-vscode/js-debug-companion/1.1.2/file/ms-vscode.js-debug-companion-1.1.2.vsix"
+}
+```
+
 _msgpackr_:
 
 If you're experiencing [`maximum callstack exceeded`](https://github.com/eclipse-theia/theia/issues/12499) errors you may need to downgrade the version of `msgpackr` pulled using a [yarn resolution](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).
@@ -72,15 +87,15 @@ For 2., `@postConstruct` methods can be refactored into a sync and an async meth
 ```diff
 -@postConstruct()
 -protected async init(): Promise<void> {
--  await longRunningOperation(); 
+-  await longRunningOperation();
 -}
 +@postConstruct()
 +protected init(): void {
-+  this.doInit();   
++  this.doInit();
 +}
 +
 +protected async doInit(): Promise<void> {
-+  await longRunningOperation();    
++  await longRunningOperation();
 +}
 ```
 

--- a/package.json
+++ b/package.json
@@ -102,7 +102,9 @@
   "theiaPlugins": {
     "eclipse-theia.builtin-extension-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.79.0/file/eclipse-theia.builtin-extension-pack-1.79.0.vsix",
     "EditorConfig.EditorConfig": "https://open-vsx.org/api/EditorConfig/EditorConfig/0.16.6/file/EditorConfig.EditorConfig-0.16.6.vsix",
-    "dbaeumer.vscode-eslint": "https://open-vsx.org/api/dbaeumer/vscode-eslint/2.4.2/file/dbaeumer.vscode-eslint-2.4.2.vsix"
+    "dbaeumer.vscode-eslint": "https://open-vsx.org/api/dbaeumer/vscode-eslint/2.4.2/file/dbaeumer.vscode-eslint-2.4.2.vsix",
+    "ms-vscode.js-debug": "https://open-vsx.org/api/ms-vscode/js-debug/1.78.0/file/ms-vscode.js-debug-1.78.0.vsix",
+    "ms-vscode.js-debug-companion": "https://open-vsx.org/api/ms-vscode/js-debug-companion/1.1.2/file/ms-vscode.js-debug-companion-1.1.2.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Related: https://github.com/eclipse-theia/vscode-builtin-extensions/issues/123.

Due to an issue when publishing the builtin extension-pack for `1.79.0` we need to manually add the `js-debug` and `js-debug-companion` plugins for JavaScript debugging support.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. confirm that the builtins are downloaded as expected
2. confirm that debugging functionality works as expected
    - start the application with `theia` as a workspace
    - open a `*.spec.ts` file
    - set a breakpoint in the file
    - select the `run mocha test` debug launch configuration
    - confirm debugging works as expected 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
