### PR TITLE
Fix backend webpack output and watching

### DIFF
--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -296,7 +296,14 @@ module.exports = [{
     stats: {
         warnings: true,
         children: true
-    }
+    },
+    ignoreWarnings: [
+        {
+            // Monaco uses 'require' in a non-standard way
+            module: /@theia\\/monaco-editor-core/,
+            message: /require function is used in a way in which dependencies cannot be statically extracted/
+        }
+    ]
 }${this.ifElectron(`, {
     mode,
     devtool: 'source-map',
@@ -449,7 +456,7 @@ const config = {
         ]
     },
     plugins: [
-        // Some native dependencies (bindings, @vscode/ripgrep) need special code replacements
+        // Some native dependencies need special handling
         nativePlugin,
         // Optional node dependencies can be safely ignored
         new webpack.IgnorePlugin({
@@ -469,6 +476,22 @@ const config = {
             })
         ]
     },
+    ignoreWarnings: [
+        // Some packages do not have source maps, that's ok
+        /Failed to parse source map/,
+        // Some packages use dynamic requires, we can safely ignore them (they are handled by the native webpack plugin)
+        /require function is used in a way in which dependencies cannot be statically extracted/, {
+            module: /yargs/
+        }, {
+            module: /node-pty/
+        }, {
+            module: /require-main-filename/
+        }, {
+            module: /ws/
+        }, {
+            module: /express/
+        }
+    ]
 };
 
 module.exports = {

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -490,6 +490,8 @@ const config = {
             module: /ws/
         }, {
             module: /express/
+        }, {
+            module: /cross-spawn/
         }
     ]
 };

--- a/dev-packages/native-webpack-plugin/package.json
+++ b/dev-packages/native-webpack-plugin/package.json
@@ -29,7 +29,6 @@
     "watch": "theiaext watch"
   },
   "dependencies": {
-    "temp": "^0.9.1",
     "webpack": "^5.76.0"
   }
 }

--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -59,7 +59,9 @@ export class NativeWebpackPlugin {
                     recursive: true
                 });
             }
-            await fs.promises.mkdir(directory);
+            await fs.promises.mkdir(directory, {
+                recursive: true
+            });
             const bindingsFile = await buildFile(directory, 'bindings.js', bindingsReplacement(Array.from(this.bindings.entries())));
             const ripgrepFile = await buildFile(directory, 'ripgrep.js', ripgrepReplacement(this.options.out));
             const keymappingFile = './build/Release/keymapping.node';


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12793
Closes https://github.com/eclipse-theia/theia/issues/12899

Apparently, using `tapAsync` to hook into the webpack generator was incorrect. I should've use `tapPromise` instead...

As the output is now correctly printed, I was also able to identify what the issue with the watch build was. The intermittently created files were deleted too fast, resulting in a failing watch build. They are now alive longer on the disk.

#### How to test

1. Run the `yarn browser/electron build` script.
2. Webpack should print output (i.e. what has been generated/bundled)
3. Run the `yarn browser/electron watch` script.
4. Perform a change in the server part of the app (i.e. add a print statement somewhere)
5. Start the app and confirm that the changes are active.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
