### PR TITLE
Improve frontend startup performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.42.0
 
 - [core] fixed logger level propagation when log config file changes at runtime [#12566](https://github.com/eclipse-theia/theia/pull/12566) - Contributed on behalf of STMicroelectronics
+- [core] improve frontend startup time [#12936](https://github.com/eclipse-theia/theia/pull/12936) - Contributed on behalf of STMicroelectronics
 - [vscode] stub TestController invalidateTestResults [#12944](https://github.com/eclipse-theia/theia/pull/12944) - Contributed by STMicroelectronics
 - [vscode] support iconPath in QuickPickItem [#12945](https://github.com/eclipse-theia/theia/pull/12945) - Contributed by STMicroelectronics
 - [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -428,6 +428,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     protected pinnedKey: ContextKey<boolean>;
 
     async configure(app: FrontendApplication): Promise<void> {
+        // FIXME: This request blocks valuable startup time (~200ms).
         const configDirUri = await this.environments.getConfigDirUri();
         // Global settings
         this.encodingRegistry.registerOverride({

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -473,8 +473,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
         this.schemaUpdater.update();
         this.configurations.load();
-        await this.breakpointManager.load();
-        await this.watchManager.load();
+        this.breakpointManager.load();
+        this.watchManager.load();
     }
 
     onStop(): void {

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -175,7 +175,7 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
     }
 
     async onStart(): Promise<void> {
-        await this.restoreState();
+        this.restoreState();
     }
 
     onStop(): void {

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -268,7 +268,7 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
     }
 
     async onStart(app: FrontendApplication): Promise<void> {
-        await this.contributeDefaultProfiles();
+        this.contributeDefaultProfiles();
 
         this.terminalPreferences.onPreferenceChanged(e => {
             if (e.preferenceName.startsWith('terminal.integrated.')) {


### PR DESCRIPTION
The frontend awaits 'initialize', 'configure' and 'onStart' for all frontend contributions. It's therefore very important that no expensive code is run there.

By not awaiting expensive operations in

 - DebugFrontendApplicationContribution.onStart (~300ms)
 - EditorNavigationContribution.onStart (~36-400ms)
 - TerminalFrontendContribution.onStart (~100-300ms)

the reported startup time without using plugins is reduced by ~400-1000ms which is an improvement of ~20-40%.

Contributed on behalf of STMicroelectronics

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

It removes some `await`ed instructions in the critical execution paths which are not really necessary to be awaited. The remaining `await` instruction in the `common-frontend-contribution` which takes about ~200ms of time to be executed was not removed as this might have some side effects in theory, although in practice I was not able to observe any.

---

Note: I also tried to run all `initialize`, `configure` and `onStart` phases each in "parallel", using `Promise.all`. However when combined with the remaining changes this actually lead to a slowdown, probably because the Javascript thread is already fully utilized.

#### How to test

Verify that Theia behaves as before. Please have a look at the code paths to see whether something was missed.

You can start Theia with `logLevel=debug` for more extensive logging and verify the reported startup times. For proper logging in `production` mode, you need to disable class name substitution. This can be achieved by adding the following to the `webpack.config.js`:

```javascript
const TerserPlugin = require('terser-webpack-plugin');
configs[0].optimization = {
    minimizer: [
        new TerserPlugin({
            terserOptions: {
                keep_classnames: true
            }
        })
    ]
};
```

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
