### PR TITLE
Implement search.quickOpen.includeHistory preference

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -32,6 +32,11 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
             type: 'string',
             enum: ['auto', 'alwaysCollapse', 'alwaysExpand'],
         },
+        'search.quickOpen.includeHistory': {
+            description: nls.localizeByDefault('Whether to include results from recently opened files in the file results for Quick Open.'),
+            default: true,
+            type: 'boolean',
+        },
         'search.searchOnType': {
             description: nls.localizeByDefault('Search all files as you type.'),
             default: true,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This adds the search.quickOpen.includeHistory preference, allowing to define whether recently opened files should be shown in a separate section at the top of the file search quick open dialog, or not.

#### How to test
Toggle the preference on and off and check if it does what it should.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
