### PR TITLE
getting-started: fixed `open folder` link

### DIFF
--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -270,8 +270,8 @@ export class GettingStartedWidget extends ReactWidget {
                 <a
                     role={'button'}
                     tabIndex={0}
-                    onClick={this.doOpenWorkspace}
-                    onKeyDown={this.doOpenWorkspaceEnter}>
+                    onClick={this.doOpenFolder}
+                    onKeyDown={this.doOpenFolderEnter}>
                     {nls.localizeByDefault('open a folder')}
                 </a>
                 {' ' + nls.localizeByDefault('to start.')}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request fixes a bug where the getting-started page prompted users to select a workspace file instead of a workspace folder when triggering the `open folder` link when no recent workspaces are present.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. setup: clear history (ex: `rm ~/.theia/recentworkspace.json`)
2. start the application
3. open the `getting-started` (welcome) page
4. in the `recent` list, select `open a folder`
5. confirm the open folder dialog is present, and allows users to select folders

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
