### PR TITLE
vsx-registry: add hint to fetching extensions error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 - [task] added handling to ensure contributed problem matchers are successfully discovered [#12805](https://github.com/eclipse-theia/theia/pull/12805)
 - [task] fixed error thrown for custom task execution [#12770](https://github.com/eclipse-theia/theia/pull/12770)
 - [vscode] added support for tree checkbox api [#12836](https://github.com/eclipse-theia/theia/pull/12836) - Contributed on behalf of STMicroelectronics
-- [vsx-registry] added a hint to extension fetching errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics
+- [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics
 - [workspace] fixed saving of untitled text editors when closing a workspace or closing the application [#12577](https://github.com/eclipse-theia/theia/pull/12577)
 
 <a name="breaking_changes_1.41.0">[Breaking Changes:](#breaking_changes_1.41.0)</a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v1.42.0
+
+- [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics
+
 ## v1.41.0 - 08/31/2023
 
 - [application-package] added handling to quit the electron app when the backend fails to start [#12778](https://github.com/eclipse-theia/theia/pull/12778) - Contributed on behalf of STMicroelectronics.
@@ -45,7 +49,6 @@
 - [task] added handling to ensure contributed problem matchers are successfully discovered [#12805](https://github.com/eclipse-theia/theia/pull/12805)
 - [task] fixed error thrown for custom task execution [#12770](https://github.com/eclipse-theia/theia/pull/12770)
 - [vscode] added support for tree checkbox api [#12836](https://github.com/eclipse-theia/theia/pull/12836) - Contributed on behalf of STMicroelectronics
-- [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics
 - [workspace] fixed saving of untitled text editors when closing a workspace or closing the application [#12577](https://github.com/eclipse-theia/theia/pull/12577)
 
 <a name="breaking_changes_1.41.0">[Breaking Changes:](#breaking_changes_1.41.0)</a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [task] added handling to ensure contributed problem matchers are successfully discovered [#12805](https://github.com/eclipse-theia/theia/pull/12805)
 - [task] fixed error thrown for custom task execution [#12770](https://github.com/eclipse-theia/theia/pull/12770)
 - [vscode] added support for tree checkbox api [#12836](https://github.com/eclipse-theia/theia/pull/12836) - Contributed on behalf of STMicroelectronics
+- [vsx-registry] added a hint to extension fetching errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics
 - [workspace] fixed saving of untitled text editors when closing a workspace or closing the application [#12577](https://github.com/eclipse-theia/theia/pull/12577)
 
 <a name="breaking_changes_1.41.0">[Breaking Changes:](#breaking_changes_1.41.0)</a>

--- a/packages/core/i18n/nls.json
+++ b/packages/core/i18n/nls.json
@@ -434,7 +434,6 @@
     "vsx-registry": {
       "downloadCount": "Download count: {0}",
       "errorFetching": "Error fetching extensions.",
-      "errorFetchingHint": "This could be caused by network configuration issues.",
       "failedInstallingVSIX": "Failed to install {0} from VSIX.",
       "invalidVSIX": "The selected file is not a valid \"*.vsix\" plugin.",
       "license": "License: {0}",

--- a/packages/core/i18n/nls.json
+++ b/packages/core/i18n/nls.json
@@ -434,6 +434,7 @@
     "vsx-registry": {
       "downloadCount": "Download count: {0}",
       "errorFetching": "Error fetching extensions.",
+      "errorFetchingHint": "This could be caused by network configuration issues.",
       "failedInstallingVSIX": "Failed to install {0} from VSIX.",
       "invalidVSIX": "The selected file is not a valid \"*.vsix\" plugin.",
       "license": "License: {0}",

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
@@ -143,9 +143,10 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
             const searchError = this.extensionsSource.getModel().searchError;
             if (!!searchError) {
                 const message = nls.localize('theia/vsx-registry/errorFetching', 'Error fetching extensions.');
+                const hint = nls.localize('theia/vsx-registry/errorFetchingHint', 'This could be caused by network configuration issues.');
                 return <AlertMessage
                     type='ERROR'
-                    header={`${message} ${searchError}`}
+                    header={`${message} ${searchError} ${hint}`}
                 />;
             }
         }

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
@@ -143,7 +143,8 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
             const searchError = this.extensionsSource.getModel().searchError;
             if (!!searchError) {
                 const message = nls.localize('theia/vsx-registry/errorFetching', 'Error fetching extensions.');
-                const hint = nls.localize('theia/vsx-registry/errorFetchingHint', 'This could be caused by network configuration issues.');
+                const configurationHint = nls.localize('theia/vsx-registry/errorFetchingConfigurationHint', 'This could be caused by network configuration issues.');
+                const hint = searchError.includes('ENOTFOUND') ? configurationHint : '';
                 return <AlertMessage
                     type='ERROR'
                     header={`${message} ${searchError} ${hint}`}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

When browsing the VSX registry while having network configuration issues (e.g. proxy issues), the error message is a bit vague. E.g:
"Error fetching extensions. getaddrinfo ENOTFOUND open-vsx.org"

This PR addresses the issue by changing the user message to the following:
"Error fetching extensions. getaddrinfo ENOTFOUND open-vsx.org This could be caused by network configuration issues."

Clarifies the error by suggesting it could be caused by network configuration issues.

Contributed by STMicroelectronics
Signed-off-by: Samuel BERG <samuel.berg@st.com>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Produce a network issue. E.g. adding the line "127.0.0.1 open-vsx.org" to `C:\Windows\System32\drivers\etc\hosts` (Windows) / `/etc/hosts` (Linux).
2. Launch a Theia application.
   Option A: Launch a Theia example with an invalid ovsx-router-config path (e.g. `--ovsx-router-config=invalid-path`) to exclude the local mock VSX registry.
   Option B: Launch Theia Blueprint as-is.
4. Open the `Extensions` view.
5. Enter a search term (e.g. "C++").
6. Ensure that the error message is the following:
"Error fetching extensions. _{ERROR}_ _{IP_ADDRESS}_ This could be caused by network configuration issues."

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)