### PR TITLE
Open initial electron window early and reuse it later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [vscode] stub TestController invalidateTestResults [#12944](https://github.com/eclipse-theia/theia/pull/12944) - Contributed by STMicroelectronics
 - [vscode] support iconPath in QuickPickItem [#12945](https://github.com/eclipse-theia/theia/pull/12945) - Contributed by STMicroelectronics
 - [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics
+- [electron] Open initial electron window early to improve perceived performance [#12897](https://github.com/eclipse-theia/theia/pull/12897) - Contributed on behalf of STMicroelectronics.
 
 ## v1.41.0 - 08/31/2023
 

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -32,7 +32,8 @@ export interface ApplicationConfig {
 export type ElectronFrontendApplicationConfig = RequiredRecursive<ElectronFrontendApplicationConfig.Partial>;
 export namespace ElectronFrontendApplicationConfig {
     export const DEFAULT: ElectronFrontendApplicationConfig = {
-        windowOptions: {}
+        windowOptions: {},
+        showWindowEarly: true
     };
     export interface Partial {
 
@@ -42,6 +43,13 @@ export namespace ElectronFrontendApplicationConfig {
          * Defaults to `{}`.
          */
         readonly windowOptions?: BrowserWindowConstructorOptions;
+
+        /**
+         * Whether or not to show an empty Electron window as early as possible.
+         *
+         * Defaults to `true`.
+         */
+        readonly showWindowEarly?: boolean;
     }
 }
 
@@ -59,6 +67,11 @@ export namespace DefaultTheme {
             return theme.dark;
         }
         return theme.light;
+    }
+    export function defaultBackgroundColor(dark?: boolean): string {
+        // The default light background color is based on the `colors#editor.background` value from
+        // `packages/monaco/data/monaco-themes/vscode/dark_vs.json` and the dark background comes from the `light_vs.json`.
+        return dark ? '#1E1E1E' : '#FFFFFF';
     }
 }
 

--- a/packages/core/src/browser/preload/theme-preload-contribution.ts
+++ b/packages/core/src/browser/preload/theme-preload-contribution.ts
@@ -17,15 +17,14 @@
 import { PreloadContribution } from './preloader';
 import { DEFAULT_BACKGROUND_COLOR_STORAGE_KEY } from '../frontend-application-config-provider';
 import { injectable } from 'inversify';
+import { DefaultTheme } from '@theia/application-package';
 
 @injectable()
 export class ThemePreloadContribution implements PreloadContribution {
 
     initialize(): void {
-        // The default light background color is based on the `colors#editor.background` value from
-        // `packages/monaco/data/monaco-themes/vscode/dark_vs.json` and the dark background comes from the `light_vs.json`.
         const dark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
-        const value = window.localStorage.getItem(DEFAULT_BACKGROUND_COLOR_STORAGE_KEY) || (dark ? '#1E1E1E' : '#FFFFFF');
+        const value = window.localStorage.getItem(DEFAULT_BACKGROUND_COLOR_STORAGE_KEY) || DefaultTheme.defaultBackgroundColor(dark);
         document.documentElement.style.setProperty('--theia-editor-background', value);
     }
 

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -30,6 +30,8 @@ import { WindowTitleService } from '../../browser/window/window-title-service';
 
 import '../../../src/electron-browser/menu/electron-menu-style.css';
 import { MenuDto } from '../../electron-common/electron-api';
+import { ThemeService } from '../../browser/theming';
+import { ThemeChangeEvent } from '../../common/theme';
 
 export namespace ElectronCommands {
     export const TOGGLE_DEVELOPER_TOOLS = Command.toDefaultLocalizedCommand({
@@ -88,6 +90,9 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
     @inject(WindowService)
     protected readonly windowService: WindowService;
 
+    @inject(ThemeService)
+    protected readonly themeService: ThemeService;
+
     @inject(CustomTitleWidgetFactory)
     protected readonly customTitleWidgetFactory: CustomTitleWidgetFactory;
 
@@ -123,6 +128,9 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
             this.handleToggleMaximized();
         });
         this.attachMenuBarVisibilityListener();
+        this.themeService.onDidColorThemeChange(e => {
+            this.handleThemeChange(e);
+        });
     }
 
     protected attachWindowFocusListener(app: FrontendApplication): void {
@@ -412,6 +420,11 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
         } else {
             this.shell.topPanel.hide();
         }
+    }
+
+    protected handleThemeChange(e: ThemeChangeEvent): void {
+        const backgroundColor = window.getComputedStyle(document.body).backgroundColor;
+        window.electronTheiaCore.setBackgroundColor(backgroundColor);
     }
 
 }

--- a/packages/core/src/electron-browser/preload.ts
+++ b/packages/core/src/electron-browser/preload.ts
@@ -25,7 +25,7 @@ import {
     CHANNEL_ON_WINDOW_EVENT, CHANNEL_GET_ZOOM_LEVEL, CHANNEL_SET_ZOOM_LEVEL, CHANNEL_IS_FULL_SCREENABLE, CHANNEL_TOGGLE_FULL_SCREEN,
     CHANNEL_IS_FULL_SCREEN, CHANNEL_SET_MENU_BAR_VISIBLE, CHANNEL_REQUEST_CLOSE, CHANNEL_SET_TITLE_STYLE, CHANNEL_RESTART,
     CHANNEL_REQUEST_RELOAD, CHANNEL_APP_STATE_CHANGED, CHANNEL_SHOW_ITEM_IN_FOLDER, CHANNEL_READ_CLIPBOARD, CHANNEL_WRITE_CLIPBOARD,
-    CHANNEL_KEYBOARD_LAYOUT_CHANGED, CHANNEL_IPC_CONNECTION, InternalMenuDto, CHANNEL_REQUEST_SECONDARY_CLOSE
+    CHANNEL_KEYBOARD_LAYOUT_CHANGED, CHANNEL_IPC_CONNECTION, InternalMenuDto, CHANNEL_REQUEST_SECONDARY_CLOSE, CHANNEL_SET_BACKGROUND_COLOR
 } from '../electron-common/electron-api';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -100,6 +100,9 @@ const api: TheiaCoreAPI = {
     },
     setTitleBarStyle: function (style): void {
         ipcRenderer.send(CHANNEL_SET_TITLE_STYLE, style);
+    },
+    setBackgroundColor: function (backgroundColor): void {
+        ipcRenderer.send(CHANNEL_SET_BACKGROUND_COLOR, backgroundColor);
     },
     minimize: function (): void {
         ipcRenderer.send(CHANNEL_MINIMIZE);

--- a/packages/core/src/electron-common/electron-api.ts
+++ b/packages/core/src/electron-common/electron-api.ts
@@ -56,6 +56,7 @@ export interface TheiaCoreAPI {
 
     getTitleBarStyleAtStartup(): Promise<string>;
     setTitleBarStyle(style: string): void;
+    setBackgroundColor(backgroundColor: string): void;
     minimize(): void;
     isMaximized(): boolean; // TODO: this should really be async, since it blocks the renderer process
     maximize(): void;
@@ -109,6 +110,7 @@ export const CHANNEL_ATTACH_SECURITY_TOKEN = 'AttachSecurityToken';
 
 export const CHANNEL_GET_TITLE_STYLE_AT_STARTUP = 'GetTitleStyleAtStartup';
 export const CHANNEL_SET_TITLE_STYLE = 'SetTitleStyle';
+export const CHANNEL_SET_BACKGROUND_COLOR = 'SetBackgroundColor';
 export const CHANNEL_CLOSE = 'Close';
 export const CHANNEL_MINIMIZE = 'Minimize';
 export const CHANNEL_MAXIMIZE = 'Maximize';

--- a/packages/core/src/electron-main/electron-api-main.ts
+++ b/packages/core/src/electron-main/electron-api-main.ts
@@ -50,7 +50,8 @@ import {
     CHANNEL_SET_MENU_BAR_VISIBLE,
     CHANNEL_TOGGLE_FULL_SCREEN,
     CHANNEL_IS_MAXIMIZED,
-    CHANNEL_REQUEST_SECONDARY_CLOSE
+    CHANNEL_REQUEST_SECONDARY_CLOSE,
+    CHANNEL_SET_BACKGROUND_COLOR
 } from '../electron-common/electron-api';
 import { ElectronMainApplication, ElectronMainApplicationContribution } from './electron-main-application';
 import { Disposable, DisposableCollection, isOSX, MaybePromise } from '../common';
@@ -151,6 +152,8 @@ export class TheiaMainApi implements ElectronMainApplicationContribution {
         ipcMain.handle(CHANNEL_GET_TITLE_STYLE_AT_STARTUP, event => application.getTitleBarStyleAtStartup(event.sender));
 
         ipcMain.on(CHANNEL_SET_TITLE_STYLE, (event, style) => application.setTitleBarStyle(event.sender, style));
+
+        ipcMain.on(CHANNEL_SET_BACKGROUND_COLOR, (event, backgroundColor) => application.setBackgroundColor(event.sender, backgroundColor));
 
         ipcMain.on(CHANNEL_MINIMIZE, event => {
             BrowserWindow.fromWebContents(event.sender)?.minimize();


### PR DESCRIPTION
#### What it does

This avoids having a rather long pause from Theia start until something is visibly coming up. In my initial experiment, I observe the empty window showing up ~1.5s earlier than usual.

This behavior can be controlled via the application config in the application's package.json. For instance, to turn off, use:

```
  "theia": {
    "target": "electron",
    "frontend": {
      "config": {
        "applicationName": "Theia Electron Example",
        "electron": {
          "showWindowEarly": false
        }
      }
    }
  }
```

To mitigate flickering, we set a background color of the window, which shows before any page is loaded, according to the expected background color of the Theia app. Also, we store the background color of the current color theme to be able to show the correct background color in the initial window.

In future changes, we may consider loading a very simple static web page mimicking the basic workbench structure before we switch to the actual application and in the Theia app don't show a spinner but a loading indicator on top of the basic workbench structure. With that, the application rather builds up visually instead of flickering between nothing, the spinner and the actual app.

Contributed on behalf of STMicroelectronics.

##### Without this change

https://github.com/eclipse-theia/theia/assets/588090/289051fa-9862-4651-ba0c-52faaa447b11

##### With this change

https://github.com/eclipse-theia/theia/assets/588090/91f9d7b8-05c9-4e10-ba03-63ff662d1bcf

#### How to test

Build the example electron app with `"showWindowEarly": false` and with `"showWindowEarly": true` to compare the differences.

In addition, it is worth testing the following aspects:

* Window size is correctly restored after opening the electron app
* Window layout is correctly restored after opening the electron app
* Opening a new window from the app works as before

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
