### PR TITLE
dialogs - Allow multiple selection on Open...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [core] fixed logger level propagation when log config file changes at runtime [#12566](https://github.com/eclipse-theia/theia/pull/12566) - Contributed on behalf of STMicroelectronics
 - [core] improve frontend startup time [#12936](https://github.com/eclipse-theia/theia/pull/12936) - Contributed on behalf of STMicroelectronics
 - [dev-packages] restore src-gen frontend production behavior [12950](https://github.com/eclipse-theia/theia/pull/12950) - Contributed on behalf of STMicroelectronics
+- [dialogs] allow multiple selection on Open... [#12923](https://github.com/eclipse-theia/theia/pull/12923) - Contributed on behalf of STMicroelectronics.
 - [vscode] stub TestController invalidateTestResults [#12944](https://github.com/eclipse-theia/theia/pull/12944) - Contributed by STMicroelectronics
 - [vscode] support iconPath in QuickPickItem [#12945](https://github.com/eclipse-theia/theia/pull/12945) - Contributed by STMicroelectronics
 - [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -262,50 +262,76 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
      * This is the generic `Open` method. Opens files and directories too. Resolves to the opened URI.
      * Except when you are on either Windows or Linux `AND` running in electron. If so, it opens a file.
      */
-    protected async doOpen(): Promise<URI | undefined> {
+    protected async doOpen(): Promise<URI[] | undefined> {
         if (!isOSX && this.isElectron()) {
             return this.doOpenFile();
         }
         const [rootStat] = await this.workspaceService.roots;
-        const destinationUri = await this.fileDialogService.showOpenDialog({
+        let selectedUris = await this.fileDialogService.showOpenDialog({
             title: WorkspaceCommands.OPEN.dialogLabel,
             canSelectFolders: true,
-            canSelectFiles: true
+            canSelectFiles: true,
+            canSelectMany: true
         }, rootStat);
-        if (destinationUri && this.getCurrentWorkspaceUri()?.toString() !== destinationUri.toString()) {
-            const destination = await this.fileService.resolve(destinationUri);
-            if (destination.isDirectory) {
-                this.workspaceService.open(destinationUri);
-            } else {
-                await open(this.openerService, destinationUri);
+        if (selectedUris) {
+            if (!Array.isArray(selectedUris)) {
+                selectedUris = [selectedUris];
             }
-            return destinationUri;
+            const folders: URI[] = [];
+            //  Only open files then open all folders in a new workspace, as done with Electron see doOpenFolder.
+            for (const uri of selectedUris) {
+                const destination = await this.fileService.resolve(uri);
+                if (destination.isDirectory) {
+                    if (this.getCurrentWorkspaceUri()?.toString() !== uri.toString()) {
+                        folders.push(uri);
+                    }
+                } else {
+                    await open(this.openerService, uri);
+                }
+            }
+            if (folders.length > 0) {
+                const openableURI = await this.getOpenableWorkspaceUri(folders);
+                if (openableURI && (!this.workspaceService.workspace || !openableURI.isEqual(this.workspaceService.workspace.resource))) {
+                    this.workspaceService.open(openableURI);
+                }
+            }
+
+            return selectedUris;
         }
         return undefined;
     }
 
     /**
-     * Opens a file after prompting the `Open File` dialog. Resolves to `undefined`, if
+     * Opens a set of files after prompting the `Open File` dialog. Resolves to `undefined`, if
      *  - the workspace root is not set,
      *  - the file to open does not exist, or
      *  - it was not a file, but a directory.
      *
-     * Otherwise, resolves to the URI of the file.
+     * Otherwise, resolves to the set of URIs of the files.
      */
-    protected async doOpenFile(): Promise<URI | undefined> {
+    protected async doOpenFile(): Promise<URI[] | undefined> {
         const props: OpenFileDialogProps = {
             title: WorkspaceCommands.OPEN_FILE.dialogLabel,
             canSelectFolders: false,
-            canSelectFiles: true
+            canSelectFiles: true,
+            canSelectMany: true
         };
         const [rootStat] = await this.workspaceService.roots;
-        const destinationFileUri = await this.fileDialogService.showOpenDialog(props, rootStat);
-        if (destinationFileUri) {
-            const destinationFile = await this.fileService.resolve(destinationFileUri);
-            if (!destinationFile.isDirectory) {
-                await open(this.openerService, destinationFileUri);
-                return destinationFileUri;
+        let selectedFilesUris: MaybeArray<URI> | undefined = await this.fileDialogService.showOpenDialog(props, rootStat);
+        if (selectedFilesUris) {
+            if (!Array.isArray(selectedFilesUris)) {
+                selectedFilesUris = [selectedFilesUris];
             }
+
+            const result = [];
+            for (const uri of selectedFilesUris) {
+                const destination = await this.fileService.resolve(uri);
+                if (destination.isFile) {
+                    await open(this.openerService, uri);
+                    result.push(uri);
+                }
+            }
+            return result;
         }
         return undefined;
     }
@@ -329,11 +355,11 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         const [rootStat] = await this.workspaceService.roots;
         const targetFolders = await this.fileDialogService.showOpenDialog(props, rootStat);
         if (targetFolders) {
-            const openableURI = await this.getOpenableWorkspaceUri(targetFolders);
-            if (openableURI) {
-                if (!this.workspaceService.workspace || !openableURI.isEqual(this.workspaceService.workspace.resource)) {
-                    this.workspaceService.open(openableURI);
-                    return openableURI;
+            const openableUri = await this.getOpenableWorkspaceUri(targetFolders);
+            if (openableUri) {
+                if (!this.workspaceService.workspace || !openableUri.isEqual(this.workspaceService.workspace.resource)) {
+                    this.workspaceService.open(openableUri);
+                    return openableUri;
                 }
             };
         }


### PR DESCRIPTION
#### What it does

fixes #12905 - Allow multiple selection on Open...

- allow multiple selection in doOpen dialog 
- handle an array or a single URI or undefined when closing dialog

Contributed on behalf of ST Microelectronics

#### How to test

When running Theia in browser, select the Open... dialog:
- It is now possible to open multiple files at once. 
- It is also possible to select multiple folders. In that case, all folders will be open as folders in a new workspace (as done in Electron).
- In case of heterogeneous selection, all files will be opened in current workspace, and the folders will be opened together as a new workspace.

![12905-browser](https://github.com/eclipse-theia/theia/assets/3964263/e2b50414-2f4a-4f42-9429-213c9de035b3)

Electron has 2 different menus to select either Folder or Files:
- This patch updates the `Open file...` selection dialog to also be able to select multiple items. If the selection has several files and a folder selected in the dialog, the open button of the dialog won't react. It is supposed to browse the folder if there is only one folder selected. 
- The `open folder` command already supports multiple folder selection, creating a new workspace containing all folders. No updates were done to this command.

#### Follow-ups

No Follow-up was identified during this task development. 

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [X] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
