### PR TITLE
tabbar: fix command contributions regression

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -150,7 +150,7 @@ export class TabBarToolbar extends ReactWidget {
         return <React.Fragment>
             {this.renderMore()}
             {[...this.inline.values()].map(item => TabBarToolbarItem.is(item)
-                ? (MenuToolbarItem.is(item) ? this.renderMenuItem(item) : this.renderItem(item))
+                ? (MenuToolbarItem.is(item) && !item.command ? this.renderMenuItem(item) : this.renderItem(item))
                 : item.render(this.current))}
         </React.Fragment>;
     }


### PR DESCRIPTION
#### What it does

The merge of #12799 introduced a regression in the rendering of `MenuToolbarItem`s that aren't pop-up menus but instead just commands that
happen to have a menu path: they were rendered as pop-up menus instead of simple buttons.

This fix refines the condition for the new pop-up menu rendering to check that the menu to be rendered is not a command to be executed directly on click.

Fixes #12687

#### How to test

1. Re-verify the original test scenario from #12799, the original fix for the issue.
2. Quit Theia.
3. Switch your clone of [the OP's Theia Sandbox repository](/jcortell68/theiasandbox) to the `menu_bug_1` branch.
4. Launch Theia again.
5. Observe that in an editor now the "Hello World" and "Goodbye World" actions contributed by the `myext` extension to the toolbar are rendered as separate buttons that don't show pop-up menus when clicked but just execute their commands, as is correct. _Note that the action without the icon will not be rendered correctly, which is the problem to be addressed in #12686._ It should look like this, exactly as in the description of 12686:

![CleanShot 2023-08-28 at 17 37 30](https://github.com/eclipse-theia/theia/assets/1615558/f06687e8-879f-464f-aefd-9934d1f6b70f)

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
