### PR TITLE
Codicon color and URI support to `TerminalOptions`

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -171,6 +171,17 @@
   padding-right: 8px;
 }
 
+.p-TabBar.theia-app-centers .p-TabBar-tabIcon[class*="plugin-icon-"],
+.p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon[class*="plugin-icon-"] {
+  background: none;
+  height: var(--theia-icon-size);
+}
+
+.p-TabBar.theia-app-centers .p-TabBar-tabIcon[class*="plugin-icon-"]::before,
+.p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon[class*="plugin-icon-"]::before {
+  display: inline-block;
+}
+
 /* codicons */
 .p-TabBar.theia-app-centers .p-TabBar-tabIcon.codicon,
 .p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon.codicon {

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -30,6 +30,7 @@ import { getIconClass } from '../../plugin/terminal-ext';
 import { PluginTerminalRegistry } from './plugin-terminal-registry';
 import { CancellationToken } from '@theia/core';
 import { HostedPluginSupport } from '../../hosted/browser/hosted-plugin';
+import { PluginSharedStyle } from './plugin-shared-style';
 
 /**
  * Plugin api service allows working with terminal emulator.
@@ -41,6 +42,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
     private readonly hostedPluginSupport: HostedPluginSupport;
     private readonly shell: ApplicationShell;
     private readonly extProxy: TerminalServiceExt;
+    private readonly sharedStyle: PluginSharedStyle;
     private readonly shellTerminalServer: ShellTerminalServerProxy;
     private readonly terminalLinkProviders: string[] = [];
 
@@ -50,6 +52,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
         this.terminals = container.get(TerminalService);
         this.pluginTerminalRegistry = container.get(PluginTerminalRegistry);
         this.hostedPluginSupport = container.get(HostedPluginSupport);
+        this.sharedStyle = container.get(PluginSharedStyle);
         this.shell = container.get(ApplicationShell);
         this.shellTerminalServer = container.get(ShellTerminalServerProxy);
         this.extProxy = rpc.getProxy(MAIN_RPC_CONTEXT.TERMINAL_EXT);
@@ -140,7 +143,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
         const terminal = await this.terminals.newTerminal({
             id,
             title: options.name,
-            iconClass: getIconClass(options),
+            iconClass: getIconClass(options, this.sharedStyle, this.toDispose),
             shellPath: options.shellPath,
             shellArgs: options.shellArgs,
             cwd: options.cwd ? new URI(options.cwd) : undefined,

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -530,7 +530,7 @@ export function createAPIFactory(
             createTerminal(nameOrOptions: theia.TerminalOptions | theia.ExtensionTerminalOptions | theia.ExtensionTerminalOptions | (string | undefined),
                 shellPath?: string,
                 shellArgs?: string[] | string): theia.Terminal {
-                return terminalExt.createTerminal(nameOrOptions, shellPath, shellArgs);
+                return terminalExt.createTerminal(plugin, nameOrOptions, shellPath, shellArgs);
             },
             onDidChangeTerminalState,
             onDidCloseTerminal,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3140,7 +3140,7 @@ export module '@theia/plugin' {
         /**
          * The icon path or {@link ThemeIcon} for the terminal.
          */
-        iconPath?: ThemeIcon;
+        iconPath?: string | ThemeIcon | Uri | { light: Uri | string, dark: Uri | string };
 
         /**
          * The icon {@link ThemeColor} for the terminal.
@@ -3261,7 +3261,7 @@ export module '@theia/plugin' {
         /**
          * The icon path or {@link ThemeIcon} for the terminal.
          */
-        iconPath?: ThemeIcon;
+        iconPath?: string | ThemeIcon | Uri | { light: Uri | string, dark: Uri | string };
 
         /**
          * The icon {@link ThemeColor} for the terminal.

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -178,9 +178,9 @@ export interface TerminalWidgetOptions {
     readonly title?: string;
 
     /**
-     * icon class
+     * icon class with or without color modifier
      */
-    readonly iconClass?: string;
+    readonly iconClass?: string | {icon: string, color: string};
 
     /**
      * Path to the executable shell. For example: `/bin/bash`, `bash`, `sh`.


### PR DESCRIPTION
#### What it does
Closes #12074

- This commit adds URI and { light, dark } support for terminal icons.
- This commit adds ColorTheme support for ThemeIcons
- Support for `ExtensionTerminalOptions#iconPath`

#### How to test
1. Open Theia
2. Install from VSIX [the test extension](https://github.com/eclipse-theia/theia/files/12434150/terminalcreationtests-0.0.1.zip)
3. Check the result follow VSCode test results seen below:

VSCode test Results
Dark
<img width="190" alt="TerminalIconTests" src="https://github.com/eclipse-theia/theia/assets/48699277/fe36b9c4-9ea8-450f-8d36-6dfa165f85ff">
Light
<img width="192" alt="TerminalIconTestsLight" src="https://github.com/eclipse-theia/theia/assets/48699277/ea7f19ca-f685-493e-b011-20723b88b5f7">

###### Wishlist or Missing
- Manage color change for URI icons
  - Possible implementation using CSS filter property with possible issues with older browsers.
- Manage other color formats aside from default `terminal.ansi**color**`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
