### PR TITLE
[vscode] Stub TestController invalidateTestResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.42.0
 
 - [core] fixed logger level propagation when log config file changes at runtime [#12566](https://github.com/eclipse-theia/theia/pull/12566) - Contributed on behalf of STMicroelectronics
+- [vscode] stub TestController invalidateTestResults [#12944](https://github.com/eclipse-theia/theia/pull/12944) - Contributed by STMicroelectronics
 - [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics
 
 ## v1.41.0 - 08/31/2023

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -232,7 +232,8 @@ import {
     createRunProfile,
     createTestRun,
     testItemCollection,
-    createTestItem
+    createTestItem,
+    invalidateTestResults
 } from './stubs/tests-api';
 import { TimelineExtImpl } from './timeline';
 import { ThemingExtImpl } from './theming';
@@ -1010,6 +1011,7 @@ export function createAPIFactory(
                     createRunProfile,
                     createTestRun,
                     createTestItem,
+                    invalidateTestResults,
                     dispose: () => undefined,
                 };
             },

--- a/packages/plugin-ext/src/plugin/stubs/tests-api.ts
+++ b/packages/plugin-ext/src/plugin/stubs/tests-api.ts
@@ -96,3 +96,7 @@ export const createTestItem = (
     range: undefined,
     error: undefined,
 });
+
+export const invalidateTestResults = (
+    items?: theia.TestItem | readonly theia.TestItem[]
+): void => undefined;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -15981,6 +15981,25 @@ export module '@theia/plugin' {
         createTestItem(id: string, label: string, uri?: Uri): TestItem;
 
         /**
+         * Marks an item's results as being outdated. This is commonly called when
+         * code or configuration changes and previous results should no longer
+         * be considered relevant. The same logic used to mark results as outdated
+         * may be used to drive {@link TestRunRequest.continuous continuous test runs}.
+         *
+         * If an item is passed to this method, test results for the item and all of
+         * its children will be marked as outdated. If no item is passed, then all
+         * test owned by the TestController will be marked as outdated.
+         *
+         * Any test runs started before the moment this method is called, including
+         * runs which may still be ongoing, will be marked as outdated and deprioritized
+         * in the editor's UI.
+         *
+         * @param item Item to mark as outdated. If undefined, all the controller's items are marked outdated.
+         * @stubbed
+         */
+        invalidateTestResults(items?: TestItem | readonly TestItem[]): void;
+
+        /**
          * Unregisters the test controller, disposing of its associated tests
          * and unpersisted results.
          * @stubbed


### PR DESCRIPTION
#### What it does

Stub new method on TestController for 1.81 vs code compat

This can push the compatibility towards 1.81 until Test API implementation has been reviewed and merged (see https://github.com/eclipse-theia/theia/pull/12935)

Fixes #12884 

Contributed on behalf of ST Microelectronics

#### How to test 
Not much, as this is a stubbed API. 

Results of the API report:
![invalidateTestResults_stubbed](https://github.com/eclipsesource/theia/assets/3964263/0fca016d-db6b-4d01-923d-dbe30ed2133b)

#### Follow-ups

This will be replaced by a concrete (empty) implementation when PR #12935 is merged

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
