### PR TITLE
[perf] Load localizations lazily

### DIFF
--- a/packages/core/src/node/i18n/localization-provider.ts
+++ b/packages/core/src/node/i18n/localization-provider.ts
@@ -17,24 +17,70 @@
 import { injectable } from 'inversify';
 import { nls } from '../../common/nls';
 import { LanguageInfo, Localization } from '../../common/i18n/localization';
+import { Disposable } from '../../common/disposable';
+import { isObject } from '../../common/types';
+
+/**
+ * Localization data structure that contributes its localizations asynchronously.
+ * Allows to load localizations on demand when requested by the user.
+ */
+export interface LazyLocalization extends LanguageInfo {
+    getTranslations(): Promise<Record<string, string>>;
+}
+
+export namespace LazyLocalization {
+    export function is(obj: unknown): obj is LazyLocalization {
+        return isObject<LazyLocalization>(obj) && typeof obj.languageId === 'string' && typeof obj.getTranslations === 'function';
+    }
+    export function fromLocalization(localization: Localization): LazyLocalization {
+        const {
+            languageId,
+            languageName,
+            languagePack,
+            localizedLanguageName,
+            translations
+        } = localization;
+        return {
+            languageId,
+            languageName,
+            languagePack,
+            localizedLanguageName,
+            getTranslations: () => Promise.resolve(translations)
+        };
+    }
+    export async function toLocalization(localization: LazyLocalization): Promise<Localization> {
+        const {
+            languageId,
+            languageName,
+            languagePack,
+            localizedLanguageName
+        } = localization;
+        return {
+            languageId,
+            languageName,
+            languagePack,
+            localizedLanguageName,
+            translations: await localization.getTranslations()
+        };
+    }
+}
 
 @injectable()
 export class LocalizationProvider {
 
-    protected localizations: Localization[] = [];
+    protected localizations: LazyLocalization[] = [];
     protected currentLanguage = nls.defaultLocale;
 
-    addLocalizations(...localizations: Localization[]): void {
+    addLocalizations(...localizations: LazyLocalization[]): Disposable {
         this.localizations.push(...localizations);
-    }
-
-    removeLocalizations(...localizations: Localization[]): void {
-        for (const localization of localizations) {
-            const index = this.localizations.indexOf(localization);
-            if (index >= 0) {
-                this.localizations.splice(index, 1);
+        return Disposable.create(() => {
+            for (const localization of localizations) {
+                const index = this.localizations.indexOf(localization);
+                if (index >= 0) {
+                    this.localizations.splice(index, 1);
+                }
             }
-        }
+        });
     }
 
     setCurrentLanguage(languageId: string): void {
@@ -61,12 +107,13 @@ export class LocalizationProvider {
         return Array.from(languageInfos.values()).sort((a, b) => a.languageId.localeCompare(b.languageId));
     }
 
-    loadLocalization(languageId: string): Localization {
+    async loadLocalization(languageId: string): Promise<Localization> {
         const merged: Localization = {
             languageId,
             translations: {}
         };
-        for (const localization of this.localizations.filter(e => e.languageId === languageId)) {
+        const localizations = await Promise.all(this.localizations.filter(e => e.languageId === languageId).map(LazyLocalization.toLocalization));
+        for (const localization of localizations) {
             merged.languageName ||= localization.languageName;
             merged.localizedLanguageName ||= localization.localizedLanguageName;
             merged.languagePack ||= localization.languagePack;

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -643,8 +643,7 @@ export interface Localization {
 export interface Translation {
     id: string;
     path: string;
-    version: string;
-    contents: { [scope: string]: { [key: string]: string } }
+    cachedContents?: { [scope: string]: { [key: string]: string } };
 }
 
 export interface SnippetContribution {


### PR DESCRIPTION
#### What it does

Related to https://github.com/eclipse-theia/theia/issues/12924

Makes the localization entries used in the `LocalizationProvider` lazy. This is mainly relevant for localizations contributed by language packs, as they are usually split into dozens of files, which takes quite a while to load and parse. Each language pack takes roughly ~50-100ms to load. Having 10+ language packs installed can slow down startup time considerably.

#### How to test

1. Load a language pack and assert that it still works as expected.
2. Install all language packs (see [here](https://open-vsx.org/?category=Language%20Packs)) and assert that the startup time isn't influenced (at least not noticably).

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
