### PR TITLE
fix: restore src-gen frontend production behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [core] fixed logger level propagation when log config file changes at runtime [#12566](https://github.com/eclipse-theia/theia/pull/12566) - Contributed on behalf of STMicroelectronics
 - [core] improve frontend startup time [#12936](https://github.com/eclipse-theia/theia/pull/12936) - Contributed on behalf of STMicroelectronics
+- [dev-packages] restore src-gen frontend production behavior [12950](https://github.com/eclipse-theia/theia/pull/12950) - Contributed on behalf of STMicroelectronics
 - [vscode] stub TestController invalidateTestResults [#12944](https://github.com/eclipse-theia/theia/pull/12944) - Contributed by STMicroelectronics
 - [vscode] support iconPath in QuickPickItem [#12945](https://github.com/eclipse-theia/theia/pull/12945) - Contributed by STMicroelectronics
 - [vsx-registry] added a hint to extension fetching ENOTFOUND errors [#12858](https://github.com/eclipse-theia/theia/pull/12858) - Contributed by STMicroelectronics

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -97,7 +97,7 @@ async function preload(parent) {
     container.parent = parent;
     try {
 ${Array.from(frontendPreloadModules.values(), jsModulePath => `\
-        await load(container, import('${jsModulePath}'));`).join(EOL)}
+        await load(container, ${this.importOrRequire()}('${jsModulePath}'));`).join(EOL)}
         const { Preloader } = require('@theia/core/lib/browser/preload/preloader');
         const preloader = container.get(Preloader);
         await preloader.initialize();
@@ -125,7 +125,7 @@ module.exports = (async () => {
 
     try {
 ${Array.from(frontendModules.values(), jsModulePath => `\
-        await load(container, import('${jsModulePath}'));`).join(EOL)}
+        await load(container, ${this.importOrRequire()}('${jsModulePath}'));`).join(EOL)}
         await start();
     } catch (reason) {
         console.error('Failed to start the frontend application.');
@@ -140,6 +140,10 @@ ${Array.from(frontendModules.values(), jsModulePath => `\
     }
 })();
 `;
+    }
+
+    protected importOrRequire(): string {
+        return this.options.mode !== 'production' ? 'import' : 'require';
     }
 
     /** HTML for secondary windows that contain an extracted widget. */


### PR DESCRIPTION
Restores the usage of 'require' in production mode when loading included modules.

At the moment, both in development as well as in production mode, the frontend will be generated using the 'import' function. Webpack will use this opportunity for code splitting, leading to the generation of many small bundles. As they are sequentially loaded, this has a negative effect on the startup speed of the frontend.

By using 'require' instead, webpack will produce a single bundle, which is faster to transmit without additional roundtrips. This behavior was used for production mode in all previous Theia versions and is now restored.

Contributed on behalf of STMicroelectronics

#### What it does

Use `require` for importing frontend modules in `production` mode, use `import` in the remaining modes (mainly development).

#### How to test

Trigger src-gen for the included example applications. Trigger with `--mode development` as well as `--mode production`.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

#### Context

The require generation was removed with https://github.com/eclipse-theia/theia/pull/12590
