### PR TITLE
Update nls metadata to vscode version 1.80.0

### DIFF
--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -1,5 +1,8 @@
 {
 	"keys": {
+		"vs/platform/terminal/node/ptyHostMain": [
+			"ptyHost"
+		],
 		"vs/code/electron-main/main": [
 			"mainLog",
 			"secondInstanceAdmin",
@@ -21,9 +24,6 @@
 		],
 		"vs/code/node/sharedProcess/sharedProcessMain": [
 			"sharedLog"
-		],
-		"vs/platform/terminal/node/ptyHostMain": [
-			"ptyHost"
 		],
 		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
 			"name",
@@ -92,6 +92,7 @@
 			"argv.crashReporterId",
 			"argv.enebleProposedApi",
 			"argv.logLevel",
+			"argv.disableChromiumSandbox",
 			"argv.force-renderer-accessibility"
 		],
 		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
@@ -116,6 +117,14 @@
 			"workspaceOpenedDetail",
 			"restartExtensionHost.reason"
 		],
+		"vs/workbench/services/secrets/electron-sandbox/secretStorageService": [
+			"troubleshootingButton",
+			"encryptionNotAvailableJustTroubleshootingGuide",
+			"usePlainTextExtraSentence",
+			"usePlainText",
+			"isGnome",
+			"isKwallet"
+		],
 		"vs/workbench/services/localization/electron-sandbox/localeService": [
 			"argvInvalid",
 			"openArgv",
@@ -133,13 +142,13 @@
 			"local",
 			"remote"
 		],
-		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
-			"join.workingCopyBackups"
-		],
 		"vs/workbench/services/integrity/electron-sandbox/integrityService": [
 			"integrity.prompt",
 			"integrity.moreInformation",
 			"integrity.dontShowAgain"
+		],
+		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
+			"join.workingCopyBackups"
 		],
 		"vs/workbench/services/extensions/electron-sandbox/nativeExtensionService": [
 			"extensionService.versionMismatchCrash",
@@ -323,6 +332,56 @@
 				]
 			}
 		],
+		"vs/platform/environment/node/argv": [
+			"optionsUpperCase",
+			"extensionsManagement",
+			"troubleshooting",
+			"cliDataDir",
+			"diff",
+			"merge",
+			"add",
+			"goto",
+			"newWindow",
+			"reuseWindow",
+			"wait",
+			"locale",
+			"userDataDir",
+			"profileName",
+			"help",
+			"extensionHomePath",
+			"listExtensions",
+			"showVersions",
+			"category",
+			"installExtension",
+			"install prerelease",
+			"uninstallExtension",
+			"experimentalApis",
+			"version",
+			"verbose",
+			"log",
+			"status",
+			"prof-startup",
+			"disableExtensions",
+			"disableExtension",
+			"turn sync",
+			"inspect-extensions",
+			"inspect-brk-extensions",
+			"disableGPU",
+			"disableChromiumSandbox",
+			"telemetry",
+			"deprecated.useInstead",
+			"paths",
+			"usage",
+			"options",
+			"stdinWindows",
+			"stdinUnix",
+			"subcommands",
+			"unknownVersion",
+			"unknownCommit"
+		],
+		"vs/platform/terminal/node/ptyService": [
+			"terminal-history-restored"
+		],
 		"vs/editor/common/config/editorOptions": [
 			"accessibilitySupport.auto",
 			"accessibilitySupport.on",
@@ -504,6 +563,7 @@
 			"editor.suggest.showUsers",
 			"editor.suggest.showIssues",
 			"selectLeadingAndTrailingWhitespace",
+			"selectSubwords",
 			"wrappingIndent.none",
 			"wrappingIndent.same",
 			"wrappingIndent.indent",
@@ -548,6 +608,10 @@
 			"codeLensFontFamily",
 			"codeLensFontSize",
 			"colorDecorators",
+			"editor.colorDecoratorActivatedOn.clickAndHover",
+			"editor.colorDecoratorActivatedOn.hover",
+			"editor.colorDecoratorActivatedOn.click",
+			"colorDecoratorActivatedOn",
 			"colorDecoratorsLimit",
 			"columnSelection",
 			"copyWithSyntaxHighlighting",
@@ -851,6 +915,15 @@
 			"notInstalleddOnLocation",
 			"notInstalled"
 		],
+		"vs/platform/extensionManagement/common/extensionsScannerService": [
+			"fileReadFail",
+			"jsonParseFail",
+			"jsonParseInvalidType",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat"
+		],
 		"vs/platform/extensionManagement/node/extensionManagementService": [
 			"incompatible",
 			"MarketPlaceDisabled",
@@ -861,61 +934,6 @@
 			"cannot read",
 			"restartCode",
 			"restartCode"
-		],
-		"vs/platform/environment/node/argv": [
-			"optionsUpperCase",
-			"extensionsManagement",
-			"troubleshooting",
-			"cliDataDir",
-			"diff",
-			"merge",
-			"add",
-			"goto",
-			"newWindow",
-			"reuseWindow",
-			"wait",
-			"locale",
-			"userDataDir",
-			"profileName",
-			"help",
-			"extensionHomePath",
-			"listExtensions",
-			"showVersions",
-			"category",
-			"installExtension",
-			"install prerelease",
-			"uninstallExtension",
-			"experimentalApis",
-			"version",
-			"verbose",
-			"log",
-			"status",
-			"prof-startup",
-			"disableExtensions",
-			"disableExtension",
-			"turn sync",
-			"inspect-extensions",
-			"inspect-brk-extensions",
-			"disableGPU",
-			"telemetry",
-			"deprecated.useInstead",
-			"paths",
-			"usage",
-			"options",
-			"stdinWindows",
-			"stdinUnix",
-			"subcommands",
-			"unknownVersion",
-			"unknownCommit"
-		],
-		"vs/platform/extensionManagement/common/extensionsScannerService": [
-			"fileReadFail",
-			"jsonParseFail",
-			"jsonParseInvalidType",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat"
 		],
 		"vs/platform/languagePacks/common/languagePacks": [
 			"currentDisplayLanguage"
@@ -1049,8 +1067,101 @@
 			},
 			"remoteTunnelService.openTunnel"
 		],
-		"vs/platform/terminal/node/ptyService": [
-			"terminal-history-restored"
+		"vs/workbench/browser/workbench": [
+			"loaderErrorNative"
+		],
+		"vs/workbench/electron-sandbox/window": [
+			"restart",
+			"configure",
+			"learnMore",
+			"keychainWriteError",
+			"troubleshooting",
+			"runningTranslated",
+			"downloadArmBuild",
+			"proxyAuthRequired",
+			{
+				"key": "loginButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"username",
+			"password",
+			"proxyDetail",
+			"rememberCredentials",
+			"quitMessageMac",
+			"quitMessage",
+			"closeWindowMessage",
+			{
+				"key": "quitButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "exitButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "closeWindowButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"doNotAskAgain",
+			"shutdownErrorDetail",
+			"willShutdownDetail",
+			"shutdownErrorClose",
+			"shutdownErrorQuit",
+			"shutdownErrorReload",
+			"shutdownErrorLoad",
+			"shutdownTitleClose",
+			"shutdownTitleQuit",
+			"shutdownTitleReload",
+			"shutdownTitleLoad",
+			"shutdownForceClose",
+			"shutdownForceQuit",
+			"shutdownForceReload",
+			"shutdownForceLoad",
+			"loaderCycle",
+			"runningAsRoot",
+			"appRootWarning.banner",
+			"windowseolmessage",
+			"windowseolBannerLearnMore",
+			"windowseolarialabel",
+			"learnMore",
+			"macoseolmessage",
+			"macoseolBannerLearnMore",
+			"macoseolarialabel",
+			"learnMore",
+			"resolveShellEnvironment",
+			"learnMore"
+		],
+		"vs/workbench/services/configuration/browser/configurationService": [
+			"configurationDefaults.description",
+			"experimental"
+		],
+		"vs/platform/workspace/common/workspace": [
+			"codeWorkspace"
+		],
+		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
+			"devTools",
+			"directUrl",
+			"connectionError"
+		],
+		"vs/workbench/services/log/electron-sandbox/logService": [
+			"rendererLog"
+		],
+		"vs/platform/workspace/common/workspaceTrust": [
+			"trusted",
+			"untrusted"
+		],
+		"vs/workbench/services/userDataProfile/common/userDataProfile": [
+			"defaultProfileIcon",
+			"profiles",
+			"profile"
 		],
 		"vs/platform/list/browser/listService": [
 			"workbenchConfigurationTitle",
@@ -1095,6 +1206,9 @@
 			"sev.warning",
 			"sev.info"
 		],
+		"vs/platform/contextkey/browser/contextKeyService": [
+			"getContextKeyInfo"
+		],
 		"vs/platform/contextkey/common/contextkey": [
 			"contextkey.parser.error.emptyString",
 			"contextkey.parser.error.emptyString.hint",
@@ -1108,8 +1222,13 @@
 			"contextkey.scanner.errorForLinterWithHint",
 			"contextkey.scanner.errorForLinter"
 		],
-		"vs/platform/contextkey/browser/contextKeyService": [
-			"getContextKeyInfo"
+		"vs/workbench/browser/actions/textInputActions": [
+			"undo",
+			"redo",
+			"cut",
+			"copy",
+			"paste",
+			"selectAll"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"workbench.editor.titleScrollbarSizing.default",
@@ -1171,7 +1290,18 @@
 				],
 				"key": "tabSizing"
 			},
-			"workbench.editor.tabSizingFixedMaxWidth",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.editor.tabSizingFixedMinWidth"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.editor.tabSizingFixedMaxWidth"
+			},
 			"workbench.editor.pinnedTabSizing.normal",
 			"workbench.editor.pinnedTabSizing.compact",
 			"workbench.editor.pinnedTabSizing.shrink",
@@ -1181,6 +1311,7 @@
 				],
 				"key": "pinnedTabSizing"
 			},
+			"workbench.editor.splitSizingAuto",
 			"workbench.editor.splitSizingDistribute",
 			"workbench.editor.splitSizingSplit",
 			{
@@ -1217,6 +1348,12 @@
 			"workbench.editor.splitInGroupLayoutHorizontal",
 			"centeredLayoutAutoResize",
 			"centeredLayoutDynamicWidth",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "doubleClickTabToToggleEditorGroupSizes"
+			},
 			"limitEditorsEnablement",
 			"limitEditorsMaximum",
 			"limitEditorsExcludeDirty",
@@ -1435,14 +1572,6 @@
 					"&& denotes a mnemonic"
 				]
 			}
-		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"undo",
-			"redo",
-			"cut",
-			"copy",
-			"paste",
-			"selectAll"
 		],
 		"vs/workbench/browser/actions/layoutActions": [
 			"menuBarIcon",
@@ -1750,6 +1879,14 @@
 			"addFolderToWorkspaceTitle",
 			"workspaceFolderPickerPlaceholder"
 		],
+		"vs/workbench/browser/actions/quickAccessActions": [
+			"quickOpen",
+			"quickOpenWithModes",
+			"quickNavigateNext",
+			"quickNavigatePrevious",
+			"quickSelectNext",
+			"quickSelectPrevious"
+		],
 		"vs/workbench/services/actions/common/menusExtensionPoint": [
 			"menus.commandPalette",
 			"menus.touchBar",
@@ -1869,14 +2006,6 @@
 			"unsupported.submenureference",
 			"missing.submenu",
 			"submenuItem.duplicate"
-		],
-		"vs/workbench/browser/actions/quickAccessActions": [
-			"quickOpen",
-			"quickOpenWithModes",
-			"quickNavigateNext",
-			"quickNavigatePrevious",
-			"quickSelectNext",
-			"quickSelectPrevious"
 		],
 		"vs/workbench/api/common/configurationExtensionPoint": [
 			"vscode.extension.contributes.configuration.title",
@@ -2498,15 +2627,15 @@
 			"cancel",
 			"dismiss"
 		],
-		"vs/workbench/services/configuration/common/jsonEditingService": [
-			"errorInvalidFile"
-		],
 		"vs/workbench/services/preferences/browser/preferencesService": [
 			"openFolderFirst",
 			"emptyKeybindingsHeader",
 			"defaultKeybindings",
 			"defaultKeybindings",
 			"fail.createSettings"
+		],
+		"vs/workbench/services/configuration/common/jsonEditingService": [
+			"errorInvalidFile"
 		],
 		"vs/workbench/services/editor/browser/editorResolverService": [
 			"editorResolver.conflictingDefaults",
@@ -2623,15 +2752,6 @@
 			"neverShowAgain",
 			"neverShowAgain"
 		],
-		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
-			"reload message when removed",
-			"reload message when removed",
-			"cannotRenameDefaultProfile",
-			"cannotDeleteDefaultProfile",
-			"switch profile",
-			"reload message",
-			"reload button"
-		],
 		"vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService": [
 			"profile import error",
 			"resolving uri",
@@ -2639,6 +2759,8 @@
 			"import profile",
 			"export",
 			"close",
+			"troubleshoot issue",
+			"troubleshoot profile progress",
 			"profiles.exporting",
 			"export success",
 			{
@@ -2677,7 +2799,6 @@
 			"progress extensions",
 			"switching profile",
 			"select profile content handler",
-			"preview",
 			"profile already exists",
 			{
 				"key": "overwrite",
@@ -2705,15 +2826,98 @@
 			"export profile title",
 			"profile name required"
 		],
+		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
+			"reload message when removed",
+			"reload message when removed",
+			"cannotRenameDefaultProfile",
+			"cannotDeleteDefaultProfile",
+			"switch profile",
+			"reload message",
+			"reload button"
+		],
 		"vs/workbench/services/remote/common/remoteExplorerService": [
 			"tunnel.source.user",
 			"tunnel.source.auto",
 			"remote.localPortMismatch.single",
 			"tunnel.staticallyForwarded"
 		],
+		"vs/workbench/services/filesConfiguration/common/filesConfigurationService": [
+			"providerReadonly",
+			{
+				"key": "sessionReadonly",
+				"comment": [
+					"Please do not translate the word \"command\", it is part of our internal syntax which must not change",
+					"{Locked=\"](command:{0})\"}"
+				]
+			},
+			{
+				"key": "configuredReadonly",
+				"comment": [
+					"Please do not translate the word \"command\", it is part of our internal syntax which must not change",
+					"{Locked=\"](command:{0})\"}"
+				]
+			},
+			{
+				"key": "fileLocked",
+				"comment": [
+					"Please do not translate the word \"command\", it is part of our internal syntax which must not change",
+					"{Locked=\"](command:{0})\"}"
+				]
+			},
+			"fileReadonly"
+		],
 		"vs/workbench/services/views/browser/viewDescriptorService": [
 			"hideView",
 			"resetViewLocation"
+		],
+		"vs/workbench/services/authentication/browser/authenticationService": [
+			"authentication.id",
+			"authentication.label",
+			{
+				"key": "authenticationExtensionPoint",
+				"comment": [
+					"'Contributes' means adds here"
+				]
+			},
+			"authentication.Placeholder",
+			"authentication.missingId",
+			"authentication.missingLabel",
+			"authentication.idConflict",
+			"loading",
+			"sign in",
+			"confirmAuthenticationAccess",
+			{
+				"key": "allow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "deny",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"useOtherAccount",
+			{
+				"key": "selectAccount",
+				"comment": [
+					"The placeholder {0} is the name of an extension. {1} is the name of the type of account, such as Microsoft or GitHub."
+				]
+			},
+			"getSessionPlateholder",
+			{
+				"key": "accessRequest",
+				"comment": [
+					"The placeholder {0} will be replaced with an authentication provider''s label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count"
+				]
+			},
+			{
+				"key": "signInRequest",
+				"comment": [
+					"The placeholder {0} will be replaced with an authentication provider's label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count."
+				]
+			}
 		],
 		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
 			"no authentication providers",
@@ -2765,52 +2969,53 @@
 			"others",
 			"sign in using account"
 		],
-		"vs/workbench/services/authentication/browser/authenticationService": [
-			"authentication.id",
-			"authentication.label",
+		"vs/workbench/services/assignment/common/assignmentService": [
+			"workbench.enableExperiments"
+		],
+		"vs/workbench/services/issue/browser/issueTroubleshoot": [
+			"troubleshoot issue",
+			"detail.start",
 			{
-				"key": "authenticationExtensionPoint",
-				"comment": [
-					"'Contributes' means adds here"
-				]
-			},
-			"authentication.Placeholder",
-			"authentication.missingId",
-			"authentication.missingLabel",
-			"authentication.idConflict",
-			"loading",
-			"sign in",
-			"confirmAuthenticationAccess",
-			{
-				"key": "allow",
+				"key": "msg",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
 			},
+			"profile.extensions.disabled",
+			"empty.profile",
+			"issue is with configuration",
+			"issue is in core",
+			"I cannot reproduce",
+			"This is Bad",
+			"Stop",
+			"troubleshoot issue",
+			"use insiders",
+			"troubleshoot issue",
+			"download insiders",
+			"report anyway",
+			"ask to download insiders",
+			"troubleshoot issue",
+			"good",
+			"bad",
+			"stop",
+			"ask to reproduce issue",
+			"troubleshootIssue",
+			"title.stop"
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"defineKeybinding.kbLayoutErrorMessage",
 			{
-				"key": "deny",
+				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
 				"comment": [
-					"&& denotes a mnemonic"
+					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
+					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
 				]
 			},
-			"useOtherAccount",
 			{
-				"key": "selectAccount",
+				"key": "defineKeybinding.kbLayoutLocalMessage",
 				"comment": [
-					"The placeholder {0} is the name of an extension. {1} is the name of the type of account, such as Microsoft or GitHub."
-				]
-			},
-			"getSessionPlateholder",
-			{
-				"key": "accessRequest",
-				"comment": [
-					"The placeholder {0} will be replaced with an authentication provider''s label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count"
-				]
-			},
-			{
-				"key": "signInRequest",
-				"comment": [
-					"The placeholder {0} will be replaced with an authentication provider's label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count."
+					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
+					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
 				]
 			}
 		],
@@ -2882,22 +3087,11 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"defineKeybinding.kbLayoutErrorMessage",
-			{
-				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
-					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			},
-			{
-				"key": "defineKeybinding.kbLayoutLocalMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
-					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			}
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"show.label",
+			"cycles",
+			"insta.trace",
+			"emitter"
 		],
 		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
 			"notebook.editorOptions.experimentalCustomization",
@@ -2943,12 +3137,6 @@
 			"notebook.confirmDeleteRunningCell",
 			"notebook.findScope"
 		],
-		"vs/workbench/contrib/performance/browser/performance.contribution": [
-			"show.label",
-			"cycles",
-			"insta.trace",
-			"emitter"
-		],
 		"vs/workbench/contrib/chat/browser/chat.contribution": [
 			"interactiveSessionConfigurationTitle",
 			"interactiveSession.editor.fontSize",
@@ -2956,9 +3144,9 @@
 			"interactiveSession.editor.fontWeight",
 			"interactiveSession.editor.wordWrap",
 			"interactiveSession.editor.lineHeight",
-			"interactiveSession.experimental.quickQuestion.enable",
 			"chat",
-			"chat"
+			"chat",
+			"chatAccessibleView"
 		],
 		"vs/workbench/contrib/interactive/browser/interactive.contribution": [
 			"interactiveWindow",
@@ -2974,8 +3162,7 @@
 			"interactive.history.focus",
 			"interactive.activeCodeBorder",
 			"interactive.inactiveCodeBorder",
-			"interactiveWindow.alwaysScrollOnNewCell",
-			"interactiveWindow.restore"
+			"interactiveWindow.alwaysScrollOnNewCell"
 		],
 		"vs/workbench/contrib/testing/browser/testing.contribution": [
 			"test",
@@ -3076,46 +3263,6 @@
 					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
 				]
 			}
-		],
-		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
-			"summary.0",
-			"summary.nm",
-			"summary.n0",
-			"summary.textFiles",
-			"workspaceEdit",
-			"workspaceEdit",
-			"nothing",
-			"closeTheWindow.message",
-			{
-				"key": "closeTheWindow",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"changeWorkspace.message",
-			{
-				"key": "changeWorkspace",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"reloadTheWindow.message",
-			{
-				"key": "reloadTheWindow",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"quit.message",
-			{
-				"key": "quit",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"areYouSureQuiteBulkEdit.detail",
-			"fileOperation",
-			"refactoring.autoSave"
 		],
 		"vs/workbench/contrib/files/browser/fileActions.contribution": [
 			"copyPath",
@@ -3274,6 +3421,8 @@
 			"askUser",
 			"overwriteFileOnDisk",
 			"files.saveConflictResolution",
+			"defaultPathErrorMessage",
+			"fileDialogDefaultPath",
 			"files.simpleDialog.enable",
 			"files.participants.timeout",
 			"formatOnSave",
@@ -3363,6 +3512,46 @@
 			"fileNestingPatterns",
 			"fileNesting.description"
 		],
+		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
+			"summary.0",
+			"summary.nm",
+			"summary.n0",
+			"summary.textFiles",
+			"workspaceEdit",
+			"workspaceEdit",
+			"nothing",
+			"closeTheWindow.message",
+			{
+				"key": "closeTheWindow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"changeWorkspace.message",
+			{
+				"key": "changeWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"reloadTheWindow.message",
+			{
+				"key": "reloadTheWindow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"quit.message",
+			{
+				"key": "quit",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"areYouSureQuiteBulkEdit.detail",
+			"fileOperation",
+			"refactoring.autoSave"
+		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
 			"overlap",
 			"detail",
@@ -3387,10 +3576,6 @@
 			"refactorPreviewViewIcon",
 			"panel",
 			"panel"
-		],
-		"vs/workbench/contrib/sash/browser/sash.contribution": [
-			"sashSize",
-			"sashHoverDelay"
 		],
 		"vs/workbench/contrib/search/browser/search.contribution": [
 			"name",
@@ -3494,6 +3679,10 @@
 			"searchEditor.action.decreaseSearchEditorContextLines",
 			"searchEditor.action.selectAllSearchEditorMatches",
 			"search.openNewEditor"
+		],
+		"vs/workbench/contrib/sash/browser/sash.contribution": [
+			"sashSize",
+			"sashHoverDelay"
 		],
 		"vs/workbench/contrib/search/browser/searchView": [
 			"searchCanceled",
@@ -4031,7 +4220,13 @@
 			"comments.openView.firstFile",
 			"comments.openView",
 			"useRelativeTime",
-			"comments.visible"
+			"comments.visible",
+			"comments.maxHeight"
+		],
+		"vs/workbench/contrib/url/browser/url.contribution": [
+			"openUrl",
+			"urlToOpen",
+			"workbench.trustedDomains.promptInTrustedWorkspace"
 		],
 		"vs/workbench/contrib/webview/browser/webview.contribution": [
 			"cut",
@@ -4041,10 +4236,51 @@
 		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
 			"webview.editor.label"
 		],
-		"vs/workbench/contrib/url/browser/url.contribution": [
-			"openUrl",
-			"urlToOpen",
-			"workbench.trustedDomains.promptInTrustedWorkspace"
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			{
+				"key": "remote",
+				"comment": [
+					"Remote as in remote machine"
+				]
+			},
+			"installed",
+			"select and install local extensions",
+			"install remote in local",
+			"popularExtensions",
+			"recommendedExtensions",
+			"enabledExtensions",
+			"disabledExtensions",
+			"marketPlace",
+			"installed",
+			"recently updated",
+			"enabled",
+			"disabled",
+			"availableUpdates",
+			"builtin",
+			"workspaceUnsupported",
+			"workspaceRecommendedExtensions",
+			"otherRecommendedExtensions",
+			"builtinFeatureExtensions",
+			"builtInThemesExtensions",
+			"builtinProgrammingLanguageExtensions",
+			"untrustedUnsupportedExtensions",
+			"untrustedPartiallySupportedExtensions",
+			"virtualUnsupportedExtensions",
+			"virtualPartiallySupportedExtensions",
+			"deprecated",
+			"searchExtensions",
+			"extensionFoundInSection",
+			"extensionFound",
+			"extensionsFoundInSection",
+			"extensionsFound",
+			"suggestProxyError",
+			"open user settings",
+			"extensionToUpdate",
+			"extensionsToUpdate",
+			"extensionToReload",
+			"extensionsToReload",
+			"malicious warning",
+			"reloadNow"
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
 			"manageExtensionsQuickAccessPlaceholder",
@@ -4197,58 +4433,6 @@
 			"extensions",
 			"extensions"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			{
-				"key": "remote",
-				"comment": [
-					"Remote as in remote machine"
-				]
-			},
-			"installed",
-			"select and install local extensions",
-			"install remote in local",
-			"popularExtensions",
-			"recommendedExtensions",
-			"enabledExtensions",
-			"disabledExtensions",
-			"marketPlace",
-			"installed",
-			"recently updated",
-			"enabled",
-			"disabled",
-			"availableUpdates",
-			"builtin",
-			"workspaceUnsupported",
-			"workspaceRecommendedExtensions",
-			"otherRecommendedExtensions",
-			"builtinFeatureExtensions",
-			"builtInThemesExtensions",
-			"builtinProgrammingLanguageExtensions",
-			"untrustedUnsupportedExtensions",
-			"untrustedPartiallySupportedExtensions",
-			"virtualUnsupportedExtensions",
-			"virtualPartiallySupportedExtensions",
-			"deprecated",
-			"searchExtensions",
-			"extensionFoundInSection",
-			"extensionFound",
-			"extensionsFoundInSection",
-			"extensionsFound",
-			"suggestProxyError",
-			"open user settings",
-			"extensionToUpdate",
-			"extensionsToUpdate",
-			"extensionToReload",
-			"extensionsToReload",
-			"malicious warning",
-			"reloadNow"
-		],
-		"vs/workbench/contrib/output/browser/outputView": [
-			"output model title",
-			"channel",
-			"output",
-			"outputViewAriaLabel"
-		],
 		"vs/workbench/contrib/output/browser/output.contribution": [
 			"outputViewIcon",
 			"output",
@@ -4275,6 +4459,7 @@
 			"extensionLogs",
 			"selectlog",
 			"openLogFile",
+			"logFile",
 			"selectlogFile",
 			"output",
 			"output.smartScroll.enabled"
@@ -4440,11 +4625,6 @@
 		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
 			"toggleKeybindingsLog"
 		],
-		"vs/workbench/contrib/folding/browser/folding.contribution": [
-			"null",
-			"nullFormatterDescription",
-			"formatter.default"
-		],
 		"vs/workbench/contrib/snippets/browser/snippets.contribution": [
 			"editor.snippets.codeActions.enabled",
 			"snippetSchema.json.prefix",
@@ -4456,6 +4636,17 @@
 			"snippetSchema.json.default",
 			"snippetSchema.json",
 			"snippetSchema.json.scope"
+		],
+		"vs/workbench/contrib/output/browser/outputView": [
+			"output model title",
+			"channel",
+			"output",
+			"outputViewAriaLabel"
+		],
+		"vs/workbench/contrib/folding/browser/folding.contribution": [
+			"null",
+			"nullFormatterDescription",
+			"formatter.default"
 		],
 		"vs/workbench/contrib/limitIndicator/browser/limitIndicator.contribution": [
 			"status.button.configure",
@@ -4720,9 +4911,6 @@
 			"name.pattern",
 			"reset"
 		],
-		"vs/workbench/contrib/experiments/browser/experiments.contribution": [
-			"workbench.enableExperiments"
-		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution": [
 			{
 				"key": "local too many requests - reload",
@@ -4963,7 +5151,10 @@
 			"audioCues.diffLineDeleted",
 			"audioCues.diffLineModified",
 			"audioCues.notebookCellCompleted",
-			"audioCues.notebookCellFailed"
+			"audioCues.notebookCellFailed",
+			"audioCues.chatRequestSent",
+			"audioCues.chatResponsePending",
+			"audioCues.chatResponseReceived"
 		],
 		"vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExtensionMigrator.contribution": [
 			"bracketPairColorizer.notification",
@@ -4971,106 +5162,18 @@
 			"bracketPairColorizer.notification.action.enableNative",
 			"bracketPairColorizer.notification.action.showMoreInfo"
 		],
+		"vs/workbench/contrib/accessibility/browser/accessibility.contribution": [
+			"editor-help",
+			"hoverAccessibleView"
+		],
 		"vs/workbench/contrib/share/browser/share.contribution": [
 			"share",
 			"generating link",
+			"shareTextSuccess",
 			"shareSuccess",
 			"close",
-			"open link"
-		],
-		"vs/workbench/browser/workbench": [
-			"loaderErrorNative"
-		],
-		"vs/workbench/electron-sandbox/window": [
-			"restart",
-			"configure",
-			"learnMore",
-			"keychainWriteError",
-			"troubleshooting",
-			"proxyAuthRequired",
-			{
-				"key": "loginButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"username",
-			"password",
-			"proxyDetail",
-			"rememberCredentials",
-			"quitMessageMac",
-			"quitMessage",
-			"closeWindowMessage",
-			{
-				"key": "quitButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "exitButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "closeWindowButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"doNotAskAgain",
-			"shutdownErrorDetail",
-			"willShutdownDetail",
-			"shutdownErrorClose",
-			"shutdownErrorQuit",
-			"shutdownErrorReload",
-			"shutdownErrorLoad",
-			"shutdownTitleClose",
-			"shutdownTitleQuit",
-			"shutdownTitleReload",
-			"shutdownTitleLoad",
-			"shutdownForceClose",
-			"shutdownForceQuit",
-			"shutdownForceReload",
-			"shutdownForceLoad",
-			"loaderCycle",
-			"runningAsRoot",
-			"appRootWarning.banner",
-			"windowseolmessage",
-			"windowseolBannerLearnMore",
-			"windowseolarialabel",
-			"learnMore",
-			"macoseolmessage",
-			"macoseolBannerLearnMore",
-			"macoseolarialabel",
-			"learnMore",
-			"resolveShellEnvironment",
-			"learnMore"
-		],
-		"vs/workbench/services/configuration/browser/configurationService": [
-			"configurationDefaults.description",
-			"experimental"
-		],
-		"vs/platform/workspace/common/workspace": [
-			"codeWorkspace"
-		],
-		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
-			"devTools",
-			"directUrl",
-			"connectionError"
-		],
-		"vs/workbench/services/log/electron-sandbox/logService": [
-			"rendererLog"
-		],
-		"vs/platform/workspace/common/workspaceTrust": [
-			"trusted",
-			"untrusted"
-		],
-		"vs/workbench/services/userDataProfile/common/userDataProfile": [
-			"defaultProfileIcon",
-			"profiles",
-			"profile"
+			"open link",
+			"experimental.share.enabled"
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
 			"defaultLanguageConfigurationOverrides.title",
@@ -5138,6 +5241,13 @@
 			"productQualityType",
 			"inputFocus"
 		],
+		"vs/workbench/electron-sandbox/actions/installActions": [
+			"shellCommand",
+			"install",
+			"successIn",
+			"uninstall",
+			"successFrom"
+		],
 		"vs/workbench/common/contextkeys": [
 			"workbenchState",
 			"workspaceFolderCount",
@@ -5199,13 +5309,6 @@
 			"resourceExtname",
 			"resourceSet",
 			"isFileSystemResource"
-		],
-		"vs/workbench/electron-sandbox/actions/installActions": [
-			"shellCommand",
-			"install",
-			"successIn",
-			"uninstall",
-			"successFrom"
 		],
 		"vs/workbench/common/configuration": [
 			"applicationConfigurationTitle",
@@ -5411,6 +5514,8 @@
 			"diffEditorBorder",
 			"diffDiagonalFill",
 			"diffEditor.unchangedRegionBackground",
+			"diffEditor.unchangedRegionForeground",
+			"diffEditor.unchangedCodeBackground",
 			"listFocusBackground",
 			"listFocusForeground",
 			"listFocusOutline",
@@ -5625,6 +5730,12 @@
 		"vs/base/common/actions": [
 			"submenu.empty"
 		],
+		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
+			"save",
+			"saveWorkspace",
+			"errorInvalidTaskConfiguration",
+			"openWorkspaceConfigurationFile"
+		],
 		"vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService": [
 			"commandVariable.noStringType",
 			"inputVariable.noInputSection",
@@ -5697,6 +5808,12 @@
 			"revertBeforeShutdown",
 			"discardBackupsBeforeShutdown"
 		],
+		"vs/workbench/services/workingCopy/common/workingCopyHistoryService": [
+			"default.source",
+			"moved.source",
+			"renamed.source",
+			"join.workingCopyHistory"
+		],
 		"vs/platform/action/common/actionCommonCategories": [
 			"view",
 			"help",
@@ -5710,12 +5827,6 @@
 				]
 			}
 		],
-		"vs/workbench/services/workingCopy/common/workingCopyHistoryService": [
-			"default.source",
-			"moved.source",
-			"renamed.source",
-			"join.workingCopyHistory"
-		],
 		"vs/workbench/services/extensions/common/abstractExtensionService": [
 			"looping",
 			"looping",
@@ -5727,12 +5838,6 @@
 			"extensionService.autoRestart",
 			"extensionService.crash",
 			"restart"
-		],
-		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
-			"save",
-			"saveWorkspace",
-			"errorInvalidTaskConfiguration",
-			"openWorkspaceConfigurationFile"
 		],
 		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
 			"extensionCache.invalid",
@@ -5919,11 +6024,6 @@
 			"sync category",
 			"syncViewIcon"
 		],
-		"vs/workbench/contrib/tasks/common/tasks": [
-			"tasks.taskRunningContext",
-			"tasksCategory",
-			"TaskDefinition.missingRequiredProperty"
-		],
 		"vs/workbench/contrib/performance/electron-sandbox/startupProfiler": [
 			"prof.message",
 			"prof.detail",
@@ -5943,12 +6043,22 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"tasks.taskRunningContext",
+			"tasksCategory",
+			"TaskDefinition.missingRequiredProperty"
+		],
 		"vs/workbench/contrib/tasks/common/taskService": [
 			"tasks.customExecutionSupported",
 			"tasks.shellExecutionSupported",
 			"tasks.taskCommandsRegistered",
 			"tasks.processExecutionSupported",
 			"tasks.serverlessWebContext"
+		],
+		"vs/workbench/common/views": [
+			"defaultViewIcon",
+			"duplicateId",
+			"treeView.notRegistered"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"ConfigureTaskRunnerAction.label",
@@ -6110,15 +6220,14 @@
 			"audioCues.notebookCellFailed",
 			"audioCues.diffLineInserted",
 			"audioCues.diffLineDeleted",
-			"audioCues.diffLineModified"
-		],
-		"vs/workbench/common/views": [
-			"defaultViewIcon",
-			"duplicateId",
-			"treeView.notRegistered"
+			"audioCues.diffLineModified",
+			"audioCues.chatRequestSent",
+			"audioCues.chatResponseReceived",
+			"audioCues.chatResponsePending"
 		],
 		"vs/workbench/contrib/terminal/common/terminalContextKey": [
 			"terminalFocusContextKey",
+			"terminalFocusInAnyContextKey",
 			"terminalAccessibleBufferFocusContextKey",
 			"terminalEditorFocusContextKey",
 			"terminalCountContextKey",
@@ -6128,6 +6237,7 @@
 			"terminalSuggestWidgetVisible",
 			"terminalViewShowing",
 			"terminalTextSelectedContextKey",
+			"terminalTextSelectedInFocusedContextKey",
 			"terminalProcessSupportedContextKey",
 			"terminalTabsSingularSelectedContextKey",
 			"isSplitTerminalContextKey",
@@ -6138,16 +6248,16 @@
 			"openToolsLabel",
 			"iframeWebviewAlert"
 		],
+		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
+			"revealInWindows",
+			"revealInMac",
+			"openContainer"
+		],
 		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
 			"mergeEditor",
 			"merge.dev.openState",
 			"mergeEditor.enterJSON",
 			"merge.dev.openSelectionInTemporaryMergeEditor"
-		],
-		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
-			"revealInWindows",
-			"revealInMac",
-			"openContainer"
 		],
 		"vs/workbench/api/common/extHostExtensionService": [
 			"extensionTestError1",
@@ -6167,12 +6277,18 @@
 			"worker",
 			"local"
 		],
-		"vs/workbench/api/node/extHostTunnelService": [
-			"tunnelPrivacy.private",
-			"tunnelPrivacy.public"
+		"vs/platform/terminal/node/terminalProcess": [
+			"launchFail.cwdNotDirectory",
+			"launchFail.cwdDoesNotExist",
+			"launchFail.executableDoesNotExist",
+			"launchFail.executableIsNotFileOrSymlink"
 		],
 		"vs/workbench/api/node/extHostDebugService": [
 			"debug.terminal.title"
+		],
+		"vs/workbench/api/node/extHostTunnelService": [
+			"tunnelPrivacy.private",
+			"tunnelPrivacy.public"
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"open",
@@ -6253,6 +6369,14 @@
 			"cantUninstall",
 			"sourceMissing"
 		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"newWindow",
+			"newWindowDesc",
+			"recentFoldersAndWorkspaces",
+			"recentFolders",
+			"untitledWorkspace",
+			"workspaceName"
+		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			{
 				"key": "ok",
@@ -6285,14 +6409,6 @@
 			"confirmOpenMessage",
 			"confirmOpenDetail",
 			"doNotAskAgain"
-		],
-		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
-			"newWindow",
-			"newWindowDesc",
-			"recentFoldersAndWorkspaces",
-			"recentFolders",
-			"untitledWorkspace",
-			"workspaceName"
 		],
 		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
 			{
@@ -6327,6 +6443,20 @@
 			"versionSpecificity2",
 			"versionMismatch"
 		],
+		"vs/base/common/jsonErrorMessages": [
+			"error.invalidSymbol",
+			"error.invalidNumberFormat",
+			"error.propertyNameExpected",
+			"error.valueExpected",
+			"error.colonExpected",
+			"error.commaExpected",
+			"error.closeBraceExpected",
+			"error.closeBracketExpected",
+			"error.endOfFileExpected"
+		],
+		"vs/platform/extensionManagement/common/extensionNls": [
+			"missingNLSKey"
+		],
 		"vs/base/node/zip": [
 			"invalid file",
 			"incompleteExtract",
@@ -6348,20 +6478,6 @@
 		],
 		"vs/platform/extensionManagement/node/extensionManagementUtil": [
 			"invalidManifest"
-		],
-		"vs/base/common/jsonErrorMessages": [
-			"error.invalidSymbol",
-			"error.invalidNumberFormat",
-			"error.propertyNameExpected",
-			"error.valueExpected",
-			"error.colonExpected",
-			"error.commaExpected",
-			"error.closeBraceExpected",
-			"error.closeBracketExpected",
-			"error.endOfFileExpected"
-		],
-		"vs/platform/extensionManagement/common/extensionNls": [
-			"missingNLSKey"
 		],
 		"vs/base/browser/ui/button/button": [
 			"button dropdown more actions"
@@ -6447,12 +6563,6 @@
 			"session expired",
 			"turned off machine"
 		],
-		"vs/platform/terminal/node/terminalProcess": [
-			"launchFail.cwdNotDirectory",
-			"launchFail.cwdDoesNotExist",
-			"launchFail.executableDoesNotExist",
-			"launchFail.executableIsNotFileOrSymlink"
-		],
 		"vs/base/browser/ui/tree/abstractTree": [
 			"filter",
 			"fuzzySearch",
@@ -6468,6 +6578,113 @@
 			"widgetClose",
 			"previousChangeIcon",
 			"nextChangeIcon"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"alertErrorMessage",
+			"alertWarningMessage",
+			"alertInfoMessage"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"notificationsEmpty",
+			"notifications",
+			"notificationsToolbar",
+			"notificationsCenterWidgetAriaLabel"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsStatus": [
+			"status.notifications",
+			"status.notifications",
+			"status.doNotDisturb",
+			"status.doNotDisturbTooltip",
+			"hideNotifications",
+			"zeroNotifications",
+			"noNotifications",
+			"oneNotification",
+			{
+				"key": "notifications",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "noNotificationsWithProgress",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "oneNotificationWithProgress",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "notificationsWithProgress",
+				"comment": [
+					"{0} and {1} will be replaced by a number"
+				]
+			},
+			"status.message"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCommands": [
+			"notifications",
+			"showNotifications",
+			"hideNotifications",
+			"clearAllNotifications",
+			"acceptNotificationPrimaryAction",
+			"toggleDoNotDisturbMode",
+			"focusNotificationToasts"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsToasts": [
+			"notificationAriaLabel",
+			"notificationWithSourceAriaLabel"
+		],
+		"vs/platform/actions/browser/menuEntryActionViewItem": [
+			"titleAndKb",
+			"titleAndKb",
+			"titleAndKbAndAlt"
+		],
+		"vs/workbench/services/configuration/common/configurationEditing": [
+			"openTasksConfiguration",
+			"openLaunchConfiguration",
+			"open",
+			"openTasksConfiguration",
+			"openLaunchConfiguration",
+			"saveAndRetry",
+			"saveAndRetry",
+			"open",
+			"errorPolicyConfiguration",
+			"errorUnknownKey",
+			"errorInvalidWorkspaceConfigurationApplication",
+			"errorInvalidWorkspaceConfigurationMachine",
+			"errorInvalidFolderConfiguration",
+			"errorInvalidUserTarget",
+			"errorInvalidWorkspaceTarget",
+			"errorInvalidFolderTarget",
+			"errorInvalidResourceLanguageConfiguration",
+			"errorNoWorkspaceOpened",
+			"errorInvalidTaskConfiguration",
+			"errorInvalidLaunchConfiguration",
+			"errorInvalidConfiguration",
+			"errorInvalidRemoteConfiguration",
+			"errorInvalidConfigurationWorkspace",
+			"errorInvalidConfigurationFolder",
+			"errorTasksConfigurationFileDirty",
+			"errorLaunchConfigurationFileDirty",
+			"errorConfigurationFileDirty",
+			"errorRemoteConfigurationFileDirty",
+			"errorConfigurationFileDirtyWorkspace",
+			"errorConfigurationFileDirtyFolder",
+			"errorTasksConfigurationFileModifiedSince",
+			"errorLaunchConfigurationFileModifiedSince",
+			"errorConfigurationFileModifiedSince",
+			"errorRemoteConfigurationFileModifiedSince",
+			"errorConfigurationFileModifiedSinceWorkspace",
+			"errorConfigurationFileModifiedSinceFolder",
+			"errorUnknown",
+			"userTarget",
+			"remoteUserTarget",
+			"workspaceTarget",
+			"folderTarget"
 		],
 		"vs/editor/common/core/editorColorRegistry": [
 			"lineHighlight",
@@ -6536,6 +6753,10 @@
 			"stickydesc",
 			"removedCursor"
 		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"cursors.maximum",
+			"goToSetting"
+		],
 		"vs/editor/contrib/anchorSelect/browser/anchorSelect": [
 			"selectionAnchor",
 			"anchorSet",
@@ -6543,10 +6764,6 @@
 			"goToSelectionAnchor",
 			"selectFromAnchorToCursor",
 			"cancelSelectionAnchor"
-		],
-		"vs/editor/contrib/caretOperations/browser/caretOperations": [
-			"caret.moveLeft",
-			"caret.moveRight"
 		],
 		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
 			"overviewRulerBracketMatchForeground",
@@ -6559,6 +6776,20 @@
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/editor/browser/widget/diffEditorWidget": [
+			"diffInsertIcon",
+			"diffRemoveIcon",
+			"diff-aria-navigation-tip",
+			"diff.tooLarge",
+			"revertChangeHoverMessage"
+		],
+		"vs/editor/contrib/caretOperations/browser/caretOperations": [
+			"caret.moveLeft",
+			"caret.moveRight"
+		],
+		"vs/editor/contrib/caretOperations/browser/transpose": [
+			"transposeLetters.label"
 		],
 		"vs/editor/contrib/clipboard/browser/clipboard": [
 			{
@@ -6595,25 +6826,32 @@
 			"actions.clipboard.pasteLabel",
 			"actions.clipboard.copyWithSyntaxHighlightingLabel"
 		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"cursors.maximum",
-			"goToSetting"
-		],
-		"vs/editor/browser/widget/diffEditorWidget": [
-			"diffInsertIcon",
-			"diffRemoveIcon",
-			"diff-aria-navigation-tip",
-			"diff.tooLarge",
-			"revertChangeHoverMessage"
-		],
-		"vs/editor/contrib/caretOperations/browser/transpose": [
-			"transposeLetters.label"
-		],
 		"vs/editor/contrib/codeAction/browser/codeActionContributions": [
 			"showCodeActionHeaders"
 		],
 		"vs/editor/contrib/codelens/browser/codelensController": [
 			"showLensOnLine"
+		],
+		"vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions": [
+			"showOrFocusStandaloneColorPicker",
+			{
+				"key": "mishowOrFocusStandaloneColorPicker",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "hideColorPicker",
+				"comment": [
+					"Action that hides the color picker"
+				]
+			},
+			{
+				"key": "insertColorWithStandaloneColorPicker",
+				"comment": [
+					"Action that inserts color with standalone color picker"
+				]
+			}
 		],
 		"vs/editor/contrib/comment/browser/comment": [
 			"comment.line",
@@ -6644,27 +6882,6 @@
 			"context.minimap.slider.mouseover",
 			"context.minimap.slider.always",
 			"action.showContextMenu.label"
-		],
-		"vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions": [
-			"showOrFocusStandaloneColorPicker",
-			{
-				"key": "mishowOrFocusStandaloneColorPicker",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "hideColorPicker",
-				"comment": [
-					"Action that hides the color picker"
-				]
-			},
-			{
-				"key": "insertColorWithStandaloneColorPicker",
-				"comment": [
-					"Action that inserts color with standalone color picker"
-				]
-			}
 		],
 		"vs/editor/contrib/cursorUndo/browser/cursorUndo": [
 			"cursor.undo",
@@ -6705,11 +6922,6 @@
 				]
 			}
 		],
-		"vs/editor/contrib/fontZoom/browser/fontZoom": [
-			"EditorFontZoomIn.label",
-			"EditorFontZoomOut.label",
-			"EditorFontZoomReset.label"
-		],
 		"vs/editor/contrib/folding/browser/folding": [
 			"unfoldAction.label",
 			"unFoldRecursivelyAction.label",
@@ -6733,6 +6945,11 @@
 		"vs/editor/contrib/format/browser/formatActions": [
 			"formatDocument.label",
 			"formatSelection.label"
+		],
+		"vs/editor/contrib/fontZoom/browser/fontZoom": [
+			"EditorFontZoomIn.label",
+			"EditorFontZoomOut.label",
+			"EditorFontZoomReset.label"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/goToCommands": [
 			"peek.submenu",
@@ -6800,9 +7017,6 @@
 			"generic.noResult",
 			"ref.title"
 		],
-		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
-			"multipleResults"
-		],
 		"vs/editor/contrib/gotoError/browser/gotoError": [
 			"markerAction.next.label",
 			"nextMarkerIcon",
@@ -6822,6 +7036,9 @@
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
+			"multipleResults"
 		],
 		"vs/editor/contrib/hover/browser/hover": [
 			{
@@ -7099,6 +7316,16 @@
 		"vs/editor/contrib/tokenization/browser/tokenization": [
 			"forceRetokenize"
 		],
+		"vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode": [
+			{
+				"key": "toggle.tabMovesFocus",
+				"comment": [
+					"Turn on/off use of tab key for moving focus around VS Code"
+				]
+			},
+			"toggle.tabMovesFocus.on",
+			"toggle.tabMovesFocus.off"
+		],
 		"vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter": [
 			"warningIcon",
 			"unicodeHighlighting.thisDocumentHasManyNonBasicAsciiUnicodeCharacters",
@@ -7149,23 +7376,8 @@
 			"editor.simple.readonly",
 			"editor.readonly"
 		],
-		"vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode": [
-			{
-				"key": "toggle.tabMovesFocus",
-				"comment": [
-					"Turn on/off use of tab key for moving focus around VS Code"
-				]
-			},
-			"toggle.tabMovesFocus.on",
-			"toggle.tabMovesFocus.off"
-		],
 		"vs/editor/common/standaloneStrings": [
-			"noSelection",
-			"singleSelectionRange",
-			"singleSelection",
-			"multiSelectionRange",
-			"multiSelection",
-			"emergencyConfOn",
+			"accessibilityHelpTitle",
 			"openingDocs",
 			"readonlyDiffEditor",
 			"editableDiffEditor",
@@ -7179,11 +7391,7 @@
 			"tabFocusModeOnMsgNoKb",
 			"tabFocusModeOffMsg",
 			"tabFocusModeOffMsgNoKb",
-			"openDocMac",
-			"openDocWinLinux",
-			"outroMsg",
 			"showAccessibilityHelpAction",
-			"accessibilityHelpTitle",
 			"inspectTokens",
 			"gotoLineActionLabel",
 			"helpQuickAccess",
@@ -7195,6 +7403,35 @@
 			"accessibilityHelpMessage",
 			"toggleHighContrast",
 			"bulkEditServiceSummary"
+		],
+		"vs/workbench/api/common/jsonValidationExtensionPoint": [
+			"contributes.jsonValidation",
+			"contributes.jsonValidation.fileMatch",
+			"contributes.jsonValidation.url",
+			"invalid.jsonValidation",
+			"invalid.fileMatch",
+			"invalid.url",
+			"invalid.path.1",
+			"invalid.url.fileschema",
+			"invalid.url.schema"
+		],
+		"vs/workbench/services/themes/common/colorExtensionPoint": [
+			"contributes.color",
+			"contributes.color.id",
+			"contributes.color.id.format",
+			"contributes.color.description",
+			"contributes.defaults.light",
+			"contributes.defaults.dark",
+			"contributes.defaults.highContrast",
+			"contributes.defaults.highContrastLight",
+			"invalid.colorConfiguration",
+			"invalid.default.colorType",
+			"invalid.id",
+			"invalid.id.format",
+			"invalid.description",
+			"invalid.defaults",
+			"invalid.defaults.highContrast",
+			"invalid.defaults.highContrastLight"
 		],
 		"vs/workbench/services/themes/common/iconExtensionPoint": [
 			"contributes.icons",
@@ -7210,6 +7447,46 @@
 			"invalid.icons.default.fontPath.extension",
 			"invalid.icons.default.fontPath.path",
 			"invalid.icons.default"
+		],
+		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
+			"contributes.semanticTokenTypes",
+			"contributes.semanticTokenTypes.id",
+			"contributes.semanticTokenTypes.id.format",
+			"contributes.semanticTokenTypes.superType",
+			"contributes.semanticTokenTypes.superType.format",
+			"contributes.color.description",
+			"contributes.semanticTokenModifiers",
+			"contributes.semanticTokenModifiers.id",
+			"contributes.semanticTokenModifiers.id.format",
+			"contributes.semanticTokenModifiers.description",
+			"contributes.semanticTokenScopes",
+			"contributes.semanticTokenScopes.languages",
+			"contributes.semanticTokenScopes.scopes",
+			"invalid.id",
+			"invalid.id.format",
+			"invalid.superType.format",
+			"invalid.description",
+			"invalid.semanticTokenTypeConfiguration",
+			"invalid.semanticTokenModifierConfiguration",
+			"invalid.semanticTokenScopes.configuration",
+			"invalid.semanticTokenScopes.language",
+			"invalid.semanticTokenScopes.scopes",
+			"invalid.semanticTokenScopes.scopes.value",
+			"invalid.semanticTokenScopes.scopes.selector"
+		],
+		"vs/workbench/api/browser/statusBarExtensionPoint": [
+			"id",
+			"name",
+			"text",
+			"tooltip",
+			"command",
+			"alignment",
+			"priority",
+			"accessibilityInformation",
+			"accessibilityInformation.role",
+			"accessibilityInformation.label",
+			"vscode.extension.contributes.statusBarItems",
+			"invalid"
 		],
 		"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint": [
 			"parseErrors",
@@ -7276,41 +7553,8 @@
 			"schema.onEnterRules.action.appendText",
 			"schema.onEnterRules.action.removeText"
 		],
-		"vs/workbench/api/browser/statusBarExtensionPoint": [
-			"id",
-			"name",
-			"text",
-			"command",
-			"alignment",
-			"priority",
-			"vscode.extension.contributes.statusBarItems",
-			"invalid"
-		],
-		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
-			"contributes.semanticTokenTypes",
-			"contributes.semanticTokenTypes.id",
-			"contributes.semanticTokenTypes.id.format",
-			"contributes.semanticTokenTypes.superType",
-			"contributes.semanticTokenTypes.superType.format",
-			"contributes.color.description",
-			"contributes.semanticTokenModifiers",
-			"contributes.semanticTokenModifiers.id",
-			"contributes.semanticTokenModifiers.id.format",
-			"contributes.semanticTokenModifiers.description",
-			"contributes.semanticTokenScopes",
-			"contributes.semanticTokenScopes.languages",
-			"contributes.semanticTokenScopes.scopes",
-			"invalid.id",
-			"invalid.id.format",
-			"invalid.superType.format",
-			"invalid.description",
-			"invalid.semanticTokenTypeConfiguration",
-			"invalid.semanticTokenModifierConfiguration",
-			"invalid.semanticTokenScopes.configuration",
-			"invalid.semanticTokenScopes.language",
-			"invalid.semanticTokenScopes.scopes",
-			"invalid.semanticTokenScopes.scopes.value",
-			"invalid.semanticTokenScopes.scopes.selector"
+		"vs/workbench/api/browser/mainThreadCLICommands": [
+			"cannot be installed"
 		],
 		"vs/workbench/api/browser/mainThreadExtensionService": [
 			"reload window",
@@ -7324,21 +7568,6 @@
 			"uninstalledDep",
 			"install missing dep",
 			"unknownDep"
-		],
-		"vs/workbench/api/browser/mainThreadCLICommands": [
-			"cannot be installed"
-		],
-		"vs/workbench/api/browser/mainThreadMessageService": [
-			"extensionSource",
-			"defaultSource",
-			"manageExtension",
-			"cancel",
-			{
-				"key": "ok",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
 		],
 		"vs/workbench/api/browser/mainThreadFileSystemEventService": [
 			"ask.1.create",
@@ -7395,37 +7624,20 @@
 		"vs/workbench/api/browser/mainThreadProgress": [
 			"manageExtension"
 		],
-		"vs/workbench/services/themes/common/colorExtensionPoint": [
-			"contributes.color",
-			"contributes.color.id",
-			"contributes.color.id.format",
-			"contributes.color.description",
-			"contributes.defaults.light",
-			"contributes.defaults.dark",
-			"contributes.defaults.highContrast",
-			"contributes.defaults.highContrastLight",
-			"invalid.colorConfiguration",
-			"invalid.default.colorType",
-			"invalid.id",
-			"invalid.id.format",
-			"invalid.description",
-			"invalid.defaults",
-			"invalid.defaults.highContrast",
-			"invalid.defaults.highContrastLight"
+		"vs/workbench/api/browser/mainThreadMessageService": [
+			"extensionSource",
+			"defaultSource",
+			"manageExtension",
+			"cancel",
+			{
+				"key": "ok",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/api/browser/mainThreadSaveParticipant": [
 			"timeout.onWillSave"
-		],
-		"vs/workbench/api/common/jsonValidationExtensionPoint": [
-			"contributes.jsonValidation",
-			"contributes.jsonValidation.fileMatch",
-			"contributes.jsonValidation.url",
-			"invalid.jsonValidation",
-			"invalid.fileMatch",
-			"invalid.url",
-			"invalid.path.1",
-			"invalid.url.fileschema",
-			"invalid.url.schema"
 		],
 		"vs/workbench/api/browser/mainThreadEditSessionIdentityParticipant": [
 			"timeout.onWillCreateEditSessionIdentity"
@@ -7652,6 +7864,14 @@
 			"treeView.toggleCollapseAll",
 			"command-error"
 		],
+		"vs/workbench/browser/parts/views/viewPaneContainer": [
+			"views",
+			"viewMoveUp",
+			"viewMoveLeft",
+			"viewMoveDown",
+			"viewMoveRight",
+			"viewsMove"
+		],
 		"vs/workbench/contrib/debug/common/debug": [
 			"debugType",
 			"debugConfigurationType",
@@ -7707,14 +7927,6 @@
 			"debuggerDisabled",
 			"internalConsoleOptions"
 		],
-		"vs/workbench/browser/parts/views/viewPaneContainer": [
-			"views",
-			"viewMoveUp",
-			"viewMoveLeft",
-			"viewMoveDown",
-			"viewMoveRight",
-			"viewsMove"
-		],
 		"vs/workbench/contrib/files/common/files": [
 			"explorerViewletVisible",
 			"foldersViewVisible",
@@ -7749,20 +7961,11 @@
 			"remote.tunnelsView.makePublic",
 			"remote.tunnelsView.elevationButton"
 		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"ariaLabelGroupActions",
-			"emptyEditorGroup",
-			"groupLabel",
-			"groupAriaLabel"
-		],
-		"vs/workbench/browser/parts/editor/editorDropTarget": [
-			"dropIntoEditorPrompt"
+		"vs/workbench/common/editor/sideBySideEditorInput": [
+			"sideBySideLabels"
 		],
 		"vs/workbench/browser/parts/editor/sideBySideEditor": [
 			"sideBySideEditor"
-		],
-		"vs/workbench/common/editor/sideBySideEditorInput": [
-			"sideBySideLabels"
 		],
 		"vs/workbench/common/editor/diffEditorInput": [
 			"sideBySideLabels"
@@ -7774,49 +7977,6 @@
 		],
 		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
 			"metadataDiff"
-		],
-		"vs/workbench/browser/parts/editor/editorCommands": [
-			"editorCommand.activeEditorMove.description",
-			"editorCommand.activeEditorMove.arg.name",
-			"editorCommand.activeEditorMove.arg.description",
-			"editorCommand.activeEditorCopy.description",
-			"editorCommand.activeEditorCopy.arg.name",
-			"editorCommand.activeEditorCopy.arg.description",
-			"toggleInlineView",
-			"compare",
-			"splitEditorInGroup",
-			"joinEditorInGroup",
-			"toggleJoinEditorInGroup",
-			"toggleSplitEditorInGroupLayout",
-			"focusLeftSideEditor",
-			"focusRightSideEditor",
-			"focusOtherSideEditor",
-			"toggleEditorGroupLock",
-			"lockEditorGroup",
-			"unlockEditorGroup"
-		],
-		"vs/editor/browser/editorExtensions": [
-			{
-				"key": "miUndo",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"undo",
-			{
-				"key": "miRedo",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"redo",
-			{
-				"key": "miSelectAll",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"selectAll"
 		],
 		"vs/workbench/browser/parts/editor/editorStatus": [
 			"singleSelectionRange",
@@ -8023,12 +8183,48 @@
 			"toggleEditorType",
 			"reopenTextEditor"
 		],
-		"vs/workbench/browser/parts/editor/editorQuickAccess": [
-			"noViewResults",
-			"entryAriaLabelWithGroupDirty",
-			"entryAriaLabelWithGroup",
-			"entryAriaLabelDirty",
-			"closeEditor"
+		"vs/editor/browser/editorExtensions": [
+			{
+				"key": "miUndo",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"undo",
+			{
+				"key": "miRedo",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"redo",
+			{
+				"key": "miSelectAll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"selectAll"
+		],
+		"vs/workbench/browser/parts/editor/editorCommands": [
+			"editorCommand.activeEditorMove.description",
+			"editorCommand.activeEditorMove.arg.name",
+			"editorCommand.activeEditorMove.arg.description",
+			"editorCommand.activeEditorCopy.description",
+			"editorCommand.activeEditorCopy.arg.name",
+			"editorCommand.activeEditorCopy.arg.description",
+			"toggleInlineView",
+			"compare",
+			"splitEditorInGroup",
+			"joinEditorInGroup",
+			"toggleJoinEditorInGroup",
+			"toggleSplitEditorInGroupLayout",
+			"focusLeftSideEditor",
+			"focusRightSideEditor",
+			"focusOtherSideEditor",
+			"toggleEditorGroupLock",
+			"lockEditorGroup",
+			"unlockEditorGroup"
 		],
 		"vs/workbench/browser/parts/editor/editorConfiguration": [
 			"interactiveWindow",
@@ -8038,12 +8234,37 @@
 			"editor.editorAssociations",
 			"editorLargeFileSizeConfirmation"
 		],
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"noViewResults",
+			"entryAriaLabelWithGroupDirty",
+			"entryAriaLabelWithGroup",
+			"entryAriaLabelDirty",
+			"closeEditor"
+		],
 		"vs/workbench/browser/parts/editor/accessibilityStatus": [
 			"screenReaderDetectedExplanation.question",
 			"screenReaderDetectedExplanation.answerYes",
 			"screenReaderDetectedExplanation.answerNo",
 			"screenReaderDetected",
 			"status.editor.screenReaderMode"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
+			"toggleCollapseUnchangedRegions",
+			"collapseUnchangedRegions",
+			"showUnchangedRegions",
+			"toggleShowMovedCodeBlocks",
+			"showMoves"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"ariaLabelGroupActions",
+			"emptyEditorGroup",
+			"groupLabel",
+			"groupAriaLabel"
+		],
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
+			"move second side bar left",
+			"move second side bar right",
+			"hide second side bar"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
 			"settingsViewBarIcon",
@@ -8059,11 +8280,6 @@
 			"accounts",
 			"accounts"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
-			"toggleCollapseUnchangedRegions",
-			"collapseUnchangedRegions",
-			"showUnchangedRegions"
-		],
 		"vs/workbench/browser/parts/panel/panelPart": [
 			"resetLocation",
 			"resetLocation",
@@ -8073,20 +8289,18 @@
 			"align panel",
 			"hidePanel"
 		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
-			"move second side bar left",
-			"move second side bar right",
-			"hide second side bar"
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"dropIntoEditorPrompt"
 		],
 		"vs/workbench/browser/parts/statusbar/statusbarActions": [
 			"hide",
 			"focusStatusBar"
 		],
-		"vs/platform/actions/common/menuService": [
-			"hide.label"
-		],
 		"vs/platform/actions/common/menuResetAction": [
 			"title"
+		],
+		"vs/platform/actions/common/menuService": [
+			"hide.label"
 		],
 		"vs/base/browser/ui/dialog/dialog": [
 			"ok",
@@ -8323,6 +8537,21 @@
 			"reqid",
 			"invalid.path.1"
 		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"schema.token.settings",
+			"schema.token.foreground",
+			"schema.token.background.warning",
+			"schema.token.fontStyle",
+			"schema.fontStyle.error",
+			"schema.token.fontStyle.none",
+			"schema.properties.name",
+			"schema.properties.scope",
+			"schema.workbenchColors",
+			"schema.tokenColors.path",
+			"schema.colors",
+			"schema.supportsSemanticHighlighting",
+			"schema.semanticTokenColors"
+		],
 		"vs/workbench/services/themes/common/themeConfiguration": [
 			"colorTheme",
 			"colorThemeError",
@@ -8396,21 +8625,6 @@
 			"editorColors.semanticHighlighting.rules",
 			"semanticTokenColors"
 		],
-		"vs/workbench/services/themes/common/colorThemeSchema": [
-			"schema.token.settings",
-			"schema.token.foreground",
-			"schema.token.background.warning",
-			"schema.token.fontStyle",
-			"schema.fontStyle.error",
-			"schema.token.fontStyle.none",
-			"schema.properties.name",
-			"schema.properties.scope",
-			"schema.workbenchColors",
-			"schema.tokenColors.path",
-			"schema.colors",
-			"schema.supportsSemanticHighlighting",
-			"schema.semanticTokenColors"
-		],
 		"vs/workbench/services/themes/browser/productIconThemeData": [
 			"error.parseicondefs",
 			"defaultTheme",
@@ -8425,7 +8639,19 @@
 			"error.icon.font",
 			"error.icon.fontCharacter"
 		],
+		"vs/workbench/services/themes/common/productIconThemeSchema": [
+			"schema.id",
+			"schema.id.formatError",
+			"schema.src",
+			"schema.font-path",
+			"schema.font-format",
+			"schema.font-weight",
+			"schema.font-style",
+			"schema.iconDefinitions"
+		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
+			"I cannot reproduce",
+			"This is Bad",
 			"bisect.singular",
 			"bisect.plural",
 			"title.start",
@@ -8478,16 +8704,6 @@
 			},
 			"title.stop"
 		],
-		"vs/workbench/services/themes/common/productIconThemeSchema": [
-			"schema.id",
-			"schema.id.formatError",
-			"schema.src",
-			"schema.font-path",
-			"schema.font-format",
-			"schema.font-weight",
-			"schema.font-style",
-			"schema.iconDefinitions"
-		],
 		"vs/workbench/services/userDataProfile/browser/settingsResource": [
 			"settings"
 		],
@@ -8500,19 +8716,22 @@
 		"vs/workbench/services/userDataProfile/browser/tasksResource": [
 			"tasks"
 		],
-		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
-			"globalState"
-		],
 		"vs/workbench/services/userDataProfile/browser/extensionsResource": [
 			"extensions",
 			"disabled",
 			"exclude"
+		],
+		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
+			"globalState"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopySaveParticipant": [
 			"saveParticipants"
 		],
 		"vs/workbench/services/views/common/viewContainerModel": [
 			"views log"
+		],
+		"vs/workbench/services/hover/browser/hoverWidget": [
+			"hoverhint"
 		],
 		"vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl": [
 			"alreadyDebugging",
@@ -8527,6 +8746,12 @@
 			"invalid.tokenTypes",
 			"invalid.path.1"
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"defineKeybinding.initial",
+			"defineKeybinding.oneExists",
+			"defineKeybinding.existing",
+			"defineKeybinding.chordsTo"
+		],
 		"vs/editor/contrib/suggest/browser/suggest": [
 			"suggestWidgetHasSelection",
 			"suggestWidgetDetailsVisible",
@@ -8536,6 +8761,11 @@
 			"suggestionHasInsertAndReplaceRange",
 			"suggestionInsertMode",
 			"suggestionCanResolve"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"configureLanguageBasedSettings",
+			"languageDescriptionConfigured",
+			"pickLanguage"
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"recordKeysLabel",
@@ -8572,14 +8802,6 @@
 			"noWhen",
 			"keyboard shortcuts aria label"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"configureLanguageBasedSettings",
-			"languageDescriptionConfigured",
-			"pickLanguage"
-		],
-		"vs/workbench/services/hover/browser/hoverWidget": [
-			"hoverhint"
-		],
 		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
 			"settingsScopeDropDownIcon",
 			"settingsMoreActionIcon",
@@ -8593,6 +8815,13 @@
 			"preferencesClearInput",
 			"settingsFilter",
 			"preferencesOpenSettings"
+		],
+		"vs/workbench/contrib/preferences/common/preferencesContribution": [
+			"splitSettingsEditorLabel",
+			"enableNaturalLanguageSettingsSearch",
+			"settingsSearchTocBehavior.hide",
+			"settingsSearchTocBehavior.filter",
+			"settingsSearchTocBehavior"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditor2": [
 			"SearchSettings.AriaLabel",
@@ -8608,19 +8837,6 @@
 			"turnOnSyncButton",
 			"lastSyncedLabel"
 		],
-		"vs/workbench/contrib/preferences/common/preferencesContribution": [
-			"splitSettingsEditorLabel",
-			"enableNaturalLanguageSettingsSearch",
-			"settingsSearchTocBehavior.hide",
-			"settingsSearchTocBehavior.filter",
-			"settingsSearchTocBehavior"
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
-			"defineKeybinding.initial",
-			"defineKeybinding.oneExists",
-			"defineKeybinding.existing",
-			"defineKeybinding.chordsTo"
-		],
 		"vs/workbench/contrib/performance/browser/perfviewEditor": [
 			"name"
 		],
@@ -8632,11 +8848,25 @@
 			"notebookOpenAsText",
 			"notebookOpenInTextEditor"
 		],
+		"vs/workbench/contrib/notebook/common/notebookEditorInput": [
+			"vetoExtHostRestart"
+		],
 		"vs/workbench/contrib/notebook/browser/services/notebookServiceImpl": [
 			"notebookOpenInstallMissingViewType"
 		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor": [
 			"notebookTreeAriaLabel"
+		],
+		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
+			"notebookRunTrust"
+		],
+		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
+			"disableOtherKeymapsConfirmation",
+			"yes",
+			"no"
+		],
+		"vs/editor/common/languages/modesRegistry": [
+			"plainText.alias"
 		],
 		"vs/workbench/contrib/comments/browser/commentReply": [
 			"reply",
@@ -8644,8 +8874,42 @@
 			"reply",
 			"reply"
 		],
-		"vs/editor/common/languages/modesRegistry": [
-			"plainText.alias"
+		"vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl": [
+			"workbench.notebook.clearNotebookKernelsMRUCache"
+		],
+		"vs/workbench/contrib/notebook/browser/services/notebookLoggingServiceImpl": [
+			"renderChannelName"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibilityContribution": [
+			"accessibilityConfigurationTitle",
+			"verbosity.terminal.description",
+			"verbosity.diffEditor.description",
+			"verbosity.chat.description",
+			"verbosity.interactiveEditor.description",
+			"verbosity.keybindingsEditor.description",
+			"verbosity.notebook",
+			"editor.action.accessibilityHelp",
+			"editor.action.accessibleView"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
+			"notebookActions.category",
+			"notebookMenu.insertCell",
+			"notebookMenu.cellTitle",
+			"miShare"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookAccessibilityHelp": [
+			"notebook.overview",
+			"notebook.cell.edit",
+			"notebook.cell.editNoKb",
+			"notebook.cell.quitEdit",
+			"notebook.cell.quitEditNoKb",
+			"notebook.cell.focusInOutput",
+			"notebook.cell.focusInOutputNoKb",
+			"notebook.cellNavigation",
+			"notebook.cell.executeAndFocusContainer",
+			"notebook.cell.executeAndFocusContainerNoKb",
+			"notebook.cell.insertCodeCellBelowAndFocusContainer",
+			"notebook.changeCellType"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/insertCellActions": [
 			"notebookActions.insertCodeCellAbove",
@@ -8672,30 +8936,6 @@
 			"notebookActions.menu.insertMarkdown.tooltip",
 			"notebookActions.menu.insertMarkdown",
 			"notebookActions.menu.insertMarkdown.tooltip"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
-			"notebookActions.category",
-			"notebookMenu.insertCell",
-			"notebookMenu.cellTitle",
-			"miShare"
-		],
-		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
-			"notebookRunTrust"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
-			"workbench.notebook.layout.select.label",
-			"workbench.notebook.layout.configure.label",
-			"workbench.notebook.layout.configure.label",
-			"customizeNotebook",
-			"notebook.toggleLineNumbers",
-			"notebook.showLineNumbers",
-			"notebook.toggleCellToolbarPosition",
-			"notebook.toggleBreadcrumb",
-			"notebook.saveMimeTypeOrder",
-			"notebook.placeholder",
-			"saveTarget.machine",
-			"saveTarget.workspace",
-			"workbench.notebook.layout.webview.reset.label"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/executeActions": [
 			"notebookActions.renderMarkdown",
@@ -8739,24 +8979,25 @@
 			"detectLanguage",
 			"noDetection"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
+			"workbench.notebook.layout.select.label",
+			"workbench.notebook.layout.configure.label",
+			"workbench.notebook.layout.configure.label",
+			"customizeNotebook",
+			"notebook.toggleLineNumbers",
+			"notebook.showLineNumbers",
+			"notebook.toggleCellToolbarPosition",
+			"notebook.toggleBreadcrumb",
+			"notebook.saveMimeTypeOrder",
+			"notebook.placeholder",
+			"saveTarget.machine",
+			"saveTarget.workspace",
+			"workbench.notebook.layout.webview.reset.label"
+		],
 		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
 			"fold.cell",
 			"unfold.cell",
 			"fold.cell"
-		],
-		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
-			"disableOtherKeymapsConfirmation",
-			"yes",
-			"no"
-		],
-		"vs/workbench/contrib/notebook/browser/services/notebookLoggingServiceImpl": [
-			"renderChannelName"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
-			"format.title",
-			"label",
-			"formatCell.label",
-			"formatCells.label"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
 			"notebookActions.copy",
@@ -8765,8 +9006,15 @@
 			"notebookActions.pasteAbove",
 			"toggleNotebookClipboardLog"
 		],
-		"vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl": [
-			"workbench.notebook.clearNotebookKernelsMRUCache"
+		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFind": [
+			"notebookActions.hideFind",
+			"notebookActions.findInNotebook"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
+			"format.title",
+			"label",
+			"formatCell.label",
+			"formatCells.label"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
 			"notebookFormatSave.formatting",
@@ -8781,27 +9029,8 @@
 			},
 			"codeAction.apply"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
-			"workbench.notebook.layout.gettingStarted.label"
-		],
 		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
 			"notebook.toggleCellToolbarPosition"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFind": [
-			"notebookActions.hideFind",
-			"notebookActions.findInNotebook"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders": [
-			"notebook.cell.status.language",
-			"notebook.cell.status.autoDetectLanguage"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
-			"setProfileTitle"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
-			"empty",
-			"outline.showCodeCells",
-			"breadcrumbs.showCodeCells"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
 			"cursorMoveDown",
@@ -8817,15 +9046,20 @@
 			"cursorPageDownSelect",
 			"notebook.navigation.allowNavigateToSurroundingCells"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar": [
-			"notebook.info",
-			"tooltop",
-			"notebook.select",
-			"kernel.select.label",
-			"kernel.select.label",
-			"notebook.activeCellStatusName",
-			"notebook.multiActiveCellIndicator",
-			"notebook.singleActiveCellIndicator"
+		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
+			"empty",
+			"outline.showCodeCells",
+			"breadcrumbs.showCodeCells"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
+			"workbench.notebook.layout.gettingStarted.label"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
+			"setProfileTitle"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders": [
+			"notebook.cell.status.language",
+			"notebook.cell.status.autoDetectLanguage"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController": [
 			"notebook.cell.status.success",
@@ -8835,39 +9069,15 @@
 			"notebook.cell.statusBar.timerTooltip.reportIssueFootnote",
 			"notebook.cell.statusBar.timerTooltip"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
-			"workbench.notebook.toggleLayoutTroubleshoot",
-			"workbench.notebook.inspectLayout",
-			"workbench.notebook.clearNotebookEdtitorTypeCache"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatActions": [
-			"chat.category",
-			{
-				"key": "actions.chat.acceptInput",
-				"comment": [
-					"Apply input from the chat input box"
-				]
-			},
-			"interactiveSession.clearHistory.label",
-			"actions.interactiveSession.focus",
-			"chat.action.accessibiltyHelp",
-			"interactiveSession.focusInput.label",
-			"interactiveSession.open",
-			"interactiveSession.history.label",
-			"interactiveSession.history.delete",
-			"interactiveSession.history.pick"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
-			"interactive.copyCodeBlock.label",
-			"interactive.insertCodeBlock.label",
-			"interactive.insertIntoNewFile.label",
-			"interactive.runInTerminal.label",
-			"interactive.nextCodeBlock.label",
-			"interactive.previousCodeBlock.label"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatCopyActions": [
-			"interactive.copyAll.label",
-			"interactive.copyItem.label"
+		"vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar": [
+			"notebook.info",
+			"tooltop",
+			"notebook.select",
+			"kernel.select.label",
+			"kernel.select.label",
+			"notebook.activeCellStatusName",
+			"notebook.multiActiveCellIndicator",
+			"notebook.singleActiveCellIndicator"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands": [
 			"notebookActions.moveCellUp",
@@ -8892,46 +9102,10 @@
 			"notebookActions.expandAllCellOutput",
 			"notebookActions.toggleScrolling"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatExecuteActions": [
-			"interactive.submit.label",
-			"interactive.cancel.label"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
-			"askQuickQuestion",
-			"askabot"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatImportExport": [
-			"chat.file.label",
-			"chat.export.label",
-			"chat.import.label"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
-			"interactive.voteUp.label",
-			"interactive.voteDown.label",
-			"interactive.insertIntoNotebook.label",
-			"chat.remove.label"
-		],
-		"vs/workbench/contrib/chat/browser/chatContributionServiceImpl": [
-			"vscode.extension.contributes.interactiveSession",
-			"vscode.extension.contributes.interactiveSession.id",
-			"vscode.extension.contributes.interactiveSession.label",
-			"vscode.extension.contributes.interactiveSession.icon",
-			"vscode.extension.contributes.interactiveSession.when",
-			"chat.viewContainer.label"
-		],
-		"vs/workbench/contrib/chat/browser/chatEditorInput": [
-			"chatEditorName"
-		],
-		"vs/workbench/contrib/chat/common/chatServiceImpl": [
-			"emptyResponse"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatClearActions": [
-			"interactiveSession.clear.label",
-			"interactiveSession.clear.label",
-			"interactiveSession.clear.label"
-		],
-		"vs/workbench/contrib/chat/browser/chatWidget": [
-			"clear"
+		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
+			"workbench.notebook.toggleLayoutTroubleshoot",
+			"workbench.notebook.inspectLayout",
+			"workbench.notebook.clearNotebookEdtitorTypeCache"
 		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions": [
 			"notebook.diff.switchToText",
@@ -8946,18 +9120,184 @@
 			"notebook.diff.ignoreMetadata",
 			"notebook.diff.ignoreOutputs"
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatActions": [
+			"chat.category",
+			{
+				"key": "actions.chat.acceptInput",
+				"comment": [
+					"Apply input from the chat input box"
+				]
+			},
+			"interactiveSession.clearHistory.label",
+			"actions.interactiveSession.focus",
+			"interactiveSession.focusInput.label",
+			"interactiveSession.open",
+			"interactiveSession.history.label",
+			"interactiveSession.history.delete",
+			"interactiveSession.history.pick"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
+			"interactive.copyCodeBlock.label",
+			"interactive.insertCodeBlock.label",
+			"interactive.insertIntoNewFile.label",
+			"interactive.runInTerminal.label",
+			"interactive.nextCodeBlock.label",
+			"interactive.previousCodeBlock.label"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatCopyActions": [
+			"interactive.copyAll.label",
+			"interactive.copyItem.label"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatExecuteActions": [
+			"interactive.submit.label",
+			"interactive.cancel.label"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
+			"askQuickQuestion",
+			"askabot"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
+			"interactive.helpful.label",
+			"interactive.unhelpful.label",
+			"interactive.insertIntoNotebook.label",
+			"chat.remove.label"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatImportExport": [
+			"chat.file.label",
+			"chat.export.label",
+			"chat.import.label"
+		],
+		"vs/workbench/contrib/chat/browser/chatContributionServiceImpl": [
+			"vscode.extension.contributes.interactiveSession",
+			"vscode.extension.contributes.interactiveSession.id",
+			"vscode.extension.contributes.interactiveSession.label",
+			"vscode.extension.contributes.interactiveSession.icon",
+			"vscode.extension.contributes.interactiveSession.when",
+			"chat.viewContainer.label"
+		],
+		"vs/workbench/contrib/chat/browser/chatEditorInput": [
+			"chatEditorName"
+		],
+		"vs/workbench/contrib/chat/browser/chatWidget": [
+			"clear"
+		],
+		"vs/workbench/contrib/chat/common/chatServiceImpl": [
+			"emptyResponse"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatMoveActions": [
 			"chat.openInEditor.label",
 			"interactiveSession.openInEditor.label",
 			"interactiveSession.openInSidebar.label"
 		],
-		"vs/workbench/contrib/chat/common/chatColors": [
-			"chat.requestBackground",
-			"chat.requestBorder"
+		"vs/workbench/contrib/chat/browser/actions/chatClearActions": [
+			"interactiveSession.clear.label",
+			"interactiveSession.clear.label",
+			"interactiveSession.clear.label"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibleView": [
+			"openDoc",
+			"disable-help-hint",
+			"exit-tip"
+		],
+		"vs/workbench/contrib/chat/common/chatViewModel": [
+			"thinking"
+		],
+		"vs/workbench/contrib/chat/common/chatContextKeys": [
+			"interactiveSessionResponseHasProviderId",
+			"interactiveSessionResponseVote",
+			"interactiveSessionRequestInProgress",
+			"chatResponse",
+			"chatRequest",
+			"interactiveInputHasText",
+			"inInteractiveInput",
+			"inChat",
+			"hasChatProvider"
 		],
 		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
 			"interactive.input.placeholderWithCommands",
 			"interactive.input.placeholderNoCommands"
+		],
+		"vs/workbench/contrib/chat/common/chatColors": [
+			"chat.requestBackground",
+			"chat.requestBorder"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
+			"welcome.1",
+			"welcome.2",
+			"create.fail",
+			"create.fail.detail",
+			"welcome.1",
+			"default.placeholder",
+			"default.placeholder.history",
+			"thinking",
+			"empty",
+			"markdownResponseMessage",
+			"editResponseMessage",
+			"err.apply",
+			"err.discard"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
+			"run",
+			"unstash",
+			"cat",
+			"accept",
+			"rerun",
+			"rerunShort",
+			"stop",
+			"arrowUp",
+			"arrowDown",
+			"focus",
+			"previousFromHistory",
+			"nextFromHistory",
+			"discardMenu",
+			"discard",
+			"undo.clipboard",
+			"undo.newfile",
+			"feedback.helpful",
+			"feedback.unhelpful",
+			"toggleDiff",
+			"toggleDiff2",
+			"apply1",
+			"apply2",
+			"cancel",
+			"copyRecordings",
+			"label",
+			"viewInChat",
+			"expandMessage",
+			"contractMessage"
+		],
+		"vs/workbench/contrib/inlineChat/common/inlineChat": [
+			"inlineChatHasProvider",
+			"inlineChatVisible",
+			"inlineChatFocused",
+			"inlineChatEmpty",
+			"inlineChatInnerCursorFirst",
+			"inlineChatInnerCursorLast",
+			"inlineChatMarkdownMessageCropState",
+			"inlineChatOuterCursorPosition",
+			"inlineChatHasActiveRequest",
+			"inlineChatHasStashedSession",
+			"inlineChatDiff",
+			"inlineChatResponseType",
+			"inlineChatResponseTypes",
+			"inlineChatDidEdit",
+			"inlineChatUserDidEdit",
+			"inlineChatLastFeedbackKind",
+			"inlineChatDocumentChanged",
+			"inlineChat.background",
+			"inlineChat.border",
+			"inlineChat.shadow",
+			"inlineChat.regionHighlight",
+			"inlineChatInput.border",
+			"inlineChatInput.focusBorder",
+			"inlineChatInput.placeholderForeground",
+			"inlineChatInput.background",
+			"inlineChatDiff.inserted",
+			"inlineChatDiff.removed",
+			"mode",
+			"mode.livePreview",
+			"mode.preview",
+			"mode.live"
 		],
 		"vs/editor/contrib/peekView/browser/peekView": [
 			"inReferenceSearchEditor",
@@ -8980,14 +9320,6 @@
 		],
 		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
 			"interactiveInputPlaceHolder"
-		],
-		"vs/workbench/contrib/files/browser/fileConstants": [
-			"saveAs",
-			"save",
-			"saveWithoutFormatting",
-			"saveAll",
-			"removeFolderFromWorkspace",
-			"newUntitledFile"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookIcons": [
 			"selectKernelIcon",
@@ -9015,6 +9347,14 @@
 			"mimetypeIcon",
 			"previousChangeIcon",
 			"nextChangeIcon"
+		],
+		"vs/workbench/contrib/files/browser/fileConstants": [
+			"saveAs",
+			"save",
+			"saveWithoutFormatting",
+			"saveAll",
+			"removeFolderFromWorkspace",
+			"newUntitledFile"
 		],
 		"vs/workbench/contrib/testing/browser/icons": [
 			"testViewIcon",
@@ -9079,16 +9419,31 @@
 			},
 			"testExplorer"
 		],
-		"vs/workbench/contrib/testing/browser/testingOutputTerminalService": [
-			"testOutputTerminalTitleWithDate",
-			"testOutputTerminalTitleWithDateAndTaskName",
-			"testOutputTerminalTitle",
-			"testNoRunYet",
+		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
+			"testing.markdownPeekError",
+			"testOutputTitle",
+			"testingOutputExpected",
+			"testingOutputActual",
 			"runNoOutout",
-			"runFinished"
-		],
-		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
-			"testing"
+			"runNoOutputForPast",
+			"close",
+			"testUnnamedTask",
+			"messageMoreLinesN",
+			"messageMoreLines1",
+			"testingPeekLabel",
+			"testing.showResultOutput",
+			"testing.showResultOutput",
+			"testing.reRunLastRun",
+			"testing.debugLastRun",
+			"testing.goToFile",
+			"testing.revealInExplorer",
+			"run test",
+			"debug test",
+			"testing.goToError",
+			"testing.goToNextMessage",
+			"testing.goToPreviousMessage",
+			"testing.openMessageInEditor",
+			"testing.toggleTestingPeekHistory"
 		],
 		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
 			"testProgress.runningInitial",
@@ -9097,31 +9452,17 @@
 			"testProgress.completed",
 			"testProgressWithSkip.completed"
 		],
-		"vs/workbench/contrib/testing/common/configuration": [
-			"testConfigurationTitle",
-			"testing.autoRun.delay",
-			"testing.automaticallyOpenPeekView",
-			"testing.automaticallyOpenPeekView.failureAnywhere",
-			"testing.automaticallyOpenPeekView.failureInVisibleDocument",
-			"testing.automaticallyOpenPeekView.never",
-			"testing.automaticallyOpenPeekViewDuringContinuousRun",
-			"testing.countBadge",
-			"testing.countBadge.failed",
-			"testing.countBadge.off",
-			"testing.countBadge.passed",
-			"testing.countBadge.skipped",
-			"testing.followRunningTest",
-			"testing.defaultGutterClickAction",
-			"testing.defaultGutterClickAction.run",
-			"testing.defaultGutterClickAction.debug",
-			"testing.defaultGutterClickAction.contextMenu",
-			"testing.gutterEnabled",
-			"testing.saveBeforeTest",
-			"testing.openTesting.neverOpen",
-			"testing.openTesting.openOnTestStart",
-			"testing.openTesting.openOnTestFailure",
-			"testing.openTesting",
-			"testing.alwaysRevealTestOnStateChange"
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"testing"
+		],
+		"vs/workbench/contrib/testing/common/testServiceImpl": [
+			"testTrust",
+			"testError",
+			"testTrust",
+			"testError"
+		],
+		"vs/workbench/contrib/testing/common/testingContentProvider": [
+			"runNoOutout"
 		],
 		"vs/workbench/contrib/testing/common/testingContextKeys": [
 			"testing.canRefresh",
@@ -9140,44 +9481,6 @@
 			"testing.testId",
 			"testing.testItemHasUri",
 			"testing.testItemIsHidden"
-		],
-		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
-			"testing.markdownPeekError",
-			"testOutputTitle",
-			"testingOutputExpected",
-			"testingOutputActual",
-			"close",
-			"testUnnamedTask",
-			"messageMoreLinesN",
-			"messageMoreLines1",
-			"testingPeekLabel",
-			"testing.showResultOutput",
-			"testing.showResultOutput",
-			"testing.reRunLastRun",
-			"testing.debugLastRun",
-			"testing.goToFile",
-			"testing.revealInExplorer",
-			"run test",
-			"debug test",
-			"testing.goToError",
-			"testing.showMessageInTerminal",
-			"testing.goToNextMessage",
-			"testing.goToPreviousMessage",
-			"testing.openMessageInEditor",
-			"testing.toggleTestingPeekHistory"
-		],
-		"vs/workbench/contrib/testing/common/testingContentProvider": [
-			"runNoOutout"
-		],
-		"vs/workbench/contrib/testing/common/testServiceImpl": [
-			"testTrust",
-			"testError",
-			"testTrust",
-			"testError"
-		],
-		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
-			"testConfigurationUi.pick",
-			"updateTestConfiguration"
 		],
 		"vs/workbench/contrib/testing/browser/testExplorerActions": [
 			"hideTest",
@@ -9212,8 +9515,6 @@
 			"testing.sortByLocation",
 			"testing.sortByDuration",
 			"testing.showMostRecentOutput",
-			"testing.pickTaskUnnamed",
-			"testing.pickTask",
 			"testing.collapseAll",
 			"testing.clearResults",
 			"testing.editFocusedTest",
@@ -9233,75 +9534,36 @@
 			"testing.refreshTests",
 			"testing.cancelTestRefresh"
 		],
-		"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController": [
-			"create.fail",
-			"create.fail.detail",
-			"welcome.1",
-			"default.placeholder",
-			"default.placeholder.history",
-			"thinking",
-			"empty",
-			"err.apply",
-			"err.discard"
+		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
+			"testConfigurationUi.pick",
+			"updateTestConfiguration"
 		],
-		"vs/workbench/contrib/interactiveEditor/common/interactiveEditor": [
-			"interactiveEditorHasProvider",
-			"interactiveEditorVisible",
-			"interactiveEditorFocused",
-			"interactiveEditorEmpty",
-			"interactiveEditorInnerCursorFirst",
-			"interactiveEditorInnerCursorLast",
-			"interactiveEditorMarkdownMessageCropState",
-			"interactiveEditorOuterCursorPosition",
-			"interactiveEditorHasActiveRequest",
-			"interactiveEditorHasStashedSession",
-			"interactiveEditorDiff",
-			"interactiveEditorResponseType",
-			"interactiveEditorDidEdit",
-			"interactiveEditorLastFeedbackKind",
-			"interactiveEditorDocumentChanged",
-			"interactiveEditor.border",
-			"interactiveEditor.shadow",
-			"interactiveEditor.regionHighlight",
-			"interactiveEditorInput.border",
-			"interactiveEditorInput.focusBorder",
-			"interactiveEditorInput.placeholderForeground",
-			"interactiveEditorInput.background",
-			"interactiveEditorDiff.inserted",
-			"interactiveEditorDiff.removed",
-			"editMode",
-			"editMode.livePreview",
-			"editMode.preview",
-			"editMode.live"
-		],
-		"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorActions": [
-			"run",
-			"unstash",
-			"cat",
-			"accept",
-			"stop",
-			"arrowUp",
-			"arrowDown",
-			"focus",
-			"previousFromHistory",
-			"nextFromHistory",
-			"discardMenu",
-			"discard",
-			"undo.clipboard",
-			"undo.newfile",
-			"feedback.helpful",
-			"feedback.unhelpful",
-			"toggleDiff",
-			"toggleDiff2",
-			"apply1",
-			"apply2",
-			"cancel",
-			"copyRecordings",
-			"label",
-			"viewInChat",
-			"expandMessage",
-			"contractMessage",
-			"actions.interactiveSession.accessibiltyHelpEditor"
+		"vs/workbench/contrib/testing/common/configuration": [
+			"testConfigurationTitle",
+			"testing.autoRun.delay",
+			"testing.automaticallyOpenPeekView",
+			"testing.automaticallyOpenPeekView.failureAnywhere",
+			"testing.automaticallyOpenPeekView.failureInVisibleDocument",
+			"testing.automaticallyOpenPeekView.never",
+			"testing.showAllMessages",
+			"testing.automaticallyOpenPeekViewDuringContinuousRun",
+			"testing.countBadge",
+			"testing.countBadge.failed",
+			"testing.countBadge.off",
+			"testing.countBadge.passed",
+			"testing.countBadge.skipped",
+			"testing.followRunningTest",
+			"testing.defaultGutterClickAction",
+			"testing.defaultGutterClickAction.run",
+			"testing.defaultGutterClickAction.debug",
+			"testing.defaultGutterClickAction.contextMenu",
+			"testing.gutterEnabled",
+			"testing.saveBeforeTest",
+			"testing.openTesting.neverOpen",
+			"testing.openTesting.openOnTestStart",
+			"testing.openTesting.openOnTestFailure",
+			"testing.openTesting",
+			"testing.alwaysRevealTestOnStateChange"
 		],
 		"vs/workbench/contrib/logs/common/logsActions": [
 			"setLogLevel",
@@ -9327,24 +9589,6 @@
 		"vs/platform/quickinput/browser/helpQuickAccess": [
 			"helpPickAriaLabel"
 		],
-		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
-			"askXInChat",
-			"noCommandResults",
-			"configure keybinding",
-			"semanticSimilarity",
-			"commandWithCategory",
-			"showTriggerActions",
-			"clearCommandHistory",
-			"confirmClearMessage",
-			"confirmClearDetail",
-			{
-				"key": "clearButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"askInChat"
-		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"noViewResults",
 			"views",
@@ -9356,6 +9600,30 @@
 			"channels",
 			"openView",
 			"quickOpenView"
+		],
+		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
+			"noCommandResults",
+			"configure keybinding",
+			"semanticSimilarity",
+			"askXInChat",
+			"commandWithCategory",
+			"showTriggerActions",
+			"clearCommandHistory",
+			"confirmClearMessage",
+			"confirmClearDetail",
+			{
+				"key": "clearButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/files/browser/views/explorerView": [
+			"explorerSection",
+			"createNewFile",
+			"createNewFolder",
+			"refreshExplorer",
+			"collapseExplorerFolders"
 		],
 		"vs/workbench/contrib/files/browser/views/emptyView": [
 			"noWorkspace"
@@ -9378,57 +9646,6 @@
 				]
 			},
 			"newUntitledFile"
-		],
-		"vs/workbench/contrib/files/browser/views/explorerView": [
-			"explorerSection",
-			"createNewFile",
-			"createNewFolder",
-			"refreshExplorer",
-			"collapseExplorerFolders"
-		],
-		"vs/workbench/contrib/files/browser/fileCommands": [
-			"modifiedLabel",
-			{
-				"key": "genericSaveError",
-				"comment": [
-					"{0} is the resource that failed to save and {1} the error message"
-				]
-			},
-			"retry",
-			"discard",
-			"genericRevertError",
-			"newFileCommand.saveLabel"
-		],
-		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
-			"userGuide",
-			"staleSaveError",
-			"readonlySaveErrorAdmin",
-			"readonlySaveErrorSudo",
-			"readonlySaveError",
-			"permissionDeniedSaveError",
-			"permissionDeniedSaveErrorSudo",
-			{
-				"key": "genericSaveError",
-				"comment": [
-					"{0} is the resource that failed to save and {1} the error message"
-				]
-			},
-			"learnMore",
-			"dontShowAgain",
-			"compareChanges",
-			"saveConflictDiffLabel",
-			"overwriteElevated",
-			"overwriteElevatedSudo",
-			"saveElevated",
-			"saveElevatedSudo",
-			"retry",
-			"discard",
-			"overwrite",
-			"overwrite",
-			"configure"
-		],
-		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
-			"binaryFileEditor"
 		],
 		"vs/workbench/contrib/files/browser/fileActions": [
 			"newFile",
@@ -9591,9 +9808,55 @@
 			"toggleActiveEditorReadonlyInSession",
 			"resetActiveEditorReadonlyInSession"
 		],
-		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
-			"dirtyFile",
-			"dirtyFiles"
+		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
+			"userGuide",
+			"staleSaveError",
+			"readonlySaveErrorAdmin",
+			"readonlySaveErrorSudo",
+			"readonlySaveError",
+			"permissionDeniedSaveError",
+			"permissionDeniedSaveErrorSudo",
+			{
+				"key": "genericSaveError",
+				"comment": [
+					"{0} is the resource that failed to save and {1} the error message"
+				]
+			},
+			"learnMore",
+			"dontShowAgain",
+			"compareChanges",
+			"saveConflictDiffLabel",
+			"overwriteElevated",
+			"overwriteElevatedSudo",
+			"saveElevated",
+			"saveElevatedSudo",
+			"retry",
+			"discard",
+			"overwrite",
+			"overwrite",
+			"configure"
+		],
+		"vs/workbench/contrib/files/browser/fileCommands": [
+			"modifiedLabel",
+			{
+				"key": "genericSaveError",
+				"comment": [
+					"{0} is the resource that failed to save and {1} the error message"
+				]
+			},
+			"retry",
+			"discard",
+			"genericRevertError",
+			"newFileCommand.saveLabel"
+		],
+		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
+			"binaryFileEditor"
+		],
+		"vs/workbench/contrib/files/browser/workspaceWatcher": [
+			"enospcError",
+			"learnMore",
+			"eshutdownError",
+			"reload"
 		],
 		"vs/editor/common/config/editorConfigurationSchema": [
 			"editorConfigurationTitle",
@@ -9636,13 +9899,9 @@
 			"diffAlgorithm.legacy",
 			"diffAlgorithm.advanced",
 			"collapseUnchangedRegions",
-			"useVersion2"
-		],
-		"vs/workbench/contrib/files/browser/workspaceWatcher": [
-			"enospcError",
-			"learnMore",
-			"eshutdownError",
-			"reload"
+			"showMoves",
+			"useVersion2",
+			"showEmptyDecorations"
 		],
 		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
 			"textFileEditor",
@@ -9653,6 +9912,20 @@
 			"fileTooLargeForHeapErrorWithoutSize",
 			"unavailableResourceErrorEditorText",
 			"createFile"
+		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"dirtyFile",
+			"dirtyFiles"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
+			"default"
+		],
+		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
+			"cannotRunGotoLine",
+			"gotoLineColumnLabel",
+			"gotoLineLabel",
+			"gotoLineLabelEmptyWithLimit",
+			"gotoLineLabelEmpty"
 		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
 			"ok",
@@ -9666,16 +9939,6 @@
 			"edt.title.2",
 			"edt.title.1"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
-			"default"
-		],
-		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
-			"cannotRunGotoLine",
-			"gotoLineColumnLabel",
-			"gotoLineLabel",
-			"gotoLineLabelEmptyWithLimit",
-			"gotoLineLabelEmpty"
-		],
 		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
 			"empty",
 			"gotoSymbol",
@@ -9688,24 +9951,6 @@
 			"gotoSymbolQuickAccessPlaceholder",
 			"gotoSymbolQuickAccess",
 			"gotoSymbolByCategoryQuickAccess"
-		],
-		"vs/workbench/contrib/search/browser/searchIcons": [
-			"searchDetailsIcon",
-			"searchShowContextIcon",
-			"searchHideReplaceIcon",
-			"searchShowReplaceIcon",
-			"searchReplaceAllIcon",
-			"searchReplaceIcon",
-			"searchRemoveIcon",
-			"searchRefreshIcon",
-			"searchCollapseAllIcon",
-			"searchExpandAllIcon",
-			"searchShowAsTree",
-			"searchShowAsList",
-			"searchClearIcon",
-			"searchStopIcon",
-			"searchViewIcon",
-			"searchNewEditorIcon"
 		],
 		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
 			"noAnythingResults",
@@ -9728,10 +9973,23 @@
 			"closeEditor",
 			"filePickAriaLabelDirty"
 		],
-		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
-			"noSymbolResults",
-			"openToSide",
-			"openToBottom"
+		"vs/workbench/contrib/search/browser/searchIcons": [
+			"searchDetailsIcon",
+			"searchShowContextIcon",
+			"searchHideReplaceIcon",
+			"searchShowReplaceIcon",
+			"searchReplaceAllIcon",
+			"searchReplaceIcon",
+			"searchRemoveIcon",
+			"searchRefreshIcon",
+			"searchCollapseAllIcon",
+			"searchExpandAllIcon",
+			"searchShowAsTree",
+			"searchShowAsList",
+			"searchClearIcon",
+			"searchStopIcon",
+			"searchViewIcon",
+			"searchNewEditorIcon"
 		],
 		"vs/workbench/contrib/search/browser/searchWidget": [
 			"search.action.replaceAll.disabled.label",
@@ -9742,6 +10000,11 @@
 			"showContext",
 			"label.Replace",
 			"search.replace.placeHolder"
+		],
+		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
+			"noSymbolResults",
+			"openToSide",
+			"openToBottom"
 		],
 		"vs/workbench/contrib/search/browser/searchActionsCopy": [
 			"copyMatchLabel",
@@ -9763,16 +10026,6 @@
 			"findInFiles.args",
 			"findInFolder",
 			"findInWorkspace"
-		],
-		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
-			"showTriggerActions",
-			"showTriggerActions",
-			{
-				"key": "miGotoSymbolInWorkspace",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
 		],
 		"vs/workbench/contrib/search/browser/searchActionsNav": [
 			"ToggleQueryDetailsAction.label",
@@ -9799,8 +10052,15 @@
 			"file.replaceAll.label",
 			"file.replaceAll.label"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsBase": [
-			"search"
+		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
+			"showTriggerActions",
+			"showTriggerActions",
+			{
+				"key": "miGotoSymbolInWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/search/browser/searchActionsTopBar": [
 			"clearSearchHistoryLabel",
@@ -9812,10 +10072,8 @@
 			"ViewAsTreeAction.label",
 			"ViewAsListAction.label"
 		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
-			"searchTitle.withQuery",
-			"searchTitle.withQuery",
-			"searchTitle"
+		"vs/workbench/contrib/search/browser/searchActionsBase": [
+			"search"
 		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
 			"moreSearch",
@@ -9828,15 +10086,24 @@
 			"searchEditor",
 			"textInputBoxBorder"
 		],
-		"vs/workbench/contrib/search/browser/patternInputWidget": [
-			"defaultLabel",
-			"onlySearchInOpenEditors",
-			"useExcludesAndIgnoreFilesDescription"
+		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
+			"searchTitle.withQuery",
+			"searchTitle.withQuery",
+			"searchTitle"
 		],
 		"vs/workbench/browser/parts/views/viewPane": [
 			"viewPaneContainerExpandedIcon",
 			"viewPaneContainerCollapsedIcon",
 			"viewToolbarAriaLabel"
+		],
+		"vs/workbench/contrib/search/browser/searchMessage": [
+			"unable to open trust",
+			"unable to open"
+		],
+		"vs/workbench/contrib/search/browser/patternInputWidget": [
+			"defaultLabel",
+			"onlySearchInOpenEditors",
+			"useExcludesAndIgnoreFilesDescription"
 		],
 		"vs/workbench/contrib/search/browser/searchResultsView": [
 			"searchFolderMatch.other.label",
@@ -9860,16 +10127,6 @@
 		"vs/workbench/contrib/scm/browser/activity": [
 			"status.scm",
 			"scmPendingChangesBadge"
-		],
-		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
-			"source control"
-		],
-		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
-			"scm"
-		],
-		"vs/workbench/contrib/search/browser/searchMessage": [
-			"unable to open trust",
-			"unable to open"
 		],
 		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
 			"changes",
@@ -9903,9 +10160,8 @@
 			"overviewRulerAddedForeground",
 			"overviewRulerDeletedForeground"
 		],
-		"vs/workbench/contrib/workspace/common/workspace": [
-			"workspaceTrustEnabledCtx",
-			"workspaceTrustedCtx"
+		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
+			"source control"
 		],
 		"vs/workbench/contrib/scm/browser/scmViewPane": [
 			"scm",
@@ -9925,78 +10181,12 @@
 			"label.close",
 			"scm.providerBorder"
 		],
-		"vs/workbench/contrib/debug/browser/debugColors": [
-			"debugToolBarBackground",
-			"debugToolBarBorder",
-			"debugIcon.startForeground",
-			"debugIcon.pauseForeground",
-			"debugIcon.stopForeground",
-			"debugIcon.disconnectForeground",
-			"debugIcon.restartForeground",
-			"debugIcon.stepOverForeground",
-			"debugIcon.stepIntoForeground",
-			"debugIcon.stepOutForeground",
-			"debugIcon.continueForeground",
-			"debugIcon.stepBackForeground"
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"scm"
 		],
-		"vs/workbench/contrib/debug/browser/callStackView": [
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"showMoreStackFrames2",
-			{
-				"key": "session",
-				"comment": [
-					"Session is a noun"
-				]
-			},
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"restartFrame",
-			"loadAllStackFrames",
-			"showMoreAndOrigin",
-			"showMoreStackFrames",
-			{
-				"key": "pausedOn",
-				"comment": [
-					"indicates reason for program being paused"
-				]
-			},
-			"paused",
-			{
-				"comment": [
-					"Debug is a noun in this context, not a verb."
-				],
-				"key": "callStackAriaLabel"
-			},
-			{
-				"key": "threadAriaLabel",
-				"comment": [
-					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
-				]
-			},
-			"stackFrameAriaLabel",
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			{
-				"key": "sessionLabel",
-				"comment": [
-					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
-				]
-			},
-			"showMoreStackFrames",
-			"collapse"
+		"vs/workbench/contrib/workspace/common/workspace": [
+			"workspaceTrustEnabledCtx",
+			"workspaceTrustedCtx"
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"unverifiedExceptionBreakpoint",
@@ -10072,65 +10262,78 @@
 			"editBreakpoint",
 			"editHitCount"
 		],
-		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
-			"workbench.action.debug.startDebug"
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"debugToolBarBackground",
+			"debugToolBarBorder",
+			"debugIcon.startForeground",
+			"debugIcon.pauseForeground",
+			"debugIcon.stopForeground",
+			"debugIcon.disconnectForeground",
+			"debugIcon.restartForeground",
+			"debugIcon.stepOverForeground",
+			"debugIcon.stepIntoForeground",
+			"debugIcon.stepOutForeground",
+			"debugIcon.continueForeground",
+			"debugIcon.stepBackForeground"
 		],
-		"vs/workbench/contrib/debug/browser/debugIcons": [
-			"debugConsoleViewIcon",
-			"runViewIcon",
-			"variablesViewIcon",
-			"watchViewIcon",
-			"callStackViewIcon",
-			"breakpointsViewIcon",
-			"loadedScriptsViewIcon",
-			"debugBreakpoint",
-			"debugBreakpointDisabled",
-			"debugBreakpointUnverified",
-			"debugBreakpointFunction",
-			"debugBreakpointFunctionDisabled",
-			"debugBreakpointFunctionUnverified",
-			"debugBreakpointConditional",
-			"debugBreakpointConditionalDisabled",
-			"debugBreakpointConditionalUnverified",
-			"debugBreakpointData",
-			"debugBreakpointDataDisabled",
-			"debugBreakpointDataUnverified",
-			"debugBreakpointLog",
-			"debugBreakpointLogDisabled",
-			"debugBreakpointLogUnverified",
-			"debugBreakpointHint",
-			"debugBreakpointUnsupported",
-			"debugStackframe",
-			"debugStackframeFocused",
-			"debugGripper",
-			"debugRestartFrame",
-			"debugStop",
-			"debugDisconnect",
-			"debugRestart",
-			"debugStepOver",
-			"debugStepInto",
-			"debugStepOut",
-			"debugStepBack",
-			"debugPause",
-			"debugContinue",
-			"debugReverseContinue",
-			"debugRun",
-			"debugStart",
-			"debugConfigure",
-			"debugConsole",
-			"debugRemoveConfig",
-			"debugCollapseAll",
-			"callstackViewSession",
-			"debugConsoleClearAll",
-			"watchExpressionsRemoveAll",
-			"watchExpressionRemove",
-			"watchExpressionsAdd",
-			"watchExpressionsAddFuncBreakpoint",
-			"breakpointsRemoveAll",
-			"breakpointsActivate",
-			"debugConsoleEvaluationInput",
-			"debugConsoleEvaluationPrompt",
-			"debugInspectMemory"
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"showMoreStackFrames2",
+			{
+				"key": "session",
+				"comment": [
+					"Session is a noun"
+				]
+			},
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"restartFrame",
+			"loadAllStackFrames",
+			"showMoreAndOrigin",
+			"showMoreStackFrames",
+			{
+				"key": "pausedOn",
+				"comment": [
+					"indicates reason for program being paused"
+				]
+			},
+			"paused",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "callStackAriaLabel"
+			},
+			{
+				"key": "threadAriaLabel",
+				"comment": [
+					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
+				]
+			},
+			"stackFrameAriaLabel",
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			{
+				"key": "sessionLabel",
+				"comment": [
+					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
+				]
+			},
+			"showMoreStackFrames",
+			"collapse"
 		],
 		"vs/workbench/contrib/debug/browser/debugCommands": [
 			"debug",
@@ -10165,25 +10368,8 @@
 			"addConfiguration",
 			"addInlineBreakpoint"
 		],
-		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
-			"noDebugResults",
-			"customizeLaunchConfig",
-			{
-				"key": "contributed",
-				"comment": [
-					"contributed is lower case because it looks better like that in UI. Nothing preceeds it. It is a name of the grouping of debug configurations."
-				]
-			},
-			"removeLaunchConfig",
-			{
-				"key": "providerAriaLabel",
-				"comment": [
-					"Placeholder stands for the provider label. For example \"NodeJS\"."
-				]
-			},
-			"configure",
-			"addConfigTo",
-			"addConfiguration"
+		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
+			"workbench.action.debug.startDebug"
 		],
 		"vs/workbench/contrib/debug/browser/debugEditorActions": [
 			"toggleBreakpointAction",
@@ -10243,15 +10429,87 @@
 			"goToPreviousBreakpoint",
 			"closeExceptionWidget"
 		],
+		"vs/workbench/contrib/debug/browser/debugIcons": [
+			"debugConsoleViewIcon",
+			"runViewIcon",
+			"variablesViewIcon",
+			"watchViewIcon",
+			"callStackViewIcon",
+			"breakpointsViewIcon",
+			"loadedScriptsViewIcon",
+			"debugBreakpoint",
+			"debugBreakpointDisabled",
+			"debugBreakpointUnverified",
+			"debugBreakpointFunction",
+			"debugBreakpointFunctionDisabled",
+			"debugBreakpointFunctionUnverified",
+			"debugBreakpointConditional",
+			"debugBreakpointConditionalDisabled",
+			"debugBreakpointConditionalUnverified",
+			"debugBreakpointData",
+			"debugBreakpointDataDisabled",
+			"debugBreakpointDataUnverified",
+			"debugBreakpointLog",
+			"debugBreakpointLogDisabled",
+			"debugBreakpointLogUnverified",
+			"debugBreakpointHint",
+			"debugBreakpointUnsupported",
+			"debugStackframe",
+			"debugStackframeFocused",
+			"debugGripper",
+			"debugRestartFrame",
+			"debugStop",
+			"debugDisconnect",
+			"debugRestart",
+			"debugStepOver",
+			"debugStepInto",
+			"debugStepOut",
+			"debugStepBack",
+			"debugPause",
+			"debugContinue",
+			"debugReverseContinue",
+			"debugRun",
+			"debugStart",
+			"debugConfigure",
+			"debugConsole",
+			"debugRemoveConfig",
+			"debugCollapseAll",
+			"callstackViewSession",
+			"debugConsoleClearAll",
+			"watchExpressionsRemoveAll",
+			"watchExpressionRemove",
+			"watchExpressionsAdd",
+			"watchExpressionsAddFuncBreakpoint",
+			"breakpointsRemoveAll",
+			"breakpointsActivate",
+			"debugConsoleEvaluationInput",
+			"debugConsoleEvaluationPrompt",
+			"debugInspectMemory"
+		],
+		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
+			"noDebugResults",
+			"customizeLaunchConfig",
+			{
+				"key": "contributed",
+				"comment": [
+					"contributed is lower case because it looks better like that in UI. Nothing preceeds it. It is a name of the grouping of debug configurations."
+				]
+			},
+			"removeLaunchConfig",
+			{
+				"key": "providerAriaLabel",
+				"comment": [
+					"Placeholder stands for the provider label. For example \"NodeJS\"."
+				]
+			},
+			"configure",
+			"addConfigTo",
+			"addConfiguration"
+		],
 		"vs/workbench/contrib/debug/browser/debugStatus": [
 			"status.debug",
 			"debugTarget",
 			"selectAndStartDebug"
-		],
-		"vs/workbench/contrib/debug/browser/debugToolBar": [
-			"notebook.moreRunActionsLabel",
-			"stepBackDebug",
-			"reverseContinue"
 		],
 		"vs/workbench/contrib/debug/browser/debugService": [
 			"1activeSession",
@@ -10292,6 +10550,20 @@
 			"breakpointAdded",
 			"breakpointRemoved"
 		],
+		"vs/workbench/contrib/debug/browser/debugToolBar": [
+			"notebook.moreRunActionsLabel",
+			"stepBackDebug",
+			"reverseContinue"
+		],
+		"vs/workbench/contrib/debug/browser/disassemblyView": [
+			"instructionNotAvailable",
+			"disassemblyTableColumnLabel",
+			"editorOpenedFromDisassemblyDescription",
+			"disassemblyView",
+			"instructionAddress",
+			"instructionBytes",
+			"instructionText"
+		],
 		"vs/workbench/contrib/debug/browser/loadedScriptsView": [
 			"loadedScriptsSession",
 			{
@@ -10310,14 +10582,37 @@
 			"statusBarDebuggingForeground",
 			"statusBarDebuggingBorder"
 		],
-		"vs/workbench/contrib/debug/browser/disassemblyView": [
-			"instructionNotAvailable",
-			"disassemblyTableColumnLabel",
-			"editorOpenedFromDisassemblyDescription",
-			"disassemblyView",
-			"instructionAddress",
-			"instructionBytes",
-			"instructionText"
+		"vs/workbench/contrib/debug/browser/variablesView": [
+			"variableValueAriaLabel",
+			"variablesAriaTreeLabel",
+			"variableScopeAriaLabel",
+			{
+				"key": "variableAriaLabel",
+				"comment": [
+					"Placeholders are variable name and variable value respectivly. They should not be translated."
+				]
+			},
+			"viewMemory.prompt",
+			"cancel",
+			"install",
+			"viewMemory.install.progress",
+			"collapse"
+		],
+		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
+			"typeNewValue",
+			"watchExpressionInputAriaLabel",
+			"watchExpressionPlaceholder",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "watchAriaTreeLabel"
+			},
+			"watchExpressionAriaLabel",
+			"watchVariableAriaLabel",
+			"collapse",
+			"addWatchExpression",
+			"removeAllWatchExpressions"
 		],
 		"vs/workbench/contrib/debug/browser/welcomeView": [
 			"run",
@@ -10359,22 +10654,6 @@
 			},
 			"allDebuggersDisabled"
 		],
-		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
-			"typeNewValue",
-			"watchExpressionInputAriaLabel",
-			"watchExpressionPlaceholder",
-			{
-				"comment": [
-					"Debug is a noun in this context, not a verb."
-				],
-				"key": "watchAriaTreeLabel"
-			},
-			"watchExpressionAriaLabel",
-			"watchVariableAriaLabel",
-			"collapse",
-			"addWatchExpression",
-			"removeAllWatchExpressions"
-		],
 		"vs/workbench/contrib/debug/common/debugContentProvider": [
 			"unable",
 			"canNotResolveSourceWithError",
@@ -10393,29 +10672,6 @@
 		"vs/workbench/contrib/debug/common/disassemblyViewInput": [
 			"disassemblyInputName"
 		],
-		"vs/workbench/contrib/debug/browser/variablesView": [
-			"variableValueAriaLabel",
-			"variablesAriaTreeLabel",
-			"variableScopeAriaLabel",
-			{
-				"key": "variableAriaLabel",
-				"comment": [
-					"Placeholders are variable name and variable value respectivly. They should not be translated."
-				]
-			},
-			"viewMemory.prompt",
-			"cancel",
-			"install",
-			"viewMemory.install.progress",
-			"collapse"
-		],
-		"vs/workbench/contrib/debug/browser/exceptionWidget": [
-			"debugExceptionWidgetBorder",
-			"debugExceptionWidgetBackground",
-			"exceptionThrownWithId",
-			"exceptionThrown",
-			"close"
-		],
 		"vs/workbench/contrib/debug/browser/debugHover": [
 			{
 				"key": "quickTip",
@@ -10431,14 +10687,12 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/debug/browser/breakpointWidget": [
-			"breakpointWidgetLogMessagePlaceholder",
-			"breakpointWidgetHitCountPlaceholder",
-			"breakpointWidgetExpressionPlaceholder",
-			"expression",
-			"hitCount",
-			"logMessage",
-			"breakpointType"
+		"vs/workbench/contrib/debug/browser/exceptionWidget": [
+			"debugExceptionWidgetBorder",
+			"debugExceptionWidgetBackground",
+			"exceptionThrownWithId",
+			"exceptionThrown",
+			"close"
 		],
 		"vs/workbench/contrib/debug/common/debugModel": [
 			"invalidVariableAttributes",
@@ -10459,10 +10713,14 @@
 			},
 			"breakpointDirtydHover"
 		],
-		"vs/platform/actions/browser/menuEntryActionViewItem": [
-			"titleAndKb",
-			"titleAndKb",
-			"titleAndKbAndAlt"
+		"vs/workbench/contrib/debug/browser/breakpointWidget": [
+			"breakpointWidgetLogMessagePlaceholder",
+			"breakpointWidgetHitCountPlaceholder",
+			"breakpointWidgetExpressionPlaceholder",
+			"expression",
+			"hitCount",
+			"logMessage",
+			"breakpointType"
 		],
 		"vs/platform/history/browser/contextScopedHistoryWidget": [
 			"suggestWidgetVisible"
@@ -10496,6 +10754,12 @@
 		],
 		"vs/workbench/contrib/debug/common/replModel": [
 			"consoleCleared"
+		],
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"showing filtered problems",
+			"No problems filtered",
+			"problems filtered",
+			"clearFilter"
 		],
 		"vs/workbench/contrib/markers/browser/messages": [
 			"problems.view.toggle.label",
@@ -10546,39 +10810,14 @@
 			"problems.tree.aria.label.relatedinfo.message",
 			"errors.warnings.show.label"
 		],
+		"vs/workbench/browser/parts/views/viewFilter": [
+			"more filters"
+		],
 		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
 			"label",
 			"tooltip.1",
 			"tooltip.N",
 			"markers.showOnFile"
-		],
-		"vs/workbench/browser/parts/views/viewFilter": [
-			"more filters"
-		],
-		"vs/workbench/contrib/markers/browser/markersView": [
-			"showing filtered problems",
-			"No problems filtered",
-			"problems filtered",
-			"clearFilter"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
-			"name"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/commands/devCommands": [
-			"mergeEditor",
-			"merge.dev.copyState",
-			"mergeEditor.name",
-			"mergeEditor.noActiveMergeEditor",
-			"mergeEditor.name",
-			"mergeEditor.successfullyCopiedMergeEditorContents",
-			"merge.dev.saveContentsToFolder",
-			"mergeEditor.name",
-			"mergeEditor.noActiveMergeEditor",
-			"mergeEditor.selectFolderToSaveTo",
-			"mergeEditor.name",
-			"mergeEditor.successfullySavedMergeEditorContentsToFolder",
-			"merge.dev.loadContentsFromFolder",
-			"mergeEditor.selectFolderToSaveTo"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/commands/commands": [
 			"title",
@@ -10614,11 +10853,27 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/mergeEditor/browser/commands/devCommands": [
+			"mergeEditor",
+			"merge.dev.copyState",
+			"mergeEditor.name",
+			"mergeEditor.noActiveMergeEditor",
+			"mergeEditor.name",
+			"mergeEditor.successfullyCopiedMergeEditorContents",
+			"merge.dev.saveContentsToFolder",
+			"mergeEditor.name",
+			"mergeEditor.noActiveMergeEditor",
+			"mergeEditor.selectFolderToSaveTo",
+			"mergeEditor.name",
+			"mergeEditor.successfullySavedMergeEditorContentsToFolder",
+			"merge.dev.loadContentsFromFolder",
+			"mergeEditor.selectFolderToSaveTo"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
+			"name"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
 			"mergeEditor"
-		],
-		"vs/workbench/contrib/comments/browser/commentService": [
-			"hasCommentingProvider"
 		],
 		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
 			"nextCommentThreadAction",
@@ -10628,6 +10883,17 @@
 			"comments.collapseAll",
 			"comments.expandAll",
 			"comments.expandUnresolved"
+		],
+		"vs/workbench/contrib/comments/browser/commentService": [
+			"hasCommentingProvider"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomains": [
+			"trustedDomain.manageTrustedDomain",
+			"trustedDomain.trustDomain",
+			"trustedDomain.trustAllPorts",
+			"trustedDomain.trustSubDomain",
+			"trustedDomain.trustAllDomains",
+			"trustedDomain.manageTrustedDomains"
 		],
 		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
 			"openExternalLinkAt",
@@ -10650,6 +10916,9 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
+			"context.activeWebviewId"
+		],
 		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
 			"editor.action.webvieweditor.showFind",
 			"editor.action.webvieweditor.hideFind",
@@ -10657,8 +10926,8 @@
 			"editor.action.webvieweditor.findPrevious",
 			"refreshWebviewLabel"
 		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
-			"context.activeWebviewId"
+		"vs/workbench/contrib/customEditor/common/customEditor": [
+			"context.customEditor"
 		],
 		"vs/workbench/contrib/externalUriOpener/common/configuration": [
 			"externalUriOpeners",
@@ -10666,168 +10935,8 @@
 			"externalUriOpeners.uri",
 			"externalUriOpeners.defaultId"
 		],
-		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
-			"selectOpenerDefaultLabel.web",
-			"selectOpenerDefaultLabel",
-			"selectOpenerConfigureTitle",
-			"selectOpenerPlaceHolder"
-		],
-		"vs/workbench/contrib/customEditor/common/customEditor": [
-			"context.customEditor"
-		],
-		"vs/workbench/contrib/url/browser/trustedDomains": [
-			"trustedDomain.manageTrustedDomain",
-			"trustedDomain.trustDomain",
-			"trustedDomain.trustAllPorts",
-			"trustedDomain.trustSubDomain",
-			"trustedDomain.trustAllDomains",
-			"trustedDomain.manageTrustedDomains"
-		],
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"extensionsInputName"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
-			"app.extensions.json.title",
-			"app.extensions.json.recommendations",
-			"app.extension.identifier.errorMessage",
-			"app.extensions.json.unwantedRecommendations",
-			"app.extension.identifier.errorMessage"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionEditor": [
-			"extension version",
-			"preRelease",
-			"name",
-			"preview",
-			"preview",
-			"builtin",
-			"publisher",
-			"install count",
-			"rating",
-			"details",
-			"detailstooltip",
-			"contributions",
-			"contributionstooltip",
-			"changelog",
-			"changelogtooltip",
-			"dependencies",
-			"dependenciestooltip",
-			"extensionpack",
-			"extensionpacktooltip",
-			"runtimeStatus",
-			"runtimeStatus description",
-			"noReadme",
-			"Readme title",
-			"extension pack",
-			"noReadme",
-			"Readme title",
-			"categories",
-			"Marketplace",
-			"repository",
-			"license",
-			"resources",
-			"Marketplace Info",
-			"published",
-			"last released",
-			"last updated",
-			"id",
-			"noChangelog",
-			"Changelog title",
-			"noContributions",
-			"noContributions",
-			"noDependencies",
-			"activation reason",
-			"startup",
-			"activation time",
-			"activatedBy",
-			"not yet activated",
-			"uncaught errors",
-			"messages",
-			"noStatus",
-			"settings",
-			"setting name",
-			"description",
-			"default",
-			"debuggers",
-			"debugger name",
-			"debugger type",
-			"viewContainers",
-			"view container id",
-			"view container title",
-			"view container location",
-			"views",
-			"view id",
-			"view name",
-			"view location",
-			"localizations",
-			"localizations language id",
-			"localizations language name",
-			"localizations localized language name",
-			"customEditors",
-			"customEditors view type",
-			"customEditors priority",
-			"customEditors filenamePattern",
-			"codeActions",
-			"codeActions.title",
-			"codeActions.kind",
-			"codeActions.description",
-			"codeActions.languages",
-			"authentication",
-			"authentication.label",
-			"authentication.id",
-			"colorThemes",
-			"iconThemes",
-			"productThemes",
-			"colors",
-			"colorId",
-			"description",
-			"defaultDark",
-			"defaultLight",
-			"defaultHC",
-			"JSON Validation",
-			"fileMatch",
-			"schema",
-			"commands",
-			"command name",
-			"command title",
-			"keyboard shortcuts",
-			"menuContexts",
-			"languages",
-			"language id",
-			"language name",
-			"file extensions",
-			"grammar",
-			"snippets",
-			"activation events",
-			"Notebooks",
-			"Notebook id",
-			"Notebook name",
-			"NotebookRenderers",
-			"Notebook renderer name",
-			"Notebook mimetypes",
-			"find",
-			"find next",
-			"find previous"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"disableOtherKeymapsConfirmation",
-			"yes",
-			"no"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"extensions",
-			"auto install missing deps",
-			"finished installing missing deps",
-			"reload",
-			"no missing deps"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
-			"activation"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"type",
-			"searchFor",
-			"install",
-			"manage"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"VS Code for Web",
@@ -10875,30 +10984,6 @@
 			"install",
 			"install release version",
 			"install",
-			"do no sync",
-			{
-				"key": "install extension in remote and do not sync",
-				"comment": [
-					"First placeholder is install action label.",
-					"Second placeholder is the name of the action to install an extension in remote server and do not sync it. Placeholder is for the name of remote server.",
-					"Third placeholder is do not sync label."
-				]
-			},
-			{
-				"key": "install extension in remote",
-				"comment": [
-					"First placeholder is install action label.",
-					"Second placeholder is the name of the action to install an extension in remote server and do not sync it. Placeholder is for the name of remote server."
-				]
-			},
-			"install extension locally and do not sync",
-			"install extension locally",
-			{
-				"key": "install everywhere tooltip",
-				"comment": [
-					"Placeholder is the name of the product. Eg: Visual Studio Code or Visual Studio Code - Insiders"
-				]
-			},
 			"installing",
 			"install",
 			"installing",
@@ -11036,6 +11121,219 @@
 			"extensionButtonProminentForeground",
 			"extensionButtonProminentHoverBackground"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"extensions",
+			"offline error",
+			"error",
+			"no extensions found",
+			"suggestProxyError",
+			"open user settings",
+			"no local extensions",
+			"extension.arialabel.verifiedPublihser",
+			"extension.arialabel.publihser",
+			"extension.arialabel.deprecated",
+			"extension.arialabel.rating"
+		],
+		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
+			"selectOpenerDefaultLabel.web",
+			"selectOpenerDefaultLabel",
+			"selectOpenerConfigureTitle",
+			"selectOpenerPlaceHolder"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"extensionsViewIcon",
+			"manageExtensionIcon",
+			"clearSearchResultsIcon",
+			"refreshIcon",
+			"filterIcon",
+			"installLocalInRemoteIcon",
+			"installWorkspaceRecommendedIcon",
+			"configureRecommendedIcon",
+			"syncEnabledIcon",
+			"syncIgnoredIcon",
+			"remoteIcon",
+			"installCountIcon",
+			"ratingIcon",
+			"verifiedPublisher",
+			"preReleaseIcon",
+			"sponsorIcon",
+			"starFullIcon",
+			"starHalfIcon",
+			"starEmptyIcon",
+			"errorIcon",
+			"warningIcon",
+			"infoIcon",
+			"trustIcon",
+			"activationtimeIcon"
+		],
+		"vs/platform/dnd/browser/dnd": [
+			"fileTooLarge"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
+			"app.extensions.json.title",
+			"app.extensions.json.recommendations",
+			"app.extension.identifier.errorMessage",
+			"app.extensions.json.unwantedRecommendations",
+			"app.extension.identifier.errorMessage"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"disableOtherKeymapsConfirmation",
+			"yes",
+			"no"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionEditor": [
+			"extension version",
+			"preRelease",
+			"name",
+			"preview",
+			"preview",
+			"builtin",
+			"publisher",
+			"install count",
+			"rating",
+			"details",
+			"detailstooltip",
+			"contributions",
+			"contributionstooltip",
+			"changelog",
+			"changelogtooltip",
+			"dependencies",
+			"dependenciestooltip",
+			"extensionpack",
+			"extensionpacktooltip",
+			"runtimeStatus",
+			"runtimeStatus description",
+			"noReadme",
+			"Readme title",
+			"extension pack",
+			"noReadme",
+			"Readme title",
+			"categories",
+			"Marketplace",
+			"repository",
+			"license",
+			"resources",
+			"Marketplace Info",
+			"published",
+			"last released",
+			"last updated",
+			"id",
+			"noChangelog",
+			"Changelog title",
+			"noContributions",
+			"noContributions",
+			"noDependencies",
+			"activation reason",
+			"startup",
+			"activation time",
+			"activatedBy",
+			"not yet activated",
+			"uncaught errors",
+			"messages",
+			"noStatus",
+			"settings",
+			"setting name",
+			"description",
+			"default",
+			"debuggers",
+			"debugger name",
+			"debugger type",
+			"viewContainers",
+			"view container id",
+			"view container title",
+			"view container location",
+			"views",
+			"view id",
+			"view name",
+			"view location",
+			"localizations",
+			"localizations language id",
+			"localizations language name",
+			"localizations localized language name",
+			"customEditors",
+			"customEditors view type",
+			"customEditors priority",
+			"customEditors filenamePattern",
+			"codeActions",
+			"codeActions.title",
+			"codeActions.kind",
+			"codeActions.description",
+			"codeActions.languages",
+			"authentication",
+			"authentication.label",
+			"authentication.id",
+			"colorThemes",
+			"iconThemes",
+			"productThemes",
+			"colors",
+			"colorId",
+			"description",
+			"defaultDark",
+			"defaultLight",
+			"defaultHC",
+			"JSON Validation",
+			"fileMatch",
+			"schema",
+			"commands",
+			"command name",
+			"command title",
+			"keyboard shortcuts",
+			"menuContexts",
+			"languages",
+			"language id",
+			"language name",
+			"file extensions",
+			"grammar",
+			"snippets",
+			"activation events",
+			"Notebooks",
+			"Notebook id",
+			"Notebook name",
+			"NotebookRenderers",
+			"Notebook renderer name",
+			"Notebook mimetypes",
+			"find",
+			"find next",
+			"find previous"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"activation"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"extensions",
+			"auto install missing deps",
+			"finished installing missing deps",
+			"reload",
+			"no missing deps"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"type",
+			"searchFor",
+			"install",
+			"manage"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
+			"Manifest is not found",
+			"postUninstallTooltip",
+			"postUpdateTooltip",
+			"enable locally",
+			"enable remote",
+			"postEnableTooltip",
+			"postEnableTooltip",
+			"postDisableTooltip",
+			"postEnableTooltip",
+			"postEnableTooltip",
+			"malicious",
+			"incompatible",
+			"uninstallingExtension",
+			"not found",
+			"installing extension",
+			"installing named extension",
+			"disable all",
+			"singleDependentError",
+			"twoDependentsError",
+			"multipleDependentsError"
+		],
 		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
 			"neverShowAgain",
 			"ignoreExtensionRecommendations",
@@ -11113,133 +11411,19 @@
 			"disable",
 			"showRuntimeExtensions"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
-			"extensionsViewIcon",
-			"manageExtensionIcon",
-			"clearSearchResultsIcon",
-			"refreshIcon",
-			"filterIcon",
-			"installLocalInRemoteIcon",
-			"installWorkspaceRecommendedIcon",
-			"configureRecommendedIcon",
-			"syncEnabledIcon",
-			"syncIgnoredIcon",
-			"remoteIcon",
-			"installCountIcon",
-			"ratingIcon",
-			"verifiedPublisher",
-			"preReleaseIcon",
-			"sponsorIcon",
-			"starFullIcon",
-			"starHalfIcon",
-			"starEmptyIcon",
-			"errorIcon",
-			"warningIcon",
-			"infoIcon",
-			"trustIcon",
-			"activationtimeIcon"
-		],
 		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
 			"restartExtensionHost.reason"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsCompletionItemsProvider": [
 			"exampleExtension"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
-			"Manifest is not found",
-			"postUninstallTooltip",
-			"postUpdateTooltip",
-			"enable locally",
-			"enable remote",
-			"postEnableTooltip",
-			"postEnableTooltip",
-			"postDisableTooltip",
-			"postEnableTooltip",
-			"postEnableTooltip",
-			"malicious",
-			"incompatible",
-			"uninstallingExtension",
-			"not found",
-			"installing extension",
-			"installing named extension",
-			"disable all",
-			"singleDependentError",
-			"twoDependentsError",
-			"multipleDependentsError"
-		],
 		"vs/workbench/contrib/extensions/browser/deprecatedExtensionsChecker": [
 			"deprecated extensions",
 			"showDeprecated",
 			"neverShowAgain"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViews": [
-			"extensions",
-			"offline error",
-			"error",
-			"no extensions found",
-			"suggestProxyError",
-			"open user settings",
-			"no local extensions",
-			"extension.arialabel.verifiedPublihser",
-			"extension.arialabel.publihser",
-			"extension.arialabel.deprecated",
-			"extension.arialabel.rating"
-		],
-		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
-			"tasksQuickAccessPlaceholder",
-			"tasksQuickAccessHelp",
-			"terminal",
-			"terminal",
-			{
-				"key": "miToggleIntegratedTerminal",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/platform/dnd/browser/dnd": [
-			"fileTooLarge"
-		],
 		"vs/workbench/contrib/output/browser/logViewer": [
 			"logViewerAriaLabel"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalView": [
-			"terminal.useMonospace",
-			"terminal.monospaceOnly",
-			"terminals",
-			"terminalConnectingLabel"
-		],
-		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
-			"workbench.action.terminal.showEnvironmentContributions",
-			"envChanges",
-			"extension"
-		],
-		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
-			"workbench.action.terminal.showTextureAtlas",
-			"workbench.action.terminal.writeDataToTerminal",
-			"workbench.action.terminal.writeDataToTerminal.prompt"
-		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
-			"workbench.action.terminal.showAccessibilityHelp",
-			"workbench.action.terminal.focusAccessibleBuffer",
-			"workbench.action.terminal.navigateAccessibleBuffer",
-			"workbench.action.terminal.accessibleBufferGoToNextCommand",
-			"workbench.action.terminal.accessibleBufferGoToPreviousCommand"
-		],
-		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
-			"workbench.action.terminal.focusFind",
-			"workbench.action.terminal.hideFind",
-			"workbench.action.terminal.toggleFindRegex",
-			"workbench.action.terminal.toggleFindWholeWord",
-			"workbench.action.terminal.toggleFindCaseSensitive",
-			"workbench.action.terminal.findNext",
-			"workbench.action.terminal.findPrevious",
-			"workbench.action.terminal.searchWorkspace"
-		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
-			"workbench.action.terminal.openDetectedLink",
-			"workbench.action.terminal.openLastUrlLink",
-			"workbench.action.terminal.openLastLocalFileLink"
 		],
 		"vs/workbench/contrib/tasks/common/problemMatcher": [
 			"ProblemPatternParser.problemPattern.missingRegExp",
@@ -11311,9 +11495,6 @@
 			"eslint-stylish",
 			"go"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
-			"workbench.action.terminal.showQuickFixes"
-		],
 		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
 			"workbench.action.tasks.manageAutomaticRunning",
 			"workbench.action.tasks.allowAutomaticTasks",
@@ -11328,10 +11509,6 @@
 			"JsonSchema.mac",
 			"JsonSchema.linux",
 			"JsonSchema.shell"
-		],
-		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
-			"noTaskResults",
-			"TaskService.pickRunTask"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v2": [
 			"JsonSchema.shell",
@@ -11417,18 +11594,9 @@
 			"JsonSchema.mac",
 			"JsonSchema.linux"
 		],
-		"vs/workbench/contrib/remote/browser/tunnelFactory": [
-			"tunnelPrivacy.private",
-			"tunnelPrivacy.public"
-		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"expandAbbreviationAction",
-			{
-				"key": "miEmmetExpandAbbreviation",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
+		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
+			"noTaskResults",
+			"TaskService.pickRunTask"
 		],
 		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
 			"TaskDefinition.description",
@@ -11436,6 +11604,42 @@
 			"TaskDefinition.when",
 			"TaskTypeConfiguration.noType",
 			"TaskDefinitionExtPoint"
+		],
+		"vs/workbench/contrib/remote/browser/tunnelFactory": [
+			"tunnelPrivacy.private",
+			"tunnelPrivacy.public"
+		],
+		"vs/workbench/contrib/remote/browser/remote": [
+			"getStartedWalkthrough.id",
+			"RemoteHelpInformationExtPoint",
+			"RemoteHelpInformationExtPoint.getStarted",
+			"RemoteHelpInformationExtPoint.documentation",
+			"RemoteHelpInformationExtPoint.feedback",
+			"RemoteHelpInformationExtPoint.feedback.deprecated",
+			"RemoteHelpInformationExtPoint.reportIssue",
+			"RemoteHelpInformationExtPoint.issues",
+			"remote.help.getStarted",
+			"remote.help.documentation",
+			"remote.help.issues",
+			"remote.help.report",
+			"pickRemoteExtension",
+			"remote.help",
+			"remotehelp",
+			"remote.explorer",
+			"remote.explorer",
+			"reconnectionWaitOne",
+			"reconnectionWaitMany",
+			"reconnectNow",
+			"reloadWindow",
+			"connectionLost",
+			"reconnectionRunning",
+			"reconnectionPermanentFailure",
+			{
+				"key": "reloadWindow.dialog",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/remote/browser/remoteIndicator": [
 			"statusBarOfflineBackground",
@@ -11479,8 +11683,57 @@
 			"closeRemoteConnection.title",
 			"reloadWindow",
 			"closeVirtualWorkspace.title",
-			"installRemotes",
-			"remoteActions"
+			"remote.startActions.help",
+			"remote.startActions.install",
+			"remoteActions",
+			"remote.startActions.installingExtension"
+		],
+		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
+			"tasksQuickAccessPlaceholder",
+			"tasksQuickAccessHelp",
+			"terminal",
+			"terminal",
+			{
+				"key": "miToggleIntegratedTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
+			"workbench.action.terminal.focusAccessibleBuffer",
+			"workbench.action.terminal.navigateAccessibleBuffer",
+			"workbench.action.terminal.accessibleBufferGoToNextCommand",
+			"workbench.action.terminal.accessibleBufferGoToPreviousCommand"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"terminal.useMonospace",
+			"terminal.monospaceOnly",
+			"terminals",
+			"terminalConnectingLabel"
+		],
+		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
+			"workbench.action.terminal.showTextureAtlas",
+			"workbench.action.terminal.writeDataToTerminal",
+			"workbench.action.terminal.writeDataToTerminal.prompt",
+			"workbench.action.terminal.restartPtyHost"
+		],
+		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
+			"workbench.action.terminal.showEnvironmentContributions",
+			"envChanges",
+			"extension"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
+			"workbench.action.terminal.showQuickFixes"
+		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"expandAbbreviationAction",
+			{
+				"key": "miEmmetExpandAbbreviation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
 			"accessibilityHelpTitle",
@@ -11502,45 +11755,27 @@
 			"openDocMac",
 			"openDocWinLinux",
 			"outroMsg",
-			"ShowAccessibilityHelpAction",
 			"toggleScreenReaderMode"
 		],
-		"vs/workbench/contrib/remote/browser/remote": [
-			"getStartedWalkthrough.id",
-			"RemoteHelpInformationExtPoint",
-			"RemoteHelpInformationExtPoint.getStarted",
-			"RemoteHelpInformationExtPoint.documentation",
-			"RemoteHelpInformationExtPoint.feedback",
-			"RemoteHelpInformationExtPoint.feedback.deprecated",
-			"RemoteHelpInformationExtPoint.reportIssue",
-			"RemoteHelpInformationExtPoint.issues",
-			"remote.help.getStarted",
-			"remote.help.documentation",
-			"remote.help.issues",
-			"remote.help.report",
-			"pickRemoteExtension",
-			"remote.help",
-			"remotehelp",
-			"remote.explorer",
-			"remote.explorer",
-			"reconnectionWaitOne",
-			"reconnectionWaitMany",
-			"reconnectNow",
-			"reloadWindow",
-			"connectionLost",
-			"reconnectionRunning",
-			"reconnectionPermanentFailure",
-			{
-				"key": "reloadWindow.dialog",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
+		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
+			"workbench.action.terminal.openDetectedLink",
+			"workbench.action.terminal.openLastUrlLink",
+			"workbench.action.terminal.openLastLocalFileLink"
 		],
 		"vs/workbench/contrib/codeEditor/browser/diffEditorHelper": [
 			"hintTimeout",
 			"removeTimeout",
 			"hintWhitespace"
+		],
+		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
+			"workbench.action.terminal.focusFind",
+			"workbench.action.terminal.hideFind",
+			"workbench.action.terminal.toggleFindRegex",
+			"workbench.action.terminal.toggleFindWholeWord",
+			"workbench.action.terminal.toggleFindCaseSensitive",
+			"workbench.action.terminal.findNext",
+			"workbench.action.terminal.findPrevious",
+			"workbench.action.terminal.searchWorkspace"
 		],
 		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
 			"workbench.action.inspectKeyMap",
@@ -11556,28 +11791,14 @@
 			"removeOptimizations",
 			"reopenFilePrompt"
 		],
+		"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens": [
+			"inspectEditorTokens",
+			"inspectTMScopesWidget.loading"
+		],
 		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess": [
 			"gotoLine",
 			"gotoLineQuickAccessPlaceholder",
 			"gotoLineQuickAccess"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
-			"toggleMinimap",
-			{
-				"key": "miMinimap",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
-			"toggleColumnSelection",
-			{
-				"key": "miColumnSelection",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
 		],
 		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
 			{
@@ -11595,9 +11816,23 @@
 			},
 			"codeAction.apply"
 		],
-		"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens": [
-			"inspectEditorTokens",
-			"inspectTMScopesWidget.loading"
+		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
+			"toggleColumnSelection",
+			{
+				"key": "miColumnSelection",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
+			"toggleMinimap",
+			{
+				"key": "miMinimap",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
 			"toggleLocation",
@@ -11605,19 +11840,19 @@
 			"miMultiCursorCmd",
 			"miMultiCursorCtrl"
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
-			"toggleRenderWhitespace",
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
+			"toggleRenderControlCharacters",
 			{
-				"key": "miToggleRenderWhitespace",
+				"key": "miToggleRenderControlCharacters",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
 			}
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
-			"toggleRenderControlCharacters",
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"toggleRenderWhitespace",
 			{
-				"key": "miToggleRenderControlCharacters",
+				"key": "miToggleRenderWhitespace",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
@@ -11644,16 +11879,56 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/format/browser/formatActionsNone": [
-			"formatDocument.label.multiple",
-			"too.large",
-			"no.provider",
+		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
+			"global.scope",
+			"global.1",
+			"detail.label",
+			"name",
+			"bad_name1",
+			"bad_name2",
+			"bad_name3",
+			"openSnippet.label",
+			"userSnippets",
 			{
-				"key": "install.formatter",
+				"key": "miOpenSnippets",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
-			}
+			},
+			"new.global_scope",
+			"new.global",
+			"new.workspace_scope",
+			"new.folder",
+			"group.global",
+			"new.global.sep",
+			"new.global.sep",
+			"openSnippet.pickLanguage"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
+			"label",
+			"placeholder"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
+			"snippet.suggestions.label"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
+			"label"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
+			"codeAction",
+			"overflow.start.title",
+			"title"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"invalid.path.0",
+			"invalid.language.0",
+			"invalid.language",
+			"invalid.path.1",
+			"vscode.extension.contributes.snippets",
+			"vscode.extension.contributes.snippets-language",
+			"vscode.extension.contributes.snippets-path",
+			"badVariableUse",
+			"badFile"
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
 			"null",
@@ -11681,34 +11956,19 @@
 			"formatDocument.label.multiple",
 			"formatSelection.label.multiple"
 		],
+		"vs/workbench/contrib/format/browser/formatActionsNone": [
+			"formatDocument.label.multiple",
+			"too.large",
+			"no.provider",
+			{
+				"key": "install.formatter",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/workbench/contrib/format/browser/formatModified": [
 			"formatChanges"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
-			"codeAction",
-			"overflow.start.title",
-			"title"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"invalid.path.0",
-			"invalid.language.0",
-			"invalid.language",
-			"invalid.path.1",
-			"vscode.extension.contributes.snippets",
-			"vscode.extension.contributes.snippets-language",
-			"vscode.extension.contributes.snippets-path",
-			"badVariableUse",
-			"badFile"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
-			"snippet.suggestions.label"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
-			"label"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
-			"label",
-			"placeholder"
 		],
 		"vs/workbench/contrib/update/browser/update": [
 			"update.noReleaseNotesOnline",
@@ -11768,52 +12028,10 @@
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
 			"getStarted"
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
-			"startupPage.markdownPreviewError"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
-			"global.scope",
-			"global.1",
-			"detail.label",
-			"name",
-			"bad_name1",
-			"bad_name2",
-			"bad_name3",
-			"openSnippet.label",
-			"userSnippets",
-			{
-				"key": "miOpenSnippets",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"new.global_scope",
-			"new.global",
-			"new.workspace_scope",
-			"new.folder",
-			"group.global",
-			"new.global.sep",
-			"new.global.sep",
-			"openSnippet.pickLanguage"
-		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
 			"builtin",
 			"developer",
 			"resetWelcomePageWalkthroughProgress"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons": [
-			"gettingStartedUnchecked",
-			"gettingStartedChecked"
-		],
-		"vs/workbench/contrib/remote/browser/remoteStartEntry": [
-			"remote.category",
-			"remote.showStartEntryActions",
-			"remote.showTunnelStartEntryActions",
-			"remote.startActions.help",
-			"remote.startActions.install",
-			"remote.startActions.quickPickPlaceholder",
-			"remote.startActions.installingExtension",
-			"workbench.remote.showStartListEntry"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted": [
 			"welcomeAriaLabel",
@@ -11863,9 +12081,24 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
+			"welcome.displayName",
+			"startupPage.markdownPreviewError"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons": [
+			"gettingStartedUnchecked",
+			"gettingStartedChecked"
+		],
 		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
 			"walkThrough.unboundCommand",
 			"walkThrough.gitNotFound"
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
+			"editorWalkThrough.title",
+			"editorWalkThrough"
+		],
+		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
+			"ViewsWelcomeExtensionPoint.proposedAPI"
 		],
 		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeExtensionPoint": [
 			"contributes.viewsWelcome",
@@ -11876,9 +12109,6 @@
 			"contributes.viewsWelcome.view.when",
 			"contributes.viewsWelcome.view.group",
 			"contributes.viewsWelcome.view.enablement"
-		],
-		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
-			"ViewsWelcomeExtensionPoint.proposedAPI"
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
 			"callFrom",
@@ -11945,15 +12175,6 @@
 			"status.feedback.name",
 			"status.feedback",
 			"status.feedback"
-		],
-		"vs/workbench/contrib/editSessions/common/editSessions": [
-			"cloud changes",
-			"cloud changes",
-			"editSessionViewIcon"
-		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
-			"editorWalkThrough.title",
-			"editorWalkThrough"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
 			"stop sync",
@@ -12044,107 +12265,6 @@
 			"complete merges title",
 			"workbench.actions.syncData.reset"
 		],
-		"vs/workbench/contrib/editSessions/browser/editSessionsStorageService": [
-			"choose account placeholder",
-			"signed in",
-			"others",
-			"sign in using account",
-			"sign in",
-			"reset auth.v3",
-			"sign out of cloud changes clear data prompt",
-			"delete all cloud changes"
-		],
-		"vs/workbench/contrib/editSessions/common/editSessionsLogService": [
-			"cloudChangesLog"
-		],
-		"vs/workbench/contrib/editSessions/browser/editSessionsViews": [
-			"noStoredChanges",
-			"storeWorkingChangesTitle",
-			"workbench.editSessions.actions.resume.v2",
-			"workbench.editSessions.actions.store.v2",
-			"workbench.editSessions.actions.delete.v2",
-			"confirm delete.v2",
-			"confirm delete detail.v2",
-			"workbench.editSessions.actions.deleteAll",
-			"confirm delete all",
-			"confirm delete all detail",
-			"compare changes",
-			"local copy",
-			"cloud changes",
-			"open file"
-		],
-		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
-			"contributes.codeActions",
-			"contributes.codeActions.languages",
-			"contributes.codeActions.kind",
-			"contributes.codeActions.title",
-			"contributes.codeActions.description"
-		],
-		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
-			"contributes.documentation",
-			"contributes.documentation.refactorings",
-			"contributes.documentation.refactoring",
-			"contributes.documentation.refactoring.title",
-			"contributes.documentation.refactoring.when",
-			"contributes.documentation.refactoring.command"
-		],
-		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
-			"codeActionsOnSave.fixAll",
-			"codeActionsOnSave",
-			"codeActionsOnSave.generic"
-		],
-		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": [
-			"localHistory"
-		],
-		"vs/workbench/contrib/localHistory/browser/localHistoryCommands": [
-			"localHistory.category",
-			"localHistory.compareWithFile",
-			"localHistory.compareWithPrevious",
-			"localHistory.selectForCompare",
-			"localHistory.compareWithSelected",
-			"localHistory.open",
-			"localHistory.restore",
-			"localHistoryRestore.source",
-			"confirmRestoreMessage",
-			"confirmRestoreDetail",
-			{
-				"key": "restoreButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"unableToRestore",
-			"localHistory.restoreViaPicker",
-			"restoreViaPicker.filePlaceholder",
-			"restoreViaPicker.entryPlaceholder",
-			"localHistory.rename",
-			"renameLocalHistoryEntryTitle",
-			"renameLocalHistoryPlaceholder",
-			"localHistory.delete",
-			"confirmDeleteMessage",
-			"confirmDeleteDetail",
-			{
-				"key": "deleteButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"localHistory.deleteAll",
-			"confirmDeleteAllMessage",
-			"confirmDeleteAllDetail",
-			{
-				"key": "deleteAllButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"localHistory.create",
-			"createLocalHistoryEntryTitle",
-			"createLocalHistoryPlaceholder",
-			"localHistoryEditorLabel",
-			"localHistoryCompareToFileEditorLabel",
-			"localHistoryCompareToPreviousEditorLabel"
-		],
 		"vs/workbench/contrib/userDataProfile/browser/userDataProfile": [
 			"create empty profile",
 			"save profile as",
@@ -12192,6 +12312,61 @@
 			"cleanup profile",
 			"reset workspaces"
 		],
+		"vs/workbench/contrib/editSessions/common/editSessions": [
+			"cloud changes",
+			"cloud changes",
+			"editSessionViewIcon"
+		],
+		"vs/workbench/contrib/editSessions/browser/editSessionsStorageService": [
+			"choose account placeholder",
+			"signed in",
+			"others",
+			"sign in using account",
+			"sign in",
+			"sign in badge",
+			"reset auth.v3",
+			"sign out of cloud changes clear data prompt",
+			"delete all cloud changes"
+		],
+		"vs/workbench/contrib/editSessions/common/editSessionsLogService": [
+			"cloudChangesLog"
+		],
+		"vs/workbench/contrib/editSessions/browser/editSessionsViews": [
+			"noStoredChanges",
+			"storeWorkingChangesTitle",
+			"workbench.editSessions.actions.resume.v2",
+			"workbench.editSessions.actions.store.v2",
+			"workbench.editSessions.actions.delete.v2",
+			"confirm delete.v2",
+			"confirm delete detail.v2",
+			"workbench.editSessions.actions.deleteAll",
+			"confirm delete all",
+			"confirm delete all detail",
+			"compare changes",
+			"local copy",
+			"cloud changes",
+			"open file"
+		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"contributes.codeActions",
+			"contributes.codeActions.languages",
+			"contributes.codeActions.kind",
+			"contributes.codeActions.title",
+			"contributes.codeActions.description"
+		],
+		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
+			"contributes.documentation",
+			"contributes.documentation.refactorings",
+			"contributes.documentation.refactoring",
+			"contributes.documentation.refactoring.title",
+			"contributes.documentation.refactoring.when",
+			"contributes.documentation.refactoring.command"
+		],
+		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
+			"codeActionsOnSave.fixAll",
+			"codeActionsOnSave",
+			"codeActionsOnSave.generic"
+		],
 		"vs/workbench/contrib/timeline/browser/timelinePane": [
 			"timeline.loadingMore",
 			"timeline.loadMore",
@@ -12212,8 +12387,58 @@
 			"timeline.toggleFollowActiveEditorCommand.unfollow",
 			"timeline"
 		],
-		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
-			"workspaceTrustEditorInputName"
+		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": [
+			"localHistory"
+		],
+		"vs/workbench/contrib/localHistory/browser/localHistoryCommands": [
+			"localHistory.category",
+			"localHistory.compareWithFile",
+			"localHistory.compareWithPrevious",
+			"localHistory.selectForCompare",
+			"localHistory.compareWithSelected",
+			"localHistory.open",
+			"localHistory.restore",
+			"localHistoryRestore.source",
+			"confirmRestoreMessage",
+			"confirmRestoreDetail",
+			{
+				"key": "restoreButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"unableToRestore",
+			"localHistory.restoreViaPicker",
+			"restoreViaPicker.filePlaceholder",
+			"restoreViaPicker.entryPlaceholder",
+			"localHistory.restoreViaPickerMenu",
+			"localHistory.rename",
+			"renameLocalHistoryEntryTitle",
+			"renameLocalHistoryPlaceholder",
+			"localHistory.delete",
+			"confirmDeleteMessage",
+			"confirmDeleteDetail",
+			{
+				"key": "deleteButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"localHistory.deleteAll",
+			"confirmDeleteAllMessage",
+			"confirmDeleteAllDetail",
+			{
+				"key": "deleteAllButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"localHistory.create",
+			"createLocalHistoryEntryTitle",
+			"createLocalHistoryPlaceholder",
+			"localHistoryEditorLabel",
+			"localHistoryCompareToFileEditorLabel",
+			"localHistoryCompareToPreviousEditorLabel"
 		],
 		"vs/workbench/contrib/workspace/browser/workspaceTrustEditor": [
 			"shieldIcon",
@@ -12319,6 +12544,9 @@
 			"untrustedFolderReason",
 			"trustedForcedReason"
 		],
+		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
+			"workspaceTrustEditorInputName"
+		],
 		"vs/workbench/contrib/audioCues/browser/commands": [
 			"audioCues.help",
 			"disabled",
@@ -12328,112 +12556,6 @@
 		"vs/workbench/contrib/share/browser/shareService": [
 			"shareProviderCount",
 			"type to filter"
-		],
-		"vs/workbench/contrib/accessibility/browser/accessibilityContribution": [
-			"accessibilityConfigurationTitle",
-			"verbosity.terminal.description",
-			"verbosity.diffEditor.description",
-			"verbosity.chat.description",
-			"verbosity.interactiveEditor.description",
-			"verbosity.keybindingsEditor.description",
-			"verbosity.notebook"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"notificationsEmpty",
-			"notifications",
-			"notificationsToolbar",
-			"notificationsCenterWidgetAriaLabel"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsStatus": [
-			"status.notifications",
-			"status.notifications",
-			"status.doNotDisturb",
-			"status.doNotDisturbTooltip",
-			"hideNotifications",
-			"zeroNotifications",
-			"noNotifications",
-			"oneNotification",
-			{
-				"key": "notifications",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "noNotificationsWithProgress",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "oneNotificationWithProgress",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "notificationsWithProgress",
-				"comment": [
-					"{0} and {1} will be replaced by a number"
-				]
-			},
-			"status.message"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCommands": [
-			"notifications",
-			"showNotifications",
-			"hideNotifications",
-			"clearAllNotifications",
-			"acceptNotificationPrimaryAction",
-			"toggleDoNotDisturbMode",
-			"focusNotificationToasts"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsToasts": [
-			"notificationAriaLabel",
-			"notificationWithSourceAriaLabel"
-		],
-		"vs/workbench/services/configuration/common/configurationEditing": [
-			"openTasksConfiguration",
-			"openLaunchConfiguration",
-			"open",
-			"openTasksConfiguration",
-			"openLaunchConfiguration",
-			"saveAndRetry",
-			"saveAndRetry",
-			"open",
-			"errorPolicyConfiguration",
-			"errorUnknownKey",
-			"errorInvalidWorkspaceConfigurationApplication",
-			"errorInvalidWorkspaceConfigurationMachine",
-			"errorInvalidFolderConfiguration",
-			"errorInvalidUserTarget",
-			"errorInvalidWorkspaceTarget",
-			"errorInvalidFolderTarget",
-			"errorInvalidResourceLanguageConfiguration",
-			"errorNoWorkspaceOpened",
-			"errorInvalidTaskConfiguration",
-			"errorInvalidLaunchConfiguration",
-			"errorInvalidConfiguration",
-			"errorInvalidRemoteConfiguration",
-			"errorInvalidConfigurationWorkspace",
-			"errorInvalidConfigurationFolder",
-			"errorTasksConfigurationFileDirty",
-			"errorLaunchConfigurationFileDirty",
-			"errorConfigurationFileDirty",
-			"errorRemoteConfigurationFileDirty",
-			"errorConfigurationFileDirtyWorkspace",
-			"errorConfigurationFileDirtyFolder",
-			"errorTasksConfigurationFileModifiedSince",
-			"errorLaunchConfigurationFileModifiedSince",
-			"errorConfigurationFileModifiedSince",
-			"errorRemoteConfigurationFileModifiedSince",
-			"errorConfigurationFileModifiedSinceWorkspace",
-			"errorConfigurationFileModifiedSinceFolder",
-			"errorUnknown",
-			"userTarget",
-			"remoteUserTarget",
-			"workspaceTarget",
-			"folderTarget"
 		],
 		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
 			{
@@ -12450,11 +12572,6 @@
 			"focusTitleBar",
 			"toggle.commandCenter",
 			"toggle.layout"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
-			"alertErrorMessage",
-			"alertWarningMessage",
-			"alertInfoMessage"
 		],
 		"vs/workbench/services/configurationResolver/common/variableResolver": [
 			"canNotResolveFile",
@@ -12504,22 +12621,33 @@
 		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
 			"reportExtensionIssue"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalProfileResolverService": [
-			"terminalProfileMigration",
-			"migrateToProfile"
-		],
 		"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote": [
 			"workbench.action.terminal.newLocal"
-		],
-		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
-			"restartPtyHost",
-			"nonResponsivePtyHost"
 		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"dotnetCore",
 			"msbuild",
 			"externalCommand",
 			"Maven"
+		],
+		"vs/workbench/contrib/tasks/browser/taskQuickPick": [
+			"taskQuickPick.showAll",
+			"configureTaskIcon",
+			"removeTaskIcon",
+			"configureTask",
+			"contributedTasks",
+			"taskType",
+			"removeRecent",
+			"recentlyUsed",
+			"configured",
+			"configured",
+			"TaskQuickPick.changeSettingDetails",
+			"TaskQuickPick.changeSettingNo",
+			"TaskService.pickRunTask",
+			"TaskQuickPick.changeSettingsOptions",
+			"TaskQuickPick.goBack",
+			"TaskQuickPick.noTasksForType",
+			"noProviderForTask"
 		],
 		"vs/workbench/contrib/tasks/common/taskConfiguration": [
 			"ConfigurationParser.invalidCWD",
@@ -12544,24 +12672,11 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/tasks/browser/taskQuickPick": [
-			"taskQuickPick.showAll",
-			"configureTaskIcon",
-			"removeTaskIcon",
-			"configureTask",
-			"contributedTasks",
-			"taskType",
-			"removeRecent",
-			"recentlyUsed",
-			"configured",
-			"configured",
-			"TaskQuickPick.changeSettingDetails",
-			"TaskQuickPick.changeSettingNo",
-			"TaskService.pickRunTask",
-			"TaskQuickPick.changeSettingsOptions",
-			"TaskQuickPick.goBack",
-			"TaskQuickPick.noTasksForType",
-			"noProviderForTask"
+		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
+			"ptyHostStatus",
+			"ptyHostStatus.short",
+			"nonResponsivePtyHost",
+			"ptyHostStatus.ariaLabel"
 		],
 		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
 			"taskTerminalStatus.active",
@@ -12752,42 +12867,10 @@
 					"{0} is the platform, {1} is a code block, {2} and {3} are a link start and end"
 				]
 			},
-			"terminal.integrated.shell.linux.deprecation",
-			"terminal.integrated.shell.osx.deprecation",
-			"terminal.integrated.shell.windows.deprecation",
-			"terminal.integrated.automationShell.linux.deprecation",
-			"terminal.integrated.automationShell.osx.deprecation",
-			"terminal.integrated.automationShell.windows.deprecation",
 			"terminalIntegratedConfigurationTitle",
-			{
-				"key": "terminal.integrated.automationShell.linux",
-				"comment": [
-					"{0} and {1} are the `shell` and `shellArgs` settings keys"
-				]
-			},
-			{
-				"key": "terminal.integrated.automationShell.osx",
-				"comment": [
-					"{0} and {1} are the `shell` and `shellArgs` settings keys"
-				]
-			},
-			{
-				"key": "terminal.integrated.automationShell.windows",
-				"comment": [
-					"{0} and {1} are the `shell` and `shellArgs` settings keys"
-				]
-			},
 			"terminal.integrated.automationProfile.linux",
 			"terminal.integrated.automationProfile.osx",
 			"terminal.integrated.automationProfile.windows",
-			"terminal.integrated.shell.linux",
-			"terminal.integrated.shell.osx",
-			"terminal.integrated.shell.windows",
-			"terminal.integrated.shellArgs.linux",
-			"terminal.integrated.shellArgs.osx",
-			"terminal.integrated.shellArgs.windows",
-			"terminal.integrated.shellArgs.windows",
-			"terminal.integrated.shellArgs.windows.string",
 			"terminalProfile.windowsSource",
 			"terminalProfile.windowsExtensionIdentifier",
 			"terminalProfile.windowsExtensionId",
@@ -12823,6 +12906,40 @@
 			},
 			"clearedInput"
 		],
+		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"notificationAriaLabel",
+			"notificationWithSourceAriaLabel",
+			"notificationsList"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsActions": [
+			"clearIcon",
+			"clearAllIcon",
+			"hideIcon",
+			"expandIcon",
+			"collapseIcon",
+			"configureIcon",
+			"doNotDisturbIcon",
+			"clearNotification",
+			"clearNotifications",
+			"toggleDoNotDisturbMode",
+			"hideNotificationsCenter",
+			"expandNotification",
+			"collapseNotification",
+			"configureNotification",
+			"copyNotification"
+		],
+		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
+			"moreActions"
+		],
+		"vs/base/browser/ui/actionbar/actionViewItems": [
+			{
+				"key": "titleLabel",
+				"comment": [
+					"action title",
+					"action keybinding"
+				]
+			}
+		],
 		"vs/editor/browser/widget/diffReview": [
 			"diffReviewInsertIcon",
 			"diffReviewRemoveIcon",
@@ -12851,9 +12968,7 @@
 			},
 			"equalLine",
 			"insertLine",
-			"deleteLine",
-			"editor.action.diffReview.next",
-			"editor.action.diffReview.prev"
+			"deleteLine"
 		],
 		"vs/editor/browser/widget/inlineDiffMargin": [
 			"diff.clipboard.copyDeletedLinesContent.label",
@@ -12900,19 +13015,14 @@
 			"autoFix.label",
 			"editor.action.autoFix.noneMessage"
 		],
+		"vs/editor/contrib/codeAction/browser/codeActionController": [
+			"hideMoreActions",
+			"showMoreActions"
+		],
 		"vs/editor/contrib/codeAction/browser/lightBulbWidget": [
 			"preferredcodeActionWithKb",
 			"codeActionWithKb",
 			"codeAction"
-		],
-		"vs/base/browser/ui/actionbar/actionViewItems": [
-			{
-				"key": "titleLabel",
-				"comment": [
-					"action title",
-					"action keybinding"
-				]
-			}
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
 			"pasteWidgetVisible",
@@ -12944,6 +13054,7 @@
 			"findReplaceAllIcon",
 			"findPreviousMatchIcon",
 			"findNextMatchIcon",
+			"label.findDialog",
 			"label.find",
 			"placeholder.find",
 			"label.previousMatchButton",
@@ -12978,9 +13089,6 @@
 			"hint1n",
 			"hintnn"
 		],
-		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
-			"inlineSuggestionFollows"
-		],
 		"vs/editor/contrib/inlineCompletions/browser/commands": [
 			"action.inlineSuggest.showNext",
 			"action.inlineSuggest.showPrevious",
@@ -12994,15 +13102,13 @@
 			"action.inlineSuggest.hide",
 			"action.inlineSuggest.alwaysShowToolbar"
 		],
+		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
+			"inlineSuggestionFollows"
+		],
 		"vs/editor/contrib/gotoSymbol/browser/peek/referencesController": [
 			"referenceSearchVisible",
 			"labelLoading",
 			"metaTitle.N"
-		],
-		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
-			"hasSymbols",
-			"location.kb",
-			"location"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/referencesModel": [
 			"aria.oneReference",
@@ -13018,6 +13124,11 @@
 			"aria.result.1",
 			"aria.result.n1",
 			"aria.result.nm"
+		],
+		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
+			"hasSymbols",
+			"location.kb",
+			"location"
 		],
 		"vs/editor/contrib/message/browser/messageController": [
 			"messageVisible"
@@ -13037,10 +13148,6 @@
 			"editorMarkerNavigationInfo",
 			"editorMarkerNavigationInfoHeaderBackground",
 			"editorMarkerNavigationBackground"
-		],
-		"vs/editor/contrib/codeAction/browser/codeActionController": [
-			"hideMoreActions",
-			"showMoreActions"
 		],
 		"vs/editor/contrib/hover/browser/markdownHoverParticipant": [
 			"modesContentHover.loading",
@@ -13149,12 +13256,6 @@
 			"label.desc",
 			"ariaCurrenttSuggestionReadDetails"
 		],
-		"vs/workbench/api/browser/mainThreadWebviews": [
-			"errorMessage"
-		],
-		"vs/workbench/browser/parts/editor/textEditor": [
-			"editor"
-		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
 			"schema.token.settings",
 			"schema.token.foreground",
@@ -13199,6 +13300,12 @@
 			"async",
 			"readonly"
 		],
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"errorMessage"
+		],
+		"vs/workbench/browser/parts/editor/textEditor": [
+			"editor"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalEditorInput": [
 			"confirmDirtyTerminal.message",
 			{
@@ -13236,9 +13343,6 @@
 			"commentRange",
 			"lastReplyFrom"
 		],
-		"vs/workbench/contrib/notebook/common/notebookEditorModel": [
-			"vetoExtHostRestart"
-		],
 		"vs/workbench/contrib/testing/common/testResult": [
 			"runFinished"
 		],
@@ -13261,25 +13365,6 @@
 		"vs/workbench/browser/parts/views/checkbox": [
 			"checked",
 			"unchecked"
-		],
-		"vs/workbench/contrib/remote/browser/remoteIcons": [
-			"getStartedIcon",
-			"documentationIcon",
-			"feedbackIcon",
-			"reviewIssuesIcon",
-			"reportIssuesIcon",
-			"remoteExplorerViewIcon",
-			"portsViewIcon",
-			"portIcon",
-			"privatePortIcon",
-			"forwardPortIcon",
-			"stopForwardIcon",
-			"openBrowserIcon",
-			"openPreviewIcon",
-			"copyAddressIcon",
-			"labelPortIcon",
-			"forwardedPortWithoutProcessIcon",
-			"forwardedPortWithProcessIcon"
 		],
 		"vs/base/browser/ui/splitview/paneview": [
 			"viewSection"
@@ -13345,6 +13430,36 @@
 			"tunnelContext.protocolMenu",
 			"portWithRunningProcess.foreground"
 		],
+		"vs/workbench/contrib/remote/browser/remoteIcons": [
+			"getStartedIcon",
+			"documentationIcon",
+			"feedbackIcon",
+			"reviewIssuesIcon",
+			"reportIssuesIcon",
+			"remoteExplorerViewIcon",
+			"portsViewIcon",
+			"portIcon",
+			"privatePortIcon",
+			"forwardPortIcon",
+			"stopForwardIcon",
+			"openBrowserIcon",
+			"openPreviewIcon",
+			"copyAddressIcon",
+			"labelPortIcon",
+			"forwardedPortWithoutProcessIcon",
+			"forwardedPortWithProcessIcon"
+		],
+		"vs/workbench/browser/parts/editor/textCodeEditor": [
+			"textEditor"
+		],
+		"vs/workbench/browser/parts/editor/binaryEditor": [
+			"binaryEditor",
+			"binaryError",
+			"openAnyway"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/colors": [
+			"diffEditor.move.border"
+		],
 		"vs/workbench/browser/parts/editor/editorPanes": [
 			"editorOpenErrorDialog",
 			{
@@ -13380,17 +13495,6 @@
 				]
 			},
 			"watermark.showSettings"
-		],
-		"vs/workbench/browser/parts/editor/textCodeEditor": [
-			"textEditor"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2": [
-			"diff-aria-navigation-tip"
-		],
-		"vs/workbench/browser/parts/editor/binaryEditor": [
-			"binaryEditor",
-			"binaryError",
-			"openAnyway"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
 			"loading",
@@ -13487,13 +13591,13 @@
 				]
 			}
 		],
-		"vs/base/browser/ui/toolbar/toolbar": [
-			"moreActions"
-		],
 		"vs/workbench/browser/parts/compositePart": [
 			"ariaCompositeToolbarLabel",
 			"viewsAndMoreActions",
 			"titleTooltip"
+		],
+		"vs/base/browser/ui/toolbar/toolbar": [
+			"moreActions"
 		],
 		"vs/workbench/browser/parts/sidebar/sidebarActions": [
 			"focusSideBar"
@@ -13540,6 +13644,9 @@
 			"validations.objectIncorrectType",
 			"validations.objectPattern"
 		],
+		"vs/editor/common/model/editStack": [
+			"edit"
+		],
 		"vs/platform/quickinput/browser/quickInput": [
 			"quickInput.back",
 			"inputModeEntry",
@@ -13575,8 +13682,17 @@
 			"vscode.extension.contributes.grammars.balancedBracketScopes",
 			"vscode.extension.contributes.grammars.unbalancedBracketScopes"
 		],
-		"vs/editor/common/model/editStack": [
-			"edit"
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"folderSettings",
+			"settingsSwitcherBarAriaLabel",
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"userSettings",
+			"workspaceSettings"
 		],
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"unbound"
@@ -13621,15 +13737,6 @@
 			"manage workspace trust",
 			"unsupportedProperty"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
-			"userSettings",
-			"userSettingsRemote",
-			"workspaceSettings",
-			"folderSettings",
-			"settingsSwitcherBarAriaLabel",
-			"workspaceSettings",
-			"userSettings"
-		],
 		"vs/workbench/contrib/preferences/browser/settingsLayout": [
 			"commonlyUsed",
 			"textEditor",
@@ -13668,7 +13775,7 @@
 			"notebook",
 			"audioCues",
 			"mergeEditor",
-			"interactiveSession",
+			"chat",
 			"application",
 			"proxy",
 			"keyboard",
@@ -13689,22 +13796,6 @@
 			},
 			"groupRowAriaLabel"
 		],
-		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
-			"modifiedSettingsSearch",
-			"modifiedSettingsSearchTooltip",
-			"extSettingsSearch",
-			"extSettingsSearchTooltip",
-			"featureSettingsSearch",
-			"featureSettingsSearchTooltip",
-			"tagSettingsSearch",
-			"tagSettingsSearchTooltip",
-			"langSettingsSearch",
-			"langSettingsSearchTooltip",
-			"onlineSettingsSearch",
-			"onlineSettingsSearchTooltip",
-			"policySettingsSearch",
-			"policySettingsSearchTooltip"
-		],
 		"vs/workbench/contrib/preferences/browser/settingsTree": [
 			"extensions",
 			"modified",
@@ -13723,6 +13814,26 @@
 			"copySettingIdLabel",
 			"copySettingAsJSONLabel",
 			"stopSyncingSetting"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
+			"modifiedSettingsSearch",
+			"modifiedSettingsSearchTooltip",
+			"extSettingsSearch",
+			"extSettingsSearchTooltip",
+			"featureSettingsSearch",
+			"featureSettingsSearchTooltip",
+			"tagSettingsSearch",
+			"tagSettingsSearchTooltip",
+			"langSettingsSearch",
+			"langSettingsSearchTooltip",
+			"onlineSettingsSearch",
+			"onlineSettingsSearchTooltip",
+			"policySettingsSearch",
+			"policySettingsSearchTooltip"
+		],
+		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView": [
+			"notebookActions.selectKernel",
+			"notebookActions.selectKernel.args"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookExtensionPoint": [
 			"contributes.notebook.provider",
@@ -13780,9 +13891,21 @@
 			"notebook.cellEditorBackground",
 			"notebook.editorBackground"
 		],
-		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView": [
-			"notebookActions.selectKernel",
-			"notebookActions.selectKernel.args"
+		"vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView": [
+			"notebook.emptyMarkdownPlaceholder",
+			{
+				"key": "notebook.error.rendererNotFound",
+				"comment": [
+					"$0 is a placeholder for the mime type"
+				]
+			},
+			{
+				"key": "notebook.error.rendererFallbacksExhausted",
+				"comment": [
+					"$0 is a placeholder for the mime type"
+				]
+			},
+			"webview title"
 		],
 		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
 			"fileWorkingCopyCreate.source",
@@ -13799,33 +13922,6 @@
 					"&& denotes a mnemonic"
 				]
 			}
-		],
-		"vs/workbench/contrib/comments/common/commentContextKeys": [
-			"commentThreadIsEmpty",
-			"commentIsEmpty",
-			"comment",
-			"commentThread",
-			"commentController"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/cellOperations": [
-			"notebookActions.joinSelectedCells",
-			"notebookActions.joinSelectedCells.label"
-		],
-		"vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView": [
-			"notebook.emptyMarkdownPlaceholder",
-			{
-				"key": "notebook.error.rendererNotFound",
-				"comment": [
-					"$0 is a placeholder for the mime type"
-				]
-			},
-			{
-				"key": "notebook.error.rendererFallbacksExhausted",
-				"comment": [
-					"$0 is a placeholder for the mime type"
-				]
-			},
-			"webview title"
 		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy": [
 			"current1",
@@ -13845,24 +13941,29 @@
 			"kernels.detecting",
 			"select"
 		],
+		"vs/workbench/contrib/comments/common/commentContextKeys": [
+			"commentThreadIsEmpty",
+			"commentIsEmpty",
+			"comment",
+			"commentThread",
+			"commentController"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/cellOperations": [
+			"notebookActions.joinSelectedCells",
+			"notebookActions.joinSelectedCells.label"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget": [
+			"ariaSearchNoResultEmpty",
+			"ariaSearchNoResult",
+			"ariaSearchNoResultWithLineNumNoCurrentMatch"
+		],
 		"vs/editor/contrib/codeAction/browser/codeAction": [
 			"applyCodeActionFailed"
 		],
-		"vs/workbench/contrib/chat/common/chatContextKeys": [
-			"interactiveSessionResponseHasProviderId",
-			"interactiveSessionResponseVote",
-			"interactiveSessionRequestInProgress",
-			"chatResponse",
-			"chatRequest",
-			"interactiveInputHasText",
-			"inInteractiveInput",
-			"inChat",
-			"hasChatProvider"
-		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
-			"interactiveSession.helpMenuExit",
 			"chat.overview",
 			"chat.requestHistory",
+			"chat.announcement",
 			"workbench.action.chat.focus",
 			"workbench.action.chat.focusNoKb",
 			"workbench.action.chat.focusInput",
@@ -13871,21 +13972,18 @@
 			"workbench.action.chat.nextCodeBlockNoKb",
 			"workbench.action.chat.clear",
 			"workbench.action.chat.clearNoKb",
-			"interactiveSession.makeRequest",
-			"interactiveSession.diff",
-			"interactiveSession.diffNoKb",
-			"interactiveSession.acceptReject",
-			"interactiveSession.explain",
-			"interactiveSession.chatViewFocus",
-			"interactiveSession.toolbar"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget": [
-			"ariaSearchNoResultEmpty",
-			"ariaSearchNoResult",
-			"ariaSearchNoResultWithLineNumNoCurrentMatch"
-		],
-		"vs/workbench/contrib/chat/common/chatViewModel": [
-			"thinking"
+			"inlineChat.overview",
+			"inlineChat.access",
+			"inlineChat.requestHistory",
+			"inlineChat.contextActions",
+			"inlineChat.fix",
+			"inlineChat.diff",
+			"inlineChat.diffNoKb",
+			"inlineChat.explain",
+			"inlineChat.toolbar",
+			"chat.audioCues",
+			"chat-help-label",
+			"inline-chat-label"
 		],
 		"vs/workbench/contrib/chat/browser/chatListRenderer": [
 			"chat",
@@ -13900,6 +13998,19 @@
 			"actions.chat.accessibiltyHelp",
 			"chatInput.accessibilityHelpNoKb",
 			"chatInput"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
+			"lines.0",
+			"lines.1",
+			"lines.N"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
+			"aria-label",
+			"original",
+			"modified",
+			"inlineChat.accessibilityHelp",
+			"inlineChat.accessibilityHelpNoKb",
+			"inlineChatClosed"
 		],
 		"vs/workbench/contrib/testing/browser/theme": [
 			"testing.iconFailed",
@@ -13946,17 +14057,35 @@
 			"testing.filters.showExcludedTests",
 			"testing.filters.removeTestExclusions"
 		],
-		"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies": [
-			"lines.0",
-			"lines.1",
-			"lines.N"
+		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
+			"terminal.integrated.copySelection.noSelection",
+			"yes",
+			"no",
+			"dontShowAgain",
+			"terminal.slowRendering"
 		],
-		"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget": [
-			"aria-label",
-			"original",
-			"modified",
-			"interactiveEditor.accessibilityHelp",
-			"interactiveSessionInput.accessibilityHelpNoKb"
+		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
+			"terminal.background",
+			"terminal.foreground",
+			"terminalCursor.foreground",
+			"terminalCursor.background",
+			"terminal.selectionBackground",
+			"terminal.inactiveSelectionBackground",
+			"terminal.selectionForeground",
+			"terminalCommandDecoration.defaultBackground",
+			"terminalCommandDecoration.successBackground",
+			"terminalCommandDecoration.errorBackground",
+			"terminalOverviewRuler.cursorForeground",
+			"terminal.border",
+			"terminal.findMatchBackground",
+			"terminal.findMatchHighlightBorder",
+			"terminal.findMatchBorder",
+			"terminal.findMatchHighlightBackground",
+			"terminal.findMatchHighlightBorder",
+			"terminalOverviewRuler.findMatchHighlightForeground",
+			"terminal.dragAndDropBackground",
+			"terminal.tab.activeBorder",
+			"terminal.ansiColor"
 		],
 		"vs/platform/quickinput/browser/commandsQuickAccess": [
 			"recentlyUsed",
@@ -14075,10 +14204,6 @@
 			"detail.del",
 			"title"
 		],
-		"vs/workbench/contrib/search/browser/replaceService": [
-			"searchReplace.source",
-			"fileReplaceChanges"
-		],
 		"vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess": [
 			"cannotRunGotoSymbolWithoutEditor",
 			"cannotRunGotoSymbolWithoutSymbolProvider",
@@ -14113,6 +14238,10 @@
 			"key",
 			"field",
 			"constant"
+		],
+		"vs/workbench/contrib/search/browser/replaceService": [
+			"searchReplace.source",
+			"fileReplaceChanges"
 		],
 		"vs/workbench/contrib/search/browser/searchFindInput": [
 			"searchFindInputNotebookFilter.label"
@@ -14166,6 +14295,13 @@
 			"installLanguage",
 			"installExt",
 			"selectDebug"
+		],
+		"vs/workbench/contrib/debug/browser/debugConfigurationManager": [
+			"editLaunchConfig",
+			"selectConfiguration",
+			"DebugConfig.failed",
+			"workspace",
+			"user settings"
 		],
 		"vs/workbench/contrib/debug/browser/debugTaskRunner": [
 			"preLaunchTaskErrors",
@@ -14243,9 +14379,6 @@
 		"vs/workbench/contrib/debug/common/debugSource": [
 			"unknownSource"
 		],
-		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
-			"moreActions"
-		],
 		"vs/base/browser/ui/findinput/replaceInput": [
 			"defaultLabel",
 			"label.preserveCaseToggle"
@@ -14262,6 +14395,16 @@
 			"messageColumnLabel",
 			"fileColumnLabel",
 			"sourceColumnLabel"
+		],
+		"vs/workbench/contrib/mergeEditor/common/mergeEditor": [
+			"is",
+			"isr",
+			"editorLayout",
+			"showBase",
+			"showBaseAtTop",
+			"showNonConflictingChanges",
+			"baseUri",
+			"resultUri"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInputModel": [
 			"messageN",
@@ -14339,18 +14482,33 @@
 			},
 			"noMoreWarn"
 		],
-		"vs/workbench/contrib/mergeEditor/common/mergeEditor": [
-			"is",
-			"isr",
-			"editorLayout",
-			"showBase",
-			"showBaseAtTop",
-			"showNonConflictingChanges",
-			"baseUri",
-			"resultUri"
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
+			"base",
+			"compareWith",
+			"compareWithTooltip"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/viewModel": [
 			"noConflictMessage"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
+			"result",
+			"mergeEditor.remainingConflicts",
+			"mergeEditor.remainingConflict",
+			"goToNextConflict",
+			"allConflictHandled"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView": [
+			"input1",
+			"input2",
+			"mergeEditor.accept",
+			"mergeEditor.accept",
+			"mergeEditor.acceptBoth",
+			"mergeEditor.swap",
+			"mergeEditor.markAsHandled",
+			"accept.excluded",
+			"accept.conflicting",
+			"accept.first",
+			"accept.second"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/colors": [
 			"mergeEditor.change.background",
@@ -14367,49 +14525,16 @@
 			"mergeEditor.conflict.input1.background",
 			"mergeEditor.conflict.input2.background"
 		],
-		"vs/workbench/contrib/debug/browser/debugConfigurationManager": [
-			"editLaunchConfig",
-			"selectConfiguration",
-			"DebugConfig.failed",
-			"workspace",
-			"user settings"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView": [
-			"input1",
-			"input2",
-			"mergeEditor.accept",
-			"mergeEditor.accept",
-			"mergeEditor.acceptBoth",
-			"mergeEditor.swap",
-			"mergeEditor.markAsHandled",
-			"accept.excluded",
-			"accept.conflicting",
-			"accept.first",
-			"accept.second"
-		],
 		"vs/workbench/contrib/comments/browser/commentsController": [
 			"hasCommentingRange",
 			"pickCommentService"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
-			"result",
-			"mergeEditor.remainingConflicts",
-			"mergeEditor.remainingConflict",
-			"goToNextConflict",
-			"allConflictHandled"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
-			"base",
-			"compareWith",
-			"compareWithTooltip"
-		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
 			"builtinProviderDisplayName"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
-			"error",
-			"Unknown Extension",
-			"extensions"
+		"vs/platform/files/browser/htmlFileSystemProvider": [
+			"fileSystemRenameError",
+			"fileSystemNotAllowedError"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"ratedLabel",
@@ -14437,6 +14562,11 @@
 			"extensionPreReleaseForeground",
 			"extensionIcon.sponsorForeground"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
+			"error",
+			"Unknown Extension",
+			"extensions"
+		],
 		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
 			"exeBasedRecommendation"
 		],
@@ -14456,38 +14586,80 @@
 		"vs/workbench/contrib/extensions/browser/webRecommendations": [
 			"reason"
 		],
-		"vs/platform/files/browser/htmlFileSystemProvider": [
-			"fileSystemRenameError",
-			"fileSystemNotAllowedError"
+		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
+			"JsonSchema.options",
+			"JsonSchema.options.cwd",
+			"JsonSchema.options.env",
+			"JsonSchema.tasks.matcherError",
+			"JsonSchema.tasks.matcherError",
+			"JsonSchema.shellConfiguration",
+			"JsonSchema.shell.executable",
+			"JsonSchema.shell.args",
+			"JsonSchema.command",
+			"JsonSchema.tasks.args",
+			"JsonSchema.tasks.taskName",
+			"JsonSchema.command",
+			"JsonSchema.tasks.args",
+			"JsonSchema.tasks.windows",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.mac",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.linux",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.suppressTaskName",
+			"JsonSchema.tasks.showOutput",
+			"JsonSchema.echoCommand",
+			"JsonSchema.tasks.watching.deprecation",
+			"JsonSchema.tasks.watching",
+			"JsonSchema.tasks.background",
+			"JsonSchema.tasks.promptOnClose",
+			"JsonSchema.tasks.build",
+			"JsonSchema.tasks.test",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.command",
+			"JsonSchema.args",
+			"JsonSchema.showOutput",
+			"JsonSchema.watching.deprecation",
+			"JsonSchema.watching",
+			"JsonSchema.background",
+			"JsonSchema.promptOnClose",
+			"JsonSchema.echoCommand",
+			"JsonSchema.suppressTaskName",
+			"JsonSchema.taskSelector",
+			"JsonSchema.matchers",
+			"JsonSchema.tasks"
 		],
-		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
-			"terminal.background",
-			"terminal.foreground",
-			"terminalCursor.foreground",
-			"terminalCursor.background",
-			"terminal.selectionBackground",
-			"terminal.inactiveSelectionBackground",
-			"terminal.selectionForeground",
-			"terminalCommandDecoration.defaultBackground",
-			"terminalCommandDecoration.successBackground",
-			"terminalCommandDecoration.errorBackground",
-			"terminalOverviewRuler.cursorForeground",
-			"terminal.border",
-			"terminal.findMatchBackground",
-			"terminal.findMatchHighlightBorder",
-			"terminal.findMatchBorder",
-			"terminal.findMatchHighlightBackground",
-			"terminal.findMatchHighlightBorder",
-			"terminalOverviewRuler.findMatchHighlightForeground",
-			"terminal.dragAndDropBackground",
-			"terminal.tab.activeBorder",
-			"terminal.ansiColor"
+		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
+			"deprecatedVariables"
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
+			"JsonSchema.input.id",
+			"JsonSchema.input.type",
+			"JsonSchema.input.description",
+			"JsonSchema.input.default",
+			"JsonSchema.inputs",
+			"JsonSchema.input.type.promptString",
+			"JsonSchema.input.password",
+			"JsonSchema.input.type.pickString",
+			"JsonSchema.input.options",
+			"JsonSchema.input.pickString.optionLabel",
+			"JsonSchema.input.pickString.optionValue",
+			"JsonSchema.input.type.command",
+			"JsonSchema.input.command.command",
+			"JsonSchema.input.command.args",
+			"JsonSchema.input.command.args",
+			"JsonSchema.input.command.args"
+		],
+		"vs/workbench/contrib/remote/browser/explorerViewItems": [
+			"remotes",
+			"remote.explorer.switch"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
 			"showTerminalTabs",
 			"workbench.action.terminal.newWorkspacePlaceholder",
 			"terminalLaunchHelp",
 			"workbench.action.terminal.newInActiveWorkspace",
+			"workbench.action.terminal.createTerminalEditor",
 			"workbench.action.terminal.createTerminalEditor",
 			"workbench.action.terminal.createTerminalEditorSide",
 			"workbench.action.terminal.showTabs",
@@ -14523,7 +14695,6 @@
 			"workbench.action.terminal.selectToNextCommand",
 			"workbench.action.terminal.selectToPreviousLine",
 			"workbench.action.terminal.selectToNextLine",
-			"workbench.action.terminal.toggleEscapeSequenceLogging",
 			"sendSequence",
 			"workbench.action.terminal.newWithCwd.cwd",
 			"workbench.action.terminal.renameWithArg.name",
@@ -14581,44 +14752,6 @@
 			"workbench.action.terminal.newplus",
 			"workbench.action.terminal.newWithProfilePlus",
 			"renameTerminal"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalIcons": [
-			"terminalViewIcon",
-			"renameTerminalIcon",
-			"killTerminalIcon",
-			"newTerminalIcon",
-			"configureTerminalProfileIcon",
-			"terminalDecorationMark",
-			"terminalDecorationIncomplete",
-			"terminalDecorationError",
-			"terminalDecorationSuccess",
-			"terminalCommandHistoryRemove",
-			"terminalCommandHistoryOutput",
-			"terminalCommandHistoryFuzzySearch"
-		],
-		"vs/workbench/contrib/terminal/common/terminalStrings": [
-			"terminal",
-			"terminal.new",
-			"doNotShowAgain",
-			"currentSessionCategory",
-			"previousSessionCategory",
-			"terminalCategory",
-			"workbench.action.terminal.focus",
-			"killTerminal",
-			"killTerminal.short",
-			"moveToEditor",
-			"workbench.action.terminal.moveToTerminalPanel",
-			"workbench.action.terminal.changeIcon",
-			"workbench.action.terminal.changeColor",
-			"splitTerminal",
-			"splitTerminal.short",
-			"unsplitTerminal",
-			"workbench.action.terminal.rename",
-			"workbench.action.terminal.sizeToContentWidthInstance",
-			"workbench.action.terminal.focusHover",
-			"workbench.action.terminal.sendSequence",
-			"workbench.action.terminal.newWithCwd",
-			"workbench.action.terminal.renameWithArg"
 		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
 			"cwd",
@@ -14762,7 +14895,21 @@
 			"terminal.integrated.shellIntegration.history",
 			"terminal.integrated.shellIntegration.suggestEnabled",
 			"terminal.integrated.smoothScrolling",
-			"terminal.integrated.experimentalImageSupport"
+			"terminal.integrated.enableImages"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalIcons": [
+			"terminalViewIcon",
+			"renameTerminalIcon",
+			"killTerminalIcon",
+			"newTerminalIcon",
+			"configureTerminalProfileIcon",
+			"terminalDecorationMark",
+			"terminalDecorationIncomplete",
+			"terminalDecorationError",
+			"terminalDecorationSuccess",
+			"terminalCommandHistoryRemove",
+			"terminalCommandHistoryOutput",
+			"terminalCommandHistoryFuzzySearch"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalMenus": [
 			{
@@ -14820,10 +14967,32 @@
 			"defaultTerminalProfile",
 			"splitTerminal"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
-			"moveTabsRight",
-			"moveTabsLeft",
-			"hideTabs"
+		"vs/workbench/contrib/terminal/common/terminalStrings": [
+			"terminal",
+			"terminal.new",
+			"doNotShowAgain",
+			"currentSessionCategory",
+			"previousSessionCategory",
+			"terminalCategory",
+			"workbench.action.terminal.focus",
+			"killTerminal",
+			"killTerminal.short",
+			"moveToEditor",
+			"workbench.action.terminal.moveToTerminalPanel",
+			"workbench.action.terminal.changeIcon",
+			"workbench.action.terminal.changeColor",
+			"splitTerminal",
+			"splitTerminal.short",
+			"unsplitTerminal",
+			"workbench.action.terminal.rename",
+			"workbench.action.terminal.sizeToContentWidthInstance",
+			"workbench.action.terminal.focusHover",
+			"workbench.action.terminal.sendSequence",
+			"workbench.action.terminal.newWithCwd",
+			"workbench.action.terminal.renameWithArg"
+		],
+		"vs/platform/terminal/common/terminalLogService": [
+			"terminalLoggerName"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
 			"shellIntegration.enabled",
@@ -14837,12 +15006,13 @@
 			},
 			"shellProcessTooltip.commandLine"
 		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer": [
-			"terminal.integrated.accessibleBuffer",
-			"terminal.integrated.symbolQuickPick.labelNoExitCode"
+		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
+			"moveTabsRight",
+			"moveTabsLeft",
+			"hideTabs"
 		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
-			"terminal.integrated.accessiblityHelp",
+			"terminal-help-label",
 			"focusAccessibleBuffer",
 			"focusAccessibleBufferNoKb",
 			"commandPromptMigration",
@@ -14863,17 +15033,27 @@
 			"openDetectedLinkNoKb",
 			"newWithProfile",
 			"newWithProfileNoKb",
-			"accessibilitySettings",
-			"readMore",
-			"dismiss",
-			"introMsg"
+			"accessibilitySettings"
 		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick": [
-			"terminal.integrated.openDetectedLink",
-			"terminal.integrated.urlLinks",
-			"terminal.integrated.localFileLinks",
-			"terminal.integrated.searchLinks",
-			"terminal.integrated.showMoreLinks"
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer": [
+			"terminal.integrated.accessibleBuffer",
+			"terminal.integrated.symbolQuickPick.labelNoExitCode"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
+			"terminal.freePort",
+			"terminal.createPR"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
+			"quickFix.command",
+			"quickFix.opener",
+			"codeAction.widget.id.quickfix"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
+			"vscode.extension.contributes.terminalQuickFixes",
+			"vscode.extension.contributes.terminalQuickFixes.id",
+			"vscode.extension.contributes.terminalQuickFixes.commandLineMatcher",
+			"vscode.extension.contributes.terminalQuickFixes.outputMatcher",
+			"vscode.extension.contributes.terminalQuickFixes.commandExitResult"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
 			"terminalLinkHandler.followLinkAlt.mac",
@@ -14884,89 +15064,24 @@
 			"followForwardedLink",
 			"followLinkUrl"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
-			"vscode.extension.contributes.terminalQuickFixes",
-			"vscode.extension.contributes.terminalQuickFixes.id",
-			"vscode.extension.contributes.terminalQuickFixes.commandLineMatcher",
-			"vscode.extension.contributes.terminalQuickFixes.outputMatcher",
-			"vscode.extension.contributes.terminalQuickFixes.commandExitResult"
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick": [
+			"terminal.integrated.openDetectedLink",
+			"terminal.integrated.urlLinks",
+			"terminal.integrated.localFileLinks",
+			"terminal.integrated.searchLinks",
+			"terminal.integrated.showMoreLinks"
 		],
-		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
-			"JsonSchema.options",
-			"JsonSchema.options.cwd",
-			"JsonSchema.options.env",
-			"JsonSchema.tasks.matcherError",
-			"JsonSchema.tasks.matcherError",
-			"JsonSchema.shellConfiguration",
-			"JsonSchema.shell.executable",
-			"JsonSchema.shell.args",
-			"JsonSchema.command",
-			"JsonSchema.tasks.args",
-			"JsonSchema.tasks.taskName",
-			"JsonSchema.command",
-			"JsonSchema.tasks.args",
-			"JsonSchema.tasks.windows",
-			"JsonSchema.tasks.matchers",
-			"JsonSchema.tasks.mac",
-			"JsonSchema.tasks.matchers",
-			"JsonSchema.tasks.linux",
-			"JsonSchema.tasks.matchers",
-			"JsonSchema.tasks.suppressTaskName",
-			"JsonSchema.tasks.showOutput",
-			"JsonSchema.echoCommand",
-			"JsonSchema.tasks.watching.deprecation",
-			"JsonSchema.tasks.watching",
-			"JsonSchema.tasks.background",
-			"JsonSchema.tasks.promptOnClose",
-			"JsonSchema.tasks.build",
-			"JsonSchema.tasks.test",
-			"JsonSchema.tasks.matchers",
-			"JsonSchema.command",
-			"JsonSchema.args",
-			"JsonSchema.showOutput",
-			"JsonSchema.watching.deprecation",
-			"JsonSchema.watching",
-			"JsonSchema.background",
-			"JsonSchema.promptOnClose",
-			"JsonSchema.echoCommand",
-			"JsonSchema.suppressTaskName",
-			"JsonSchema.taskSelector",
-			"JsonSchema.matchers",
-			"JsonSchema.tasks"
+		"vs/workbench/contrib/snippets/browser/commands/abstractSnippetsActions": [
+			"snippets"
 		],
-		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
-			"deprecatedVariables"
-		],
-		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
-			"JsonSchema.input.id",
-			"JsonSchema.input.type",
-			"JsonSchema.input.description",
-			"JsonSchema.input.default",
-			"JsonSchema.inputs",
-			"JsonSchema.input.type.promptString",
-			"JsonSchema.input.password",
-			"JsonSchema.input.type.pickString",
-			"JsonSchema.input.options",
-			"JsonSchema.input.pickString.optionLabel",
-			"JsonSchema.input.pickString.optionValue",
-			"JsonSchema.input.type.command",
-			"JsonSchema.input.command.command",
-			"JsonSchema.input.command.args",
-			"JsonSchema.input.command.args",
-			"JsonSchema.input.command.args"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
-			"quickFix.command",
-			"quickFix.opener",
-			"codeAction.widget.id.quickfix"
-		],
-		"vs/workbench/contrib/remote/browser/explorerViewItems": [
-			"remotes",
-			"remote.explorer.switch"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
-			"terminal.freePort",
-			"terminal.createPR"
+		"vs/workbench/contrib/snippets/browser/snippetPicker": [
+			"sep.userSnippet",
+			"sep.workspaceSnippet",
+			"disableSnippet",
+			"isDisabled",
+			"enable.snippet",
+			"pick.placeholder",
+			"pick.noSnippetAvailable"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetsFile": [
 			"source.workspaceSnippetGlobal",
@@ -14978,22 +15093,10 @@
 			"snippetSuggest.longLabel",
 			"snippetSuggest.longLabel"
 		],
-		"vs/workbench/contrib/snippets/browser/snippetPicker": [
-			"sep.userSnippet",
-			"sep.workspaceSnippet",
-			"disableSnippet",
-			"isDisabled",
-			"enable.snippet",
-			"pick.placeholder",
-			"pick.noSnippetAvailable"
-		],
 		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
 			"releaseNotesInputName",
 			"unassigned",
 			"showOnUpdate"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/abstractSnippetsActions": [
-			"snippets"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent": [
 			"getting-started-setup-icon",
@@ -15086,6 +15189,9 @@
 			"gettingStarted.settings.title",
 			"gettingStarted.settings.description.interpolated",
 			"tweakSettings",
+			"gettingStarted.profiles.title",
+			"gettingStarted.profiles.description.interpolated",
+			"tryProfiles",
 			"gettingStarted.workspaceTrust.title",
 			"gettingStarted.workspaceTrust.description.interpolated",
 			"workspaceTrust",
@@ -15168,7 +15274,6 @@
 			"walkthroughs.steps.when"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
-			"gettingStarted.featuredTitle",
 			"gettingStarted.featuredTitle"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
@@ -15179,6 +15284,9 @@
 			"welcomePage.progress.background",
 			"welcomePage.progress.foreground",
 			"walkthrough.stepTitle.foreground"
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/common/walkThroughUtils": [
+			"walkThrough.embeddedEditorBackground"
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
 			"tree.aria",
@@ -15312,33 +15420,13 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/welcomeWalkthrough/common/walkThroughUtils": [
-			"walkThrough.embeddedEditorBackground"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsActions": [
-			"clearIcon",
-			"clearAllIcon",
-			"hideIcon",
-			"expandIcon",
-			"collapseIcon",
-			"configureIcon",
-			"doNotDisturbIcon",
-			"clearNotification",
-			"clearNotifications",
-			"toggleDoNotDisturbMode",
-			"hideNotificationsCenter",
-			"expandNotification",
-			"collapseNotification",
-			"configureNotification",
-			"copyNotification"
-		],
 		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
 			"saveParticipants"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsList": [
-			"notificationAriaLabel",
-			"notificationWithSourceAriaLabel",
-			"notificationsList"
+		"vs/workbench/browser/parts/titlebar/windowTitle": [
+			"userIsAdmin",
+			"userIsSudo",
+			"devExtensionWindowTitlePrefix"
 		],
 		"vs/workbench/browser/parts/titlebar/commandCenterControl": [
 			"label.dfl",
@@ -15354,11 +15442,6 @@
 			"commandCenter-border",
 			"commandCenter-activeBorder",
 			"commandCenter-inactiveBorder"
-		],
-		"vs/workbench/browser/parts/titlebar/windowTitle": [
-			"userIsAdmin",
-			"userIsSudo",
-			"devExtensionWindowTitlePrefix"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopy": [
 			"staleSaveError",
@@ -15426,9 +15509,23 @@
 			"wordsDescription",
 			"regexDescription"
 		],
+		"vs/workbench/browser/parts/notifications/notificationsViewer": [
+			"executeCommand",
+			"notificationActions",
+			"notificationSource"
+		],
+		"vs/platform/languagePacks/common/localizedStrings": [
+			"open",
+			"close",
+			"find"
+		],
 		"vs/editor/browser/controller/textAreaHandler": [
 			"editor",
 			"accessibilityOffAriaLabel"
+		],
+		"vs/editor/browser/widget/diffEditor.contribution": [
+			"editor.action.diffReview.next",
+			"editor.action.diffReview.prev"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionMenu": [
 			"codeAction.widget.id.more",
@@ -15440,10 +15537,6 @@
 			"codeAction.widget.id.surround",
 			"codeAction.widget.id.source"
 		],
-		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
-			"clickToToggleColorOptions",
-			"closeIcon"
-		],
 		"vs/platform/actionWidget/browser/actionWidget": [
 			"codeActionMenuVisible",
 			"hideCodeActionWidget.title",
@@ -15451,6 +15544,10 @@
 			"selectNextCodeAction.title",
 			"acceptSelected.title",
 			"previewSelected.title"
+		],
+		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
+			"clickToToggleColorOptions",
+			"closeIcon"
 		],
 		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys": [
 			"inlineSuggestionVisible",
@@ -15547,6 +15644,42 @@
 			"commentThreadActiveRangeBackground",
 			"commentThreadActiveRangeBorder"
 		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffReview": [
+			"diffReviewInsertIcon",
+			"diffReviewRemoveIcon",
+			"diffReviewCloseIcon",
+			"label.close",
+			"no_lines_changed",
+			"one_line_changed",
+			"more_lines_changed",
+			{
+				"key": "header",
+				"comment": [
+					"This is the ARIA label for a git diff header.",
+					"A git diff header looks like this: @@ -154,12 +159,39 @@.",
+					"That encodes that at original line 154 (which is now line 159), 12 lines were removed/changed with 39 lines.",
+					"Variables 0 and 1 refer to the diff index out of total number of diffs.",
+					"Variables 2 and 4 will be numbers (a line number).",
+					"Variables 3 and 5 will be \"no lines changed\", \"1 line changed\" or \"X lines changed\", localized separately."
+				]
+			},
+			"blankLine",
+			{
+				"key": "unchangedLine",
+				"comment": [
+					"The placeholders are contents of the line and should not be translated."
+				]
+			},
+			"equalLine",
+			"insertLine",
+			"deleteLine"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
+			"foldUnchanged"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
+			"diff-aria-navigation-tip"
+		],
 		"vs/workbench/browser/parts/editor/editorPlaceholder": [
 			"trustRequiredEditor",
 			"requiresFolderTrustText",
@@ -15589,11 +15722,51 @@
 			"mAppMenu",
 			"mMore"
 		],
+		"vs/platform/quickinput/browser/quickInputUtils": [
+			"executeCommand"
+		],
 		"vs/platform/quickinput/browser/quickInputList": [
 			"quickInput"
 		],
-		"vs/platform/quickinput/browser/quickInputUtils": [
-			"executeCommand"
+		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
+			"workspaceUntrustedLabel",
+			"trustLabel",
+			"manageWorkspaceTrust",
+			"extensionSyncIgnoredLabel",
+			"syncIgnoredTitle",
+			"defaultOverriddenLabel",
+			"user",
+			"workspace",
+			"remote",
+			"policyLabelText",
+			"policyDescription",
+			"policyFilterLink",
+			"applicationSetting",
+			"applicationSettingDescription",
+			"alsoConfiguredIn",
+			"configuredIn",
+			"alsoConfiguredElsewhere",
+			"configuredElsewhere",
+			"alsoModifiedInScopes",
+			"modifiedInScopes",
+			"hasDefaultOverridesForLanguages",
+			"defaultOverriddenDetails",
+			"user",
+			"workspace",
+			"remote",
+			"modifiedInScopeForLanguage",
+			"user",
+			"workspace",
+			"remote",
+			"modifiedInScopeForLanguageMidSentence",
+			"workspaceUntrustedAriaLabel",
+			"policyDescriptionAccessible",
+			"applicationSettingDescriptionAccessible",
+			"alsoConfiguredIn",
+			"configuredIn",
+			"syncIgnoredAriaLabel",
+			"defaultOverriddenDetailsAriaLabel",
+			"defaultOverriddenLanguagesList"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsWidgets": [
 			"okButton",
@@ -15638,46 +15811,6 @@
 			"objectKeyHeader",
 			"objectValueHeader"
 		],
-		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
-			"workspaceUntrustedLabel",
-			"trustLabel",
-			"manageWorkspaceTrust",
-			"extensionSyncIgnoredLabel",
-			"syncIgnoredTitle",
-			"defaultOverriddenLabel",
-			"user",
-			"workspace",
-			"remote",
-			"policyLabelText",
-			"policyDescription",
-			"policyFilterLink",
-			"applicationSetting",
-			"applicationSettingDescription",
-			"alsoConfiguredIn",
-			"configuredIn",
-			"alsoConfiguredElsewhere",
-			"configuredElsewhere",
-			"alsoModifiedInScopes",
-			"modifiedInScopes",
-			"hasDefaultOverridesForLanguages",
-			"defaultOverriddenDetails",
-			"user",
-			"workspace",
-			"remote",
-			"modifiedInScopeForLanguage",
-			"user",
-			"workspace",
-			"remote",
-			"modifiedInScopeForLanguageMidSentence",
-			"workspaceUntrustedAriaLabel",
-			"policyDescriptionAccessible",
-			"applicationSettingDescriptionAccessible",
-			"alsoConfiguredIn",
-			"configuredIn",
-			"syncIgnoredAriaLabel",
-			"defaultOverriddenDetailsAriaLabel",
-			"defaultOverriddenLanguagesList"
-		],
 		"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer": [
 			"cellExecutionOrderCountLabel"
 		],
@@ -15701,6 +15834,26 @@
 			"notebook.find.filter.findInMarkupPreview",
 			"notebook.find.filter.findInCodeInput",
 			"notebook.find.filter.findInCodeOutput"
+		],
+		"vs/platform/actions/browser/buttonbar": [
+			"labelWithKeybinding"
+		],
+		"vs/workbench/contrib/terminal/browser/xterm/decorationAddon": [
+			"terminal.rerunCommand",
+			"rerun",
+			"yes",
+			"no",
+			"terminal.copyCommand",
+			"terminal.copyOutput",
+			"terminal.copyOutputAsHtml",
+			"workbench.action.terminal.runRecentCommand",
+			"workbench.action.terminal.goToRecentDirectory",
+			"terminal.configureCommandDecorations",
+			"terminal.learnShellIntegration",
+			"toggleVisibility",
+			"toggleVisibility",
+			"gutter",
+			"overviewRuler"
 		],
 		"vs/workbench/contrib/debug/common/debugger": [
 			"cannot.find.da",
@@ -15757,18 +15910,6 @@
 			"app.launch.json.compound.stopAll",
 			"compoundPrelaunchTask"
 		],
-		"vs/base/browser/ui/selectBox/selectBoxCustom": [
-			{
-				"key": "selectBox",
-				"comment": [
-					"Behave like native select dropdown element."
-				]
-			}
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
-			"conflictingLine",
-			"conflictingLines"
-		],
 		"vs/workbench/contrib/debug/browser/rawDebugSession": [
 			"noDebugAdapterStart",
 			"canNotStart",
@@ -15781,9 +15922,55 @@
 			"noDebugAdapter",
 			"moreInfo"
 		],
+		"vs/base/browser/ui/selectBox/selectBoxCustom": [
+			{
+				"key": "selectBox",
+				"comment": [
+					"Behave like native select dropdown element."
+				]
+			}
+		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
+			"conflictingLine",
+			"conflictingLines"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
 			"setInputHandled",
 			"undoMarkAsHandled"
+		],
+		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
+			"editorGutterCommentRangeForeground",
+			"editorOverviewRuler.commentForeground",
+			"editorOverviewRuler.commentUnresolvedForeground",
+			"editorGutterCommentGlyphForeground",
+			"editorGutterCommentUnresolvedGlyphForeground"
+		],
+		"vs/workbench/contrib/customEditor/common/extensionPoint": [
+			"contributes.customEditors",
+			"contributes.viewType",
+			"contributes.displayName",
+			"contributes.selector",
+			"contributes.selector.filenamePattern",
+			"contributes.priority",
+			"contributes.priority.default",
+			"contributes.priority.option"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
+			"useWslExtension.title",
+			"install"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick": [
+			"terminal.integrated.selectProfileToCreate",
+			"terminal.integrated.chooseDefaultProfile",
+			"enterTerminalProfileName",
+			"terminalProfileAlreadyExists",
+			"terminalProfiles",
+			"ICreateContributedTerminalProfileOptions",
+			"terminalProfiles.detected",
+			"unsafePathWarning",
+			"yes",
+			"cancel",
+			"createQuickLaunchProfile"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/conflictActions": [
 			"accept",
@@ -15808,37 +15995,15 @@
 			"resetToBase",
 			"resetToBaseTooltip"
 		],
-		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
-			"editorGutterCommentRangeForeground",
-			"editorOverviewRuler.commentForeground",
-			"editorOverviewRuler.commentUnresolvedForeground",
-			"editorGutterCommentGlyphForeground",
-			"editorGutterCommentUnresolvedGlyphForeground"
-		],
-		"vs/workbench/contrib/customEditor/common/extensionPoint": [
-			"contributes.customEditors",
-			"contributes.viewType",
-			"contributes.displayName",
-			"contributes.selector",
-			"contributes.selector.filenamePattern",
-			"contributes.priority",
-			"contributes.priority.default",
-			"contributes.priority.option"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
-			"useWslExtension.title",
-			"install"
-		],
 		"vs/workbench/contrib/terminal/browser/terminalInstance": [
+			"terminalTypeTask",
+			"terminalTypeLocal",
 			"terminal.integrated.a11yPromptLabel",
 			"terminal.integrated.useAccessibleBuffer",
 			"terminal.integrated.useAccessibleBufferNoKb",
-			"terminalTypeTask",
-			"terminalTypeLocal",
 			"bellStatus",
 			"keybindingHandling",
 			"configureTerminalSettings",
-			"terminal.integrated.copySelection.noSelection",
 			"preview",
 			"confirmMoveTrashMessageFilesAndDirectories",
 			{
@@ -15868,19 +16033,6 @@
 			"terminated.exitCodeOnly",
 			"launchFailed.errorMessage"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick": [
-			"terminal.integrated.selectProfileToCreate",
-			"terminal.integrated.chooseDefaultProfile",
-			"enterTerminalProfileName",
-			"terminalProfileAlreadyExists",
-			"terminalProfiles",
-			"ICreateContributedTerminalProfileOptions",
-			"terminalProfiles.detected",
-			"unsafePathWarning",
-			"yes",
-			"cancel",
-			"createQuickLaunchProfile"
-		],
 		"vs/workbench/contrib/terminal/browser/terminalTabsList": [
 			"terminalInputAriaLabel",
 			"terminal.tabs",
@@ -15902,6 +16054,19 @@
 			},
 			"label"
 		],
+		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
+			"terminalPromptContextMenu",
+			"terminalPromptCommandFailed",
+			"terminalPromptCommandFailedWithExitCode",
+			"terminalPromptCommandSuccess"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
+			"searchWorkspace",
+			"openFile",
+			"focusFolder",
+			"openFolder",
+			"followLink"
+		],
 		"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget": [
 			"label.find",
 			"placeholder.find",
@@ -15912,19 +16077,6 @@
 			"ariaSearchNoResultEmpty",
 			"ariaSearchNoResult",
 			"ariaSearchNoResultWithLineNumNoCurrentMatch"
-		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
-			"searchWorkspace",
-			"openFile",
-			"focusFolder",
-			"openFolder",
-			"followLink"
-		],
-		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
-			"terminalPromptContextMenu",
-			"terminalPromptCommandFailed",
-			"terminalPromptCommandFailedWithExitCode",
-			"terminalPromptCommandSuccess"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/media/theme_picker": [
 			"dark",
@@ -15953,20 +16105,10 @@
 			"Theirs",
 			"Yours"
 		],
-		"vs/platform/languagePacks/common/localizedStrings": [
-			"open",
-			"close",
-			"find"
-		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
 			"default",
 			"jupyter",
 			"colab"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsViewer": [
-			"executeCommand",
-			"notificationActions",
-			"notificationSource"
 		],
 		"vs/platform/actionWidget/browser/actionList": [
 			{
@@ -15998,6 +16140,20 @@
 			"referencesCount",
 			"referenceCount",
 			"treeAriaLabel"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/decorations": [
+			"diffInsertIcon",
+			"diffRemoveIcon",
+			"revertChangeHoverMessage"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin": [
+			"diff.clipboard.copyDeletedLinesContent.label",
+			"diff.clipboard.copyDeletedLinesContent.single.label",
+			"diff.clipboard.copyChangedLinesContent.label",
+			"diff.clipboard.copyChangedLinesContent.single.label",
+			"diff.clipboard.copyDeletedLineContent.label",
+			"diff.clipboard.copyChangedLineContent.label",
+			"diff.inline.revertChange.label"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbs": [
 			"title",
@@ -16045,11 +16201,24 @@
 		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
 			"breadcrumbs"
 		],
+		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
+			"mimeTypePicker",
+			"empty",
+			"noRenderer.2",
+			"curruentActiveMimeType",
+			"promptChooseMimeTypeInSecure.placeHolder",
+			"promptChooseMimeType.placeHolder",
+			"builtinRenderInfo"
+		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/cellEditorOptions": [
 			"notebook.lineNumbers",
 			"notebook.toggleLineNumbers",
 			"notebook.showLineNumbers",
 			"notebook.cell.toggleLineNumbers.title"
+		],
+		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCell": [
+			"cellExpandInputButtonLabelWithDoubleClick",
+			"cellExpandInputButtonLabel"
 		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellRunToolbar": [
 			"notebook.moreRunActionsLabel"
@@ -16063,22 +16232,20 @@
 			"hiddenCellsLabel",
 			"hiddenCellsLabelPlural"
 		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCell": [
-			"cellExpandInputButtonLabelWithDoubleClick",
-			"cellExpandInputButtonLabel"
-		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/markupCell": [
 			"cellExpandInputButtonLabelWithDoubleClick",
 			"cellExpandInputButtonLabel"
 		],
-		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
-			"mimeTypePicker",
-			"empty",
-			"noRenderer.2",
-			"curruentActiveMimeType",
-			"promptChooseMimeTypeInSecure.placeHolder",
-			"promptChooseMimeType.placeHolder",
-			"builtinRenderInfo"
+		"vs/workbench/services/suggest/browser/simpleSuggestWidget": [
+			"suggest",
+			"label.full",
+			"label.detail",
+			"label.desc",
+			"ariaCurrenttSuggestionReadDetails"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
+			"killportfailure",
+			"ptyHostRelaunch"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick": [
 			"removeCommand",
@@ -16089,26 +16256,26 @@
 			"selectRecentDirectoryMac",
 			"selectRecentDirectory"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
-			"killportfailure",
-			"ptyHostRelaunch"
-		],
-		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
-			"yes",
-			"no",
-			"dontShowAgain",
-			"terminal.slowRendering"
-		],
-		"vs/workbench/contrib/comments/browser/commentThreadBody": [
-			"commentThreadAria.withRange",
-			"commentThreadAria.document",
-			"commentThreadAria"
+		"vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput": [
+			"empty",
+			"noRenderer.2",
+			"pickMimeType",
+			"curruentActiveMimeType",
+			"installJupyterPrompt",
+			"promptChooseMimeTypeInSecure.placeHolder",
+			"promptChooseMimeType.placeHolder",
+			"unavailableRenderInfo"
 		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
 			"notebook.cell.status.success",
 			"notebook.cell.status.failed",
 			"notebook.cell.status.pending",
 			"notebook.cell.status.executing"
+		],
+		"vs/workbench/contrib/comments/browser/commentThreadBody": [
+			"commentThreadAria.withRange",
+			"commentThreadAria.document",
+			"commentThreadAria"
 		],
 		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
 			"collapseIcon",
@@ -16122,33 +16289,6 @@
 			"showEnvironmentContributions",
 			"ScopedEnvironmentContributionInfo"
 		],
-		"vs/workbench/contrib/terminal/browser/xterm/decorationAddon": [
-			"terminal.rerunCommand",
-			"rerun",
-			"yes",
-			"no",
-			"terminal.copyCommand",
-			"terminal.copyOutput",
-			"terminal.copyOutputAsHtml",
-			"workbench.action.terminal.runRecentCommand",
-			"workbench.action.terminal.goToRecentDirectory",
-			"terminal.configureCommandDecorations",
-			"terminal.learnShellIntegration",
-			"toggleVisibility",
-			"toggleVisibility",
-			"gutter",
-			"overviewRuler"
-		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput": [
-			"empty",
-			"noRenderer.2",
-			"pickMimeType",
-			"curruentActiveMimeType",
-			"installJupyterPrompt",
-			"promptChooseMimeTypeInSecure.placeHolder",
-			"promptChooseMimeType.placeHolder",
-			"unavailableRenderInfo"
-		],
 		"vs/workbench/contrib/comments/browser/commentNode": [
 			"commentToggleReaction",
 			"commentToggleReactionError",
@@ -16157,13 +16297,6 @@
 			"commentDeleteReactionDefaultError",
 			"commentAddReactionError",
 			"commentAddReactionDefaultError"
-		],
-		"vs/workbench/services/suggest/browser/simpleSuggestWidget": [
-			"suggest",
-			"label.full",
-			"label.detail",
-			"label.desc",
-			"ariaCurrenttSuggestionReadDetails"
 		],
 		"vs/workbench/contrib/comments/browser/reactionsAction": [
 			"pickReactions",
@@ -16194,6 +16327,9 @@
 		]
 	},
 	"messages": {
+		"vs/platform/terminal/node/ptyHostMain": [
+			"Pty Host"
+		],
 		"vs/code/electron-main/main": [
 			"Main",
 			"Another instance of {0} is already running as administrator.",
@@ -16210,9 +16346,6 @@
 		],
 		"vs/code/node/sharedProcess/sharedProcessMain": [
 			"Shared"
-		],
-		"vs/platform/terminal/node/ptyHostMain": [
-			"Pty Host"
 		],
 		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
 			"Process Name",
@@ -16276,6 +16409,7 @@
 			"Unique id used for correlating crash reports sent from this app instance.",
 			"Enable proposed APIs for a list of extension ids (such as `vscode.git`). Proposed APIs are unstable and subject to breaking without warning at any time. This should only be set for extension development and testing purposes.",
 			"Log level to use. Default is 'info'. Allowed values are 'error', 'warn', 'info', 'debug', 'trace', 'off'.",
+			"Disables the Chromium sandbox. This is useful when running VS Code as elevated on Linux and running under Applocker on Windows.",
 			"Forces the renderer to be accessible. ONLY change this if you are using a screen reader on Linux. On other platforms the renderer will automatically be accessible. This flag is automatically set if you have editor.accessibilitySupport: on."
 		],
 		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
@@ -16290,6 +16424,14 @@
 			"The workspace is already opened in another window. Please close that window first and then try again.",
 			"Opening a multi-root workspace."
 		],
+		"vs/workbench/services/secrets/electron-sandbox/secretStorageService": [
+			"Open troubleshooting guide",
+			"An OS keyring couldn't be identified for storing the encryption related data in your current desktop environment.",
+			"Open the troubleshooting guide to address this or you can use weaker encryption that doesn't use the OS keyring.",
+			"Use weaker encryption",
+			"You're running in a GNOME environment but the OS keyring is not available for encryption. Ensure you have gnome-keyring or another libsecret compatible implementation installed and running.",
+			"You're running in a KDE environment but the OS keyring is not available for encryption. Ensure you have kwallet running."
+		],
 		"vs/workbench/services/localization/electron-sandbox/localeService": [
 			"Unable to write display language. Please open the runtime settings, correct errors/warnings in it and try again.",
 			"Open Runtime Settings",
@@ -16302,13 +16444,13 @@
 			"Local",
 			"Remote"
 		],
-		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
-			"Backup working copies"
-		],
 		"vs/workbench/services/integrity/electron-sandbox/integrityService": [
 			"Your {0} installation appears to be corrupt. Please reinstall.",
 			"More Information",
 			"Don't Show Again"
+		],
+		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
+			"Backup working copies"
 		],
 		"vs/workbench/services/extensions/electron-sandbox/nativeExtensionService": [
 			"Extension host cannot start: version mismatch.",
@@ -16421,6 +16563,56 @@
 		],
 		"vs/base/common/platform": [
 			"_"
+		],
+		"vs/platform/environment/node/argv": [
+			"Options",
+			"Extensions Management",
+			"Troubleshooting",
+			"Directory where CLI metadata should be stored.",
+			"Compare two files with each other.",
+			"Perform a three-way merge by providing paths for two modified versions of a file, the common origin of both modified versions and the output file to save merge results.",
+			"Add folder(s) to the last active window.",
+			"Open a file at the path on the specified line and character position.",
+			"Force to open a new window.",
+			"Force to open a file or folder in an already opened window.",
+			"Wait for the files to be closed before returning.",
+			"The locale to use (e.g. en-US or zh-TW).",
+			"Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.",
+			"Opens the provided folder or workspace with the given profile and associates the profile with the workspace. If the profile does not exist, a new empty one is created. A folder or workspace must be provided for the profile to take effect.",
+			"Print usage.",
+			"Set the root path for extensions.",
+			"List the installed extensions.",
+			"Show versions of installed extensions, when using --list-extensions.",
+			"Filters installed extensions by provided category, when using --list-extensions.",
+			"Installs or updates an extension. The argument is either an extension id or a path to a VSIX. The identifier of an extension is '${publisher}.${name}'. Use '--force' argument to update to latest version. To install a specific version provide '@${version}'. For example: 'vscode.csharp@1.2.3'.",
+			"Installs the pre-release version of the extension, when using --install-extension",
+			"Uninstalls an extension.",
+			"Enables proposed API features for extensions. Can receive one or more extension IDs to enable individually.",
+			"Print version.",
+			"Print verbose output (implies --wait).",
+			"Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'. You can also configure the log level of an extension by passing extension id and log level in the following format: '${publisher}.${name}:${logLevel}'. For example: 'vscode.csharp:trace'. Can receive one or more such entries.",
+			"Print process usage and diagnostics information.",
+			"Run CPU profiler during startup.",
+			"Disable all installed extensions. This option is not persisted and is effective only when the command opens a new window.",
+			"Disable the provided extension. This option is not persisted and is effective only when the command opens a new window.",
+			"Turn sync on or off.",
+			"Allow debugging and profiling of extensions. Check the developer tools for the connection URI.",
+			"Allow debugging and profiling of extensions with the extension host being paused after start. Check the developer tools for the connection URI.",
+			"Disable GPU hardware acceleration.",
+			"Use this option only when there is requirement to launch the application as sudo user on Linux or when running as an elevated user in an applocker environment on Windows.",
+			"Shows all telemetry events which VS code collects.",
+			"Use {0} instead.",
+			"paths",
+			"Usage",
+			"options",
+			"To read output from another program, append '-' (e.g. 'echo Hello World | {0} -')",
+			"To read from stdin, append '-' (e.g. 'ps aux | grep code | {0} -')",
+			"Subcommands",
+			"Unknown version",
+			"Unknown commit"
+		],
+		"vs/platform/terminal/node/ptyService": [
+			"History restored"
 		],
 		"vs/editor/common/config/editorOptions": [
 			"Use platform APIs to detect when a Screen Reader is attached",
@@ -16603,6 +16795,7 @@
 			"When enabled IntelliSense shows `user`-suggestions.",
 			"When enabled IntelliSense shows `issues`-suggestions.",
 			"Whether leading and trailing whitespace should always be selected.",
+			"Whether subwords (like 'foo' in 'fooBar' or 'foo_bar') should be selected.",
 			"No indentation. Wrapped lines begin at column 1.",
 			"Wrapped lines get the same indentation as the parent.",
 			"Wrapped lines get +1 indentation toward the parent.",
@@ -16647,6 +16840,10 @@
 			"Controls the font family for CodeLens.",
 			"Controls the font size in pixels for CodeLens. When set to 0, 90% of `#editor.fontSize#` is used.",
 			"Controls whether the editor should render the inline color decorators and color picker.",
+			"Make the color picker appear both on click and hover of the color decorator",
+			"Make the color picker appear on hover of the color decorator",
+			"Make the color picker appear on click of the color decorator",
+			"Controls the condition to make a color picker appear from a color decorator",
 			"Controls the max number of color decorators that can be rendered in an editor at once.",
 			"Enable that the selection with the mouse and keys is doing column selection.",
 			"Controls whether syntax highlighting should be copied into the clipboard.",
@@ -16814,8 +17011,8 @@
 			"Unable to atomically delete file '{0}' because using trash is enabled.",
 			"Unable to delete nonexistent file '{0}'",
 			"Unable to delete non-empty folder '{0}'.",
-			"Unable to modify readonly file '{0}'",
-			"Unable to modify readonly file '{0}'"
+			"Unable to modify read-only file '{0}'",
+			"Unable to modify read-only file '{0}'"
 		],
 		"vs/platform/files/node/diskFileSystemProvider": [
 			"File already exists",
@@ -16896,6 +17093,15 @@
 			"Extension '{0}' is not installed on {1}.",
 			"Extension '{0}' is not installed."
 		],
+		"vs/platform/extensionManagement/common/extensionsScannerService": [
+			"Cannot read file {0}: {1}.",
+			"Failed to parse {0}: [{1}, {2}] {3}.",
+			"Invalid manifest file {0}: Not an JSON object.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected."
+		],
 		"vs/platform/extensionManagement/node/extensionManagementService": [
 			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.",
 			"Marketplace is not enabled",
@@ -16906,61 +17112,6 @@
 			"Cannot read the extension from {0}",
 			"Please restart VS Code before reinstalling {0}.",
 			"Please restart VS Code before reinstalling {0}."
-		],
-		"vs/platform/environment/node/argv": [
-			"Options",
-			"Extensions Management",
-			"Troubleshooting",
-			"Directory where CLI metadata should be stored.",
-			"Compare two files with each other.",
-			"Perform a three-way merge by providing paths for two modified versions of a file, the common origin of both modified versions and the output file to save merge results.",
-			"Add folder(s) to the last active window.",
-			"Open a file at the path on the specified line and character position.",
-			"Force to open a new window.",
-			"Force to open a file or folder in an already opened window.",
-			"Wait for the files to be closed before returning.",
-			"The locale to use (e.g. en-US or zh-TW).",
-			"Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.",
-			"Opens the provided folder or workspace with the given profile and associates the profile with the workspace. If the profile does not exist, a new empty one is created. A folder or workspace must be provided for the profile to take effect.",
-			"Print usage.",
-			"Set the root path for extensions.",
-			"List the installed extensions.",
-			"Show versions of installed extensions, when using --list-extensions.",
-			"Filters installed extensions by provided category, when using --list-extensions.",
-			"Installs or updates an extension. The argument is either an extension id or a path to a VSIX. The identifier of an extension is '${publisher}.${name}'. Use '--force' argument to update to latest version. To install a specific version provide '@${version}'. For example: 'vscode.csharp@1.2.3'.",
-			"Installs the pre-release version of the extension, when using --install-extension",
-			"Uninstalls an extension.",
-			"Enables proposed API features for extensions. Can receive one or more extension IDs to enable individually.",
-			"Print version.",
-			"Print verbose output (implies --wait).",
-			"Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'. You can also configure the log level of an extension by passing extension id and log level in the following format: '${publisher}.${name}:${logLevel}'. For example: 'vscode.csharp:trace'. Can receive one or more such entries.",
-			"Print process usage and diagnostics information.",
-			"Run CPU profiler during startup.",
-			"Disable all installed extensions. This option is not persisted and is effective only when the command opens a new window.",
-			"Disable the provided extension. This option is not persisted and is effective only when the command opens a new window.",
-			"Turn sync on or off.",
-			"Allow debugging and profiling of extensions. Check the developer tools for the connection URI.",
-			"Allow debugging and profiling of extensions with the extension host being paused after start. Check the developer tools for the connection URI.",
-			"Disable GPU hardware acceleration.",
-			"Shows all telemetry events which VS code collects.",
-			"Use {0} instead.",
-			"paths",
-			"Usage",
-			"options",
-			"To read output from another program, append '-' (e.g. 'echo Hello World | {0} -')",
-			"To read from stdin, append '-' (e.g. 'ps aux | grep code | {0} -')",
-			"Subcommands",
-			"Unknown version",
-			"Unknown commit"
-		],
-		"vs/platform/extensionManagement/common/extensionsScannerService": [
-			"Cannot read file {0}: {1}.",
-			"Failed to parse {0}: [{1}, {2}] {3}.",
-			"Invalid manifest file {0}: Not an JSON object.",
-			"Failed to parse {0}: {1}.",
-			"Invalid format {0}: JSON object expected.",
-			"Failed to parse {0}: {1}.",
-			"Invalid format {0}: JSON object expected."
 		],
 		"vs/platform/languagePacks/common/languagePacks": [
 			" (Current)"
@@ -17078,8 +17229,81 @@
 			"Opening tunnel {0}",
 			"Opening tunnel"
 		],
-		"vs/platform/terminal/node/ptyService": [
-			"History restored"
+		"vs/workbench/browser/workbench": [
+			"Failed to load a required file. Please restart the application to try again. Details: {0}"
+		],
+		"vs/workbench/electron-sandbox/window": [
+			"Restart",
+			"Configure",
+			"Learn More",
+			"Writing login information to the keychain failed with error '{0}'.",
+			"Troubleshooting Guide",
+			"You are running an emulated version of {0}. For better performance download the native arm64 version of {0} build for your machine.",
+			"Download",
+			"Proxy Authentication Required",
+			"&&Log In",
+			"Username",
+			"Password",
+			"The proxy {0} requires a username and password.",
+			"Remember my credentials",
+			"Are you sure you want to quit?",
+			"Are you sure you want to exit?",
+			"Are you sure you want to close the window?",
+			"&&Quit",
+			"&&Exit",
+			"&&Close Window",
+			"Do not ask me again",
+			"Error: {0}",
+			"The following operations are still running: \n{0}",
+			"An unexpected error prevented the window to close",
+			"An unexpected error prevented the application to quit",
+			"An unexpected error prevented the window to reload",
+			"An unexpected error prevented to change the workspace",
+			"Closing the window is taking a bit longer...",
+			"Quitting the application is taking a bit longer...",
+			"Reloading the window is taking a bit longer...",
+			"Changing the workspace is taking a bit longer...",
+			"Close Anyway",
+			"Quit Anyway",
+			"Reload Anyway",
+			"Change Anyway",
+			"There is a dependency cycle in the AMD modules that needs to be resolved!",
+			"It is not recommended to run {0} as root user.",
+			"Files you store within the installation folder ('{0}') may be OVERWRITTEN or DELETED IRREVERSIBLY without warning at update time.",
+			"{0} on {1} will soon stop receiving updates. Consider upgrading your windows version.",
+			"Learn More",
+			"{0}. Use navigation keys to access banner actions.",
+			"Learn More",
+			"{0} on {1} will soon stop receiving updates. Consider upgrading your macOS version.",
+			"Learn More",
+			"{0}. Use navigation keys to access banner actions.",
+			"Learn More",
+			"Resolving shell environment...",
+			"Learn More"
+		],
+		"vs/workbench/services/configuration/browser/configurationService": [
+			"Contribute defaults for configurations",
+			"Experiments"
+		],
+		"vs/platform/workspace/common/workspace": [
+			"Code Workspace"
+		],
+		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
+			"Open Developer Tools",
+			"Open in browser",
+			"Failed to connect to the remote extension host server (Error: {0})"
+		],
+		"vs/workbench/services/log/electron-sandbox/logService": [
+			"Window"
+		],
+		"vs/platform/workspace/common/workspaceTrust": [
+			"Trusted",
+			"Restricted Mode"
+		],
+		"vs/workbench/services/userDataProfile/common/userDataProfile": [
+			"Icon for Default Profile.",
+			"Profiles",
+			"Profile"
 		],
 		"vs/platform/list/browser/listService": [
 			"Workbench",
@@ -17113,6 +17337,9 @@
 			"Warning",
 			"Info"
 		],
+		"vs/platform/contextkey/browser/contextKeyService": [
+			"A command that returns information about context keys"
+		],
 		"vs/platform/contextkey/common/contextkey": [
 			"Empty context key expression",
 			"Did you forget to write an expression? You can also put 'false' or 'true' to always evaluate to false or true, respectively.",
@@ -17126,8 +17353,13 @@
 			"Unexpected token. Hint: {0}",
 			"Unexpected token."
 		],
-		"vs/platform/contextkey/browser/contextKeyService": [
-			"A command that returns information about context keys"
+		"vs/workbench/browser/actions/textInputActions": [
+			"Undo",
+			"Redo",
+			"Cut",
+			"Copy",
+			"Paste",
+			"Select All"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"The default size.",
@@ -17159,11 +17391,13 @@
 			"Allow tabs to get smaller when the available space is not enough to show all tabs at once.",
 			"Make all tabs the same size, while allowing them to get smaller when the available space is not enough to show all tabs at once.",
 			"Controls the size of editor tabs. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
-			"Controls the maximum width of tabs when {0} is set to {1}.",
+			"Controls the minimum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.",
+			"Controls the maximum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.",
 			"A pinned tab inherits the look of non pinned tabs.",
 			"A pinned tab will show in a compact form with only icon or first letter of the editor name.",
 			"A pinned tab shrinks to a compact fixed size showing parts of the editor name.",
 			"Controls the size of pinned editor tabs. Pinned tabs are sorted to the beginning of all opened tabs and typically do not close until unpinned. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"Splits all the editor groups to equal parts unless a part has been changed in size.",
 			"Splits all the editor groups to equal parts.",
 			"Splits the active editor group to equal parts.",
 			"Controls the size of editor groups when splitting them.",
@@ -17190,6 +17424,7 @@
 			"Editors are positioned from left to right.",
 			"Controls if the centered layout should automatically resize to maximum width when more than one group is open. Once only one group is open it will resize back to the original centered width.",
 			"Controls whether the centered layout tries to maintain constant width when the window is resized.",
+			"Controls whether to maximize/restore the editor group when double clicking on a tab. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
 			"Controls if the number of opened editors should be limited or not. When enabled, less recently used editors will close to make space for newly opening editors.",
 			"Controls the maximum number of opened editors. Use the {0} setting to control this limit per editor group or across all groups.",
 			"Controls if the maximum number of opened editors should exclude dirty editors for counting towards the configured limit.",
@@ -17197,7 +17432,7 @@
 			"Controls whether local file history is enabled. When enabled, the file contents of an editor that is saved will be stored to a backup location to be able to restore or review the contents later. Changing this setting has no effect on existing local file history entries.",
 			"Controls the maximum size of a file (in KB) to be considered for local file history. Files that are larger will not be added to the local file history. Changing this setting has no effect on existing local file history entries.",
 			"Controls the maximum number of local file history entries per file. When the number of local file history entries exceeds this number for a file, the oldest entries will be discarded.",
-			"Configure paths or [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) for excluding files from the local file history. Glob patterns are always evaluated relative to the path of the workspace folder unless they are absolute paths. Changing this setting has no effect on existing local file history entries.",
+			"Configure paths or [glob patterns](https://aka.ms/vscode-glob-patterns) for excluding files from the local file history. Glob patterns are always evaluated relative to the path of the workspace folder unless they are absolute paths. Changing this setting has no effect on existing local file history entries.",
 			"Configure an interval in seconds during which the last entry in local file history is replaced with the entry that is being added. This helps reduce the overall number of entries that are added, for example when auto save is enabled. This setting is only applied to entries that have the same source of origin. Changing this setting has no effect on existing local file history entries.",
 			"Controls the number of recently used commands to keep in history for the command palette. Set to 0 to disable command history.",
 			"Controls whether the last typed input to the command palette should be restored when opening it the next time.",
@@ -17343,14 +17578,6 @@
 			"View &&License",
 			"Privacy Statement",
 			"Privac&&y Statement"
-		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"Undo",
-			"Redo",
-			"Cut",
-			"Copy",
-			"Paste",
-			"Select All"
 		],
 		"vs/workbench/browser/actions/layoutActions": [
 			"Represents the menu bar",
@@ -17528,6 +17755,14 @@
 			"Add Folder to Workspace",
 			"Select workspace folder"
 		],
+		"vs/workbench/browser/actions/quickAccessActions": [
+			"Go to File...",
+			"Quick Open",
+			"Navigate Next in Quick Open",
+			"Navigate Previous in Quick Open",
+			"Select Next in Quick Open",
+			"Select Previous in Quick Open"
+		],
 		"vs/workbench/services/actions/common/menusExtensionPoint": [
 			"The Command Palette",
 			"The touch bar (macOS only)",
@@ -17637,14 +17872,6 @@
 			"Menu item references a submenu for a menu which doesn't have submenu support.",
 			"Menu item references a submenu `{0}` which is not defined in the 'submenus' section.",
 			"The `{0}` submenu was already contributed to the `{1}` menu."
-		],
-		"vs/workbench/browser/actions/quickAccessActions": [
-			"Go to File...",
-			"Quick Open",
-			"Navigate Next in Quick Open",
-			"Navigate Previous in Quick Open",
-			"Select Next in Quick Open",
-			"Select Previous in Quick Open"
 		],
 		"vs/workbench/api/common/configurationExtensionPoint": [
 			"A title for the current category of settings. This label will be rendered in the Settings editor as a subheading. If the title is the same as the extension display name, then the category will be grouped under the main extension heading.",
@@ -17946,15 +18173,15 @@
 			"Cancel",
 			"Dismiss"
 		],
-		"vs/workbench/services/configuration/common/jsonEditingService": [
-			"Unable to write into the file. Please open the file to correct errors/warnings in the file and try again."
-		],
 		"vs/workbench/services/preferences/browser/preferencesService": [
 			"Open a folder or workspace first to create workspace or folder settings.",
 			"Place your key bindings in this file to override the defaults",
 			"Default Keybindings",
 			"Default Keybindings",
 			"Unable to create '{0}' ({1})."
+		],
+		"vs/workbench/services/configuration/common/jsonEditingService": [
+			"Unable to write into the file. Please open the file to correct errors/warnings in the file and try again."
 		],
 		"vs/workbench/services/editor/browser/editorResolverService": [
 			"There are multiple default editors available for the resource.",
@@ -18071,15 +18298,6 @@
 			"Don't Show Again",
 			"Don't Show Again"
 		],
-		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
-			"The current profile has been removed. Please reload to switch back to default profile",
-			"The current profile has been removed. Please reload to switch back to default profile",
-			"Cannot rename the default profile",
-			"Cannot delete the default profile",
-			"Switching to a profile.",
-			"Switching a profile requires reloading VS Code.",
-			"&&Reload"
-		],
 		"vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService": [
 			"Error while importing profile: {0}",
 			"{0}: Resolving profile content...",
@@ -18087,6 +18305,8 @@
 			"Create Profile",
 			"Export",
 			"Close",
+			"Troubleshoot Issue",
+			"Setting up Troubleshoot Profile: {0}",
 			"{0}: Exporting...",
 			"Profile '{0}' was exported successfully.",
 			"&&Copy Link",
@@ -18102,15 +18322,14 @@
 			"Cancel",
 			"Create Profile",
 			"{0} ({1})...",
-			"{0} ({1}): Applying Settings...",
-			"{0} ({1}): Applying Keyboard Shortcuts...",
-			"{0} ({1}): Applying Tasks...",
-			"{0} ({1}): Applying Snippets...",
-			"{0} ({1}): Applying State...",
-			"{0} ({1}): Applying Extensions...",
-			"{0} ({1}): Applying...",
+			"Applying Settings...",
+			"{0}ying Keyboard Shortcuts...",
+			"Applying Tasks...",
+			"Applying Snippets...",
+			"Applying State...",
+			"Applying Extensions...",
+			" Applying...",
 			"Export '{0}' profile as...",
-			"Preview",
 			"Profile with name '{0}' already exists. Do you want to overwrite it?",
 			"&&Overwrite",
 			"&&Create New Profile",
@@ -18128,15 +18347,50 @@
 			"Export Profile",
 			"Profile name must be provided."
 		],
+		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
+			"The current profile has been removed. Please reload to switch back to default profile",
+			"The current profile has been removed. Please reload to switch back to default profile",
+			"Cannot rename the default profile",
+			"Cannot delete the default profile",
+			"Switching to a profile.",
+			"Switching a profile requires reloading VS Code.",
+			"&&Reload"
+		],
 		"vs/workbench/services/remote/common/remoteExplorerService": [
 			"User Forwarded",
 			"Auto Forwarded",
 			"Local port {0} could not be used for forwarding to remote port {1}.\n\nThis usually happens when there is already another process using local port {0}.\n\nPort number {2} has been used instead.",
 			"Statically Forwarded"
 		],
+		"vs/workbench/services/filesConfiguration/common/filesConfigurationService": [
+			"Editor is read-only because the file system of the file is read-only.",
+			"Editor is read-only because the file was set read-only in this session. [Click here](command:{0}) to set writeable.",
+			"Editor is read-only because the file was set read-only via settings. [Click here](command:{0}) to configure.",
+			"Editor is read-only because of file permissions. [Click here](command:{0}) to set writeable anyway.",
+			"Editor is read-only because the file is read-only."
+		],
 		"vs/workbench/services/views/browser/viewDescriptorService": [
 			"Hide '{0}'",
 			"Reset Location"
+		],
+		"vs/workbench/services/authentication/browser/authenticationService": [
+			"The id of the authentication provider.",
+			"The human readable name of the authentication provider.",
+			"Contributes authentication",
+			"No accounts requested yet...",
+			"An authentication contribution must specify an id.",
+			"An authentication contribution must specify a label.",
+			"This authentication id '{0}' has already been registered",
+			"Loading...",
+			"Sign in requested",
+			"The extension '{0}' wants to access the {1} account '{2}'.",
+			"&&Allow",
+			"&&Deny",
+			"Sign in to another account",
+			"The extension '{0}' wants to access a {1} account",
+			"Select an account for '{0}' to use or Esc to cancel",
+			"Grant access to {0} for {1}... (1)",
+			"Sign in with {0} to use {1} (1)"
 		],
 		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
 			"Settings sync cannot be turned on because there are no authentication providers available.",
@@ -18163,24 +18417,38 @@
 			"Others",
 			"Sign in with {0}"
 		],
-		"vs/workbench/services/authentication/browser/authenticationService": [
-			"The id of the authentication provider.",
-			"The human readable name of the authentication provider.",
-			"Contributes authentication",
-			"No accounts requested yet...",
-			"An authentication contribution must specify an id.",
-			"An authentication contribution must specify a label.",
-			"This authentication id '{0}' has already been registered",
-			"Loading...",
-			"Sign in requested",
-			"The extension '{0}' wants to access the {1} account '{2}'.",
-			"&&Allow",
-			"&&Deny",
-			"Sign in to another account",
-			"The extension '{0}' wants to access a {1} account",
-			"Select an account for '{0}' to use or Esc to cancel",
-			"Grant access to {0} for {1}... (1)",
-			"Sign in with {0} to use {1} (1)"
+		"vs/workbench/services/assignment/common/assignmentService": [
+			"Fetches experiments to run from a Microsoft online service."
+		],
+		"vs/workbench/services/issue/browser/issueTroubleshoot": [
+			"Troubleshoot Issue",
+			"Issue troubleshooting is a process to help you identify the cause for an issue. The cause for an issue can be a misconfiguration, due to an extension, or be {0} itself.\n\nDuring the process the window reloads repeatedly. Each time you must confirm if you are still seeing the issue.",
+			"&&Troubleshoot Issue",
+			"Issue troubleshooting is active and has temporarily disabled all installed extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
+			"Issue troubleshooting is active and has temporarily reset your configurations to defaults. Check if you can still reproduce the problem and proceed by selecting from these options.",
+			"Issue troubleshooting has identified that the issue is caused by your configurations. Please report the issue by exporting your configurations using \"Export Profile\" command and share the file in the issue report.",
+			"Issue troubleshooting has identified that the issue is with {0}.",
+			"I can't reproduce",
+			"I can reproduce",
+			"Stop",
+			"Troubleshoot Issue",
+			"This likely means that the issue has been addressed already and will be available in an upcoming release. You can safely use {0} insiders until the new stable version is available.",
+			"Troubleshoot Issue",
+			"Download {0} Insiders",
+			"Report Issue Anyway",
+			"Please try to download and reproduce the issue in {0} insiders.",
+			"Troubleshoot Issue",
+			"I can't reproduce",
+			"I can reproduce",
+			"Stop",
+			"Please try to reproduce the issue in {0} insiders and confirm if the issue exists there.",
+			"Troubleshoot Issue...",
+			"Stop Troubleshoot Issue"
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"You won't be able to produce this key combination under your current keyboard layout.",
+			"**{0}** for your current keyboard layout (**{1}** for US standard).",
+			"**{0}** for your current keyboard layout."
 		],
 		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
 			"Settings Editor 2",
@@ -18230,10 +18498,11 @@
 			"Define Keybinding",
 			"&&Preferences"
 		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"You won't be able to produce this key combination under your current keyboard layout.",
-			"**{0}** for your current keyboard layout (**{1}** for US standard).",
-			"**{0}** for your current keyboard layout."
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"Startup Performance",
+			"Print Service Cycles",
+			"Print Service Traces",
+			"Print Emitter Profiles"
 		],
 		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
 			"Settings for code editors used in notebooks. This can be used to customize most editor.* settings.",
@@ -18279,12 +18548,6 @@
 			"Control whether a confirmation prompt is required to delete a running cell.",
 			"Customize the Find Widget behavior for searching within notebook cells. When both markup source and markup preview are enabled, the Find Widget will search either the source code or preview based on the current state of the cell."
 		],
-		"vs/workbench/contrib/performance/browser/performance.contribution": [
-			"Startup Performance",
-			"Print Service Cycles",
-			"Print Service Traces",
-			"Print Emitter Profiles"
-		],
 		"vs/workbench/contrib/chat/browser/chat.contribution": [
 			"Chat",
 			"Controls the font size in pixels in chat codeblocks.",
@@ -18292,9 +18555,9 @@
 			"Controls the font weight in chat codeblocks.",
 			"Controls whether lines should wrap in chat codeblocks.",
 			"Controls the line height in pixels in chat codeblocks. Use 0 to compute the line height from the font size.",
-			"Controls whether the quick question feature is enabled.",
 			"Chat",
-			"Chat"
+			"Chat",
+			"Chat Accessible View"
 		],
 		"vs/workbench/contrib/interactive/browser/interactive.contribution": [
 			"Interactive Window",
@@ -18310,8 +18573,7 @@
 			"Focus History",
 			"The border color for the current interactive code cell when the editor has focus.",
 			"The border color for the current interactive code cell when the editor does not have focus.",
-			"Automatically scroll the interactive window to show the output of the last statement executed. If this value is false, the window will only scroll if the last cell was already the one scrolled to.",
-			"Controls whether the Interactive Window sessions/history should be restored across window reloads. Whether the state of controllers used in Interactive Windows is persisted across window reloads are controlled by extensions contributing controllers."
+			"Automatically scroll the interactive window to show the output of the last statement executed. If this value is false, the window will only scroll if the last cell was already the one scrolled to."
 		],
 		"vs/workbench/contrib/testing/browser/testing.contribution": [
 			"Testing",
@@ -18357,26 +18619,6 @@
 			"Connected to remote.\n{0}",
 			"You have not yet opened a folder.\n{0}\nOpening a folder will close all currently open editors. To keep them open, {1} instead.",
 			"You have not yet opened a folder.\n{0}"
-		],
-		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
-			"Made no edits",
-			"Made {0} text edits in {1} files",
-			"Made {0} text edits in one file",
-			"Made {0} text edits in {1} files, also created or deleted {2} files",
-			"Workspace Edit",
-			"Workspace Edit",
-			"Made no edits",
-			"Are you sure you want to close the window?",
-			"&&Close Window",
-			"Are you sure you want to change the workspace?",
-			"Change &&Workspace",
-			"Are you sure you want to reload the window?",
-			"&&Reload Window",
-			"Are you sure you want to quit?",
-			"&&Quit",
-			"'{0}' is in progress.",
-			"File operation",
-			"Controls if files that were part of a refactoring are saved automatically"
 		],
 		"vs/workbench/contrib/files/browser/fileActions.contribution": [
 			"Copy Path",
@@ -18428,7 +18670,7 @@
 			"Hot exit will be triggered when the browser quits or the window or tab is closed.",
 			"Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.",
 			"Files",
-			"Configure [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) for excluding files and folders. For example, the File Explorer decides which files and folders to show or hide based on this setting. Refer to the `#search.exclude#` setting to define search-specific excludes. Refer to the `#explorer.excludeGitIgnore#` setting for ignoring files based on your `.gitignore`.",
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) for excluding files and folders. For example, the File Explorer decides which files and folders to show or hide based on this setting. Refer to the `#search.exclude#` setting to define search-specific excludes. Refer to the `#explorer.excludeGitIgnore#` setting for ignoring files based on your `.gitignore`.",
 			"Enable the pattern.",
 			"Disable the pattern.",
 			"The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.",
@@ -18450,16 +18692,18 @@
 			"An editor with changes is automatically saved when the window loses focus.",
 			"Controls [auto save](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save) of editors that have unsaved changes.",
 			"Controls the delay in milliseconds after which an editor with unsaved changes is saved automatically. Only applies when `#files.autoSave#` is set to `{0}`.",
-			"Configure paths or glob patterns to exclude from file watching. Paths can either be relative to the watched folder or absolute. Glob patterns are matched relative from the watched folder. When you experience the file watcher process consuming a lot of CPU, make sure to exclude large folders that are of less interest (such as build output folders).",
+			"Configure paths or [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from file watching. Paths can either be relative to the watched folder or absolute. Glob patterns are matched relative from the watched folder. When you experience the file watcher process consuming a lot of CPU, make sure to exclude large folders that are of less interest (such as build output folders).",
 			"Configure extra paths to watch for changes inside the workspace. By default, all workspace folders will be watched recursively, except for folders that are symbolic links. You can explicitly add absolute or relative paths to support watching folders that are symbolic links. Relative paths will be resolved to an absolute path using the currently opened workspace.",
 			"The default language identifier that is assigned to new files. If configured to `${activeEditorLanguage}`, will use the language identifier of the currently active text editor if any.",
-			"Configure paths or [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) to mark as read-only. Glob patterns are always evaluated relative to the path of the workspace folder unless they are absolute paths. You can exclude matching paths via the `#files.readonlyExclude#` setting. Files from readonly file system providers will always be read-only independent of this setting.",
-			"Configure paths or [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) to exclude from being marked as read-only if they match as a result of the `#files.readonlyInclude#` setting. Glob patterns are always evaluated relative to the path of the workspace folder unless they are absolute paths. Files from readonly file system providers will always be read-only independent of this setting.",
-			"Marks files as readonly when their file permissions indicate as such. This can be overridden via `#files.readonlyInclude#` and `#files.readonlyExclude#` settings.",
+			"Configure paths or [glob patterns](https://aka.ms/vscode-glob-patterns) to mark as read-only. Glob patterns are always evaluated relative to the path of the workspace folder unless they are absolute paths. You can exclude matching paths via the `#files.readonlyExclude#` setting. Files from readonly file system providers will always be read-only independent of this setting.",
+			"Configure paths or [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from being marked as read-only if they match as a result of the `#files.readonlyInclude#` setting. Glob patterns are always evaluated relative to the path of the workspace folder unless they are absolute paths. Files from readonly file system providers will always be read-only independent of this setting.",
+			"Marks files as read-only when their file permissions indicate as such. This can be overridden via `#files.readonlyInclude#` and `#files.readonlyExclude#` settings.",
 			"Restore the undo stack when a file is reopened.",
 			"Will refuse to save and ask for resolving the save conflict manually.",
 			"Will resolve the save conflict by overwriting the file on disk with the changes in the editor.",
 			"A save conflict can occur when a file is saved to disk that was changed by another program in the meantime. To prevent data loss, the user is asked to compare the changes in the editor with the version on disk. This setting should only be changed if you frequently encounter save conflict errors and may result in data loss if used without caution.",
+			"Default path for file dialogs must be an absolute path (e.g. C:\\\\myFolder or /myFolder).",
+			"Default path for file dialogs, overriding user's home path. Only used in the absence of a context-specific path, such as most recently opened file or folder.",
 			"Enables the simple file dialog for opening and saving files and folders. The simple file dialog replaces the system file dialog when enabled.",
 			"Timeout in milliseconds after which file participants for create, rename, and delete are cancelled. Use `0` to disable participants.",
 			"Format a file on save. A formatter must be available, the file must not be saved after delay, and the editor must not be shutting down.",
@@ -18478,7 +18722,7 @@
 			"Files will not be revealed and selected.",
 			"Files will not be scrolled into view, but will still be focused.",
 			"Controls whether the Explorer should automatically reveal and select files when opening them.",
-			"Configure paths or [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) for excluding files and folders from being revealed and selected in the Explorer when they are opened. Glob patterns are always evaluated relative to the path of the workspace folder unless they are absolute paths.",
+			"Configure paths or [glob patterns](https://aka.ms/vscode-glob-patterns) for excluding files and folders from being revealed and selected in the Explorer when they are opened. Glob patterns are always evaluated relative to the path of the workspace folder unless they are absolute paths.",
 			"The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.",
 			"Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.",
 			"Controls whether the Explorer should allow to move files and folders via drag and drop. This setting only effects drag and drop from inside the Explorer.",
@@ -18519,6 +18763,26 @@
 			"Controls nesting of files in the Explorer. {0} must be set for this to take effect. Each __Item__ represents a parent pattern and may contain a single `*` character that matches any string. Each __Value__ represents a comma separated list of the child patterns that should be shown nested under a given parent. Child patterns may contain several special tokens:\n- `${capture}`: Matches the resolved value of the `*` from the parent pattern\n- `${basename}`: Matches the parent file's basename, the `file` in `file.ts`\n- `${extname}`: Matches the parent file's extension, the `ts` in `file.ts`\n- `${dirname}`: Matches the parent file's directory name, the `src` in `src/file.ts`\n- `*`:  Matches any string, may only be used once per child pattern",
 			"Each key pattern may contain a single `*` character which will match any string."
 		],
+		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
+			"Made no edits",
+			"Made {0} text edits in {1} files",
+			"Made {0} text edits in one file",
+			"Made {0} text edits in {1} files, also created or deleted {2} files",
+			"Workspace Edit",
+			"Workspace Edit",
+			"Made no edits",
+			"Are you sure you want to close the window?",
+			"&&Close Window",
+			"Are you sure you want to change the workspace?",
+			"Change &&Workspace",
+			"Are you sure you want to reload the window?",
+			"&&Reload Window",
+			"Are you sure you want to quit?",
+			"&&Quit",
+			"'{0}' is in progress.",
+			"File operation",
+			"Controls if files that were part of a refactoring are saved automatically"
+		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
 			"Another refactoring is being previewed.",
 			"Press 'Continue' to discard the previous refactoring and continue with the current refactoring.",
@@ -18538,10 +18802,6 @@
 			"View icon of the refactor preview view.",
 			"Refactor Preview",
 			"Refactor Preview"
-		],
-		"vs/workbench/contrib/sash/browser/sash.contribution": [
-			"Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it's hard to resize views using the mouse.",
-			"Controls the hover feedback delay in milliseconds of the dragging area in between views/editors."
 		],
 		"vs/workbench/contrib/search/browser/search.contribution": [
 			"Search",
@@ -18630,6 +18890,10 @@
 			"Decrease Context Lines",
 			"Select All Matches",
 			"Open New Search Editor"
+		],
+		"vs/workbench/contrib/sash/browser/sash.contribution": [
+			"Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it's hard to resize views using the mouse.",
+			"Controls the hover feedback delay in milliseconds of the dragging area in between views/editors."
 		],
 		"vs/workbench/contrib/search/browser/searchView": [
 			"Search was canceled before any results could be found - ",
@@ -18977,7 +19241,13 @@
 			"If the comments view has not been opened yet during this session it will open the first time during a session that a file with comments is active.",
 			"Controls when the comments view should open.",
 			"Determines if relative time will be used in comment timestamps (ex. '1 day ago').",
-			"Controls the visibility of the comments bar and comment threads in editors that have commenting ranges and comments. Comments are still accessible via the Comments view and will cause commenting to be toggled on in the same way running the command \"Comments: Toggle Editor Commenting\" toggles comments."
+			"Controls the visibility of the comments bar and comment threads in editors that have commenting ranges and comments. Comments are still accessible via the Comments view and will cause commenting to be toggled on in the same way running the command \"Comments: Toggle Editor Commenting\" toggles comments.",
+			"Controls whether the comments widget scrolls or expands."
+		],
+		"vs/workbench/contrib/url/browser/url.contribution": [
+			"Open URL",
+			"URL to open",
+			"When enabled, trusted domain prompts will appear when opening links in trusted workspaces."
 		],
 		"vs/workbench/contrib/webview/browser/webview.contribution": [
 			"Cut",
@@ -18987,10 +19257,46 @@
 		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
 			"webview editor"
 		],
-		"vs/workbench/contrib/url/browser/url.contribution": [
-			"Open URL",
-			"URL to open",
-			"When enabled, trusted domain prompts will appear when opening links in trusted workspaces."
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			"Remote",
+			"Installed",
+			"Install Local Extensions in '{0}'...",
+			"Install Remote Extensions Locally...",
+			"Popular",
+			"Recommended",
+			"Enabled",
+			"Disabled",
+			"Marketplace",
+			"Installed",
+			"Recently Updated",
+			"Enabled",
+			"Disabled",
+			"Available Updates",
+			"Builtin",
+			"Workspace Unsupported",
+			"Workspace Recommendations",
+			"Other Recommendations",
+			"Features",
+			"Themes",
+			"Programming Languages",
+			"Disabled in Restricted Mode",
+			"Limited in Restricted Mode",
+			"Disabled in Virtual Workspaces",
+			"Limited in Virtual Workspaces",
+			"Deprecated",
+			"Search Extensions in Marketplace",
+			"1 extension found in the {0} section.",
+			"1 extension found.",
+			"{0} extensions found in the {1} section.",
+			"{0} extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"{0} requires update",
+			"{0} require update",
+			"{0} requires reload",
+			"{0} require reload",
+			"We have uninstalled '{0}' which was reported to be problematic.",
+			"Reload Now"
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
 			"Press Enter to manage extensions.",
@@ -19128,53 +19434,6 @@
 			"Extensions",
 			"Extensions"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			"Remote",
-			"Installed",
-			"Install Local Extensions in '{0}'...",
-			"Install Remote Extensions Locally...",
-			"Popular",
-			"Recommended",
-			"Enabled",
-			"Disabled",
-			"Marketplace",
-			"Installed",
-			"Recently Updated",
-			"Enabled",
-			"Disabled",
-			"Available Updates",
-			"Builtin",
-			"Workspace Unsupported",
-			"Workspace Recommendations",
-			"Other Recommendations",
-			"Features",
-			"Themes",
-			"Programming Languages",
-			"Disabled in Restricted Mode",
-			"Limited in Restricted Mode",
-			"Disabled in Virtual Workspaces",
-			"Limited in Virtual Workspaces",
-			"Deprecated",
-			"Search Extensions in Marketplace",
-			"1 extension found in the {0} section.",
-			"1 extension found.",
-			"{0} extensions found in the {1} section.",
-			"{0} extensions found.",
-			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
-			"Open User Settings",
-			"{0} requires update",
-			"{0} require update",
-			"{0} requires reload",
-			"{0} require reload",
-			"We have uninstalled '{0}' which was reported to be problematic.",
-			"Reload Now"
-		],
-		"vs/workbench/contrib/output/browser/outputView": [
-			"{0} - Output",
-			"Output channel for '{0}'",
-			"Output",
-			"Output panel"
-		],
 		"vs/workbench/contrib/output/browser/output.contribution": [
 			"View icon of the output view.",
 			"Output",
@@ -19196,7 +19455,8 @@
 			"Extension Logs",
 			"Select Log",
 			"Open Log File...",
-			"Select Log file",
+			"The id of the log file to open, for example `\"window\"`. Currently the best way to get this is to get the ID by checking the `workbench.action.output.show.<id>` commands",
+			"Select Log File",
 			"Output",
 			"Enable/disable the ability of smart scrolling in the output view. Smart scrolling allows you to lock scrolling automatically when you click in the output view and unlocks when you click in the last line."
 		],
@@ -19311,11 +19571,6 @@
 		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
 			"Toggle Keyboard Shortcuts Troubleshooting"
 		],
-		"vs/workbench/contrib/folding/browser/folding.contribution": [
-			"All",
-			"All active folding range providers",
-			"Defines a default folding range provider that takes precedence over all other folding range providers. Must be the identifier of an extension contributing a folding range provider."
-		],
 		"vs/workbench/contrib/snippets/browser/snippets.contribution": [
 			"Controls if surround-with-snippets or file template snippets show as Code Actions.",
 			"The prefix to use when selecting the snippet in intellisense",
@@ -19327,6 +19582,17 @@
 			"Empty snippet",
 			"User snippet configuration",
 			"A list of language names to which this snippet applies, e.g. 'typescript,javascript'."
+		],
+		"vs/workbench/contrib/output/browser/outputView": [
+			"{0} - Output",
+			"Output channel for '{0}'",
+			"Output",
+			"Output panel"
+		],
+		"vs/workbench/contrib/folding/browser/folding.contribution": [
+			"All",
+			"All active folding range providers",
+			"Defines a default folding range provider that takes precedence over all other folding range providers. Must be the identifier of an extension contributing a folding range provider."
 		],
 		"vs/workbench/contrib/limitIndicator/browser/limitIndicator.contribution": [
 			"Configure",
@@ -19536,9 +19802,6 @@
 			"{0} (Language Status)",
 			"Reset Language Status Interaction Counter"
 		],
-		"vs/workbench/contrib/experiments/browser/experiments.contribution": [
-			"Fetches experiments to run from a Microsoft online service."
-		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution": [
 			"Settings sync is suspended temporarily because the current device is making too many requests. Please reload {0} to resume.",
 			"Settings sync is suspended temporarily because the current device is making too many requests. Please restart {0} to resume.",
@@ -19714,7 +19977,10 @@
 			"Plays a sound when the focus moves to a deleted line in diff review mode or to the next/previous change",
 			"Plays a sound when the focus moves to a modified line in diff review mode or to the next/previous change",
 			"Plays a sound when a notebook cell execution is successfully completed.",
-			"Plays a sound when a notebook cell execution fails."
+			"Plays a sound when a notebook cell execution fails.",
+			"Plays a sound when a chat request is made.",
+			"Plays a sound on loop while the response is pending.",
+			"Plays a sound on loop while the response has been received."
 		],
 		"vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExtensionMigrator.contribution": [
 			"The extension 'Bracket pair Colorizer' got disabled because it was deprecated.",
@@ -19722,86 +19988,18 @@
 			"Enable Native Bracket Pair Colorization",
 			"More Info"
 		],
+		"vs/workbench/contrib/accessibility/browser/accessibility.contribution": [
+			"editor accessibility help",
+			"Hover Accessible View"
+		],
 		"vs/workbench/contrib/share/browser/share.contribution": [
 			"Share...",
 			"Generating link...",
+			"Copied text to clipboard!",
 			"Copied link to clipboard!",
 			"Close",
-			"Open Link"
-		],
-		"vs/workbench/browser/workbench": [
-			"Failed to load a required file. Please restart the application to try again. Details: {0}"
-		],
-		"vs/workbench/electron-sandbox/window": [
-			"Restart",
-			"Configure",
-			"Learn More",
-			"Writing login information to the keychain failed with error '{0}'.",
-			"Troubleshooting Guide",
-			"Proxy Authentication Required",
-			"&&Log In",
-			"Username",
-			"Password",
-			"The proxy {0} requires a username and password.",
-			"Remember my credentials",
-			"Are you sure you want to quit?",
-			"Are you sure you want to exit?",
-			"Are you sure you want to close the window?",
-			"&&Quit",
-			"&&Exit",
-			"&&Close Window",
-			"Do not ask me again",
-			"Error: {0}",
-			"The following operations are still running: \n{0}",
-			"An unexpected error prevented the window to close",
-			"An unexpected error prevented the application to quit",
-			"An unexpected error prevented the window to reload",
-			"An unexpected error prevented to change the workspace",
-			"Closing the window is taking a bit longer...",
-			"Quitting the application is taking a bit longer...",
-			"Reloading the window is taking a bit longer...",
-			"Changing the workspace is taking a bit longer...",
-			"Close Anyway",
-			"Quit Anyway",
-			"Reload Anyway",
-			"Change Anyway",
-			"There is a dependency cycle in the AMD modules that needs to be resolved!",
-			"It is not recommended to run {0} as root user.",
-			"Files you store within the installation folder ('{0}') may be OVERWRITTEN or DELETED IRREVERSIBLY without warning at update time.",
-			"{0} on {1} will soon stop receiving updates. Consider upgrading your windows version.",
-			"Learn More",
-			"{0}. Use navigation keys to access banner actions.",
-			"Learn More",
-			"{0} on {1} will soon stop receiving updates. Consider upgrading your macOS version.",
-			"Learn More",
-			"{0}. Use navigation keys to access banner actions.",
-			"Learn More",
-			"Resolving shell environment...",
-			"Learn More"
-		],
-		"vs/workbench/services/configuration/browser/configurationService": [
-			"Contribute defaults for configurations",
-			"Experiments"
-		],
-		"vs/platform/workspace/common/workspace": [
-			"Code Workspace"
-		],
-		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
-			"Open Developer Tools",
-			"Open in browser",
-			"Failed to connect to the remote extension host server (Error: {0})"
-		],
-		"vs/workbench/services/log/electron-sandbox/logService": [
-			"Window"
-		],
-		"vs/platform/workspace/common/workspaceTrust": [
-			"Trusted",
-			"Restricted Mode"
-		],
-		"vs/workbench/services/userDataProfile/common/userDataProfile": [
-			"Icon for Default Profile.",
-			"Profiles",
-			"Profile"
+			"Open Link",
+			"Controls whether to render the Share action next to the command center when {0} is {1}."
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
 			"Default Language Configuration Overrides",
@@ -19849,6 +20047,13 @@
 			"Quality type of VS Code",
 			"Whether keyboard focus is inside an input box"
 		],
+		"vs/workbench/electron-sandbox/actions/installActions": [
+			"Shell Command",
+			"Install '{0}' command in PATH",
+			"Shell command '{0}' successfully installed in PATH.",
+			"Uninstall '{0}' command from PATH",
+			"Shell command '{0}' successfully uninstalled from PATH."
+		],
 		"vs/workbench/common/contextkeys": [
 			"The kind of workspace opened in the window, either 'empty' (no workspace), 'folder' (single folder) or 'workspace' (multi-root workspace)",
 			"The number of root folders in the workspace",
@@ -19863,8 +20068,8 @@
 			"Whether the active editor is the first one in its group",
 			"Whether the active editor is the last one in its group",
 			"Whether the active editor is pinned",
-			"Whether the active editor is readonly",
-			"Whether the active editor can toggle between being readonly or writeable",
+			"Whether the active editor is read-only",
+			"Whether the active editor can toggle between being read-only or writeable",
 			"Whether the active editor can revert",
 			"The identifier of the active editor",
 			"The available editor identifiers that are usable for the active editor",
@@ -19911,13 +20116,6 @@
 			"Whether a resource is present or not",
 			"Whether the resource is backed by a file system provider"
 		],
-		"vs/workbench/electron-sandbox/actions/installActions": [
-			"Shell Command",
-			"Install '{0}' command in PATH",
-			"Shell command '{0}' successfully installed in PATH.",
-			"Uninstall '{0}' command from PATH",
-			"Shell command '{0}' successfully uninstalled from PATH."
-		],
 		"vs/workbench/common/configuration": [
 			"Application",
 			"Workbench",
@@ -19929,7 +20127,7 @@
 			"OK"
 		],
 		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
-			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nChromium: {4}\nNode.js: {5}\nV8: {6}\nOS: {7}",
+			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
 			"&&Copy",
 			"OK"
 		],
@@ -19937,8 +20135,8 @@
 			"File Created",
 			"File Replaced",
 			"Text File Model Decorations",
-			"Deleted, Read Only",
-			"Read Only",
+			"Deleted, Read-only",
+			"Read-only",
 			"Deleted",
 			"File seems to be binary and cannot be opened as text",
 			"'{0}' already exists. Do you want to replace it?",
@@ -20086,7 +20284,9 @@
 			"Outline color for text that got removed.",
 			"Border color between the two text editors.",
 			"Color of the diff editor's diagonal fill. The diagonal fill is used in side-by-side diff views.",
-			"The color of unchanged blocks in diff editor.",
+			"The background color of unchanged blocks in the diff editor.",
+			"The foreground color of unchanged blocks in the diff editor.",
+			"The background color of unchanged code in the diff editor.",
 			"List/Tree background color for the focused item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree foreground color for the focused item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
 			"List/Tree outline color for the focused item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
@@ -20301,6 +20501,12 @@
 		"vs/base/common/actions": [
 			"(empty)"
 		],
+		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
+			"Save",
+			"Save Workspace",
+			"Unable to write into workspace configuration file. Please open the file to correct errors/warnings in it and try again.",
+			"Open Workspace Configuration"
+		],
 		"vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService": [
 			"Cannot substitute command variable '{0}' because command did not return a result of type string.",
 			"Variable '{0}' must be defined in an '{1}' section of the debug or task configuration.",
@@ -20353,6 +20559,12 @@
 			"Reverting editors with unsaved changes is taking a bit longer...",
 			"Discarding backups is taking a bit longer..."
 		],
+		"vs/workbench/services/workingCopy/common/workingCopyHistoryService": [
+			"File Saved",
+			"File Moved",
+			"File Renamed",
+			"Saving local history"
+		],
 		"vs/platform/action/common/actionCommonCategories": [
 			"View",
 			"Help",
@@ -20360,12 +20572,6 @@
 			"File",
 			"Preferences",
 			"Developer"
-		],
-		"vs/workbench/services/workingCopy/common/workingCopyHistoryService": [
-			"File Saved",
-			"File Moved",
-			"File Renamed",
-			"Saving local history"
 		],
 		"vs/workbench/services/extensions/common/abstractExtensionService": [
 			"The following extensions contain dependency loops and have been disabled: {0}",
@@ -20378,12 +20584,6 @@
 			"The remote extension host terminated unexpectedly. Restarting...",
 			"Remote Extension host terminated unexpectedly 3 times within the last 5 minutes.",
 			"Restart Remote Extension Host"
-		],
-		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
-			"Save",
-			"Save Workspace",
-			"Unable to write into workspace configuration file. Please open the file to correct errors/warnings in it and try again.",
-			"Open Workspace Configuration"
 		],
 		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
 			"Extensions have been modified on disk. Please reload the window.",
@@ -20419,7 +20619,7 @@
 			"Whether the editor text has focus (cursor is blinking)",
 			"Whether the editor or an editor widget has focus (e.g. focus is in the find widget)",
 			"Whether an editor or a rich text input has focus (cursor is blinking)",
-			"Whether the editor is read only",
+			"Whether the editor is read-only",
 			"Whether the context is a diff editor",
 			"Whether the context is an embedded diff editor",
 			"Whether `editor.columnSelection` is enabled",
@@ -20549,11 +20749,6 @@
 			"Settings Sync",
 			"View icon of the Settings Sync view."
 		],
-		"vs/workbench/contrib/tasks/common/tasks": [
-			"Whether a task is currently running.",
-			"Tasks",
-			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
-		],
 		"vs/workbench/contrib/performance/electron-sandbox/startupProfiler": [
 			"Successfully created profiles.",
 			"Please create an issue and manually attach the following files:\n{0}",
@@ -20563,12 +20758,22 @@
 			"A final restart is required to continue to use '{0}'. Again, thank you for your contribution.",
 			"&&Restart"
 		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"Whether a task is currently running.",
+			"Tasks",
+			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
+		],
 		"vs/workbench/contrib/tasks/common/taskService": [
 			"Whether CustomExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
 			"Whether ShellExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
 			"Whether the task commands have been registered yet",
 			"Whether ProcessExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
 			"True when in the web with no remote authority."
+		],
+		"vs/workbench/common/views": [
+			"Default view icon.",
+			"A view with id '{0}' is already registered",
+			"No tree view with id '{0}' registered."
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"Configure Task",
@@ -20693,15 +20898,14 @@
 			"Notebook Cell Failed",
 			"Diff Line Inserted",
 			"Diff Line Deleted",
-			"Diff Line Modified"
-		],
-		"vs/workbench/common/views": [
-			"Default view icon.",
-			"A view with id '{0}' is already registered",
-			"No tree view with id '{0}' registered."
+			"Diff Line Modified",
+			"Chat Request Sent",
+			"Chat Response Received",
+			"Chat Response Pending"
 		],
 		"vs/workbench/contrib/terminal/common/terminalContextKey": [
 			"Whether the terminal is focused.",
+			"Whether any terminal is focused, including detached terminals used in other UI.",
 			"Whether the terminal accessible buffer is focused.",
 			"Whether a terminal in the editor area is focused.",
 			"The current number of terminals.",
@@ -20711,6 +20915,7 @@
 			"Whether the terminal's suggest widget is visible.",
 			"Whether the terminal view is showing",
 			"Whether text is selected in the active terminal.",
+			"Whether text is selected in a focused terminal.",
 			"Whether terminal processes can be launched in the current workspace.",
 			"Whether one terminal is selected in the terminal tabs list.",
 			"Whether the focused tab's terminal is a split terminal.",
@@ -20721,16 +20926,16 @@
 			"Open Webview Developer Tools",
 			"Using standard dev tools to debug iframe based webview"
 		],
+		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
+			"Reveal in File Explorer",
+			"Reveal in Finder",
+			"Open Containing Folder"
+		],
 		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
 			"Merge Editor (Dev)",
 			"Open Merge Editor State from JSON",
 			"Enter JSON",
 			"Open Selection In Temporary Merge Editor"
-		],
-		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
-			"Reveal in File Explorer",
-			"Reveal in Finder",
-			"Open Containing Folder"
 		],
 		"vs/workbench/api/common/extHostExtensionService": [
 			"Cannot load test runner.",
@@ -20750,12 +20955,18 @@
 			"Extension Host (Worker)",
 			"Extension Host"
 		],
-		"vs/workbench/api/node/extHostTunnelService": [
-			"Private",
-			"Public"
+		"vs/platform/terminal/node/terminalProcess": [
+			"Starting directory (cwd) \"{0}\" is not a directory",
+			"Starting directory (cwd) \"{0}\" does not exist",
+			"Path to shell executable \"{0}\" does not exist",
+			"Path to shell executable \"{0}\" is not a file or a symlink"
 		],
 		"vs/workbench/api/node/extHostDebugService": [
 			"Debug Process"
+		],
+		"vs/workbench/api/node/extHostTunnelService": [
+			"Private",
+			"Public"
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"Open",
@@ -20806,6 +21017,14 @@
 			"Unable to uninstall the shell command '{0}'.",
 			"Unable to find shell script in '{0}'"
 		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"New Window",
+			"Opens a new window",
+			"Recent Folders & Workspaces",
+			"Recent Folders",
+			"Untitled (Workspace)",
+			"{0} (Workspace)"
+		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			"&&OK",
 			"Path does not exist",
@@ -20818,14 +21037,6 @@
 			"The host '{0}' was not found in the list of allowed hosts. Do you want to allow it anyway?",
 			"The path '{0}' uses a host that is not allowed. Unless you trust the host, you should press 'Cancel'",
 			"Permanently allow host '{0}'"
-		],
-		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
-			"New Window",
-			"Opens a new window",
-			"Recent Folders & Workspaces",
-			"Recent Folders",
-			"Untitled (Workspace)",
-			"{0} (Workspace)"
 		],
 		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
 			"&&OK",
@@ -20855,6 +21066,20 @@
 			"Version specified in `engines.vscode` ({0}) is not specific enough. For vscode versions after 1.0.0, please define at a minimum the major desired version. E.g. ^1.10.0, 1.10.x, 1.x.x, 2.x.x, etc.",
 			"Extension is not compatible with Code {0}. Extension requires: {1}."
 		],
+		"vs/base/common/jsonErrorMessages": [
+			"Invalid symbol",
+			"Invalid number format",
+			"Property name expected",
+			"Value expected",
+			"Colon expected",
+			"Comma expected",
+			"Closing brace expected",
+			"Closing bracket expected",
+			"End of file expected"
+		],
+		"vs/platform/extensionManagement/common/extensionNls": [
+			"Couldn't find message for key {0}."
+		],
 		"vs/base/node/zip": [
 			"Error extracting {0}. Invalid file.",
 			"Incomplete. Found {0} of {1} entries",
@@ -20876,20 +21101,6 @@
 		],
 		"vs/platform/extensionManagement/node/extensionManagementUtil": [
 			"VSIX invalid: package.json is not a JSON file."
-		],
-		"vs/base/common/jsonErrorMessages": [
-			"Invalid symbol",
-			"Invalid number format",
-			"Property name expected",
-			"Value expected",
-			"Colon expected",
-			"Comma expected",
-			"Closing brace expected",
-			"Closing bracket expected",
-			"End of file expected"
-		],
-		"vs/platform/extensionManagement/common/extensionNls": [
-			"Couldn't find message for key {0}."
 		],
 		"vs/base/browser/ui/button/button": [
 			"More Actions..."
@@ -20970,12 +21181,6 @@
 			"Cannot sync because current session is expired",
 			"Cannot sync because syncing is turned off on this machine from another machine."
 		],
-		"vs/platform/terminal/node/terminalProcess": [
-			"Starting directory (cwd) \"{0}\" is not a directory",
-			"Starting directory (cwd) \"{0}\" does not exist",
-			"Path to shell executable \"{0}\" does not exist",
-			"Path to shell executable \"{0}\" is not a file or a symlink"
-		],
 		"vs/base/browser/ui/tree/abstractTree": [
 			"Filter",
 			"Fuzzy Match",
@@ -20991,6 +21196,93 @@
 			"Icon for the close action in widgets.",
 			"Icon for goto previous editor location.",
 			"Icon for goto next editor location."
+		],
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"Error: {0}",
+			"Warning: {0}",
+			"Info: {0}"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"No new notifications",
+			"Notifications",
+			"Notification Center Actions",
+			"Notifications Center"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsStatus": [
+			"Notifications",
+			"Notifications",
+			"Do Not Disturb",
+			"Do Not Disturb Mode is Enabled",
+			"Hide Notifications",
+			"No Notifications",
+			"No New Notifications",
+			"1 New Notification",
+			"{0} New Notifications",
+			"No New Notifications ({0} in progress)",
+			"1 New Notification ({0} in progress)",
+			"{0} New Notifications ({1} in progress)",
+			"Status Message"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCommands": [
+			"Notifications",
+			"Show Notifications",
+			"Hide Notifications",
+			"Clear All Notifications",
+			"Accept Notification Primary Action",
+			"Toggle Do Not Disturb Mode",
+			"Focus Notification Toast"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsToasts": [
+			"{0}, notification",
+			"{0}, source: {1}, notification"
+		],
+		"vs/platform/actions/browser/menuEntryActionViewItem": [
+			"{0} ({1})",
+			"{0} ({1})",
+			"{0}\n[{1}] {2}"
+		],
+		"vs/workbench/services/configuration/common/configurationEditing": [
+			"Open Tasks Configuration",
+			"Open Launch Configuration",
+			"Open Settings",
+			"Open Tasks Configuration",
+			"Open Launch Configuration",
+			"Save and Retry",
+			"Save and Retry",
+			"Open Settings",
+			"Unable to write {0} because it is configured in system policy.",
+			"Unable to write to {0} because {1} is not a registered configuration.",
+			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
+			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
+			"Unable to write to Folder Settings because {0} does not support the folder resource scope.",
+			"Unable to write to User Settings because {0} does not support for global scope.",
+			"Unable to write to Workspace Settings because {0} does not support for workspace scope in a multi folder workspace.",
+			"Unable to write to Folder Settings because no resource is provided.",
+			"Unable to write to Language Settings because {0} is not a resource language setting.",
+			"Unable to write to {0} because no workspace is opened. Please open a workspace first and try again.",
+			"Unable to write into the tasks configuration file. Please open it to correct errors/warnings in it and try again.",
+			"Unable to write into the launch configuration file. Please open it to correct errors/warnings in it and try again.",
+			"Unable to write into user settings. Please open the user settings to correct errors/warnings in it and try again.",
+			"Unable to write into remote user settings. Please open the remote user settings to correct errors/warnings in it and try again.",
+			"Unable to write into workspace settings. Please open the workspace settings to correct errors/warnings in the file and try again.",
+			"Unable to write into folder settings. Please open the '{0}' folder settings to correct errors/warnings in it and try again.",
+			"Unable to write into tasks configuration file because the file has unsaved changes. Please save it first and then try again.",
+			"Unable to write into launch configuration file because the file has unsaved changes. Please save it first and then try again.",
+			"Unable to write into user settings because the file has unsaved changes. Please save the user settings file first and then try again.",
+			"Unable to write into remote user settings because the file has unsaved changes. Please save the remote user settings file first and then try again.",
+			"Unable to write into workspace settings because the file has unsaved changes. Please save the workspace settings file first and then try again.",
+			"Unable to write into folder settings because the file has unsaved changes. Please save the '{0}' folder settings file first and then try again.",
+			"Unable to write into tasks configuration file because the content of the file is newer.",
+			"Unable to write into launch configuration file because the content of the file is newer.",
+			"Unable to write into user settings because the content of the file is newer.",
+			"Unable to write into remote user settings because the content of the file is newer.",
+			"Unable to write into workspace settings because the content of the file is newer.",
+			"Unable to write into folder settings because the content of the file is newer.",
+			"Unable to write to {0} because of an internal error.",
+			"User Settings",
+			"Remote User Settings",
+			"Workspace Settings",
+			"Folder Settings"
 		],
 		"vs/editor/common/core/editorColorRegistry": [
 			"Background color for the highlight of line at the cursor position.",
@@ -21059,6 +21351,10 @@
 			"Stick to the end even when going to longer lines",
 			"Removed secondary cursors"
 		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"The number of cursors has been limited to {0}. Consider using [find and replace](https://code.visualstudio.com/docs/editor/codebasics#_find-and-replace) for larger changes or increase the editor multi cursor limit setting.",
+			"Increase Multi Cursor Limit"
+		],
 		"vs/editor/contrib/anchorSelect/browser/anchorSelect": [
 			"Selection Anchor",
 			"Anchor set at {0}:{1}",
@@ -21067,16 +21363,26 @@
 			"Select from Anchor to Cursor",
 			"Cancel Selection Anchor"
 		],
-		"vs/editor/contrib/caretOperations/browser/caretOperations": [
-			"Move Selected Text Left",
-			"Move Selected Text Right"
-		],
 		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
 			"Overview ruler marker color for matching brackets.",
 			"Go to Bracket",
 			"Select to Bracket",
 			"Remove Brackets",
 			"Go to &&Bracket"
+		],
+		"vs/editor/browser/widget/diffEditorWidget": [
+			"Line decoration for inserts in the diff editor.",
+			"Line decoration for removals in the diff editor.",
+			" use Shift + F7 to navigate changes",
+			"Cannot compare files because one file is too large.",
+			"Click to revert change"
+		],
+		"vs/editor/contrib/caretOperations/browser/caretOperations": [
+			"Move Selected Text Left",
+			"Move Selected Text Right"
+		],
+		"vs/editor/contrib/caretOperations/browser/transpose": [
+			"Transpose Letters"
 		],
 		"vs/editor/contrib/clipboard/browser/clipboard": [
 			"Cu&&t",
@@ -21098,25 +21404,17 @@
 			"Paste",
 			"Copy With Syntax Highlighting"
 		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"The number of cursors has been limited to {0}. Consider using [find and replace](https://code.visualstudio.com/docs/editor/codebasics#_find-and-replace) for larger changes or increase the editor multi cursor limit setting.",
-			"Increase Multi Cursor Limit"
-		],
-		"vs/editor/browser/widget/diffEditorWidget": [
-			"Line decoration for inserts in the diff editor.",
-			"Line decoration for removals in the diff editor.",
-			" use Shift + F7 to navigate changes",
-			"Cannot compare files because one file is too large.",
-			"Click to revert change"
-		],
-		"vs/editor/contrib/caretOperations/browser/transpose": [
-			"Transpose Letters"
-		],
 		"vs/editor/contrib/codeAction/browser/codeActionContributions": [
 			"Enable/disable showing group headers in the Code Action menu."
 		],
 		"vs/editor/contrib/codelens/browser/codelensController": [
 			"Show CodeLens Commands For Current Line"
+		],
+		"vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions": [
+			"Show or Focus Standalone Color Picker",
+			"&&Show or Focus Standalone Color Picker",
+			"Hide the Color Picker",
+			"Insert Color with Standalone Color Picker"
 		],
 		"vs/editor/contrib/comment/browser/comment": [
 			"Toggle Line Comment",
@@ -21137,12 +21435,6 @@
 			"Mouse Over",
 			"Always",
 			"Show Editor Context Menu"
-		],
-		"vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions": [
-			"Show or Focus Standalone Color Picker",
-			"&&Show or Focus Standalone Color Picker",
-			"Hide the Color Picker",
-			"Insert Color with Standalone Color Picker"
 		],
 		"vs/editor/contrib/cursorUndo/browser/cursorUndo": [
 			"Cursor Undo",
@@ -21173,11 +21465,6 @@
 			"Replace",
 			"&&Replace"
 		],
-		"vs/editor/contrib/fontZoom/browser/fontZoom": [
-			"Editor Font Zoom In",
-			"Editor Font Zoom Out",
-			"Editor Font Zoom Reset"
-		],
 		"vs/editor/contrib/folding/browser/folding": [
 			"Unfold",
 			"Unfold Recursively",
@@ -21201,6 +21488,11 @@
 		"vs/editor/contrib/format/browser/formatActions": [
 			"Format Document",
 			"Format Selection"
+		],
+		"vs/editor/contrib/fontZoom/browser/fontZoom": [
+			"Editor Font Zoom In",
+			"Editor Font Zoom Out",
+			"Editor Font Zoom Reset"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/goToCommands": [
 			"Peek",
@@ -21243,9 +21535,6 @@
 			"No results for '{0}'",
 			"References"
 		],
-		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
-			"Click to show {0} definitions."
-		],
 		"vs/editor/contrib/gotoError/browser/gotoError": [
 			"Go to Next Problem (Error, Warning, Info)",
 			"Icon for goto next marker.",
@@ -21255,6 +21544,9 @@
 			"Next &&Problem",
 			"Go to Previous Problem in Files (Error, Warning, Info)",
 			"Previous &&Problem"
+		],
+		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
+			"Click to show {0} definitions."
 		],
 		"vs/editor/contrib/hover/browser/hover": [
 			"Show or Focus Hover",
@@ -21403,6 +21695,11 @@
 		"vs/editor/contrib/tokenization/browser/tokenization": [
 			"Developer: Force Retokenize"
 		],
+		"vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode": [
+			"Toggle Tab Key Moves Focus",
+			"Pressing Tab will now move focus to the next focusable element",
+			"Pressing Tab will now insert the tab character"
+		],
 		"vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter": [
 			"Icon shown with a warning message in the extensions editor.",
 			"This document contains many non-basic ASCII unicode characters",
@@ -21448,36 +21745,22 @@
 			"Cannot edit in read-only input",
 			"Cannot edit in read-only editor"
 		],
-		"vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode": [
-			"Toggle Tab Key Moves Focus",
-			"Pressing Tab will now move focus to the next focusable element",
-			"Pressing Tab will now insert the tab character"
-		],
 		"vs/editor/common/standaloneStrings": [
-			"No selection",
-			"Line {0}, Column {1} ({2} selected)",
-			"Line {0}, Column {1}",
-			"{0} selections ({1} characters selected)",
-			"{0} selections",
-			"Now changing the setting `accessibilitySupport` to 'on'.",
-			"Now opening the Editor Accessibility documentation page.",
-			" in a read-only pane of a diff editor.",
-			" in a pane of a diff editor.",
-			" in a read-only code editor",
-			" in a code editor",
+			"Accessibility Help",
+			"Now opening the Accessibility documentation page.",
+			"You are in a read-only pane of a diff editor.",
+			"You are in a pane of a diff editor.",
+			"You are in a read-only code editor",
+			"You are in a code editor",
 			"To configure the editor to be optimized for usage with a Screen Reader press Command+E now.",
 			"To configure the editor to be optimized for usage with a Screen Reader press Control+E now.",
 			"The editor is configured to be optimized for usage with a Screen Reader.",
-			"The editor is configured to never be optimized for usage with a Screen Reader, which is not the case at this time.",
+			"The editor is configured to never be optimized for usage with a Screen Reader",
 			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
 			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
 			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
 			"Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.",
-			"Press Command+H now to open a browser window with more information related to editor accessibility.",
-			"Press Control+H now to open a browser window with more information related to editor accessibility.",
-			"You can dismiss this tooltip and return to the editor by pressing Escape or Shift+Escape.",
 			"Show Accessibility Help",
-			"Accessibility Help",
 			"Developer: Inspect Tokens",
 			"Go to Line/Column...",
 			"Show all Quick Access Providers",
@@ -21489,6 +21772,35 @@
 			"Press Alt+F1 for Accessibility Options.",
 			"Toggle High Contrast Theme",
 			"Made {0} edits in {1} files"
+		],
+		"vs/workbench/api/common/jsonValidationExtensionPoint": [
+			"Contributes json schema configuration.",
+			"The file pattern (or an array of patterns) to match, for example \"package.json\" or \"*.launch\". Exclusion patterns start with '!'",
+			"A schema URL ('http:', 'https:') or relative path to the extension folder ('./').",
+			"'configuration.jsonValidation' must be a array",
+			"'configuration.jsonValidation.fileMatch' must be defined as a string or an array of strings.",
+			"'configuration.jsonValidation.url' must be a URL or relative path",
+			"Expected `contributes.{0}.url` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"'configuration.jsonValidation.url' is an invalid relative URL: {0}",
+			"'configuration.jsonValidation.url' must be an absolute URL or start with './'  to reference schemas located in the extension."
+		],
+		"vs/workbench/services/themes/common/colorExtensionPoint": [
+			"Contributes extension defined themable colors",
+			"The identifier of the themable color",
+			"Identifiers must only contain letters, digits and dots and can not start with a dot",
+			"The description of the themable color",
+			"The default color for light themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default.",
+			"The default color for dark themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default.",
+			"The default color for high contrast dark themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default. If not provided, the `dark` color is used as default for high contrast dark themes.",
+			"The default color for high contrast light themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default. If not provided, the `light` color is used as default for high contrast light themes.",
+			"'configuration.colors' must be a array",
+			"{0} must be either a color value in hex (#RRGGBB[AA] or #RGB[A]) or the identifier of a themable color which provides the default.",
+			"'configuration.colors.id' must be defined and can not be empty",
+			"'configuration.colors.id' must only contain letters, digits and dots and can not start with a dot",
+			"'configuration.colors.description' must be defined and can not be empty",
+			"'configuration.colors.defaults' must be defined and must contain 'light' and 'dark'",
+			"If defined, 'configuration.colors.defaults.highContrast' must be a string.",
+			"If defined, 'configuration.colors.defaults.highContrastLight' must be a string."
 		],
 		"vs/workbench/services/themes/common/iconExtensionPoint": [
 			"Contributes extension defined themable icons",
@@ -21504,6 +21816,46 @@
 			"Expected `contributes.icons.default.fontPath` to have file extension 'woff', woff2' or 'ttf', is '{0}'.",
 			"Expected `contributes.icons.default.fontPath` ({0}) to be included inside extension's folder ({0}).",
 			"'configuration.icons.default' must be either a reference to the id of an other theme icon (string) or a icon definition (object) with properties `fontPath` and `fontCharacter`."
+		],
+		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
+			"Contributes semantic token types.",
+			"The identifier of the semantic token type",
+			"Identifiers should be in the form letterOrDigit[_-letterOrDigit]*",
+			"The super type of the semantic token type",
+			"Super types should be in the form letterOrDigit[_-letterOrDigit]*",
+			"The description of the semantic token type",
+			"Contributes semantic token modifiers.",
+			"The identifier of the semantic token modifier",
+			"Identifiers should be in the form letterOrDigit[_-letterOrDigit]*",
+			"The description of the semantic token modifier",
+			"Contributes semantic token scope maps.",
+			"Lists the languge for which the defaults are.",
+			"Maps a semantic token (described by semantic token selector) to one or more textMate scopes used to represent that token.",
+			"'configuration.{0}.id' must be defined and can not be empty",
+			"'configuration.{0}.id' must follow the pattern letterOrDigit[-_letterOrDigit]*",
+			"'configuration.{0}.superType' must follow the pattern letterOrDigit[-_letterOrDigit]*",
+			"'configuration.{0}.description' must be defined and can not be empty",
+			"'configuration.semanticTokenType' must be an array",
+			"'configuration.semanticTokenModifier' must be an array",
+			"'configuration.semanticTokenScopes' must be an array",
+			"'configuration.semanticTokenScopes.language' must be a string",
+			"'configuration.semanticTokenScopes.scopes' must be defined as an object",
+			"'configuration.semanticTokenScopes.scopes' values must be an array of strings",
+			"configuration.semanticTokenScopes.scopes': Problems parsing selector {0}."
+		],
+		"vs/workbench/api/browser/statusBarExtensionPoint": [
+			"The identifier of the status bar entry. Must be unique within the extension. The same value must be used when calling the `vscode.window.createStatusBarItem(id, ...)`-API",
+			"The name of the entry, like 'Python Language Indicator', 'Git Status' etc. Try to keep the length of the name short, yet descriptive enough that users can understand what the status bar item is about.",
+			"The text to show for the entry. You can embed icons in the text by leveraging the `$(<name>)`-syntax, like 'Hello $(globe)!'",
+			"The tooltip text for the entry.",
+			"The command to execute when the status bar entry is clicked.",
+			"The alignment of the status bar entry.",
+			"The priority of the status bar entry. Higher value means the item should be shown more to the left.",
+			"Defines the role and aria label to be used when the status bar entry is focused.",
+			"The role of the status bar entry which defines how a screen reader interacts with it. More about aria roles can be found here https://w3c.github.io/aria/#widget_roles",
+			"The aria label of the status bar entry. Defaults to the entry's text.",
+			"Contributes items to the status bar.",
+			"Invalid status bar item contribution."
 		],
 		"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint": [
 			"Errors parsing {0}: {1}",
@@ -21570,41 +21922,8 @@
 			"Describes text to be appended after the new line and after the indentation.",
 			"Describes the number of characters to remove from the new line's indentation."
 		],
-		"vs/workbench/api/browser/statusBarExtensionPoint": [
-			"The identifier of the status bar entry. Must be unique within the extension. The same value must be used when calling the `vscode.window.createStatusBarItem(id, ...)`-API",
-			"The name of the entry, like 'Python Language Indicator', 'Git Status' etc. Try to keep the length of the name short, yet descriptive enough that users can understand what the status bar item is about.",
-			"The text to show for the entry. You can embed icons in the text by leveraging the `$(<name>)`-syntax, like 'Hello $(globe)!'",
-			"The command to execute when the status bar entry is clicked.",
-			"The alignment of the status bar entry.",
-			"The priority of the status bar entry. Higher value means the item should be shown more to the left.",
-			"Contributes items to the status bar.",
-			"Invalid status bar item contribution."
-		],
-		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
-			"Contributes semantic token types.",
-			"The identifier of the semantic token type",
-			"Identifiers should be in the form letterOrDigit[_-letterOrDigit]*",
-			"The super type of the semantic token type",
-			"Super types should be in the form letterOrDigit[_-letterOrDigit]*",
-			"The description of the semantic token type",
-			"Contributes semantic token modifiers.",
-			"The identifier of the semantic token modifier",
-			"Identifiers should be in the form letterOrDigit[_-letterOrDigit]*",
-			"The description of the semantic token modifier",
-			"Contributes semantic token scope maps.",
-			"Lists the languge for which the defaults are.",
-			"Maps a semantic token (described by semantic token selector) to one or more textMate scopes used to represent that token.",
-			"'configuration.{0}.id' must be defined and can not be empty",
-			"'configuration.{0}.id' must follow the pattern letterOrDigit[-_letterOrDigit]*",
-			"'configuration.{0}.superType' must follow the pattern letterOrDigit[-_letterOrDigit]*",
-			"'configuration.{0}.description' must be defined and can not be empty",
-			"'configuration.semanticTokenType' must be an array",
-			"'configuration.semanticTokenModifier' must be an array",
-			"'configuration.semanticTokenScopes' must be an array",
-			"'configuration.semanticTokenScopes.language' must be a string",
-			"'configuration.semanticTokenScopes.scopes' must be defined as an object",
-			"'configuration.semanticTokenScopes.scopes' values must be an array of strings",
-			"configuration.semanticTokenScopes.scopes': Problems parsing selector {0}."
+		"vs/workbench/api/browser/mainThreadCLICommands": [
+			"Cannot install the '{0}' extension because it is declared to not run in this setup."
 		],
 		"vs/workbench/api/browser/mainThreadExtensionService": [
 			"Cannot activate the '{0}' extension because it depends on the '{1}' extension, which is not loaded. Would you like to reload the window to load the extension?",
@@ -21618,16 +21937,6 @@
 			"Cannot activate the '{0}' extension because it depends on the '{1}' extension, which is not installed. Would you like to install the extension and reload the window?",
 			"Install and Reload",
 			"Cannot activate the '{0}' extension because it depends on an unknown '{1}' extension."
-		],
-		"vs/workbench/api/browser/mainThreadCLICommands": [
-			"Cannot install the '{0}' extension because it is declared to not run in this setup."
-		],
-		"vs/workbench/api/browser/mainThreadMessageService": [
-			"{0} (Extension)",
-			"Extension",
-			"Manage Extension",
-			"Cancel",
-			"&&OK"
 		],
 		"vs/workbench/api/browser/mainThreadFileSystemEventService": [
 			"Extension '{0}' wants to make refactoring changes with this file creation",
@@ -21654,37 +21963,15 @@
 		"vs/workbench/api/browser/mainThreadProgress": [
 			"Manage Extension"
 		],
-		"vs/workbench/services/themes/common/colorExtensionPoint": [
-			"Contributes extension defined themable colors",
-			"The identifier of the themable color",
-			"Identifiers must only contain letters, digits and dots and can not start with a dot",
-			"The description of the themable color",
-			"The default color for light themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default.",
-			"The default color for dark themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default.",
-			"The default color for high contrast dark themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default. If not provided, the `dark` color is used as default for high contrast dark themes.",
-			"The default color for high contrast light themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default. If not provided, the `light` color is used as default for high contrast light themes.",
-			"'configuration.colors' must be a array",
-			"{0} must be either a color value in hex (#RRGGBB[AA] or #RGB[A]) or the identifier of a themable color which provides the default.",
-			"'configuration.colors.id' must be defined and can not be empty",
-			"'configuration.colors.id' must only contain letters, digits and dots and can not start with a dot",
-			"'configuration.colors.description' must be defined and can not be empty",
-			"'configuration.colors.defaults' must be defined and must contain 'light' and 'dark'",
-			"If defined, 'configuration.colors.defaults.highContrast' must be a string.",
-			"If defined, 'configuration.colors.defaults.highContrastLight' must be a string."
+		"vs/workbench/api/browser/mainThreadMessageService": [
+			"{0} (Extension)",
+			"Extension",
+			"Manage Extension",
+			"Cancel",
+			"&&OK"
 		],
 		"vs/workbench/api/browser/mainThreadSaveParticipant": [
 			"Aborted onWillSaveTextDocument-event after 1750ms"
-		],
-		"vs/workbench/api/common/jsonValidationExtensionPoint": [
-			"Contributes json schema configuration.",
-			"The file pattern (or an array of patterns) to match, for example \"package.json\" or \"*.launch\". Exclusion patterns start with '!'",
-			"A schema URL ('http:', 'https:') or relative path to the extension folder ('./').",
-			"'configuration.jsonValidation' must be a array",
-			"'configuration.jsonValidation.fileMatch' must be defined as a string or an array of strings.",
-			"'configuration.jsonValidation.url' must be a URL or relative path",
-			"Expected `contributes.{0}.url` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
-			"'configuration.jsonValidation.url' is an invalid relative URL: {0}",
-			"'configuration.jsonValidation.url' must be an absolute URL or start with './'  to reference schemas located in the extension."
 		],
 		"vs/workbench/api/browser/mainThreadEditSessionIdentityParticipant": [
 			"Aborted onWillCreateEditSessionIdentity-event after 10000ms"
@@ -21875,6 +22162,14 @@
 			"Whether collapse all is toggled for the tree view with id {0}.",
 			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
 		],
+		"vs/workbench/browser/parts/views/viewPaneContainer": [
+			"Views",
+			"Move View Up",
+			"Move View Left",
+			"Move View Down",
+			"Move View Right",
+			"Move Views"
+		],
 		"vs/workbench/contrib/debug/common/debug": [
 			"Debug type of the active debug session. For example 'python'.",
 			"Debug type of the selected launch configuration. For example 'python'.",
@@ -21919,7 +22214,7 @@
 			"True when the focused session supports the terminate debuggee capability.",
 			"True when the focused session supports the suspend debuggee capability.",
 			"True when the focused variable has an 'evalauteName' field set.",
-			"True when the focused variable is readonly.",
+			"True when the focused variable is read-only.",
 			"True when the exception widget is visible.",
 			"True when there is more than 1 debug console.",
 			"True when there is more than 1 active debug session.",
@@ -21930,19 +22225,11 @@
 			"Configured debug type '{0}' is installed but not supported in this environment.",
 			"Controls when the internal Debug Console should open."
 		],
-		"vs/workbench/browser/parts/views/viewPaneContainer": [
-			"Views",
-			"Move View Up",
-			"Move View Left",
-			"Move View Down",
-			"Move View Right",
-			"Move Views"
-		],
 		"vs/workbench/contrib/files/common/files": [
 			"True when the EXPLORER viewlet is visible.",
 			"True when the FOLDERS view (the file tree within the explorer view container) is visible.",
 			"True when the focused item in the EXPLORER is a folder.",
-			"True when the focused item in the EXPLORER is readonly.",
+			"True when the focused item in the EXPLORER is read-only.",
 			"True when the focused item in the EXPLORER is a root folder.",
 			"True when an item in the EXPLORER has been cut for cut and paste.",
 			"True when the focused item in the EXPLORER can be moved to trash.",
@@ -21967,20 +22254,11 @@
 			"Make Public",
 			"Use Port {0} as Sudo..."
 		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"Empty editor group actions",
-			"{0} (empty)",
-			"Group {0}",
-			"Editor Group {0}"
-		],
-		"vs/workbench/browser/parts/editor/editorDropTarget": [
-			"Hold __{0}__ to drop into editor"
+		"vs/workbench/common/editor/sideBySideEditorInput": [
+			"{0} - {1}"
 		],
 		"vs/workbench/browser/parts/editor/sideBySideEditor": [
 			"Side by Side Editor"
-		],
-		"vs/workbench/common/editor/sideBySideEditorInput": [
-			"{0} - {1}"
 		],
 		"vs/workbench/common/editor/diffEditorInput": [
 			"{0} ↔ {1}"
@@ -21992,34 +22270,6 @@
 		],
 		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
 			"{0} ↔ {1}"
-		],
-		"vs/workbench/browser/parts/editor/editorCommands": [
-			"Move the active editor by tabs or groups",
-			"Active editor move argument",
-			"Argument Properties:\n\t* 'to': String value providing where to move.\n\t* 'by': String value providing the unit for move (by tab or by group).\n\t* 'value': Number value providing how many positions or an absolute position to move.",
-			"Copy the active editor by groups",
-			"Active editor copy argument",
-			"Argument Properties:\n\t* 'to': String value providing where to copy.\n\t* 'value': Number value providing how many positions or an absolute position to copy.",
-			"Toggle Inline View",
-			"Compare",
-			"Split Editor in Group",
-			"Join Editor in Group",
-			"Toggle Split Editor in Group",
-			"Toggle Layout of Split Editor in Group",
-			"Focus First Side in Active Editor",
-			"Focus Second Side in Active Editor",
-			"Focus Other Side in Active Editor",
-			"Toggle Editor Group Lock",
-			"Lock Editor Group",
-			"Unlock Editor Group"
-		],
-		"vs/editor/browser/editorExtensions": [
-			"&&Undo",
-			"Undo",
-			"&&Redo",
-			"Redo",
-			"&&Select All",
-			"Select All"
 		],
 		"vs/workbench/browser/parts/editor/editorStatus": [
 			"Ln {0}, Col {1} ({2} selected)",
@@ -22201,6 +22451,42 @@
 			"Toggle Editor Type",
 			"Reopen Editor With Text Editor"
 		],
+		"vs/editor/browser/editorExtensions": [
+			"&&Undo",
+			"Undo",
+			"&&Redo",
+			"Redo",
+			"&&Select All",
+			"Select All"
+		],
+		"vs/workbench/browser/parts/editor/editorCommands": [
+			"Move the active editor by tabs or groups",
+			"Active editor move argument",
+			"Argument Properties:\n\t* 'to': String value providing where to move.\n\t* 'by': String value providing the unit for move (by tab or by group).\n\t* 'value': Number value providing how many positions or an absolute position to move.",
+			"Copy the active editor by groups",
+			"Active editor copy argument",
+			"Argument Properties:\n\t* 'to': String value providing where to copy.\n\t* 'value': Number value providing how many positions or an absolute position to copy.",
+			"Toggle Inline View",
+			"Compare",
+			"Split Editor in Group",
+			"Join Editor in Group",
+			"Toggle Split Editor in Group",
+			"Toggle Layout of Split Editor in Group",
+			"Focus First Side in Active Editor",
+			"Focus Second Side in Active Editor",
+			"Focus Other Side in Active Editor",
+			"Toggle Editor Group Lock",
+			"Lock Editor Group",
+			"Unlock Editor Group"
+		],
+		"vs/workbench/browser/parts/editor/editorConfiguration": [
+			"Interactive Window",
+			"Markdown Preview",
+			"If an editor matching one of the listed types is opened as the first in an editor group and more than one group is open, the group is automatically locked. Locked groups will only be used for opening editors when explicitly chosen by a user gesture (for example drag and drop), but not by default. Consequently, the active editor in a locked group is less likely to be replaced accidentally with a different editor.",
+			"The default editor for files detected as binary. If undefined, the user will be presented with a picker.",
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
+			"Controls the minimum size of a file in MB before asking for confirmation when opening in the editor. Note that this setting may not apply to all editor types and environments."
+		],
 		"vs/workbench/browser/parts/editor/editorQuickAccess": [
 			"No matching editors",
 			"{0}, unsaved changes, {1}",
@@ -22208,20 +22494,30 @@
 			"{0}, unsaved changes",
 			"Close Editor"
 		],
-		"vs/workbench/browser/parts/editor/editorConfiguration": [
-			"Interactive Window",
-			"Markdown Preview",
-			"If an editor matching one of the listed types is opened as the first in an editor group and more than one group is open, the group is automatically locked. Locked groups will only be used for opening editors when explicitly chosen by a user gesture (for example drag and drop), but not by default. Consequently, the active editor in a locked group is less likely to be replaced accidentally with a different editor.",
-			"The default editor for files detected as binary. If undefined, the user will be presented with a picker.",
-			"Configure glob patterns to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
-			"Controls the minimum size of a file in MB before asking for confirmation when opening in the editor. Note that this setting may not apply to all editor types and environments."
-		],
 		"vs/workbench/browser/parts/editor/accessibilityStatus": [
 			"Are you using a screen reader to operate VS Code?",
 			"Yes",
 			"No",
 			"Screen Reader Optimized",
 			"Screen Reader Mode"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
+			"Toggle Collapse Unchanged Regions",
+			"Show Unchanged Regions",
+			"Collapse Unchanged Regions",
+			"Toggle Show Moved Code Blocks",
+			"Show Moves"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"Empty editor group actions",
+			"{0} (empty)",
+			"Group {0}",
+			"Editor Group {0}"
+		],
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
+			"Move Secondary Side Bar Left",
+			"Move Secondary Side Bar Right",
+			"Hide Secondary Side Bar"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
 			"Settings icon in the view bar.",
@@ -22237,11 +22533,6 @@
 			"Accounts",
 			"Accounts"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
-			"Toggle Collapse Unchanged Regions",
-			"Collapse Unchanged Regions",
-			"Show Unchanged Regions"
-		],
 		"vs/workbench/browser/parts/panel/panelPart": [
 			"Reset Location",
 			"Reset Location",
@@ -22251,20 +22542,18 @@
 			"Align Panel",
 			"Hide Panel"
 		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
-			"Move Secondary Side Bar Left",
-			"Move Secondary Side Bar Right",
-			"Hide Secondary Side Bar"
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"Hold __{0}__ to drop into editor"
 		],
 		"vs/workbench/browser/parts/statusbar/statusbarActions": [
 			"Hide '{0}'",
 			"Focus Status Bar"
 		],
-		"vs/platform/actions/common/menuService": [
-			"Hide '{0}'"
-		],
 		"vs/platform/actions/common/menuResetAction": [
 			"Reset All Menus"
+		],
+		"vs/platform/actions/common/menuService": [
+			"Hide '{0}'"
 		],
 		"vs/base/browser/ui/dialog/dialog": [
 			"OK",
@@ -22288,7 +22577,7 @@
 			"File Encoding Changed"
 		],
 		"vs/workbench/services/editor/common/editorResolverService": [
-			"Configure glob patterns to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior."
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior."
 		],
 		"vs/base/common/keybindingLabels": [
 			"Ctrl",
@@ -22386,6 +22675,21 @@
 			"Expected string in `contributes.{0}.id`. Provided value: {1}",
 			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
 		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"Colors and styles for the token.",
+			"Foreground color for the token.",
+			"Token background colors are currently not supported.",
+			"Font style of the rule: 'italic', 'bold', 'underline', 'strikethrough' or a combination. The empty string unsets inherited settings.",
+			"Font style must be 'italic', 'bold', 'underline', 'strikethrough' or a combination or the empty string.",
+			"None (clear inherited style)",
+			"Description of the rule.",
+			"Scope selector against which this rule matches.",
+			"Colors in the workbench",
+			"Path to a tmTheme file (relative to the current file).",
+			"Colors for syntax highlighting",
+			"Whether semantic highlighting should be enabled for this theme.",
+			"Colors for semantic tokens"
+		],
 		"vs/workbench/services/themes/common/themeConfiguration": [
 			"Specifies the color theme used in the workbench.",
 			"Theme is unknown or not installed.",
@@ -22424,21 +22728,6 @@
 			"Semantic token styling rules for this theme.",
 			"Overrides editor semantic token color and styles from the currently selected color theme."
 		],
-		"vs/workbench/services/themes/common/colorThemeSchema": [
-			"Colors and styles for the token.",
-			"Foreground color for the token.",
-			"Token background colors are currently not supported.",
-			"Font style of the rule: 'italic', 'bold', 'underline', 'strikethrough' or a combination. The empty string unsets inherited settings.",
-			"Font style must be 'italic', 'bold', 'underline', 'strikethrough' or a combination or the empty string.",
-			"None (clear inherited style)",
-			"Description of the rule.",
-			"Scope selector against which this rule matches.",
-			"Colors in the workbench",
-			"Path to a tmTheme file (relative to the current file).",
-			"Colors for syntax highlighting",
-			"Whether semantic highlighting should be enabled for this theme.",
-			"Colors for semantic tokens"
-		],
 		"vs/workbench/services/themes/browser/productIconThemeData": [
 			"Problems processing product icons definitions in {0}:\n{1}",
 			"Default",
@@ -22453,7 +22742,19 @@
 			"Skipping icon definition '{0}'. Unknown font.",
 			"Skipping icon definition '{0}'. Unknown fontCharacter."
 		],
+		"vs/workbench/services/themes/common/productIconThemeSchema": [
+			"The ID of the font.",
+			"The ID must only contain letters, numbers, underscore and minus.",
+			"The location of the font.",
+			"The font path, relative to the current product icon theme file.",
+			"The format of the font.",
+			"The weight of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for valid values.",
+			"The style of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-style for valid values.",
+			"Association of icon name to a font character."
+		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
+			"I can't reproduce",
+			"I can reproduce",
 			"Extension Bisect is active and has disabled 1 extension. Check if you can still reproduce the problem and proceed by selecting from these options.",
 			"Extension Bisect is active and has disabled {0} extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
 			"Start Extension Bisect",
@@ -22470,21 +22771,11 @@
 			"Keep this extension disabled",
 			"Extension Bisect",
 			"Extension Bisect is active and has disabled {0} extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
-			"&&Good now",
-			"This is &&bad",
+			"I ca&&n't reproduce",
+			"I can &&reproduce",
 			"&&Stop Bisect",
 			"&&Cancel Bisect",
 			"Stop Extension Bisect"
-		],
-		"vs/workbench/services/themes/common/productIconThemeSchema": [
-			"The ID of the font.",
-			"The ID must only contain letters, numbers, underscore and minus.",
-			"The location of the font.",
-			"The font path, relative to the current product icon theme file.",
-			"The format of the font.",
-			"The weight of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for valid values.",
-			"The style of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-style for valid values.",
-			"Association of icon name to a font character."
 		],
 		"vs/workbench/services/userDataProfile/browser/settingsResource": [
 			"Settings"
@@ -22498,19 +22789,22 @@
 		"vs/workbench/services/userDataProfile/browser/tasksResource": [
 			"User Tasks"
 		],
-		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
-			"UI State"
-		],
 		"vs/workbench/services/userDataProfile/browser/extensionsResource": [
 			"Extensions",
 			"Disabled",
 			"Select {0} Extension"
+		],
+		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
+			"UI State"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopySaveParticipant": [
 			"Saving '{0}'"
 		],
 		"vs/workbench/services/views/common/viewContainerModel": [
 			"Views"
+		],
+		"vs/workbench/services/hover/browser/hoverWidget": [
+			"Hold {0} key to mouse over"
 		],
 		"vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl": [
 			"Already Logging.",
@@ -22525,6 +22819,12 @@
 			"Invalid value in `contributes.{0}.tokenTypes`. Must be an object map from scope name to token type. Provided value: {1}",
 			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"Press desired key combination and then press ENTER.",
+			"1 existing command has this keybinding",
+			"{0} existing commands have this keybinding",
+			"chord to"
+		],
 		"vs/editor/contrib/suggest/browser/suggest": [
 			"Whether any suggestion is focused",
 			"Whether suggestion details are visible",
@@ -22534,6 +22834,11 @@
 			"Whether the current suggestion has insert and replace behaviour",
 			"Whether the default behaviour is to insert or replace",
 			"Whether the current suggestion supports to resolve further details"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"Configure Language Specific Settings...",
+			"({0})",
+			"Select Language"
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"Record Keys",
@@ -22570,14 +22875,6 @@
 			"No when context",
 			"use space or enter to change the keybinding."
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"Configure Language Specific Settings...",
-			"({0})",
-			"Select Language"
-		],
-		"vs/workbench/services/hover/browser/hoverWidget": [
-			"Hold {0} key to mouse over"
-		],
 		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
 			"Icon for the folder dropdown button in the split JSON Settings editor.",
 			"Icon for the 'more actions' action in the Settings UI.",
@@ -22591,6 +22888,13 @@
 			"Icon for clear input in the Settings and keybinding UI.",
 			"Icon for the button that suggests filters for the Settings UI.",
 			"Icon for open settings commands."
+		],
+		"vs/workbench/contrib/preferences/common/preferencesContribution": [
+			"Split Settings Editor",
+			"Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service.",
+			"Hide the Table of Contents while searching.",
+			"Filter the Table of Contents to just categories that have matching settings. Clicking a category will filter the results to that category.",
+			"Controls the behavior of the settings editor Table of Contents while searching."
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditor2": [
 			"Search settings",
@@ -22606,19 +22910,6 @@
 			"Turn on Settings Sync",
 			"Last synced: {0}"
 		],
-		"vs/workbench/contrib/preferences/common/preferencesContribution": [
-			"Split Settings Editor",
-			"Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service.",
-			"Hide the Table of Contents while searching.",
-			"Filter the Table of Contents to just categories that have matching settings. Clicking a category will filter the results to that category.",
-			"Controls the behavior of the settings editor Table of Contents while searching."
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
-			"Press desired key combination and then press ENTER.",
-			"1 existing command has this keybinding",
-			"{0} existing commands have this keybinding",
-			"chord to"
-		],
 		"vs/workbench/contrib/performance/browser/perfviewEditor": [
 			"Startup Performance"
 		],
@@ -22630,11 +22921,25 @@
 			"Open As Text",
 			"Open in Text Editor"
 		],
+		"vs/workbench/contrib/notebook/common/notebookEditorInput": [
+			"Notebook '{0}' could not be saved."
+		],
 		"vs/workbench/contrib/notebook/browser/services/notebookServiceImpl": [
 			"Install extension for '{0}'"
 		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor": [
 			"Notebook Text Diff"
+		],
+		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
+			"Executing a notebook cell will run code from this workspace."
+		],
+		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
+			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
+			"Yes",
+			"No"
+		],
+		"vs/editor/common/languages/modesRegistry": [
+			"Plain Text"
 		],
 		"vs/workbench/contrib/comments/browser/commentReply": [
 			"Reply...",
@@ -22642,8 +22947,42 @@
 			"Reply...",
 			"Reply..."
 		],
-		"vs/editor/common/languages/modesRegistry": [
-			"Plain Text"
+		"vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl": [
+			"Clear Notebook Kernels MRU Cache"
+		],
+		"vs/workbench/contrib/notebook/browser/services/notebookLoggingServiceImpl": [
+			"Notebook rendering"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibilityContribution": [
+			"Accessibility",
+			"Provide information about how to access the terminal accessibility help menu when the terminal is focused",
+			"Provide information about how to navigate changes in the diff editor when it is focused",
+			"Provide information about how to access the chat help menu when the chat input is focused",
+			"Provide information about how to access the inline editor chat accessibility help menu when the input is focused",
+			"Provide information about how to change a keybinding in the keybindings editor when a row is focused",
+			"Provide information about how to focus the cell container or inner editor when a notebook cell is focused.",
+			"Open Accessibility Help",
+			"Open Accessible View"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
+			"Notebook",
+			"Insert Cell",
+			"Notebook Cell",
+			"Share"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookAccessibilityHelp": [
+			"The notebook view is a collection of code and markdown cells. Code cells can be executed and will produce output directly below the cell.",
+			"The Edit Cell command ({0}) will focus on the cell input.",
+			"The Edit Cell command will focus on the cell input and is currently not triggerable by a keybinding.",
+			"The Quit Edit command ({0}) will set focus on the cell container. The default (Escape) key may need to be pressed twice first exit the virtual cursor if active.",
+			"The Quit Edit command will set focus on the cell container and is currently not triggerable by a keybinding.",
+			"The Focus Output command ({0}) will set focus in the cell's output.",
+			"The Quit Edit command will set focus in the cell's output and is currently not triggerable by a keybinding.",
+			"The up and down arrows will move focus between cells while focused on the outer cell container",
+			"The Execute Cell command ({0}) executes the cell that currently has focus.",
+			"The Execute Cell command executes the cell that currently has focus and is currently not triggerable by a keybinding.",
+			"The Insert Cell Above/Below commands will create new empty code cells",
+			"The Change Cell to Code/Markdown commands are used to switch between cell types."
 		],
 		"vs/workbench/contrib/notebook/browser/controller/insertCellActions": [
 			"Insert Code Cell Above",
@@ -22670,30 +23009,6 @@
 			"Add Markdown Cell",
 			"Markdown",
 			"Add Markdown Cell"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
-			"Notebook",
-			"Insert Cell",
-			"Notebook Cell",
-			"Share"
-		],
-		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
-			"Executing a notebook cell will run code from this workspace."
-		],
-		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
-			"Select between Notebook Layouts",
-			"Customize Notebook Layout",
-			"Customize Notebook Layout",
-			"Customize Notebook...",
-			"Toggle Notebook Line Numbers",
-			"Notebook Line Numbers",
-			"Toggle Cell Toolbar Position",
-			"Toggle Breadcrumbs",
-			"Save Mimetype Display Order",
-			"Settings file to save in",
-			"User Settings",
-			"Workspace Settings",
-			"Reset Notebook Webview"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/executeActions": [
 			"Render All Markdown Cells",
@@ -22737,24 +23052,25 @@
 			"Accept Detected Language for Cell",
 			"Unable to detect cell language"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
+			"Select between Notebook Layouts",
+			"Customize Notebook Layout",
+			"Customize Notebook Layout",
+			"Customize Notebook...",
+			"Toggle Notebook Line Numbers",
+			"Notebook Line Numbers",
+			"Toggle Cell Toolbar Position",
+			"Toggle Breadcrumbs",
+			"Save Mimetype Display Order",
+			"Settings file to save in",
+			"User Settings",
+			"Workspace Settings",
+			"Reset Notebook Webview"
+		],
 		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
 			"Fold Cell",
 			"Unfold Cell",
 			"Fold Cell"
-		],
-		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
-			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
-			"Yes",
-			"No"
-		],
-		"vs/workbench/contrib/notebook/browser/services/notebookLoggingServiceImpl": [
-			"Notebook rendering"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
-			"Format Notebook",
-			"Format Notebook",
-			"Format Cell",
-			"Format Cells"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
 			"Copy Cell",
@@ -22763,8 +23079,15 @@
 			"Paste Cell Above",
 			"Toggle Notebook Clipboard Troubleshooting"
 		],
-		"vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl": [
-			"Clear Notebook Kernels MRU Cache"
+		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFind": [
+			"Hide Find in Notebook",
+			"Find in Notebook"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
+			"Format Notebook",
+			"Format Notebook",
+			"Format Cell",
+			"Format Cells"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
 			"Formatting",
@@ -22774,27 +23097,8 @@
 			"Getting code actions from '{0}' ([configure]({1})).",
 			"Applying code action '{0}'."
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
-			"Reset notebook getting started"
-		],
 		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
 			"Toggle Cell Toolbar Position"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFind": [
-			"Hide Find in Notebook",
-			"Find in Notebook"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders": [
-			"Select Cell Language Mode",
-			"Accept Detected Language: {0}"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
-			"Set Profile"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
-			"empty cell",
-			"When enabled notebook outline shows code cells.",
-			"When enabled notebook breadcrumbs contain code cells."
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
 			"Focus Next Cell Editor",
@@ -22810,15 +23114,20 @@
 			"Cell Cursor Page Down Select",
 			"When enabled cursor can navigate to the next/previous cell when the current cursor in the cell editor is at the first/last line."
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar": [
-			"Notebook Kernel Info",
-			"{0} (suggestion)",
-			"Notebook Kernel Selection",
-			"Select Kernel",
-			"Select Kernel",
-			"Notebook Editor Selections",
-			"Cell {0} ({1} selected)",
-			"Cell {0} of {1}"
+		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
+			"empty cell",
+			"When enabled notebook outline shows code cells.",
+			"When enabled notebook breadcrumbs contain code cells."
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
+			"Reset notebook getting started"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
+			"Set Profile"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders": [
+			"Select Cell Language Mode",
+			"Accept Detected Language: {0}"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController": [
 			"Success",
@@ -22828,34 +23137,15 @@
 			"Use the links above to file an issue using the issue reporter.",
 			"**Last Execution** {0}\n\n**Execution Time** {1}\n\n**Overhead Time** {2}\n\n**Render Times**\n\n{3}"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
-			"Toggle Layout Troubleshoot",
-			"Inspect Notebook Layout",
-			"Clear Notebook Editor Type Cache"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatActions": [
-			"Chat",
-			"Accept Chat Input",
-			"Clear Input History",
-			"Focus Chat List",
-			"Chat View Accessibility Help",
-			"Focus Chat Input",
-			"Open Editor ({0})",
-			"Show History",
-			"Delete",
-			"Select a chat session to restore"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
-			"Copy",
-			"Insert at Cursor",
-			"Insert Into New File",
-			"Run in Terminal",
-			"Next Code Block",
-			"Previous Code Block"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatCopyActions": [
-			"Copy All",
-			"Copy"
+		"vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar": [
+			"Notebook Kernel Info",
+			"{0} (suggestion)",
+			"Notebook Kernel Selection",
+			"Select Kernel",
+			"Select Kernel",
+			"Notebook Editor Selections",
+			"Cell {0} ({1} selected)",
+			"Cell {0} of {1}"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands": [
 			"Move Cell Up",
@@ -22880,46 +23170,10 @@
 			"Expand All Cell Outputs",
 			"Toggle Scroll Cell Output"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatExecuteActions": [
-			"Submit",
-			"Cancel"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
-			"Ask Quick Question",
-			"Ask {0} a question..."
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatImportExport": [
-			"Chat Session",
-			"Export Session",
-			"Import Session"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
-			"Vote Up",
-			"Vote Down",
-			"Insert into Notebook",
-			"Remove Request and Response"
-		],
-		"vs/workbench/contrib/chat/browser/chatContributionServiceImpl": [
-			"Contributes an Interactive Session provider",
-			"Unique identifier for this Interactive Session provider.",
-			"Display name for this Interactive Session provider.",
-			"An icon for this Interactive Session provider.",
-			"A condition which must be true to enable this Interactive Session provider.",
-			"Chat"
-		],
-		"vs/workbench/contrib/chat/browser/chatEditorInput": [
-			"Chat"
-		],
-		"vs/workbench/contrib/chat/common/chatServiceImpl": [
-			"Provider returned null response"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatClearActions": [
-			"Clear",
-			"Clear",
-			"Clear"
-		],
-		"vs/workbench/contrib/chat/browser/chatWidget": [
-			"Clear the session"
+		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
+			"Toggle Layout Troubleshoot",
+			"Inspect Notebook Layout",
+			"Clear Notebook Editor Type Cache"
 		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions": [
 			"Open Text Diff Editor",
@@ -22934,18 +23188,179 @@
 			"Hide Metadata Differences",
 			"Hide Outputs Differences"
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatActions": [
+			"Chat",
+			"Accept Chat Input",
+			"Clear Input History",
+			"Focus Chat List",
+			"Focus Chat Input",
+			"Open Editor ({0})",
+			"Show History",
+			"Delete",
+			"Select a chat session to restore"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
+			"Copy",
+			"Insert at Cursor",
+			"Insert Into New File",
+			"Run in Terminal",
+			"Next Code Block",
+			"Previous Code Block"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatCopyActions": [
+			"Copy All",
+			"Copy"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatExecuteActions": [
+			"Submit",
+			"Cancel"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
+			"Ask Quick Question",
+			"Ask {0} a question..."
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
+			"Helpful",
+			"Unhelpful",
+			"Insert into Notebook",
+			"Remove Request and Response"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatImportExport": [
+			"Chat Session",
+			"Export Session",
+			"Import Session"
+		],
+		"vs/workbench/contrib/chat/browser/chatContributionServiceImpl": [
+			"Contributes an Interactive Session provider",
+			"Unique identifier for this Interactive Session provider.",
+			"Display name for this Interactive Session provider.",
+			"An icon for this Interactive Session provider.",
+			"A condition which must be true to enable this Interactive Session provider.",
+			"Chat"
+		],
+		"vs/workbench/contrib/chat/browser/chatEditorInput": [
+			"Chat"
+		],
+		"vs/workbench/contrib/chat/browser/chatWidget": [
+			"Clear the session"
+		],
+		"vs/workbench/contrib/chat/common/chatServiceImpl": [
+			"Provider returned null response"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatMoveActions": [
 			"Open Session In Editor",
 			"Open Session In Editor",
 			"Open Session In Sidebar"
 		],
-		"vs/workbench/contrib/chat/common/chatColors": [
-			"The background color of a chat request.",
-			"The border color of a chat request."
+		"vs/workbench/contrib/chat/browser/actions/chatClearActions": [
+			"Clear",
+			"Clear",
+			"Clear"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibleView": [
+			"\nPress H now to open a browser window with more information related to accessibility.\n",
+			"\nTo disable the `accessibility.verbosity` hint for this feature, press D now.\n",
+			"Exit this menu via the Escape key."
+		],
+		"vs/workbench/contrib/chat/common/chatViewModel": [
+			"Thinking"
+		],
+		"vs/workbench/contrib/chat/common/chatContextKeys": [
+			"True when the provider has assigned an id to this response.",
+			"When the response has been voted up, is set to 'up'. When voted down, is set to 'down'. Otherwise an empty string.",
+			"True when the current request is still in progress.",
+			"The chat item is a response.",
+			"The chat item is a request",
+			"True when the chat input has text.",
+			"True when focus is in the chat input, false otherwise.",
+			"True when focus is in the chat widget, false otherwise.",
+			"True when some chat provider has been registered."
 		],
 		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
 			"Ask a question or type '/' for topics",
 			"Ask a question"
+		],
+		"vs/workbench/contrib/chat/common/chatColors": [
+			"The background color of a chat request.",
+			"The border color of a chat request."
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
+			"AI-generated code may be incorrect",
+			"Getting ready...",
+			"Failed to start editor chat",
+			"Please consult the error log and try again later.",
+			"AI-generated code may be incorrect",
+			"Ask a question",
+			"{0} ({1}, {2} for history)",
+			"Thinking…",
+			"No results, please refine your input and try again",
+			"{0}",
+			"Use tab to navigate to the diff editor and review proposed changes.",
+			"Failed to apply changes.",
+			"Failed to discard changes."
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
+			"Start Code Chat",
+			"Resume Last Dismissed Code Chat",
+			"Inline Chat",
+			"Make Request",
+			"Regenerate Response",
+			"Regenerate",
+			"Stop Request",
+			"Cursor Up",
+			"Cursor Down",
+			"Focus Input",
+			"Previous From History",
+			"Next From History",
+			"Discard...",
+			"Discard",
+			"Discard to Clipboard",
+			"Discard to New File",
+			"Helpful",
+			"Unhelpful",
+			"Toggle Diff",
+			"Show Inline Diff",
+			"Accept Changes",
+			"Accept",
+			"Cancel",
+			"(Developer) Write Exchange to Clipboard",
+			"'{0}' and {1} follow ups ({2})",
+			"View in Chat",
+			"Show More",
+			"Show Less"
+		],
+		"vs/workbench/contrib/inlineChat/common/inlineChat": [
+			"Whether a provider for interactive editors exists",
+			"Whether the interactive editor input is visible",
+			"Whether the interactive editor input is focused",
+			"Whether the interactive editor input is empty",
+			"Whether the cursor of the iteractive editor input is on the first line",
+			"Whether the cursor of the iteractive editor input is on the last line",
+			"Whether the interactive editor message is cropped, not cropped or expanded",
+			"Whether the cursor of the outer editor is above or below the interactive editor input",
+			"Whether interactive editor has an active request",
+			"Whether interactive editor has kept a session for quick restore",
+			"Whether interactive editor show diffs for changes",
+			"What type was the last response of the current interactive editor session",
+			"What type was the responses have been receieved",
+			"Whether interactive editor did change any code",
+			"Whether the user did changes ontop of the inline chat",
+			"The last kind of feedback that was provided",
+			"Whether the document has changed concurrently",
+			"Background color of the interactive editor widget",
+			"Border color of the interactive editor widget",
+			"Shadow color of the interactive editor widget",
+			"Background highlighting of the current interactive region. Must be transparent.",
+			"Border color of the interactive editor input",
+			"Border color of the interactive editor input when focused",
+			"Foreground color of the interactive editor input placeholder",
+			"Background color of the interactive editor input",
+			"Background color of inserted text in the interactive editor input",
+			"Background color of removed text in the interactive editor input",
+			"Configure if changes crafted in the interactive editor are applied directly to the document or are previewed first.",
+			"Changes are applied directly to the document and are highlighted visually via inline or side-by-side diffs. Ending a session will keep the changes.",
+			"Changes are previewed only and need to be accepted via the apply button. Ending a session will discard the changes.",
+			"Changes are applied directly to the document but can be highlighted via inline diffs. Ending a session will keep the changes."
 		],
 		"vs/editor/contrib/peekView/browser/peekView": [
 			"Whether the current code editor is embedded inside peek",
@@ -22968,14 +23383,6 @@
 		],
 		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
 			"Type '{0}' code here and press {1} to run"
-		],
-		"vs/workbench/contrib/files/browser/fileConstants": [
-			"Save As...",
-			"Save",
-			"Save without Formatting",
-			"Save All",
-			"Remove Folder from Workspace",
-			"New Untitled Text File"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookIcons": [
 			"Configure icon to select a kernel in notebook editors.",
@@ -23003,6 +23410,14 @@
 			"Icon for a mime type in notebook editors.",
 			"Icon for the previous change action in the diff editor.",
 			"Icon for the next change action in the diff editor."
+		],
+		"vs/workbench/contrib/files/browser/fileConstants": [
+			"Save As...",
+			"Save",
+			"Save without Formatting",
+			"Save All",
+			"Remove Folder from Workspace",
+			"New Untitled Text File"
 		],
 		"vs/workbench/contrib/testing/browser/icons": [
 			"View icon of the test view.",
@@ -23057,16 +23472,31 @@
 			"{0}, outdated result",
 			"Test Explorer"
 		],
-		"vs/workbench/contrib/testing/browser/testingOutputTerminalService": [
-			"Test Output at {0}",
-			"{0} at {1}",
+		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
+			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled.",
 			"Test Output",
-			"\r\nNo tests have been run, yet.\r\n",
+			"Expected result",
+			"Actual result",
 			"The test run did not record any output.",
-			"Test run finished at {0}"
-		],
-		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
-			"Testing"
+			"Test output is only available for new test runs.",
+			"Close",
+			"Unnamed Task",
+			"+ {0} more lines",
+			"+ 1 more line",
+			"Test Result Messages",
+			"Show Result Output",
+			"Show Result Output",
+			"Rerun Test Run",
+			"Debug Test Run",
+			"Go to File",
+			"Reveal in Test Explorer",
+			"Run Test",
+			"Debug Test",
+			"Go to Source",
+			"Go to Next Test Failure",
+			"Go to Previous Test Failure",
+			"Open in Editor",
+			"Toggle Test History in Peek"
 		],
 		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
 			"Running tests...",
@@ -23075,31 +23505,17 @@
 			"{0}/{1} tests passed ({2}%)",
 			"{0}/{1} tests passed ({2}%, {3} skipped)"
 		],
-		"vs/workbench/contrib/testing/common/configuration": [
-			"Testing",
-			"How long to wait, in milliseconds, after a test is marked as outdated and starting a new run.",
-			"Configures when the error Peek view is automatically opened.",
-			"Open automatically no matter where the failure is.",
-			"Open automatically when a test fails in a visible document.",
-			"Never automatically open.",
-			"Controls whether to automatically open the Peek view during continuous run mode.",
-			"Controls the count badge on the Testing icon on the Activity Bar.",
-			"Show the number of failed tests",
-			"Disable the testing count badge",
-			"Show the number of passed tests",
-			"Show the number of skipped tests",
-			"Controls whether the running test should be followed in the Test Explorer view.",
-			"Controls the action to take when left-clicking on a test decoration in the gutter.",
-			"Run the test.",
-			"Debug the test.",
-			"Open the context menu for more options.",
-			"Controls whether test decorations are shown in the editor gutter.",
-			"Control whether save all dirty editors before running a test.",
-			"Never automatically open the testing view",
-			"Open the testing view when tests start",
-			"Open the testing view on any test failure",
-			"Controls when the testing view should open.",
-			"Always reveal the executed test when `#testing.followRunningTest#` is on. If this setting is turned off, only failed tests will be revealed."
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"Testing"
+		],
+		"vs/workbench/contrib/testing/common/testServiceImpl": [
+			"Running tests may execute code in your workspace.",
+			"An error occurred attempting to run tests: {0}",
+			"Running tests may execute code in your workspace.",
+			"An error occurred attempting to run tests: {0}"
+		],
+		"vs/workbench/contrib/testing/common/testingContentProvider": [
+			"The test run did not record any output."
 		],
 		"vs/workbench/contrib/testing/common/testingContextKeys": [
 			"Indicates whether any test controller has an attached refresh handler.",
@@ -23118,44 +23534,6 @@
 			"ID of the current test item, set when creating or opening menus on test items",
 			"Boolean indicating whether the test item has a URI defined",
 			"Boolean indicating whether the test item is hidden"
-		],
-		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
-			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled.",
-			"Test Output",
-			"Expected result",
-			"Actual result",
-			"Close",
-			"Unnamed Task",
-			"+ {0} more lines",
-			"+ 1 more line",
-			"Test Result Messages",
-			"Show Result Output",
-			"Show Result Output",
-			"Rerun Test Run",
-			"Debug Test Run",
-			"Go to File",
-			"Reveal in Test Explorer",
-			"Run Test",
-			"Debug Test",
-			"Go to Source",
-			"Show Output in Terminal",
-			"Go to Next Test Failure",
-			"Go to Previous Test Failure",
-			"Open in Editor",
-			"Toggle Test History in Peek"
-		],
-		"vs/workbench/contrib/testing/common/testingContentProvider": [
-			"The test run did not record any output."
-		],
-		"vs/workbench/contrib/testing/common/testServiceImpl": [
-			"Running tests may execute code in your workspace.",
-			"An error occurred attempting to run tests: {0}",
-			"Running tests may execute code in your workspace.",
-			"An error occurred attempting to run tests: {0}"
-		],
-		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
-			"Pick a test profile to use",
-			"Update Test Configuration"
 		],
 		"vs/workbench/contrib/testing/browser/testExplorerActions": [
 			"Hide Test",
@@ -23190,8 +23568,6 @@
 			"Sort by Location",
 			"Sort by Duration",
 			"Show Output",
-			"Run #{0}",
-			"Pick a run to show output for",
 			"Collapse All Tests",
 			"Clear All Results",
 			"Go to Test",
@@ -23211,75 +23587,36 @@
 			"Refresh Tests",
 			"Cancel Test Refresh"
 		],
-		"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController": [
-			"Failed to start editor chat",
-			"Please consult the error log and try again later.",
-			"AI-generated code may be incorrect",
-			"Ask a question",
-			"{0} ({1}, {2} for history)",
-			"Thinking…",
-			"No results, please refine your input and try again",
-			"Failed to apply changes.",
-			"Failed to discard changes."
+		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
+			"Pick a test profile to use",
+			"Update Test Configuration"
 		],
-		"vs/workbench/contrib/interactiveEditor/common/interactiveEditor": [
-			"Whether a provider for interactive editors exists",
-			"Whether the interactive editor input is visible",
-			"Whether the interactive editor input is focused",
-			"Whether the interactive editor input is empty",
-			"Whether the cursor of the iteractive editor input is on the first line",
-			"Whether the cursor of the iteractive editor input is on the last line",
-			"Whether the interactive editor message is cropped, not cropped or expanded",
-			"Whether the cursor of the outer editor is above or below the interactive editor input",
-			"Whether interactive editor has an active request",
-			"Whether interactive editor has kept a session for quick restore",
-			"Whether interactive editor show diffs for changes",
-			"What type was the last response of the current interactive editor session",
-			"Whether interactive editor did change any code",
-			"The last kind of feedback that was provided",
-			"Whether the document has changed concurrently",
-			"Border color of the interactive editor widget",
-			"Shadow color of the interactive editor widget",
-			"Background highlighting of the current interactive region. Must be transparent.",
-			"Border color of the interactive editor input",
-			"Border color of the interactive editor input when focused",
-			"Foreground color of the interactive editor input placeholder",
-			"Background color of the interactive editor input",
-			"Background color of inserted text in the interactive editor input",
-			"Background color of removed text in the interactive editor input",
-			"Configure if changes crafted in the interactive editor are applied directly to the document or are previewed first.",
-			"Changes are applied directly to the document and are highlighted visually via inline or side-by-side diffs. Ending a session will keep the changes.",
-			"Changes are previewed only and need to be accepted via the apply button. Ending a session will discard the changes.",
-			"Changes are applied directly to the document but can be highlighted via inline diffs. Ending a session will keep the changes."
-		],
-		"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorActions": [
-			"Start Code Chat",
-			"Resume Last Dismissed Code Chat",
-			"Interactive Editor",
-			"Make Request",
-			"Stop Request",
-			"Cursor Up",
-			"Cursor Down",
-			"Focus Input",
-			"Previous From History",
-			"Next From History",
-			"Discard...",
-			"Discard",
-			"Discard to Clipboard",
-			"Discard to New File",
-			"Helpful",
-			"Unhelpful",
-			"Toggle Diff",
-			"Show Inline Diff",
-			"Accept Changes",
-			"Accept",
-			"Cancel",
-			"(Developer) Write Exchange to Clipboard",
-			"'{0}' and {1} follow ups ({2})",
-			"View in Chat",
-			"Expand Message",
-			"Contract Message",
-			"Interactive Session Editor Accessibility Help"
+		"vs/workbench/contrib/testing/common/configuration": [
+			"Testing",
+			"How long to wait, in milliseconds, after a test is marked as outdated and starting a new run.",
+			"Configures when the error Peek view is automatically opened.",
+			"Open automatically no matter where the failure is.",
+			"Open automatically when a test fails in a visible document.",
+			"Never automatically open.",
+			"Controls whether to show messages from all test runs.",
+			"Controls whether to automatically open the Peek view during continuous run mode.",
+			"Controls the count badge on the Testing icon on the Activity Bar.",
+			"Show the number of failed tests",
+			"Disable the testing count badge",
+			"Show the number of passed tests",
+			"Show the number of skipped tests",
+			"Controls whether the running test should be followed in the Test Explorer view.",
+			"Controls the action to take when left-clicking on a test decoration in the gutter.",
+			"Run the test.",
+			"Debug the test.",
+			"Open the context menu for more options.",
+			"Controls whether test decorations are shown in the editor gutter.",
+			"Control whether save all dirty editors before running a test.",
+			"Never automatically open the testing view",
+			"Open the testing view when tests start",
+			"Open the testing view on any test failure",
+			"Controls when the testing view should open.",
+			"Always reveal the executed test when `#testing.followRunningTest#` is on. If this setting is turned off, only failed tests will be revealed."
 		],
 		"vs/workbench/contrib/logs/common/logsActions": [
 			"Set Log Level...",
@@ -23305,19 +23642,6 @@
 		"vs/platform/quickinput/browser/helpQuickAccess": [
 			"{0}, {1}"
 		],
-		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
-			"Ask {0}: {1}",
-			"No matching commands",
-			"Configure Keybinding",
-			"similar commands",
-			"{0}: {1}",
-			"Show All Commands",
-			"Clear Command History",
-			"Do you want to clear the history of recently used commands?",
-			"This action is irreversible!",
-			"&&Clear",
-			"Ask In Chat"
-		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"No matching views",
 			"Side Bar",
@@ -23330,6 +23654,25 @@
 			"Open View",
 			"Quick Open View"
 		],
+		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
+			"No matching commands",
+			"Configure Keybinding",
+			"similar commands",
+			"Ask {0}: {1}",
+			"{0}: {1}",
+			"Show All Commands",
+			"Clear Command History",
+			"Do you want to clear the history of recently used commands?",
+			"This action is irreversible!",
+			"&&Clear"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerView": [
+			"Explorer Section: {0}",
+			"New File...",
+			"New Folder...",
+			"Refresh Explorer",
+			"Collapse Folders in Explorer"
+		],
 		"vs/workbench/contrib/files/browser/views/emptyView": [
 			"No Folder Opened"
 		],
@@ -23341,47 +23684,6 @@
 			"Flip Layout",
 			"Flip &&Layout",
 			"New Untitled Text File"
-		],
-		"vs/workbench/contrib/files/browser/views/explorerView": [
-			"Explorer Section: {0}",
-			"New File...",
-			"New Folder...",
-			"Refresh Explorer",
-			"Collapse Folders in Explorer"
-		],
-		"vs/workbench/contrib/files/browser/fileCommands": [
-			"{0} (in file) ↔ {1}",
-			"Failed to save '{0}': {1}",
-			"Retry",
-			"Discard",
-			"Failed to revert '{0}': {1}",
-			"Create File"
-		],
-		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
-			"Use the actions in the editor tool bar to either undo your changes or overwrite the content of the file with your changes.",
-			"Failed to save '{0}': The content of the file is newer. Please compare your version with the file contents or overwrite the content of the file with your changes.",
-			"Failed to save '{0}': File is read-only. Select 'Overwrite as Admin' to retry as administrator.",
-			"Failed to save '{0}': File is read-only. Select 'Overwrite as Sudo' to retry as superuser.",
-			"Failed to save '{0}': File is read-only. Select 'Overwrite' to attempt to make it writeable.",
-			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Admin' to retry as administrator.",
-			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Sudo' to retry as superuser.",
-			"Failed to save '{0}': {1}",
-			"Learn More",
-			"Don't Show Again",
-			"Compare",
-			"{0} (in file) ↔ {1} (in {2}) - Resolve save conflict",
-			"Overwrite as Admin...",
-			"Overwrite as Sudo...",
-			"Retry as Admin...",
-			"Retry as Sudo...",
-			"Retry",
-			"Discard",
-			"Overwrite",
-			"Overwrite",
-			"Configure"
-		],
-		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
-			"Binary File Viewer"
 		],
 		"vs/workbench/contrib/files/browser/fileActions": [
 			"New File...",
@@ -23459,14 +23761,50 @@
 			"Paste {0} files",
 			"Paste {0}",
 			"The file(s) to paste have been deleted or moved since you copied them. {0}",
-			"Set Active Editor Readonly in Session",
+			"Set Active Editor Read-only in Session",
 			"Set Active Editor Writeable in Session",
-			"Toggle Active Editor Readonly in Session",
-			"Reset Active Editor Readonly in Session"
+			"Toggle Active Editor Read-only in Session",
+			"Reset Active Editor Read-only in Session"
 		],
-		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
-			"1 unsaved file",
-			"{0} unsaved files"
+		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
+			"Use the actions in the editor tool bar to either undo your changes or overwrite the content of the file with your changes.",
+			"Failed to save '{0}': The content of the file is newer. Please compare your version with the file contents or overwrite the content of the file with your changes.",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite as Admin' to retry as administrator.",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite as Sudo' to retry as superuser.",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite' to attempt to make it writeable.",
+			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Admin' to retry as administrator.",
+			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Sudo' to retry as superuser.",
+			"Failed to save '{0}': {1}",
+			"Learn More",
+			"Don't Show Again",
+			"Compare",
+			"{0} (in file) ↔ {1} (in {2}) - Resolve save conflict",
+			"Overwrite as Admin...",
+			"Overwrite as Sudo...",
+			"Retry as Admin...",
+			"Retry as Sudo...",
+			"Retry",
+			"Discard",
+			"Overwrite",
+			"Overwrite",
+			"Configure"
+		],
+		"vs/workbench/contrib/files/browser/fileCommands": [
+			"{0} (in file) ↔ {1}",
+			"Failed to save '{0}': {1}",
+			"Retry",
+			"Discard",
+			"Failed to revert '{0}': {1}",
+			"Create File"
+		],
+		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
+			"Binary File Viewer"
+		],
+		"vs/workbench/contrib/files/browser/workspaceWatcher": [
+			"Unable to watch for file changes in this large workspace folder. Please follow the instructions link to resolve this issue.",
+			"Instructions",
+			"File changes watcher stopped unexpectedly. A reload of the window may enable the watcher again unless the workspace cannot be watched for file changes.",
+			"Reload"
 		],
 		"vs/editor/common/config/editorConfigurationSchema": [
 			"Editor",
@@ -23508,14 +23846,10 @@
 			"Lines will wrap according to the {0} setting.",
 			"Uses the legacy diffing algorithm.",
 			"Uses the advanced diffing algorithm.",
-			"Controls whether the diff editor shows unchanged regions. Only works when 'diffEditor.experimental.useVersion2' is set.",
-			"Controls whether the diff editor uses the new or the old implementation."
-		],
-		"vs/workbench/contrib/files/browser/workspaceWatcher": [
-			"Unable to watch for file changes in this large workspace folder. Please follow the instructions link to resolve this issue.",
-			"Instructions",
-			"File changes watcher stopped unexpectedly. A reload of the window may enable the watcher again unless the workspace cannot be watched for file changes.",
-			"Reload"
+			"Controls whether the diff editor shows unchanged regions. Only works when {0} is set.",
+			"Controls whether the diff editor should show detected code moves. Only works when {0} is set.",
+			"Controls whether the diff editor uses the new or the old implementation.",
+			"Controls whether the diff editor shows empty decorations to see where characters got inserted or deleted."
 		],
 		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
 			"Text File Editor",
@@ -23526,6 +23860,20 @@
 			"The file is not displayed in the text editor because it is very large.",
 			"The editor could not be opened because the file was not found.",
 			"Create File"
+		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"1 unsaved file",
+			"{0} unsaved files"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
+			"Other"
+		],
+		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
+			"Open a text editor first to go to a line.",
+			"Go to line {0} and character {1}.",
+			"Go to line {0}.",
+			"Current Line: {0}, Character: {1}. Type a line number between 1 and {2} to navigate to.",
+			"Current Line: {0}, Character: {1}. Type a line number to navigate to."
 		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
 			"Apply",
@@ -23539,16 +23887,6 @@
 			"{0} ({1}, refactor preview)",
 			"{0} (refactor preview)"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
-			"Other"
-		],
-		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
-			"Open a text editor first to go to a line.",
-			"Go to line {0} and character {1}.",
-			"Go to line {0}.",
-			"Current Line: {0}, Character: {1}. Type a line number between 1 and {2} to navigate to.",
-			"Current Line: {0}, Character: {1}. Type a line number to navigate to."
-		],
 		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
 			"No matching entries",
 			"Go to Symbol in Editor...",
@@ -23556,6 +23894,17 @@
 			"Type the name of a symbol to go to.",
 			"Go to Symbol in Editor",
 			"Go to Symbol in Editor by Category"
+		],
+		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
+			"No matching results",
+			"recently opened",
+			"file and symbol results",
+			"file results",
+			"More",
+			"Open to the Side",
+			"Open to the Bottom",
+			"Remove from Recently Opened",
+			"{0} unsaved changes"
 		],
 		"vs/workbench/contrib/search/browser/searchIcons": [
 			"Icon to make search details visible.",
@@ -23575,22 +23924,6 @@
 			"View icon of the search view.",
 			"Icon for the action to open a new search editor."
 		],
-		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
-			"No matching results",
-			"recently opened",
-			"file and symbol results",
-			"file results",
-			"More",
-			"Open to the Side",
-			"Open to the Bottom",
-			"Remove from Recently Opened",
-			"{0} unsaved changes"
-		],
-		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
-			"No matching workspace symbols",
-			"Open to the Side",
-			"Open to the Bottom"
-		],
 		"vs/workbench/contrib/search/browser/searchWidget": [
 			"Replace All (Submit Search to Enable)",
 			"Replace All",
@@ -23600,6 +23933,11 @@
 			"Toggle Context Lines",
 			"Replace: Type replace term and press Enter to preview",
 			"Replace"
+		],
+		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
+			"No matching workspace symbols",
+			"Open to the Side",
+			"Open to the Bottom"
 		],
 		"vs/workbench/contrib/search/browser/searchActionsCopy": [
 			"Copy",
@@ -23616,11 +23954,6 @@
 			"A set of options for the search",
 			"Find in Folder...",
 			"Find in Workspace..."
-		],
-		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
-			"Go to Symbol in Workspace...",
-			"Go to Symbol in Workspace...",
-			"Go to Symbol in &&Workspace..."
 		],
 		"vs/workbench/contrib/search/browser/searchActionsNav": [
 			"Toggle Query Details",
@@ -23647,8 +23980,10 @@
 			"Replace All",
 			"Replace All"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsBase": [
-			"Search"
+		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
+			"Go to Symbol in Workspace...",
+			"Go to Symbol in Workspace...",
+			"Go to Symbol in &&Workspace..."
 		],
 		"vs/workbench/contrib/search/browser/searchActionsTopBar": [
 			"Clear Search History",
@@ -23660,9 +23995,7 @@
 			"View as Tree",
 			"View as List"
 		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
-			"Search: {0}",
-			"Search: {0}",
+		"vs/workbench/contrib/search/browser/searchActionsBase": [
 			"Search"
 		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
@@ -23676,15 +24009,24 @@
 			"Search",
 			"Search editor text input box border."
 		],
-		"vs/workbench/contrib/search/browser/patternInputWidget": [
-			"input",
-			"Search only in Open Editors",
-			"Use Exclude Settings and Ignore Files"
+		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
+			"Search: {0}",
+			"Search: {0}",
+			"Search"
 		],
 		"vs/workbench/browser/parts/views/viewPane": [
 			"Icon for an expanded view pane container.",
 			"Icon for a collapsed view pane container.",
 			"{0} actions"
+		],
+		"vs/workbench/contrib/search/browser/searchMessage": [
+			"Unable to open command link from untrusted source: {0}",
+			"Unable to open unknown link: {0}"
+		],
+		"vs/workbench/contrib/search/browser/patternInputWidget": [
+			"input",
+			"Search only in Open Editors",
+			"Use Exclude Settings and Ignore Files"
 		],
 		"vs/workbench/contrib/search/browser/searchResultsView": [
 			"Other files",
@@ -23709,16 +24051,6 @@
 			"Source Control",
 			"{0} pending changes"
 		],
-		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
-			"Source Control"
-		],
-		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
-			"Source Control Repositories"
-		],
-		"vs/workbench/contrib/search/browser/searchMessage": [
-			"Unable to open command link from untrusted source: {0}",
-			"Unable to open unknown link: {0}"
-		],
 		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
 			"{0} - {1} of {2} changes",
 			"{0} - {1} of {2} change",
@@ -23741,9 +24073,8 @@
 			"Overview ruler marker color for added content.",
 			"Overview ruler marker color for deleted content."
 		],
-		"vs/workbench/contrib/workspace/common/workspace": [
-			"Whether the workspace trust feature is enabled.",
-			"Whether the current workspace has been trusted by the user."
+		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
+			"Source Control"
 		],
 		"vs/workbench/contrib/scm/browser/scmViewPane": [
 			"Source Control Management",
@@ -23763,38 +24094,12 @@
 			"Close",
 			"SCM Provider separator border."
 		],
-		"vs/workbench/contrib/debug/browser/debugColors": [
-			"Debug toolbar background color.",
-			"Debug toolbar border color.",
-			"Debug toolbar icon for start debugging.",
-			"Debug toolbar icon for pause.",
-			"Debug toolbar icon for stop.",
-			"Debug toolbar icon for disconnect.",
-			"Debug toolbar icon for restart.",
-			"Debug toolbar icon for step over.",
-			"Debug toolbar icon for step into.",
-			"Debug toolbar icon for step over.",
-			"Debug toolbar icon for continue.",
-			"Debug toolbar icon for step back."
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"Source Control Repositories"
 		],
-		"vs/workbench/contrib/debug/browser/callStackView": [
-			"Running",
-			"Show More Stack Frames",
-			"Session",
-			"Running",
-			"Restart Frame",
-			"Load More Stack Frames",
-			"Show {0} More: {1}",
-			"Show {0} More Stack Frames",
-			"Paused on {0}",
-			"Paused",
-			"Debug Call Stack",
-			"Thread {0} {1}",
-			"Stack Frame {0}, line {1}, {2}",
-			"Running",
-			"Session {0} {1}",
-			"Show {0} More Stack Frames",
-			"Collapse All"
+		"vs/workbench/contrib/workspace/common/workspace": [
+			"Whether the workspace trust feature is enabled.",
+			"Whether the current workspace has been trusted by the user."
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"Unverified Exception Breakpoint",
@@ -23850,8 +24155,97 @@
 			"Edit Function Breakpoint...",
 			"Edit Hit Count..."
 		],
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"Debug toolbar background color.",
+			"Debug toolbar border color.",
+			"Debug toolbar icon for start debugging.",
+			"Debug toolbar icon for pause.",
+			"Debug toolbar icon for stop.",
+			"Debug toolbar icon for disconnect.",
+			"Debug toolbar icon for restart.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for step into.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for continue.",
+			"Debug toolbar icon for step back."
+		],
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			"Running",
+			"Show More Stack Frames",
+			"Session",
+			"Running",
+			"Restart Frame",
+			"Load More Stack Frames",
+			"Show {0} More: {1}",
+			"Show {0} More Stack Frames",
+			"Paused on {0}",
+			"Paused",
+			"Debug Call Stack",
+			"Thread {0} {1}",
+			"Stack Frame {0}, line {1}, {2}",
+			"Running",
+			"Session {0} {1}",
+			"Show {0} More Stack Frames",
+			"Collapse All"
+		],
+		"vs/workbench/contrib/debug/browser/debugCommands": [
+			"Debug",
+			"Restart",
+			"Step Over",
+			"Step Into",
+			"Step Into Target",
+			"Step Out",
+			"Pause",
+			"Disconnect",
+			"Disconnect and Suspend",
+			"Stop",
+			"Continue",
+			"Focus Session",
+			"Select and Start Debugging",
+			"Open '{0}'",
+			"Start Debugging",
+			"Start Without Debugging",
+			"Focus Next Debug Console",
+			"Focus Previous Debug Console",
+			"Open Loaded Script...",
+			"Navigate to Top of Call Stack",
+			"Navigate to Bottom of Call Stack",
+			"Navigate Up Call Stack",
+			"Navigate Down Call Stack",
+			"Select Debug Console",
+			"Select Debug Session",
+			"Choose the specific location",
+			"No executable code is associated at the current cursor position.",
+			"Jump to Cursor",
+			"No step targets available",
+			"Add Configuration...",
+			"Add Inline Breakpoint"
+		],
 		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
 			"Start a New Debug Session"
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorActions": [
+			"Debug: Toggle Breakpoint",
+			"Toggle &&Breakpoint",
+			"Debug: Add Conditional Breakpoint...",
+			"&&Conditional Breakpoint...",
+			"Debug: Add Logpoint...",
+			"&&Logpoint...",
+			"Debug: Edit Breakpoint",
+			"&&Edit Breakpoint",
+			"Open Disassembly View",
+			"&&DisassemblyView",
+			"Toggle Source Code in Disassembly View",
+			"&&ToggleSource",
+			"Run to Cursor",
+			"Evaluate in Debug Console",
+			"Add to Watch",
+			"Debug: Show Hover",
+			"Step targets are not available here",
+			"Step Into Target",
+			"Debug: Go to Next Breakpoint",
+			"Debug: Go to Previous Breakpoint",
+			"Close Exception Widget"
 		],
 		"vs/workbench/contrib/debug/browser/debugIcons": [
 			"View icon of the debug console view.",
@@ -23910,39 +24304,6 @@
 			"Icon for the debug evaluation prompt.",
 			"Icon for the inspect memory action."
 		],
-		"vs/workbench/contrib/debug/browser/debugCommands": [
-			"Debug",
-			"Restart",
-			"Step Over",
-			"Step Into",
-			"Step Into Target",
-			"Step Out",
-			"Pause",
-			"Disconnect",
-			"Disconnect and Suspend",
-			"Stop",
-			"Continue",
-			"Focus Session",
-			"Select and Start Debugging",
-			"Open '{0}'",
-			"Start Debugging",
-			"Start Without Debugging",
-			"Focus Next Debug Console",
-			"Focus Previous Debug Console",
-			"Open Loaded Script...",
-			"Navigate to Top of Call Stack",
-			"Navigate to Bottom of Call Stack",
-			"Navigate Up Call Stack",
-			"Navigate Down Call Stack",
-			"Select Debug Console",
-			"Select Debug Session",
-			"Choose the specific location",
-			"No executable code is associated at the current cursor position.",
-			"Jump to Cursor",
-			"No step targets available",
-			"Add Configuration...",
-			"Add Inline Breakpoint"
-		],
 		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
 			"No matching launch configurations",
 			"Configure Launch Configuration",
@@ -23953,38 +24314,10 @@
 			"Add Config ({0})...",
 			"Add Configuration..."
 		],
-		"vs/workbench/contrib/debug/browser/debugEditorActions": [
-			"Debug: Toggle Breakpoint",
-			"Toggle &&Breakpoint",
-			"Debug: Add Conditional Breakpoint...",
-			"&&Conditional Breakpoint...",
-			"Debug: Add Logpoint...",
-			"&&Logpoint...",
-			"Debug: Edit Breakpoint",
-			"&&Edit Breakpoint",
-			"Open Disassembly View",
-			"&&DisassemblyView",
-			"Toggle Source Code in Disassembly View",
-			"&&ToggleSource",
-			"Run to Cursor",
-			"Evaluate in Debug Console",
-			"Add to Watch",
-			"Debug: Show Hover",
-			"Step targets are not available here",
-			"Step Into Target",
-			"Debug: Go to Next Breakpoint",
-			"Debug: Go to Previous Breakpoint",
-			"Close Exception Widget"
-		],
 		"vs/workbench/contrib/debug/browser/debugStatus": [
 			"Debug",
 			"Debug: {0}",
 			"Select and start debug configuration"
-		],
-		"vs/workbench/contrib/debug/browser/debugToolBar": [
-			"More...",
-			"Step Back",
-			"Reverse"
 		],
 		"vs/workbench/contrib/debug/browser/debugService": [
 			"1 active session",
@@ -24009,6 +24342,20 @@
 			"Added breakpoint, line {0}, file {1}",
 			"Removed breakpoint, line {0}, file {1}"
 		],
+		"vs/workbench/contrib/debug/browser/debugToolBar": [
+			"More...",
+			"Step Back",
+			"Reverse"
+		],
+		"vs/workbench/contrib/debug/browser/disassemblyView": [
+			"Disassembly not available.",
+			"instructions",
+			"from disassembly",
+			"Disassembly View",
+			"Address",
+			"Bytes",
+			"Instruction"
+		],
 		"vs/workbench/contrib/debug/browser/loadedScriptsView": [
 			"Debug Session",
 			"Debug Loaded Scripts",
@@ -24022,23 +24369,16 @@
 			"Status bar foreground color when a program is being debugged. The status bar is shown in the bottom of the window",
 			"Status bar border color separating to the sidebar and editor when a program is being debugged. The status bar is shown in the bottom of the window"
 		],
-		"vs/workbench/contrib/debug/browser/disassemblyView": [
-			"Disassembly not available.",
-			"instructions",
-			"from disassembly",
-			"Disassembly View",
-			"Address",
-			"Bytes",
-			"Instruction"
-		],
-		"vs/workbench/contrib/debug/browser/welcomeView": [
-			"Run",
-			"[Open a file](command:{0}) which can be debugged or run.",
-			"[Run and Debug{0}](command:{1})",
-			"[Show all automatic debug configurations](command:{0}).",
-			"To customize Run and Debug [create a launch.json file](command:{0}).",
-			"To customize Run and Debug, [open a folder](command:{0}) and create a launch.json file.",
-			"All debug extensions are disabled. Enable a debug extension or install a new one from the Marketplace."
+		"vs/workbench/contrib/debug/browser/variablesView": [
+			"Type new variable value",
+			"Debug Variables",
+			"Scope {0}",
+			"{0}, value {1}",
+			"Inspecting binary data requires the Hex Editor extension. Would you like to install it now?",
+			"Cancel",
+			"Install",
+			"Installing the Hex Editor...",
+			"Collapse All"
 		],
 		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
 			"Type new value",
@@ -24050,6 +24390,15 @@
 			"Collapse All",
 			"Add Expression",
 			"Remove All Expressions"
+		],
+		"vs/workbench/contrib/debug/browser/welcomeView": [
+			"Run",
+			"[Open a file](command:{0}) which can be debugged or run.",
+			"[Run and Debug{0}](command:{1})",
+			"[Show all automatic debug configurations](command:{0}).",
+			"To customize Run and Debug [create a launch.json file](command:{0}).",
+			"To customize Run and Debug, [open a folder](command:{0}) and create a launch.json file.",
+			"All debug extensions are disabled. Enable a debug extension or install a new one from the Marketplace."
 		],
 		"vs/workbench/contrib/debug/common/debugContentProvider": [
 			"Unable to resolve the resource without a debug session",
@@ -24064,16 +24413,10 @@
 		"vs/workbench/contrib/debug/common/disassemblyViewInput": [
 			"Disassembly"
 		],
-		"vs/workbench/contrib/debug/browser/variablesView": [
-			"Type new variable value",
-			"Debug Variables",
-			"Scope {0}",
-			"{0}, value {1}",
-			"Inspecting binary data requires the Hex Editor extension. Would you like to install it now?",
-			"Cancel",
-			"Install",
-			"Installing the Hex Editor...",
-			"Collapse All"
+		"vs/workbench/contrib/debug/browser/debugHover": [
+			"Hold {0} key to switch to editor language hover",
+			"Debug Hover",
+			"{0}, value {1}, variables, debug"
 		],
 		"vs/workbench/contrib/debug/browser/exceptionWidget": [
 			"Exception widget border color.",
@@ -24081,20 +24424,6 @@
 			"Exception has occurred: {0}",
 			"Exception has occurred.",
 			"Close"
-		],
-		"vs/workbench/contrib/debug/browser/debugHover": [
-			"Hold {0} key to switch to editor language hover",
-			"Debug Hover",
-			"{0}, value {1}, variables, debug"
-		],
-		"vs/workbench/contrib/debug/browser/breakpointWidget": [
-			"Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.",
-			"Break when hit count condition is met. 'Enter' to accept, 'esc' to cancel.",
-			"Break when expression evaluates to true. 'Enter' to accept, 'esc' to cancel.",
-			"Expression",
-			"Hit Count",
-			"Log Message",
-			"Breakpoint Type"
 		],
 		"vs/workbench/contrib/debug/common/debugModel": [
 			"Invalid variable attributes",
@@ -24105,10 +24434,14 @@
 			"Running",
 			"Unverified breakpoint. File is modified, please restart debug session."
 		],
-		"vs/platform/actions/browser/menuEntryActionViewItem": [
-			"{0} ({1})",
-			"{0} ({1})",
-			"{0}\n[{1}] {2}"
+		"vs/workbench/contrib/debug/browser/breakpointWidget": [
+			"Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.",
+			"Break when hit count condition is met. 'Enter' to accept, 'esc' to cancel.",
+			"Break when expression evaluates to true. 'Enter' to accept, 'esc' to cancel.",
+			"Expression",
+			"Hit Count",
+			"Log Message",
+			"Breakpoint Type"
 		],
 		"vs/platform/history/browser/contextScopedHistoryWidget": [
 			"Whether suggestion are visible"
@@ -24137,6 +24470,12 @@
 		],
 		"vs/workbench/contrib/debug/common/replModel": [
 			"Console was cleared"
+		],
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"Showing {0} of {1}",
+			"Showing {0} problems",
+			"Showing {0} of {1} problems",
+			"Clear Filters"
 		],
 		"vs/workbench/contrib/markers/browser/messages": [
 			"Toggle Problems (Errors, Warnings, Infos)",
@@ -24187,39 +24526,14 @@
 			"{0} at line {1} and character {2} in {3}",
 			"Show Errors and Warnings"
 		],
+		"vs/workbench/browser/parts/views/viewFilter": [
+			"More Filters..."
+		],
 		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
 			"Problems",
 			"1 problem in this file",
 			"{0} problems in this file",
 			"Show Errors & Warnings on files and folder."
-		],
-		"vs/workbench/browser/parts/views/viewFilter": [
-			"More Filters..."
-		],
-		"vs/workbench/contrib/markers/browser/markersView": [
-			"Showing {0} of {1}",
-			"Showing {0} problems",
-			"Showing {0} of {1} problems",
-			"Clear Filters"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
-			"Merging: {0}"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/commands/devCommands": [
-			"Merge Editor (Dev)",
-			"Copy Merge Editor State as JSON",
-			"Merge Editor",
-			"No active merge editor",
-			"Merge Editor",
-			"Successfully copied merge editor state",
-			"Save Merge Editor State to Folder",
-			"Merge Editor",
-			"No active merge editor",
-			"Select folder to save to",
-			"Merge Editor",
-			"Successfully saved merge editor state to folder",
-			"Load Merge Editor State from Folder",
-			"Select folder to save to"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/commands/commands": [
 			"Open Merge Editor",
@@ -24250,11 +24564,27 @@
 			"The file contains unhandled conflicts.",
 			"&&Complete with Conflicts"
 		],
+		"vs/workbench/contrib/mergeEditor/browser/commands/devCommands": [
+			"Merge Editor (Dev)",
+			"Copy Merge Editor State as JSON",
+			"Merge Editor",
+			"No active merge editor",
+			"Merge Editor",
+			"Successfully copied merge editor state",
+			"Save Merge Editor State to Folder",
+			"Merge Editor",
+			"No active merge editor",
+			"Select folder to save to",
+			"Merge Editor",
+			"Successfully saved merge editor state to folder",
+			"Load Merge Editor State from Folder",
+			"Select folder to save to"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
+			"Merging: {0}"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
 			"Text Merge Editor"
-		],
-		"vs/workbench/contrib/comments/browser/commentService": [
-			"Whether the open workspace has either comments or commenting ranges."
 		],
 		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
 			"Go to Next Comment Thread",
@@ -24265,36 +24595,8 @@
 			"Expand All Comments",
 			"Expand Unresolved Comments"
 		],
-		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
-			"Do you want {0} to open the external website?",
-			"&&Open",
-			"&&Copy",
-			"Configure &&Trusted Domains"
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
-			"Show find",
-			"Stop find",
-			"Find next",
-			"Find previous",
-			"Reload Webviews"
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
-			"The viewType of the currently active webview panel."
-		],
-		"vs/workbench/contrib/externalUriOpener/common/configuration": [
-			"Configure the opener to use for external URIs (http, https).",
-			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
-			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
-			"Open using VS Code's standard opener."
-		],
-		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
-			"Open in new browser window",
-			"Open in default browser",
-			"Configure default opener...",
-			"How would you like to open: {0}"
-		],
-		"vs/workbench/contrib/customEditor/common/customEditor": [
-			"The viewType of the currently active custom editor."
+		"vs/workbench/contrib/comments/browser/commentService": [
+			"Whether the open workspace has either comments or commenting ranges."
 		],
 		"vs/workbench/contrib/url/browser/trustedDomains": [
 			"Manage Trusted Domains",
@@ -24304,151 +24606,33 @@
 			"Trust all domains (disables link protection)",
 			"Manage Trusted Domains"
 		],
+		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
+			"Do you want {0} to open the external website?",
+			"&&Open",
+			"&&Copy",
+			"Configure &&Trusted Domains"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
+			"The viewType of the currently active webview panel."
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
+			"Show find",
+			"Stop find",
+			"Find next",
+			"Find previous",
+			"Reload Webviews"
+		],
+		"vs/workbench/contrib/customEditor/common/customEditor": [
+			"The viewType of the currently active custom editor."
+		],
+		"vs/workbench/contrib/externalUriOpener/common/configuration": [
+			"Configure the opener to use for external URIs (http, https).",
+			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
+			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
+			"Open using VS Code's standard opener."
+		],
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"Extension: {0}"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
-			"Extensions",
-			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
-			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
-			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
-			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionEditor": [
-			"Extension Version",
-			"Pre-Release",
-			"Extension name",
-			"Preview",
-			"Preview",
-			"Built-in",
-			"Publisher",
-			"Install count",
-			"Rating",
-			"Details",
-			"Extension details, rendered from the extension's 'README.md' file",
-			"Feature Contributions",
-			"Lists contributions to VS Code by this extension",
-			"Changelog",
-			"Extension update history, rendered from the extension's 'CHANGELOG.md' file",
-			"Dependencies",
-			"Lists extensions this extension depends on",
-			"Extension Pack",
-			"Lists extensions those will be installed together with this extension",
-			"Runtime Status",
-			"Extension runtime status",
-			"No README available.",
-			"Readme",
-			"Extension Pack ({0})",
-			"No README available.",
-			"Readme",
-			"Categories",
-			"Marketplace",
-			"Repository",
-			"License",
-			"Extension Resources",
-			"More Info",
-			"Published",
-			"Last released",
-			"Last updated",
-			"Identifier",
-			"No Changelog available.",
-			"Changelog",
-			"No Contributions",
-			"No Contributions",
-			"No Dependencies",
-			"Activation Event:",
-			"Startup",
-			"Activation Time:",
-			"Activated By:",
-			"Not yet activated.",
-			"Uncaught Errors ({0})",
-			"Messages ({0})",
-			"No status available.",
-			"Settings ({0})",
-			"ID",
-			"Description",
-			"Default",
-			"Debuggers ({0})",
-			"Name",
-			"Type",
-			"View Containers ({0})",
-			"ID",
-			"Title",
-			"Where",
-			"Views ({0})",
-			"ID",
-			"Name",
-			"Where",
-			"Localizations ({0})",
-			"Language ID",
-			"Language Name",
-			"Language Name (Localized)",
-			"Custom Editors ({0})",
-			"View Type",
-			"Priority",
-			"Filename Pattern",
-			"Code Actions ({0})",
-			"Title",
-			"Kind",
-			"Description",
-			"Languages",
-			"Authentication ({0})",
-			"Label",
-			"ID",
-			"Color Themes ({0})",
-			"File Icon Themes ({0})",
-			"Product Icon Themes ({0})",
-			"Colors ({0})",
-			"ID",
-			"Description",
-			"Dark Default",
-			"Light Default",
-			"High Contrast Default",
-			"JSON Validation ({0})",
-			"File Match",
-			"Schema",
-			"Commands ({0})",
-			"ID",
-			"Title",
-			"Keyboard Shortcuts",
-			"Menu Contexts",
-			"Languages ({0})",
-			"ID",
-			"Name",
-			"File Extensions",
-			"Grammar",
-			"Snippets",
-			"Activation Events ({0})",
-			"Notebooks ({0})",
-			"ID",
-			"Name",
-			"Notebook Renderers ({0})",
-			"Name",
-			"Mimetypes",
-			"Find",
-			"Find Next",
-			"Find Previous"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
-			"Yes",
-			"No"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"Extensions",
-			"Install Missing Dependencies",
-			"Finished installing missing dependencies. Please reload the window now.",
-			"Reload Window",
-			"There are no missing dependencies to install."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
-			"Activating Extensions..."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"Type an extension name to install or search.",
-			"Press Enter to search for extension '{0}'.",
-			"Press Enter to install extension '{0}'.",
-			"Press Enter to manage your extensions."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"{0} for the Web",
@@ -24481,12 +24665,6 @@
 			"Install",
 			"Install Release Version",
 			"Install",
-			"Do not sync",
-			"{0} in {1} ({2})",
-			"{0} in {1}",
-			"{0} Locally ({1})",
-			"{0} Locally",
-			"Install this extension in all your synced {0} instances",
 			"Installing",
 			"Install",
 			"Installing",
@@ -24619,6 +24797,219 @@
 			"Button foreground color for extension actions that stand out (e.g. install button).",
 			"Button background hover color for extension actions that stand out (e.g. install button)."
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"Extensions",
+			"Unable to search the Marketplace when offline, please check your network connection.",
+			"Error while fetching extensions. {0}",
+			"No extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"There are no extensions to install.",
+			"Verified Publisher {0}",
+			"Publisher {0}",
+			"Deprecated",
+			"Rated {0} out of 5 stars by {1} users"
+		],
+		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
+			"Open in new browser window",
+			"Open in default browser",
+			"Configure default opener...",
+			"How would you like to open: {0}"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"View icon of the extensions view.",
+			"Icon for the 'Manage' action in the extensions view.",
+			"Icon for the 'Clear Search Result' action in the extensions view.",
+			"Icon for the 'Refresh' action in the extensions view.",
+			"Icon for the 'Filter' action in the extensions view.",
+			"Icon for the 'Install Local Extension in Remote' action in the extensions view.",
+			"Icon for the 'Install Workspace Recommended Extensions' action in the extensions view.",
+			"Icon for the 'Configure Recommended Extensions' action in the extensions view.",
+			"Icon to indicate that an extension is synced.",
+			"Icon to indicate that an extension is ignored when syncing.",
+			"Icon to indicate that an extension is remote in the extensions view and editor.",
+			"Icon shown along with the install count in the extensions view and editor.",
+			"Icon shown along with the rating in the extensions view and editor.",
+			"Icon used for the verified extension publisher in the extensions view and editor.",
+			"Icon shown for extensions having pre-release versions in extensions view and editor.",
+			"Icon used for sponsoring extensions in the extensions view and editor.",
+			"Full star icon used for the rating in the extensions editor.",
+			"Half star icon used for the rating in the extensions editor.",
+			"Empty star icon used for the rating in the extensions editor.",
+			"Icon shown with a error message in the extensions editor.",
+			"Icon shown with a warning message in the extensions editor.",
+			"Icon shown with an info message in the extensions editor.",
+			"Icon shown with a workspace trust message in the extension editor.",
+			"Icon shown with a activation time message in the extension editor."
+		],
+		"vs/platform/dnd/browser/dnd": [
+			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
+		],
+		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
+			"Extensions",
+			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
+			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
+		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
+			"Yes",
+			"No"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionEditor": [
+			"Extension Version",
+			"Pre-Release",
+			"Extension name",
+			"Preview",
+			"Preview",
+			"Built-in",
+			"Publisher",
+			"Install count",
+			"Rating",
+			"Details",
+			"Extension details, rendered from the extension's 'README.md' file",
+			"Feature Contributions",
+			"Lists contributions to VS Code by this extension",
+			"Changelog",
+			"Extension update history, rendered from the extension's 'CHANGELOG.md' file",
+			"Dependencies",
+			"Lists extensions this extension depends on",
+			"Extension Pack",
+			"Lists extensions those will be installed together with this extension",
+			"Runtime Status",
+			"Extension runtime status",
+			"No README available.",
+			"Readme",
+			"Extension Pack ({0})",
+			"No README available.",
+			"Readme",
+			"Categories",
+			"Marketplace",
+			"Repository",
+			"License",
+			"Extension Resources",
+			"More Info",
+			"Published",
+			"Last released",
+			"Last updated",
+			"Identifier",
+			"No Changelog available.",
+			"Changelog",
+			"No Contributions",
+			"No Contributions",
+			"No Dependencies",
+			"Activation Event:",
+			"Startup",
+			"Activation Time:",
+			"Activated By:",
+			"Not yet activated.",
+			"Uncaught Errors ({0})",
+			"Messages ({0})",
+			"No status available.",
+			"Settings ({0})",
+			"ID",
+			"Description",
+			"Default",
+			"Debuggers ({0})",
+			"Name",
+			"Type",
+			"View Containers ({0})",
+			"ID",
+			"Title",
+			"Where",
+			"Views ({0})",
+			"ID",
+			"Name",
+			"Where",
+			"Localizations ({0})",
+			"Language ID",
+			"Language Name",
+			"Language Name (Localized)",
+			"Custom Editors ({0})",
+			"View Type",
+			"Priority",
+			"Filename Pattern",
+			"Code Actions ({0})",
+			"Title",
+			"Kind",
+			"Description",
+			"Languages",
+			"Authentication ({0})",
+			"Label",
+			"ID",
+			"Color Themes ({0})",
+			"File Icon Themes ({0})",
+			"Product Icon Themes ({0})",
+			"Colors ({0})",
+			"ID",
+			"Description",
+			"Dark Default",
+			"Light Default",
+			"High Contrast Default",
+			"JSON Validation ({0})",
+			"File Match",
+			"Schema",
+			"Commands ({0})",
+			"ID",
+			"Title",
+			"Keyboard Shortcuts",
+			"Menu Contexts",
+			"Languages ({0})",
+			"ID",
+			"Name",
+			"File Extensions",
+			"Grammar",
+			"Snippets",
+			"Activation Events ({0})",
+			"Notebooks ({0})",
+			"ID",
+			"Name",
+			"Notebook Renderers ({0})",
+			"Name",
+			"Mimetypes",
+			"Find",
+			"Find Next",
+			"Find Previous"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"Activating Extensions..."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"Extensions",
+			"Install Missing Dependencies",
+			"Finished installing missing dependencies. Please reload the window now.",
+			"Reload Window",
+			"There are no missing dependencies to install."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"Type an extension name to install or search.",
+			"Press Enter to search for extension '{0}'.",
+			"Press Enter to install extension '{0}'.",
+			"Press Enter to manage your extensions."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
+			"Manifest is not found",
+			"Please reload Visual Studio Code to complete the uninstallation of this extension.",
+			"Please reload Visual Studio Code to enable the updated extension.",
+			"Please reload Visual Studio Code to enable this extension locally.",
+			"Please reload Visual Studio Code to enable this extension in {0}.",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Please reload Visual Studio Code to disable this extension.",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Please reload Visual Studio Code to enable this extension.",
+			"This extension is reported to be problematic.",
+			"Can't install '{0}' extension because it is not compatible.",
+			"Uninstalling extension....",
+			"Unable to install extension '{0}' because the requested version '{1}' is not found.",
+			"Installing extension....",
+			"Installing '{0}' extension....",
+			"Disable All",
+			"Cannot disable '{0}' extension alone. '{1}' extension depends on this. Do you want to disable all these extensions?",
+			"Cannot disable '{0}' extension alone. '{1}' and '{2}' extensions depend on this. Do you want to disable all these extensions?",
+			"Cannot disable '{0}' extension alone. '{1}', '{2}' and other extensions depend on this. Do you want to disable all these extensions?"
+		],
 		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
 			"Don't Show Again",
 			"Do you want to ignore all extension recommendations?",
@@ -24652,128 +25043,19 @@
 			"Disable",
 			"Show Running Extensions"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
-			"View icon of the extensions view.",
-			"Icon for the 'Manage' action in the extensions view.",
-			"Icon for the 'Clear Search Result' action in the extensions view.",
-			"Icon for the 'Refresh' action in the extensions view.",
-			"Icon for the 'Filter' action in the extensions view.",
-			"Icon for the 'Install Local Extension in Remote' action in the extensions view.",
-			"Icon for the 'Install Workspace Recommended Extensions' action in the extensions view.",
-			"Icon for the 'Configure Recommended Extensions' action in the extensions view.",
-			"Icon to indicate that an extension is synced.",
-			"Icon to indicate that an extension is ignored when syncing.",
-			"Icon to indicate that an extension is remote in the extensions view and editor.",
-			"Icon shown along with the install count in the extensions view and editor.",
-			"Icon shown along with the rating in the extensions view and editor.",
-			"Icon used for the verified extension publisher in the extensions view and editor.",
-			"Icon shown for extensions having pre-release versions in extensions view and editor.",
-			"Icon used for sponsoring extensions in the extensions view and editor.",
-			"Full star icon used for the rating in the extensions editor.",
-			"Half star icon used for the rating in the extensions editor.",
-			"Empty star icon used for the rating in the extensions editor.",
-			"Icon shown with a error message in the extensions editor.",
-			"Icon shown with a warning message in the extensions editor.",
-			"Icon shown with an info message in the extensions editor.",
-			"Icon shown with a workspace trust message in the extension editor.",
-			"Icon shown with a activation time message in the extension editor."
-		],
 		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
 			"Restarting extension host due to workspace trust change."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsCompletionItemsProvider": [
 			"Example"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
-			"Manifest is not found",
-			"Please reload Visual Studio Code to complete the uninstallation of this extension.",
-			"Please reload Visual Studio Code to enable the updated extension.",
-			"Please reload Visual Studio Code to enable this extension locally.",
-			"Please reload Visual Studio Code to enable this extension in {0}.",
-			"Please reload Visual Studio Code to enable this extension.",
-			"Please reload Visual Studio Code to enable this extension.",
-			"Please reload Visual Studio Code to disable this extension.",
-			"Please reload Visual Studio Code to enable this extension.",
-			"Please reload Visual Studio Code to enable this extension.",
-			"This extension is reported to be problematic.",
-			"Can't install '{0}' extension because it is not compatible.",
-			"Uninstalling extension....",
-			"Unable to install extension '{0}' because the requested version '{1}' is not found.",
-			"Installing extension....",
-			"Installing '{0}' extension....",
-			"Disable All",
-			"Cannot disable '{0}' extension alone. '{1}' extension depends on this. Do you want to disable all these extensions?",
-			"Cannot disable '{0}' extension alone. '{1}' and '{2}' extensions depend on this. Do you want to disable all these extensions?",
-			"Cannot disable '{0}' extension alone. '{1}', '{2}' and other extensions depend on this. Do you want to disable all these extensions?"
-		],
 		"vs/workbench/contrib/extensions/browser/deprecatedExtensionsChecker": [
 			"You have deprecated extensions installed. We recommend to review them and migrate to alternatives.",
 			"Show Deprecated Extensions",
 			"Don't Show Again"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViews": [
-			"Extensions",
-			"Unable to search the Marketplace when offline, please check your network connection.",
-			"Error while fetching extensions. {0}",
-			"No extensions found.",
-			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
-			"Open User Settings",
-			"There are no extensions to install.",
-			"Verified Publisher {0}",
-			"Publisher {0}",
-			"Deprecated",
-			"Rated {0} out of 5 stars by {1} users"
-		],
-		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
-			"Type the name of a terminal to open.",
-			"Show All Opened Terminals",
-			"Terminal",
-			"Terminal",
-			"&&Terminal"
-		],
-		"vs/platform/dnd/browser/dnd": [
-			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
-		],
 		"vs/workbench/contrib/output/browser/logViewer": [
 			"Log viewer"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalView": [
-			"Use 'monospace'",
-			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font.",
-			"Open Terminals.",
-			"Starting..."
-		],
-		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
-			"Show Environment Contributions",
-			"Terminal Environment Changes",
-			"Extension: {0}"
-		],
-		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
-			"Show Terminal Texture Atlas",
-			"Write Data to Terminal",
-			"Enter data to write directly to the terminal, bypassing the pty"
-		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
-			"Show Terminal Accessibility Help",
-			"Focus Accessible Buffer",
-			"Navigate Accessible Buffer",
-			"Accessible Buffer Go to Next Command",
-			"Accessible Buffer Go to Previous Command"
-		],
-		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
-			"Focus Find",
-			"Hide Find",
-			"Toggle Find Using Regex",
-			"Toggle Find Using Whole Word",
-			"Toggle Find Using Case Sensitive",
-			"Find Next",
-			"Find Previous",
-			"Search Workspace"
-		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
-			"Open Detected Link...",
-			"Open Last URL Link",
-			"Open Last Local File Link"
 		],
 		"vs/workbench/contrib/tasks/common/problemMatcher": [
 			"The problem pattern is missing a regular expression.",
@@ -24845,9 +25127,6 @@
 			"ESLint stylish problems",
 			"Go problems"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
-			"Show Terminal Quick Fixes"
-		],
 		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
 			"Manage Automatic Tasks",
 			"Allow Automatic Tasks",
@@ -24862,10 +25141,6 @@
 			"Mac specific command configuration",
 			"Linux specific command configuration",
 			"Specifies whether the command is a shell command or an external program. Defaults to false if omitted."
-		],
-		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
-			"No matching tasks",
-			"Select the task to run"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v2": [
 			"Specifies whether the command is a shell command or an external program. Defaults to false if omitted.",
@@ -24951,13 +25226,9 @@
 			"Mac specific command configuration",
 			"Linux specific command configuration"
 		],
-		"vs/workbench/contrib/remote/browser/tunnelFactory": [
-			"Private",
-			"Public"
-		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"Emmet: Expand Abbreviation",
-			"Emmet: E&&xpand Abbreviation"
+		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
+			"No matching tasks",
+			"Select the task to run"
 		],
 		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
 			"The actual task type. Please note that types starting with a '$' are reserved for internal usage.",
@@ -24966,53 +25237,9 @@
 			"The task type configuration is missing the required 'taskType' property",
 			"Contributes task kinds"
 		],
-		"vs/workbench/contrib/remote/browser/remoteIndicator": [
-			"Status bar background color when the workbench is offline. The status bar is shown in the bottom of the window",
-			"Status bar foreground color when the workbench is offline. The status bar is shown in the bottom of the window",
-			"Remote",
-			"Show Remote Menu",
-			"Close Remote Connection",
-			"Close Re&&mote Connection",
-			"Install Remote Development Extensions",
-			"Opening Remote...",
-			"Opening Remote...",
-			"Reconnecting to {0}...",
-			"Disconnected from {0}",
-			"Editing on {0}",
-			"Editing on {0}",
-			"Some [features are not available]({0}) for resources located on a virtual file system.",
-			"Open a Remote Window",
-			"Remote Host",
-			"Network appears to be offline, certain features might be unavailable.",
-			"Network appears to have high latency ({0}ms last, {1}ms average), certain features may be slow to respond.",
-			"Close Remote Connection",
-			"Reload Window",
-			"Close Remote Workspace",
-			"Install Additional Remote Extensions...",
-			"Select an option to open a Remote Window"
-		],
-		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
-			"Accessibility Help",
-			"Now changing the setting `editor.accessibilitySupport` to 'on'.",
-			"Now opening the VS Code Accessibility documentation page.",
-			"Thank you for trying out VS Code's accessibility options.",
-			"Status:",
-			"To configure the editor to be permanently optimized for usage with a Screen Reader press Command+E now.",
-			"To configure the editor to be permanently optimized for usage with a Screen Reader press Control+E now.",
-			"The editor is configured to use platform APIs to detect when a Screen Reader is attached, but the current runtime does not support this.",
-			"The editor has automatically detected a Screen Reader is attached.",
-			"The editor is configured to automatically detect when a Screen Reader is attached, which is not the case at this time.",
-			"The editor is configured to be permanently optimized for usage with a Screen Reader - you can change this via the command `Toggle Screen Reader Accessibility Mode` or by editing the setting `editor.accessibilitySupport`",
-			"The editor is configured to never be optimized for usage with a Screen Reader.",
-			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
-			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
-			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
-			"Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.",
-			"Press Command+H now to open a browser window with more VS Code information related to Accessibility.",
-			"Press Control+H now to open a browser window with more VS Code information related to Accessibility.",
-			"You can dismiss this tooltip and return to the editor by pressing Escape or Shift+Escape.",
-			"Show Accessibility Help",
-			"Toggle Screen Reader Accessibility Mode"
+		"vs/workbench/contrib/remote/browser/tunnelFactory": [
+			"Private",
+			"Public"
 		],
 		"vs/workbench/contrib/remote/browser/remote": [
 			"The ID of a Get Started walkthrough to open.",
@@ -25041,10 +25268,111 @@
 			"Cannot reconnect. Please reload the window.",
 			"&&Reload Window"
 		],
+		"vs/workbench/contrib/remote/browser/remoteIndicator": [
+			"Status bar background color when the workbench is offline. The status bar is shown in the bottom of the window",
+			"Status bar foreground color when the workbench is offline. The status bar is shown in the bottom of the window",
+			"Remote",
+			"Show Remote Menu",
+			"Close Remote Connection",
+			"Close Re&&mote Connection",
+			"Install Remote Development Extensions",
+			"Opening Remote...",
+			"Opening Remote...",
+			"Reconnecting to {0}...",
+			"Disconnected from {0}",
+			"Editing on {0}",
+			"Editing on {0}",
+			"Some [features are not available]({0}) for resources located on a virtual file system.",
+			"Open a Remote Window",
+			"Remote Host",
+			"Network appears to be offline, certain features might be unavailable.",
+			"Network appears to have high latency ({0}ms last, {1}ms average), certain features may be slow to respond.",
+			"Close Remote Connection",
+			"Reload Window",
+			"Close Remote Workspace",
+			"Learn More",
+			"Install",
+			"Select an option to open a Remote Window",
+			"Installing extension... "
+		],
+		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
+			"Type the name of a terminal to open.",
+			"Show All Opened Terminals",
+			"Terminal",
+			"Terminal",
+			"&&Terminal"
+		],
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
+			"Focus Accessible Buffer",
+			"Navigate Accessible Buffer",
+			"Accessible Buffer Go to Next Command",
+			"Accessible Buffer Go to Previous Command"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"Use 'monospace'",
+			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font.",
+			"Open Terminals.",
+			"Starting..."
+		],
+		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
+			"Show Terminal Texture Atlas",
+			"Write Data to Terminal",
+			"Enter data to write directly to the terminal, bypassing the pty",
+			"Restart Pty Host"
+		],
+		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
+			"Show Environment Contributions",
+			"Terminal Environment Changes",
+			"Extension: {0}"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
+			"Show Terminal Quick Fixes"
+		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"Emmet: Expand Abbreviation",
+			"Emmet: E&&xpand Abbreviation"
+		],
+		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
+			"Accessibility Help",
+			"Now changing the setting `editor.accessibilitySupport` to 'on'.",
+			"Now opening the VS Code Accessibility documentation page.",
+			"Thank you for trying out VS Code's accessibility options.",
+			"Status:",
+			"To configure the editor to be permanently optimized for usage with a Screen Reader press Command+E now.",
+			"To configure the editor to be permanently optimized for usage with a Screen Reader press Control+E now.",
+			"The editor is configured to use platform APIs to detect when a Screen Reader is attached, but the current runtime does not support this.",
+			"The editor has automatically detected a Screen Reader is attached.",
+			"The editor is configured to automatically detect when a Screen Reader is attached, which is not the case at this time.",
+			"The editor is configured to be permanently optimized for usage with a Screen Reader - you can change this via the command `Toggle Screen Reader Accessibility Mode` or by editing the setting `editor.accessibilitySupport`",
+			"The editor is configured to never be optimized for usage with a Screen Reader.",
+			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
+			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
+			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
+			"Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.",
+			"Press Command+H now to open a browser window with more VS Code information related to Accessibility.",
+			"Press Control+H now to open a browser window with more VS Code information related to Accessibility.",
+			"You can dismiss this tooltip and return to the editor by pressing Escape or Shift+Escape.",
+			"Toggle Screen Reader Accessibility Mode"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
+			"Open Detected Link...",
+			"Open Last URL Link",
+			"Open Last Local File Link"
+		],
 		"vs/workbench/contrib/codeEditor/browser/diffEditorHelper": [
 			"The diff algorithm was stopped early (after {0} ms.)",
 			"Remove Limit",
 			"Show Whitespace Differences"
+		],
+		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
+			"Focus Find",
+			"Hide Find",
+			"Toggle Find Using Regex",
+			"Toggle Find Using Whole Word",
+			"Toggle Find Using Case Sensitive",
+			"Find Next",
+			"Find Previous",
+			"Search Workspace"
 		],
 		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
 			"Inspect Key Mappings",
@@ -25055,18 +25383,14 @@
 			"Forcefully Enable Features",
 			"Please reopen file in order for this setting to take effect."
 		],
+		"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens": [
+			"Developer: Inspect Editor Tokens and Scopes",
+			"Loading..."
+		],
 		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess": [
 			"Go to Line/Column...",
 			"Type the line number and optional column to go to (e.g. 42:5 for line 42 and column 5).",
 			"Go to Line/Column"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
-			"Toggle Minimap",
-			"&&Minimap"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
-			"Toggle Column Selection Mode",
-			"Column &&Selection Mode"
 		],
 		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
 			"Running '{0}' Formatter ([configure]({1})).",
@@ -25074,9 +25398,13 @@
 			"Getting code actions from '{0}' ([configure]({1})).",
 			"Applying code action '{0}'."
 		],
-		"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens": [
-			"Developer: Inspect Editor Tokens and Scopes",
-			"Loading..."
+		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
+			"Toggle Column Selection Mode",
+			"Column &&Selection Mode"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
+			"Toggle Minimap",
+			"&&Minimap"
 		],
 		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
 			"Toggle Multi-Cursor Modifier",
@@ -25084,13 +25412,13 @@
 			"Switch to Cmd+Click for Multi-Cursor",
 			"Switch to Ctrl+Click for Multi-Cursor"
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
-			"Toggle Render Whitespace",
-			"&&Render Whitespace"
-		],
 		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
 			"Toggle Control Characters",
 			"Render &&Control Characters"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"Toggle Render Whitespace",
+			"&&Render Whitespace"
 		],
 		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
 			"Whether the editor is currently using word wrapping.",
@@ -25102,11 +25430,51 @@
 		"vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint": [
 			"[[Select a language]], or [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don't show]] this again."
 		],
-		"vs/workbench/contrib/format/browser/formatActionsNone": [
-			"Format Document",
-			"This file cannot be formatted because it is too large",
-			"There is no formatter for '{0}' files installed.",
-			"&&Install Formatter..."
+		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
+			"(global)",
+			"({0})",
+			"({0}) {1}",
+			"Type snippet file name",
+			"Invalid file name",
+			"'{0}' is not a valid file name",
+			"'{0}' already exists",
+			"Configure User Snippets",
+			"User Snippets",
+			"User &&Snippets",
+			"global",
+			"New Global Snippets file...",
+			"{0} workspace",
+			"New Snippets file for '{0}'...",
+			"Existing Snippets",
+			"New Snippets",
+			"New Snippets",
+			"Select Snippets File or Create Snippets"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
+			"Fill File with Snippet",
+			"Select a snippet"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
+			"Insert Snippet"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
+			"Surround With Snippet..."
+		],
+		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
+			"Surround With: {0}",
+			"Start with Snippet",
+			"Start with: {0}"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"Expected string in `contributes.{0}.path`. Provided value: {1}",
+			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
+			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
+			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"Contributes snippets.",
+			"Language identifier for which this snippet is contributed to.",
+			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
+			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
+			"The snippet file \"{0}\" could not be read."
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
 			"None",
@@ -25129,34 +25497,14 @@
 			"Format Document With...",
 			"Format Selection With..."
 		],
+		"vs/workbench/contrib/format/browser/formatActionsNone": [
+			"Format Document",
+			"This file cannot be formatted because it is too large",
+			"There is no formatter for '{0}' files installed.",
+			"&&Install Formatter..."
+		],
 		"vs/workbench/contrib/format/browser/formatModified": [
 			"Format Modified Lines"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
-			"Surround With: {0}",
-			"Start with Snippet",
-			"Start with: {0}"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"Expected string in `contributes.{0}.path`. Provided value: {1}",
-			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
-			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
-			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
-			"Contributes snippets.",
-			"Language identifier for which this snippet is contributed to.",
-			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
-			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
-			"The snippet file \"{0}\" could not be read."
-		],
-		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
-			"Insert Snippet"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
-			"Surround With Snippet..."
-		],
-		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
-			"Fill File with Snippet",
-			"Select a snippet"
 		],
 		"vs/workbench/contrib/update/browser/update": [
 			"This version of {0} does not have release notes online",
@@ -25201,47 +25549,10 @@
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
 			"Welcome"
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
-			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled."
-		],
-		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
-			"(global)",
-			"({0})",
-			"({0}) {1}",
-			"Type snippet file name",
-			"Invalid file name",
-			"'{0}' is not a valid file name",
-			"'{0}' already exists",
-			"Configure User Snippets",
-			"User Snippets",
-			"User &&Snippets",
-			"global",
-			"New Global Snippets file...",
-			"{0} workspace",
-			"New Snippets file for '{0}'...",
-			"Existing Snippets",
-			"New Snippets",
-			"New Snippets",
-			"Select Snippets File or Create Snippets"
-		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
 			"Built-In",
 			"Developer",
 			"Reset Welcome Page Walkthrough Progress"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons": [
-			"Used to represent walkthrough steps which have not been completed",
-			"Used to represent walkthrough steps which have been completed"
-		],
-		"vs/workbench/contrib/remote/browser/remoteStartEntry": [
-			"Remote",
-			"Show Remote Start Entry Actions",
-			"Show Start Entry for Remote Tunnels",
-			"Learn More",
-			"Install",
-			"Select an option to connect",
-			"Installing extension... ",
-			"When enabled, a start list entry for getting started with remote experiences in shown on the welcome page."
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted": [
 			"Overview of how to get up to speed with your editor.",
@@ -25276,9 +25587,24 @@
 			"opt out",
 			"{0} collects usage data. Read our {1} and learn how to {2}."
 		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
+			"Welcome Page",
+			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled."
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons": [
+			"Used to represent walkthrough steps which have not been completed",
+			"Used to represent walkthrough steps which have been completed"
+		],
 		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
 			"unbound",
 			"It looks like Git is not installed on your system."
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
+			"Editor Playground",
+			"Interactive Editor Playground"
+		],
+		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
+			"The viewsWelcome contribution in '{0}' requires 'enabledApiProposals: [\"contribViewsWelcome\"]' in order to use the 'group' proposed property."
 		],
 		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeExtensionPoint": [
 			"Contributed views welcome content. Welcome content will be rendered in tree based views whenever they have no meaningful content to display, ie. the File Explorer when no folder is open. Such content is useful as in-product documentation to drive users to use certain features before they are available. A good example would be a `Clone Repository` button in the File Explorer welcome view.",
@@ -25289,9 +25615,6 @@
 			"Condition when the welcome content should be displayed.",
 			"Group to which this welcome content belongs. Proposed API.",
 			"Condition when the welcome content buttons and command links should be enabled."
-		],
-		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
-			"The viewsWelcome contribution in '{0}' requires 'enabledApiProposals: [\"contribViewsWelcome\"]' in order to use the 'group' proposed property."
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
 			"Calls from '{0}'",
@@ -25358,15 +25681,6 @@
 			"Feedback",
 			"Tweet Feedback",
 			"Tweet Feedback"
-		],
-		"vs/workbench/contrib/editSessions/common/editSessions": [
-			"Cloud Changes",
-			"Cloud Changes",
-			"View icon of the cloud changes view."
-		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
-			"Editor Playground",
-			"Interactive Editor Playground"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
 			"Turn Off",
@@ -25447,92 +25761,6 @@
 			"Complete Merge",
 			"Clear Data in Cloud..."
 		],
-		"vs/workbench/contrib/editSessions/browser/editSessionsStorageService": [
-			"Select an account to store your working changes in the cloud",
-			"Signed In",
-			"Others",
-			"Sign in with {0}",
-			"Turn on Cloud Changes...",
-			"Turn off Cloud Changes...",
-			"Do you want to disable storing working changes in the cloud?",
-			"Delete all stored data from the cloud."
-		],
-		"vs/workbench/contrib/editSessions/common/editSessionsLogService": [
-			"Cloud Changes"
-		],
-		"vs/workbench/contrib/editSessions/browser/editSessionsViews": [
-			"You have no stored changes in the cloud to display.\n{0}",
-			"Store Working Changes",
-			"Resume Working Changes",
-			"Store Working Changes",
-			"Delete Working Changes",
-			"Are you sure you want to permanently delete your working changes with ref {0}?",
-			" You cannot undo this action.",
-			"Delete All Working Changes from Cloud",
-			"Are you sure you want to permanently delete all stored changes from the cloud?",
-			" You cannot undo this action.",
-			"Compare Changes",
-			"Local Copy",
-			"Cloud Changes",
-			"Open File"
-		],
-		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
-			"Configure which editor to use for a resource.",
-			"Language modes that the code actions are enabled for.",
-			"`CodeActionKind` of the contributed code action.",
-			"Label for the code action used in the UI.",
-			"Description of what the code action does."
-		],
-		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
-			"Contributed documentation.",
-			"Contributed documentation for refactorings.",
-			"Contributed documentation for refactoring.",
-			"Label for the documentation used in the UI.",
-			"When clause.",
-			"Command executed."
-		],
-		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
-			"Controls whether auto fix action should be run on file save.",
-			"Code Action kinds to be run on save.",
-			"Controls whether '{0}' actions should be run on file save."
-		],
-		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": [
-			"Local History"
-		],
-		"vs/workbench/contrib/localHistory/browser/localHistoryCommands": [
-			"Local History",
-			"Compare with File",
-			"Compare with Previous",
-			"Select for Compare",
-			"Compare with Selected",
-			"Show Contents",
-			"Restore Contents",
-			"File Restored",
-			"Do you want to restore the contents of '{0}'?",
-			"Restoring will discard any unsaved changes.",
-			"&&Restore",
-			"Unable to restore '{0}'.",
-			"Find Entry to Restore",
-			"Select the file to show local history for",
-			"Select the local history entry to open",
-			"Rename",
-			"Rename Local History Entry",
-			"Enter the new name of the local history entry",
-			"Delete",
-			"Do you want to delete the local history entry of '{0}' from {1}?",
-			"This action is irreversible!",
-			"&&Delete",
-			"Delete All",
-			"Do you want to delete all entries of all files in local history?",
-			"This action is irreversible!",
-			"&&Delete All",
-			"Create Entry",
-			"Create Local History Entry",
-			"Enter the new name of the local history entry for '{0}'",
-			"{0} ({1} • {2})",
-			"{0} ({1} • {2}) ↔ {3}",
-			"{0} ({1} • {2}) ↔ {3} ({4} • {5})"
-		],
 		"vs/workbench/contrib/userDataProfile/browser/userDataProfile": [
 			"Create an Empty Profile...",
 			"Create from Current Profile...",
@@ -25580,6 +25808,61 @@
 			"Cleanup Profiles",
 			"Reset Workspace Profiles Associations"
 		],
+		"vs/workbench/contrib/editSessions/common/editSessions": [
+			"Cloud Changes",
+			"Cloud Changes",
+			"View icon of the cloud changes view."
+		],
+		"vs/workbench/contrib/editSessions/browser/editSessionsStorageService": [
+			"Select an account to store your working changes in the cloud",
+			"Signed In",
+			"Others",
+			"Sign in with {0}",
+			"Turn on Cloud Changes...",
+			"Turn on Cloud Changes... (1)",
+			"Turn off Cloud Changes...",
+			"Do you want to disable storing working changes in the cloud?",
+			"Delete all stored data from the cloud."
+		],
+		"vs/workbench/contrib/editSessions/common/editSessionsLogService": [
+			"Cloud Changes"
+		],
+		"vs/workbench/contrib/editSessions/browser/editSessionsViews": [
+			"You have no stored changes in the cloud to display.\n{0}",
+			"Store Working Changes",
+			"Resume Working Changes",
+			"Store Working Changes",
+			"Delete Working Changes",
+			"Are you sure you want to permanently delete your working changes with ref {0}?",
+			" You cannot undo this action.",
+			"Delete All Working Changes from Cloud",
+			"Are you sure you want to permanently delete all stored changes from the cloud?",
+			" You cannot undo this action.",
+			"Compare Changes",
+			"Local Copy",
+			"Cloud Changes",
+			"Open File"
+		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"Configure which editor to use for a resource.",
+			"Language modes that the code actions are enabled for.",
+			"`CodeActionKind` of the contributed code action.",
+			"Label for the code action used in the UI.",
+			"Description of what the code action does."
+		],
+		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
+			"Contributed documentation.",
+			"Contributed documentation for refactorings.",
+			"Contributed documentation for refactoring.",
+			"Label for the documentation used in the UI.",
+			"When clause.",
+			"Command executed."
+		],
+		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
+			"Controls whether auto fix action should be run on file save.",
+			"Code Action kinds to be run on save.",
+			"Controls whether '{0}' actions should be run on file save."
+		],
 		"vs/workbench/contrib/timeline/browser/timelinePane": [
 			"Loading...",
 			"Load more",
@@ -25600,8 +25883,43 @@
 			"Unpin the Current Timeline",
 			"Timeline"
 		],
-		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
-			"Workspace Trust"
+		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": [
+			"Local History"
+		],
+		"vs/workbench/contrib/localHistory/browser/localHistoryCommands": [
+			"Local History",
+			"Compare with File",
+			"Compare with Previous",
+			"Select for Compare",
+			"Compare with Selected",
+			"Show Contents",
+			"Restore Contents",
+			"File Restored",
+			"Do you want to restore the contents of '{0}'?",
+			"Restoring will discard any unsaved changes.",
+			"&&Restore",
+			"Unable to restore '{0}'.",
+			"Find Entry to Restore",
+			"Select the file to show local history for",
+			"Select the local history entry to open",
+			"Local History: Find Entry to Restore...",
+			"Rename",
+			"Rename Local History Entry",
+			"Enter the new name of the local history entry",
+			"Delete",
+			"Do you want to delete the local history entry of '{0}' from {1}?",
+			"This action is irreversible!",
+			"&&Delete",
+			"Delete All",
+			"Do you want to delete all entries of all files in local history?",
+			"This action is irreversible!",
+			"&&Delete All",
+			"Create Entry",
+			"Create Local History Entry",
+			"Enter the new name of the local history entry for '{0}'",
+			"{0} ({1} • {2})",
+			"{0} ({1} • {2}) ↔ {3}",
+			"{0} ({1} • {2}) ↔ {3} ({4} • {5})"
 		],
 		"vs/workbench/contrib/workspace/browser/workspaceTrustEditor": [
 			"Icon for workspace trust ion the banner.",
@@ -25676,6 +25994,9 @@
 			"This folder is trusted via the bolded entries in the the trusted folders below.",
 			"This window is trusted by nature of the workspace that is opened."
 		],
+		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
+			"Workspace Trust"
+		],
 		"vs/workbench/contrib/audioCues/browser/commands": [
 			"Help: List Audio Cues",
 			"Disabled",
@@ -25685,92 +26006,6 @@
 		"vs/workbench/contrib/share/browser/shareService": [
 			"The number of available share providers",
 			"Choose how to share {0}"
-		],
-		"vs/workbench/contrib/accessibility/browser/accessibilityContribution": [
-			"Accessibility",
-			"Provide information about how to access the terminal accessibility help menu when the terminal is focused",
-			"Provide information about how to navigate changes in the diff editor when it is focused",
-			"Provide information about how to access the chat help menu when the chat input is focused",
-			"Provide information about how to access the interactive editor accessibility help menu when the interactive editor input is focused",
-			"Provide information about how to change a keybinding in the keybindings editor when a row is focused",
-			"Provide information about how to focus the cell container or inner editor when a notebook cell is focused."
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"No new notifications",
-			"Notifications",
-			"Notification Center Actions",
-			"Notifications Center"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsStatus": [
-			"Notifications",
-			"Notifications",
-			"Do Not Disturb",
-			"Do Not Disturb Mode is Enabled",
-			"Hide Notifications",
-			"No Notifications",
-			"No New Notifications",
-			"1 New Notification",
-			"{0} New Notifications",
-			"No New Notifications ({0} in progress)",
-			"1 New Notification ({0} in progress)",
-			"{0} New Notifications ({1} in progress)",
-			"Status Message"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCommands": [
-			"Notifications",
-			"Show Notifications",
-			"Hide Notifications",
-			"Clear All Notifications",
-			"Accept Notification Primary Action",
-			"Toggle Do Not Disturb Mode",
-			"Focus Notification Toast"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsToasts": [
-			"{0}, notification",
-			"{0}, source: {1}, notification"
-		],
-		"vs/workbench/services/configuration/common/configurationEditing": [
-			"Open Tasks Configuration",
-			"Open Launch Configuration",
-			"Open Settings",
-			"Open Tasks Configuration",
-			"Open Launch Configuration",
-			"Save and Retry",
-			"Save and Retry",
-			"Open Settings",
-			"Unable to write {0} because it is configured in system policy.",
-			"Unable to write to {0} because {1} is not a registered configuration.",
-			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
-			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
-			"Unable to write to Folder Settings because {0} does not support the folder resource scope.",
-			"Unable to write to User Settings because {0} does not support for global scope.",
-			"Unable to write to Workspace Settings because {0} does not support for workspace scope in a multi folder workspace.",
-			"Unable to write to Folder Settings because no resource is provided.",
-			"Unable to write to Language Settings because {0} is not a resource language setting.",
-			"Unable to write to {0} because no workspace is opened. Please open a workspace first and try again.",
-			"Unable to write into the tasks configuration file. Please open it to correct errors/warnings in it and try again.",
-			"Unable to write into the launch configuration file. Please open it to correct errors/warnings in it and try again.",
-			"Unable to write into user settings. Please open the user settings to correct errors/warnings in it and try again.",
-			"Unable to write into remote user settings. Please open the remote user settings to correct errors/warnings in it and try again.",
-			"Unable to write into workspace settings. Please open the workspace settings to correct errors/warnings in the file and try again.",
-			"Unable to write into folder settings. Please open the '{0}' folder settings to correct errors/warnings in it and try again.",
-			"Unable to write into tasks configuration file because the file has unsaved changes. Please save it first and then try again.",
-			"Unable to write into launch configuration file because the file has unsaved changes. Please save it first and then try again.",
-			"Unable to write into user settings because the file has unsaved changes. Please save the user settings file first and then try again.",
-			"Unable to write into remote user settings because the file has unsaved changes. Please save the remote user settings file first and then try again.",
-			"Unable to write into workspace settings because the file has unsaved changes. Please save the workspace settings file first and then try again.",
-			"Unable to write into folder settings because the file has unsaved changes. Please save the '{0}' folder settings file first and then try again.",
-			"Unable to write into tasks configuration file because the content of the file is newer.",
-			"Unable to write into launch configuration file because the content of the file is newer.",
-			"Unable to write into user settings because the content of the file is newer.",
-			"Unable to write into remote user settings because the content of the file is newer.",
-			"Unable to write into workspace settings because the content of the file is newer.",
-			"Unable to write into folder settings because the content of the file is newer.",
-			"Unable to write to {0} because of an internal error.",
-			"User Settings",
-			"Remote User Settings",
-			"Workspace Settings",
-			"Folder Settings"
 		],
 		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
 			"Failed to save '{0}': {1}"
@@ -25782,11 +26017,6 @@
 			"Focus Title Bar",
 			"Command Center",
 			"Layout Controls"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
-			"Error: {0}",
-			"Warning: {0}",
-			"Info: {0}"
 		],
 		"vs/workbench/services/configurationResolver/common/variableResolver": [
 			"Variable {0} can not be resolved. Please open an editor.",
@@ -25836,40 +26066,14 @@
 		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
 			"Report Issue"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalProfileResolverService": [
-			"The terminal is using deprecated shell/shellArgs settings, do you want to migrate it to a profile?",
-			"Migrate"
-		],
 		"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote": [
 			"Create New Integrated Terminal (Local)"
-		],
-		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
-			"Restart pty host",
-			"The connection to the terminal's pty host process is unresponsive, the terminals may stop working."
 		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"Executes .NET Core build command",
 			"Executes the build target",
 			"Example to run an arbitrary external command",
 			"Executes common maven commands"
-		],
-		"vs/workbench/contrib/tasks/common/taskConfiguration": [
-			"Warning: options.cwd must be of type string. Ignoring value {0}\n",
-			"Error: command argument must either be a string or a quoted string. Provided value is:\n{0}",
-			"Warning: shell configuration is only supported when executing tasks in the terminal.",
-			"Error: Problem Matcher in declare scope must have a name:\n{0}\n",
-			"Warning: the defined problem matcher is unknown. Supported types are string | ProblemMatcher | Array<string | ProblemMatcher>.\n{0}\n",
-			"Error: Invalid problemMatcher reference: {0}\n",
-			"Error: tasks configuration must have a type property. The configuration will be ignored.\n{0}\n",
-			"Error: there is no registered task type '{0}'. Did you miss installing an extension that provides a corresponding task provider?",
-			"Error: the task configuration '{0}' is missing the required property 'type'. The task configuration will be ignored.",
-			"Error: the task configuration '{0}' is using an unknown type. The task configuration will be ignored.",
-			"Error: tasks is not declared as a custom task. The configuration will be ignored.\n{0}\n",
-			"Error: a task must provide a label property. The task will be ignored.\n{0}\n",
-			"Warning: {0} tasks are unavailable in the current environment.\n",
-			"Error: the task '{0}' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:\n{1}",
-			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
-			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
 		],
 		"vs/workbench/contrib/tasks/browser/taskQuickPick": [
 			"Show All Tasks...",
@@ -25889,6 +26093,30 @@
 			"Go back ↩",
 			"No {0} tasks found. Go back ↩",
 			"There is no task provider registered for tasks of type \"{0}\"."
+		],
+		"vs/workbench/contrib/tasks/common/taskConfiguration": [
+			"Warning: options.cwd must be of type string. Ignoring value {0}\n",
+			"Error: command argument must either be a string or a quoted string. Provided value is:\n{0}",
+			"Warning: shell configuration is only supported when executing tasks in the terminal.",
+			"Error: Problem Matcher in declare scope must have a name:\n{0}\n",
+			"Warning: the defined problem matcher is unknown. Supported types are string | ProblemMatcher | Array<string | ProblemMatcher>.\n{0}\n",
+			"Error: Invalid problemMatcher reference: {0}\n",
+			"Error: tasks configuration must have a type property. The configuration will be ignored.\n{0}\n",
+			"Error: there is no registered task type '{0}'. Did you miss installing an extension that provides a corresponding task provider?",
+			"Error: the task configuration '{0}' is missing the required property 'type'. The task configuration will be ignored.",
+			"Error: the task configuration '{0}' is using an unknown type. The task configuration will be ignored.",
+			"Error: tasks is not declared as a custom task. The configuration will be ignored.\n{0}\n",
+			"Error: a task must provide a label property. The task will be ignored.\n{0}\n",
+			"Warning: {0} tasks are unavailable in the current environment.\n",
+			"Error: the task '{0}' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:\n{1}",
+			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
+			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
+		],
+		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
+			"Pty Host Status",
+			"Pty Host",
+			"The connection to the terminal's pty host process is unresponsive, terminals may stop working. Click to manually restart the pty host.",
+			"Pty Host is unresponsive"
 		],
 		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
 			"Task is running",
@@ -25979,27 +26207,10 @@
 			"A single path to a shell executable or an array of paths that will be used as fallbacks when one fails.",
 			"A single path to a shell executable.",
 			"A set of terminal profile customizations for {0} which allows adding, removing or changing how terminals are launched. Profiles are made up of a mandatory path, optional arguments and other presentation options.\n\nTo override an existing profile use its profile name as the key, for example:\n\n{1}\n\n{2}Read more about configuring profiles{3}.",
-			"This is deprecated, the new recommended way to configure your default shell is by creating a terminal profile in {0} and setting its profile name as the default in {1}. This will currently take priority over the new profiles settings but that will change in the future.",
-			"This is deprecated, the new recommended way to configure your default shell is by creating a terminal profile in {0} and setting its profile name as the default in {1}. This will currently take priority over the new profiles settings but that will change in the future.",
-			"This is deprecated, the new recommended way to configure your default shell is by creating a terminal profile in {0} and setting its profile name as the default in {1}. This will currently take priority over the new profiles settings but that will change in the future.",
-			"This is deprecated, the new recommended way to configure your automation shell is by creating a terminal automation profile with {0}. This will currently take priority over the new automation profile settings but that will change in the future.",
-			"This is deprecated, the new recommended way to configure your automation shell is by creating a terminal automation profile with {0}. This will currently take priority over the new automation profile settings but that will change in the future.",
-			"This is deprecated, the new recommended way to configure your automation shell is by creating a terminal automation profile with {0}. This will currently take priority over the new automation profile settings but that will change in the future.",
 			"Integrated Terminal",
-			"A path that when set will override {0} and ignore {1} values for automation-related terminal usage like tasks and debug.",
-			"A path that when set will override {0} and ignore {1} values for automation-related terminal usage like tasks and debug.",
-			"A path that when set will override {0} and ignore {1} values for automation-related terminal usage like tasks and debug.",
-			"The terminal profile to use on Linux for automation-related terminal usage like tasks and debug. This setting will currently be ignored if {0} (now deprecated) is set.",
-			"The terminal profile to use on macOS for automation-related terminal usage like tasks and debug. This setting will currently be ignored if {0} (now deprecated) is set.",
+			"The terminal profile to use on Linux for automation-related terminal usage like tasks and debug.",
+			"The terminal profile to use on macOS for automation-related terminal usage like tasks and debug.",
 			"The terminal profile to use for automation-related terminal usage like tasks and debug. This setting will currently be ignored if {0} (now deprecated) is set.",
-			"The path of the shell that the terminal uses on Linux. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles).",
-			"The path of the shell that the terminal uses on macOS. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles).",
-			"The path of the shell that the terminal uses on Windows. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles).",
-			"The command line arguments to use when on the Linux terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles).",
-			"The command line arguments to use when on the macOS terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles).",
-			"The command line arguments to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles).",
-			"The command line arguments to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles).",
-			"The command line arguments in [command-line format](https://msdn.microsoft.com/en-au/08dfcab2-eb6e-49a4-80eb-87d4076c98c6) to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles).",
 			"A profile source that will auto detect the paths to the shell. Note that non-standard executable locations are not supported and must be created manually in a new profile.",
 			"The extension that contributed this profile.",
 			"The id of the extension terminal",
@@ -26016,9 +26227,9 @@
 			"Whether to show hovers for links in the terminal output.",
 			"A set of process names to ignore when using the {0} setting.",
 			"Integrated Terminal",
-			"The default profile used on Linux. This setting will currently be ignored if either {0} or {1} are set.",
-			"The default profile used on macOS. This setting will currently be ignored if either {0} or {1} are set.",
-			"The default profile used on Windows. This setting will currently be ignored if either {0} or {1} are set."
+			"The default terminal profile on Linux.",
+			"The default terminal profile on macOS.",
+			"The default terminal profile on Windows."
 		],
 		"vs/base/browser/ui/findinput/findInput": [
 			"input"
@@ -26029,6 +26240,34 @@
 			"Info: {0}",
 			"for history",
 			"Cleared Input"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"{0}, notification",
+			"{0}, source: {1}, notification",
+			"Notifications List"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsActions": [
+			"Icon for the clear action in notifications.",
+			"Icon for the clear all action in notifications.",
+			"Icon for the hide action in notifications.",
+			"Icon for the expand action in notifications.",
+			"Icon for the collapse action in notifications.",
+			"Icon for the configure action in notifications.",
+			"Icon for the mute all action in notifications.",
+			"Clear Notification",
+			"Clear All Notifications",
+			"Toggle Do Not Disturb Mode",
+			"Hide Notifications",
+			"Expand Notification",
+			"Collapse Notification",
+			"Configure Notification",
+			"Copy Text"
+		],
+		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
+			"More Actions..."
+		],
+		"vs/base/browser/ui/actionbar/actionViewItems": [
+			"{0} ({1})"
 		],
 		"vs/editor/browser/widget/diffReview": [
 			"Icon for 'Insert' in diff review.",
@@ -26043,9 +26282,7 @@
 			"{0} unchanged line {1}",
 			"{0} original line {1} modified line {2}",
 			"+ {0} modified line {1}",
-			"- {0} original line {1}",
-			"Go to Next Difference",
-			"Go to Previous Difference"
+			"- {0} original line {1}"
 		],
 		"vs/editor/browser/widget/inlineDiffMargin": [
 			"Copy deleted lines",
@@ -26092,13 +26329,14 @@
 			"Auto Fix...",
 			"No auto fixes available"
 		],
+		"vs/editor/contrib/codeAction/browser/codeActionController": [
+			"Hide Disabled",
+			"Show Disabled"
+		],
 		"vs/editor/contrib/codeAction/browser/lightBulbWidget": [
 			"Show Code Actions. Preferred Quick Fix Available ({0})",
 			"Show Code Actions ({0})",
 			"Show Code Actions"
-		],
-		"vs/base/browser/ui/actionbar/actionViewItems": [
-			"{0} ({1})"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
 			"Whether the paste widget is showing",
@@ -26130,6 +26368,7 @@
 			"Icon for 'Replace All' in the editor find widget.",
 			"Icon for 'Find Previous' in the editor find widget.",
 			"Icon for 'Find Next' in the editor find widget.",
+			"Find / Replace",
 			"Find",
 			"Find",
 			"Previous Match",
@@ -26164,9 +26403,6 @@
 			"Made 1 formatting edit between lines {0} and {1}",
 			"Made {0} formatting edits between lines {1} and {2}"
 		],
-		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
-			"Suggestion:"
-		],
 		"vs/editor/contrib/inlineCompletions/browser/commands": [
 			"Show Next Inline Suggestion",
 			"Show Previous Inline Suggestion",
@@ -26180,15 +26416,13 @@
 			"Hide Inline Suggestion",
 			"Always Show Toolbar"
 		],
+		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
+			"Suggestion:"
+		],
 		"vs/editor/contrib/gotoSymbol/browser/peek/referencesController": [
 			"Whether reference peek is visible, like 'Peek References' or 'Peek Definition'",
 			"Loading...",
 			"{0} ({1})"
-		],
-		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
-			"Whether there are symbol locations that can be navigated via keyboard-only.",
-			"Symbol {0} of {1}, {2} for next",
-			"Symbol {0} of {1}"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/referencesModel": [
 			"in {0} on line {1} at column {2}",
@@ -26199,6 +26433,11 @@
 			"Found 1 symbol in {0}",
 			"Found {0} symbols in {1}",
 			"Found {0} symbols in {1} files"
+		],
+		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
+			"Whether there are symbol locations that can be navigated via keyboard-only.",
+			"Symbol {0} of {1}, {2} for next",
+			"Symbol {0} of {1}"
 		],
 		"vs/editor/contrib/message/browser/messageController": [
 			"Whether the editor is currently showing an inline message"
@@ -26218,10 +26457,6 @@
 			"Editor marker navigation widget info color.",
 			"Editor marker navigation widget info heading background.",
 			"Editor marker navigation widget background."
-		],
-		"vs/editor/contrib/codeAction/browser/codeActionController": [
-			"Hide Disabled",
-			"Show Disabled"
 		],
 		"vs/editor/contrib/hover/browser/markdownHoverParticipant": [
 			"Loading...",
@@ -26304,12 +26539,6 @@
 			"{0}, {1}",
 			"{0}, docs: {1}"
 		],
-		"vs/workbench/api/browser/mainThreadWebviews": [
-			"An error occurred while loading view: {0}"
-		],
-		"vs/workbench/browser/parts/editor/textEditor": [
-			"Editor"
-		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
 			"Colors and styles for the token.",
 			"Foreground color for the token.",
@@ -26352,7 +26581,13 @@
 			"Style to use for symbols that are deprecated.",
 			"Style to use for write accesses.",
 			"Style to use for symbols that are async.",
-			"Style to use for symbols that are readonly."
+			"Style to use for symbols that are read-only."
+		],
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"An error occurred while loading view: {0}"
+		],
+		"vs/workbench/browser/parts/editor/textEditor": [
+			"Editor"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalEditorInput": [
 			"Do you want to terminate running processes?",
@@ -26386,9 +26621,6 @@
 			"[Ln {0}-{1}]",
 			"Last reply from {0}"
 		],
-		"vs/workbench/contrib/notebook/common/notebookEditorModel": [
-			"Notebook '{0}' could not be saved."
-		],
 		"vs/workbench/contrib/testing/common/testResult": [
 			"Test run at {0}"
 		],
@@ -26411,25 +26643,6 @@
 		"vs/workbench/browser/parts/views/checkbox": [
 			"Checked",
 			"Unchecked"
-		],
-		"vs/workbench/contrib/remote/browser/remoteIcons": [
-			"Getting started icon in the remote explorer view.",
-			"Documentation icon in the remote explorer view.",
-			"Feedback icon in the remote explorer view.",
-			"Review issue icon in the remote explorer view.",
-			"Report issue icon in the remote explorer view.",
-			"View icon of the remote explorer view.",
-			"View icon of the remote ports view.",
-			"Icon representing a remote port.",
-			"Icon representing a private remote port.",
-			"Icon for the forward action.",
-			"Icon for the stop forwarding action.",
-			"Icon for the open browser action.",
-			"Icon for the open preview action.",
-			"Icon for the copy local address action.",
-			"Icon for the label port action.",
-			"Icon for forwarded ports that don't have a running process.",
-			"Icon for forwarded ports that do have a running process."
 		],
 		"vs/base/browser/ui/splitview/paneview": [
 			"{0} Section"
@@ -26495,6 +26708,36 @@
 			"Change Port Protocol",
 			"The color of the icon for a port that has an associated running process."
 		],
+		"vs/workbench/contrib/remote/browser/remoteIcons": [
+			"Getting started icon in the remote explorer view.",
+			"Documentation icon in the remote explorer view.",
+			"Feedback icon in the remote explorer view.",
+			"Review issue icon in the remote explorer view.",
+			"Report issue icon in the remote explorer view.",
+			"View icon of the remote explorer view.",
+			"View icon of the remote ports view.",
+			"Icon representing a remote port.",
+			"Icon representing a private remote port.",
+			"Icon for the forward action.",
+			"Icon for the stop forwarding action.",
+			"Icon for the open browser action.",
+			"Icon for the open preview action.",
+			"Icon for the copy local address action.",
+			"Icon for the label port action.",
+			"Icon for forwarded ports that don't have a running process.",
+			"Icon for forwarded ports that do have a running process."
+		],
+		"vs/workbench/browser/parts/editor/textCodeEditor": [
+			"Text Editor"
+		],
+		"vs/workbench/browser/parts/editor/binaryEditor": [
+			"Binary Viewer",
+			"The file is not displayed in the text editor because it is either binary or uses an unsupported text encoding.",
+			"Open Anyway"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/colors": [
+			"The border color for text that got moved in the diff editor."
+		],
 		"vs/workbench/browser/parts/editor/editorPanes": [
 			"Unable to open '{0}'",
 			"&&OK"
@@ -26515,17 +26758,6 @@
 			"Start Debugging",
 			"Toggle Full Screen",
 			"Show Settings"
-		],
-		"vs/workbench/browser/parts/editor/textCodeEditor": [
-			"Text Editor"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2": [
-			" use Shift + F7 to navigate changes"
-		],
-		"vs/workbench/browser/parts/editor/binaryEditor": [
-			"Binary Viewer",
-			"The file is not displayed in the text editor because it is either binary or uses an unsupported text encoding.",
-			"Open Anyway"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
 			"Loading...",
@@ -26562,13 +26794,13 @@
 			"Installing Update...",
 			"Restart to &&Update"
 		],
-		"vs/base/browser/ui/toolbar/toolbar": [
-			"More Actions..."
-		],
 		"vs/workbench/browser/parts/compositePart": [
 			"{0} actions",
 			"Views and More Actions...",
 			"{0} ({1})"
+		],
+		"vs/base/browser/ui/toolbar/toolbar": [
+			"More Actions..."
 		],
 		"vs/workbench/browser/parts/sidebar/sidebarActions": [
 			"Focus into Primary Side Bar"
@@ -26615,6 +26847,9 @@
 			"Incorrect type. Expected an object.",
 			"Property {0} is not allowed.\n"
 		],
+		"vs/editor/common/model/editStack": [
+			"Typing"
+		],
 		"vs/platform/quickinput/browser/quickInput": [
 			"Back",
 			"Press 'Enter' to confirm your input or 'Escape' to cancel",
@@ -26640,8 +26875,17 @@
 			"Defines which scope names contain balanced brackets.",
 			"Defines which scope names do not contain balanced brackets."
 		],
-		"vs/editor/common/model/editStack": [
-			"Typing"
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"User",
+			"Remote",
+			"Workspace",
+			"Folder",
+			"Settings Switcher",
+			"User",
+			"Remote",
+			"Workspace",
+			"User",
+			"Workspace"
 		],
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"Unbound"
@@ -26686,15 +26930,6 @@
 			"Manage Workspace Trust",
 			"Unsupported Property"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
-			"User",
-			"Remote",
-			"Workspace",
-			"Folder",
-			"Settings Switcher",
-			"Workspace",
-			"User"
-		],
 		"vs/workbench/contrib/preferences/browser/settingsLayout": [
 			"Commonly Used",
 			"Text Editor",
@@ -26733,7 +26968,7 @@
 			"Notebook",
 			"Audio Cues",
 			"Merge Editor",
-			"Interactive Session",
+			"Chat",
 			"Application",
 			"Proxy",
 			"Keyboard",
@@ -26748,22 +26983,6 @@
 		"vs/workbench/contrib/preferences/browser/tocTree": [
 			"Settings Table of Contents",
 			"{0}, group"
-		],
-		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
-			"Modified",
-			"Add or remove modified settings filter",
-			"Extension ID...",
-			"Add extension ID filter",
-			"Feature...",
-			"Add feature filter",
-			"Tag...",
-			"Add tag filter",
-			"Language...",
-			"Add language ID filter",
-			"Online services",
-			"Show settings for online services",
-			"Policy services",
-			"Show settings for policy services"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsTree": [
 			"Extensions",
@@ -26783,6 +27002,26 @@
 			"Copy Setting ID",
 			"Copy Setting as JSON",
 			"Sync This Setting"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
+			"Modified",
+			"Add or remove modified settings filter",
+			"Extension ID...",
+			"Add extension ID filter",
+			"Feature...",
+			"Add feature filter",
+			"Tag...",
+			"Add tag filter",
+			"Language...",
+			"Add language ID filter",
+			"Online services",
+			"Show settings for online services",
+			"Policy services",
+			"Show settings for policy services"
+		],
+		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView": [
+			"Select Notebook Kernel",
+			"Notebook Kernel Args"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookExtensionPoint": [
 			"Contributes notebook document provider.",
@@ -26840,37 +27079,22 @@
 			"Cell editor background color.",
 			"Notebook background color."
 		],
-		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView": [
-			"Select Notebook Kernel",
-			"Notebook Kernel Args"
-		],
-		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
-			"File Created",
-			"File Replaced",
-			"File Working Copy Decorations",
-			"Deleted, Read Only",
-			"Read Only",
-			"Deleted",
-			"'{0}' already exists. Do you want to replace it?",
-			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
-			"&&Replace"
-		],
-		"vs/workbench/contrib/comments/common/commentContextKeys": [
-			"Set when the comment thread has no comments",
-			"Set when the comment has no input",
-			"The context value of the comment",
-			"The context value of the comment thread",
-			"The comment controller id associated with a comment thread"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/cellOperations": [
-			"Cannot join cells of different kinds",
-			"Join Notebook Cells"
-		],
 		"vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView": [
 			"Empty markdown cell, double-click or press enter to edit.",
 			"No renderer found for '$0'",
 			"Could not render content for '$0'",
 			"Notebook webview content"
+		],
+		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
+			"File Created",
+			"File Replaced",
+			"File Working Copy Decorations",
+			"Deleted, Read-only",
+			"Read-only",
+			"Deleted",
+			"'{0}' already exists. Do you want to replace it?",
+			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
+			"&&Replace"
 		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy": [
 			"Currently Selected",
@@ -26890,47 +27114,49 @@
 			"Detecting Kernels",
 			"Select Kernel"
 		],
-		"vs/editor/contrib/codeAction/browser/codeAction": [
-			"An unknown error occurred while applying the code action"
+		"vs/workbench/contrib/comments/common/commentContextKeys": [
+			"Set when the comment thread has no comments",
+			"Set when the comment has no input",
+			"The context value of the comment",
+			"The context value of the comment thread",
+			"The comment controller id associated with a comment thread"
 		],
-		"vs/workbench/contrib/chat/common/chatContextKeys": [
-			"True when the provider has assigned an id to this response.",
-			"When the response has been voted up, is set to 'up'. When voted down, is set to 'down'. Otherwise an empty string.",
-			"True when the current request is still in progress.",
-			"The chat item is a response.",
-			"The chat item is a request",
-			"True when the chat input has text.",
-			"True when focus is in the chat input, false otherwise.",
-			"True when focus is in the chat widget, false otherwise.",
-			"True when some chat provider has been registered."
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
-			"Exit this menu and return to the input via the Escape key.",
-			"Chat responses will be announced as they come in. A response will indicate the number of code blocks, if any, and then the rest of the response.",
-			"In the input box, use UpArrow/DownArrow to navigate your request history. Edit input and use enter to run a new request.",
-			"The Focus Chat command ({0}) focuses the chat request/response list, which can be navigated with UpArrow/DownArrow.",
-			"The Focus Chat List command focuses the chat request/response list, which can be navigated with UpArrow/DownArrow and is currently not triggerable by a keybinding.",
-			"The Focus Chat Input command ({0}) focuses the input box for chat requests.",
-			"Focus Chat Input command focuses the input box for chat requests and is currently not triggerable by a keybinding.",
-			"The Chat: Next Code Block command ({0}) focuses the next code block within a response.",
-			"The Chat: Next Code Block command focuses the next code block within a response and is currently not triggerable by a keybinding.",
-			"The Chat Clear command ({0}) clears the request/response list.",
-			"The Chat Clear command clears the request/response list and is currently not triggerable by a keybinding.",
-			"Tab once to reach the make request button, which will re-run the request.",
-			"Tab again to enter the Diff editor with the changes and enter review mode with ({0}). Use Up/DownArrow to navigate lines with the proposed changes.",
-			"Tab again to enter the Diff editor with the changes and enter review mode with the Go to Next Difference Command. Use Up/DownArrow to navigate lines with the proposed changes.",
-			"Tab again to reach the action bar, which can be navigated with Left/RightArrow.",
-			"/explain commands will be run in the chat view.",
-			"To focus the chat view, run the GitHub Copilot: Focus on GitHub Copilot View command, which will focus the input box.",
-			"Use tab to reach conditional parts like commands, status message, message responses and more."
+		"vs/workbench/contrib/notebook/browser/controller/cellOperations": [
+			"Cannot join cells of different kinds",
+			"Join Notebook Cells"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget": [
 			"{0} found",
 			"{0} found for '{1}'",
 			"{0} found for '{1}'"
 		],
-		"vs/workbench/contrib/chat/common/chatViewModel": [
-			"Thinking"
+		"vs/editor/contrib/codeAction/browser/codeAction": [
+			"An unknown error occurred while applying the code action"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
+			"The chat view is comprised of an input box and a request/response list. The input box is used to make requests and the list is used to display responses.",
+			"In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.",
+			"Chat responses will be announced as they come in. A response will indicate the number of code blocks, if any, and then the rest of the response.",
+			"To focus the chat request/response list, which can be navigated with up and down arrows, invoke The Focus Chat command ({0}).",
+			"To focus the chat request/response list, which can be navigated with up and down arrows, invoke The Focus Chat List command, which is currently not triggerable by a keybinding.",
+			"To focus the input box for chat requests, invoke the Focus Chat Input command ({0})",
+			"To focus the input box for chat requests, invoke the Focus Chat Input command, which is currently not triggerable by a keybinding.",
+			"To focus the next code block within a response, invoke the Chat: Next Code Block command ({0}).",
+			"To focus the next code block within a response, invoke the Chat: Next Code Block command, which is currently not triggerable by a keybinding.",
+			"To clear the request/response list, invoke the Chat Clear command ({0}).",
+			"To clear the request/response list, invoke the Chat Clear command, which is currently not triggerable by a keybinding.",
+			"Inline chat occurs within a code editor and takes into account the current selection. It is useful for making changes to the current editor. For example, fixing diagnostics, documenting or refactoring code. Keep in mind that AI generated code may be incorrect.",
+			"It can be activated via code actions or directly using the command: Inline Chat: Start Code Chat ({0}).",
+			"In the input box, use {0} and {1} to navigate your request history. Edit input and use enter or the submit button to run a new request.",
+			"Context menu actions may run a request prefixed with /fix or /explain. Type / to discover more ready-made commands.",
+			"When a request is prefixed with /fix, a response will indicate the problem with the current code. A diff editor will be rendered and can be reached by tabbing.",
+			"Once in the diff editor, enter review mode with ({0}). Use up and down arrows to navigate lines with the proposed changes.",
+			"Tab again to enter the Diff editor with the changes and enter review mode with the Go to Next Difference Command. Use Up/DownArrow to navigate lines with the proposed changes.",
+			"When a request is prefixed with /explain, a response will explain the code in the current selection and the chat view will be focused.",
+			"Use tab to reach conditional parts like commands, status, message responses and more.",
+			"Audio cues can be changed via settings with a prefix of audioCues.chat. By default, if a request takes more than 4 seconds, you will hear an audio cue indicating that progress is still occurring.",
+			"Chat accessibility help",
+			"Inline chat accessibility help"
 		],
 		"vs/workbench/contrib/chat/browser/chatListRenderer": [
 			"Chat",
@@ -26942,9 +27168,22 @@
 			"Code block {0}"
 		],
 		"vs/workbench/contrib/chat/browser/chatInputPart": [
-			"Chat Input,  Type code here and press enter to run. Use {0} for Chat Accessibility Help.",
+			"Chat Input,  Type to ask questions or type / for topics, press enter to send out the request. Use {0} for Chat Accessibility Help.",
 			"Chat Input,  Type code here and press Enter to run. Use the Chat Accessibility Help command for more information.",
 			"Chat Input"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
+			"Nothing changed",
+			"Changed 1 line",
+			"Changed {0} lines"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
+			"Inline Chat Input",
+			"Original",
+			"Modified",
+			"Inline Chat Input, Use {0} for Inline Chat Accessibility Help.",
+			"Inline Chat Input, Run the Inline Chat Accessibility Help command for more information.",
+			"Closed inline chat widget"
 		],
 		"vs/workbench/contrib/testing/browser/theme": [
 			"Color for the 'failed' icon in the test explorer.",
@@ -26986,17 +27225,35 @@
 			"Show Hidden Tests",
 			"Unhide All Tests"
 		],
-		"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies": [
-			"Nothing changed",
-			"Changed 1 line",
-			"Changed {0} lines"
+		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
+			"The terminal has no selection to copy",
+			"Yes",
+			"No",
+			"Don't Show Again",
+			"Terminal GPU acceleration appears to be slow on your computer. Would you like to switch to disable it which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered)."
 		],
-		"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget": [
-			"Interactive Editor Input",
-			"Original",
-			"Modified",
-			"Interactive Editor Input, Use {0} for Interactive Editor Accessibility Help.",
-			"Interactive Editor Input, Run the Interactive Editor Accessibility Help command for more information."
+		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
+			"The background color of the terminal, this allows coloring the terminal differently to the panel.",
+			"The foreground color of the terminal.",
+			"The foreground color of the terminal cursor.",
+			"The background color of the terminal cursor. Allows customizing the color of a character overlapped by a block cursor.",
+			"The selection background color of the terminal.",
+			"The selection background color of the terminal when it does not have focus.",
+			"The selection foreground color of the terminal. When this is null the selection foreground will be retained and have the minimum contrast ratio feature applied.",
+			"The default terminal command decoration background color.",
+			"The terminal command decoration background color for successful commands.",
+			"The terminal command decoration background color for error commands.",
+			"The overview ruler cursor color.",
+			"The color of the border that separates split panes within the terminal. This defaults to panel.border.",
+			"Color of the current search match in the terminal. The color must not be opaque so as not to hide underlying terminal content.",
+			"Border color of the other search matches in the terminal.",
+			"Border color of the current search match in the terminal.",
+			"Color of the other search matches in the terminal. The color must not be opaque so as not to hide underlying terminal content.",
+			"Border color of the other search matches in the terminal.",
+			"Overview ruler marker color for find matches in the terminal.",
+			"Background color when dragging on top of terminals. The color should have transparency so that the terminal contents can still shine through.",
+			"Border on the side of the terminal tab in the panel. This defaults to tab.activeBorder.",
+			"'{0}' ANSI color in the terminal."
 		],
 		"vs/platform/quickinput/browser/commandsQuickAccess": [
 			"recently used",
@@ -27080,10 +27337,6 @@
 			"(deleting)",
 			"{0} - {1}"
 		],
-		"vs/workbench/contrib/search/browser/replaceService": [
-			"Search and Replace",
-			"{0} ↔ {1} (Replace Preview)"
-		],
 		"vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess": [
 			"To go to a symbol, first open a text editor with symbol information.",
 			"The active text editor does not provide symbol information.",
@@ -27118,6 +27371,10 @@
 			"keys ({0})",
 			"fields ({0})",
 			"constants ({0})"
+		],
+		"vs/workbench/contrib/search/browser/replaceService": [
+			"Search and Replace",
+			"{0} ↔ {1} (Replace Preview)"
 		],
 		"vs/workbench/contrib/search/browser/searchFindInput": [
 			"Notebook Find Filters"
@@ -27166,6 +27423,13 @@
 			"Install an extension for {0}...",
 			"Install extension...",
 			"Select debugger"
+		],
+		"vs/workbench/contrib/debug/browser/debugConfigurationManager": [
+			"Edit Debug Configuration in launch.json",
+			"Select Launch Configuration",
+			"Unable to create 'launch.json' file inside the '.vscode' folder ({0}).",
+			"workspace",
+			"user settings"
 		],
 		"vs/workbench/contrib/debug/browser/debugTaskRunner": [
 			"Errors exist after running preLaunchTask '{0}'.",
@@ -27228,9 +27492,6 @@
 		"vs/workbench/contrib/debug/common/debugSource": [
 			"Unknown Source"
 		],
-		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
-			"More Actions..."
-		],
 		"vs/base/browser/ui/findinput/replaceInput": [
 			"input",
 			"Preserve Case"
@@ -27247,6 +27508,16 @@
 			"Message",
 			"File",
 			"Source"
+		],
+		"vs/workbench/contrib/mergeEditor/common/mergeEditor": [
+			"The editor is a merge editor",
+			"The editor is a the result editor of a merge editor.",
+			"The layout mode of a merge editor",
+			"If the merge editor shows the base version",
+			"If base should be shown at the top",
+			"If the merge editor shows non-conflicting changes",
+			"The uri of the baser of a merge editor",
+			"The uri of the result of a merge editor"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInputModel": [
 			"Do you want keep the merge result of {0} files?",
@@ -27279,18 +27550,33 @@
 			"&&Close",
 			"Don't ask again"
 		],
-		"vs/workbench/contrib/mergeEditor/common/mergeEditor": [
-			"The editor is a merge editor",
-			"The editor is a the result editor of a merge editor.",
-			"The layout mode of a merge editor",
-			"If the merge editor shows the base version",
-			"If base should be shown at the top",
-			"If the merge editor shows non-conflicting changes",
-			"The uri of the baser of a merge editor",
-			"The uri of the result of a merge editor"
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
+			"Base",
+			"Comparing with {0}",
+			"Differences are highlighted with a background color."
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/viewModel": [
 			"There is currently no conflict focused that can be toggled."
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
+			"Result",
+			"{0} Conflict Remaining",
+			"{0} Conflicts Remaining ",
+			"Go to next conflict",
+			"All conflicts handled, the merge can be completed now."
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView": [
+			"Input 1",
+			"Input 2",
+			"Accept {0}",
+			"Accept {0}",
+			"Accept Both",
+			"Swap",
+			"Mark as Handled",
+			"Accept",
+			"Accept (result is dirty)",
+			"Undo accept",
+			"Undo accept (currently second)"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/colors": [
 			"The background color for changes.",
@@ -27307,49 +27593,16 @@
 			"The background color of decorations in input 1.",
 			"The background color of decorations in input 2."
 		],
-		"vs/workbench/contrib/debug/browser/debugConfigurationManager": [
-			"Edit Debug Configuration in launch.json",
-			"Select Launch Configuration",
-			"Unable to create 'launch.json' file inside the '.vscode' folder ({0}).",
-			"workspace",
-			"user settings"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView": [
-			"Input 1",
-			"Input 2",
-			"Accept {0}",
-			"Accept {0}",
-			"Accept Both",
-			"Swap",
-			"Mark as Handled",
-			"Accept",
-			"Accept (result is dirty)",
-			"Undo accept",
-			"Undo accept (currently second)"
-		],
 		"vs/workbench/contrib/comments/browser/commentsController": [
 			"Whether the position at the active cursor has a commenting range",
 			"Select Comment Provider"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
-			"Result",
-			"{0} Conflict Remaining",
-			"{0} Conflicts Remaining ",
-			"Go to next conflict",
-			"All conflicts handled, the merge can be completed now."
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
-			"Base",
-			"Comparing with {0}",
-			"Differences are highlighted with a background color."
-		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
 			"Built-in"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
-			"Error",
-			"Unknown Extension:",
-			"Extensions"
+		"vs/platform/files/browser/htmlFileSystemProvider": [
+			"Rename is only supported for files.",
+			"Insufficient permissions. Please retry and allow the operation."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"Average rating: {0} out of 5",
@@ -27377,6 +27630,11 @@
 			"The icon color for pre-release extension.",
 			"The icon color for extension sponsor."
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
+			"Error",
+			"Unknown Extension:",
+			"Extensions"
+		],
 		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
 			"This extension is recommended because you have {0} installed."
 		],
@@ -27396,38 +27654,80 @@
 		"vs/workbench/contrib/extensions/browser/webRecommendations": [
 			"This extension is recommended for {0} for the Web"
 		],
-		"vs/platform/files/browser/htmlFileSystemProvider": [
-			"Rename is only supported for files.",
-			"Insufficient permissions. Please retry and allow the operation."
+		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
+			"Additional command options",
+			"The current working directory of the executed program or script. If omitted Code's current workspace root is used.",
+			"The environment of the executed program or shell. If omitted the parent process' environment is used.",
+			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
+			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
+			"Configures the shell to be used.",
+			"The shell to be used.",
+			"The shell arguments.",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Arguments passed to the command when this task is invoked.",
+			"The task's name",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Arguments passed to the command when this task is invoked.",
+			"Windows specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Mac specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Linux specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Controls whether the task name is added as an argument to the command. If omitted the globally defined value is used.",
+			"Controls whether the output of the running task is shown or not. If omitted the globally defined value is used.",
+			"Controls whether the executed command is echoed to the output. Default is false.",
+			"Deprecated. Use isBackground instead.",
+			"Whether the executed task is kept alive and is watching the file system.",
+			"Whether the executed task is kept alive and is running in the background.",
+			"Whether the user is prompted when VS Code closes with a running task.",
+			"Maps this task to Code's default build command.",
+			"Maps this task to Code's default test command.",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Additional arguments passed to the command.",
+			"Controls whether the output of the running task is shown or not. If omitted 'always' is used.",
+			"Deprecated. Use isBackground instead.",
+			"Whether the executed task is kept alive and is watching the file system.",
+			"Whether the executed task is kept alive and is running in the background.",
+			"Whether the user is prompted when VS Code closes with a running background task.",
+			"Controls whether the executed command is echoed to the output. Default is false.",
+			"Controls whether the task name is added as an argument to the command. Default is false.",
+			"Prefix to indicate that an argument is task.",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"The task configurations. Usually these are enrichments of task already defined in the external task runner."
 		],
-		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
-			"The background color of the terminal, this allows coloring the terminal differently to the panel.",
-			"The foreground color of the terminal.",
-			"The foreground color of the terminal cursor.",
-			"The background color of the terminal cursor. Allows customizing the color of a character overlapped by a block cursor.",
-			"The selection background color of the terminal.",
-			"The selection background color of the terminal when it does not have focus.",
-			"The selection foreground color of the terminal. When this is null the selection foreground will be retained and have the minimum contrast ratio feature applied.",
-			"The default terminal command decoration background color.",
-			"The terminal command decoration background color for successful commands.",
-			"The terminal command decoration background color for error commands.",
-			"The overview ruler cursor color.",
-			"The color of the border that separates split panes within the terminal. This defaults to panel.border.",
-			"Color of the current search match in the terminal. The color must not be opaque so as not to hide underlying terminal content.",
-			"Border color of the other search matches in the terminal.",
-			"Border color of the current search match in the terminal.",
-			"Color of the other search matches in the terminal. The color must not be opaque so as not to hide underlying terminal content.",
-			"Border color of the other search matches in the terminal.",
-			"Overview ruler marker color for find matches in the terminal.",
-			"Background color when dragging on top of terminals. The color should have transparency so that the terminal contents can still shine through.",
-			"Border on the side of the terminal tab in the panel. This defaults to tab.activeBorder.",
-			"'{0}' ANSI color in the terminal."
+		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
+			"'env.', 'config.' and 'command.' are deprecated, use 'env:', 'config:' and 'command:' instead."
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
+			"The input's id is used to associate an input with a variable of the form ${input:id}.",
+			"The type of user input prompt to use.",
+			"The description is shown when the user is prompted for input.",
+			"The default value for the input.",
+			"User inputs. Used for defining user input prompts, such as free string input or a choice from several options.",
+			"The 'promptString' type opens an input box to ask the user for input.",
+			"Controls if a password input is shown. Password input hides the typed text.",
+			"The 'pickString' type shows a selection list.",
+			"An array of strings that defines the options for a quick pick.",
+			"Label for the option.",
+			"Value for the option.",
+			"The 'command' type executes a command.",
+			"The command to execute for this input variable.",
+			"Optional arguments passed to the command.",
+			"Optional arguments passed to the command.",
+			"Optional arguments passed to the command."
+		],
+		"vs/workbench/contrib/remote/browser/explorerViewItems": [
+			"Switch Remote",
+			"Switch Remote"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
 			"Show Tabs",
 			"Select current working directory for new terminal",
 			"Open Help",
 			"Create New Terminal (In Active Workspace)",
+			"Create New Terminal in Editor Area",
 			"Create New Terminal in Editor Area",
 			"Create New Terminal in Editor Area to the Side",
 			"Show Tabs",
@@ -27463,7 +27763,6 @@
 			"Select To Next Command",
 			"Select To Previous Line",
 			"Select To Next Line",
-			"Toggle Escape Sequence Logging",
 			"The sequence of text to send to the terminal",
 			"The directory to start the terminal at",
 			"The new name for the terminal",
@@ -27516,44 +27815,6 @@
 			"Create New Terminal",
 			"Create New Terminal With Profile",
 			"Rename Terminal"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalIcons": [
-			"View icon of the terminal view.",
-			"Icon for rename in the terminal quick menu.",
-			"Icon for killing a terminal instance.",
-			"Icon for creating a new terminal instance.",
-			"Icon for creating a new terminal profile.",
-			"Icon for a terminal decoration mark.",
-			"Icon for a terminal decoration of a command that was incomplete.",
-			"Icon for a terminal decoration of a command that errored.",
-			"Icon for a terminal decoration of a command that was successful.",
-			"Icon for removing a terminal command from command history.",
-			"Icon for viewing output of a terminal command.",
-			"Icon for toggling fuzzy search of command history."
-		],
-		"vs/workbench/contrib/terminal/common/terminalStrings": [
-			"Terminal",
-			"New Terminal",
-			"Do Not Show Again",
-			"current session",
-			"previous session",
-			"Terminal",
-			"Focus Terminal",
-			"Kill Terminal",
-			"Kill",
-			"Move Terminal into Editor Area",
-			"Move Terminal into Panel",
-			"Change Icon...",
-			"Change Color...",
-			"Split Terminal",
-			"Split",
-			"Unsplit Terminal",
-			"Rename...",
-			"Toggle Size to Content Width",
-			"Focus Hover",
-			"Send Custom Sequence To Terminal",
-			"Create New Terminal Starting in a Custom Working Directory",
-			"Rename the Currently Active Terminal"
 		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
 			"the terminal's current working directory",
@@ -27697,7 +27958,21 @@
 			"Controls the number of recently used commands to keep in the terminal command history. Set to 0 to disable terminal command history.",
 			"Enables experimental terminal Intellisense suggestions for supported shells when {0} is set to {1}. If shell integration is installed manually, {2} needs to be set to {3} before calling the script.",
 			"Controls whether the terminal will scroll using an animation.",
-			"Enables experimental image support in the terminal. Both sixel and iTerm's inline image protocol are supported on Linux and macOS, Windows support will light up automatically when ConPTY passes through the sequences. Images will not be retained currently between window reloads/reconnects."
+			"Enables image support in the terminal, this will only work when {0} is enabled. Both sixel and iTerm's inline image protocol are supported on Linux and macOS, Windows support will light up automatically when ConPTY passes through the sequences. Images will currently not be restored between window reloads/reconnects."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalIcons": [
+			"View icon of the terminal view.",
+			"Icon for rename in the terminal quick menu.",
+			"Icon for killing a terminal instance.",
+			"Icon for creating a new terminal instance.",
+			"Icon for creating a new terminal profile.",
+			"Icon for a terminal decoration mark.",
+			"Icon for a terminal decoration of a command that was incomplete.",
+			"Icon for a terminal decoration of a command that errored.",
+			"Icon for a terminal decoration of a command that was successful.",
+			"Icon for removing a terminal command from command history.",
+			"Icon for viewing output of a terminal command.",
+			"Icon for toggling fuzzy search of command history."
 		],
 		"vs/workbench/contrib/terminal/browser/terminalMenus": [
 			"&&New Terminal",
@@ -27735,10 +28010,32 @@
 			"{0} (Default)",
 			"Split Terminal"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
-			"Move Tabs Right",
-			"Move Tabs Left",
-			"Hide Tabs"
+		"vs/workbench/contrib/terminal/common/terminalStrings": [
+			"Terminal",
+			"New Terminal",
+			"Do Not Show Again",
+			"current session",
+			"previous session",
+			"Terminal",
+			"Focus Terminal",
+			"Kill Terminal",
+			"Kill",
+			"Move Terminal into Editor Area",
+			"Move Terminal into Panel",
+			"Change Icon...",
+			"Change Color...",
+			"Split Terminal",
+			"Split",
+			"Unsplit Terminal",
+			"Rename...",
+			"Toggle Size to Content Width",
+			"Focus Hover",
+			"Send Custom Sequence To Terminal",
+			"Create New Terminal Starting in a Custom Working Directory",
+			"Rename the Currently Active Terminal"
+		],
+		"vs/platform/terminal/common/terminalLogService": [
+			"Terminal"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
 			"Shell integration activated",
@@ -27747,12 +28044,13 @@
 			"Process ID ({0}): {1}",
 			"Command line: {0}"
 		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer": [
-			"Terminal buffer",
-			"{0}"
+		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
+			"Move Tabs Right",
+			"Move Tabs Left",
+			"Hide Tabs"
 		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
-			"Terminal accessibility help",
+			"terminal accessibility help",
 			"The Focus Accessible Buffer ({0}) command enables screen readers to read terminal contents.",
 			"The Focus Accessible Buffer command enables screen readers to read terminal contents and is currently not triggerable by a keybinding.",
 			"Consider using powershell instead of command prompt for an improved experience",
@@ -27773,17 +28071,27 @@
 			"The Open Detected Link command enables screen readers to easily open links found in the terminal and is currently not triggerable by a keybinding.",
 			"The Create New Terminal (With Profile) ({0}) command allows for easy terminal creation using a specific profile.",
 			"The Create New Terminal (With Profile) command allows for easy terminal creation using a specific profile and is currently not triggerable by a keybinding.",
-			"Access accessibility settings such as `terminal.integrated.tabFocusMode` via the Preferences: Open Accessibility Settings command.",
-			"[Read more about terminal accessibility](https://code.visualstudio.com/docs/editor/accessibility#_terminal-accessibility)",
-			"You can dismiss this dialog by pressing Escape, tab, or focusing elsewhere.",
-			"Welcome to Terminal Accessibility Help"
+			"Access accessibility settings such as `terminal.integrated.tabFocusMode` via the Preferences: Open Accessibility Settings command."
 		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick": [
-			"Select the link to open",
-			"Url",
-			"Local File",
-			"Workspace Search",
-			"Show more links"
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer": [
+			"Terminal buffer",
+			"{0}"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
+			"Free port {0}",
+			"Create PR {0}"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
+			"Run: {0}",
+			"Open: {0}",
+			"Quick Fix"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
+			"Contributes terminal quick fixes.",
+			"The ID of the quick fix provider",
+			"A regular expression or string to test the command line against",
+			"A regular expression or string to match a single line of the output against, which provides groups to be referenced in terminalCommand and uri.\n\nFor example:\n\n `lineMatcher: /git push --set-upstream origin (?<branchName>[^s]+)/;`\n\n`terminalCommand: 'git push --set-upstream origin ${group:branchName}';`\n",
+			"The command exit result to match on"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
 			"option + click",
@@ -27794,89 +28102,24 @@
 			"Follow link using forwarded port",
 			"Link"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
-			"Contributes terminal quick fixes.",
-			"The ID of the quick fix provider",
-			"A regular expression or string to test the command line against",
-			"A regular expression or string to match a single line of the output against, which provides groups to be referenced in terminalCommand and uri.\n\nFor example:\n\n `lineMatcher: /git push --set-upstream origin (?<branchName>[^s]+)/;`\n\n`terminalCommand: 'git push --set-upstream origin ${group:branchName}';`\n",
-			"The command exit result to match on"
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick": [
+			"Select the link to open",
+			"Url",
+			"Local File",
+			"Workspace Search",
+			"Show more links"
 		],
-		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
-			"Additional command options",
-			"The current working directory of the executed program or script. If omitted Code's current workspace root is used.",
-			"The environment of the executed program or shell. If omitted the parent process' environment is used.",
-			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
-			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
-			"Configures the shell to be used.",
-			"The shell to be used.",
-			"The shell arguments.",
-			"The command to be executed. Can be an external program or a shell command.",
-			"Arguments passed to the command when this task is invoked.",
-			"The task's name",
-			"The command to be executed. Can be an external program or a shell command.",
-			"Arguments passed to the command when this task is invoked.",
-			"Windows specific command configuration",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"Mac specific command configuration",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"Linux specific command configuration",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"Controls whether the task name is added as an argument to the command. If omitted the globally defined value is used.",
-			"Controls whether the output of the running task is shown or not. If omitted the globally defined value is used.",
-			"Controls whether the executed command is echoed to the output. Default is false.",
-			"Deprecated. Use isBackground instead.",
-			"Whether the executed task is kept alive and is watching the file system.",
-			"Whether the executed task is kept alive and is running in the background.",
-			"Whether the user is prompted when VS Code closes with a running task.",
-			"Maps this task to Code's default build command.",
-			"Maps this task to Code's default test command.",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"The command to be executed. Can be an external program or a shell command.",
-			"Additional arguments passed to the command.",
-			"Controls whether the output of the running task is shown or not. If omitted 'always' is used.",
-			"Deprecated. Use isBackground instead.",
-			"Whether the executed task is kept alive and is watching the file system.",
-			"Whether the executed task is kept alive and is running in the background.",
-			"Whether the user is prompted when VS Code closes with a running background task.",
-			"Controls whether the executed command is echoed to the output. Default is false.",
-			"Controls whether the task name is added as an argument to the command. Default is false.",
-			"Prefix to indicate that an argument is task.",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"The task configurations. Usually these are enrichments of task already defined in the external task runner."
+		"vs/workbench/contrib/snippets/browser/commands/abstractSnippetsActions": [
+			"Snippets"
 		],
-		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
-			"'env.', 'config.' and 'command.' are deprecated, use 'env:', 'config:' and 'command:' instead."
-		],
-		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
-			"The input's id is used to associate an input with a variable of the form ${input:id}.",
-			"The type of user input prompt to use.",
-			"The description is shown when the user is prompted for input.",
-			"The default value for the input.",
-			"User inputs. Used for defining user input prompts, such as free string input or a choice from several options.",
-			"The 'promptString' type opens an input box to ask the user for input.",
-			"Controls if a password input is shown. Password input hides the typed text.",
-			"The 'pickString' type shows a selection list.",
-			"An array of strings that defines the options for a quick pick.",
-			"Label for the option.",
-			"Value for the option.",
-			"The 'command' type executes a command.",
-			"The command to execute for this input variable.",
-			"Optional arguments passed to the command.",
-			"Optional arguments passed to the command.",
-			"Optional arguments passed to the command."
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
-			"Run: {0}",
-			"Open: {0}",
-			"Quick Fix"
-		],
-		"vs/workbench/contrib/remote/browser/explorerViewItems": [
-			"Switch Remote",
-			"Switch Remote"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
-			"Free port {0}",
-			"Create PR {0}"
+		"vs/workbench/contrib/snippets/browser/snippetPicker": [
+			"User Snippets",
+			"Workspace Snippets",
+			"Hide from IntelliSense",
+			"(hidden from IntelliSense)",
+			"Show in IntelliSense",
+			"Select a snippet",
+			"No snippet available"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetsFile": [
 			"Workspace Snippet",
@@ -27888,22 +28131,10 @@
 			"{0}, {1}",
 			"{0}, {1}"
 		],
-		"vs/workbench/contrib/snippets/browser/snippetPicker": [
-			"User Snippets",
-			"Workspace Snippets",
-			"Hide from IntelliSense",
-			"(hidden from IntelliSense)",
-			"Show in IntelliSense",
-			"Select a snippet",
-			"No snippet available"
-		],
 		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
 			"Release Notes: {0}",
 			"unassigned",
 			"Show release notes after an update"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/abstractSnippetsActions": [
-			"Snippets"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent": [
 			"Icon used for the setup category of welcome page",
@@ -27996,6 +28227,9 @@
 			"Tune your settings",
 			"Tweak every aspect of VS Code and your extensions to your liking. Commonly used settings are listed first to get you started.\n{0}",
 			"Tweak my Settings",
+			"Customize VS Code with Profiles",
+			"Profiles let you create sets of VS Code customizations that include settings, extensions and UI state. Create your own profile from scratch or use the predefined set of profile templates for your specific workflow.\n{0}",
+			"Try Profiles",
 			"Safely browse and edit code",
 			"{0} lets you decide whether your project folders should **allow or restrict** automatic code execution __(required for extensions, debugging, etc)__.\nOpening a file/folder will prompt to grant trust. You can always {1} later.",
 			"Workspace Trust",
@@ -28073,8 +28307,7 @@
 			"Context key expression to control the visibility of this step."
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
-			"Featured",
-			"Featured"
+			"Recommended"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
 			"Background color for the Welcome page.",
@@ -28084,6 +28317,9 @@
 			"Foreground color for the Welcome page progress bars.",
 			"Background color for the Welcome page progress bars.",
 			"Foreground color of the heading of each walkthrough step"
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/common/walkThroughUtils": [
+			"Background color for the embedded editors on the Interactive Playground."
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
 			"Call Hierarchy",
@@ -28182,33 +28418,13 @@
 			"Last Synced Remotes",
 			"Current"
 		],
-		"vs/workbench/contrib/welcomeWalkthrough/common/walkThroughUtils": [
-			"Background color for the embedded editors on the Interactive Playground."
-		],
-		"vs/workbench/browser/parts/notifications/notificationsActions": [
-			"Icon for the clear action in notifications.",
-			"Icon for the clear all action in notifications.",
-			"Icon for the hide action in notifications.",
-			"Icon for the expand action in notifications.",
-			"Icon for the collapse action in notifications.",
-			"Icon for the configure action in notifications.",
-			"Icon for the mute all action in notifications.",
-			"Clear Notification",
-			"Clear All Notifications",
-			"Toggle Do Not Disturb Mode",
-			"Hide Notifications",
-			"Expand Notification",
-			"Collapse Notification",
-			"Configure Notification",
-			"Copy Text"
-		],
 		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
 			"Saving '{0}'"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsList": [
-			"{0}, notification",
-			"{0}, source: {1}, notification",
-			"Notifications List"
+		"vs/workbench/browser/parts/titlebar/windowTitle": [
+			"[Administrator]",
+			"[Superuser]",
+			"[Extension Development Host]"
 		],
 		"vs/workbench/browser/parts/titlebar/commandCenterControl": [
 			"Search",
@@ -28224,11 +28440,6 @@
 			"Border color of the command center",
 			"Active border color of the command center",
 			"Border color of the command center when the window is inactive"
-		],
-		"vs/workbench/browser/parts/titlebar/windowTitle": [
-			"[Administrator]",
-			"[Superuser]",
-			"[Extension Development Host]"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopy": [
 			"Failed to save '{0}': The content of the file is newer. Do you want to overwrite the file with your changes?",
@@ -28286,9 +28497,23 @@
 			"Match Whole Word",
 			"Use Regular Expression"
 		],
+		"vs/workbench/browser/parts/notifications/notificationsViewer": [
+			"Click to execute command '{0}'",
+			"Notification Actions",
+			"Source: {0}"
+		],
+		"vs/platform/languagePacks/common/localizedStrings": [
+			"open",
+			"close",
+			"find"
+		],
 		"vs/editor/browser/controller/textAreaHandler": [
 			"editor",
 			"The editor is not accessible at this time. Press {0} for options."
+		],
+		"vs/editor/browser/widget/diffEditor.contribution": [
+			"Go to Next Difference",
+			"Go to Previous Difference"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionMenu": [
 			"More Actions...",
@@ -28300,10 +28525,6 @@
 			"Surround With...",
 			"Source Action..."
 		],
-		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
-			"Click to toggle color options (rgb/hsl/hex)",
-			"Icon to close the color picker"
-		],
 		"vs/platform/actionWidget/browser/actionWidget": [
 			"Whether the action widget list is visible",
 			"Hide action widget",
@@ -28311,6 +28532,10 @@
 			"Select next action",
 			"Accept selected action",
 			"Preview selected action"
+		],
+		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
+			"Click to toggle color options (rgb/hsl/hex)",
+			"Icon to close the color picker"
 		],
 		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys": [
 			"Whether an inline suggestion is visible",
@@ -28401,6 +28626,27 @@
 			"Color of background for currently selected or hovered comment range.",
 			"Color of border for currently selected or hovered comment range."
 		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffReview": [
+			"Icon for 'Insert' in diff review.",
+			"Icon for 'Remove' in diff review.",
+			"Icon for 'Close' in diff review.",
+			"Close",
+			"no lines changed",
+			"1 line changed",
+			"{0} lines changed",
+			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
+			"blank",
+			"{0} unchanged line {1}",
+			"{0} original line {1} modified line {2}",
+			"+ {0} modified line {1}",
+			"- {0} original line {1}"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
+			"Fold Unchanged Region"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
+			" use Shift + F7 to navigate changes"
+		],
 		"vs/workbench/browser/parts/editor/editorPlaceholder": [
 			"Workspace Trust Required",
 			"The file is not displayed in the editor because trust has not been granted to the folder.",
@@ -28433,11 +28679,51 @@
 			"Application Menu",
 			"More"
 		],
+		"vs/platform/quickinput/browser/quickInputUtils": [
+			"Click to execute command '{0}'"
+		],
 		"vs/platform/quickinput/browser/quickInputList": [
 			"Quick Input"
 		],
-		"vs/platform/quickinput/browser/quickInputUtils": [
-			"Click to execute command '{0}'"
+		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
+			"Setting value not applied",
+			"The setting value can only be applied in a trusted workspace.",
+			"Manage Workspace Trust",
+			"Not synced",
+			"This setting is ignored during sync",
+			"Default value changed",
+			"User",
+			"Workspace",
+			"Remote",
+			"Setting value not applied",
+			"This setting is managed by your organization and its applied value cannot be changed.",
+			"View policy settings",
+			"Applies to all profiles",
+			"The setting is not specific to the current profile, and will retain its value when switching profiles.",
+			"Also modified in",
+			"Modified in",
+			"Also modified elsewhere",
+			"Modified elsewhere",
+			"The setting has also been modified in the following scopes:",
+			"The setting has been modified in the following scopes:",
+			"The following languages have default overrides:",
+			"Default setting value overridden by {0}",
+			"User",
+			"Workspace",
+			"Remote",
+			"The {0} scope for {1}",
+			"User",
+			"Workspace",
+			"Remote",
+			"the {0} scope for {1}",
+			"Workspace untrusted; setting value not applied",
+			"Managed by organization policy; setting value not applied",
+			"Setting value retained when switching profiles",
+			"Also modified in",
+			"Modified in",
+			"Setting ignored during sync",
+			"{0} overrides the default value",
+			"Language-specific default values exist for {0}"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsWidgets": [
 			"OK",
@@ -28482,46 +28768,6 @@
 			"Item",
 			"Value"
 		],
-		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
-			"Setting value not applied",
-			"The setting value can only be applied in a trusted workspace.",
-			"Manage Workspace Trust",
-			"Not synced",
-			"This setting is ignored during sync",
-			"Default value changed",
-			"User",
-			"Workspace",
-			"Remote",
-			"Setting value not applied",
-			"This setting is managed by your organization and its applied value cannot be changed.",
-			"View policy settings",
-			"Applies to all profiles",
-			"The setting is not specific to the current profile, and will retain its value when switching profiles.",
-			"Also modified in",
-			"Modified in",
-			"Also modified elsewhere",
-			"Modified elsewhere",
-			"The setting has also been modified in the following scopes:",
-			"The setting has been modified in the following scopes:",
-			"The following languages have default overrides:",
-			"Default setting value overridden by {0}",
-			"User",
-			"Workspace",
-			"Remote",
-			"The {0} scope for {1}",
-			"User",
-			"Workspace",
-			"Remote",
-			"the {0} scope for {1}",
-			"Workspace untrusted; setting value not applied",
-			"Managed by organization policy; setting value not applied",
-			"Setting value retained when switching profiles",
-			"Also modified in",
-			"Modified in",
-			"Setting ignored during sync",
-			"{0} overrides the default value",
-			"Language-specific default values exist for {0}"
-		],
 		"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer": [
 			"Execution Order"
 		],
@@ -28545,6 +28791,26 @@
 			"Rendered Markdown",
 			"Code Cell Source",
 			"Code Cell Output"
+		],
+		"vs/platform/actions/browser/buttonbar": [
+			"{0} ({1})"
+		],
+		"vs/workbench/contrib/terminal/browser/xterm/decorationAddon": [
+			"Rerun Command",
+			"Do you want to run the command: {0}",
+			"Yes",
+			"No",
+			"Copy Command",
+			"Copy Output",
+			"Copy Output as HTML",
+			"Run Recent Command",
+			"Go To Recent Directory",
+			"Configure Command Decorations",
+			"Learn About Shell Integration",
+			"Toggle visibility",
+			"Toggle visibility",
+			"Gutter command decorations",
+			"Overview ruler command decorations"
 		],
 		"vs/workbench/contrib/debug/common/debugger": [
 			"Cannot find debug adapter for type '{0}'.",
@@ -28601,13 +28867,6 @@
 			"Controls whether manually terminating one session will stop all of the compound sessions.",
 			"Task to run before any of the compound configurations start."
 		],
-		"vs/base/browser/ui/selectBox/selectBoxCustom": [
-			"Select Box"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
-			"1 Conflicting Line",
-			"{0} Conflicting Lines"
-		],
 		"vs/workbench/contrib/debug/browser/rawDebugSession": [
 			"No debug adapter, can not start debug session.",
 			"The debugger needs to open a new tab or window for the debuggee but the browser prevented this. You must give permission to continue.",
@@ -28615,9 +28874,50 @@
 			"No debugger available found. Can not send '{0}'.",
 			"More Info"
 		],
+		"vs/base/browser/ui/selectBox/selectBoxCustom": [
+			"Select Box"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
+			"1 Conflicting Line",
+			"{0} Conflicting Lines"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
 			"Set Input Handled",
 			"Undo Mark As Handled"
+		],
+		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
+			"Editor gutter decoration color for commenting ranges. This color should be opaque.",
+			"Editor overview ruler decoration color for resolved comments. This color should be opaque.",
+			"Editor overview ruler decoration color for unresolved comments. This color should be opaque.",
+			"Editor gutter decoration color for commenting glyphs.",
+			"Editor gutter decoration color for commenting glyphs for unresolved comment threads."
+		],
+		"vs/workbench/contrib/customEditor/common/extensionPoint": [
+			"Contributed custom editors.",
+			"Identifier for the custom editor. This must be unique across all custom editors, so we recommend including your extension id as part of `viewType`. The `viewType` is used when registering custom editors with `vscode.registerCustomEditorProvider` and in the `onCustomEditor:${id}` [activation event](https://code.visualstudio.com/api/references/activation-events).",
+			"Human readable name of the custom editor. This is displayed to users when selecting which editor to use.",
+			"Set of globs that the custom editor is enabled for.",
+			"Glob that the custom editor is enabled for.",
+			"Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.",
+			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
+			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
+			"The '{0}' extension is recommended for opening a terminal in WSL.",
+			"Install"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick": [
+			"Select the terminal profile to create",
+			"Select your default terminal profile",
+			"Enter terminal profile name",
+			"A terminal profile already exists with that name",
+			"profiles",
+			"contributed",
+			"detected",
+			"This terminal profile uses a potentially unsafe path that can be modified by another user: {0}. Are you sure you want to use it?",
+			"Yes",
+			"Cancel",
+			"Configure Terminal Profile"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/conflictActions": [
 			"Accept {0}",
@@ -28642,37 +28942,15 @@
 			"Reset to base",
 			"Reset this conflict to the common ancestor of both the right and left changes."
 		],
-		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
-			"Editor gutter decoration color for commenting ranges. This color should be opaque.",
-			"Editor overview ruler decoration color for resolved comments. This color should be opaque.",
-			"Editor overview ruler decoration color for unresolved comments. This color should be opaque.",
-			"Editor gutter decoration color for commenting glyphs.",
-			"Editor gutter decoration color for commenting glyphs for unresolved comment threads."
-		],
-		"vs/workbench/contrib/customEditor/common/extensionPoint": [
-			"Contributed custom editors.",
-			"Identifier for the custom editor. This must be unique across all custom editors, so we recommend including your extension id as part of `viewType`. The `viewType` is used when registering custom editors with `vscode.registerCustomEditorProvider` and in the `onCustomEditor:${id}` [activation event](https://code.visualstudio.com/api/references/activation-events).",
-			"Human readable name of the custom editor. This is displayed to users when selecting which editor to use.",
-			"Set of globs that the custom editor is enabled for.",
-			"Glob that the custom editor is enabled for.",
-			"Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.",
-			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
-			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command."
-		],
-		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
-			"The '{0}' extension is recommended for opening a terminal in WSL.",
-			"Install"
-		],
 		"vs/workbench/contrib/terminal/browser/terminalInstance": [
+			"Task",
+			"Local",
 			"Terminal input",
 			"Use the accessible buffer {0} to manually review output",
 			"Use the Terminal: Focus Accessible Buffer command to manually review output",
-			"Task",
-			"Local",
 			"Bell",
 			"Some keybindings don't go to the terminal by default and are handled by {0} instead.",
 			"Configure Terminal Settings",
-			"The terminal has no selection to copy",
 			"Preview:",
 			"Are you sure you want to paste {0} lines of text into the terminal?",
 			"&&Paste",
@@ -28697,25 +28975,25 @@
 			"The terminal process terminated with exit code: {0}.",
 			"The terminal process failed to launch: {0}."
 		],
-		"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick": [
-			"Select the terminal profile to create",
-			"Select your default terminal profile",
-			"Enter terminal profile name",
-			"A terminal profile already exists with that name",
-			"profiles",
-			"contributed",
-			"detected",
-			"This terminal profile uses a potentially unsafe path that can be modified by another user: {0}. Are you sure you want to use it?",
-			"Yes",
-			"Cancel",
-			"Configure Terminal Profile"
-		],
 		"vs/workbench/contrib/terminal/browser/terminalTabsList": [
 			"Type terminal name. Press Enter to confirm or Escape to cancel.",
 			"Terminal tabs",
 			"Terminal {0} {1}, split {2} of {3}",
 			"Terminal {0} {1}",
 			"Terminal"
+		],
+		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
+			"Show Command Actions",
+			"Command executed {0} and failed",
+			"Command executed {0} and failed (Exit Code {1})",
+			"Command executed {0}"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
+			"Search workspace",
+			"Open file in editor",
+			"Focus folder in explorer",
+			"Open folder in new window",
+			"Follow link"
 		],
 		"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget": [
 			"Find",
@@ -28727,19 +29005,6 @@
 			"{0} found",
 			"{0} found for '{1}'",
 			"{0} found for '{1}'"
-		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
-			"Search workspace",
-			"Open file in editor",
-			"Focus folder in explorer",
-			"Open folder in new window",
-			"Follow link"
-		],
-		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
-			"Show Command Actions",
-			"Command executed {0} and failed",
-			"Command executed {0} and failed (Exit Code {1})",
-			"Command executed {0}"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/media/theme_picker": [
 			"Dark Modern",
@@ -28758,20 +29023,10 @@
 			"Theirs",
 			"Yours"
 		],
-		"vs/platform/languagePacks/common/localizedStrings": [
-			"open",
-			"close",
-			"find"
-		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
 			"Default",
 			"Jupyter",
 			"Colab"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsViewer": [
-			"Click to execute command '{0}'",
-			"Notification Actions",
-			"Source: {0}"
 		],
 		"vs/platform/actionWidget/browser/actionList": [
 			"{0} to apply, {1} to preview",
@@ -28783,6 +29038,20 @@
 			"{0} references",
 			"{0} reference",
 			"References"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/decorations": [
+			"Line decoration for inserts in the diff editor.",
+			"Line decoration for removals in the diff editor.",
+			"Click to revert change"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin": [
+			"Copy deleted lines",
+			"Copy deleted line",
+			"Copy changed lines",
+			"Copy changed line",
+			"Copy deleted line ({0})",
+			"Copy changed line ({0})",
+			"Revert this change"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbs": [
 			"Breadcrumb Navigation",
@@ -28830,11 +29099,24 @@
 		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
 			"Breadcrumbs"
 		],
+		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
+			"Choose a different output mimetype, available mimetypes: {0}",
+			"Cell has no output",
+			"No renderer could be found for output. It has the following mimetypes: {0}",
+			"Currently Active",
+			"Select mimetype to render for current output. Rich mimetypes are available only when the notebook is trusted",
+			"Select mimetype to render for current output",
+			"built-in"
+		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/cellEditorOptions": [
 			"Controls the display of line numbers in the cell editor.",
 			"Toggle Notebook Line Numbers",
 			"Notebook Line Numbers",
 			"Show Cell Line Numbers"
+		],
+		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCell": [
+			"Double-click to expand cell input ({0})",
+			"Expand Cell Input ({0})"
 		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellRunToolbar": [
 			"More..."
@@ -28848,22 +29130,20 @@
 			"1 cell hidden",
 			"{0} cells hidden"
 		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCell": [
-			"Double-click to expand cell input ({0})",
-			"Expand Cell Input ({0})"
-		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/markupCell": [
 			"Double-click to expand cell input ({0})",
 			"Expand Cell Input ({0})"
 		],
-		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
-			"Choose a different output mimetype, available mimetypes: {0}",
-			"Cell has no output",
-			"No renderer could be found for output. It has the following mimetypes: {0}",
-			"Currently Active",
-			"Select mimetype to render for current output. Rich mimetypes are available only when the notebook is trusted",
-			"Select mimetype to render for current output",
-			"built-in"
+		"vs/workbench/services/suggest/browser/simpleSuggestWidget": [
+			"Suggest",
+			"{0}{1}, {2}",
+			"{0}{1}",
+			"{0}, {1}",
+			"{0}, docs: {1}"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
+			"Could not kill process listening on port {0}, command exited with error {1}",
+			"Restarting the terminal because the connection to the shell process was lost..."
 		],
 		"vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick": [
 			"Remove from Command History",
@@ -28874,26 +29154,26 @@
 			"Select a directory to go to (hold Option-key to edit the command)",
 			"Select a directory to go to (hold Alt-key to edit the command)"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
-			"Could not kill process listening on port {0}, command exited with error {1}",
-			"Restarting the terminal because the connection to the shell process was lost..."
-		],
-		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
-			"Yes",
-			"No",
-			"Don't Show Again",
-			"Terminal GPU acceleration appears to be slow on your computer. Would you like to switch to disable it which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered)."
-		],
-		"vs/workbench/contrib/comments/browser/commentThreadBody": [
-			"Comment thread with {0} comments on lines {1} through {2}. {3}.",
-			"Comment thread with {0} comments on the entire document. {1}.",
-			"Comment thread with {0} comments. {1}."
+		"vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput": [
+			"Cell has no output",
+			"No renderer could be found for output. It has the following mimetypes: {0}",
+			"Change Presentation",
+			"Currently Active",
+			"Install additional renderers from the marketplace",
+			"Select mimetype to render for current output",
+			"Select mimetype to render for current output",
+			"renderer not available"
 		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
 			"Success",
 			"Failed",
 			"Pending",
 			"Executing"
+		],
+		"vs/workbench/contrib/comments/browser/commentThreadBody": [
+			"Comment thread with {0} comments on lines {1} through {2}. {3}.",
+			"Comment thread with {0} comments on the entire document. {1}.",
+			"Comment thread with {0} comments. {1}."
 		],
 		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
 			"Icon to collapse a review comment.",
@@ -28907,33 +29187,6 @@
 			"Show environment contributions",
 			"workspace"
 		],
-		"vs/workbench/contrib/terminal/browser/xterm/decorationAddon": [
-			"Rerun Command",
-			"Do you want to run the command: {0}",
-			"Yes",
-			"No",
-			"Copy Command",
-			"Copy Output",
-			"Copy Output as HTML",
-			"Run Recent Command",
-			"Go To Recent Directory",
-			"Configure Command Decorations",
-			"Learn About Shell Integration",
-			"Toggle visibility",
-			"Toggle visibility",
-			"Gutter command decorations",
-			"Overview ruler command decorations"
-		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput": [
-			"Cell has no output",
-			"No renderer could be found for output. It has the following mimetypes: {0}",
-			"Change Presentation",
-			"Currently Active",
-			"Install additional renderers from the marketplace",
-			"Select mimetype to render for current output",
-			"Select mimetype to render for current output",
-			"renderer not available"
-		],
 		"vs/workbench/contrib/comments/browser/commentNode": [
 			"Toggle Reaction",
 			"Toggling the comment reaction failed: {0}.",
@@ -28942,13 +29195,6 @@
 			"Deleting the comment reaction failed",
 			"Deleting the comment reaction failed: {0}.",
 			"Deleting the comment reaction failed"
-		],
-		"vs/workbench/services/suggest/browser/simpleSuggestWidget": [
-			"Suggest",
-			"{0}{1}, {2}",
-			"{0}{1}",
-			"{0}, {1}",
-			"{0}, docs: {1}"
 		],
 		"vs/workbench/contrib/comments/browser/reactionsAction": [
 			"Pick Reactions...",
@@ -28986,9 +29232,15 @@
 			"vs/editor/browser/coreCommands",
 			"vs/editor/browser/editorExtensions",
 			"vs/editor/browser/widget/codeEditorWidget",
+			"vs/editor/browser/widget/diffEditor.contribution",
 			"vs/editor/browser/widget/diffEditorWidget",
-			"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2",
+			"vs/editor/browser/widget/diffEditorWidget2/colors",
+			"vs/editor/browser/widget/diffEditorWidget2/decorations",
+			"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors",
 			"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution",
+			"vs/editor/browser/widget/diffEditorWidget2/diffReview",
+			"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin",
+			"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges",
 			"vs/editor/browser/widget/diffReview",
 			"vs/editor/browser/widget/inlineDiffMargin",
 			"vs/editor/common/config/editorConfigurationSchema",
@@ -29082,6 +29334,7 @@
 			"vs/platform/action/common/actionCommonCategories",
 			"vs/platform/actionWidget/browser/actionList",
 			"vs/platform/actionWidget/browser/actionWidget",
+			"vs/platform/actions/browser/buttonbar",
 			"vs/platform/actions/browser/menuEntryActionViewItem",
 			"vs/platform/actions/browser/toolbar",
 			"vs/platform/actions/common/menuResetAction",
@@ -29119,6 +29372,7 @@
 			"vs/platform/remoteTunnel/common/remoteTunnel",
 			"vs/platform/request/common/request",
 			"vs/platform/telemetry/common/telemetryService",
+			"vs/platform/terminal/common/terminalLogService",
 			"vs/platform/terminal/common/terminalPlatformConfiguration",
 			"vs/platform/terminal/common/terminalProfiles",
 			"vs/platform/theme/common/colorRegistry",
@@ -29229,7 +29483,9 @@
 			"vs/workbench/common/editor/textEditorModel",
 			"vs/workbench/common/theme",
 			"vs/workbench/common/views",
+			"vs/workbench/contrib/accessibility/browser/accessibility.contribution",
 			"vs/workbench/contrib/accessibility/browser/accessibilityContribution",
+			"vs/workbench/contrib/accessibility/browser/accessibleView",
 			"vs/workbench/contrib/audioCues/browser/audioCues.contribution",
 			"vs/workbench/contrib/audioCues/browser/commands",
 			"vs/workbench/contrib/bulkEdit/browser/bulkEditService",
@@ -29359,7 +29615,6 @@
 			"vs/workbench/contrib/editSessions/common/editSessions",
 			"vs/workbench/contrib/editSessions/common/editSessionsLogService",
 			"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation",
-			"vs/workbench/contrib/experiments/browser/experiments.contribution",
 			"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor",
 			"vs/workbench/contrib/extensions/browser/configBasedRecommendations",
 			"vs/workbench/contrib/extensions/browser/deprecatedExtensionsChecker",
@@ -29424,13 +29679,13 @@
 			"vs/workbench/contrib/format/browser/formatActionsNone",
 			"vs/workbench/contrib/format/browser/formatModified",
 			"vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty",
+			"vs/workbench/contrib/inlineChat/browser/inlineChatActions",
+			"vs/workbench/contrib/inlineChat/browser/inlineChatController",
+			"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies",
+			"vs/workbench/contrib/inlineChat/browser/inlineChatWidget",
+			"vs/workbench/contrib/inlineChat/common/inlineChat",
 			"vs/workbench/contrib/interactive/browser/interactive.contribution",
 			"vs/workbench/contrib/interactive/browser/interactiveEditor",
-			"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorActions",
-			"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController",
-			"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies",
-			"vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget",
-			"vs/workbench/contrib/interactiveEditor/common/interactiveEditor",
 			"vs/workbench/contrib/issue/common/issue.contribution",
 			"vs/workbench/contrib/issue/electron-sandbox/issue.contribution",
 			"vs/workbench/contrib/keybindings/browser/keybindings.contribution",
@@ -29497,6 +29752,7 @@
 			"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions",
 			"vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor",
 			"vs/workbench/contrib/notebook/browser/notebook.contribution",
+			"vs/workbench/contrib/notebook/browser/notebookAccessibilityHelp",
 			"vs/workbench/contrib/notebook/browser/notebookEditor",
 			"vs/workbench/contrib/notebook/browser/notebookEditorWidget",
 			"vs/workbench/contrib/notebook/browser/notebookExtensionPoint",
@@ -29518,7 +29774,7 @@
 			"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer",
 			"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy",
 			"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView",
-			"vs/workbench/contrib/notebook/common/notebookEditorModel",
+			"vs/workbench/contrib/notebook/common/notebookEditorInput",
 			"vs/workbench/contrib/outline/browser/outline.contribution",
 			"vs/workbench/contrib/outline/browser/outlineActions",
 			"vs/workbench/contrib/outline/browser/outlinePane",
@@ -29555,7 +29811,6 @@
 			"vs/workbench/contrib/remote/browser/remoteExplorer",
 			"vs/workbench/contrib/remote/browser/remoteIcons",
 			"vs/workbench/contrib/remote/browser/remoteIndicator",
-			"vs/workbench/contrib/remote/browser/remoteStartEntry",
 			"vs/workbench/contrib/remote/browser/tunnelFactory",
 			"vs/workbench/contrib/remote/browser/tunnelView",
 			"vs/workbench/contrib/remote/common/remote.contribution",
@@ -29636,7 +29891,6 @@
 			"vs/workbench/contrib/terminal/browser/terminalMenus",
 			"vs/workbench/contrib/terminal/browser/terminalProcessManager",
 			"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick",
-			"vs/workbench/contrib/terminal/browser/terminalProfileResolverService",
 			"vs/workbench/contrib/terminal/browser/terminalQuickAccess",
 			"vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick",
 			"vs/workbench/contrib/terminal/browser/terminalService",
@@ -29675,7 +29929,6 @@
 			"vs/workbench/contrib/testing/browser/testingExplorerFilter",
 			"vs/workbench/contrib/testing/browser/testingExplorerView",
 			"vs/workbench/contrib/testing/browser/testingOutputPeek",
-			"vs/workbench/contrib/testing/browser/testingOutputTerminalService",
 			"vs/workbench/contrib/testing/browser/testingProgressUiService",
 			"vs/workbench/contrib/testing/browser/testingViewPaneContainer",
 			"vs/workbench/contrib/testing/browser/theme",
@@ -29741,6 +29994,7 @@
 			"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler",
 			"vs/workbench/electron-sandbox/window",
 			"vs/workbench/services/actions/common/menusExtensionPoint",
+			"vs/workbench/services/assignment/common/assignmentService",
 			"vs/workbench/services/authentication/browser/authenticationService",
 			"vs/workbench/services/configuration/browser/configurationService",
 			"vs/workbench/services/configuration/common/configurationEditing",
@@ -29768,9 +30022,11 @@
 			"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner",
 			"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost",
 			"vs/workbench/services/extensions/electron-sandbox/nativeExtensionService",
+			"vs/workbench/services/filesConfiguration/common/filesConfigurationService",
 			"vs/workbench/services/history/browser/historyService",
 			"vs/workbench/services/hover/browser/hoverWidget",
 			"vs/workbench/services/integrity/electron-sandbox/integrityService",
+			"vs/workbench/services/issue/browser/issueTroubleshoot",
 			"vs/workbench/services/keybinding/browser/keybindingService",
 			"vs/workbench/services/keybinding/common/keybindingEditing",
 			"vs/workbench/services/label/common/labelService",
@@ -29788,6 +30044,7 @@
 			"vs/workbench/services/remote/common/remoteExplorerService",
 			"vs/workbench/services/remote/electron-sandbox/remoteAgentService",
 			"vs/workbench/services/search/common/queryBuilder",
+			"vs/workbench/services/secrets/electron-sandbox/secretStorageService",
 			"vs/workbench/services/suggest/browser/simpleSuggestWidget",
 			"vs/workbench/services/textMate/browser/textMateTokenizationFeatureImpl",
 			"vs/workbench/services/textMate/common/TMGrammars",

--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -73,7 +73,7 @@ export class EditorWidgetFactory implements WidgetFactory {
     private setLabels(editor: EditorWidget, uri: URI): void {
         editor.title.caption = uri.path.fsPath();
         if (editor.editor.isReadonly) {
-            editor.title.caption += ` • ${nls.localizeByDefault('Read Only')}`;
+            editor.title.caption += ` • ${nls.localizeByDefault('Read-only')}`;
         }
         const icon = this.labelProvider.getIcon(uri);
         editor.title.label = this.labelProvider.getName(uri);

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -1681,7 +1681,7 @@ export class FileService {
 
     protected throwIfFileSystemIsReadonly<T extends FileSystemProvider>(provider: T, resource: URI): T {
         if (provider.capabilities & FileSystemProviderCapabilities.Readonly) {
-            throw new FileOperationError(nls.localizeByDefault("Unable to modify readonly file '{0}'", this.resourceForError(resource)), FileOperationResult.FILE_PERMISSION_DENIED);
+            throw new FileOperationError(nls.localizeByDefault("Unable to modify read-only file '{0}'", this.resourceForError(resource)), FileOperationResult.FILE_PERMISSION_DENIED);
         }
 
         return provider;

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -40,7 +40,7 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
     properties: {
         'files.watcherExclude': {
             // eslint-disable-next-line max-len
-            description: nls.localizeByDefault('Configure paths or glob patterns to exclude from file watching. Paths can either be relative to the watched folder or absolute. Glob patterns are matched relative from the watched folder. When you experience the file watcher process consuming a lot of CPU, make sure to exclude large folders that are of less interest (such as build output folders).'),
+            description: nls.localizeByDefault('Configure paths or [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from file watching. Paths can either be relative to the watched folder or absolute. Glob patterns are matched relative from the watched folder. When you experience the file watcher process consuming a lot of CPU, make sure to exclude large folders that are of less interest (such as build output folders).'),
             additionalProperties: {
                 type: 'boolean'
             },


### PR DESCRIPTION
#### What it does

Updates our localization metadata for the vscode API version 1.80.0

#### How to test

CI is supposed to be green, Localization features work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
