### PR TITLE
Bump API version to 1.81.0 (#12882)

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.80.0';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.81.0';


### PR DESCRIPTION
#### What it does
Increase compatibility version to 1.81.0 as implementation tasks from task #12885 are closed.
Fixes https://github.com/eclipse-theia/theia/issues/12882

Contributed on behalf of ST Microelectronics

#### How to test
Make sure the system starts and built-ins work as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)