### PR TITLE
Create new untitled file when double clicking on the main area or tabbar

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -246,8 +246,8 @@ export class ApplicationShell extends Widget {
     protected readonly onDidChangeCurrentWidgetEmitter = new Emitter<FocusTracker.IChangedArgs<Widget>>();
     readonly onDidChangeCurrentWidget = this.onDidChangeCurrentWidgetEmitter.event;
 
-    protected readonly onDidRequestNewUntitledTextFileEmitter = new Emitter<void>();
-    readonly onDidRequestNewUntitledTextFile = this.onDidRequestNewUntitledTextFileEmitter.event;
+    protected readonly onDidDoubleClickMainAreaEmitter = new Emitter<void>();
+    readonly onDidDoubleClickMainArea = this.onDidDoubleClickMainAreaEmitter.event;
 
     @inject(TheiaDockPanel.Factory)
     protected readonly dockPanelFactory: TheiaDockPanel.Factory;
@@ -585,7 +585,7 @@ export class ApplicationShell extends Widget {
         dockPanel.node.addEventListener('dblclick', event => {
             const el = event.target as Element;
             if (el.id === MAIN_AREA_ID || el.classList.contains('p-TabBar-content')) {
-                this.onDidRequestNewUntitledTextFileEmitter.fire();
+                this.onDidDoubleClickMainAreaEmitter.fire();
             }
         });
 

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -246,6 +246,9 @@ export class ApplicationShell extends Widget {
     protected readonly onDidChangeCurrentWidgetEmitter = new Emitter<FocusTracker.IChangedArgs<Widget>>();
     readonly onDidChangeCurrentWidget = this.onDidChangeCurrentWidgetEmitter.event;
 
+    protected readonly onDidRequestNewUntitledTextFileEmitter = new Emitter<void>();
+    readonly onDidRequestNewUntitledTextFile = this.onDidRequestNewUntitledTextFileEmitter.event;
+
     @inject(TheiaDockPanel.Factory)
     protected readonly dockPanelFactory: TheiaDockPanel.Factory;
 
@@ -578,6 +581,14 @@ export class ApplicationShell extends Widget {
                 }
             }
         });
+
+        dockPanel.node.addEventListener('dblclick', event => {
+            const el = event.target as Element;
+            if (el.id === MAIN_AREA_ID || el.classList.contains('p-TabBar-content')) {
+                this.onDidRequestNewUntitledTextFileEmitter.fire();
+            }
+        });
+
         const handler = (e: DragEvent) => {
             if (e.dataTransfer) {
                 e.dataTransfer.dropEffect = 'link';

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -61,6 +61,7 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     protected override init(): void {
         super.init();
         this.shell.onDidChangeActiveWidget(() => this.updateActiveEditor());
+        this.shell.onDidChangeCurrentWidget(() => this.updateCurrentEditor());
         this.shell.onDidDoubleClickMainArea(() =>
             this.commands.executeCommand(CommonCommands.NEW_UNTITLED_TEXT_FILE.id)
         );

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -16,8 +16,8 @@
 
 import { injectable, postConstruct, inject } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
-import { RecursivePartial, Emitter, Event, MaybePromise } from '@theia/core/lib/common';
-import { WidgetOpenerOptions, NavigatableWidgetOpenHandler, NavigatableWidgetOptions, Widget, PreferenceService } from '@theia/core/lib/browser';
+import { RecursivePartial, Emitter, Event, MaybePromise, CommandService } from '@theia/core/lib/common';
+import { WidgetOpenerOptions, NavigatableWidgetOpenHandler, NavigatableWidgetOptions, Widget, PreferenceService, CommonCommands } from '@theia/core/lib/browser';
 import { EditorWidget } from './editor-widget';
 import { Range, Position, Location, TextEditor } from './editor';
 import { EditorWidgetFactory } from './editor-widget-factory';
@@ -54,13 +54,16 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
      */
     readonly onCurrentEditorChanged: Event<EditorWidget | undefined> = this.onCurrentEditorChangedEmitter.event;
 
+    @inject(CommandService) protected readonly commands: CommandService;
     @inject(PreferenceService) protected readonly preferenceService: PreferenceService;
 
     @postConstruct()
     protected override init(): void {
         super.init();
         this.shell.onDidChangeActiveWidget(() => this.updateActiveEditor());
-        this.shell.onDidChangeCurrentWidget(() => this.updateCurrentEditor());
+        this.shell.onDidRequestNewUntitledTextFile(() =>
+            this.commands.executeCommand(CommonCommands.NEW_UNTITLED_TEXT_FILE.id)
+        );
         this.onCreated(widget => {
             widget.onDidChangeVisibility(() => {
                 if (widget.isVisible) {

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -61,7 +61,7 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     protected override init(): void {
         super.init();
         this.shell.onDidChangeActiveWidget(() => this.updateActiveEditor());
-        this.shell.onDidRequestNewUntitledTextFile(() =>
+        this.shell.onDidDoubleClickMainArea(() =>
             this.commands.executeCommand(CommonCommands.NEW_UNTITLED_TEXT_FILE.id)
         );
         this.onCreated(widget => {


### PR DESCRIPTION
#### What it does
Fixes #8916

#### How to test
Double click on the empty area of the main dock panel when no widgets are opened or on the empty area of a tabbar. It should open a new untitled text file.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
