### PR TITLE
fix scm history going out of sync after commit (with fixed avatar cache)

### DIFF
--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -179,7 +179,6 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
     }
 
     protected async addCommits(options?: HistoryWidgetOptions): Promise<void> {
-        // const repository: Repository | undefined = this.repositoryProvider.findRepositoryOrSelected(options);
         const repository = this.scmService.selectedRepository;
 
         this.cancelIndicator.cancel();
@@ -189,19 +188,17 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
         if (repository) {
             if (this.historySupport) {
                 try {
-                    const currentCommits = this.status.state === 'ready' ? this.status.commits : [];
-
-                    let history = await this.historySupport.getCommitHistory(options);
+                    const history = await this.historySupport.getCommitHistory(options);
                     if (token.isCancellationRequested || !this.hasMoreCommits) {
                         return;
                     }
 
-                    if (options && ((options.maxCount && history.length < options.maxCount) || (!options.maxCount && currentCommits))) {
+                    if (options && (options.maxCount && history.length < options.maxCount)) {
                         this.hasMoreCommits = false;
                     }
-                    if (currentCommits.length > 0) {
-                        history = history.slice(1);
-                    }
+
+                    const avatarCache = new Map<string, string>();
+
                     const commits: ScmCommitNode[] = [];
                     for (const commit of history) {
                         const fileChangeNodes: ScmFileChangeNode[] = [];
@@ -211,7 +208,13 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
                             });
                         }));
 
-                        const avatarUrl = await this.avatarService.getAvatar(commit.authorEmail);
+                        let avatarUrl = '';
+                        if (avatarCache.has(commit.authorEmail)) {
+                            avatarUrl = avatarCache.get(commit.authorEmail)!;
+                        } else {
+                            avatarUrl = await this.avatarService.getAvatar(commit.authorEmail);
+                        }
+
                         commits.push({
                             commitDetails: commit,
                             authorAvatar: avatarUrl,
@@ -220,8 +223,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
                             selected: false
                         });
                     }
-                    currentCommits.push(...commits);
-                    this.status = { state: 'ready', commits: currentCommits };
+                    this.status = { state: 'ready', commits };
                 } catch (error) {
                     if (options && options.uri && repository) {
                         this.hasMoreCommits = false;

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -213,6 +213,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
                             avatarUrl = avatarCache.get(commit.authorEmail)!;
                         } else {
                             avatarUrl = await this.avatarService.getAvatar(commit.authorEmail);
+                            avatarCache.set(commit.authorEmail, avatarUrl);
                         }
 
                         commits.push({


### PR DESCRIPTION
Continuation of https://github.com/eclipse-theia/theia/pull/12592 to address https://github.com/eclipse-theia/theia/pull/12592#issuecomment-1677292372.
Closes https://github.com/eclipse-theia/theia/pull/12592.

> #### What it does
> * Fixes [Git extension widgets "Git" and "Git History" not synchronized #2922](https://github.com/eclipse-theia/theia/issues/2922) issue where new git commits don't appear in the history view
> * Also fixes duplicate commits appearing in the history view
> 
> #### How to test
> * open a git repository
> * change a file and commit it
> * switch to the history view
> * the commit should appear at the top
> 
> #### Review checklist
> * [x]  As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
> 
> #### Reminder for reviewers
> * As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

