### PR TITLE
fix(preference-tree-widget): sync. Theia and VSCode behavior about extensions' node naming

### DIFF
--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -165,6 +165,8 @@ export class TheiaPluginScanner implements PluginScanner {
                 for (const c of configurations) {
                     const config = this.readConfiguration(c, rawPlugin.packagePath);
                     if (config) {
+                        const keys = Object.keys(config.properties);
+                        keys.forEach(key => { config.properties[key].title = config.title; });
                         contributions.configuration.push(config);
                     }
                 }

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -111,7 +111,7 @@ export class PreferenceTreeGenerator {
                 const subgroupName = this.getSubgroupName(labels, groupID);
                 const subgroupID = [groupID, subgroupName].join('.');
                 const toplevelParent = this.getOrCreatePreferencesGroup(groupID, groupID, root, groups);
-                const immediateParent = subgroupName && this.getOrCreatePreferencesGroup(subgroupID, groupID, toplevelParent, groups);
+                const immediateParent = subgroupName && this.getOrCreatePreferencesGroup(subgroupID, groupID, toplevelParent, groups, property);
                 this.createLeafNode(propertyName, immediateParent || toplevelParent, property);
             }
         }
@@ -192,7 +192,7 @@ export class PreferenceTreeGenerator {
         return newNode;
     }
 
-    protected createPreferencesGroup(id: string, group: string, root: CompositeTreeNode): Preference.CompositeTreeNode {
+    protected createPreferencesGroup(id: string, group: string, root: CompositeTreeNode, property?: PreferenceDataProperty): Preference.CompositeTreeNode {
         const newNode = {
             id: `${group}@${id}`,
             visible: true,
@@ -201,6 +201,7 @@ export class PreferenceTreeGenerator {
             expanded: false,
             selected: false,
             depth: 0,
+            title: property?.title,
         };
         const isTopLevel = Preference.TreeNode.isTopLevel(newNode);
         if (!isTopLevel) {
@@ -216,10 +217,11 @@ export class PreferenceTreeGenerator {
         return this.topLevelCategories.get(id);
     }
 
-    protected getOrCreatePreferencesGroup(id: string, group: string, root: CompositeTreeNode, groups: Map<string, Preference.CompositeTreeNode>): Preference.CompositeTreeNode {
+    protected getOrCreatePreferencesGroup(id: string, group: string, root: CompositeTreeNode, groups: Map<string, Preference.CompositeTreeNode>, property?: PreferenceDataProperty):
+        Preference.CompositeTreeNode {
         const existingGroup = groups.get(id);
         if (existingGroup) { return existingGroup; }
-        const newNode = this.createPreferencesGroup(id, group, root);
+        const newNode = this.createPreferencesGroup(id, group, root, property);
         groups.set(id, newNode);
         return newNode;
     };

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -60,6 +60,11 @@ export namespace Preference {
 
     export interface CompositeTreeNode extends BaseCompositeTreeNode {
         depth: number;
+        title?: string;
+    }
+
+    export namespace CompositeTreeNode {
+        export const is = (node: BaseTreeNode): node is CompositeTreeNode => 'depth' in node && 'title' in node;
     }
 
     export interface LeafNode extends BaseTreeNode {

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -143,7 +143,10 @@ export class PreferenceHeaderRenderer extends PreferenceNodeRenderer {
         wrapper.id = `${this.preferenceNode.id}-editor`;
         const isCategory = Preference.TreeNode.isTopLevel(this.preferenceNode);
         const hierarchyClassName = isCategory ? HEADER_CLASS : SUBHEADER_CLASS;
-        const name = this.labelProvider.getName(this.preferenceNode);
+        let name = this.labelProvider.getName(this.preferenceNode);
+        if (Preference.CompositeTreeNode.is(this.preferenceNode)) {
+            name = this.preferenceNode.title ?? name;
+        }
         const label = document.createElement('li');
         label.classList.add('settings-section-title', hierarchyClassName);
         label.textContent = name;

--- a/packages/preferences/src/browser/views/preference-tree-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-tree-widget.tsx
@@ -24,6 +24,7 @@ import {
 } from '@theia/core/lib/browser';
 import React = require('@theia/core/shared/react');
 import { PreferenceTreeModel, PreferenceTreeNodeRow, PreferenceTreeNodeProps } from '../preference-tree-model';
+import { Preference } from '../util/preference-types';
 
 @injectable()
 export class PreferencesTreeWidget extends TreeWidget {
@@ -84,7 +85,10 @@ export class PreferencesTreeWidget extends TreeWidget {
 
     protected override toNodeName(node: TreeNode): string {
         const visibleChildren = this.model.currentRows.get(node.id)?.visibleChildren;
-        const baseName = this.labelProvider.getName(node);
+        let baseName = this.labelProvider.getName(node);
+        if (Preference.CompositeTreeNode.is(node)) {
+            baseName = node.title ?? baseName;
+        }
         const printedNameWithVisibleChildren = this.model.isFiltered && visibleChildren !== undefined
             ? `${baseName} (${visibleChildren})`
             : baseName;


### PR DESCRIPTION
#### What it does

Fix https://github.com/eclipse-theia/theia/issues/12928

Contributed by STMicroelectronics
Signed-off-by: Vincent GRENET [vincent.grenet@st.com](mailto:vincent.grenet@st.com)

#### How to test

1. Hack package.json of your preferred VSCode extension
2. Install it within Theia
3. Just check configuration.title is now considered asking for Settings widget

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [X ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

