### PR TITLE
Update nls metadata file for API version 1.81.0

### DIFF
--- a/examples/playwright/src/tests/theia-explorer-view.test.ts
+++ b/examples/playwright/src/tests/theia-explorer-view.test.ts
@@ -153,7 +153,7 @@ test.describe('Theia Explorer View', () => {
         const menuItems = await menu.visibleMenuItems();
         expect(menuItems).toContain('New File...');
         expect(menuItems).toContain('New Folder...');
-        expect(menuItems).toContain('Open in Terminal');
+        expect(menuItems).toContain('Open in Integrated Terminal');
         expect(menuItems).toContain('Find in Folder...');
 
         await menu.close();

--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -19,12 +19,6 @@
 				]
 			}
 		],
-		"vs/code/node/cliProcessMain": [
-			"cli"
-		],
-		"vs/code/node/sharedProcess/sharedProcessMain": [
-			"sharedLog"
-		],
 		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
 			"name",
 			"cpu",
@@ -35,6 +29,12 @@
 			"copy",
 			"copyAll",
 			"debug"
+		],
+		"vs/code/node/cliProcessMain": [
+			"cli"
+		],
+		"vs/code/node/sharedProcess/sharedProcessMain": [
+			"sharedLog"
 		],
 		"vs/workbench/electron-sandbox/desktop.main": [
 			"join.closeStorage"
@@ -75,6 +75,7 @@
 			"window.doubleClickIconToClose",
 			"titleBarStyle",
 			"windowControlsOverlay",
+			"nativeContextMenuLocation",
 			"dialogStyle",
 			"window.nativeTabs",
 			"window.nativeFullScreen",
@@ -168,18 +169,6 @@
 			"restartExtensionHost",
 			"restartExtensionHost.reason"
 		],
-		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
-			"updateLocale",
-			"changeAndRestart",
-			"neverAgain"
-		],
-		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
-			"revealInWindows",
-			"revealInMac",
-			"openContainer",
-			"miShare",
-			"filesCategory"
-		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution": [
 			"runtimeExtension"
 		],
@@ -243,6 +232,10 @@
 			"terminal.explorerKind.external",
 			"terminal.explorerKind.both",
 			"explorer.openInTerminalKind",
+			"terminal.sourceControlRepositoriesKind.integrated",
+			"terminal.sourceControlRepositoriesKind.external",
+			"terminal.sourceControlRepositoriesKind.both",
+			"sourceControlRepositories.openInTerminalKind",
 			"terminal.external.windowsExec",
 			"terminal.external.osxExec",
 			"terminal.external.linuxExec"
@@ -275,6 +268,12 @@
 					"Only translate 'Starting remote tunnel', do not change the format of the rest (markdown link format)"
 				]
 			},
+			{
+				"key": "remoteTunnel.serviceInstallFailed",
+				"comment": [
+					"{Locked=\"](command:{0})\"}"
+				]
+			},
 			"accountPreference.placeholder",
 			"signed in",
 			"others",
@@ -291,6 +290,11 @@
 					"&& denotes a mnemonic"
 				]
 			},
+			"tunnel.enable.placeholder",
+			"tunnel.enable.session",
+			"tunnel.enable.session.description",
+			"tunnel.enable.service",
+			"tunnel.enable.service.description",
 			{
 				"key": "progress.turnOn.final",
 				"comment": [
@@ -323,6 +327,18 @@
 			"remoteTunnelAccess.machineName",
 			"remoteTunnelAccess.machineNameRegex",
 			"remoteTunnelAccess.preventSleep"
+		],
+		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
+			"updateLocale",
+			"changeAndRestart",
+			"neverAgain"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
+			"revealInWindows",
+			"revealInMac",
+			"openContainer",
+			"miShare",
+			"filesCategory"
 		],
 		"vs/base/common/platform": [
 			{
@@ -753,214 +769,6 @@
 			"defaultColorDecorators",
 			"tabFocusMode"
 		],
-		"vs/base/common/errorMessage": [
-			"stackTrace.format",
-			"nodeExceptionMessage",
-			"error.defaultMessage",
-			"error.defaultMessage",
-			"error.moreErrors",
-			"error.defaultMessage"
-		],
-		"vs/code/electron-main/app": [
-			{
-				"key": "open",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "cancel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"confirmOpenMessage",
-			"confirmOpenDetail"
-		],
-		"vs/platform/environment/node/argvHelper": [
-			"multipleValues",
-			"emptyValue",
-			"deprecatedArgument",
-			"unknownSubCommandOption",
-			"unknownOption",
-			"gotoValidation"
-		],
-		"vs/platform/files/common/files": [
-			"unknownError",
-			"sizeB",
-			"sizeKB",
-			"sizeMB",
-			"sizeGB",
-			"sizeTB"
-		],
-		"vs/platform/files/common/fileService": [
-			"invalidPath",
-			"noProviderFound",
-			"fileNotFoundError",
-			"fileExists",
-			"err.write",
-			"writeFailedUnlockUnsupported",
-			"writeFailedAtomicUnsupported",
-			"writeFailedAtomicUnlock",
-			"fileIsDirectoryWriteError",
-			"fileModifiedError",
-			"err.read",
-			"fileIsDirectoryReadError",
-			"fileNotModifiedError",
-			"fileTooLargeError",
-			"unableToMoveCopyError1",
-			"unableToMoveCopyError2",
-			"unableToMoveCopyError3",
-			"unableToMoveCopyError4",
-			"mkdirExistsError",
-			"deleteFailedTrashUnsupported",
-			"deleteFailedAtomicUnsupported",
-			"deleteFailedTrashAndAtomicUnsupported",
-			"deleteFailedNotFound",
-			"deleteFailedNonEmptyFolder",
-			"err.readonly",
-			"err.readonly"
-		],
-		"vs/platform/files/node/diskFileSystemProvider": [
-			"fileExists",
-			"fileNotExists",
-			"moveError",
-			"copyError",
-			"fileCopyErrorPathCase",
-			"fileMoveCopyErrorNotFound",
-			"fileMoveCopyErrorExists"
-		],
-		"vs/platform/request/common/request": [
-			"request",
-			"httpConfigurationTitle",
-			"proxy",
-			"strictSSL",
-			"proxyAuthorization",
-			"proxySupportOff",
-			"proxySupportOn",
-			"proxySupportFallback",
-			"proxySupportOverride",
-			"proxySupport",
-			"systemCertificates"
-		],
-		"vs/platform/dialogs/common/dialogs": [
-			{
-				"key": "yesButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"cancelButton",
-			"cancelButton",
-			"cancelButton",
-			{
-				"key": "okButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "okButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"cancelButton",
-			"moreFile",
-			"moreFiles"
-		],
-		"vs/platform/update/common/update.config.contribution": [
-			"updateConfigurationTitle",
-			"updateMode",
-			"none",
-			"manual",
-			"start",
-			"default",
-			"updateMode",
-			"deprecated",
-			"enableWindowsBackgroundUpdatesTitle",
-			"enableWindowsBackgroundUpdates",
-			"showReleaseNotes"
-		],
-		"vs/platform/extensionManagement/common/extensionManagement": [
-			"extensions",
-			"preferences"
-		],
-		"vs/platform/extensionManagement/common/extensionManagementCLI": [
-			"notFound",
-			"useId",
-			"listFromLocation",
-			"installingExtensionsOnLocation",
-			"installingExtensions",
-			"alreadyInstalled-checkAndUpdate",
-			"alreadyInstalled",
-			"error while installing extensions",
-			"installation failed",
-			"successVsixInstall",
-			"cancelVsixInstall",
-			"alreadyInstalled",
-			"updateMessage",
-			"installing builtin with version",
-			"installing builtin ",
-			"installing with version",
-			"installing",
-			"successInstall",
-			"cancelInstall",
-			"forceDowngrade",
-			"builtin",
-			"forceUninstall",
-			"uninstalling",
-			"successUninstallFromLocation",
-			"successUninstall",
-			"notInstalleddOnLocation",
-			"notInstalled"
-		],
-		"vs/platform/extensionManagement/common/extensionsScannerService": [
-			"fileReadFail",
-			"jsonParseFail",
-			"jsonParseInvalidType",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat"
-		],
-		"vs/platform/extensionManagement/node/extensionManagementService": [
-			"incompatible",
-			"MarketPlaceDisabled",
-			"Not a Marketplace extension",
-			"removeError",
-			"errorDeleting",
-			"renameError",
-			"cannot read",
-			"restartCode",
-			"restartCode"
-		],
-		"vs/platform/languagePacks/common/languagePacks": [
-			"currentDisplayLanguage"
-		],
-		"vs/platform/telemetry/common/telemetryService": [
-			"telemetry.telemetryLevelMd",
-			"telemetry.docsStatement",
-			"telemetry.docsAndPrivacyStatement",
-			"telemetry.restart",
-			"telemetry.crashReports",
-			"telemetry.errors",
-			"telemetry.usage",
-			"telemetry.telemetryLevel.tableDescription",
-			"telemetry.telemetryLevel.deprecated",
-			"telemetryConfigurationTitle",
-			"telemetry.telemetryLevel.default",
-			"telemetry.telemetryLevel.error",
-			"telemetry.telemetryLevel.crash",
-			"telemetry.telemetryLevel.off",
-			"telemetryConfigurationTitle",
-			"telemetry.enableTelemetry",
-			"telemetry.enableTelemetryMd",
-			"enableTelemetryDeprecated"
-		],
-		"vs/platform/userDataProfile/common/userDataProfile": [
-			"defaultProfile"
-		],
 		"vs/code/electron-sandbox/issue/issueReporterPage": [
 			"sendSystemInfo",
 			"sendProcessInfo",
@@ -1029,15 +837,214 @@
 			"disabledExtensions",
 			"noCurrentExperiments"
 		],
-		"vs/platform/telemetry/common/telemetryLogAppender": [
-			"telemetryLog"
+		"vs/platform/environment/node/argvHelper": [
+			"multipleValues",
+			"emptyValue",
+			"deprecatedArgument",
+			"unknownSubCommandOption",
+			"unknownOption",
+			"gotoValidation"
 		],
-		"vs/platform/userDataSync/common/userDataSync": [
-			"settings sync",
-			"settingsSync.keybindingsPerPlatform",
-			"settingsSync.ignoredExtensions",
-			"app.extension.identifier.errorMessage",
-			"settingsSync.ignoredSettings"
+		"vs/base/common/errorMessage": [
+			"stackTrace.format",
+			"nodeExceptionMessage",
+			"error.defaultMessage",
+			"error.defaultMessage",
+			"error.moreErrors",
+			"error.defaultMessage"
+		],
+		"vs/code/electron-main/app": [
+			{
+				"key": "open",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "cancel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"confirmOpenMessage",
+			"confirmOpenDetail"
+		],
+		"vs/platform/files/common/files": [
+			"unknownError",
+			"sizeB",
+			"sizeKB",
+			"sizeMB",
+			"sizeGB",
+			"sizeTB"
+		],
+		"vs/platform/files/common/fileService": [
+			"invalidPath",
+			"noProviderFound",
+			"fileNotFoundError",
+			"fileExists",
+			"err.write",
+			"writeFailedUnlockUnsupported",
+			"writeFailedAtomicUnsupported",
+			"writeFailedAtomicUnlock",
+			"fileIsDirectoryWriteError",
+			"fileModifiedError",
+			"err.read",
+			"fileIsDirectoryReadError",
+			"fileNotModifiedError",
+			"fileTooLargeError",
+			"unableToMoveCopyError1",
+			"unableToMoveCopyError2",
+			"unableToMoveCopyError3",
+			"unableToMoveCopyError4",
+			"mkdirExistsError",
+			"deleteFailedTrashUnsupported",
+			"deleteFailedAtomicUnsupported",
+			"deleteFailedTrashAndAtomicUnsupported",
+			"deleteFailedNotFound",
+			"deleteFailedNonEmptyFolder",
+			"err.readonly",
+			"err.readonly"
+		],
+		"vs/platform/files/node/diskFileSystemProvider": [
+			"fileExists",
+			"fileNotExists",
+			"moveError",
+			"copyError",
+			"fileCopyErrorPathCase",
+			"fileMoveCopyErrorNotFound",
+			"fileMoveCopyErrorExists"
+		],
+		"vs/platform/request/common/request": [
+			"request",
+			"httpConfigurationTitle",
+			"proxy",
+			"strictSSL",
+			"proxyKerberosServicePrincipal",
+			"proxyAuthorization",
+			"proxySupportOff",
+			"proxySupportOn",
+			"proxySupportFallback",
+			"proxySupportOverride",
+			"proxySupport",
+			"systemCertificates"
+		],
+		"vs/platform/dialogs/common/dialogs": [
+			{
+				"key": "yesButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cancelButton",
+			"cancelButton",
+			"cancelButton",
+			{
+				"key": "okButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "okButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cancelButton",
+			"moreFile",
+			"moreFiles"
+		],
+		"vs/platform/update/common/update.config.contribution": [
+			"updateConfigurationTitle",
+			"updateMode",
+			"none",
+			"manual",
+			"start",
+			"default",
+			"updateMode",
+			"deprecated",
+			"enableWindowsBackgroundUpdatesTitle",
+			"enableWindowsBackgroundUpdates",
+			"showReleaseNotes"
+		],
+		"vs/platform/extensionManagement/common/extensionManagement": [
+			"extensions",
+			"preferences"
+		],
+		"vs/platform/extensionManagement/common/extensionsScannerService": [
+			"fileReadFail",
+			"jsonParseFail",
+			"jsonParseInvalidType",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat"
+		],
+		"vs/platform/extensionManagement/common/extensionManagementCLI": [
+			"notFound",
+			"useId",
+			"listFromLocation",
+			"installingExtensionsOnLocation",
+			"installingExtensions",
+			"alreadyInstalled-checkAndUpdate",
+			"alreadyInstalled",
+			"error while installing extensions",
+			"installation failed",
+			"successVsixInstall",
+			"cancelVsixInstall",
+			"alreadyInstalled",
+			"updateMessage",
+			"installing builtin with version",
+			"installing builtin ",
+			"installing with version",
+			"installing",
+			"successInstall",
+			"cancelInstall",
+			"forceDowngrade",
+			"builtin",
+			"forceUninstall",
+			"uninstalling",
+			"successUninstallFromLocation",
+			"successUninstall",
+			"notInstalleddOnLocation",
+			"notInstalled"
+		],
+		"vs/platform/extensionManagement/node/extensionManagementService": [
+			"incompatible",
+			"MarketPlaceDisabled",
+			"Not a Marketplace extension",
+			"removeError",
+			"errorDeleting",
+			"renameError",
+			"cannot read",
+			"restartCode",
+			"restartCode"
+		],
+		"vs/platform/languagePacks/common/languagePacks": [
+			"currentDisplayLanguage"
+		],
+		"vs/platform/telemetry/common/telemetryService": [
+			"telemetry.telemetryLevelMd",
+			"telemetry.docsStatement",
+			"telemetry.docsAndPrivacyStatement",
+			"telemetry.restart",
+			"telemetry.crashReports",
+			"telemetry.errors",
+			"telemetry.usage",
+			"telemetry.telemetryLevel.tableDescription",
+			"telemetry.telemetryLevel.deprecated",
+			"telemetryConfigurationTitle",
+			"telemetry.telemetryLevel.default",
+			"telemetry.telemetryLevel.error",
+			"telemetry.telemetryLevel.crash",
+			"telemetry.telemetryLevel.off",
+			"telemetryConfigurationTitle",
+			"telemetry.enableTelemetry",
+			"telemetry.enableTelemetryMd",
+			"enableTelemetryDeprecated"
+		],
+		"vs/platform/userDataProfile/common/userDataProfile": [
+			"defaultProfile"
 		],
 		"vs/platform/userDataSync/common/userDataSyncLog": [
 			"userDataSyncLog"
@@ -1050,6 +1057,13 @@
 		],
 		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
 			"incompatible sync data"
+		],
+		"vs/platform/userDataSync/common/userDataSync": [
+			"settings sync",
+			"settingsSync.keybindingsPerPlatform",
+			"settingsSync.ignoredExtensions",
+			"app.extension.identifier.errorMessage",
+			"settingsSync.ignoredSettings"
 		],
 		"vs/platform/remoteTunnel/node/remoteTunnelService": [
 			"remoteTunnelService.building",
@@ -1065,7 +1079,11 @@
 					"{0} is a tunnel name"
 				]
 			},
-			"remoteTunnelService.openTunnel"
+			"remoteTunnelService.openTunnel",
+			"remoteTunnelService.serviceInstallFailed"
+		],
+		"vs/platform/telemetry/common/telemetryLogAppender": [
+			"telemetryLog"
 		],
 		"vs/workbench/browser/workbench": [
 			"loaderErrorNative"
@@ -1141,10 +1159,8 @@
 		],
 		"vs/workbench/services/configuration/browser/configurationService": [
 			"configurationDefaults.description",
-			"experimental"
-		],
-		"vs/platform/workspace/common/workspace": [
-			"codeWorkspace"
+			"experimental",
+			"setting description"
 		],
 		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
 			"devTools",
@@ -1201,13 +1217,16 @@
 			"expand mode",
 			"typeNavigationMode"
 		],
+		"vs/platform/workspace/common/workspace": [
+			"codeWorkspace"
+		],
+		"vs/platform/contextkey/browser/contextKeyService": [
+			"getContextKeyInfo"
+		],
 		"vs/platform/markers/common/markers": [
 			"sev.error",
 			"sev.warning",
 			"sev.info"
-		],
-		"vs/platform/contextkey/browser/contextKeyService": [
-			"getContextKeyInfo"
 		],
 		"vs/platform/contextkey/common/contextkey": [
 			"contextkey.parser.error.emptyString",
@@ -1221,14 +1240,6 @@
 			"contextkey.parser.error.expectedButGot",
 			"contextkey.scanner.errorForLinterWithHint",
 			"contextkey.scanner.errorForLinter"
-		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"undo",
-			"redo",
-			"cut",
-			"copy",
-			"paste",
-			"selectAll"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"workbench.editor.titleScrollbarSizing.default",
@@ -1477,42 +1488,15 @@
 			"zenMode.hideActivityBar",
 			"zenMode.hideLineNumbers",
 			"zenMode.restore",
-			"zenMode.silentNotifications",
-			"security.allowedUNCHosts.patternErrorMessage",
-			"security.allowedUNCHosts",
-			"security.restrictUNCAccess"
+			"zenMode.silentNotifications"
 		],
-		"vs/workbench/browser/actions/developerActions": [
-			"inspect context keys",
-			"toggle screencast mode",
-			{
-				"key": "logStorage",
-				"comment": [
-					"A developer only action to log the contents of the storage for the current window."
-				]
-			},
-			"storageLogDialogMessage",
-			"storageLogDialogDetails",
-			{
-				"key": "logWorkingCopies",
-				"comment": [
-					"A developer only action to log the working copies that exist."
-				]
-			},
-			"screencastModeConfigurationTitle",
-			"screencastMode.location.verticalPosition",
-			"screencastMode.fontSize",
-			"keyboardShortcutsFormat.keys",
-			"keyboardShortcutsFormat.command",
-			"keyboardShortcutsFormat.commandWithGroup",
-			"keyboardShortcutsFormat.commandAndKeys",
-			"keyboardShortcutsFormat.commandWithGroupAndKeys",
-			"screencastMode.keyboardShortcutsFormat",
-			"screencastMode.onlyKeyboardShortcuts",
-			"screencastMode.hideSingleEditorCursorMoves",
-			"screencastMode.keyboardOverlayTimeout",
-			"screencastMode.mouseIndicatorColor",
-			"screencastMode.mouseIndicatorSize"
+		"vs/workbench/browser/actions/textInputActions": [
+			"undo",
+			"redo",
+			"cut",
+			"copy",
+			"paste",
+			"selectAll"
 		],
 		"vs/workbench/browser/actions/helpActions": [
 			"keybindingsReference",
@@ -1572,6 +1556,35 @@
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/workbench/browser/actions/developerActions": [
+			"inspect context keys",
+			"toggle screencast mode",
+			{
+				"key": "logStorage",
+				"comment": [
+					"A developer only action to log the contents of the storage for the current window."
+				]
+			},
+			"storageLogDialogMessage",
+			"storageLogDialogDetails",
+			{
+				"key": "logWorkingCopies",
+				"comment": [
+					"A developer only action to log the working copies that exist."
+				]
+			},
+			"screencastModeConfigurationTitle",
+			"screencastMode.location.verticalPosition",
+			"screencastMode.fontSize",
+			"screencastMode.keyboardOptions.description",
+			"screencastMode.keyboardOptions.showKeys",
+			"screencastMode.keyboardOptions.showCommands",
+			"screencastMode.keyboardOptions.showCommandGroups",
+			"screencastMode.keyboardOptions.showSingleEditorCursorMoves",
+			"screencastMode.keyboardOverlayTimeout",
+			"screencastMode.mouseIndicatorColor",
+			"screencastMode.mouseIndicatorSize"
 		],
 		"vs/workbench/browser/actions/layoutActions": [
 			"menuBarIcon",
@@ -1879,14 +1892,6 @@
 			"addFolderToWorkspaceTitle",
 			"workspaceFolderPickerPlaceholder"
 		],
-		"vs/workbench/browser/actions/quickAccessActions": [
-			"quickOpen",
-			"quickOpenWithModes",
-			"quickNavigateNext",
-			"quickNavigatePrevious",
-			"quickSelectNext",
-			"quickSelectPrevious"
-		],
 		"vs/workbench/services/actions/common/menusExtensionPoint": [
 			"menus.commandPalette",
 			"menus.touchBar",
@@ -2007,49 +2012,13 @@
 			"missing.submenu",
 			"submenuItem.duplicate"
 		],
-		"vs/workbench/api/common/configurationExtensionPoint": [
-			"vscode.extension.contributes.configuration.title",
-			"vscode.extension.contributes.configuration.order",
-			"vscode.extension.contributes.configuration.properties",
-			"vscode.extension.contributes.configuration.property.empty",
-			"vscode.extension.contributes.configuration.properties.schema",
-			"scope.application.description",
-			"scope.machine.description",
-			"scope.window.description",
-			"scope.resource.description",
-			"scope.language-overridable.description",
-			"scope.machine-overridable.description",
-			"scope.description",
-			"scope.enumDescriptions",
-			"scope.markdownEnumDescriptions",
-			"scope.enumItemLabels",
-			"scope.markdownDescription",
-			"scope.deprecationMessage",
-			"scope.markdownDeprecationMessage",
-			"scope.singlelineText.description",
-			"scope.multilineText.description",
-			"scope.editPresentation",
-			"scope.order",
-			"scope.ignoreSync",
-			"config.property.defaultConfiguration.warning",
-			"vscode.extension.contributes.configuration",
-			"invalid.title",
-			"invalid.properties",
-			"config.property.duplicate",
-			"invalid.property",
-			"invalid.allOf",
-			"workspaceConfig.folders.description",
-			"workspaceConfig.path.description",
-			"workspaceConfig.name.description",
-			"workspaceConfig.uri.description",
-			"workspaceConfig.name.description",
-			"workspaceConfig.settings.description",
-			"workspaceConfig.launch.description",
-			"workspaceConfig.tasks.description",
-			"workspaceConfig.extensions.description",
-			"workspaceConfig.remoteAuthority",
-			"workspaceConfig.transient",
-			"unknownWorkspaceProperty"
+		"vs/workbench/browser/actions/quickAccessActions": [
+			"quickOpen",
+			"quickOpenWithModes",
+			"quickNavigateNext",
+			"quickNavigatePrevious",
+			"quickSelectNext",
+			"quickSelectPrevious"
 		],
 		"vs/workbench/api/browser/viewsExtensionPoint": [
 			{
@@ -2106,6 +2075,50 @@
 			"optstring",
 			"optstring",
 			"optenum"
+		],
+		"vs/workbench/api/common/configurationExtensionPoint": [
+			"vscode.extension.contributes.configuration.title",
+			"vscode.extension.contributes.configuration.order",
+			"vscode.extension.contributes.configuration.properties",
+			"vscode.extension.contributes.configuration.property.empty",
+			"vscode.extension.contributes.configuration.properties.schema",
+			"scope.application.description",
+			"scope.machine.description",
+			"scope.window.description",
+			"scope.resource.description",
+			"scope.language-overridable.description",
+			"scope.machine-overridable.description",
+			"scope.description",
+			"scope.enumDescriptions",
+			"scope.markdownEnumDescriptions",
+			"scope.enumItemLabels",
+			"scope.markdownDescription",
+			"scope.deprecationMessage",
+			"scope.markdownDeprecationMessage",
+			"scope.singlelineText.description",
+			"scope.multilineText.description",
+			"scope.editPresentation",
+			"scope.order",
+			"scope.ignoreSync",
+			"config.property.defaultConfiguration.warning",
+			"vscode.extension.contributes.configuration",
+			"invalid.title",
+			"invalid.properties",
+			"config.property.duplicate",
+			"invalid.property",
+			"invalid.allOf",
+			"workspaceConfig.folders.description",
+			"workspaceConfig.path.description",
+			"workspaceConfig.name.description",
+			"workspaceConfig.uri.description",
+			"workspaceConfig.name.description",
+			"workspaceConfig.settings.description",
+			"workspaceConfig.launch.description",
+			"workspaceConfig.tasks.description",
+			"workspaceConfig.extensions.description",
+			"workspaceConfig.remoteAuthority",
+			"workspaceConfig.transient",
+			"unknownWorkspaceProperty"
 		],
 		"vs/workbench/browser/parts/editor/editor.contribution": [
 			"textEditor",
@@ -2573,6 +2586,35 @@
 				]
 			}
 		],
+		"vs/workbench/services/keybinding/common/keybindingEditing": [
+			"errorKeybindingsFileDirty",
+			"parseErrors",
+			"errorInvalidConfiguration",
+			"emptyKeybindingsHeader"
+		],
+		"vs/workbench/services/decorations/browser/decorationsService": [
+			"bubbleTitle"
+		],
+		"vs/workbench/services/progress/browser/progressService": [
+			"progress.text2",
+			"progress.title3",
+			"progress.title2",
+			"progress.title2",
+			"status.progress",
+			"cancel",
+			"cancel",
+			"dismiss"
+		],
+		"vs/workbench/services/preferences/browser/preferencesService": [
+			"openFolderFirst",
+			"emptyKeybindingsHeader",
+			"defaultKeybindings",
+			"defaultKeybindings",
+			"fail.createSettings"
+		],
+		"vs/workbench/services/configuration/common/jsonEditingService": [
+			"errorInvalidFile"
+		],
 		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
 			"confirmUrl",
 			"rememberConfirmUrl",
@@ -2607,35 +2649,6 @@
 			"manage",
 			"extensions",
 			"no"
-		],
-		"vs/workbench/services/keybinding/common/keybindingEditing": [
-			"errorKeybindingsFileDirty",
-			"parseErrors",
-			"errorInvalidConfiguration",
-			"emptyKeybindingsHeader"
-		],
-		"vs/workbench/services/decorations/browser/decorationsService": [
-			"bubbleTitle"
-		],
-		"vs/workbench/services/progress/browser/progressService": [
-			"progress.text2",
-			"progress.title3",
-			"progress.title2",
-			"progress.title2",
-			"status.progress",
-			"cancel",
-			"cancel",
-			"dismiss"
-		],
-		"vs/workbench/services/preferences/browser/preferencesService": [
-			"openFolderFirst",
-			"emptyKeybindingsHeader",
-			"defaultKeybindings",
-			"defaultKeybindings",
-			"fail.createSettings"
-		],
-		"vs/workbench/services/configuration/common/jsonEditingService": [
-			"errorInvalidFile"
 		],
 		"vs/workbench/services/editor/browser/editorResolverService": [
 			"editorResolver.conflictingDefaults",
@@ -2757,10 +2770,36 @@
 			"resolving uri",
 			"preview profile",
 			"import profile",
+			"create profile",
+			"save profile",
+			"create new profle",
+			"settings",
+			"keybindings",
+			"snippets",
+			"tasks",
+			"extensions",
+			"name placeholder",
+			"save",
+			"create",
+			"customise the profile",
+			"profileExists",
+			"invalid configurations",
+			"use default profile",
+			"name required",
+			"create from",
+			"empty profile",
+			"from templates",
+			"from existing profiles",
+			"create profile",
 			"export",
 			"close",
+			"create from profile",
+			"progress extensions",
+			"switching profile",
 			"troubleshoot issue",
 			"troubleshoot profile progress",
+			"progress extensions",
+			"switching profile",
 			"profiles.exporting",
 			"export success",
 			{
@@ -2788,16 +2827,16 @@
 			"preview profile message",
 			"learn more",
 			"install extensions title",
+			"create profile",
 			"cancel",
 			"import",
-			"Importing profile",
+			"switching profile",
 			"progress settings",
 			"progress keybindings",
 			"progress tasks",
 			"progress snippets",
 			"progress global state",
 			"progress extensions",
-			"switching profile",
 			"select profile content handler",
 			"profile already exists",
 			{
@@ -2822,11 +2861,14 @@
 			"export profile dialog",
 			"select profile",
 			"select",
+			"select",
+			"from default",
 			"export profile name",
 			"export profile title",
 			"profile name required"
 		],
 		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
+			"reload message when updated",
 			"reload message when removed",
 			"reload message when removed",
 			"cannotRenameDefaultProfile",
@@ -2869,55 +2911,6 @@
 		"vs/workbench/services/views/browser/viewDescriptorService": [
 			"hideView",
 			"resetViewLocation"
-		],
-		"vs/workbench/services/authentication/browser/authenticationService": [
-			"authentication.id",
-			"authentication.label",
-			{
-				"key": "authenticationExtensionPoint",
-				"comment": [
-					"'Contributes' means adds here"
-				]
-			},
-			"authentication.Placeholder",
-			"authentication.missingId",
-			"authentication.missingLabel",
-			"authentication.idConflict",
-			"loading",
-			"sign in",
-			"confirmAuthenticationAccess",
-			{
-				"key": "allow",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "deny",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"useOtherAccount",
-			{
-				"key": "selectAccount",
-				"comment": [
-					"The placeholder {0} is the name of an extension. {1} is the name of the type of account, such as Microsoft or GitHub."
-				]
-			},
-			"getSessionPlateholder",
-			{
-				"key": "accessRequest",
-				"comment": [
-					"The placeholder {0} will be replaced with an authentication provider''s label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count"
-				]
-			},
-			{
-				"key": "signInRequest",
-				"comment": [
-					"The placeholder {0} will be replaced with an authentication provider's label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count."
-				]
-			}
 		],
 		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
 			"no authentication providers",
@@ -2969,6 +2962,55 @@
 			"others",
 			"sign in using account"
 		],
+		"vs/workbench/services/authentication/browser/authenticationService": [
+			"authentication.id",
+			"authentication.label",
+			{
+				"key": "authenticationExtensionPoint",
+				"comment": [
+					"'Contributes' means adds here"
+				]
+			},
+			"authentication.Placeholder",
+			"authentication.missingId",
+			"authentication.missingLabel",
+			"authentication.idConflict",
+			"loading",
+			"sign in",
+			"confirmAuthenticationAccess",
+			{
+				"key": "allow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "deny",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"useOtherAccount",
+			{
+				"key": "selectAccount",
+				"comment": [
+					"The placeholder {0} is the name of an extension. {1} is the name of the type of account, such as Microsoft or GitHub."
+				]
+			},
+			"getSessionPlateholder",
+			{
+				"key": "accessRequest",
+				"comment": [
+					"The placeholder {0} will be replaced with an authentication provider''s label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count"
+				]
+			},
+			{
+				"key": "signInRequest",
+				"comment": [
+					"The placeholder {0} will be replaced with an authentication provider's label. {1} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count."
+				]
+			}
+		],
 		"vs/workbench/services/assignment/common/assignmentService": [
 			"workbench.enableExperiments"
 		],
@@ -3002,29 +3044,12 @@
 			"troubleshootIssue",
 			"title.stop"
 		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"defineKeybinding.kbLayoutErrorMessage",
-			{
-				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
-					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			},
-			{
-				"key": "defineKeybinding.kbLayoutLocalMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
-					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			}
-		],
 		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
 			"settingsEditor2",
 			"keybindingsEditor",
 			"openSettings2",
 			"openUserSettingsJson",
-			"openCurrentProfileSettingsJson",
+			"openApplicationSettingsJson",
 			"preferences",
 			"settings",
 			{
@@ -3036,7 +3061,6 @@
 			"openSettings2",
 			"openGlobalSettings",
 			"openRawDefaultSettings",
-			"openSettingsJson",
 			"openSettingsJson",
 			"openWorkspaceSettings",
 			"openAccessibilitySettings",
@@ -3070,8 +3094,8 @@
 			"settings.focusLevelUp",
 			"preferences",
 			"openGlobalKeybindings",
-			"Keyboard Shortcuts",
-			"Keyboard Shortcuts",
+			"keyboardShortcuts",
+			"keyboardShortcuts",
 			"openDefaultKeybindingsFile",
 			"openGlobalKeybindingsFile",
 			"showDefaultKeybindings",
@@ -3086,12 +3110,6 @@
 					"&& denotes a mnemonic"
 				]
 			}
-		],
-		"vs/workbench/contrib/performance/browser/performance.contribution": [
-			"show.label",
-			"cycles",
-			"insta.trace",
-			"emitter"
 		],
 		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
 			"notebook.editorOptions.experimentalCustomization",
@@ -3115,6 +3133,7 @@
 			"insertToolbarLocation.both",
 			"insertToolbarLocation.hidden",
 			"notebook.globalToolbar.description",
+			"notebook.stickyScroll.description",
 			"notebook.consolidatedOutputButton.description",
 			"notebook.showFoldingControls.description",
 			"showFoldingControls.always",
@@ -3135,7 +3154,8 @@
 			"notebook.codeActionsOnSave",
 			"notebook.formatOnCellExecution",
 			"notebook.confirmDeleteRunningCell",
-			"notebook.findScope"
+			"notebook.findScope",
+			"notebook.remoteSaving"
 		],
 		"vs/workbench/contrib/chat/browser/chat.contribution": [
 			"interactiveSessionConfigurationTitle",
@@ -3144,9 +3164,17 @@
 			"interactiveSession.editor.fontWeight",
 			"interactiveSession.editor.wordWrap",
 			"interactiveSession.editor.lineHeight",
+			"interactiveSession.defaultMode.chatView",
+			"interactiveSession.defaultMode.quickQuestion",
+			"interactiveSession.defaultMode.both",
+			"interactiveSession.defaultMode",
+			"interactiveSession.quickQuestion.mode",
 			"chat",
 			"chat",
 			"chatAccessibleView"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChat.contribution": [
+			"inlineChatAccessibleView"
 		],
 		"vs/workbench/contrib/interactive/browser/interactive.contribution": [
 			"interactiveWindow",
@@ -3178,45 +3206,28 @@
 			"searchForAdditionalTestExtensions",
 			"testExplorer"
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"defineKeybinding.kbLayoutErrorMessage",
+			{
+				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
+					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			},
+			{
+				"key": "defineKeybinding.kbLayoutLocalMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
+					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			}
+		],
 		"vs/workbench/contrib/logs/common/logs.contribution": [
 			"setDefaultLogLevel",
 			"remote name",
 			"remote name",
 			"show window log"
-		],
-		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
-			"helpQuickAccessPlaceholder",
-			"helpQuickAccess",
-			"viewQuickAccessPlaceholder",
-			"viewQuickAccess",
-			"commandsQuickAccessPlaceholder",
-			"commandsQuickAccess",
-			{
-				"key": "miCommandPalette",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miShowAllCommands",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miOpenView",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "miGotoLine",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"commandPalette",
-			"commandPalette"
 		],
 		"vs/workbench/contrib/files/browser/explorerViewlet": [
 			"explorerViewIcon",
@@ -3263,6 +3274,40 @@
 					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
 				]
 			}
+		],
+		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
+			"helpQuickAccessPlaceholder",
+			"helpQuickAccess",
+			"viewQuickAccessPlaceholder",
+			"viewQuickAccess",
+			"commandsQuickAccessPlaceholder",
+			"commandsQuickAccess",
+			{
+				"key": "miCommandPalette",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miShowAllCommands",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenView",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoLine",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"commandPalette",
+			"commandPalette"
 		],
 		"vs/workbench/contrib/files/browser/fileActions.contribution": [
 			"copyPath",
@@ -3552,31 +3597,6 @@
 			"fileOperation",
 			"refactoring.autoSave"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
-			"overlap",
-			"detail",
-			{
-				"key": "continue",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"apply",
-			"cat",
-			"Discard",
-			"cat",
-			"toogleSelection",
-			"cat",
-			"groupByFile",
-			"cat",
-			"groupByType",
-			"cat",
-			"groupByType",
-			"cat",
-			"refactorPreviewViewIcon",
-			"panel",
-			"panel"
-		],
 		"vs/workbench/contrib/search/browser/search.contribution": [
 			"name",
 			"search",
@@ -3656,7 +3676,33 @@
 			"search.decorations.badges",
 			"scm.defaultViewMode.tree",
 			"scm.defaultViewMode.list",
-			"search.defaultViewMode"
+			"search.defaultViewMode",
+			"search.experimental.closedNotebookResults"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
+			"overlap",
+			"detail",
+			{
+				"key": "continue",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"apply",
+			"cat",
+			"Discard",
+			"cat",
+			"toogleSelection",
+			"cat",
+			"groupByFile",
+			"cat",
+			"groupByType",
+			"cat",
+			"groupByType",
+			"cat",
+			"refactorPreviewViewIcon",
+			"panel",
+			"panel"
 		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
 			"searchEditor",
@@ -3811,7 +3857,8 @@
 			"scm accept",
 			"scm view next commit",
 			"scm view previous commit",
-			"open in terminal"
+			"open in external terminal",
+			"open in integrated terminal"
 		],
 		"vs/workbench/contrib/debug/browser/debug.contribution": [
 			"debugCategory",
@@ -4108,9 +4155,21 @@
 			"debugIcon.breakpointCurrentStackframeForeground",
 			"debugIcon.breakpointStackframeForeground"
 		],
-		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
-			"topStackFrameLineHighlight",
-			"focusedStackFrameLineHighlight"
+		"vs/workbench/contrib/debug/browser/debugViewlet": [
+			{
+				"key": "miOpenConfigurations",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "selectWorkspaceFolder",
+				"comment": [
+					"User picks a workspace folder or a workspace configuration file here. Workspace configuration files can contain settings and thus a launch.json configuration can be written into one."
+				]
+			},
+			"debugPanel",
+			"startAdditionalSession"
 		],
 		"vs/workbench/contrib/debug/browser/repl": [
 			{
@@ -4137,22 +4196,6 @@
 			"paste",
 			"copyAll",
 			"copy"
-		],
-		"vs/workbench/contrib/debug/browser/debugViewlet": [
-			{
-				"key": "miOpenConfigurations",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "selectWorkspaceFolder",
-				"comment": [
-					"User picks a workspace folder or a workspace configuration file here. Workspace configuration files can contain settings and thus a launch.json configuration can be written into one."
-				]
-			},
-			"debugPanel",
-			"startAdditionalSession"
 		],
 		"vs/workbench/contrib/markers/browser/markers.contribution": [
 			"markersViewIcon",
@@ -4199,10 +4242,11 @@
 			"manyProblems",
 			"totalProblems"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
-			"name",
-			"diffAlgorithm.legacy",
-			"diffAlgorithm.advanced"
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"show.label",
+			"cycles",
+			"insta.trace",
+			"emitter"
 		],
 		"vs/workbench/contrib/commands/common/commands.contribution": [
 			"runCommands",
@@ -4210,6 +4254,10 @@
 			"runCommands.commands",
 			"runCommands.invalidArgs",
 			"runCommands.noCommandsToRun"
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"topStackFrameLineHighlight",
+			"focusedStackFrameLineHighlight"
 		],
 		"vs/workbench/contrib/comments/browser/comments.contribution": [
 			"commentsConfigurationTitle",
@@ -4236,51 +4284,10 @@
 		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
 			"webview.editor.label"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			{
-				"key": "remote",
-				"comment": [
-					"Remote as in remote machine"
-				]
-			},
-			"installed",
-			"select and install local extensions",
-			"install remote in local",
-			"popularExtensions",
-			"recommendedExtensions",
-			"enabledExtensions",
-			"disabledExtensions",
-			"marketPlace",
-			"installed",
-			"recently updated",
-			"enabled",
-			"disabled",
-			"availableUpdates",
-			"builtin",
-			"workspaceUnsupported",
-			"workspaceRecommendedExtensions",
-			"otherRecommendedExtensions",
-			"builtinFeatureExtensions",
-			"builtInThemesExtensions",
-			"builtinProgrammingLanguageExtensions",
-			"untrustedUnsupportedExtensions",
-			"untrustedPartiallySupportedExtensions",
-			"virtualUnsupportedExtensions",
-			"virtualPartiallySupportedExtensions",
-			"deprecated",
-			"searchExtensions",
-			"extensionFoundInSection",
-			"extensionFound",
-			"extensionsFoundInSection",
-			"extensionsFound",
-			"suggestProxyError",
-			"open user settings",
-			"extensionToUpdate",
-			"extensionsToUpdate",
-			"extensionToReload",
-			"extensionsToReload",
-			"malicious warning",
-			"reloadNow"
+		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
+			"name",
+			"diffAlgorithm.legacy",
+			"diffAlgorithm.advanced"
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
 			"manageExtensionsQuickAccessPlaceholder",
@@ -4418,6 +4425,7 @@
 			"workbench.extensions.action.copyExtensionId",
 			"workbench.extensions.action.configure",
 			"workbench.extensions.action.configureKeybindings",
+			"workbench.extensions.action.toggleApplyToAllProfiles",
 			"workbench.extensions.action.toggleIgnoreExtension",
 			"workbench.extensions.action.ignoreRecommendation",
 			"workbench.extensions.action.undoIgnoredRecommendation",
@@ -4432,6 +4440,52 @@
 			"workbench.extensions.action.addToWorkspaceFolderIgnoredRecommendations",
 			"extensions",
 			"extensions"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			{
+				"key": "remote",
+				"comment": [
+					"Remote as in remote machine"
+				]
+			},
+			"installed",
+			"select and install local extensions",
+			"install remote in local",
+			"popularExtensions",
+			"recommendedExtensions",
+			"enabledExtensions",
+			"disabledExtensions",
+			"marketPlace",
+			"installed",
+			"recently updated",
+			"enabled",
+			"disabled",
+			"availableUpdates",
+			"builtin",
+			"workspaceUnsupported",
+			"workspaceRecommendedExtensions",
+			"otherRecommendedExtensions",
+			"builtinFeatureExtensions",
+			"builtInThemesExtensions",
+			"builtinProgrammingLanguageExtensions",
+			"untrustedUnsupportedExtensions",
+			"untrustedPartiallySupportedExtensions",
+			"virtualUnsupportedExtensions",
+			"virtualPartiallySupportedExtensions",
+			"deprecated",
+			"searchExtensions",
+			"extensionFoundInSection",
+			"extensionFound",
+			"extensionsFoundInSection",
+			"extensionsFound",
+			"suggestProxyError",
+			"open user settings",
+			"extensionToUpdate",
+			"extensionsToUpdate",
+			"extensionToReload",
+			"extensionsToReload",
+			"malicious warning",
+			"reloadNow"
 		],
 		"vs/workbench/contrib/output/browser/output.contribution": [
 			"outputViewIcon",
@@ -4463,6 +4517,12 @@
 			"selectlogFile",
 			"output",
 			"output.smartScroll.enabled"
+		],
+		"vs/workbench/contrib/output/browser/outputView": [
+			"output model title",
+			"channel",
+			"output",
+			"outputViewAriaLabel"
 		],
 		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
 			"scopedConsoleAction.Integrated",
@@ -4547,6 +4607,7 @@
 			"ConfigureDefaultBuildTask.label",
 			"ConfigureDefaultTestTask.label",
 			"workbench.action.tasks.openUserTasks",
+			"userTasks",
 			"tasksQuickAccessPlaceholder",
 			"tasksQuickAccessHelp",
 			"tasksConfigurationTitle",
@@ -4636,12 +4697,6 @@
 			"snippetSchema.json.default",
 			"snippetSchema.json",
 			"snippetSchema.json.scope"
-		],
-		"vs/workbench/contrib/output/browser/outputView": [
-			"output model title",
-			"channel",
-			"output",
-			"outputViewAriaLabel"
 		],
 		"vs/workbench/contrib/folding/browser/folding.contribution": [
 			"null",
@@ -5164,7 +5219,9 @@
 		],
 		"vs/workbench/contrib/accessibility/browser/accessibility.contribution": [
 			"editor-help",
-			"hoverAccessibleView"
+			"hoverAccessibleView",
+			"notification.accessibleView",
+			"notification"
 		],
 		"vs/workbench/contrib/share/browser/share.contribution": [
 			"share",
@@ -5174,6 +5231,31 @@
 			"close",
 			"open link",
 			"experimental.share.enabled"
+		],
+		"vs/workbench/browser/parts/dialogs/dialogHandler": [
+			"aboutDetail",
+			{
+				"key": "copy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"ok"
+		],
+		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
+			{
+				"key": "aboutDetail",
+				"comment": [
+					"Electron, Chromium, Node.js and V8 are product names that need no translation"
+				]
+			},
+			{
+				"key": "copy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"okButton"
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
 			"defaultLanguageConfigurationOverrides.title",
@@ -5313,32 +5395,10 @@
 		"vs/workbench/common/configuration": [
 			"applicationConfigurationTitle",
 			"workbenchConfigurationTitle",
-			"securityConfigurationTitle"
-		],
-		"vs/workbench/browser/parts/dialogs/dialogHandler": [
-			"aboutDetail",
-			{
-				"key": "copy",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"ok"
-		],
-		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
-			{
-				"key": "aboutDetail",
-				"comment": [
-					"Electron, Chromium, Node.js and V8 are product names that need no translation"
-				]
-			},
-			{
-				"key": "copy",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"okButton"
+			"securityConfigurationTitle",
+			"security.allowedUNCHosts.patternErrorMessage",
+			"security.allowedUNCHosts",
+			"security.restrictUNCAccess"
 		],
 		"vs/workbench/services/textfile/browser/textFileService": [
 			"textFileCreate.source",
@@ -5727,9 +5787,6 @@
 			"windowActiveBorder",
 			"windowInactiveBorder"
 		],
-		"vs/base/common/actions": [
-			"submenu.empty"
-		],
 		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
 			"save",
 			"saveWorkspace",
@@ -5793,8 +5850,10 @@
 			"non web extensions detail",
 			"non web extensions"
 		],
+		"vs/base/common/actions": [
+			"submenu.empty"
+		],
 		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
-			"notFoundCompatiblePrereleaseDependency",
 			"notFoundReleaseExtension",
 			"notFoundCompatibleDependency"
 		],
@@ -5853,66 +5912,6 @@
 			"openLogsFolder",
 			"openExtensionLogsFolder"
 		],
-		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
-			"showLanguagePackExtensions",
-			"searchMarketplace",
-			"installAndRestartMessage",
-			"installAndRestart"
-		],
-		"vs/workbench/contrib/localization/common/localization.contribution": [
-			"vscode.extension.contributes.localizations",
-			"vscode.extension.contributes.localizations.languageId",
-			"vscode.extension.contributes.localizations.languageName",
-			"vscode.extension.contributes.localizations.languageNameLocalized",
-			"vscode.extension.contributes.localizations.translations",
-			"vscode.extension.contributes.localizations.translations.id",
-			"vscode.extension.contributes.localizations.translations.id.pattern",
-			"vscode.extension.contributes.localizations.translations.path"
-		],
-		"vs/editor/common/editorContextKeys": [
-			"editorTextFocus",
-			"editorFocus",
-			"textInputFocus",
-			"editorReadonly",
-			"inDiffEditor",
-			"isEmbeddedDiffEditor",
-			"editorColumnSelection",
-			"editorHasSelection",
-			"editorHasMultipleSelections",
-			"editorTabMovesFocus",
-			"editorHoverVisible",
-			"editorHoverFocused",
-			"stickyScrollFocused",
-			"stickyScrollVisible",
-			"standaloneColorPickerVisible",
-			"standaloneColorPickerFocused",
-			"inCompositeEditor",
-			"editorLangId",
-			"editorHasCompletionItemProvider",
-			"editorHasCodeActionsProvider",
-			"editorHasCodeLensProvider",
-			"editorHasDefinitionProvider",
-			"editorHasDeclarationProvider",
-			"editorHasImplementationProvider",
-			"editorHasTypeDefinitionProvider",
-			"editorHasHoverProvider",
-			"editorHasDocumentHighlightProvider",
-			"editorHasDocumentSymbolProvider",
-			"editorHasReferenceProvider",
-			"editorHasRenameProvider",
-			"editorHasSignatureHelpProvider",
-			"editorHasInlayHintsProvider",
-			"editorHasDocumentFormattingProvider",
-			"editorHasDocumentSelectionFormattingProvider",
-			"editorHasMultipleDocumentFormattingProvider",
-			"editorHasMultipleDocumentSelectionFormattingProvider"
-		],
-		"vs/workbench/common/editor": [
-			"promptOpenWith.defaultEditor.displayName",
-			"builtinProviderDisplayName",
-			"openLargeFile",
-			"configureEditorLargeFileConfirmation"
-		],
 		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
 			"actions.pasteSelectionClipboard"
 		],
@@ -5929,6 +5928,12 @@
 			"saveExtensionHostProfile",
 			"saveprofile.dialogTitle",
 			"saveprofile.saveButton"
+		],
+		"vs/workbench/common/editor": [
+			"promptOpenWith.defaultEditor.displayName",
+			"builtinProviderDisplayName",
+			"openLargeFile",
+			"configureEditorLargeFileConfirmation"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/debugExtensionHostAction": [
 			"debugExtensionHost",
@@ -6012,6 +6017,35 @@
 			"vscode.extension.contributes.terminal.types.icon.light",
 			"vscode.extension.contributes.terminal.types.icon.dark"
 		],
+		"vs/editor/common/languages": [
+			"Array",
+			"Boolean",
+			"Class",
+			"Constant",
+			"Constructor",
+			"Enum",
+			"EnumMember",
+			"Event",
+			"Field",
+			"File",
+			"Function",
+			"Interface",
+			"Key",
+			"Method",
+			"Module",
+			"Namespace",
+			"Null",
+			"Number",
+			"Object",
+			"Operator",
+			"Package",
+			"Property",
+			"String",
+			"Struct",
+			"TypeParameter",
+			"Variable",
+			"symbolAriaLabel"
+		],
 		"vs/workbench/services/userDataSync/common/userDataSync": [
 			"settings",
 			"keybindings",
@@ -6043,11 +6077,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/tasks/common/tasks": [
-			"tasks.taskRunningContext",
-			"tasksCategory",
-			"TaskDefinition.missingRequiredProperty"
-		],
 		"vs/workbench/contrib/tasks/common/taskService": [
 			"tasks.customExecutionSupported",
 			"tasks.shellExecutionSupported",
@@ -6055,10 +6084,130 @@
 			"tasks.processExecutionSupported",
 			"tasks.serverlessWebContext"
 		],
+		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+			"TerminalTaskSystem.unknownError",
+			"TerminalTaskSystem.taskLoadReporting",
+			"dependencyCycle",
+			"dependencyFailed",
+			"TerminalTaskSystem.nonWatchingMatcher",
+			{
+				"key": "task.executingInFolder",
+				"comment": [
+					"The workspace folder the task is running in",
+					"The task command line or label"
+				]
+			},
+			{
+				"key": "task.executing.shellIntegration",
+				"comment": [
+					"The task command line or label"
+				]
+			},
+			{
+				"key": "task.executingInFolder",
+				"comment": [
+					"The workspace folder the task is running in",
+					"The task command line or label"
+				]
+			},
+			{
+				"key": "task.executing.shell-integration",
+				"comment": [
+					"The task command line or label"
+				]
+			},
+			{
+				"key": "task.executing",
+				"comment": [
+					"The task command line or label"
+				]
+			},
+			"TerminalTaskSystem",
+			"unknownProblemMatcher",
+			"closeTerminal",
+			"reuseTerminal"
+		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"tasks.taskRunningContext",
+			"tasksCategory",
+			"TaskDefinition.missingRequiredProperty"
+		],
 		"vs/workbench/common/views": [
 			"defaultViewIcon",
 			"duplicateId",
 			"treeView.notRegistered"
+		],
+		"vs/platform/audioCues/browser/audioCueService": [
+			"audioCues.lineHasError.name",
+			"audioCues.lineHasWarning.name",
+			"audioCues.lineHasFoldedArea.name",
+			"audioCues.lineHasBreakpoint.name",
+			"audioCues.lineHasInlineSuggestion.name",
+			"audioCues.terminalQuickFix.name",
+			"audioCues.onDebugBreak.name",
+			"audioCues.noInlayHints",
+			"audioCues.taskCompleted",
+			"audioCues.taskFailed",
+			"audioCues.terminalCommandFailed",
+			"audioCues.terminalBell",
+			"audioCues.notebookCellCompleted",
+			"audioCues.notebookCellFailed",
+			"audioCues.diffLineInserted",
+			"audioCues.diffLineDeleted",
+			"audioCues.diffLineModified",
+			"audioCues.chatRequestSent",
+			"audioCues.chatResponseReceived",
+			"audioCues.chatResponsePending"
+		],
+		"vs/workbench/contrib/terminal/common/terminalContextKey": [
+			"terminalFocusContextKey",
+			"terminalFocusInAnyContextKey",
+			"terminalAccessibleBufferFocusContextKey",
+			"terminalEditorFocusContextKey",
+			"terminalCountContextKey",
+			"terminalTabsFocusContextKey",
+			"terminalShellTypeContextKey",
+			"terminalAltBufferActive",
+			"terminalSuggestWidgetVisible",
+			"terminalViewShowing",
+			"terminalTextSelectedContextKey",
+			"terminalTextSelectedInFocusedContextKey",
+			"terminalProcessSupportedContextKey",
+			"terminalTabsSingularSelectedContextKey",
+			"isSplitTerminalContextKey",
+			"inTerminalRunCommandPickerContextKey",
+			"terminalShellIntegrationEnabled"
+		],
+		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
+			"revealInWindows",
+			"revealInMac",
+			"openContainer"
+		],
+		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
+			"openToolsLabel",
+			"iframeWebviewAlert"
+		],
+		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
+			"mergeEditor",
+			"merge.dev.openState",
+			"mergeEditor.enterJSON",
+			"merge.dev.openSelectionInTemporaryMergeEditor"
+		],
+		"vs/workbench/contrib/localization/common/localization.contribution": [
+			"vscode.extension.contributes.localizations",
+			"vscode.extension.contributes.localizations.languageId",
+			"vscode.extension.contributes.localizations.languageName",
+			"vscode.extension.contributes.localizations.languageNameLocalized",
+			"vscode.extension.contributes.localizations.translations",
+			"vscode.extension.contributes.localizations.translations.id",
+			"vscode.extension.contributes.localizations.translations.id.pattern",
+			"vscode.extension.contributes.localizations.translations.path"
+		],
+		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
+			"showLanguagePackExtensions",
+			"searchMarketplace",
+			"installAndRestartMessage",
+			"installAndRestart"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"ConfigureTaskRunnerAction.label",
@@ -6160,104 +6309,44 @@
 			"taskService.openDiff",
 			"taskService.openDiffs"
 		],
-		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
-			"TerminalTaskSystem.unknownError",
-			"TerminalTaskSystem.taskLoadReporting",
-			"dependencyCycle",
-			"dependencyFailed",
-			"TerminalTaskSystem.nonWatchingMatcher",
-			{
-				"key": "task.executingInFolder",
-				"comment": [
-					"The workspace folder the task is running in",
-					"The task command line or label"
-				]
-			},
-			{
-				"key": "task.executing.shellIntegration",
-				"comment": [
-					"The task command line or label"
-				]
-			},
-			{
-				"key": "task.executingInFolder",
-				"comment": [
-					"The workspace folder the task is running in",
-					"The task command line or label"
-				]
-			},
-			{
-				"key": "task.executing.shell-integration",
-				"comment": [
-					"The task command line or label"
-				]
-			},
-			{
-				"key": "task.executing",
-				"comment": [
-					"The task command line or label"
-				]
-			},
-			"TerminalTaskSystem",
-			"unknownProblemMatcher",
-			"closeTerminal",
-			"reuseTerminal"
-		],
-		"vs/platform/audioCues/browser/audioCueService": [
-			"audioCues.lineHasError.name",
-			"audioCues.lineHasWarning.name",
-			"audioCues.lineHasFoldedArea.name",
-			"audioCues.lineHasBreakpoint.name",
-			"audioCues.lineHasInlineSuggestion.name",
-			"audioCues.terminalQuickFix.name",
-			"audioCues.onDebugBreak.name",
-			"audioCues.noInlayHints",
-			"audioCues.taskCompleted",
-			"audioCues.taskFailed",
-			"audioCues.terminalCommandFailed",
-			"audioCues.terminalBell",
-			"audioCues.notebookCellCompleted",
-			"audioCues.notebookCellFailed",
-			"audioCues.diffLineInserted",
-			"audioCues.diffLineDeleted",
-			"audioCues.diffLineModified",
-			"audioCues.chatRequestSent",
-			"audioCues.chatResponseReceived",
-			"audioCues.chatResponsePending"
-		],
-		"vs/workbench/contrib/terminal/common/terminalContextKey": [
-			"terminalFocusContextKey",
-			"terminalFocusInAnyContextKey",
-			"terminalAccessibleBufferFocusContextKey",
-			"terminalEditorFocusContextKey",
-			"terminalCountContextKey",
-			"terminalTabsFocusContextKey",
-			"terminalShellTypeContextKey",
-			"terminalAltBufferActive",
-			"terminalSuggestWidgetVisible",
-			"terminalViewShowing",
-			"terminalTextSelectedContextKey",
-			"terminalTextSelectedInFocusedContextKey",
-			"terminalProcessSupportedContextKey",
-			"terminalTabsSingularSelectedContextKey",
-			"isSplitTerminalContextKey",
-			"inTerminalRunCommandPickerContextKey",
-			"terminalShellIntegrationEnabled"
-		],
-		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
-			"openToolsLabel",
-			"iframeWebviewAlert"
-		],
-		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
-			"revealInWindows",
-			"revealInMac",
-			"openContainer"
-		],
-		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
-			"mergeEditor",
-			"merge.dev.openState",
-			"mergeEditor.enterJSON",
-			"merge.dev.openSelectionInTemporaryMergeEditor"
+		"vs/editor/common/editorContextKeys": [
+			"editorTextFocus",
+			"editorFocus",
+			"textInputFocus",
+			"editorReadonly",
+			"inDiffEditor",
+			"isEmbeddedDiffEditor",
+			"accessibleDiffViewerVisible",
+			"editorColumnSelection",
+			"editorHasSelection",
+			"editorHasMultipleSelections",
+			"editorTabMovesFocus",
+			"editorHoverVisible",
+			"editorHoverFocused",
+			"stickyScrollFocused",
+			"stickyScrollVisible",
+			"standaloneColorPickerVisible",
+			"standaloneColorPickerFocused",
+			"inCompositeEditor",
+			"editorLangId",
+			"editorHasCompletionItemProvider",
+			"editorHasCodeActionsProvider",
+			"editorHasCodeLensProvider",
+			"editorHasDefinitionProvider",
+			"editorHasDeclarationProvider",
+			"editorHasImplementationProvider",
+			"editorHasTypeDefinitionProvider",
+			"editorHasHoverProvider",
+			"editorHasDocumentHighlightProvider",
+			"editorHasDocumentSymbolProvider",
+			"editorHasReferenceProvider",
+			"editorHasRenameProvider",
+			"editorHasSignatureHelpProvider",
+			"editorHasInlayHintsProvider",
+			"editorHasDocumentFormattingProvider",
+			"editorHasDocumentSelectionFormattingProvider",
+			"editorHasMultipleDocumentFormattingProvider",
+			"editorHasMultipleDocumentSelectionFormattingProvider"
 		],
 		"vs/workbench/api/common/extHostExtensionService": [
 			"extensionTestError1",
@@ -6271,6 +6360,10 @@
 		],
 		"vs/workbench/api/common/extHostTerminalService": [
 			"launchFail.idMissingOnExtHost"
+		],
+		"vs/workbench/api/common/extHostTunnelService": [
+			"tunnelPrivacy.private",
+			"tunnelPrivacy.public"
 		],
 		"vs/workbench/api/common/extHostLogService": [
 			"remote",
@@ -6286,9 +6379,8 @@
 		"vs/workbench/api/node/extHostDebugService": [
 			"debug.terminal.title"
 		],
-		"vs/workbench/api/node/extHostTunnelService": [
-			"tunnelPrivacy.private",
-			"tunnelPrivacy.public"
+		"vs/base/browser/ui/button/button": [
+			"button dropdown more actions"
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"open",
@@ -6369,14 +6461,6 @@
 			"cantUninstall",
 			"sourceMissing"
 		],
-		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
-			"newWindow",
-			"newWindowDesc",
-			"recentFoldersAndWorkspaces",
-			"recentFolders",
-			"untitledWorkspace",
-			"workspaceName"
-		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			{
 				"key": "ok",
@@ -6410,6 +6494,14 @@
 			"confirmOpenDetail",
 			"doNotAskAgain"
 		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"newWindow",
+			"newWindowDesc",
+			"recentFoldersAndWorkspaces",
+			"recentFolders",
+			"untitledWorkspace",
+			"workspaceName"
+		],
 		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
 			{
 				"key": "ok",
@@ -6422,6 +6514,22 @@
 		],
 		"vs/platform/files/common/io": [
 			"fileTooLargeError"
+		],
+		"vs/base/browser/ui/tree/abstractTree": [
+			"filter",
+			"fuzzySearch",
+			"type to filter",
+			"type to search",
+			"type to search",
+			"close",
+			"not found"
+		],
+		"vs/platform/theme/common/iconRegistry": [
+			"iconDefinition.fontId",
+			"iconDefinition.fontCharacter",
+			"widgetClose",
+			"previousChangeIcon",
+			"nextChangeIcon"
 		],
 		"vs/platform/extensions/common/extensionValidator": [
 			"extensionDescription.publisher",
@@ -6465,8 +6573,8 @@
 		"vs/platform/extensionManagement/common/abstractExtensionManagementService": [
 			"MarketPlaceDisabled",
 			"malicious extension",
+			"notFoundDeprecatedReplacementExtension",
 			"incompatible platform",
-			"notFoundCompatiblePrereleaseDependency",
 			"notFoundReleaseExtension",
 			"notFoundCompatibleDependency",
 			"singleDependentError",
@@ -6478,9 +6586,6 @@
 		],
 		"vs/platform/extensionManagement/node/extensionManagementUtil": [
 			"invalidManifest"
-		],
-		"vs/base/browser/ui/button/button": [
-			"button dropdown more actions"
 		],
 		"vs/base/common/date": [
 			"date.fromNow.in",
@@ -6563,32 +6668,10 @@
 			"session expired",
 			"turned off machine"
 		],
-		"vs/base/browser/ui/tree/abstractTree": [
-			"filter",
-			"fuzzySearch",
-			"type to filter",
-			"type to search",
-			"type to search",
-			"close",
-			"not found"
-		],
-		"vs/platform/theme/common/iconRegistry": [
-			"iconDefinition.fontId",
-			"iconDefinition.fontCharacter",
-			"widgetClose",
-			"previousChangeIcon",
-			"nextChangeIcon"
-		],
 		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
 			"alertErrorMessage",
 			"alertWarningMessage",
 			"alertInfoMessage"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"notificationsEmpty",
-			"notifications",
-			"notificationsToolbar",
-			"notificationsCenterWidgetAriaLabel"
 		],
 		"vs/workbench/browser/parts/notifications/notificationsStatus": [
 			"status.notifications",
@@ -6625,6 +6708,16 @@
 			},
 			"status.message"
 		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"notificationsEmpty",
+			"notifications",
+			"notificationsToolbar",
+			"notificationsCenterWidgetAriaLabel"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsToasts": [
+			"notificationAriaLabel",
+			"notificationWithSourceAriaLabel"
+		],
 		"vs/workbench/browser/parts/notifications/notificationsCommands": [
 			"notifications",
 			"showNotifications",
@@ -6634,16 +6727,13 @@
 			"toggleDoNotDisturbMode",
 			"focusNotificationToasts"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsToasts": [
-			"notificationAriaLabel",
-			"notificationWithSourceAriaLabel"
-		],
 		"vs/platform/actions/browser/menuEntryActionViewItem": [
 			"titleAndKb",
 			"titleAndKb",
 			"titleAndKbAndAlt"
 		],
 		"vs/workbench/services/configuration/common/configurationEditing": [
+			"fsError",
 			"openTasksConfiguration",
 			"openLaunchConfiguration",
 			"open",
@@ -6686,6 +6776,15 @@
 			"workspaceTarget",
 			"folderTarget"
 		],
+		"vs/editor/browser/coreCommands": [
+			"stickydesc",
+			"stickydesc",
+			"removedCursor"
+		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"cursors.maximum",
+			"goToSetting"
+		],
 		"vs/editor/common/core/editorColorRegistry": [
 			"lineHighlight",
 			"lineHighlightBorderBox",
@@ -6696,9 +6795,23 @@
 			"caret",
 			"editorCursorBackground",
 			"editorWhitespaces",
-			"editorIndentGuides",
-			"editorActiveIndentGuide",
 			"editorLineNumbers",
+			"editorIndentGuides",
+			"deprecatedEditorIndentGuides",
+			"editorActiveIndentGuide",
+			"deprecatedEditorActiveIndentGuide",
+			"editorIndentGuides1",
+			"editorIndentGuides2",
+			"editorIndentGuides3",
+			"editorIndentGuides4",
+			"editorIndentGuides5",
+			"editorIndentGuides6",
+			"editorActiveIndentGuide1",
+			"editorActiveIndentGuide2",
+			"editorActiveIndentGuide3",
+			"editorActiveIndentGuide4",
+			"editorActiveIndentGuide5",
+			"editorActiveIndentGuide6",
 			"editorActiveLineNumber",
 			"deprecatedEditorActiveLineNumber",
 			"editorActiveLineNumber",
@@ -6741,22 +6854,6 @@
 			"editorUnicodeHighlight.border",
 			"editorUnicodeHighlight.background"
 		],
-		"vs/platform/contextkey/common/scanner": [
-			"contextkey.scanner.hint.didYouMean1",
-			"contextkey.scanner.hint.didYouMean2",
-			"contextkey.scanner.hint.didYouMean3",
-			"contextkey.scanner.hint.didYouForgetToOpenOrCloseQuote",
-			"contextkey.scanner.hint.didYouForgetToEscapeSlash"
-		],
-		"vs/editor/browser/coreCommands": [
-			"stickydesc",
-			"stickydesc",
-			"removedCursor"
-		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"cursors.maximum",
-			"goToSetting"
-		],
 		"vs/editor/contrib/anchorSelect/browser/anchorSelect": [
 			"selectionAnchor",
 			"anchorSet",
@@ -6764,6 +6861,20 @@
 			"goToSelectionAnchor",
 			"selectFromAnchorToCursor",
 			"cancelSelectionAnchor"
+		],
+		"vs/platform/contextkey/common/scanner": [
+			"contextkey.scanner.hint.didYouMean1",
+			"contextkey.scanner.hint.didYouMean2",
+			"contextkey.scanner.hint.didYouMean3",
+			"contextkey.scanner.hint.didYouForgetToOpenOrCloseQuote",
+			"contextkey.scanner.hint.didYouForgetToEscapeSlash"
+		],
+		"vs/editor/browser/widget/diffEditorWidget": [
+			"diffInsertIcon",
+			"diffRemoveIcon",
+			"diff-aria-navigation-tip",
+			"diff.tooLarge",
+			"revertChangeHoverMessage"
 		],
 		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
 			"overviewRulerBracketMatchForeground",
@@ -6776,13 +6887,6 @@
 					"&& denotes a mnemonic"
 				]
 			}
-		],
-		"vs/editor/browser/widget/diffEditorWidget": [
-			"diffInsertIcon",
-			"diffRemoveIcon",
-			"diff-aria-navigation-tip",
-			"diff.tooLarge",
-			"revertChangeHoverMessage"
 		],
 		"vs/editor/contrib/caretOperations/browser/caretOperations": [
 			"caret.moveLeft",
@@ -6922,6 +7026,11 @@
 				]
 			}
 		],
+		"vs/editor/contrib/fontZoom/browser/fontZoom": [
+			"EditorFontZoomIn.label",
+			"EditorFontZoomOut.label",
+			"EditorFontZoomReset.label"
+		],
 		"vs/editor/contrib/folding/browser/folding": [
 			"unfoldAction.label",
 			"unFoldRecursivelyAction.label",
@@ -6945,11 +7054,6 @@
 		"vs/editor/contrib/format/browser/formatActions": [
 			"formatDocument.label",
 			"formatSelection.label"
-		],
-		"vs/editor/contrib/fontZoom/browser/fontZoom": [
-			"EditorFontZoomIn.label",
-			"EditorFontZoomOut.label",
-			"EditorFontZoomReset.label"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/goToCommands": [
 			"peek.submenu",
@@ -7017,6 +7121,9 @@
 			"generic.noResult",
 			"ref.title"
 		],
+		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
+			"multipleResults"
+		],
 		"vs/editor/contrib/gotoError/browser/gotoError": [
 			"markerAction.next.label",
 			"nextMarkerIcon",
@@ -7037,9 +7144,6 @@
 				]
 			}
 		],
-		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
-			"multipleResults"
-		],
 		"vs/editor/contrib/hover/browser/hover": [
 			{
 				"key": "showOrFocusHover",
@@ -7050,6 +7154,8 @@
 					"If the hover is already visible, it will take focus."
 				]
 			},
+			"chatAccessibleViewHint",
+			"chatAccessibleViewHintNoKb",
 			{
 				"key": "showDefinitionPreviewHover",
 				"comment": [
@@ -7103,12 +7209,6 @@
 				"key": "goToBottomHover",
 				"comment": [
 					"Action that allows to go to the bottom in the hover widget with the end command when the hover widget is focused."
-				]
-			},
-			{
-				"key": "escapeFocusHover",
-				"comment": [
-					"Action that allows to escape from the hover widget with the escape command when the hover widget is focused."
 				]
 			}
 		],
@@ -7387,6 +7487,8 @@
 			"changeConfigToOnWinLinux",
 			"auto_on",
 			"auto_off",
+			"screenReaderModeEnabled",
+			"screenReaderModeDisabled",
 			"tabFocusModeOnMsg",
 			"tabFocusModeOnMsgNoKb",
 			"tabFocusModeOffMsg",
@@ -7474,20 +7576,6 @@
 			"invalid.semanticTokenScopes.scopes.value",
 			"invalid.semanticTokenScopes.scopes.selector"
 		],
-		"vs/workbench/api/browser/statusBarExtensionPoint": [
-			"id",
-			"name",
-			"text",
-			"tooltip",
-			"command",
-			"alignment",
-			"priority",
-			"accessibilityInformation",
-			"accessibilityInformation.role",
-			"accessibilityInformation.label",
-			"vscode.extension.contributes.statusBarItems",
-			"invalid"
-		],
 		"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint": [
 			"parseErrors",
 			"formatError",
@@ -7552,6 +7640,20 @@
 			"schema.onEnterRules.action.indent.outdent",
 			"schema.onEnterRules.action.appendText",
 			"schema.onEnterRules.action.removeText"
+		],
+		"vs/workbench/api/browser/statusBarExtensionPoint": [
+			"id",
+			"name",
+			"text",
+			"tooltip",
+			"command",
+			"alignment",
+			"priority",
+			"accessibilityInformation",
+			"accessibilityInformation.role",
+			"accessibilityInformation.label",
+			"vscode.extension.contributes.statusBarItems",
+			"invalid"
 		],
 		"vs/workbench/api/browser/mainThreadCLICommands": [
 			"cannot be installed"
@@ -7621,9 +7723,6 @@
 			"msg-write",
 			"label"
 		],
-		"vs/workbench/api/browser/mainThreadProgress": [
-			"manageExtension"
-		],
 		"vs/workbench/api/browser/mainThreadMessageService": [
 			"extensionSource",
 			"defaultSource",
@@ -7635,6 +7734,9 @@
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"manageExtension"
 		],
 		"vs/workbench/api/browser/mainThreadSaveParticipant": [
 			"timeout.onWillSave"
@@ -7667,10 +7769,6 @@
 		"vs/workbench/api/browser/mainThreadTask": [
 			"task.label"
 		],
-		"vs/workbench/api/browser/mainThreadTunnelService": [
-			"remote.tunnel.openTunnel",
-			"remote.tunnelsView.elevationButton"
-		],
 		"vs/workbench/api/browser/mainThreadAuthentication": [
 			"noTrustedExtensions",
 			"manageTrustedExtensions.cancel",
@@ -7701,70 +7799,9 @@
 				]
 			}
 		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
-			"toggleAuxiliaryIconRight",
-			"toggleAuxiliaryIconRightOn",
-			"toggleAuxiliaryIconLeft",
-			"toggleAuxiliaryIconLeftOn",
-			"toggleAuxiliaryBar",
-			"secondary sidebar",
-			{
-				"key": "secondary sidebar mnemonic",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"focusAuxiliaryBar",
-			"toggleSecondarySideBar",
-			"toggleSecondarySideBar",
-			"hideAuxiliaryBar"
-		],
-		"vs/workbench/browser/parts/panel/panelActions": [
-			"maximizeIcon",
-			"restoreIcon",
-			"closeIcon",
-			"togglePanelOffIcon",
-			"togglePanelOnIcon",
-			"togglePanelVisibility",
-			"toggle panel",
-			{
-				"key": "toggle panel mnemonic",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"focusPanel",
-			"focusPanel",
-			"positionPanelLeft",
-			"positionPanelLeftShort",
-			"positionPanelRight",
-			"positionPanelRightShort",
-			"positionPanelBottom",
-			"positionPanelBottomShort",
-			"alignPanelLeft",
-			"alignPanelLeftShort",
-			"alignPanelRight",
-			"alignPanelRightShort",
-			"alignPanelCenter",
-			"alignPanelCenterShort",
-			"alignPanelJustify",
-			"alignPanelJustifyShort",
-			"positionPanel",
-			"alignPanel",
-			"previousPanelView",
-			"nextPanelView",
-			"toggleMaximizedPanel",
-			"maximizePanel",
-			"minimizePanel",
-			"panelMaxNotSupported",
-			"closePanel",
-			"closeSecondarySideBar",
-			"togglePanel",
-			"hidePanel",
-			"movePanelToSecondarySideBar",
-			"movePanelToSecondarySideBar",
-			"moveSidePanelToPanel",
-			"moveSidePanelToPanel"
+		"vs/workbench/api/browser/mainThreadTunnelService": [
+			"remote.tunnel.openTunnel",
+			"remote.tunnelsView.elevationButton"
 		],
 		"vs/workbench/browser/quickaccess": [
 			"inQuickOpen"
@@ -7855,15 +7892,6 @@
 			},
 			"product.extensionEnabledApiProposals"
 		],
-		"vs/workbench/browser/parts/views/treeView": [
-			"no-dataprovider",
-			"treeView.enableCollapseAll",
-			"treeView.enableRefresh",
-			"refresh",
-			"collapseAll",
-			"treeView.toggleCollapseAll",
-			"command-error"
-		],
 		"vs/workbench/browser/parts/views/viewPaneContainer": [
 			"views",
 			"viewMoveUp",
@@ -7927,21 +7955,14 @@
 			"debuggerDisabled",
 			"internalConsoleOptions"
 		],
-		"vs/workbench/contrib/files/common/files": [
-			"explorerViewletVisible",
-			"foldersViewVisible",
-			"explorerResourceIsFolder",
-			"explorerResourceReadonly",
-			"explorerResourceIsRoot",
-			"explorerResourceCut",
-			"explorerResourceMoveableToTrash",
-			"filesExplorerFocus",
-			"openEditorsFocus",
-			"explorerViewletFocus",
-			"explorerViewletCompressedFocus",
-			"explorerViewletCompressedFirstFocus",
-			"explorerViewletCompressedLastFocus",
-			"viewHasSomeCollapsibleItem"
+		"vs/workbench/browser/parts/views/treeView": [
+			"no-dataprovider",
+			"treeView.enableCollapseAll",
+			"treeView.enableRefresh",
+			"refresh",
+			"collapseAll",
+			"treeView.toggleCollapseAll",
+			"command-error"
 		],
 		"vs/workbench/contrib/remote/browser/remoteExplorer": [
 			"ports",
@@ -7961,6 +7982,69 @@
 			"remote.tunnelsView.makePublic",
 			"remote.tunnelsView.elevationButton"
 		],
+		"vs/workbench/browser/parts/panel/panelActions": [
+			"maximizeIcon",
+			"restoreIcon",
+			"closeIcon",
+			"togglePanelOffIcon",
+			"togglePanelOnIcon",
+			"togglePanelVisibility",
+			"toggle panel",
+			{
+				"key": "toggle panel mnemonic",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"focusPanel",
+			"focusPanel",
+			"positionPanelLeft",
+			"positionPanelLeftShort",
+			"positionPanelRight",
+			"positionPanelRightShort",
+			"positionPanelBottom",
+			"positionPanelBottomShort",
+			"alignPanelLeft",
+			"alignPanelLeftShort",
+			"alignPanelRight",
+			"alignPanelRightShort",
+			"alignPanelCenter",
+			"alignPanelCenterShort",
+			"alignPanelJustify",
+			"alignPanelJustifyShort",
+			"positionPanel",
+			"alignPanel",
+			"previousPanelView",
+			"nextPanelView",
+			"toggleMaximizedPanel",
+			"maximizePanel",
+			"minimizePanel",
+			"panelMaxNotSupported",
+			"closePanel",
+			"closeSecondarySideBar",
+			"togglePanel",
+			"hidePanel",
+			"movePanelToSecondarySideBar",
+			"movePanelToSecondarySideBar",
+			"moveSidePanelToPanel",
+			"moveSidePanelToPanel"
+		],
+		"vs/workbench/contrib/files/common/files": [
+			"explorerViewletVisible",
+			"foldersViewVisible",
+			"explorerResourceIsFolder",
+			"explorerResourceReadonly",
+			"explorerResourceIsRoot",
+			"explorerResourceCut",
+			"explorerResourceMoveableToTrash",
+			"filesExplorerFocus",
+			"openEditorsFocus",
+			"explorerViewletFocus",
+			"explorerViewletCompressedFocus",
+			"explorerViewletCompressedFirstFocus",
+			"explorerViewletCompressedLastFocus",
+			"viewHasSomeCollapsibleItem"
+		],
 		"vs/workbench/common/editor/sideBySideEditorInput": [
 			"sideBySideLabels"
 		],
@@ -7969,6 +8053,24 @@
 		],
 		"vs/workbench/common/editor/diffEditorInput": [
 			"sideBySideLabels"
+		],
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
+			"toggleAuxiliaryIconRight",
+			"toggleAuxiliaryIconRightOn",
+			"toggleAuxiliaryIconLeft",
+			"toggleAuxiliaryIconLeftOn",
+			"toggleAuxiliaryBar",
+			"secondary sidebar",
+			{
+				"key": "secondary sidebar mnemonic",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"focusAuxiliaryBar",
+			"toggleSecondarySideBar",
+			"toggleSecondarySideBar",
+			"hideAuxiliaryBar"
 		],
 		"vs/workbench/browser/parts/editor/textDiffEditor": [
 			"textDiffEditor",
@@ -8183,6 +8285,26 @@
 			"toggleEditorType",
 			"reopenTextEditor"
 		],
+		"vs/workbench/browser/parts/editor/editorCommands": [
+			"editorCommand.activeEditorMove.description",
+			"editorCommand.activeEditorMove.arg.name",
+			"editorCommand.activeEditorMove.arg.description",
+			"editorCommand.activeEditorCopy.description",
+			"editorCommand.activeEditorCopy.arg.name",
+			"editorCommand.activeEditorCopy.arg.description",
+			"toggleInlineView",
+			"compare",
+			"splitEditorInGroup",
+			"joinEditorInGroup",
+			"toggleJoinEditorInGroup",
+			"toggleSplitEditorInGroupLayout",
+			"focusLeftSideEditor",
+			"focusRightSideEditor",
+			"focusOtherSideEditor",
+			"toggleEditorGroupLock",
+			"lockEditorGroup",
+			"unlockEditorGroup"
+		],
 		"vs/editor/browser/editorExtensions": [
 			{
 				"key": "miUndo",
@@ -8206,25 +8328,12 @@
 			},
 			"selectAll"
 		],
-		"vs/workbench/browser/parts/editor/editorCommands": [
-			"editorCommand.activeEditorMove.description",
-			"editorCommand.activeEditorMove.arg.name",
-			"editorCommand.activeEditorMove.arg.description",
-			"editorCommand.activeEditorCopy.description",
-			"editorCommand.activeEditorCopy.arg.name",
-			"editorCommand.activeEditorCopy.arg.description",
-			"toggleInlineView",
-			"compare",
-			"splitEditorInGroup",
-			"joinEditorInGroup",
-			"toggleJoinEditorInGroup",
-			"toggleSplitEditorInGroupLayout",
-			"focusLeftSideEditor",
-			"focusRightSideEditor",
-			"focusOtherSideEditor",
-			"toggleEditorGroupLock",
-			"lockEditorGroup",
-			"unlockEditorGroup"
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"noViewResults",
+			"entryAriaLabelWithGroupDirty",
+			"entryAriaLabelWithGroup",
+			"entryAriaLabelDirty",
+			"closeEditor"
 		],
 		"vs/workbench/browser/parts/editor/editorConfiguration": [
 			"interactiveWindow",
@@ -8234,37 +8343,12 @@
 			"editor.editorAssociations",
 			"editorLargeFileSizeConfirmation"
 		],
-		"vs/workbench/browser/parts/editor/editorQuickAccess": [
-			"noViewResults",
-			"entryAriaLabelWithGroupDirty",
-			"entryAriaLabelWithGroup",
-			"entryAriaLabelDirty",
-			"closeEditor"
-		],
 		"vs/workbench/browser/parts/editor/accessibilityStatus": [
 			"screenReaderDetectedExplanation.question",
 			"screenReaderDetectedExplanation.answerYes",
 			"screenReaderDetectedExplanation.answerNo",
 			"screenReaderDetected",
 			"status.editor.screenReaderMode"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
-			"toggleCollapseUnchangedRegions",
-			"collapseUnchangedRegions",
-			"showUnchangedRegions",
-			"toggleShowMovedCodeBlocks",
-			"showMoves"
-		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"ariaLabelGroupActions",
-			"emptyEditorGroup",
-			"groupLabel",
-			"groupAriaLabel"
-		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
-			"move second side bar left",
-			"move second side bar right",
-			"hide second side bar"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
 			"settingsViewBarIcon",
@@ -8280,6 +8364,19 @@
 			"accounts",
 			"accounts"
 		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
+			"toggleCollapseUnchangedRegions",
+			"collapseUnchangedRegions",
+			"showUnchangedRegions",
+			"toggleShowMovedCodeBlocks",
+			"diffEditor",
+			"switchSide"
+		],
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
+			"move second side bar left",
+			"move second side bar right",
+			"hide second side bar"
+		],
 		"vs/workbench/browser/parts/panel/panelPart": [
 			"resetLocation",
 			"resetLocation",
@@ -8288,6 +8385,12 @@
 			"panel position",
 			"align panel",
 			"hidePanel"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"ariaLabelGroupActions",
+			"emptyEditorGroup",
+			"groupLabel",
+			"groupAriaLabel"
 		],
 		"vs/workbench/browser/parts/editor/editorDropTarget": [
 			"dropIntoEditorPrompt"
@@ -8518,6 +8621,21 @@
 			"error.cannotparseicontheme",
 			"error.invalidformat"
 		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"schema.token.settings",
+			"schema.token.foreground",
+			"schema.token.background.warning",
+			"schema.token.fontStyle",
+			"schema.fontStyle.error",
+			"schema.token.fontStyle.none",
+			"schema.properties.name",
+			"schema.properties.scope",
+			"schema.workbenchColors",
+			"schema.tokenColors.path",
+			"schema.colors",
+			"schema.supportsSemanticHighlighting",
+			"schema.semanticTokenColors"
+		],
 		"vs/workbench/services/themes/common/themeExtensionPoints": [
 			"vscode.extension.contributes.themes",
 			"vscode.extension.contributes.themes.id",
@@ -8536,21 +8654,6 @@
 			"reqpath",
 			"reqid",
 			"invalid.path.1"
-		],
-		"vs/workbench/services/themes/common/colorThemeSchema": [
-			"schema.token.settings",
-			"schema.token.foreground",
-			"schema.token.background.warning",
-			"schema.token.fontStyle",
-			"schema.fontStyle.error",
-			"schema.token.fontStyle.none",
-			"schema.properties.name",
-			"schema.properties.scope",
-			"schema.workbenchColors",
-			"schema.tokenColors.path",
-			"schema.colors",
-			"schema.supportsSemanticHighlighting",
-			"schema.semanticTokenColors"
 		],
 		"vs/workbench/services/themes/common/themeConfiguration": [
 			"colorTheme",
@@ -8711,7 +8814,8 @@
 			"keybindings"
 		],
 		"vs/workbench/services/userDataProfile/browser/snippetsResource": [
-			"snippets"
+			"snippets",
+			"exclude"
 		],
 		"vs/workbench/services/userDataProfile/browser/tasksResource": [
 			"tasks"
@@ -8719,6 +8823,7 @@
 		"vs/workbench/services/userDataProfile/browser/extensionsResource": [
 			"extensions",
 			"disabled",
+			"exclude",
 			"exclude"
 		],
 		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
@@ -8746,12 +8851,6 @@
 			"invalid.tokenTypes",
 			"invalid.path.1"
 		],
-		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
-			"defineKeybinding.initial",
-			"defineKeybinding.oneExists",
-			"defineKeybinding.existing",
-			"defineKeybinding.chordsTo"
-		],
 		"vs/editor/contrib/suggest/browser/suggest": [
 			"suggestWidgetHasSelection",
 			"suggestWidgetDetailsVisible",
@@ -8761,11 +8860,6 @@
 			"suggestionHasInsertAndReplaceRange",
 			"suggestionInsertMode",
 			"suggestionCanResolve"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"configureLanguageBasedSettings",
-			"languageDescriptionConfigured",
-			"pickLanguage"
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"recordKeysLabel",
@@ -8802,6 +8896,11 @@
 			"noWhen",
 			"keyboard shortcuts aria label"
 		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"configureLanguageBasedSettings",
+			"languageDescriptionConfigured",
+			"pickLanguage"
+		],
 		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
 			"settingsScopeDropDownIcon",
 			"settingsMoreActionIcon",
@@ -8837,9 +8936,6 @@
 			"turnOnSyncButton",
 			"lastSyncedLabel"
 		],
-		"vs/workbench/contrib/performance/browser/perfviewEditor": [
-			"name"
-		],
 		"vs/workbench/contrib/notebook/browser/notebookEditor": [
 			"fail.noEditor",
 			"fail.noEditor.extensionMissing",
@@ -8860,13 +8956,13 @@
 		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
 			"notebookRunTrust"
 		],
+		"vs/editor/common/languages/modesRegistry": [
+			"plainText.alias"
+		],
 		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
 			"disableOtherKeymapsConfirmation",
 			"yes",
 			"no"
-		],
-		"vs/editor/common/languages/modesRegistry": [
-			"plainText.alias"
 		],
 		"vs/workbench/contrib/comments/browser/commentReply": [
 			"reply",
@@ -8888,16 +8984,14 @@
 			"verbosity.interactiveEditor.description",
 			"verbosity.keybindingsEditor.description",
 			"verbosity.notebook",
+			"verbosity.hover",
+			"verbosity.notification",
 			"editor.action.accessibilityHelp",
-			"editor.action.accessibleView"
+			"editor.action.accessibleView",
+			"editor.action.accessibleViewNext",
+			"editor.action.accessibleViewPrevious"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
-			"notebookActions.category",
-			"notebookMenu.insertCell",
-			"notebookMenu.cellTitle",
-			"miShare"
-		],
-		"vs/workbench/contrib/notebook/browser/notebookAccessibilityHelp": [
+		"vs/workbench/contrib/notebook/browser/notebookAccessibility": [
 			"notebook.overview",
 			"notebook.cell.edit",
 			"notebook.cell.editNoKb",
@@ -8909,7 +9003,26 @@
 			"notebook.cell.executeAndFocusContainer",
 			"notebook.cell.executeAndFocusContainerNoKb",
 			"notebook.cell.insertCodeCellBelowAndFocusContainer",
-			"notebook.changeCellType"
+			"notebook.changeCellType",
+			"NotebookCellOutputAccessibleView"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibleView": [
+			"openDoc",
+			"disable-help-hint",
+			"exit-tip",
+			"accessibleViewAriaLabelWithNav",
+			"accessibleViewAriaLabel",
+			"disableAccessibilityHelp",
+			"chatAccessibleViewNextPreviousHint",
+			"chatAccessibleViewNextPreviousHintNoKb",
+			"chatAccessibleViewHint",
+			"chatAccessibleViewHintNoKb"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
+			"notebookActions.category",
+			"notebookMenu.insertCell",
+			"notebookMenu.cellTitle",
+			"miShare"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/insertCellActions": [
 			"notebookActions.insertCodeCellAbove",
@@ -8960,45 +9073,6 @@
 			"revealLastFailedCell",
 			"revealLastFailedCellShort"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/editActions": [
-			"notebookActions.editCell",
-			"notebookActions.quitEdit",
-			"notebookActions.deleteCell",
-			"confirmDeleteButton",
-			"confirmDeleteButtonMessage",
-			"doNotAskAgain",
-			"clearCellOutputs",
-			"clearAllCellsOutputs",
-			"changeLanguage",
-			"changeLanguage",
-			"languageDescription",
-			"languageDescriptionConfigured",
-			"autoDetect",
-			"languagesPicks",
-			"pickLanguageToConfigure",
-			"detectLanguage",
-			"noDetection"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
-			"workbench.notebook.layout.select.label",
-			"workbench.notebook.layout.configure.label",
-			"workbench.notebook.layout.configure.label",
-			"customizeNotebook",
-			"notebook.toggleLineNumbers",
-			"notebook.showLineNumbers",
-			"notebook.toggleCellToolbarPosition",
-			"notebook.toggleBreadcrumb",
-			"notebook.saveMimeTypeOrder",
-			"notebook.placeholder",
-			"saveTarget.machine",
-			"saveTarget.workspace",
-			"workbench.notebook.layout.webview.reset.label"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
-			"fold.cell",
-			"unfold.cell",
-			"fold.cell"
-		],
 		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
 			"notebookActions.copy",
 			"notebookActions.cut",
@@ -9016,6 +9090,24 @@
 			"formatCell.label",
 			"formatCells.label"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
+			"workbench.notebook.layout.select.label",
+			"workbench.notebook.layout.configure.label",
+			"workbench.notebook.layout.configure.label",
+			"customizeNotebook",
+			"notebook.toggleLineNumbers",
+			"notebook.showLineNumbers",
+			"notebook.toggleCellToolbarPosition",
+			"notebook.toggleBreadcrumb",
+			"notebook.saveMimeTypeOrder",
+			"notebook.placeholder",
+			"saveTarget.machine",
+			"saveTarget.workspace",
+			"workbench.notebook.layout.webview.reset.label"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
+			"workbench.notebook.layout.gettingStarted.label"
+		],
 		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
 			"notebookFormatSave.formatting",
 			"label",
@@ -9032,27 +9124,9 @@
 		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
 			"notebook.toggleCellToolbarPosition"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
-			"cursorMoveDown",
-			"cursorMoveUp",
-			"focusFirstCell",
-			"focusLastCell",
-			"focusOutput",
-			"focusOutputOut",
-			"notebookActions.centerActiveCell",
-			"cursorPageUp",
-			"cursorPageUpSelect",
-			"cursorPageDown",
-			"cursorPageDownSelect",
-			"notebook.navigation.allowNavigateToSurroundingCells"
-		],
 		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
-			"empty",
 			"outline.showCodeCells",
 			"breadcrumbs.showCodeCells"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
-			"workbench.notebook.layout.gettingStarted.label"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
 			"setProfileTitle"
@@ -9068,6 +9142,11 @@
 			"notebook.cell.status.executing",
 			"notebook.cell.statusBar.timerTooltip.reportIssueFootnote",
 			"notebook.cell.statusBar.timerTooltip"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
+			"fold.cell",
+			"unfold.cell",
+			"fold.cell"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar": [
 			"notebook.info",
@@ -9101,6 +9180,20 @@
 			"notebookActions.collapseAllCellOutput",
 			"notebookActions.expandAllCellOutput",
 			"notebookActions.toggleScrolling"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
+			"cursorMoveDown",
+			"cursorMoveUp",
+			"focusFirstCell",
+			"focusLastCell",
+			"focusOutput",
+			"focusOutputOut",
+			"notebookActions.centerActiveCell",
+			"cursorPageUp",
+			"cursorPageUpSelect",
+			"cursorPageDown",
+			"cursorPageDownSelect",
+			"notebook.navigation.allowNavigateToSurroundingCells"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
 			"workbench.notebook.toggleLayoutTroubleshoot",
@@ -9136,6 +9229,25 @@
 			"interactiveSession.history.delete",
 			"interactiveSession.history.pick"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/editActions": [
+			"notebookActions.editCell",
+			"notebookActions.quitEdit",
+			"notebookActions.deleteCell",
+			"confirmDeleteButton",
+			"confirmDeleteButtonMessage",
+			"doNotAskAgain",
+			"clearCellOutputs",
+			"clearAllCellsOutputs",
+			"changeLanguage",
+			"changeLanguage",
+			"languageDescription",
+			"languageDescriptionConfigured",
+			"autoDetect",
+			"languagesPicks",
+			"pickLanguageToConfigure",
+			"detectLanguage",
+			"noDetection"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
 			"interactive.copyCodeBlock.label",
 			"interactive.insertCodeBlock.label",
@@ -9151,10 +9263,6 @@
 		"vs/workbench/contrib/chat/browser/actions/chatExecuteActions": [
 			"interactive.submit.label",
 			"interactive.cancel.label"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
-			"askQuickQuestion",
-			"askabot"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
 			"interactive.helpful.label",
@@ -9194,11 +9302,6 @@
 			"interactiveSession.clear.label",
 			"interactiveSession.clear.label"
 		],
-		"vs/workbench/contrib/accessibility/browser/accessibleView": [
-			"openDoc",
-			"disable-help-hint",
-			"exit-tip"
-		],
 		"vs/workbench/contrib/chat/common/chatViewModel": [
 			"thinking"
 		],
@@ -9213,13 +9316,13 @@
 			"inChat",
 			"hasChatProvider"
 		],
-		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
-			"interactive.input.placeholderWithCommands",
-			"interactive.input.placeholderNoCommands"
-		],
 		"vs/workbench/contrib/chat/common/chatColors": [
 			"chat.requestBackground",
 			"chat.requestBorder"
+		],
+		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
+			"interactive.input.placeholderWithCommands",
+			"interactive.input.placeholderNoCommands"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
 			"welcome.1",
@@ -9255,8 +9358,20 @@
 			"undo.newfile",
 			"feedback.helpful",
 			"feedback.unhelpful",
-			"toggleDiff",
-			"toggleDiff2",
+			"showDiff",
+			{
+				"key": "miShowDiff",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"showDiff2",
+			{
+				"key": "miShowDiff2",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
 			"apply1",
 			"apply2",
 			"cancel",
@@ -9270,14 +9385,16 @@
 			"inlineChatHasProvider",
 			"inlineChatVisible",
 			"inlineChatFocused",
+			"inlineChatResponseFocused",
 			"inlineChatEmpty",
 			"inlineChatInnerCursorFirst",
 			"inlineChatInnerCursorLast",
+			"inlineChatInnerCursorStart",
+			"inlineChatInnerCursorEnd",
 			"inlineChatMarkdownMessageCropState",
 			"inlineChatOuterCursorPosition",
 			"inlineChatHasActiveRequest",
 			"inlineChatHasStashedSession",
-			"inlineChatDiff",
 			"inlineChatResponseType",
 			"inlineChatResponseTypes",
 			"inlineChatDidEdit",
@@ -9297,7 +9414,8 @@
 			"mode",
 			"mode.livePreview",
 			"mode.preview",
-			"mode.live"
+			"mode.live",
+			"showDiff"
 		],
 		"vs/editor/contrib/peekView/browser/peekView": [
 			"inReferenceSearchEditor",
@@ -9419,6 +9537,13 @@
 			},
 			"testExplorer"
 		],
+		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
+			"testProgress.runningInitial",
+			"testProgress.running",
+			"testProgressWithSkip.running",
+			"testProgress.completed",
+			"testProgressWithSkip.completed"
+		],
 		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
 			"testing.markdownPeekError",
 			"testOutputTitle",
@@ -9445,12 +9570,32 @@
 			"testing.openMessageInEditor",
 			"testing.toggleTestingPeekHistory"
 		],
-		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
-			"testProgress.runningInitial",
-			"testProgress.running",
-			"testProgressWithSkip.running",
-			"testProgress.completed",
-			"testProgressWithSkip.completed"
+		"vs/workbench/contrib/testing/common/configuration": [
+			"testConfigurationTitle",
+			"testing.autoRun.delay",
+			"testing.automaticallyOpenPeekView",
+			"testing.automaticallyOpenPeekView.failureAnywhere",
+			"testing.automaticallyOpenPeekView.failureInVisibleDocument",
+			"testing.automaticallyOpenPeekView.never",
+			"testing.showAllMessages",
+			"testing.automaticallyOpenPeekViewDuringContinuousRun",
+			"testing.countBadge",
+			"testing.countBadge.failed",
+			"testing.countBadge.off",
+			"testing.countBadge.passed",
+			"testing.countBadge.skipped",
+			"testing.followRunningTest",
+			"testing.defaultGutterClickAction",
+			"testing.defaultGutterClickAction.run",
+			"testing.defaultGutterClickAction.debug",
+			"testing.defaultGutterClickAction.contextMenu",
+			"testing.gutterEnabled",
+			"testing.saveBeforeTest",
+			"testing.openTesting.neverOpen",
+			"testing.openTesting.openOnTestStart",
+			"testing.openTesting.openOnTestFailure",
+			"testing.openTesting",
+			"testing.alwaysRevealTestOnStateChange"
 		],
 		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
 			"testing"
@@ -9481,6 +9626,10 @@
 			"testing.testId",
 			"testing.testItemHasUri",
 			"testing.testItemIsHidden"
+		],
+		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
+			"testConfigurationUi.pick",
+			"updateTestConfiguration"
 		],
 		"vs/workbench/contrib/testing/browser/testExplorerActions": [
 			"hideTest",
@@ -9534,37 +9683,6 @@
 			"testing.refreshTests",
 			"testing.cancelTestRefresh"
 		],
-		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
-			"testConfigurationUi.pick",
-			"updateTestConfiguration"
-		],
-		"vs/workbench/contrib/testing/common/configuration": [
-			"testConfigurationTitle",
-			"testing.autoRun.delay",
-			"testing.automaticallyOpenPeekView",
-			"testing.automaticallyOpenPeekView.failureAnywhere",
-			"testing.automaticallyOpenPeekView.failureInVisibleDocument",
-			"testing.automaticallyOpenPeekView.never",
-			"testing.showAllMessages",
-			"testing.automaticallyOpenPeekViewDuringContinuousRun",
-			"testing.countBadge",
-			"testing.countBadge.failed",
-			"testing.countBadge.off",
-			"testing.countBadge.passed",
-			"testing.countBadge.skipped",
-			"testing.followRunningTest",
-			"testing.defaultGutterClickAction",
-			"testing.defaultGutterClickAction.run",
-			"testing.defaultGutterClickAction.debug",
-			"testing.defaultGutterClickAction.contextMenu",
-			"testing.gutterEnabled",
-			"testing.saveBeforeTest",
-			"testing.openTesting.neverOpen",
-			"testing.openTesting.openOnTestStart",
-			"testing.openTesting.openOnTestFailure",
-			"testing.openTesting",
-			"testing.alwaysRevealTestOnStateChange"
-		],
 		"vs/workbench/contrib/logs/common/logsActions": [
 			"setLogLevel",
 			"all",
@@ -9586,37 +9704,11 @@
 			"sessions placeholder",
 			"log placeholder"
 		],
-		"vs/platform/quickinput/browser/helpQuickAccess": [
-			"helpPickAriaLabel"
-		],
-		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
-			"noViewResults",
-			"views",
-			"panels",
-			"secondary side bar",
-			"terminalTitle",
-			"terminals",
-			"debugConsoles",
-			"channels",
-			"openView",
-			"quickOpenView"
-		],
-		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
-			"noCommandResults",
-			"configure keybinding",
-			"semanticSimilarity",
-			"askXInChat",
-			"commandWithCategory",
-			"showTriggerActions",
-			"clearCommandHistory",
-			"confirmClearMessage",
-			"confirmClearDetail",
-			{
-				"key": "clearButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"defineKeybinding.initial",
+			"defineKeybinding.oneExists",
+			"defineKeybinding.existing",
+			"defineKeybinding.chordsTo"
 		],
 		"vs/workbench/contrib/files/browser/views/explorerView": [
 			"explorerSection",
@@ -9624,9 +9716,6 @@
 			"createNewFolder",
 			"refreshExplorer",
 			"collapseExplorerFolders"
-		],
-		"vs/workbench/contrib/files/browser/views/emptyView": [
-			"noWorkspace"
 		],
 		"vs/workbench/contrib/files/browser/views/openEditorsView": [
 			{
@@ -9646,6 +9735,41 @@
 				]
 			},
 			"newUntitledFile"
+		],
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"noWorkspace"
+		],
+		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
+			"noViewResults",
+			"views",
+			"panels",
+			"secondary side bar",
+			"terminalTitle",
+			"terminals",
+			"debugConsoles",
+			"channels",
+			"openView",
+			"quickOpenView"
+		],
+		"vs/platform/quickinput/browser/helpQuickAccess": [
+			"helpPickAriaLabel"
+		],
+		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
+			"noCommandResults",
+			"configure keybinding",
+			"semanticSimilarity",
+			"askXInChat",
+			"commandWithCategory",
+			"showTriggerActions",
+			"clearCommandHistory",
+			"confirmClearMessage",
+			"confirmClearDetail",
+			{
+				"key": "clearButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/files/browser/fileActions": [
 			"newFile",
@@ -9903,6 +10027,10 @@
 			"useVersion2",
 			"showEmptyDecorations"
 		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"dirtyFile",
+			"dirtyFiles"
+		],
 		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
 			"textFileEditor",
 			"openFolder",
@@ -9913,31 +10041,12 @@
 			"unavailableResourceErrorEditorText",
 			"createFile"
 		],
-		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
-			"dirtyFile",
-			"dirtyFiles"
-		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
-			"default"
-		],
 		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
 			"cannotRunGotoLine",
 			"gotoLineColumnLabel",
 			"gotoLineLabel",
 			"gotoLineLabelEmptyWithLimit",
 			"gotoLineLabelEmpty"
-		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
-			"ok",
-			"cancel",
-			"empty.msg",
-			"conflict.1",
-			"conflict.N",
-			"edt.title.del",
-			"rename",
-			"create",
-			"edt.title.2",
-			"edt.title.1"
 		],
 		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
 			"empty",
@@ -9991,6 +10100,11 @@
 			"searchViewIcon",
 			"searchNewEditorIcon"
 		],
+		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
+			"noSymbolResults",
+			"openToSide",
+			"openToBottom"
+		],
 		"vs/workbench/contrib/search/browser/searchWidget": [
 			"search.action.replaceAll.disabled.label",
 			"search.action.replaceAll.enabled.label",
@@ -10000,11 +10114,6 @@
 			"showContext",
 			"label.Replace",
 			"search.replace.placeHolder"
-		],
-		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
-			"noSymbolResults",
-			"openToSide",
-			"openToBottom"
 		],
 		"vs/workbench/contrib/search/browser/searchActionsCopy": [
 			"copyMatchLabel",
@@ -10072,6 +10181,21 @@
 			"ViewAsTreeAction.label",
 			"ViewAsListAction.label"
 		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
+			"ok",
+			"cancel",
+			"empty.msg",
+			"conflict.1",
+			"conflict.N",
+			"edt.title.del",
+			"rename",
+			"create",
+			"edt.title.2",
+			"edt.title.1"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
+			"default"
+		],
 		"vs/workbench/contrib/search/browser/searchActionsBase": [
 			"search"
 		],
@@ -10096,14 +10220,14 @@
 			"viewPaneContainerCollapsedIcon",
 			"viewToolbarAriaLabel"
 		],
-		"vs/workbench/contrib/search/browser/searchMessage": [
-			"unable to open trust",
-			"unable to open"
-		],
 		"vs/workbench/contrib/search/browser/patternInputWidget": [
 			"defaultLabel",
 			"onlySearchInOpenEditors",
 			"useExcludesAndIgnoreFilesDescription"
+		],
+		"vs/workbench/contrib/search/browser/searchMessage": [
+			"unable to open trust",
+			"unable to open"
 		],
 		"vs/workbench/contrib/search/browser/searchResultsView": [
 			"searchFolderMatch.other.label",
@@ -10163,6 +10287,13 @@
 		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
 			"source control"
 		],
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"scm"
+		],
+		"vs/workbench/contrib/workspace/common/workspace": [
+			"workspaceTrustEnabledCtx",
+			"workspaceTrustedCtx"
+		],
 		"vs/workbench/contrib/scm/browser/scmViewPane": [
 			"scm",
 			"input",
@@ -10181,12 +10312,78 @@
 			"label.close",
 			"scm.providerBorder"
 		],
-		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
-			"scm"
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"showMoreStackFrames2",
+			{
+				"key": "session",
+				"comment": [
+					"Session is a noun"
+				]
+			},
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"restartFrame",
+			"loadAllStackFrames",
+			"showMoreAndOrigin",
+			"showMoreStackFrames",
+			{
+				"key": "pausedOn",
+				"comment": [
+					"indicates reason for program being paused"
+				]
+			},
+			"paused",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "callStackAriaLabel"
+			},
+			{
+				"key": "threadAriaLabel",
+				"comment": [
+					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
+				]
+			},
+			"stackFrameAriaLabel",
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			{
+				"key": "sessionLabel",
+				"comment": [
+					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
+				]
+			},
+			"showMoreStackFrames",
+			"collapse"
 		],
-		"vs/workbench/contrib/workspace/common/workspace": [
-			"workspaceTrustEnabledCtx",
-			"workspaceTrustedCtx"
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"debugToolBarBackground",
+			"debugToolBarBorder",
+			"debugIcon.startForeground",
+			"debugIcon.pauseForeground",
+			"debugIcon.stopForeground",
+			"debugIcon.disconnectForeground",
+			"debugIcon.restartForeground",
+			"debugIcon.stepOverForeground",
+			"debugIcon.stepIntoForeground",
+			"debugIcon.stepOutForeground",
+			"debugIcon.continueForeground",
+			"debugIcon.stepBackForeground"
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"unverifiedExceptionBreakpoint",
@@ -10261,112 +10458,6 @@
 			"editHitCount",
 			"editBreakpoint",
 			"editHitCount"
-		],
-		"vs/workbench/contrib/debug/browser/debugColors": [
-			"debugToolBarBackground",
-			"debugToolBarBorder",
-			"debugIcon.startForeground",
-			"debugIcon.pauseForeground",
-			"debugIcon.stopForeground",
-			"debugIcon.disconnectForeground",
-			"debugIcon.restartForeground",
-			"debugIcon.stepOverForeground",
-			"debugIcon.stepIntoForeground",
-			"debugIcon.stepOutForeground",
-			"debugIcon.continueForeground",
-			"debugIcon.stepBackForeground"
-		],
-		"vs/workbench/contrib/debug/browser/callStackView": [
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"showMoreStackFrames2",
-			{
-				"key": "session",
-				"comment": [
-					"Session is a noun"
-				]
-			},
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"restartFrame",
-			"loadAllStackFrames",
-			"showMoreAndOrigin",
-			"showMoreStackFrames",
-			{
-				"key": "pausedOn",
-				"comment": [
-					"indicates reason for program being paused"
-				]
-			},
-			"paused",
-			{
-				"comment": [
-					"Debug is a noun in this context, not a verb."
-				],
-				"key": "callStackAriaLabel"
-			},
-			{
-				"key": "threadAriaLabel",
-				"comment": [
-					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
-				]
-			},
-			"stackFrameAriaLabel",
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			{
-				"key": "sessionLabel",
-				"comment": [
-					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
-				]
-			},
-			"showMoreStackFrames",
-			"collapse"
-		],
-		"vs/workbench/contrib/debug/browser/debugCommands": [
-			"debug",
-			"restartDebug",
-			"stepOverDebug",
-			"stepIntoDebug",
-			"stepIntoTargetDebug",
-			"stepOutDebug",
-			"pauseDebug",
-			"disconnect",
-			"disconnectSuspend",
-			"stop",
-			"continueDebug",
-			"focusSession",
-			"selectAndStartDebugging",
-			"openLaunchJson",
-			"startDebug",
-			"startWithoutDebugging",
-			"nextDebugConsole",
-			"prevDebugConsole",
-			"openLoadedScript",
-			"callStackTop",
-			"callStackBottom",
-			"callStackUp",
-			"callStackDown",
-			"selectDebugConsole",
-			"selectDebugSession",
-			"chooseLocation",
-			"noExecutableCode",
-			"jumpToCursor",
-			"editor.debug.action.stepIntoTargets.none",
-			"addConfiguration",
-			"addInlineBreakpoint"
 		],
 		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
 			"workbench.action.debug.startDebug"
@@ -10506,6 +10597,39 @@
 			"addConfigTo",
 			"addConfiguration"
 		],
+		"vs/workbench/contrib/debug/browser/debugCommands": [
+			"debug",
+			"restartDebug",
+			"stepOverDebug",
+			"stepIntoDebug",
+			"stepIntoTargetDebug",
+			"stepOutDebug",
+			"pauseDebug",
+			"disconnect",
+			"disconnectSuspend",
+			"stop",
+			"continueDebug",
+			"focusSession",
+			"selectAndStartDebugging",
+			"openLaunchJson",
+			"startDebug",
+			"startWithoutDebugging",
+			"nextDebugConsole",
+			"prevDebugConsole",
+			"openLoadedScript",
+			"callStackTop",
+			"callStackBottom",
+			"callStackUp",
+			"callStackDown",
+			"selectDebugConsole",
+			"selectDebugSession",
+			"chooseLocation",
+			"noExecutableCode",
+			"jumpToCursor",
+			"editor.debug.action.stepIntoTargets.none",
+			"addConfiguration",
+			"addInlineBreakpoint"
+		],
 		"vs/workbench/contrib/debug/browser/debugStatus": [
 			"status.debug",
 			"debugTarget",
@@ -10614,6 +10738,11 @@
 			"addWatchExpression",
 			"removeAllWatchExpressions"
 		],
+		"vs/workbench/contrib/debug/common/debugContentProvider": [
+			"unable",
+			"canNotResolveSourceWithError",
+			"canNotResolveSource"
+		],
 		"vs/workbench/contrib/debug/browser/welcomeView": [
 			"run",
 			{
@@ -10623,21 +10752,8 @@
 					"{Locked=\"](command:{0})\"}"
 				]
 			},
-			{
-				"key": "runAndDebugAction",
-				"comment": [
-					"{0} will be replaced with a keybinding",
-					"Please do not translate the word \"command\", it is part of our internal syntax which must not change",
-					"{Locked=\"](command:{1})\"}"
-				]
-			},
-			{
-				"key": "detectThenRunAndDebug",
-				"comment": [
-					"Please do not translate the word \"command\", it is part of our internal syntax which must not change",
-					"{Locked=\"](command:{0})\"}"
-				]
-			},
+			"runAndDebugAction",
+			"detectThenRunAndDebug",
 			{
 				"key": "customizeRunAndDebug",
 				"comment": [
@@ -10653,11 +10769,6 @@
 				]
 			},
 			"allDebuggersDisabled"
-		],
-		"vs/workbench/contrib/debug/common/debugContentProvider": [
-			"unable",
-			"canNotResolveSourceWithError",
-			"canNotResolveSource"
 		],
 		"vs/workbench/contrib/debug/common/debugLifecycle": [
 			"debug.debugSessionCloseConfirmationSingular",
@@ -10722,15 +10833,15 @@
 			"logMessage",
 			"breakpointType"
 		],
-		"vs/platform/history/browser/contextScopedHistoryWidget": [
-			"suggestWidgetVisible"
-		],
 		"vs/workbench/contrib/debug/browser/debugActionViewItems": [
 			"debugLaunchConfigurations",
 			"noConfigurations",
 			"addConfigTo",
 			"addConfiguration",
 			"debugSession"
+		],
+		"vs/platform/history/browser/contextScopedHistoryWidget": [
+			"suggestWidgetVisible"
 		],
 		"vs/workbench/contrib/debug/browser/linkDetector": [
 			"followForwardedLink",
@@ -10819,6 +10930,60 @@
 			"tooltip.N",
 			"markers.showOnFile"
 		],
+		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+			"name"
+		],
+		"vs/workbench/contrib/comments/browser/commentService": [
+			"hasCommentingProvider"
+		],
+		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
+			"nextCommentThreadAction",
+			"previousCommentThreadAction",
+			"comments.toggleCommenting",
+			"comments.addCommand",
+			"comments.collapseAll",
+			"comments.expandAll",
+			"comments.expandUnresolved"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomains": [
+			"trustedDomain.manageTrustedDomain",
+			"trustedDomain.trustDomain",
+			"trustedDomain.trustAllPorts",
+			"trustedDomain.trustSubDomain",
+			"trustedDomain.trustAllDomains",
+			"trustedDomain.manageTrustedDomains"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
+			"openExternalLinkAt",
+			{
+				"key": "open",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "copy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "configureTrustedDomains",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
+			"editor.action.webvieweditor.showFind",
+			"editor.action.webvieweditor.hideFind",
+			"editor.action.webvieweditor.findNext",
+			"editor.action.webvieweditor.findPrevious",
+			"refreshWebviewLabel"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
+			"context.activeWebviewId"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/commands/commands": [
 			"title",
 			"layout.mixed",
@@ -10875,57 +11040,6 @@
 		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
 			"mergeEditor"
 		],
-		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
-			"nextCommentThreadAction",
-			"previousCommentThreadAction",
-			"comments.toggleCommenting",
-			"comments.addCommand",
-			"comments.collapseAll",
-			"comments.expandAll",
-			"comments.expandUnresolved"
-		],
-		"vs/workbench/contrib/comments/browser/commentService": [
-			"hasCommentingProvider"
-		],
-		"vs/workbench/contrib/url/browser/trustedDomains": [
-			"trustedDomain.manageTrustedDomain",
-			"trustedDomain.trustDomain",
-			"trustedDomain.trustAllPorts",
-			"trustedDomain.trustSubDomain",
-			"trustedDomain.trustAllDomains",
-			"trustedDomain.manageTrustedDomains"
-		],
-		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
-			"openExternalLinkAt",
-			{
-				"key": "open",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "copy",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "configureTrustedDomains",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
-			"context.activeWebviewId"
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
-			"editor.action.webvieweditor.showFind",
-			"editor.action.webvieweditor.hideFind",
-			"editor.action.webvieweditor.findNext",
-			"editor.action.webvieweditor.findPrevious",
-			"refreshWebviewLabel"
-		],
 		"vs/workbench/contrib/customEditor/common/customEditor": [
 			"context.customEditor"
 		],
@@ -10934,6 +11048,12 @@
 			"externalUriOpeners.uri",
 			"externalUriOpeners.uri",
 			"externalUriOpeners.defaultId"
+		],
+		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
+			"selectOpenerDefaultLabel.web",
+			"selectOpenerDefaultLabel",
+			"selectOpenerConfigureTitle",
+			"selectOpenerPlaceHolder"
 		],
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"extensionsInputName"
@@ -10953,8 +11073,6 @@
 			"cancel",
 			"update operation",
 			"install operation",
-			"install release version message",
-			"install release version",
 			"check logs",
 			"download",
 			"install vsix",
@@ -11121,65 +11239,12 @@
 			"extensionButtonProminentForeground",
 			"extensionButtonProminentHoverBackground"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViews": [
-			"extensions",
-			"offline error",
-			"error",
-			"no extensions found",
-			"suggestProxyError",
-			"open user settings",
-			"no local extensions",
-			"extension.arialabel.verifiedPublihser",
-			"extension.arialabel.publihser",
-			"extension.arialabel.deprecated",
-			"extension.arialabel.rating"
-		],
-		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
-			"selectOpenerDefaultLabel.web",
-			"selectOpenerDefaultLabel",
-			"selectOpenerConfigureTitle",
-			"selectOpenerPlaceHolder"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
-			"extensionsViewIcon",
-			"manageExtensionIcon",
-			"clearSearchResultsIcon",
-			"refreshIcon",
-			"filterIcon",
-			"installLocalInRemoteIcon",
-			"installWorkspaceRecommendedIcon",
-			"configureRecommendedIcon",
-			"syncEnabledIcon",
-			"syncIgnoredIcon",
-			"remoteIcon",
-			"installCountIcon",
-			"ratingIcon",
-			"verifiedPublisher",
-			"preReleaseIcon",
-			"sponsorIcon",
-			"starFullIcon",
-			"starHalfIcon",
-			"starEmptyIcon",
-			"errorIcon",
-			"warningIcon",
-			"infoIcon",
-			"trustIcon",
-			"activationtimeIcon"
-		],
-		"vs/platform/dnd/browser/dnd": [
-			"fileTooLarge"
-		],
 		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
 			"app.extensions.json.title",
 			"app.extensions.json.recommendations",
 			"app.extension.identifier.errorMessage",
 			"app.extensions.json.unwantedRecommendations",
 			"app.extension.identifier.errorMessage"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"disableOtherKeymapsConfirmation",
-			"yes",
-			"no"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionEditor": [
 			"extension version",
@@ -11296,21 +11361,13 @@
 			"find next",
 			"find previous"
 		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"disableOtherKeymapsConfirmation",
+			"yes",
+			"no"
+		],
 		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
 			"activation"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"extensions",
-			"auto install missing deps",
-			"finished installing missing deps",
-			"reload",
-			"no missing deps"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"type",
-			"searchFor",
-			"install",
-			"manage"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
 			"Manifest is not found",
@@ -11414,6 +11471,39 @@
 		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
 			"restartExtensionHost.reason"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"extensions",
+			"auto install missing deps",
+			"finished installing missing deps",
+			"reload",
+			"no missing deps"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"extensionsViewIcon",
+			"manageExtensionIcon",
+			"clearSearchResultsIcon",
+			"refreshIcon",
+			"filterIcon",
+			"installLocalInRemoteIcon",
+			"installWorkspaceRecommendedIcon",
+			"configureRecommendedIcon",
+			"syncEnabledIcon",
+			"syncIgnoredIcon",
+			"remoteIcon",
+			"installCountIcon",
+			"ratingIcon",
+			"verifiedPublisher",
+			"preReleaseIcon",
+			"sponsorIcon",
+			"starFullIcon",
+			"starHalfIcon",
+			"starEmptyIcon",
+			"errorIcon",
+			"warningIcon",
+			"infoIcon",
+			"trustIcon",
+			"activationtimeIcon"
+		],
 		"vs/workbench/contrib/extensions/browser/extensionsCompletionItemsProvider": [
 			"exampleExtension"
 		],
@@ -11422,8 +11512,89 @@
 			"showDeprecated",
 			"neverShowAgain"
 		],
+		"vs/platform/dnd/browser/dnd": [
+			"fileTooLarge"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"extensions",
+			"offline error",
+			"error",
+			"no extensions found",
+			"suggestProxyError",
+			"open user settings",
+			"no local extensions",
+			"extension.arialabel.verifiedPublihser",
+			"extension.arialabel.publihser",
+			"extension.arialabel.deprecated",
+			"extension.arialabel.rating"
+		],
 		"vs/workbench/contrib/output/browser/logViewer": [
 			"logViewerAriaLabel"
+		],
+		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
+			"tasksQuickAccessPlaceholder",
+			"tasksQuickAccessHelp",
+			"terminal",
+			"terminal",
+			{
+				"key": "miToggleIntegratedTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"type",
+			"searchFor",
+			"install",
+			"manage"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"terminal.useMonospace",
+			"terminal.monospaceOnly",
+			"terminals",
+			"terminalConnectingLabel"
+		],
+		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
+			"workbench.action.terminal.showTextureAtlas",
+			"workbench.action.terminal.writeDataToTerminal",
+			"workbench.action.terminal.writeDataToTerminal.prompt",
+			"workbench.action.terminal.restartPtyHost"
+		],
+		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
+			"workbench.action.terminal.showEnvironmentContributions",
+			"envChanges",
+			"extension",
+			"ScopedEnvironmentContributionInfo"
+		],
+		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
+			"workbench.action.terminal.focusFind",
+			"workbench.action.terminal.hideFind",
+			"workbench.action.terminal.toggleFindRegex",
+			"workbench.action.terminal.toggleFindWholeWord",
+			"workbench.action.terminal.toggleFindCaseSensitive",
+			"workbench.action.terminal.findNext",
+			"workbench.action.terminal.findPrevious",
+			"workbench.action.terminal.searchWorkspace"
+		],
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
+			"workbench.action.terminal.focusAccessibleBuffer",
+			"workbench.action.terminal.navigateAccessibleBuffer",
+			"workbench.action.terminal.accessibleBufferGoToNextCommand",
+			"workbench.action.terminal.accessibleBufferGoToPreviousCommand"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
+			"workbench.action.terminal.openDetectedLink",
+			"workbench.action.terminal.openLastUrlLink",
+			"workbench.action.terminal.openLastLocalFileLink"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
+			"workbench.action.terminal.showQuickFixes"
+		],
+		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
+			"workbench.action.tasks.manageAutomaticRunning",
+			"workbench.action.tasks.allowAutomaticTasks",
+			"workbench.action.tasks.disallowAutomaticTasks"
 		],
 		"vs/workbench/contrib/tasks/common/problemMatcher": [
 			"ProblemPatternParser.problemPattern.missingRegExp",
@@ -11494,11 +11665,6 @@
 			"eslint-compact",
 			"eslint-stylish",
 			"go"
-		],
-		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
-			"workbench.action.tasks.manageAutomaticRunning",
-			"workbench.action.tasks.allowAutomaticTasks",
-			"workbench.action.tasks.disallowAutomaticTasks"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
 			"JsonSchema.version.deprecated",
@@ -11641,6 +11807,15 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"expandAbbreviationAction",
+			{
+				"key": "miEmmetExpandAbbreviation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/workbench/contrib/remote/browser/remoteIndicator": [
 			"statusBarOfflineBackground",
 			"statusBarOfflineForeground",
@@ -11680,102 +11855,25 @@
 			"remoteHost",
 			"networkStatusOfflineTooltip",
 			"networkStatusHighLatencyTooltip",
+			"remote.startActions.help",
+			"remote.startActions.install",
 			"closeRemoteConnection.title",
 			"reloadWindow",
 			"closeVirtualWorkspace.title",
-			"remote.startActions.help",
-			"remote.startActions.install",
 			"remoteActions",
 			"remote.startActions.installingExtension"
 		],
-		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
-			"tasksQuickAccessPlaceholder",
-			"tasksQuickAccessHelp",
-			"terminal",
-			"terminal",
-			{
-				"key": "miToggleIntegratedTerminal",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
-			"workbench.action.terminal.focusAccessibleBuffer",
-			"workbench.action.terminal.navigateAccessibleBuffer",
-			"workbench.action.terminal.accessibleBufferGoToNextCommand",
-			"workbench.action.terminal.accessibleBufferGoToPreviousCommand"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalView": [
-			"terminal.useMonospace",
-			"terminal.monospaceOnly",
-			"terminals",
-			"terminalConnectingLabel"
-		],
-		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
-			"workbench.action.terminal.showTextureAtlas",
-			"workbench.action.terminal.writeDataToTerminal",
-			"workbench.action.terminal.writeDataToTerminal.prompt",
-			"workbench.action.terminal.restartPtyHost"
-		],
-		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
-			"workbench.action.terminal.showEnvironmentContributions",
-			"envChanges",
-			"extension"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
-			"workbench.action.terminal.showQuickFixes"
-		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"expandAbbreviationAction",
-			{
-				"key": "miEmmetExpandAbbreviation",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
-			"accessibilityHelpTitle",
-			"emergencyConfOn",
-			"openingDocs",
-			"introMsg",
-			"status",
-			"changeConfigToOnMac",
-			"changeConfigToOnWinLinux",
-			"auto_unknown",
-			"auto_on",
-			"auto_off",
-			"configuredOn",
-			"configuredOff",
-			"tabFocusModeOnMsg",
-			"tabFocusModeOnMsgNoKb",
-			"tabFocusModeOffMsg",
-			"tabFocusModeOffMsgNoKb",
-			"openDocMac",
-			"openDocWinLinux",
-			"outroMsg",
 			"toggleScreenReaderMode"
 		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
-			"workbench.action.terminal.openDetectedLink",
-			"workbench.action.terminal.openLastUrlLink",
-			"workbench.action.terminal.openLastLocalFileLink"
-		],
 		"vs/workbench/contrib/codeEditor/browser/diffEditorHelper": [
+			"hintWhitespace",
 			"hintTimeout",
 			"removeTimeout",
-			"hintWhitespace"
-		],
-		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
-			"workbench.action.terminal.focusFind",
-			"workbench.action.terminal.hideFind",
-			"workbench.action.terminal.toggleFindRegex",
-			"workbench.action.terminal.toggleFindWholeWord",
-			"workbench.action.terminal.toggleFindCaseSensitive",
-			"workbench.action.terminal.findNext",
-			"workbench.action.terminal.findPrevious",
-			"workbench.action.terminal.searchWorkspace"
+			"msg1",
+			"msg2",
+			"msg3",
+			"chat-help-label"
 		],
 		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
 			"workbench.action.inspectKeyMap",
@@ -11840,24 +11938,6 @@
 			"miMultiCursorCmd",
 			"miMultiCursorCtrl"
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
-			"toggleRenderControlCharacters",
-			{
-				"key": "miToggleRenderControlCharacters",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
-			"toggleRenderWhitespace",
-			{
-				"key": "miToggleRenderWhitespace",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
 			"editorWordWrap",
 			"toggle.wordwrap",
@@ -11870,12 +11950,30 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
+			"toggleRenderControlCharacters",
+			{
+				"key": "miToggleRenderControlCharacters",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint": [
 			{
 				"key": "message",
 				"comment": [
 					"Preserve double-square brackets and their order",
 					"language refers to a programming language"
+				]
+			}
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"toggleRenderWhitespace",
+			{
+				"key": "miToggleRenderWhitespace",
+				"comment": [
+					"&& denotes a mnemonic"
 				]
 			}
 		],
@@ -11913,22 +12011,6 @@
 		],
 		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
 			"label"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
-			"codeAction",
-			"overflow.start.title",
-			"title"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"invalid.path.0",
-			"invalid.language.0",
-			"invalid.language",
-			"invalid.path.1",
-			"vscode.extension.contributes.snippets",
-			"vscode.extension.contributes.snippets-language",
-			"vscode.extension.contributes.snippets-path",
-			"badVariableUse",
-			"badFile"
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
 			"null",
@@ -11974,6 +12056,8 @@
 			"update.noReleaseNotesOnline",
 			"read the release notes",
 			"releaseNotes",
+			"update service disabled",
+			"learn more",
 			"updateIsReady",
 			"checkingForUpdates",
 			"downloading",
@@ -11998,6 +12082,7 @@
 			"DownloadingUpdate",
 			"installUpdate...",
 			"installingUpdate",
+			"showUpdateReleaseNotes",
 			"restartToUpdate",
 			"switchToInsiders",
 			"switchToStable",
@@ -12025,8 +12110,10 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
-			"getStarted"
+		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
+			"codeAction",
+			"overflow.start.title",
+			"title"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
 			"builtin",
@@ -12081,6 +12168,20 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"invalid.path.0",
+			"invalid.language.0",
+			"invalid.language",
+			"invalid.path.1",
+			"vscode.extension.contributes.snippets",
+			"vscode.extension.contributes.snippets-language",
+			"vscode.extension.contributes.snippets-path",
+			"badVariableUse",
+			"badFile"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
+			"getStarted"
+		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
 			"welcome.displayName",
 			"startupPage.markdownPreviewError"
@@ -12128,33 +12229,7 @@
 			"title.template",
 			"1.problem",
 			"N.problem",
-			"deep.problem",
-			"Array",
-			"Boolean",
-			"Class",
-			"Constant",
-			"Constructor",
-			"Enum",
-			"EnumMember",
-			"Event",
-			"Field",
-			"File",
-			"Function",
-			"Interface",
-			"Key",
-			"Method",
-			"Module",
-			"Namespace",
-			"Null",
-			"Number",
-			"Object",
-			"Operator",
-			"Package",
-			"Property",
-			"String",
-			"Struct",
-			"TypeParameter",
-			"Variable"
+			"deep.problem"
 		],
 		"vs/workbench/contrib/outline/browser/outlinePane": [
 			"no-editor",
@@ -12266,39 +12341,28 @@
 			"workbench.actions.syncData.reset"
 		],
 		"vs/workbench/contrib/userDataProfile/browser/userDataProfile": [
-			"create empty profile",
-			"save profile as",
 			"profiles",
 			"switchProfile",
 			"selectProfile",
-			"rename profile",
+			"edit profile",
 			"show profile contents",
 			"export profile",
 			"export profile in share",
 			"import profile",
-			"import from file",
 			"import from url",
+			"import from file",
+			"templates",
 			"import profile quick pick title",
 			"import profile placeholder",
 			"profile import error",
 			"import profile dialog",
 			"import profile share",
-			"name",
-			"create from current profle",
-			"create empty profile",
-			"profileExists",
+			"save profile as",
 			"create profile",
-			"empty",
-			"using current",
-			"templates",
-			"create profile title",
 			"delete profile",
 			"current",
 			"delete specific profile",
-			"pick profile to delete",
-			"create profile from templates",
-			"create profile from template title",
-			"no templates"
+			"pick profile to delete"
 		],
 		"vs/workbench/contrib/userDataProfile/browser/userDataProfileActions": [
 			"create temporary profile",
@@ -12318,6 +12382,7 @@
 			"editSessionViewIcon"
 		],
 		"vs/workbench/contrib/editSessions/browser/editSessionsStorageService": [
+			"choose account read placeholder",
 			"choose account placeholder",
 			"signed in",
 			"others",
@@ -12347,13 +12412,6 @@
 			"cloud changes",
 			"open file"
 		],
-		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
-			"contributes.codeActions",
-			"contributes.codeActions.languages",
-			"contributes.codeActions.kind",
-			"contributes.codeActions.title",
-			"contributes.codeActions.description"
-		],
 		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
 			"contributes.documentation",
 			"contributes.documentation.refactorings",
@@ -12361,6 +12419,13 @@
 			"contributes.documentation.refactoring.title",
 			"contributes.documentation.refactoring.when",
 			"contributes.documentation.refactoring.command"
+		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"contributes.codeActions",
+			"contributes.codeActions.languages",
+			"contributes.codeActions.kind",
+			"contributes.codeActions.title",
+			"contributes.codeActions.description"
 		],
 		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
 			"codeActionsOnSave.fixAll",
@@ -12601,13 +12666,8 @@
 			"overwritingExtension",
 			"extensionUnderDevelopment"
 		],
-		"vs/workbench/contrib/localization/common/localizationsActions": [
-			"configureLocale",
-			"chooseLocale",
-			"installed",
-			"available",
-			"moreInfo",
-			"clearDisplayLanguage"
+		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
+			"reportExtensionIssue"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensionsSlowActions": [
 			"cmd.reportOrShow",
@@ -12618,11 +12678,61 @@
 			"attach.title",
 			"attach.msg2"
 		],
-		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
-			"reportExtensionIssue"
-		],
 		"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote": [
 			"workbench.action.terminal.newLocal"
+		],
+		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
+			"ptyHostStatus",
+			"ptyHostStatus.short",
+			"nonResponsivePtyHost",
+			"ptyHostStatus.ariaLabel"
+		],
+		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
+			"taskTerminalStatus.active",
+			"taskTerminalStatus.succeeded",
+			"taskTerminalStatus.succeededInactive",
+			"taskTerminalStatus.errors",
+			"taskTerminalStatus.errorsInactive",
+			"taskTerminalStatus.warnings",
+			"taskTerminalStatus.warningsInactive",
+			"taskTerminalStatus.infos",
+			"taskTerminalStatus.infosInactive",
+			"task.watchFirstError"
+		],
+		"vs/workbench/contrib/tasks/common/taskConfiguration": [
+			"ConfigurationParser.invalidCWD",
+			"ConfigurationParser.inValidArg",
+			"ConfigurationParser.noShell",
+			"ConfigurationParser.noName",
+			"ConfigurationParser.unknownMatcherKind",
+			"ConfigurationParser.invalidVariableReference",
+			"ConfigurationParser.noTaskType",
+			"ConfigurationParser.noTypeDefinition",
+			"ConfigurationParser.missingType",
+			"ConfigurationParser.incorrectType",
+			"ConfigurationParser.notCustom",
+			"ConfigurationParser.noTaskName",
+			"taskConfiguration.providerUnavailable",
+			"taskConfiguration.noCommandOrDependsOn",
+			"taskConfiguration.noCommand",
+			{
+				"key": "TaskParse.noOsSpecificGlobalTasks",
+				"comment": [
+					"\"Task version 2.0.0\" refers to the 2.0.0 version of the task system. The \"version 2.0.0\" is not localizable as it is a json key and value."
+				]
+			}
+		],
+		"vs/workbench/contrib/localHistory/browser/localHistory": [
+			"localHistoryIcon",
+			"localHistoryRestore"
+		],
+		"vs/workbench/contrib/localization/common/localizationsActions": [
+			"configureLocale",
+			"chooseLocale",
+			"installed",
+			"available",
+			"moreInfo",
+			"clearDisplayLanguage"
 		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"dotnetCore",
@@ -12648,51 +12758,6 @@
 			"TaskQuickPick.goBack",
 			"TaskQuickPick.noTasksForType",
 			"noProviderForTask"
-		],
-		"vs/workbench/contrib/tasks/common/taskConfiguration": [
-			"ConfigurationParser.invalidCWD",
-			"ConfigurationParser.inValidArg",
-			"ConfigurationParser.noShell",
-			"ConfigurationParser.noName",
-			"ConfigurationParser.unknownMatcherKind",
-			"ConfigurationParser.invalidVariableReference",
-			"ConfigurationParser.noTaskType",
-			"ConfigurationParser.noTypeDefinition",
-			"ConfigurationParser.missingType",
-			"ConfigurationParser.incorrectType",
-			"ConfigurationParser.notCustom",
-			"ConfigurationParser.noTaskName",
-			"taskConfiguration.providerUnavailable",
-			"taskConfiguration.noCommandOrDependsOn",
-			"taskConfiguration.noCommand",
-			{
-				"key": "TaskParse.noOsSpecificGlobalTasks",
-				"comment": [
-					"\"Task version 2.0.0\" refers to the 2.0.0 version of the task system. The \"version 2.0.0\" is not localizable as it is a json key and value."
-				]
-			}
-		],
-		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
-			"ptyHostStatus",
-			"ptyHostStatus.short",
-			"nonResponsivePtyHost",
-			"ptyHostStatus.ariaLabel"
-		],
-		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
-			"taskTerminalStatus.active",
-			"taskTerminalStatus.succeeded",
-			"taskTerminalStatus.succeededInactive",
-			"taskTerminalStatus.errors",
-			"taskTerminalStatus.errorsInactive",
-			"taskTerminalStatus.warnings",
-			"taskTerminalStatus.warningsInactive",
-			"taskTerminalStatus.infos",
-			"taskTerminalStatus.infosInactive",
-			"task.watchFirstError"
-		],
-		"vs/workbench/contrib/localHistory/browser/localHistory": [
-			"localHistoryIcon",
-			"localHistoryRestore"
 		],
 		"vs/workbench/contrib/debug/common/abstractDebugAdapter": [
 			"timeout"
@@ -12907,7 +12972,11 @@
 			"clearedInput"
 		],
 		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"notificationAccessibleViewHint",
+			"notificationAccessibleViewHintNoKb",
+			"notificationAriaLabelHint",
 			"notificationAriaLabel",
+			"notificationWithSourceAriaLabelHint",
 			"notificationWithSourceAriaLabel",
 			"notificationsList"
 		],
@@ -12940,6 +13009,17 @@
 				]
 			}
 		],
+		"vs/editor/browser/widget/inlineDiffMargin": [
+			"diff.clipboard.copyDeletedLinesContent.label",
+			"diff.clipboard.copyDeletedLinesContent.single.label",
+			"diff.clipboard.copyChangedLinesContent.label",
+			"diff.clipboard.copyChangedLinesContent.single.label",
+			"diff.clipboard.copyDeletedLineContent.label",
+			"diff.clipboard.copyChangedLineContent.label",
+			"diff.inline.revertChange.label",
+			"diff.clipboard.copyDeletedLineContent.label",
+			"diff.clipboard.copyChangedLineContent.label"
+		],
 		"vs/editor/browser/widget/diffReview": [
 			"diffReviewInsertIcon",
 			"diffReviewRemoveIcon",
@@ -12969,17 +13049,6 @@
 			"equalLine",
 			"insertLine",
 			"deleteLine"
-		],
-		"vs/editor/browser/widget/inlineDiffMargin": [
-			"diff.clipboard.copyDeletedLinesContent.label",
-			"diff.clipboard.copyDeletedLinesContent.single.label",
-			"diff.clipboard.copyChangedLinesContent.label",
-			"diff.clipboard.copyChangedLinesContent.single.label",
-			"diff.clipboard.copyDeletedLineContent.label",
-			"diff.clipboard.copyChangedLineContent.label",
-			"diff.inline.revertChange.label",
-			"diff.clipboard.copyDeletedLineContent.label",
-			"diff.clipboard.copyChangedLineContent.label"
 		],
 		"vs/editor/common/viewLayout/viewLineRenderer": [
 			"showMore",
@@ -13015,21 +13084,14 @@
 			"autoFix.label",
 			"editor.action.autoFix.noneMessage"
 		],
-		"vs/editor/contrib/codeAction/browser/codeActionController": [
-			"hideMoreActions",
-			"showMoreActions"
-		],
 		"vs/editor/contrib/codeAction/browser/lightBulbWidget": [
 			"preferredcodeActionWithKb",
 			"codeActionWithKb",
 			"codeAction"
 		],
-		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
-			"pasteWidgetVisible",
-			"postPasteWidgetTitle",
-			"pasteIntoEditorProgress",
-			"pasteAsPickerPlaceholder",
-			"pasteAsProgress"
+		"vs/editor/contrib/codeAction/browser/codeActionController": [
+			"hideMoreActions",
+			"showMoreActions"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders": [
 			"builtIn",
@@ -13040,6 +13102,13 @@
 			"defaultDropProvider.uriList.path",
 			"defaultDropProvider.uriList.relativePaths",
 			"defaultDropProvider.uriList.relativePath"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
+			"pasteWidgetVisible",
+			"postPasteWidgetTitle",
+			"pasteIntoEditorProgress",
+			"pasteAsPickerPlaceholder",
+			"pasteAsProgress"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController": [
 			"dropWidgetVisible",
@@ -13195,22 +13264,6 @@
 			"overviewRulerWordHighlightStrongForeground",
 			"overviewRulerWordHighlightTextForeground"
 		],
-		"vs/editor/contrib/parameterHints/browser/parameterHintsWidget": [
-			"parameterHintsNextIcon",
-			"parameterHintsPreviousIcon",
-			"hint",
-			"editorHoverWidgetHighlightForeground"
-		],
-		"vs/editor/contrib/rename/browser/renameInputField": [
-			"renameInputVisible",
-			"renameAriaLabel",
-			{
-				"key": "label",
-				"comment": [
-					"placeholders are keybindings, e.g \"F2 to Rename, Shift+F2 to Preview\""
-				]
-			}
-		],
 		"vs/editor/contrib/stickyScroll/browser/stickyScrollActions": [
 			"toggleStickyScroll",
 			{
@@ -13255,6 +13308,12 @@
 			"label.detail",
 			"label.desc",
 			"ariaCurrenttSuggestionReadDetails"
+		],
+		"vs/editor/contrib/parameterHints/browser/parameterHintsWidget": [
+			"parameterHintsNextIcon",
+			"parameterHintsPreviousIcon",
+			"hint",
+			"editorHoverWidgetHighlightForeground"
 		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
 			"schema.token.settings",
@@ -13333,6 +13392,16 @@
 			"collapseAll",
 			"expandAll"
 		],
+		"vs/editor/contrib/rename/browser/renameInputField": [
+			"renameInputVisible",
+			"renameAriaLabel",
+			{
+				"key": "label",
+				"comment": [
+					"placeholders are keybindings, e.g \"F2 to Rename, Shift+F2 to Preview\""
+				]
+			}
+		],
 		"vs/workbench/contrib/comments/browser/commentsTreeViewer": [
 			"comments.view.title",
 			"commentsCount",
@@ -13342,32 +13411,6 @@
 			"commentLine",
 			"commentRange",
 			"lastReplyFrom"
-		],
-		"vs/workbench/contrib/testing/common/testResult": [
-			"runFinished"
-		],
-		"vs/workbench/browser/parts/compositeBarActions": [
-			"titleKeybinding",
-			"badgeTitle",
-			"additionalViews",
-			"numberBadge",
-			"manageExtension",
-			"hide",
-			"keep",
-			"hideBadge",
-			"showBadge",
-			"toggle",
-			"toggleBadge"
-		],
-		"vs/base/browser/ui/tree/treeDefaults": [
-			"collapse all"
-		],
-		"vs/workbench/browser/parts/views/checkbox": [
-			"checked",
-			"unchecked"
-		],
-		"vs/base/browser/ui/splitview/paneview": [
-			"viewSection"
 		],
 		"vs/workbench/contrib/remote/browser/tunnelView": [
 			"tunnel.forwardedPortsViewEnabled",
@@ -13430,6 +13473,32 @@
 			"tunnelContext.protocolMenu",
 			"portWithRunningProcess.foreground"
 		],
+		"vs/workbench/contrib/testing/common/testResult": [
+			"runFinished"
+		],
+		"vs/workbench/browser/parts/compositeBarActions": [
+			"titleKeybinding",
+			"badgeTitle",
+			"additionalViews",
+			"numberBadge",
+			"manageExtension",
+			"hide",
+			"keep",
+			"hideBadge",
+			"showBadge",
+			"toggle",
+			"toggleBadge"
+		],
+		"vs/base/browser/ui/splitview/paneview": [
+			"viewSection"
+		],
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"collapse all"
+		],
+		"vs/workbench/browser/parts/views/checkbox": [
+			"checked",
+			"unchecked"
+		],
 		"vs/workbench/contrib/remote/browser/remoteIcons": [
 			"getStartedIcon",
 			"documentationIcon",
@@ -13456,45 +13525,6 @@
 			"binaryEditor",
 			"binaryError",
 			"openAnyway"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/colors": [
-			"diffEditor.move.border"
-		],
-		"vs/workbench/browser/parts/editor/editorPanes": [
-			"editorOpenErrorDialog",
-			{
-				"key": "ok",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/browser/parts/editor/tabsTitleControl": [
-			"ariaLabelTabActions"
-		],
-		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
-			"watermark.showCommands",
-			"watermark.quickAccess",
-			"watermark.openFile",
-			"watermark.openFolder",
-			"watermark.openFileFolder",
-			"watermark.openRecent",
-			"watermark.newUntitledFile",
-			"watermark.findInFiles",
-			{
-				"key": "watermark.toggleTerminal",
-				"comment": [
-					"toggle is a verb here"
-				]
-			},
-			"watermark.startDebugging",
-			{
-				"key": "watermark.toggleFullscreen",
-				"comment": [
-					"toggle is a verb here"
-				]
-			},
-			"watermark.showSettings"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
 			"loading",
@@ -13591,6 +13621,12 @@
 				]
 			}
 		],
+		"vs/editor/browser/widget/diffEditor.contribution": [
+			"accessibleDiffViewer",
+			"editor.action.accessibleDiffViewer.next",
+			"Open Accessible Diff Viewer",
+			"editor.action.accessibleDiffViewer.prev"
+		],
 		"vs/workbench/browser/parts/compositePart": [
 			"ariaCompositeToolbarLabel",
 			"viewsAndMoreActions",
@@ -13601,6 +13637,42 @@
 		],
 		"vs/workbench/browser/parts/sidebar/sidebarActions": [
 			"focusSideBar"
+		],
+		"vs/workbench/browser/parts/editor/tabsTitleControl": [
+			"ariaLabelTabActions"
+		],
+		"vs/workbench/browser/parts/editor/editorPanes": [
+			"editorOpenErrorDialog",
+			{
+				"key": "ok",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
+			"watermark.showCommands",
+			"watermark.quickAccess",
+			"watermark.openFile",
+			"watermark.openFolder",
+			"watermark.openFileFolder",
+			"watermark.openRecent",
+			"watermark.newUntitledFile",
+			"watermark.findInFiles",
+			{
+				"key": "watermark.toggleTerminal",
+				"comment": [
+					"toggle is a verb here"
+				]
+			},
+			"watermark.startDebugging",
+			{
+				"key": "watermark.toggleFullscreen",
+				"comment": [
+					"toggle is a verb here"
+				]
+			},
+			"watermark.showSettings"
 		],
 		"vs/base/browser/ui/iconLabel/iconLabelHover": [
 			"iconLabel.loading"
@@ -13647,6 +13719,14 @@
 		"vs/editor/common/model/editStack": [
 			"edit"
 		],
+		"vs/base/browser/ui/selectBox/selectBoxCustom": [
+			{
+				"key": "selectBox",
+				"comment": [
+					"Behave like native select dropdown element."
+				]
+			}
+		],
 		"vs/platform/quickinput/browser/quickInput": [
 			"quickInput.back",
 			"inputModeEntry",
@@ -13682,18 +13762,6 @@
 			"vscode.extension.contributes.grammars.balancedBracketScopes",
 			"vscode.extension.contributes.grammars.unbalancedBracketScopes"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
-			"userSettings",
-			"userSettingsRemote",
-			"workspaceSettings",
-			"folderSettings",
-			"settingsSwitcherBarAriaLabel",
-			"userSettings",
-			"userSettingsRemote",
-			"workspaceSettings",
-			"userSettings",
-			"workspaceSettings"
-		],
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"unbound"
 		],
@@ -13727,6 +13795,7 @@
 			"unsupportedPolicySetting",
 			"unsupportLanguageOverrideSetting",
 			"defaultProfileSettingWhileNonDefaultActive",
+			"allProfileSettingWhileInNonDefaultProfileSetting",
 			"unsupportedRemoteMachineSetting",
 			"unsupportedWindowSetting",
 			"unsupportedApplicationSetting",
@@ -13787,14 +13856,17 @@
 			"security",
 			"workspace"
 		],
-		"vs/workbench/contrib/preferences/browser/tocTree": [
-			{
-				"key": "settingsTOC",
-				"comment": [
-					"A label for the table of contents for the full settings list"
-				]
-			},
-			"groupRowAriaLabel"
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"folderSettings",
+			"settingsSwitcherBarAriaLabel",
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"userSettings",
+			"workspaceSettings"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsTree": [
 			"extensions",
@@ -13813,7 +13885,17 @@
 			"settings",
 			"copySettingIdLabel",
 			"copySettingAsJSONLabel",
-			"stopSyncingSetting"
+			"stopSyncingSetting",
+			"applyToAllProfiles"
+		],
+		"vs/workbench/contrib/preferences/browser/tocTree": [
+			{
+				"key": "settingsTOC",
+				"comment": [
+					"A label for the table of contents for the full settings list"
+				]
+			},
+			"groupRowAriaLabel"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
 			"modifiedSettingsSearch",
@@ -13865,6 +13947,8 @@
 			"contributes.preload.localResourceRoots"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookEditorWidget": [
+			"notebookTreeAriaLabelHelp",
+			"notebookTreeAriaLabelHelpNoKb",
 			"notebookTreeAriaLabel",
 			"notebook.cellBorderColor",
 			"notebook.focusedEditorBorder",
@@ -13960,9 +14044,14 @@
 		"vs/editor/contrib/codeAction/browser/codeAction": [
 			"applyCodeActionFailed"
 		],
+		"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider": [
+			"empty"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
 			"chat.overview",
 			"chat.requestHistory",
+			"chat.inspectResponse",
+			"chat.inspectResponseNoKb",
 			"chat.announcement",
 			"workbench.action.chat.focus",
 			"workbench.action.chat.focusNoKb",
@@ -13975,29 +14064,47 @@
 			"inlineChat.overview",
 			"inlineChat.access",
 			"inlineChat.requestHistory",
+			"inlineChat.inspectResponse",
+			"inlineChat.inspectResponseNoKb",
 			"inlineChat.contextActions",
 			"inlineChat.fix",
 			"inlineChat.diff",
 			"inlineChat.diffNoKb",
-			"inlineChat.explain",
 			"inlineChat.toolbar",
 			"chat.audioCues",
 			"chat-help-label",
 			"inline-chat-label"
 		],
+		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/quickQuestionAction": [
+			"chat"
+		],
+		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/multipleByScrollQuickQuestionAction": [
+			"clear",
+			"openInChat"
+		],
+		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/singleQuickQuestionAction": [
+			"askabot"
+		],
+		"vs/workbench/contrib/chat/browser/chatInputPart": [
+			"actions.chat.accessibiltyHelp",
+			"chatInput.accessibilityHelpNoKb",
+			"chatInput"
+		],
 		"vs/workbench/contrib/chat/browser/chatListRenderer": [
 			"chat",
+			"noCodeBlocksHint",
+			"noCodeBlocks",
+			"singleCodeBlockHint",
 			"singleCodeBlock",
+			"multiCodeBlockHint",
 			"multiCodeBlock",
 			"chat.codeBlockHelp",
 			"chat.codeBlock.toolbarVerbose",
 			"chat.codeBlock.toolbar",
 			"chat.codeBlockLabel"
 		],
-		"vs/workbench/contrib/chat/browser/chatInputPart": [
-			"actions.chat.accessibiltyHelp",
-			"chatInput.accessibilityHelpNoKb",
-			"chatInput"
+		"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget": [
+			"exited slash command mode"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
 			"lines.0",
@@ -14087,13 +14194,6 @@
 			"terminal.tab.activeBorder",
 			"terminal.ansiColor"
 		],
-		"vs/platform/quickinput/browser/commandsQuickAccess": [
-			"recentlyUsed",
-			"commonlyUsed",
-			"morecCommands",
-			"commandPickAriaLabelWithKeybinding",
-			"canNotRun"
-		],
 		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
 			"canNotResolve",
 			"symbolicLlink",
@@ -14120,6 +14220,13 @@
 			"moving",
 			"numberOfFolders",
 			"numberOfFiles"
+		],
+		"vs/platform/quickinput/browser/commandsQuickAccess": [
+			"recentlyUsed",
+			"commonlyUsed",
+			"morecCommands",
+			"commandPickAriaLabelWithKeybinding",
+			"canNotRun"
 		],
 		"vs/workbench/contrib/files/browser/fileImportExport": [
 			"uploadingFiles",
@@ -14186,24 +14293,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
-			"bulkEdit",
-			"aria.renameAndEdit",
-			"aria.createAndEdit",
-			"aria.deleteAndEdit",
-			"aria.editOnly",
-			"aria.rename",
-			"aria.create",
-			"aria.delete",
-			"aria.replace",
-			"aria.del",
-			"aria.insert",
-			"rename.label",
-			"detail.rename",
-			"detail.create",
-			"detail.del",
-			"title"
-		],
 		"vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess": [
 			"cannotRunGotoSymbolWithoutEditor",
 			"cannotRunGotoSymbolWithoutSymbolProvider",
@@ -14245,6 +14334,24 @@
 		],
 		"vs/workbench/contrib/search/browser/searchFindInput": [
 			"searchFindInputNotebookFilter.label"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
+			"bulkEdit",
+			"aria.renameAndEdit",
+			"aria.createAndEdit",
+			"aria.deleteAndEdit",
+			"aria.editOnly",
+			"aria.rename",
+			"aria.create",
+			"aria.delete",
+			"aria.replace",
+			"aria.del",
+			"aria.insert",
+			"rename.label",
+			"detail.rename",
+			"detail.create",
+			"detail.del",
+			"title"
 		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization": [
 			"invalidQueryStringError",
@@ -14335,6 +14442,9 @@
 			"taskNotTrackedWithTaskId",
 			"taskNotTracked"
 		],
+		"vs/workbench/contrib/debug/common/debugSource": [
+			"unknownSource"
+		],
 		"vs/workbench/contrib/debug/browser/debugSession": [
 			"noDebugAdapter",
 			"noDebugAdapter",
@@ -14376,9 +14486,6 @@
 			"debuggingStarted",
 			"debuggingStopped"
 		],
-		"vs/workbench/contrib/debug/common/debugSource": [
-			"unknownSource"
-		],
 		"vs/base/browser/ui/findinput/replaceInput": [
 			"defaultLabel",
 			"label.preserveCaseToggle"
@@ -14395,6 +14502,10 @@
 			"messageColumnLabel",
 			"fileColumnLabel",
 			"sourceColumnLabel"
+		],
+		"vs/workbench/contrib/comments/browser/commentsController": [
+			"hasCommentingRange",
+			"pickCommentService"
 		],
 		"vs/workbench/contrib/mergeEditor/common/mergeEditor": [
 			"is",
@@ -14482,11 +14593,6 @@
 			},
 			"noMoreWarn"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
-			"base",
-			"compareWith",
-			"compareWithTooltip"
-		],
 		"vs/workbench/contrib/mergeEditor/browser/view/viewModel": [
 			"noConflictMessage"
 		],
@@ -14525,16 +14631,8 @@
 			"mergeEditor.conflict.input1.background",
 			"mergeEditor.conflict.input2.background"
 		],
-		"vs/workbench/contrib/comments/browser/commentsController": [
-			"hasCommentingRange",
-			"pickCommentService"
-		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
 			"builtinProviderDisplayName"
-		],
-		"vs/platform/files/browser/htmlFileSystemProvider": [
-			"fileSystemRenameError",
-			"fileSystemNotAllowedError"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"ratedLabel",
@@ -14562,10 +14660,19 @@
 			"extensionPreReleaseForeground",
 			"extensionIcon.sponsorForeground"
 		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
+			"base",
+			"compareWith",
+			"compareWithTooltip"
+		],
 		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
 			"error",
 			"Unknown Extension",
 			"extensions"
+		],
+		"vs/platform/files/browser/htmlFileSystemProvider": [
+			"fileSystemRenameError",
+			"fileSystemNotAllowedError"
 		],
 		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
 			"exeBasedRecommendation"
@@ -14580,79 +14687,16 @@
 			"showLanguageExtensions",
 			"dontShowAgainExtension"
 		],
-		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
-			"exeBasedRecommendation"
-		],
 		"vs/workbench/contrib/extensions/browser/webRecommendations": [
 			"reason"
 		],
-		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
-			"JsonSchema.options",
-			"JsonSchema.options.cwd",
-			"JsonSchema.options.env",
-			"JsonSchema.tasks.matcherError",
-			"JsonSchema.tasks.matcherError",
-			"JsonSchema.shellConfiguration",
-			"JsonSchema.shell.executable",
-			"JsonSchema.shell.args",
-			"JsonSchema.command",
-			"JsonSchema.tasks.args",
-			"JsonSchema.tasks.taskName",
-			"JsonSchema.command",
-			"JsonSchema.tasks.args",
-			"JsonSchema.tasks.windows",
-			"JsonSchema.tasks.matchers",
-			"JsonSchema.tasks.mac",
-			"JsonSchema.tasks.matchers",
-			"JsonSchema.tasks.linux",
-			"JsonSchema.tasks.matchers",
-			"JsonSchema.tasks.suppressTaskName",
-			"JsonSchema.tasks.showOutput",
-			"JsonSchema.echoCommand",
-			"JsonSchema.tasks.watching.deprecation",
-			"JsonSchema.tasks.watching",
-			"JsonSchema.tasks.background",
-			"JsonSchema.tasks.promptOnClose",
-			"JsonSchema.tasks.build",
-			"JsonSchema.tasks.test",
-			"JsonSchema.tasks.matchers",
-			"JsonSchema.command",
-			"JsonSchema.args",
-			"JsonSchema.showOutput",
-			"JsonSchema.watching.deprecation",
-			"JsonSchema.watching",
-			"JsonSchema.background",
-			"JsonSchema.promptOnClose",
-			"JsonSchema.echoCommand",
-			"JsonSchema.suppressTaskName",
-			"JsonSchema.taskSelector",
-			"JsonSchema.matchers",
-			"JsonSchema.tasks"
+		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
+			"exeBasedRecommendation"
 		],
-		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
-			"deprecatedVariables"
-		],
-		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
-			"JsonSchema.input.id",
-			"JsonSchema.input.type",
-			"JsonSchema.input.description",
-			"JsonSchema.input.default",
-			"JsonSchema.inputs",
-			"JsonSchema.input.type.promptString",
-			"JsonSchema.input.password",
-			"JsonSchema.input.type.pickString",
-			"JsonSchema.input.options",
-			"JsonSchema.input.pickString.optionLabel",
-			"JsonSchema.input.pickString.optionValue",
-			"JsonSchema.input.type.command",
-			"JsonSchema.input.command.command",
-			"JsonSchema.input.command.args",
-			"JsonSchema.input.command.args",
-			"JsonSchema.input.command.args"
-		],
-		"vs/workbench/contrib/remote/browser/explorerViewItems": [
-			"remotes",
-			"remote.explorer.switch"
+		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
+			"workbench.action.terminal.newplus",
+			"workbench.action.terminal.newWithProfilePlus",
+			"renameTerminal"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
 			"showTerminalTabs",
@@ -14735,23 +14779,6 @@
 			"workbench.action.terminal.overriddenCwdDescription",
 			"workbench.action.terminal.newWorkspacePlaceholder",
 			"workbench.action.terminal.rename.prompt"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalService": [
-			"terminalService.terminalCloseConfirmationSingular",
-			"terminalService.terminalCloseConfirmationPlural",
-			{
-				"key": "terminate",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"localTerminalVirtualWorkspace",
-			"localTerminalRemote"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
-			"workbench.action.terminal.newplus",
-			"workbench.action.terminal.newWithProfilePlus",
-			"renameTerminal"
 		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
 			"cwd",
@@ -14897,6 +14924,18 @@
 			"terminal.integrated.smoothScrolling",
 			"terminal.integrated.enableImages"
 		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"terminalService.terminalCloseConfirmationSingular",
+			"terminalService.terminalCloseConfirmationPlural",
+			{
+				"key": "terminate",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"localTerminalVirtualWorkspace",
+			"localTerminalRemote"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalIcons": [
 			"terminalViewIcon",
 			"renameTerminalIcon",
@@ -14994,6 +15033,11 @@
 		"vs/platform/terminal/common/terminalLogService": [
 			"terminalLoggerName"
 		],
+		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
+			"moveTabsRight",
+			"moveTabsLeft",
+			"hideTabs"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
 			"shellIntegration.enabled",
 			"launchFailed.exitCodeOnlyShellIntegration",
@@ -15005,11 +15049,6 @@
 				]
 			},
 			"shellProcessTooltip.commandLine"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
-			"moveTabsRight",
-			"moveTabsLeft",
-			"hideTabs"
 		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
 			"terminal-help-label",
@@ -15039,22 +15078,6 @@
 			"terminal.integrated.accessibleBuffer",
 			"terminal.integrated.symbolQuickPick.labelNoExitCode"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
-			"terminal.freePort",
-			"terminal.createPR"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
-			"quickFix.command",
-			"quickFix.opener",
-			"codeAction.widget.id.quickfix"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
-			"vscode.extension.contributes.terminalQuickFixes",
-			"vscode.extension.contributes.terminalQuickFixes.id",
-			"vscode.extension.contributes.terminalQuickFixes.commandLineMatcher",
-			"vscode.extension.contributes.terminalQuickFixes.outputMatcher",
-			"vscode.extension.contributes.terminalQuickFixes.commandExitResult"
-		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
 			"terminalLinkHandler.followLinkAlt.mac",
 			"terminalLinkHandler.followLinkAlt",
@@ -15071,8 +15094,97 @@
 			"terminal.integrated.searchLinks",
 			"terminal.integrated.showMoreLinks"
 		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
+			"quickFix.command",
+			"quickFix.opener",
+			"codeAction.widget.id.quickfix"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
+			"terminal.freePort",
+			"terminal.createPR"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
+			"vscode.extension.contributes.terminalQuickFixes",
+			"vscode.extension.contributes.terminalQuickFixes.id",
+			"vscode.extension.contributes.terminalQuickFixes.commandLineMatcher",
+			"vscode.extension.contributes.terminalQuickFixes.outputMatcher",
+			"vscode.extension.contributes.terminalQuickFixes.commandExitResult"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
+			"JsonSchema.options",
+			"JsonSchema.options.cwd",
+			"JsonSchema.options.env",
+			"JsonSchema.tasks.matcherError",
+			"JsonSchema.tasks.matcherError",
+			"JsonSchema.shellConfiguration",
+			"JsonSchema.shell.executable",
+			"JsonSchema.shell.args",
+			"JsonSchema.command",
+			"JsonSchema.tasks.args",
+			"JsonSchema.tasks.taskName",
+			"JsonSchema.command",
+			"JsonSchema.tasks.args",
+			"JsonSchema.tasks.windows",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.mac",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.linux",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.suppressTaskName",
+			"JsonSchema.tasks.showOutput",
+			"JsonSchema.echoCommand",
+			"JsonSchema.tasks.watching.deprecation",
+			"JsonSchema.tasks.watching",
+			"JsonSchema.tasks.background",
+			"JsonSchema.tasks.promptOnClose",
+			"JsonSchema.tasks.build",
+			"JsonSchema.tasks.test",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.command",
+			"JsonSchema.args",
+			"JsonSchema.showOutput",
+			"JsonSchema.watching.deprecation",
+			"JsonSchema.watching",
+			"JsonSchema.background",
+			"JsonSchema.promptOnClose",
+			"JsonSchema.echoCommand",
+			"JsonSchema.suppressTaskName",
+			"JsonSchema.taskSelector",
+			"JsonSchema.matchers",
+			"JsonSchema.tasks"
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
+			"deprecatedVariables"
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
+			"JsonSchema.input.id",
+			"JsonSchema.input.type",
+			"JsonSchema.input.description",
+			"JsonSchema.input.default",
+			"JsonSchema.inputs",
+			"JsonSchema.input.type.promptString",
+			"JsonSchema.input.password",
+			"JsonSchema.input.type.pickString",
+			"JsonSchema.input.options",
+			"JsonSchema.input.pickString.optionLabel",
+			"JsonSchema.input.pickString.optionValue",
+			"JsonSchema.input.type.command",
+			"JsonSchema.input.command.command",
+			"JsonSchema.input.command.args",
+			"JsonSchema.input.command.args",
+			"JsonSchema.input.command.args"
+		],
+		"vs/workbench/contrib/remote/browser/explorerViewItems": [
+			"remotes",
+			"remote.explorer.switch"
+		],
 		"vs/workbench/contrib/snippets/browser/commands/abstractSnippetsActions": [
 			"snippets"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsFile": [
+			"source.workspaceSnippetGlobal",
+			"source.userSnippetGlobal",
+			"source.userSnippet"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetPicker": [
 			"sep.userSnippet",
@@ -15082,11 +15194,6 @@
 			"enable.snippet",
 			"pick.placeholder",
 			"pick.noSnippetAvailable"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsFile": [
-			"source.workspaceSnippetGlobal",
-			"source.userSnippetGlobal",
-			"source.userSnippet"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetCompletionProvider": [
 			"detail.snippet",
@@ -15470,13 +15577,13 @@
 		"vs/platform/terminal/common/terminalProfiles": [
 			"terminalAutomaticProfile"
 		],
+		"vs/workbench/contrib/webview/browser/webviewElement": [
+			"fatalErrorMessage"
+		],
 		"vs/platform/quickinput/browser/quickPickPin": [
 			"terminal.commands.pinned",
 			"pinCommand",
 			"pinnedCommand"
-		],
-		"vs/workbench/contrib/webview/browser/webviewElement": [
-			"fatalErrorMessage"
 		],
 		"vs/workbench/api/common/extHostDiagnostics": [
 			{
@@ -15486,12 +15593,12 @@
 				]
 			}
 		],
-		"vs/workbench/api/common/extHostProgress": [
-			"extensionSource"
-		],
 		"vs/workbench/api/common/extHostLanguageFeatures": [
 			"defaultPasteLabel",
 			"defaultDropLabel"
+		],
+		"vs/workbench/api/common/extHostProgress": [
+			"extensionSource"
 		],
 		"vs/workbench/api/common/extHostStatusBar": [
 			"extensionLabel",
@@ -15499,6 +15606,10 @@
 		],
 		"vs/workbench/api/common/extHostTreeViews": [
 			"treeView.duplicateElement"
+		],
+		"vs/workbench/api/common/extHostNotebook": [
+			"err.readonly",
+			"fileModifiedError"
 		],
 		"vs/workbench/api/common/extHostChat": [
 			"emptyResponse",
@@ -15518,14 +15629,6 @@
 			"open",
 			"close",
 			"find"
-		],
-		"vs/editor/browser/controller/textAreaHandler": [
-			"editor",
-			"accessibilityOffAriaLabel"
-		],
-		"vs/editor/browser/widget/diffEditor.contribution": [
-			"editor.action.diffReview.next",
-			"editor.action.diffReview.prev"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionMenu": [
 			"codeAction.widget.id.more",
@@ -15612,13 +15715,20 @@
 				]
 			}
 		],
-		"vs/editor/contrib/suggest/browser/suggestWidgetDetails": [
-			"details.close",
-			"loading"
-		],
 		"vs/editor/contrib/suggest/browser/suggestWidgetRenderer": [
 			"suggestMoreInfoIcon",
 			"readMore"
+		],
+		"vs/editor/browser/controller/textAreaHandler": [
+			"editor",
+			"accessibilityModeOff",
+			"accessibilityOffAriaLabel",
+			"accessibilityOffAriaLabelNoKb",
+			"accessibilityOffAriaLabelNoKbs"
+		],
+		"vs/editor/contrib/suggest/browser/suggestWidgetDetails": [
+			"details.close",
+			"loading"
 		],
 		"vs/workbench/contrib/comments/common/commentModel": [
 			"noComments"
@@ -15644,11 +15754,18 @@
 			"commentThreadActiveRangeBackground",
 			"commentThreadActiveRangeBorder"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffReview": [
-			"diffReviewInsertIcon",
-			"diffReviewRemoveIcon",
-			"diffReviewCloseIcon",
+		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
+			"foldUnchanged"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
+			"diff-aria-navigation-tip"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer": [
+			"accessibleDiffViewerInsertIcon",
+			"accessibleDiffViewerRemoveIcon",
+			"accessibleDiffViewerCloseIcon",
 			"label.close",
+			"ariaLabel",
 			"no_lines_changed",
 			"one_line_changed",
 			"more_lines_changed",
@@ -15674,11 +15791,8 @@
 			"insertLine",
 			"deleteLine"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
-			"foldUnchanged"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
-			"diff-aria-navigation-tip"
+		"vs/editor/browser/widget/diffEditorWidget2/colors": [
+			"diffEditor.move.border"
 		],
 		"vs/workbench/browser/parts/editor/editorPlaceholder": [
 			"trustRequiredEditor",
@@ -15690,6 +15804,10 @@
 			"unknownErrorEditorTextWithError",
 			"unknownErrorEditorTextWithoutError",
 			"retry"
+		],
+		"vs/base/browser/ui/menu/menubar": [
+			"mAppMenu",
+			"mMore"
 		],
 		"vs/workbench/browser/parts/editor/titleControl": [
 			"ariaLabelEditorActions",
@@ -15718,15 +15836,11 @@
 			"cmd.focusAndSelect",
 			"cmd.focus"
 		],
-		"vs/base/browser/ui/menu/menubar": [
-			"mAppMenu",
-			"mMore"
+		"vs/platform/quickinput/browser/quickInputList": [
+			"quickInput"
 		],
 		"vs/platform/quickinput/browser/quickInputUtils": [
 			"executeCommand"
-		],
-		"vs/platform/quickinput/browser/quickInputList": [
-			"quickInput"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
 			"workspaceUntrustedLabel",
@@ -15813,6 +15927,22 @@
 		],
 		"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer": [
 			"cellExecutionOrderCountLabel"
+		],
+		"vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll": [
+			"toggleStickyScroll",
+			{
+				"key": "mitoggleStickyScroll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"notebookStickyScroll",
+			{
+				"key": "miNotebookStickyScroll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopyManager": [
 			"join.fileWorkingCopyManager"
@@ -15922,28 +16052,43 @@
 			"noDebugAdapter",
 			"moreInfo"
 		],
-		"vs/base/browser/ui/selectBox/selectBoxCustom": [
-			{
-				"key": "selectBox",
-				"comment": [
-					"Behave like native select dropdown element."
-				]
-			}
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
-			"conflictingLine",
-			"conflictingLines"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
-			"setInputHandled",
-			"undoMarkAsHandled"
-		],
 		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
 			"editorGutterCommentRangeForeground",
 			"editorOverviewRuler.commentForeground",
 			"editorOverviewRuler.commentUnresolvedForeground",
 			"editorGutterCommentGlyphForeground",
 			"editorGutterCommentUnresolvedGlyphForeground"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
+			"conflictingLine",
+			"conflictingLines"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/conflictActions": [
+			"accept",
+			"acceptTooltip",
+			"acceptBoth0First",
+			"acceptBoth",
+			"acceptBothTooltip",
+			"append",
+			"appendTooltip",
+			"combine",
+			"acceptBothTooltip",
+			"ignore",
+			"markAsHandledTooltip",
+			"manualResolution",
+			"manualResolutionTooltip",
+			"noChangesAccepted",
+			"noChangesAcceptedTooltip",
+			"remove",
+			"removeTooltip",
+			"remove",
+			"removeTooltip",
+			"resetToBase",
+			"resetToBaseTooltip"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
+			"setInputHandled",
+			"undoMarkAsHandled"
 		],
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"contributes.customEditors",
@@ -15971,29 +16116,6 @@
 			"yes",
 			"cancel",
 			"createQuickLaunchProfile"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/conflictActions": [
-			"accept",
-			"acceptTooltip",
-			"acceptBoth0First",
-			"acceptBoth",
-			"acceptBothTooltip",
-			"append",
-			"appendTooltip",
-			"combine",
-			"acceptBothTooltip",
-			"ignore",
-			"markAsHandledTooltip",
-			"manualResolution",
-			"manualResolutionTooltip",
-			"noChangesAccepted",
-			"noChangesAcceptedTooltip",
-			"remove",
-			"removeTooltip",
-			"remove",
-			"removeTooltip",
-			"resetToBase",
-			"resetToBaseTooltip"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalInstance": [
 			"terminalTypeTask",
@@ -16054,12 +16176,6 @@
 			},
 			"label"
 		],
-		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
-			"terminalPromptContextMenu",
-			"terminalPromptCommandFailed",
-			"terminalPromptCommandFailedWithExitCode",
-			"terminalPromptCommandSuccess"
-		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
 			"searchWorkspace",
 			"openFile",
@@ -16078,12 +16194,23 @@
 			"ariaSearchNoResult",
 			"ariaSearchNoResultWithLineNumNoCurrentMatch"
 		],
+		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
+			"terminalPromptContextMenu",
+			"terminalPromptCommandFailed",
+			"terminalPromptCommandFailedWithExitCode",
+			"terminalPromptCommandSuccess"
+		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/media/theme_picker": [
 			"dark",
 			"light",
 			"HighContrast",
 			"HighContrastLight",
 			"seeMore"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
+			"default",
+			"jupyter",
+			"colab"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncConflictsView": [
 			"explanation",
@@ -16104,11 +16231,6 @@
 			"localResourceName",
 			"Theirs",
 			"Yours"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
-			"default",
-			"jupyter",
-			"colab"
 		],
 		"vs/platform/actionWidget/browser/actionList": [
 			{
@@ -16256,6 +16378,12 @@
 			"selectRecentDirectoryMac",
 			"selectRecentDirectory"
 		],
+		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
+			"notebook.cell.status.success",
+			"notebook.cell.status.failed",
+			"notebook.cell.status.pending",
+			"notebook.cell.status.executing"
+		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput": [
 			"empty",
 			"noRenderer.2",
@@ -16266,21 +16394,10 @@
 			"promptChooseMimeType.placeHolder",
 			"unavailableRenderInfo"
 		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
-			"notebook.cell.status.success",
-			"notebook.cell.status.failed",
-			"notebook.cell.status.pending",
-			"notebook.cell.status.executing"
-		],
 		"vs/workbench/contrib/comments/browser/commentThreadBody": [
 			"commentThreadAria.withRange",
 			"commentThreadAria.document",
 			"commentThreadAria"
-		],
-		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
-			"collapseIcon",
-			"label.collapse",
-			"startThread"
 		],
 		"vs/workbench/contrib/terminal/browser/environmentVariableInfo": [
 			"extensionEnvironmentContributionInfoStale",
@@ -16288,6 +16405,11 @@
 			"extensionEnvironmentContributionInfoActive",
 			"showEnvironmentContributions",
 			"ScopedEnvironmentContributionInfo"
+		],
+		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
+			"collapseIcon",
+			"label.collapse",
+			"startThread"
 		],
 		"vs/workbench/contrib/comments/browser/commentNode": [
 			"commentToggleReaction",
@@ -16341,12 +16463,6 @@
 			"{0}\n\nPlease make sure the following directories are writeable:\n\n{1}",
 			"&&Close"
 		],
-		"vs/code/node/cliProcessMain": [
-			"CLI"
-		],
-		"vs/code/node/sharedProcess/sharedProcessMain": [
-			"Shared"
-		],
 		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
 			"Process Name",
 			"CPU (%)",
@@ -16357,6 +16473,12 @@
 			"Copy",
 			"Copy All",
 			"Debug"
+		],
+		"vs/code/node/cliProcessMain": [
+			"CLI"
+		],
+		"vs/code/node/sharedProcess/sharedProcessMain": [
+			"Shared"
 		],
 		"vs/workbench/electron-sandbox/desktop.main": [
 			"Saving UI state"
@@ -16392,6 +16514,7 @@
 			"If enabled, this setting will close the window when the application icon in the title bar is double-clicked. The window will not be able to be dragged by the icon. This setting is effective only if `#window.titleBarStyle#` is set to `custom`.",
 			"Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.",
 			"Use window controls provided by the platform instead of our HTML-based window controls. Changes require a full restart to apply.",
+			"Let the OS handle positioning of the context menu in cases where it should appear under the mouse.",
 			"Adjust the appearance of dialog windows.",
 			"Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured.",
 			"Controls if native full-screen should be used on macOS. Disable this option to prevent macOS from creating a new space when going full-screen.",
@@ -16470,18 +16593,6 @@
 			"Restart Extension Host",
 			"Restarting extension host on explicit request."
 		],
-		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
-			"Would you like to change {0}'s display language to {1} and restart?",
-			"Change Language and Restart",
-			"Don't Show Again"
-		],
-		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
-			"Reveal in File Explorer",
-			"Reveal in Finder",
-			"Open Containing Folder",
-			"Share",
-			"File"
-		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution": [
 			"Running Extensions"
 		],
@@ -16520,6 +16631,10 @@
 			"Use the configured external terminal.",
 			"Use the other two together.",
 			"When opening a file from the Explorer in a terminal, determines what kind of terminal will be launched",
+			"Use VS Code's integrated terminal.",
+			"Use the configured external terminal.",
+			"Use the other two together.",
+			"When opening a repository from the Source Control Repositories view in a terminal, determines what kind of terminal will be launched",
 			"Customizes which terminal to run on Windows.",
 			"Customizes which terminal application to run on macOS.",
 			"Customizes which terminal to run on Linux."
@@ -16537,12 +16652,18 @@
 			"Do not show again",
 			"[Looking for remote tunnel](command:{0})",
 			"[Starting remote tunnel](command:{0})",
+			"Installation as a service failed, and we fell back to running the tunnel for this session. See the [error log](command:{0}) for details.",
 			"Sign in to an account to enable remote access",
 			"Signed In",
 			"Others",
 			"Sign in with {0}",
 			"Remote Tunnels is currently in preview. Please report any problems using the \"Help: Report Issue\" command.",
 			"&&Enable",
+			"Select how you want to enable access",
+			"Turn on for this session",
+			"Run whenever {0} is open",
+			"Install as a service",
+			"Run whenever you're logged in",
 			"You can now access this machine anywhere via the secure tunnel [{0}](command:{4}). To connect via a different machine, use the generated [{1}]({2}) link or use the [{6}]({7}) extension in the desktop or web. You can [configure](command:{3}) or [turn off](command:{5}) this access via the VS Code Accounts menu.",
 			"Copy Browser Link to Clipboard",
 			"Show Extension",
@@ -16560,6 +16681,18 @@
 			"The name under which the remote tunnel access is registered. If not set, the host name is used.",
 			"The name must only consist of letters, numbers, underscore and dash. It must not start with a dash.",
 			"Prevent the computer from sleeping when remote tunnel access is turned on."
+		],
+		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
+			"Would you like to change {0}'s display language to {1} and restart?",
+			"Change Language and Restart",
+			"Don't Show Again"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
+			"Reveal in File Explorer",
+			"Reveal in Finder",
+			"Open Containing Folder",
+			"Share",
+			"File"
 		],
 		"vs/base/common/platform": [
 			"_"
@@ -16956,189 +17089,6 @@
 			"Controls whether inline color decorations should be shown using the default document color provider",
 			"Controls whether the editor receives tabs or defers them to the workbench for navigation."
 		],
-		"vs/base/common/errorMessage": [
-			"{0}: {1}",
-			"A system error occurred ({0})",
-			"An unknown error occurred. Please consult the log for more details.",
-			"An unknown error occurred. Please consult the log for more details.",
-			"{0} ({1} errors in total)",
-			"An unknown error occurred. Please consult the log for more details."
-		],
-		"vs/code/electron-main/app": [
-			"&&Yes",
-			"&&No",
-			"An external application wants to open '{0}' in {1}. Do you want to open this file or folder?",
-			"If you did not initiate this request, it may represent an attempted attack on your system. Unless you took an explicit action to initiate this request, you should press 'No'"
-		],
-		"vs/platform/environment/node/argvHelper": [
-			"Option '{0}' is defined more than once. Using value '{1}'.",
-			"Option '{0}' requires a non empty value. Ignoring the option.",
-			"Option '{0}' is deprecated: {1}",
-			"Warning: '{0}' is not in the list of known options for subcommand '{1}'",
-			"Warning: '{0}' is not in the list of known options, but still passed to Electron/Chromium.",
-			"Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`."
-		],
-		"vs/platform/files/common/files": [
-			"Unknown Error",
-			"{0}B",
-			"{0}KB",
-			"{0}MB",
-			"{0}GB",
-			"{0}TB"
-		],
-		"vs/platform/files/common/fileService": [
-			"Unable to resolve filesystem provider with relative file path '{0}'",
-			"ENOPRO: No file system provider found for resource '{0}'",
-			"Unable to resolve nonexistent file '{0}'",
-			"Unable to create file '{0}' that already exists when overwrite flag is not set",
-			"Unable to write file '{0}' ({1})",
-			"Unable to unlock file '{0}' because provider does not support it.",
-			"Unable to atomically write file '{0}' because provider does not support it.",
-			"Unable to unlock file '{0}' because atomic write is enabled.",
-			"Unable to write file '{0}' that is actually a directory",
-			"File Modified Since",
-			"Unable to read file '{0}' ({1})",
-			"Unable to read file '{0}' that is actually a directory",
-			"File not modified since",
-			"Unable to read file '{0}' that is too large to open",
-			"Unable to copy when source '{0}' is same as target '{1}' with different path case on a case insensitive file system",
-			"Unable to move/copy when source '{0}' is parent of target '{1}'.",
-			"Unable to move/copy '{0}' because target '{1}' already exists at destination.",
-			"Unable to move/copy '{0}' into '{1}' since a file would replace the folder it is contained in.",
-			"Unable to create folder '{0}' that already exists but is not a directory",
-			"Unable to delete file '{0}' via trash because provider does not support it.",
-			"Unable to delete file '{0}' atomically because provider does not support it.",
-			"Unable to atomically delete file '{0}' because using trash is enabled.",
-			"Unable to delete nonexistent file '{0}'",
-			"Unable to delete non-empty folder '{0}'.",
-			"Unable to modify read-only file '{0}'",
-			"Unable to modify read-only file '{0}'"
-		],
-		"vs/platform/files/node/diskFileSystemProvider": [
-			"File already exists",
-			"File does not exist",
-			"Unable to move '{0}' into '{1}' ({2}).",
-			"Unable to copy '{0}' into '{1}' ({2}).",
-			"File cannot be copied to same path with different path case",
-			"File to move/copy does not exist",
-			"File at target already exists and thus will not be moved/copied to unless overwrite is specified"
-		],
-		"vs/platform/request/common/request": [
-			"Network Requests",
-			"HTTP",
-			"The proxy setting to use. If not set, will be inherited from the `http_proxy` and `https_proxy` environment variables.",
-			"Controls whether the proxy server certificate should be verified against the list of supplied CAs.",
-			"The value to send as the `Proxy-Authorization` header for every network request.",
-			"Disable proxy support for extensions.",
-			"Enable proxy support for extensions.",
-			"Enable proxy support for extensions, fall back to request options, when no proxy found.",
-			"Enable proxy support for extensions, override request options.",
-			"Use the proxy support for extensions.",
-			"Controls whether CA certificates should be loaded from the OS. (On Windows and macOS, a reload of the window is required after turning this off.)"
-		],
-		"vs/platform/dialogs/common/dialogs": [
-			"&&Yes",
-			"Cancel",
-			"Cancel",
-			"Cancel",
-			"&&OK",
-			"&&OK",
-			"Cancel",
-			"...1 additional file not shown",
-			"...{0} additional files not shown"
-		],
-		"vs/platform/update/common/update.config.contribution": [
-			"Update",
-			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
-			"Disable updates.",
-			"Disable automatic background update checks. Updates will be available if you manually check for updates.",
-			"Check for updates only on startup. Disable automatic background update checks.",
-			"Enable automatic update checks. Code will check for updates automatically and periodically.",
-			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
-			"This setting is deprecated, please use '{0}' instead.",
-			"Enable Background Updates on Windows",
-			"Enable to download and install new VS Code versions in the background on Windows.",
-			"Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."
-		],
-		"vs/platform/extensionManagement/common/extensionManagement": [
-			"Extensions",
-			"Preferences"
-		],
-		"vs/platform/extensionManagement/common/extensionManagementCLI": [
-			"Extension '{0}' not found.",
-			"Make sure you use the full extension ID, including the publisher, e.g.: {0}",
-			"Extensions installed on {0}:",
-			"Installing extensions on {0}...",
-			"Installing extensions...",
-			"Extension '{0}' v{1} is already installed. Use '--force' option to update to latest version or provide '@<version>' to install a specific version, for example: '{2}@1.2.3'.",
-			"Extension '{0}' is already installed.",
-			"Error while installing extensions: {0}",
-			"Failed Installing Extensions: {0}",
-			"Extension '{0}' was successfully installed.",
-			"Cancelled installing extension '{0}'.",
-			"Extension '{0}' is already installed.",
-			"Updating the extension '{0}' to the version {1}",
-			"Installing builtin extension '{0}' v{1}...",
-			"Installing builtin extension '{0}'...",
-			"Installing extension '{0}' v{1}...",
-			"Installing extension '{0}'...",
-			"Extension '{0}' v{1} was successfully installed.",
-			"Cancelled installing extension '{0}'.",
-			"A newer version of extension '{0}' v{1} is already installed. Use '--force' option to downgrade to older version.",
-			"Extension '{0}' is a Built-in extension and cannot be uninstalled",
-			"Extension '{0}' is marked as a Built-in extension by user. Please use '--force' option to uninstall it.",
-			"Uninstalling {0}...",
-			"Extension '{0}' was successfully uninstalled from {1}!",
-			"Extension '{0}' was successfully uninstalled!",
-			"Extension '{0}' is not installed on {1}.",
-			"Extension '{0}' is not installed."
-		],
-		"vs/platform/extensionManagement/common/extensionsScannerService": [
-			"Cannot read file {0}: {1}.",
-			"Failed to parse {0}: [{1}, {2}] {3}.",
-			"Invalid manifest file {0}: Not an JSON object.",
-			"Failed to parse {0}: {1}.",
-			"Invalid format {0}: JSON object expected.",
-			"Failed to parse {0}: {1}.",
-			"Invalid format {0}: JSON object expected."
-		],
-		"vs/platform/extensionManagement/node/extensionManagementService": [
-			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.",
-			"Marketplace is not enabled",
-			"Only Marketplace Extensions can be reinstalled",
-			"Error while removing the extension: {0}. Please Quit and Start VS Code before trying again.",
-			"Unable to delete the existing folder '{0}' while installing the extension '{1}'. Please delete the folder manually and try again",
-			"Unknown error while renaming {0} to {1}",
-			"Cannot read the extension from {0}",
-			"Please restart VS Code before reinstalling {0}.",
-			"Please restart VS Code before reinstalling {0}."
-		],
-		"vs/platform/languagePacks/common/languagePacks": [
-			" (Current)"
-		],
-		"vs/platform/telemetry/common/telemetryService": [
-			"Controls {0} telemetry, first-party extension telemetry, and participating third-party extension telemetry. Some third party extensions might not respect this setting. Consult the specific extension's documentation to be sure. Telemetry helps us better understand how {0} is performing, where improvements need to be made, and how features are being used.",
-			"Read more about the [data we collect]({0}).",
-			"Read more about the [data we collect]({0}) and our [privacy statement]({1}).",
-			"A full restart of the application is necessary for crash reporting changes to take effect.",
-			"Crash Reports",
-			"Error Telemetry",
-			"Usage Data",
-			"The following table outlines the data sent with each setting:",
-			"****Note:*** If this setting is 'off', no telemetry will be sent regardless of other telemetry settings. If this setting is set to anything except 'off' and telemetry is disabled with deprecated settings, no telemetry will be sent.*",
-			"Telemetry",
-			"Sends usage data, errors, and crash reports.",
-			"Sends general error telemetry and crash reports.",
-			"Sends OS level crash reports.",
-			"Disables all product telemetry.",
-			"Telemetry",
-			"Enable diagnostic data to be collected. This helps us to better understand how {0} is performing and where improvements need to be made.",
-			"Enable diagnostic data to be collected. This helps us to better understand how {0} is performing and where improvements need to be made. [Read more]({1}) about what we collect and our privacy statement.",
-			"If this setting is false, no telemetry will be sent regardless of the new setting's value. Deprecated in favor of the {0} setting."
-		],
-		"vs/platform/userDataProfile/common/userDataProfile": [
-			"Default"
-		],
 		"vs/code/electron-sandbox/issue/issueReporterPage": [
 			"Include my system information",
 			"Include my currently running processes",
@@ -17201,15 +17151,189 @@
 			"Extensions are disabled",
 			"No current experiments."
 		],
-		"vs/platform/telemetry/common/telemetryLogAppender": [
-			"Telemetry{0}"
+		"vs/platform/environment/node/argvHelper": [
+			"Option '{0}' is defined more than once. Using value '{1}'.",
+			"Option '{0}' requires a non empty value. Ignoring the option.",
+			"Option '{0}' is deprecated: {1}",
+			"Warning: '{0}' is not in the list of known options for subcommand '{1}'",
+			"Warning: '{0}' is not in the list of known options, but still passed to Electron/Chromium.",
+			"Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`."
 		],
-		"vs/platform/userDataSync/common/userDataSync": [
-			"Settings Sync",
-			"Synchronize keybindings for each platform.",
-			"List of extensions to be ignored while synchronizing. The identifier of an extension is always `${publisher}.${name}`. For example: `vscode.csharp`.",
-			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
-			"Configure settings to be ignored while synchronizing."
+		"vs/base/common/errorMessage": [
+			"{0}: {1}",
+			"A system error occurred ({0})",
+			"An unknown error occurred. Please consult the log for more details.",
+			"An unknown error occurred. Please consult the log for more details.",
+			"{0} ({1} errors in total)",
+			"An unknown error occurred. Please consult the log for more details."
+		],
+		"vs/code/electron-main/app": [
+			"&&Yes",
+			"&&No",
+			"An external application wants to open '{0}' in {1}. Do you want to open this file or folder?",
+			"If you did not initiate this request, it may represent an attempted attack on your system. Unless you took an explicit action to initiate this request, you should press 'No'"
+		],
+		"vs/platform/files/common/files": [
+			"Unknown Error",
+			"{0}B",
+			"{0}KB",
+			"{0}MB",
+			"{0}GB",
+			"{0}TB"
+		],
+		"vs/platform/files/common/fileService": [
+			"Unable to resolve filesystem provider with relative file path '{0}'",
+			"ENOPRO: No file system provider found for resource '{0}'",
+			"Unable to resolve nonexistent file '{0}'",
+			"Unable to create file '{0}' that already exists when overwrite flag is not set",
+			"Unable to write file '{0}' ({1})",
+			"Unable to unlock file '{0}' because provider does not support it.",
+			"Unable to atomically write file '{0}' because provider does not support it.",
+			"Unable to unlock file '{0}' because atomic write is enabled.",
+			"Unable to write file '{0}' that is actually a directory",
+			"File Modified Since",
+			"Unable to read file '{0}' ({1})",
+			"Unable to read file '{0}' that is actually a directory",
+			"File not modified since",
+			"Unable to read file '{0}' that is too large to open",
+			"Unable to copy when source '{0}' is same as target '{1}' with different path case on a case insensitive file system",
+			"Unable to move/copy when source '{0}' is parent of target '{1}'.",
+			"Unable to move/copy '{0}' because target '{1}' already exists at destination.",
+			"Unable to move/copy '{0}' into '{1}' since a file would replace the folder it is contained in.",
+			"Unable to create folder '{0}' that already exists but is not a directory",
+			"Unable to delete file '{0}' via trash because provider does not support it.",
+			"Unable to delete file '{0}' atomically because provider does not support it.",
+			"Unable to atomically delete file '{0}' because using trash is enabled.",
+			"Unable to delete nonexistent file '{0}'",
+			"Unable to delete non-empty folder '{0}'.",
+			"Unable to modify read-only file '{0}'",
+			"Unable to modify read-only file '{0}'"
+		],
+		"vs/platform/files/node/diskFileSystemProvider": [
+			"File already exists",
+			"File does not exist",
+			"Unable to move '{0}' into '{1}' ({2}).",
+			"Unable to copy '{0}' into '{1}' ({2}).",
+			"File cannot be copied to same path with different path case",
+			"File to move/copy does not exist",
+			"File at target already exists and thus will not be moved/copied to unless overwrite is specified"
+		],
+		"vs/platform/request/common/request": [
+			"Network Requests",
+			"HTTP",
+			"The proxy setting to use. If not set, will be inherited from the `http_proxy` and `https_proxy` environment variables.",
+			"Controls whether the proxy server certificate should be verified against the list of supplied CAs.",
+			"Overrides the principal service name for Kerberos authentication with the HTTP proxy. A default based on the proxy hostname is used when this is not set.",
+			"The value to send as the `Proxy-Authorization` header for every network request.",
+			"Disable proxy support for extensions.",
+			"Enable proxy support for extensions.",
+			"Enable proxy support for extensions, fall back to request options, when no proxy found.",
+			"Enable proxy support for extensions, override request options.",
+			"Use the proxy support for extensions.",
+			"Controls whether CA certificates should be loaded from the OS. (On Windows and macOS, a reload of the window is required after turning this off.)"
+		],
+		"vs/platform/dialogs/common/dialogs": [
+			"&&Yes",
+			"Cancel",
+			"Cancel",
+			"Cancel",
+			"&&OK",
+			"&&OK",
+			"Cancel",
+			"...1 additional file not shown",
+			"...{0} additional files not shown"
+		],
+		"vs/platform/update/common/update.config.contribution": [
+			"Update",
+			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
+			"Disable updates.",
+			"Disable automatic background update checks. Updates will be available if you manually check for updates.",
+			"Check for updates only on startup. Disable automatic background update checks.",
+			"Enable automatic update checks. Code will check for updates automatically and periodically.",
+			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
+			"This setting is deprecated, please use '{0}' instead.",
+			"Enable Background Updates on Windows",
+			"Enable to download and install new VS Code versions in the background on Windows.",
+			"Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."
+		],
+		"vs/platform/extensionManagement/common/extensionManagement": [
+			"Extensions",
+			"Preferences"
+		],
+		"vs/platform/extensionManagement/common/extensionsScannerService": [
+			"Cannot read file {0}: {1}.",
+			"Failed to parse {0}: [{1}, {2}] {3}.",
+			"Invalid manifest file {0}: Not an JSON object.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected."
+		],
+		"vs/platform/extensionManagement/common/extensionManagementCLI": [
+			"Extension '{0}' not found.",
+			"Make sure you use the full extension ID, including the publisher, e.g.: {0}",
+			"Extensions installed on {0}:",
+			"Installing extensions on {0}...",
+			"Installing extensions...",
+			"Extension '{0}' v{1} is already installed. Use '--force' option to update to latest version or provide '@<version>' to install a specific version, for example: '{2}@1.2.3'.",
+			"Extension '{0}' is already installed.",
+			"Error while installing extensions: {0}",
+			"Failed Installing Extensions: {0}",
+			"Extension '{0}' was successfully installed.",
+			"Cancelled installing extension '{0}'.",
+			"Extension '{0}' is already installed.",
+			"Updating the extension '{0}' to the version {1}",
+			"Installing builtin extension '{0}' v{1}...",
+			"Installing builtin extension '{0}'...",
+			"Installing extension '{0}' v{1}...",
+			"Installing extension '{0}'...",
+			"Extension '{0}' v{1} was successfully installed.",
+			"Cancelled installing extension '{0}'.",
+			"A newer version of extension '{0}' v{1} is already installed. Use '--force' option to downgrade to older version.",
+			"Extension '{0}' is a Built-in extension and cannot be uninstalled",
+			"Extension '{0}' is marked as a Built-in extension by user. Please use '--force' option to uninstall it.",
+			"Uninstalling {0}...",
+			"Extension '{0}' was successfully uninstalled from {1}!",
+			"Extension '{0}' was successfully uninstalled!",
+			"Extension '{0}' is not installed on {1}.",
+			"Extension '{0}' is not installed."
+		],
+		"vs/platform/extensionManagement/node/extensionManagementService": [
+			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.",
+			"Marketplace is not enabled",
+			"Only Marketplace Extensions can be reinstalled",
+			"Error while removing the extension: {0}. Please Quit and Start VS Code before trying again.",
+			"Unable to delete the existing folder '{0}' while installing the extension '{1}'. Please delete the folder manually and try again",
+			"Unknown error while renaming {0} to {1}",
+			"Cannot read the extension from {0}",
+			"Please restart VS Code before reinstalling {0}.",
+			"Please restart VS Code before reinstalling {0}."
+		],
+		"vs/platform/languagePacks/common/languagePacks": [
+			" (Current)"
+		],
+		"vs/platform/telemetry/common/telemetryService": [
+			"Controls {0} telemetry, first-party extension telemetry, and participating third-party extension telemetry. Some third party extensions might not respect this setting. Consult the specific extension's documentation to be sure. Telemetry helps us better understand how {0} is performing, where improvements need to be made, and how features are being used.",
+			"Read more about the [data we collect]({0}).",
+			"Read more about the [data we collect]({0}) and our [privacy statement]({1}).",
+			"A full restart of the application is necessary for crash reporting changes to take effect.",
+			"Crash Reports",
+			"Error Telemetry",
+			"Usage Data",
+			"The following table outlines the data sent with each setting:",
+			"****Note:*** If this setting is 'off', no telemetry will be sent regardless of other telemetry settings. If this setting is set to anything except 'off' and telemetry is disabled with deprecated settings, no telemetry will be sent.*",
+			"Telemetry",
+			"Sends usage data, errors, and crash reports.",
+			"Sends general error telemetry and crash reports.",
+			"Sends OS level crash reports.",
+			"Disables all product telemetry.",
+			"Telemetry",
+			"Enable diagnostic data to be collected. This helps us to better understand how {0} is performing and where improvements need to be made.",
+			"Enable diagnostic data to be collected. This helps us to better understand how {0} is performing and where improvements need to be made. [Read more]({1}) about what we collect and our privacy statement.",
+			"If this setting is false, no telemetry will be sent regardless of the new setting's value. Deprecated in favor of the {0} setting."
+		],
+		"vs/platform/userDataProfile/common/userDataProfile": [
+			"Default"
 		],
 		"vs/platform/userDataSync/common/userDataSyncLog": [
 			"Settings Sync"
@@ -17223,11 +17347,22 @@
 		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
 			"Cannot parse sync data as it is not compatible with the current version."
 		],
+		"vs/platform/userDataSync/common/userDataSync": [
+			"Settings Sync",
+			"Synchronize keybindings for each platform.",
+			"List of extensions to be ignored while synchronizing. The identifier of an extension is always `${publisher}.${name}`. For example: `vscode.csharp`.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
+			"Configure settings to be ignored while synchronizing."
+		],
 		"vs/platform/remoteTunnel/node/remoteTunnelService": [
 			"Building CLI from sources",
 			"Connecting as {0} ({1})",
 			"Opening tunnel {0}",
-			"Opening tunnel"
+			"Opening tunnel",
+			"Failed to install tunnel as a service, starting in session..."
+		],
+		"vs/platform/telemetry/common/telemetryLogAppender": [
+			"Telemetry{0}"
 		],
 		"vs/workbench/browser/workbench": [
 			"Failed to load a required file. Please restart the application to try again. Details: {0}"
@@ -17283,10 +17418,8 @@
 		],
 		"vs/workbench/services/configuration/browser/configurationService": [
 			"Contribute defaults for configurations",
-			"Experiments"
-		],
-		"vs/platform/workspace/common/workspace": [
-			"Code Workspace"
+			"Experiments",
+			"Configure settings to be applied for all profiles."
 		],
 		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
 			"Open Developer Tools",
@@ -17332,13 +17465,16 @@
 			"Controls how tree folders are expanded when clicking the folder names. Note that some trees and lists might choose to ignore this setting if it is not applicable.",
 			"Controls the how type navigation works in lists and trees in the workbench. When set to 'trigger', type navigation begins once the 'list.triggerTypeNavigation' command is run."
 		],
+		"vs/platform/workspace/common/workspace": [
+			"Code Workspace"
+		],
+		"vs/platform/contextkey/browser/contextKeyService": [
+			"A command that returns information about context keys"
+		],
 		"vs/platform/markers/common/markers": [
 			"Error",
 			"Warning",
 			"Info"
-		],
-		"vs/platform/contextkey/browser/contextKeyService": [
-			"A command that returns information about context keys"
 		],
 		"vs/platform/contextkey/common/contextkey": [
 			"Empty context key expression",
@@ -17352,14 +17488,6 @@
 			"Expected: {0}\nReceived: '{1}'.",
 			"Unexpected token. Hint: {0}",
 			"Unexpected token."
-		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"Undo",
-			"Redo",
-			"Cut",
-			"Copy",
-			"Paste",
-			"Select All"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"The default size.",
@@ -17397,7 +17525,7 @@
 			"A pinned tab will show in a compact form with only icon or first letter of the editor name.",
 			"A pinned tab shrinks to a compact fixed size showing parts of the editor name.",
 			"Controls the size of pinned editor tabs. Pinned tabs are sorted to the beginning of all opened tabs and typically do not close until unpinned. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
-			"Splits all the editor groups to equal parts unless a part has been changed in size.",
+			"Splits the active editor group to equal parts, unless all editor groups are already in equal parts. In that case, splits all the editor groups to equal parts.",
 			"Splits all the editor groups to equal parts.",
 			"Splits the active editor group to equal parts.",
 			"Controls the size of editor groups when splitting them.",
@@ -17533,32 +17661,15 @@
 			"Controls whether turning on Zen Mode also hides the activity bar either at the left or right of the workbench.",
 			"Controls whether turning on Zen Mode also hides the editor line numbers.",
 			"Controls whether a window should restore to Zen Mode if it was exited in Zen Mode.",
-			"Controls whether notifications do not disturb mode should be enabled while in Zen Mode. If true, only error notifications will pop out.",
-			"UNC host names must not contain backslashes.",
-			"A set of UNC host names (without leading or trailing backslash, for example `192.168.0.1` or `my-server`) to allow without user confirmation. If a UNC host is being accessed that is not allowed via this setting or has not been acknowledged via user confirmation, an error will occur and the operation stopped. A restart is required when changing this setting. Find out more about this setting at https://aka.ms/vscode-windows-unc.",
-			"If enabled, only allows access to UNC host names that are allowed by the `#security.allowedUNCHosts#` setting or after user confirmation. Find out more about this setting at https://aka.ms/vscode-windows-unc."
+			"Controls whether notifications do not disturb mode should be enabled while in Zen Mode. If true, only error notifications will pop out."
 		],
-		"vs/workbench/browser/actions/developerActions": [
-			"Inspect Context Keys",
-			"Toggle Screencast Mode",
-			"Log Storage Database Contents",
-			"The storage database contents have been logged to the developer tools.",
-			"Open developer tools from the menu and select the Console tab.",
-			"Log Working Copies",
-			"Screencast Mode",
-			"Controls the vertical offset of the screencast mode overlay from the bottom as a percentage of the workbench height.",
-			"Controls the font size (in pixels) of the screencast mode keyboard.",
-			"Keys.",
-			"Command title.",
-			"Command title prefixed by its group.",
-			"Command title and keys.",
-			"Command title and keys, with the command prefixed by its group.",
-			"Controls what is displayed in the keyboard overlay when showing shortcuts.",
-			"Show only keyboard shortcuts in screencast mode (do not include action names).",
-			"Hide the single editor cursor move commands in screencast mode.",
-			"Controls how long (in milliseconds) the keyboard overlay is shown in screencast mode.",
-			"Controls the color in hex (#RGB, #RGBA, #RRGGBB or #RRGGBBAA) of the mouse indicator in screencast mode.",
-			"Controls the size (in pixels) of the mouse indicator in screencast mode."
+		"vs/workbench/browser/actions/textInputActions": [
+			"Undo",
+			"Redo",
+			"Cut",
+			"Copy",
+			"Paste",
+			"Select All"
 		],
 		"vs/workbench/browser/actions/helpActions": [
 			"Keyboard Shortcuts Reference",
@@ -17578,6 +17689,25 @@
 			"View &&License",
 			"Privacy Statement",
 			"Privac&&y Statement"
+		],
+		"vs/workbench/browser/actions/developerActions": [
+			"Inspect Context Keys",
+			"Toggle Screencast Mode",
+			"Log Storage Database Contents",
+			"The storage database contents have been logged to the developer tools.",
+			"Open developer tools from the menu and select the Console tab.",
+			"Log Working Copies",
+			"Screencast Mode",
+			"Controls the vertical offset of the screencast mode overlay from the bottom as a percentage of the workbench height.",
+			"Controls the font size (in pixels) of the screencast mode keyboard.",
+			"Options for customizing the keyboard overlay in screencast mode.",
+			"Show raw keys.",
+			"Show command names.",
+			"Show command group names, when commands are also shown.",
+			"Show single editor cursor move commands.",
+			"Controls how long (in milliseconds) the keyboard overlay is shown in screencast mode.",
+			"Controls the color in hex (#RGB, #RGBA, #RRGGBB or #RRGGBBAA) of the mouse indicator in screencast mode.",
+			"Controls the size (in pixels) of the mouse indicator in screencast mode."
 		],
 		"vs/workbench/browser/actions/layoutActions": [
 			"Represents the menu bar",
@@ -17755,14 +17885,6 @@
 			"Add Folder to Workspace",
 			"Select workspace folder"
 		],
-		"vs/workbench/browser/actions/quickAccessActions": [
-			"Go to File...",
-			"Quick Open",
-			"Navigate Next in Quick Open",
-			"Navigate Previous in Quick Open",
-			"Select Next in Quick Open",
-			"Select Previous in Quick Open"
-		],
 		"vs/workbench/services/actions/common/menusExtensionPoint": [
 			"The Command Palette",
 			"The touch bar (macOS only)",
@@ -17873,49 +17995,13 @@
 			"Menu item references a submenu `{0}` which is not defined in the 'submenus' section.",
 			"The `{0}` submenu was already contributed to the `{1}` menu."
 		],
-		"vs/workbench/api/common/configurationExtensionPoint": [
-			"A title for the current category of settings. This label will be rendered in the Settings editor as a subheading. If the title is the same as the extension display name, then the category will be grouped under the main extension heading.",
-			"When specified, gives the order of this category of settings relative to other categories.",
-			"Description of the configuration properties.",
-			"Property should not be empty.",
-			"Schema of the configuration property.",
-			"Configuration that can be configured only in the user settings.",
-			"Configuration that can be configured only in the user settings or only in the remote settings.",
-			"Configuration that can be configured in the user, remote or workspace settings.",
-			"Configuration that can be configured in the user, remote, workspace or folder settings.",
-			"Resource configuration that can be configured in language specific settings.",
-			"Machine configuration that can be configured also in workspace or folder settings.",
-			"Scope in which the configuration is applicable. Available scopes are `application`, `machine`, `window`, `resource`, and `machine-overridable`.",
-			"Descriptions for enum values",
-			"Descriptions for enum values in the markdown format.",
-			"Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.",
-			"The description in the markdown format.",
-			"If set, the property is marked as deprecated and the given message is shown as an explanation.",
-			"If set, the property is marked as deprecated and the given message is shown as an explanation in the markdown format.",
-			"The value will be shown in an inputbox.",
-			"The value will be shown in a textarea.",
-			"When specified, controls the presentation format of the string setting.",
-			"When specified, gives the order of this setting relative to other settings within the same category. Settings with an order property will be placed before settings without this property set.",
-			"When enabled, Settings Sync will not sync the user value of this configuration by default.",
-			"Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.",
-			"Contributes configuration settings.",
-			"'configuration.title' must be a string",
-			"'configuration.properties' must be an object",
-			"Cannot register '{0}'. This property is already registered.",
-			"configuration.properties property '{0}' must be an object",
-			"'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point.",
-			"List of folders to be loaded in the workspace.",
-			"A file path. e.g. `/root/folderA` or `./folderA` for a relative path that will be resolved against the location of the workspace file.",
-			"An optional name for the folder. ",
-			"URI of the folder",
-			"An optional name for the folder. ",
-			"Workspace settings",
-			"Workspace launch configurations",
-			"Workspace task configurations",
-			"Workspace extensions",
-			"The remote server where the workspace is located.",
-			"A transient workspace will disappear when restarting or reloading.",
-			"Unknown workspace configuration property"
+		"vs/workbench/browser/actions/quickAccessActions": [
+			"Go to File...",
+			"Quick Open",
+			"Navigate Next in Quick Open",
+			"Navigate Previous in Quick Open",
+			"Select Next in Quick Open",
+			"Select Previous in Quick Open"
 		],
 		"vs/workbench/api/browser/viewsExtensionPoint": [
 			"Unique id used to identify the container in which views can be contributed using 'views' contribution point",
@@ -17967,6 +18053,50 @@
 			"property `{0}` can be omitted or must be of type `string`",
 			"property `{0}` can be omitted or must be of type `string`",
 			"property `{0}` can be omitted or must be one of {1}"
+		],
+		"vs/workbench/api/common/configurationExtensionPoint": [
+			"A title for the current category of settings. This label will be rendered in the Settings editor as a subheading. If the title is the same as the extension display name, then the category will be grouped under the main extension heading.",
+			"When specified, gives the order of this category of settings relative to other categories.",
+			"Description of the configuration properties.",
+			"Property should not be empty.",
+			"Schema of the configuration property.",
+			"Configuration that can be configured only in the user settings.",
+			"Configuration that can be configured only in the user settings or only in the remote settings.",
+			"Configuration that can be configured in the user, remote or workspace settings.",
+			"Configuration that can be configured in the user, remote, workspace or folder settings.",
+			"Resource configuration that can be configured in language specific settings.",
+			"Machine configuration that can be configured also in workspace or folder settings.",
+			"Scope in which the configuration is applicable. Available scopes are `application`, `machine`, `window`, `resource`, and `machine-overridable`.",
+			"Descriptions for enum values",
+			"Descriptions for enum values in the markdown format.",
+			"Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.",
+			"The description in the markdown format.",
+			"If set, the property is marked as deprecated and the given message is shown as an explanation.",
+			"If set, the property is marked as deprecated and the given message is shown as an explanation in the markdown format.",
+			"The value will be shown in an inputbox.",
+			"The value will be shown in a textarea.",
+			"When specified, controls the presentation format of the string setting.",
+			"When specified, gives the order of this setting relative to other settings within the same category. Settings with an order property will be placed before settings without this property set.",
+			"When enabled, Settings Sync will not sync the user value of this configuration by default.",
+			"Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.",
+			"Contributes configuration settings.",
+			"'configuration.title' must be a string",
+			"'configuration.properties' must be an object",
+			"Cannot register '{0}'. This property is already registered.",
+			"configuration.properties property '{0}' must be an object",
+			"'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point.",
+			"List of folders to be loaded in the workspace.",
+			"A file path. e.g. `/root/folderA` or `./folderA` for a relative path that will be resolved against the location of the workspace file.",
+			"An optional name for the folder. ",
+			"URI of the folder",
+			"An optional name for the folder. ",
+			"Workspace settings",
+			"Workspace launch configurations",
+			"Workspace task configurations",
+			"Workspace extensions",
+			"The remote server where the workspace is located.",
+			"A transient workspace will disappear when restarting or reloading.",
+			"Unknown workspace configuration property"
 		],
 		"vs/workbench/browser/parts/editor/editor.contribution": [
 			"Text Editor",
@@ -18139,21 +18269,6 @@
 			"Could not redo '{0}' across all files because an undo or redo operation occurred in the meantime",
 			"Could not redo '{0}' because there is already an undo or redo operation running."
 		],
-		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
-			"Allow an extension to open this URI?",
-			"Don't ask again for this extension.",
-			"&&Open",
-			"Extension '{0}' is not installed. Would you like to install the extension and open this URL?",
-			"&&Install and Open",
-			"Installing Extension '{0}'...",
-			"Extension '{0}' is disabled. Would you like to enable the extension and open the URL?",
-			"&&Enable and Open",
-			"Extension '{0}' is not loaded. Would you like to reload the window to load the extension and open the URL?",
-			"&&Reload Window and Open",
-			"Manage Authorized Extension URIs...",
-			"Extensions",
-			"There are currently no authorized extension URIs."
-		],
 		"vs/workbench/services/keybinding/common/keybindingEditing": [
 			"Unable to write because the keybindings configuration file has unsaved changes. Please save it first and then try again.",
 			"Unable to write to the keybindings configuration file. Please open it to correct errors/warnings in the file and try again.",
@@ -18182,6 +18297,21 @@
 		],
 		"vs/workbench/services/configuration/common/jsonEditingService": [
 			"Unable to write into the file. Please open the file to correct errors/warnings in the file and try again."
+		],
+		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
+			"Allow an extension to open this URI?",
+			"Don't ask again for this extension.",
+			"&&Open",
+			"Extension '{0}' is not installed. Would you like to install the extension and open this URL?",
+			"&&Install and Open",
+			"Installing Extension '{0}'...",
+			"Extension '{0}' is disabled. Would you like to enable the extension and open the URL?",
+			"&&Enable and Open",
+			"Extension '{0}' is not loaded. Would you like to reload the window to load the extension and open the URL?",
+			"&&Reload Window and Open",
+			"Manage Authorized Extension URIs...",
+			"Extensions",
+			"There are currently no authorized extension URIs."
 		],
 		"vs/workbench/services/editor/browser/editorResolverService": [
 			"There are multiple default editors available for the resource.",
@@ -18303,10 +18433,36 @@
 			"{0}: Resolving profile content...",
 			"Preview Profile",
 			"Create Profile",
+			"Create Profile",
+			"Edit {0} Profile...",
+			"Create New Profile...",
+			"Settings",
+			"Keyboard Shortcuts",
+			"User Snippets",
+			"User Tasks",
+			"Extensions",
+			"Profile name",
+			"Save",
+			"Create",
+			"Choose what to configure in your Profile:",
+			"Profile with name {0} already exists.",
+			"The profile should contain at least one configuration.",
+			"Using Default Profile",
+			"Provide a name for the new profile",
+			"Copy from:",
+			"None",
+			"Profile Templates",
+			"Existing Profiles",
+			"Create Profile",
 			"Export",
 			"Close",
+			"Create Profile: {0}",
+			"Applying Extensions...",
+			"Switching Profile...",
 			"Troubleshoot Issue",
 			"Setting up Troubleshoot Profile: {0}",
+			"Applying Extensions...",
+			"Switching Profile...",
 			"{0}: Exporting...",
 			"Profile '{0}' was exported successfully.",
 			"&&Copy Link",
@@ -18319,16 +18475,16 @@
 			"By default, extensions aren't installed when previewing a profile on the web. You can still install them manually before importing the profile. ",
 			"Learn more",
 			"Install Extensions",
+			"Create Profile",
 			"Cancel",
 			"Create Profile",
-			"{0} ({1})...",
+			"Switching Profile...",
 			"Applying Settings...",
-			"{0}ying Keyboard Shortcuts...",
+			"Applying Keyboard Shortcuts...",
 			"Applying Tasks...",
 			"Applying Snippets...",
 			"Applying State...",
 			"Applying Extensions...",
-			" Applying...",
 			"Export '{0}' profile as...",
 			"Profile with name '{0}' already exists. Do you want to overwrite it?",
 			"&&Overwrite",
@@ -18343,11 +18499,14 @@
 			"Save Profile",
 			"Select Profile",
 			"Select {0}",
+			"Select {0}",
+			"From Default Profile",
 			"Name the profile",
 			"Export Profile",
 			"Profile name must be provided."
 		],
 		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
+			"The current profile has been updated. Please reload to switch back to the updated profile",
 			"The current profile has been removed. Please reload to switch back to default profile",
 			"The current profile has been removed. Please reload to switch back to default profile",
 			"Cannot rename the default profile",
@@ -18372,25 +18531,6 @@
 		"vs/workbench/services/views/browser/viewDescriptorService": [
 			"Hide '{0}'",
 			"Reset Location"
-		],
-		"vs/workbench/services/authentication/browser/authenticationService": [
-			"The id of the authentication provider.",
-			"The human readable name of the authentication provider.",
-			"Contributes authentication",
-			"No accounts requested yet...",
-			"An authentication contribution must specify an id.",
-			"An authentication contribution must specify a label.",
-			"This authentication id '{0}' has already been registered",
-			"Loading...",
-			"Sign in requested",
-			"The extension '{0}' wants to access the {1} account '{2}'.",
-			"&&Allow",
-			"&&Deny",
-			"Sign in to another account",
-			"The extension '{0}' wants to access a {1} account",
-			"Select an account for '{0}' to use or Esc to cancel",
-			"Grant access to {0} for {1}... (1)",
-			"Sign in with {0} to use {1} (1)"
 		],
 		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
 			"Settings sync cannot be turned on because there are no authentication providers available.",
@@ -18417,6 +18557,25 @@
 			"Others",
 			"Sign in with {0}"
 		],
+		"vs/workbench/services/authentication/browser/authenticationService": [
+			"The id of the authentication provider.",
+			"The human readable name of the authentication provider.",
+			"Contributes authentication",
+			"No accounts requested yet...",
+			"An authentication contribution must specify an id.",
+			"An authentication contribution must specify a label.",
+			"This authentication id '{0}' has already been registered",
+			"Loading...",
+			"Sign in requested",
+			"The extension '{0}' wants to access the {1} account '{2}'.",
+			"&&Allow",
+			"&&Deny",
+			"Sign in to another account",
+			"The extension '{0}' wants to access a {1} account",
+			"Select an account for '{0}' to use or Esc to cancel",
+			"Grant access to {0} for {1}... (1)",
+			"Sign in with {0} to use {1} (1)"
+		],
 		"vs/workbench/services/assignment/common/assignmentService": [
 			"Fetches experiments to run from a Microsoft online service."
 		],
@@ -18428,8 +18587,8 @@
 			"Issue troubleshooting is active and has temporarily reset your configurations to defaults. Check if you can still reproduce the problem and proceed by selecting from these options.",
 			"Issue troubleshooting has identified that the issue is caused by your configurations. Please report the issue by exporting your configurations using \"Export Profile\" command and share the file in the issue report.",
 			"Issue troubleshooting has identified that the issue is with {0}.",
-			"I can't reproduce",
-			"I can reproduce",
+			"I Can't Reproduce",
+			"I Can Reproduce",
 			"Stop",
 			"Troubleshoot Issue",
 			"This likely means that the issue has been addressed already and will be available in an upcoming release. You can safely use {0} insiders until the new stable version is available.",
@@ -18445,24 +18604,18 @@
 			"Troubleshoot Issue...",
 			"Stop Troubleshoot Issue"
 		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"You won't be able to produce this key combination under your current keyboard layout.",
-			"**{0}** for your current keyboard layout (**{1}** for US standard).",
-			"**{0}** for your current keyboard layout."
-		],
 		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
 			"Settings Editor 2",
 			"Keybindings Editor",
 			"Open Settings (UI)",
 			"Open User Settings (JSON)",
-			"Open Current Profile Settings (JSON)",
+			"Open Application Settings (JSON)",
 			"Preferences",
 			"Settings",
 			"&&Settings",
 			"Open Settings (UI)",
 			"Open User Settings",
 			"Open Default Settings (JSON)",
-			"Open Settings (JSON)",
 			"Open Settings (JSON)",
 			"Open Workspace Settings",
 			"Open Accessibility Settings",
@@ -18498,12 +18651,6 @@
 			"Define Keybinding",
 			"&&Preferences"
 		],
-		"vs/workbench/contrib/performance/browser/performance.contribution": [
-			"Startup Performance",
-			"Print Service Cycles",
-			"Print Service Traces",
-			"Print Emitter Profiles"
-		],
 		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
 			"Settings for code editors used in notebooks. This can be used to customize most editor.* settings.",
 			"Notebook",
@@ -18526,6 +18673,7 @@
 			"Both toolbars.",
 			"The insert actions don't appear anywhere.",
 			"Control whether to render a global toolbar inside the notebook editor.",
+			"Experimental. Control whether to render notebook Sticky Scroll headers in the notebook editor.",
 			"Control whether outputs action should be rendered in the output toolbar.",
 			"Controls when the Markdown header folding arrow is shown.",
 			"The folding controls are always visible.",
@@ -18546,7 +18694,8 @@
 			"Experimental. Run a series of CodeActions for a notebook on save. CodeActions must be specified, the file must not be saved after delay, and the editor must not be shutting down. Example: `source.fixAll: true`",
 			"Format a notebook cell upon execution. A formatter must be available.",
 			"Control whether a confirmation prompt is required to delete a running cell.",
-			"Customize the Find Widget behavior for searching within notebook cells. When both markup source and markup preview are enabled, the Find Widget will search either the source code or preview based on the current state of the cell."
+			"Customize the Find Widget behavior for searching within notebook cells. When both markup source and markup preview are enabled, the Find Widget will search either the source code or preview based on the current state of the cell.",
+			"Enables the incremental saving of notebooks in Remote environment. When enabled, only the changes to the notebook are sent to the extension host, improving performance for large notebooks and slow network connections."
 		],
 		"vs/workbench/contrib/chat/browser/chat.contribution": [
 			"Chat",
@@ -18555,9 +18704,17 @@
 			"Controls the font weight in chat codeblocks.",
 			"Controls whether lines should wrap in chat codeblocks.",
 			"Controls the line height in pixels in chat codeblocks. Use 0 to compute the line height from the font size.",
+			"Use the chat view as the default mode. Displays the chat icon in the Activity Bar.",
+			"Use the quick question as the default mode. Displays the chat icon in the Title Bar.",
+			"Displays the chat icon in the Activity Bar and the Title Bar which open their respective chat modes.",
+			"Controls the default mode of the chat experience.",
+			"Controls the mode of quick question chat experience.",
 			"Chat",
 			"Chat",
 			"Chat Accessible View"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChat.contribution": [
+			"Inline Chat Accessible View"
 		],
 		"vs/workbench/contrib/interactive/browser/interactive.contribution": [
 			"Interactive Window",
@@ -18584,25 +18741,16 @@
 			"Install Additional Test Extensions...",
 			"Test Explorer"
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"You won't be able to produce this key combination under your current keyboard layout.",
+			"**{0}** for your current keyboard layout (**{1}** for US standard).",
+			"**{0}** for your current keyboard layout."
+		],
 		"vs/workbench/contrib/logs/common/logs.contribution": [
 			"Set Default Log Level",
 			"{0} (Remote)",
 			"{0} (Remote)",
 			"Show Window Log"
-		],
-		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
-			"Type '{0}' to get help on the actions you can take from here.",
-			"Show all Quick Access Providers",
-			"Type the name of a view, output channel or terminal to open.",
-			"Open View",
-			"Type the name of a command to run.",
-			"Show and Run Commands",
-			"&&Command Palette...",
-			"Show All Commands",
-			"&&Open View...",
-			"Go to &&Line/Column...",
-			"Command Palette...",
-			"Command Palette..."
 		],
 		"vs/workbench/contrib/files/browser/explorerViewlet": [
 			"View icon of the explorer view.",
@@ -18619,6 +18767,20 @@
 			"Connected to remote.\n{0}",
 			"You have not yet opened a folder.\n{0}\nOpening a folder will close all currently open editors. To keep them open, {1} instead.",
 			"You have not yet opened a folder.\n{0}"
+		],
+		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
+			"Type '{0}' to get help on the actions you can take from here.",
+			"Show all Quick Access Providers",
+			"Type the name of a view, output channel or terminal to open.",
+			"Open View",
+			"Type the name of a command to run.",
+			"Show and Run Commands",
+			"&&Command Palette...",
+			"Show All Commands",
+			"&&Open View...",
+			"Go to &&Line/Column...",
+			"Command Palette...",
+			"Command Palette..."
 		],
 		"vs/workbench/contrib/files/browser/fileActions.contribution": [
 			"Copy Path",
@@ -18783,26 +18945,6 @@
 			"File operation",
 			"Controls if files that were part of a refactoring are saved automatically"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
-			"Another refactoring is being previewed.",
-			"Press 'Continue' to discard the previous refactoring and continue with the current refactoring.",
-			"&&Continue",
-			"Apply Refactoring",
-			"Refactor Preview",
-			"Discard Refactoring",
-			"Refactor Preview",
-			"Toggle Change",
-			"Refactor Preview",
-			"Group Changes By File",
-			"Refactor Preview",
-			"Group Changes By Type",
-			"Refactor Preview",
-			"Group Changes By Type",
-			"Refactor Preview",
-			"View icon of the refactor preview view.",
-			"Refactor Preview",
-			"Refactor Preview"
-		],
 		"vs/workbench/contrib/search/browser/search.contribution": [
 			"Search",
 			"Search",
@@ -18867,7 +19009,28 @@
 			"Controls whether search file decorations should use badges.",
 			"Shows search results as a tree.",
 			"Shows search results as a list.",
-			"Controls the default search result view mode."
+			"Controls the default search result view mode.",
+			"Show notebook editor rich content results for closed notebooks. Please refresh your search results after changing this setting."
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
+			"Another refactoring is being previewed.",
+			"Press 'Continue' to discard the previous refactoring and continue with the current refactoring.",
+			"&&Continue",
+			"Apply Refactoring",
+			"Refactor Preview",
+			"Discard Refactoring",
+			"Refactor Preview",
+			"Toggle Change",
+			"Refactor Preview",
+			"Group Changes By File",
+			"Refactor Preview",
+			"Group Changes By Type",
+			"Refactor Preview",
+			"Group Changes By Type",
+			"Refactor Preview",
+			"View icon of the refactor preview view.",
+			"Refactor Preview",
+			"Refactor Preview"
 		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
 			"Search Editor",
@@ -19012,7 +19175,8 @@
 			"Source Control: Accept Input",
 			"Source Control: View Next Commit",
 			"Source Control: View Previous Commit",
-			"Open In Terminal"
+			"Open in External Terminal",
+			"Open in Integrated Terminal"
 		],
 		"vs/workbench/contrib/debug/browser/debug.contribution": [
 			"Debug",
@@ -19154,9 +19318,11 @@
 			"Icon color for the current breakpoint stack frame.",
 			"Icon color for all breakpoint stack frames."
 		],
-		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
-			"Background color for the highlight of line at the top stack frame position.",
-			"Background color for the highlight of line at focused stack frame position."
+		"vs/workbench/contrib/debug/browser/debugViewlet": [
+			"Open &&Configurations",
+			"Select a workspace folder to create a launch.json file in or add it to the workspace config file",
+			"Debug Console",
+			"Start Additional Session"
 		],
 		"vs/workbench/contrib/debug/browser/repl": [
 			"Filter (e.g. text, !exclude)",
@@ -19173,12 +19339,6 @@
 			"Paste",
 			"Copy All",
 			"Copy"
-		],
-		"vs/workbench/contrib/debug/browser/debugViewlet": [
-			"Open &&Configurations",
-			"Select a workspace folder to create a launch.json file in or add it to the workspace config file",
-			"Debug Console",
-			"Start Additional Session"
 		],
 		"vs/workbench/contrib/markers/browser/markers.contribution": [
 			"View icon of the markers view.",
@@ -19220,10 +19380,11 @@
 			"10K+",
 			"Total {0} Problems"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
-			"Merge Editor",
-			"Uses the legacy diffing algorithm.",
-			"Uses the advanced diffing algorithm."
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"Startup Performance",
+			"Print Service Cycles",
+			"Print Service Traces",
+			"Print Emitter Profiles"
 		],
 		"vs/workbench/contrib/commands/common/commands.contribution": [
 			"Run Commands",
@@ -19231,6 +19392,10 @@
 			"Commands to run",
 			"'runCommands' has received an argument with incorrect type. Please, review the argument passed to the command.",
 			"'runCommands' has not received commands to run. Did you forget to pass commands in the 'runCommands' argument?"
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"Background color for the highlight of line at the top stack frame position.",
+			"Background color for the highlight of line at focused stack frame position."
 		],
 		"vs/workbench/contrib/comments/browser/comments.contribution": [
 			"Comments",
@@ -19257,46 +19422,10 @@
 		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
 			"webview editor"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			"Remote",
-			"Installed",
-			"Install Local Extensions in '{0}'...",
-			"Install Remote Extensions Locally...",
-			"Popular",
-			"Recommended",
-			"Enabled",
-			"Disabled",
-			"Marketplace",
-			"Installed",
-			"Recently Updated",
-			"Enabled",
-			"Disabled",
-			"Available Updates",
-			"Builtin",
-			"Workspace Unsupported",
-			"Workspace Recommendations",
-			"Other Recommendations",
-			"Features",
-			"Themes",
-			"Programming Languages",
-			"Disabled in Restricted Mode",
-			"Limited in Restricted Mode",
-			"Disabled in Virtual Workspaces",
-			"Limited in Virtual Workspaces",
-			"Deprecated",
-			"Search Extensions in Marketplace",
-			"1 extension found in the {0} section.",
-			"1 extension found.",
-			"{0} extensions found in the {1} section.",
-			"{0} extensions found.",
-			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
-			"Open User Settings",
-			"{0} requires update",
-			"{0} require update",
-			"{0} requires reload",
-			"{0} require reload",
-			"We have uninstalled '{0}' which was reported to be problematic.",
-			"Reload Now"
+		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
+			"Merge Editor",
+			"Uses the legacy diffing algorithm.",
+			"Uses the advanced diffing algorithm."
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
 			"Press Enter to manage extensions.",
@@ -19419,6 +19548,7 @@
 			"Copy Extension ID",
 			"Extension Settings",
 			"Extension Keyboard Shortcuts",
+			"Apply Extension to all Profiles",
 			"Sync This Extension",
 			"Ignore Recommendation",
 			"Undo Ignored Recommendation",
@@ -19433,6 +19563,47 @@
 			"Add Extension to Workspace Folder Ignored Recommendations",
 			"Extensions",
 			"Extensions"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			"Remote",
+			"Installed",
+			"Install Local Extensions in '{0}'...",
+			"Install Remote Extensions Locally...",
+			"Popular",
+			"Recommended",
+			"Enabled",
+			"Disabled",
+			"Marketplace",
+			"Installed",
+			"Recently Updated",
+			"Enabled",
+			"Disabled",
+			"Available Updates",
+			"Builtin",
+			"Workspace Unsupported",
+			"Workspace Recommendations",
+			"Other Recommendations",
+			"Features",
+			"Themes",
+			"Programming Languages",
+			"Disabled in Restricted Mode",
+			"Limited in Restricted Mode",
+			"Disabled in Virtual Workspaces",
+			"Limited in Virtual Workspaces",
+			"Deprecated",
+			"Search Extensions in Marketplace",
+			"1 extension found in the {0} section.",
+			"1 extension found.",
+			"{0} extensions found in the {1} section.",
+			"{0} extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"{0} requires update",
+			"{0} require update",
+			"{0} requires reload",
+			"{0} require reload",
+			"We have uninstalled '{0}' which was reported to be problematic.",
+			"Reload Now"
 		],
 		"vs/workbench/contrib/output/browser/output.contribution": [
 			"View icon of the output view.",
@@ -19459,6 +19630,12 @@
 			"Select Log File",
 			"Output",
 			"Enable/disable the ability of smart scrolling in the output view. Smart scrolling allows you to lock scrolling automatically when you click in the output view and unlocks when you click in the last line."
+		],
+		"vs/workbench/contrib/output/browser/outputView": [
+			"{0} - Output",
+			"Output channel for '{0}'",
+			"Output",
+			"Output panel"
 		],
 		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
 			"Open in Integrated Terminal",
@@ -19498,6 +19675,7 @@
 			"Configure Default Build Task",
 			"Configure Default Test Task",
 			"Open User Tasks",
+			"User Tasks",
 			"Type the name of a task to run.",
 			"Run Task",
 			"Tasks",
@@ -19583,12 +19761,6 @@
 			"User snippet configuration",
 			"A list of language names to which this snippet applies, e.g. 'typescript,javascript'."
 		],
-		"vs/workbench/contrib/output/browser/outputView": [
-			"{0} - Output",
-			"Output channel for '{0}'",
-			"Output",
-			"Output panel"
-		],
 		"vs/workbench/contrib/folding/browser/folding.contribution": [
 			"All",
 			"All active folding range providers",
@@ -19668,18 +19840,18 @@
 		"vs/workbench/contrib/surveys/browser/nps.contribution": [
 			"Do you mind taking a quick feedback survey?",
 			"Take Survey",
-			"Remind Me later",
+			"Remind Me Later",
 			"Don't Show Again"
 		],
 		"vs/workbench/contrib/surveys/browser/ces.contribution": [
 			"Got a moment to help the VS Code team? Please tell us about your experience with VS Code so far.",
 			"Give Feedback",
-			"Remind Me later"
+			"Remind Me Later"
 		],
 		"vs/workbench/contrib/surveys/browser/languageSurveys.contribution": [
 			"Help us improve our support for {0}",
 			"Take Short Survey",
-			"Remind Me later",
+			"Remind Me Later",
 			"Don't Show Again"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution": [
@@ -19973,9 +20145,9 @@
 			"Plays a sound when a task fails (non-zero exit code).",
 			"Plays a sound when a terminal command fails (non-zero exit code).",
 			"Plays a sound when terminal Quick Fixes are available.",
-			"Plays a sound when the focus moves to an inserted line in diff review mode or to the next/previous change",
-			"Plays a sound when the focus moves to a deleted line in diff review mode or to the next/previous change",
-			"Plays a sound when the focus moves to a modified line in diff review mode or to the next/previous change",
+			"Plays a sound when the focus moves to an inserted line in accessible diff viewer mode or to the next/previous change",
+			"Plays a sound when the focus moves to a deleted line in accessible diff viewer mode or to the next/previous change",
+			"Plays a sound when the focus moves to a modified line in accessible diff viewer mode or to the next/previous change",
 			"Plays a sound when a notebook cell execution is successfully completed.",
 			"Plays a sound when a notebook cell execution fails.",
 			"Plays a sound when a chat request is made.",
@@ -19990,7 +20162,9 @@
 		],
 		"vs/workbench/contrib/accessibility/browser/accessibility.contribution": [
 			"editor accessibility help",
-			"Hover Accessible View"
+			"Hover Accessible View",
+			"{0} Source: {1}",
+			"Notification Accessible View"
 		],
 		"vs/workbench/contrib/share/browser/share.contribution": [
 			"Share...",
@@ -20000,6 +20174,16 @@
 			"Close",
 			"Open Link",
 			"Controls whether to render the Share action next to the command center when {0} is {1}."
+		],
+		"vs/workbench/browser/parts/dialogs/dialogHandler": [
+			"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
+			"&&Copy",
+			"OK"
+		],
+		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
+			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
+			"&&Copy",
+			"OK"
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
 			"Default Language Configuration Overrides",
@@ -20119,17 +20303,10 @@
 		"vs/workbench/common/configuration": [
 			"Application",
 			"Workbench",
-			"Security"
-		],
-		"vs/workbench/browser/parts/dialogs/dialogHandler": [
-			"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
-			"&&Copy",
-			"OK"
-		],
-		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
-			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
-			"&&Copy",
-			"OK"
+			"Security",
+			"UNC host names must not contain backslashes.",
+			"A set of UNC host names (without leading or trailing backslash, for example `192.168.0.1` or `my-server`) to allow without user confirmation. If a UNC host is being accessed that is not allowed via this setting or has not been acknowledged via user confirmation, an error will occur and the operation stopped. A restart is required when changing this setting. Find out more about this setting at https://aka.ms/vscode-windows-unc.",
+			"If enabled, only allows access to UNC host names that are allowed by the `#security.allowedUNCHosts#` setting or after user confirmation. Find out more about this setting at https://aka.ms/vscode-windows-unc."
 		],
 		"vs/workbench/services/textfile/browser/textFileService": [
 			"File Created",
@@ -20498,9 +20675,6 @@
 			"The color used for the border of the window when it is active. Only supported in the macOS and Linux desktop client when using the custom title bar.",
 			"The color used for the border of the window when it is inactive. Only supported in the macOS and Linux desktop client when using the custom title bar."
 		],
-		"vs/base/common/actions": [
-			"(empty)"
-		],
 		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
 			"Save",
 			"Save Workspace",
@@ -20544,8 +20718,10 @@
 			"Contains extensions which are not supported.",
 			"'{0}' contains extensions which are not supported in {1}."
 		],
+		"vs/base/common/actions": [
+			"(empty)"
+		],
 		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
-			"Can't install pre-release version of '{0}' extension because it is not compatible with the current version of {1} (version {2}).",
 			"Can't install release version of '{0}' extension because it has no release version.",
 			"Can't install '{0}' extension because it is not compatible with the current version of {1} (version {2})."
 		],
@@ -20599,66 +20775,6 @@
 			"Open Logs Folder",
 			"Open Extension Logs Folder"
 		],
-		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
-			"Search language packs in the Marketplace to change the display language to {0}.",
-			"Search Marketplace",
-			"Install language pack to change the display language to {0}.",
-			"Install and Restart"
-		],
-		"vs/workbench/contrib/localization/common/localization.contribution": [
-			"Contributes localizations to the editor",
-			"Id of the language into which the display strings are translated.",
-			"Name of the language in English.",
-			"Name of the language in contributed language.",
-			"List of translations associated to the language.",
-			"Id of VS Code or Extension for which this translation is contributed to. Id of VS Code is always `vscode` and of extension should be in format `publisherId.extensionName`.",
-			"Id should be `vscode` or in format `publisherId.extensionName` for translating VS code or an extension respectively.",
-			"A relative path to a file containing translations for the language."
-		],
-		"vs/editor/common/editorContextKeys": [
-			"Whether the editor text has focus (cursor is blinking)",
-			"Whether the editor or an editor widget has focus (e.g. focus is in the find widget)",
-			"Whether an editor or a rich text input has focus (cursor is blinking)",
-			"Whether the editor is read-only",
-			"Whether the context is a diff editor",
-			"Whether the context is an embedded diff editor",
-			"Whether `editor.columnSelection` is enabled",
-			"Whether the editor has text selected",
-			"Whether the editor has multiple selections",
-			"Whether `Tab` will move focus out of the editor",
-			"Whether the editor hover is visible",
-			"Whether the editor hover is focused",
-			"Whether the sticky scroll is focused",
-			"Whether the sticky scroll is visible",
-			"Whether the standalone color picker is visible",
-			"Whether the standalone color picker is focused",
-			"Whether the editor is part of a larger editor (e.g. notebooks)",
-			"The language identifier of the editor",
-			"Whether the editor has a completion item provider",
-			"Whether the editor has a code actions provider",
-			"Whether the editor has a code lens provider",
-			"Whether the editor has a definition provider",
-			"Whether the editor has a declaration provider",
-			"Whether the editor has an implementation provider",
-			"Whether the editor has a type definition provider",
-			"Whether the editor has a hover provider",
-			"Whether the editor has a document highlight provider",
-			"Whether the editor has a document symbol provider",
-			"Whether the editor has a reference provider",
-			"Whether the editor has a rename provider",
-			"Whether the editor has a signature help provider",
-			"Whether the editor has an inline hints provider",
-			"Whether the editor has a document formatting provider",
-			"Whether the editor has a document selection formatting provider",
-			"Whether the editor has multiple document formatting providers",
-			"Whether the editor has multiple document selection formatting providers"
-		],
-		"vs/workbench/common/editor": [
-			"Text Editor",
-			"Built-in",
-			"Open Anyway",
-			"Configure Limit"
-		],
 		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
 			"Paste Selection Clipboard"
 		],
@@ -20675,6 +20791,12 @@
 			"Save Extension Host Profile",
 			"Save Extension Host Profile",
 			"Save"
+		],
+		"vs/workbench/common/editor": [
+			"Text Editor",
+			"Built-in",
+			"Open Anyway",
+			"Configure Limit"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/debugExtensionHostAction": [
 			"Start Debugging Extension Host",
@@ -20737,6 +20859,35 @@
 			"Icon path when a light theme is used",
 			"Icon path when a dark theme is used"
 		],
+		"vs/editor/common/languages": [
+			"array",
+			"boolean",
+			"class",
+			"constant",
+			"constructor",
+			"enumeration",
+			"enumeration member",
+			"event",
+			"field",
+			"file",
+			"function",
+			"interface",
+			"key",
+			"method",
+			"module",
+			"namespace",
+			"null",
+			"number",
+			"object",
+			"operator",
+			"package",
+			"property",
+			"string",
+			"struct",
+			"type parameter",
+			"variable",
+			"{0} ({1})"
+		],
 		"vs/workbench/services/userDataSync/common/userDataSync": [
 			"Settings",
 			"Keyboard Shortcuts",
@@ -20758,11 +20909,6 @@
 			"A final restart is required to continue to use '{0}'. Again, thank you for your contribution.",
 			"&&Restart"
 		],
-		"vs/workbench/contrib/tasks/common/tasks": [
-			"Whether a task is currently running.",
-			"Tasks",
-			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
-		],
 		"vs/workbench/contrib/tasks/common/taskService": [
 			"Whether CustomExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
 			"Whether ShellExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
@@ -20770,10 +20916,103 @@
 			"Whether ProcessExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
 			"True when in the web with no remote authority."
 		],
+		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+			"A unknown error has occurred while executing a task. See task output log for details.",
+			"There are issues with task \"{0}\". See the output for more details.",
+			"There is a dependency cycle. See task \"{0}\".",
+			"Couldn't resolve dependent task '{0}' in workspace folder '{1}'",
+			"Task {0} is a background task but uses a problem matcher without a background pattern",
+			"Executing task in folder {0}: {1}",
+			"Executing task: {0}",
+			"Executing task in folder {0}: {1}",
+			"Executing task: {0}",
+			"Executing task: {0}",
+			"Can't execute a shell command on an UNC drive using cmd.exe.",
+			"Problem matcher {0} can't be resolved. The matcher will be ignored",
+			"Press any key to close the terminal.",
+			"Terminal will be reused by tasks, press any key to close it."
+		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"Whether a task is currently running.",
+			"Tasks",
+			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
+		],
 		"vs/workbench/common/views": [
 			"Default view icon.",
 			"A view with id '{0}' is already registered",
 			"No tree view with id '{0}' registered."
+		],
+		"vs/platform/audioCues/browser/audioCueService": [
+			"Error on Line",
+			"Warning on Line",
+			"Folded Area on Line",
+			"Breakpoint on Line",
+			"Inline Suggestion on Line",
+			"Terminal Quick Fix",
+			"Debugger Stopped on Breakpoint",
+			"No Inlay Hints on Line",
+			"Task Completed",
+			"Task Failed",
+			"Terminal Command Failed",
+			"Terminal Bell",
+			"Notebook Cell Completed",
+			"Notebook Cell Failed",
+			"Diff Line Inserted",
+			"Diff Line Deleted",
+			"Diff Line Modified",
+			"Chat Request Sent",
+			"Chat Response Received",
+			"Chat Response Pending"
+		],
+		"vs/workbench/contrib/terminal/common/terminalContextKey": [
+			"Whether the terminal is focused.",
+			"Whether any terminal is focused, including detached terminals used in other UI.",
+			"Whether the terminal accessible buffer is focused.",
+			"Whether a terminal in the editor area is focused.",
+			"The current number of terminals.",
+			"Whether the terminal tabs widget is focused.",
+			"The shell type of the active terminal, this is set to the last known value when no terminals exist.",
+			"Whether the terminal's alt buffer is active.",
+			"Whether the terminal's suggest widget is visible.",
+			"Whether the terminal view is showing",
+			"Whether text is selected in the active terminal.",
+			"Whether text is selected in a focused terminal.",
+			"Whether terminal processes can be launched in the current workspace.",
+			"Whether one terminal is selected in the terminal tabs list.",
+			"Whether the focused tab's terminal is a split terminal.",
+			"Whether the terminal run command picker is currently open.",
+			"Whether shell integration is enabled in the active terminal"
+		],
+		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
+			"Reveal in File Explorer",
+			"Reveal in Finder",
+			"Open Containing Folder"
+		],
+		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
+			"Open Webview Developer Tools",
+			"Using standard dev tools to debug iframe based webview"
+		],
+		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
+			"Merge Editor (Dev)",
+			"Open Merge Editor State from JSON",
+			"Enter JSON",
+			"Open Selection In Temporary Merge Editor"
+		],
+		"vs/workbench/contrib/localization/common/localization.contribution": [
+			"Contributes localizations to the editor",
+			"Id of the language into which the display strings are translated.",
+			"Name of the language in English.",
+			"Name of the language in contributed language.",
+			"List of translations associated to the language.",
+			"Id of VS Code or Extension for which this translation is contributed to. Id of VS Code is always `vscode` and of extension should be in format `publisherId.extensionName`.",
+			"Id should be `vscode` or in format `publisherId.extensionName` for translating VS code or an extension respectively.",
+			"A relative path to a file containing translations for the language."
+		],
+		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
+			"Search language packs in the Marketplace to change the display language to {0}.",
+			"Search Marketplace",
+			"Install language pack to change the display language to {0}.",
+			"Install and Restart"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"Configure Task",
@@ -20865,77 +21104,44 @@
 			"Open diff",
 			"Open diffs"
 		],
-		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
-			"A unknown error has occurred while executing a task. See task output log for details.",
-			"There are issues with task \"{0}\". See the output for more details.",
-			"There is a dependency cycle. See task \"{0}\".",
-			"Couldn't resolve dependent task '{0}' in workspace folder '{1}'",
-			"Task {0} is a background task but uses a problem matcher without a background pattern",
-			"Executing task in folder {0}: {1}",
-			"Executing task: {0}",
-			"Executing task in folder {0}: {1}",
-			"Executing task: {0}",
-			"Executing task: {0}",
-			"Can't execute a shell command on an UNC drive using cmd.exe.",
-			"Problem matcher {0} can't be resolved. The matcher will be ignored",
-			"Press any key to close the terminal.",
-			"Terminal will be reused by tasks, press any key to close it."
-		],
-		"vs/platform/audioCues/browser/audioCueService": [
-			"Error on Line",
-			"Warning on Line",
-			"Folded Area on Line",
-			"Breakpoint on Line",
-			"Inline Suggestion on Line",
-			"Terminal Quick Fix",
-			"Debugger Stopped on Breakpoint",
-			"No Inlay Hints on Line",
-			"Task Completed",
-			"Task Failed",
-			"Terminal Command Failed",
-			"Terminal Bell",
-			"Notebook Cell Completed",
-			"Notebook Cell Failed",
-			"Diff Line Inserted",
-			"Diff Line Deleted",
-			"Diff Line Modified",
-			"Chat Request Sent",
-			"Chat Response Received",
-			"Chat Response Pending"
-		],
-		"vs/workbench/contrib/terminal/common/terminalContextKey": [
-			"Whether the terminal is focused.",
-			"Whether any terminal is focused, including detached terminals used in other UI.",
-			"Whether the terminal accessible buffer is focused.",
-			"Whether a terminal in the editor area is focused.",
-			"The current number of terminals.",
-			"Whether the terminal tabs widget is focused.",
-			"The shell type of the active terminal, this is set to the last known value when no terminals exist.",
-			"Whether the terminal's alt buffer is active.",
-			"Whether the terminal's suggest widget is visible.",
-			"Whether the terminal view is showing",
-			"Whether text is selected in the active terminal.",
-			"Whether text is selected in a focused terminal.",
-			"Whether terminal processes can be launched in the current workspace.",
-			"Whether one terminal is selected in the terminal tabs list.",
-			"Whether the focused tab's terminal is a split terminal.",
-			"Whether the terminal run command picker is currently open.",
-			"Whether shell integration is enabled in the active terminal"
-		],
-		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
-			"Open Webview Developer Tools",
-			"Using standard dev tools to debug iframe based webview"
-		],
-		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
-			"Reveal in File Explorer",
-			"Reveal in Finder",
-			"Open Containing Folder"
-		],
-		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
-			"Merge Editor (Dev)",
-			"Open Merge Editor State from JSON",
-			"Enter JSON",
-			"Open Selection In Temporary Merge Editor"
+		"vs/editor/common/editorContextKeys": [
+			"Whether the editor text has focus (cursor is blinking)",
+			"Whether the editor or an editor widget has focus (e.g. focus is in the find widget)",
+			"Whether an editor or a rich text input has focus (cursor is blinking)",
+			"Whether the editor is read-only",
+			"Whether the context is a diff editor",
+			"Whether the context is an embedded diff editor",
+			"Whether the accessible diff viewer is visible",
+			"Whether `editor.columnSelection` is enabled",
+			"Whether the editor has text selected",
+			"Whether the editor has multiple selections",
+			"Whether `Tab` will move focus out of the editor",
+			"Whether the editor hover is visible",
+			"Whether the editor hover is focused",
+			"Whether the sticky scroll is focused",
+			"Whether the sticky scroll is visible",
+			"Whether the standalone color picker is visible",
+			"Whether the standalone color picker is focused",
+			"Whether the editor is part of a larger editor (e.g. notebooks)",
+			"The language identifier of the editor",
+			"Whether the editor has a completion item provider",
+			"Whether the editor has a code actions provider",
+			"Whether the editor has a code lens provider",
+			"Whether the editor has a definition provider",
+			"Whether the editor has a declaration provider",
+			"Whether the editor has an implementation provider",
+			"Whether the editor has a type definition provider",
+			"Whether the editor has a hover provider",
+			"Whether the editor has a document highlight provider",
+			"Whether the editor has a document symbol provider",
+			"Whether the editor has a reference provider",
+			"Whether the editor has a rename provider",
+			"Whether the editor has a signature help provider",
+			"Whether the editor has an inline hints provider",
+			"Whether the editor has a document formatting provider",
+			"Whether the editor has a document selection formatting provider",
+			"Whether the editor has multiple document formatting providers",
+			"Whether the editor has multiple document selection formatting providers"
 		],
 		"vs/workbench/api/common/extHostExtensionService": [
 			"Cannot load test runner.",
@@ -20949,6 +21155,10 @@
 		],
 		"vs/workbench/api/common/extHostTerminalService": [
 			"Could not find the terminal with id {0} on the extension host"
+		],
+		"vs/workbench/api/common/extHostTunnelService": [
+			"Private",
+			"Public"
 		],
 		"vs/workbench/api/common/extHostLogService": [
 			"Extension Host (Remote)",
@@ -20964,9 +21174,8 @@
 		"vs/workbench/api/node/extHostDebugService": [
 			"Debug Process"
 		],
-		"vs/workbench/api/node/extHostTunnelService": [
-			"Private",
-			"Public"
+		"vs/base/browser/ui/button/button": [
+			"More Actions..."
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"Open",
@@ -21017,14 +21226,6 @@
 			"Unable to uninstall the shell command '{0}'.",
 			"Unable to find shell script in '{0}'"
 		],
-		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
-			"New Window",
-			"Opens a new window",
-			"Recent Folders & Workspaces",
-			"Recent Folders",
-			"Untitled (Workspace)",
-			"{0} (Workspace)"
-		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			"&&OK",
 			"Path does not exist",
@@ -21038,6 +21239,14 @@
 			"The path '{0}' uses a host that is not allowed. Unless you trust the host, you should press 'Cancel'",
 			"Permanently allow host '{0}'"
 		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"New Window",
+			"Opens a new window",
+			"Recent Folders & Workspaces",
+			"Recent Folders",
+			"Untitled (Workspace)",
+			"{0} (Workspace)"
+		],
 		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
 			"&&OK",
 			"Unable to save workspace '{0}'",
@@ -21045,6 +21254,22 @@
 		],
 		"vs/platform/files/common/io": [
 			"File is too large to open"
+		],
+		"vs/base/browser/ui/tree/abstractTree": [
+			"Filter",
+			"Fuzzy Match",
+			"Type to filter",
+			"Type to search",
+			"Type to search",
+			"Close",
+			"No elements found."
+		],
+		"vs/platform/theme/common/iconRegistry": [
+			"The id of the font to use. If not set, the font that is defined first is used.",
+			"The font character associated with the icon definition.",
+			"Icon for the close action in widgets.",
+			"Icon for goto previous editor location.",
+			"Icon for goto next editor location."
 		],
 		"vs/platform/extensions/common/extensionValidator": [
 			"property publisher must be of type `string`.",
@@ -21088,8 +21313,8 @@
 		"vs/platform/extensionManagement/common/abstractExtensionManagementService": [
 			"Marketplace is not enabled",
 			"Can't install '{0}' extension since it was reported to be problematic.",
+			"Can't install '{0}' extension since it was deprecated and the replacement extension '{1}' can't be found.",
 			"The '{0}' extension is not available in {1} for {2}.",
-			"Can't install pre-release version of '{0}' extension because it is not compatible with the current version of {1} (version {2}).",
 			"Can't install release version of '{0}' extension because it has no release version.",
 			"Can't install '{0}' extension because it is not compatible with the current version of {1} (version {2}).",
 			"Cannot uninstall '{0}' extension. '{1}' extension depends on this.",
@@ -21101,9 +21326,6 @@
 		],
 		"vs/platform/extensionManagement/node/extensionManagementUtil": [
 			"VSIX invalid: package.json is not a JSON file."
-		],
-		"vs/base/browser/ui/button/button": [
-			"More Actions..."
 		],
 		"vs/base/common/date": [
 			"in {0}",
@@ -21181,32 +21403,10 @@
 			"Cannot sync because current session is expired",
 			"Cannot sync because syncing is turned off on this machine from another machine."
 		],
-		"vs/base/browser/ui/tree/abstractTree": [
-			"Filter",
-			"Fuzzy Match",
-			"Type to filter",
-			"Type to search",
-			"Type to search",
-			"Close",
-			"No elements found."
-		],
-		"vs/platform/theme/common/iconRegistry": [
-			"The id of the font to use. If not set, the font that is defined first is used.",
-			"The font character associated with the icon definition.",
-			"Icon for the close action in widgets.",
-			"Icon for goto previous editor location.",
-			"Icon for goto next editor location."
-		],
 		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
 			"Error: {0}",
 			"Warning: {0}",
 			"Info: {0}"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"No new notifications",
-			"Notifications",
-			"Notification Center Actions",
-			"Notifications Center"
 		],
 		"vs/workbench/browser/parts/notifications/notificationsStatus": [
 			"Notifications",
@@ -21223,6 +21423,16 @@
 			"{0} New Notifications ({1} in progress)",
 			"Status Message"
 		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"No new notifications",
+			"Notifications",
+			"Notification Center Actions",
+			"Notifications Center"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsToasts": [
+			"{0}, notification",
+			"{0}, source: {1}, notification"
+		],
 		"vs/workbench/browser/parts/notifications/notificationsCommands": [
 			"Notifications",
 			"Show Notifications",
@@ -21232,16 +21442,13 @@
 			"Toggle Do Not Disturb Mode",
 			"Focus Notification Toast"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsToasts": [
-			"{0}, notification",
-			"{0}, source: {1}, notification"
-		],
 		"vs/platform/actions/browser/menuEntryActionViewItem": [
 			"{0} ({1})",
 			"{0} ({1})",
 			"{0}\n[{1}] {2}"
 		],
 		"vs/workbench/services/configuration/common/configurationEditing": [
+			"Error while writing to {0}. {1}",
 			"Open Tasks Configuration",
 			"Open Launch Configuration",
 			"Open Settings",
@@ -21284,6 +21491,15 @@
 			"Workspace Settings",
 			"Folder Settings"
 		],
+		"vs/editor/browser/coreCommands": [
+			"Stick to the end even when going to longer lines",
+			"Stick to the end even when going to longer lines",
+			"Removed secondary cursors"
+		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"The number of cursors has been limited to {0}. Consider using [find and replace](https://code.visualstudio.com/docs/editor/codebasics#_find-and-replace) for larger changes or increase the editor multi cursor limit setting.",
+			"Increase Multi Cursor Limit"
+		],
 		"vs/editor/common/core/editorColorRegistry": [
 			"Background color for the highlight of line at the cursor position.",
 			"Background color for the border around the line at the cursor position.",
@@ -21294,9 +21510,23 @@
 			"Color of the editor cursor.",
 			"The background color of the editor cursor. Allows customizing the color of a character overlapped by a block cursor.",
 			"Color of whitespace characters in the editor.",
-			"Color of the editor indentation guides.",
-			"Color of the active editor indentation guides.",
 			"Color of editor line numbers.",
+			"Color of the editor indentation guides.",
+			"'editorIndentGuide.background' is deprecated. Use 'editorIndentGuide.background1' instead.",
+			"Color of the active editor indentation guides.",
+			"'editorIndentGuide.activeBackground' is deprecated. Use 'editorIndentGuide.activeBackground1' instead.",
+			"Color of the editor indentation guides (1).",
+			"Color of the editor indentation guides (2).",
+			"Color of the editor indentation guides (3).",
+			"Color of the editor indentation guides (4).",
+			"Color of the editor indentation guides (5).",
+			"Color of the editor indentation guides (6).",
+			"Color of the active editor indentation guides (1).",
+			"Color of the active editor indentation guides (2).",
+			"Color of the active editor indentation guides (3).",
+			"Color of the active editor indentation guides (4).",
+			"Color of the active editor indentation guides (5).",
+			"Color of the active editor indentation guides (6).",
 			"Color of editor active line number",
 			"Id is deprecated. Use 'editorLineNumber.activeForeground' instead.",
 			"Color of editor active line number",
@@ -21339,22 +21569,6 @@
 			"Border color used to highlight unicode characters.",
 			"Background color used to highlight unicode characters."
 		],
-		"vs/platform/contextkey/common/scanner": [
-			"Did you mean {0}?",
-			"Did you mean {0} or {1}?",
-			"Did you mean {0}, {1} or {2}?",
-			"Did you forget to open or close the quote?",
-			"Did you forget to escape the '/' (slash) character? Put two backslashes before it to escape, e.g., '\\\\/'."
-		],
-		"vs/editor/browser/coreCommands": [
-			"Stick to the end even when going to longer lines",
-			"Stick to the end even when going to longer lines",
-			"Removed secondary cursors"
-		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"The number of cursors has been limited to {0}. Consider using [find and replace](https://code.visualstudio.com/docs/editor/codebasics#_find-and-replace) for larger changes or increase the editor multi cursor limit setting.",
-			"Increase Multi Cursor Limit"
-		],
 		"vs/editor/contrib/anchorSelect/browser/anchorSelect": [
 			"Selection Anchor",
 			"Anchor set at {0}:{1}",
@@ -21363,12 +21577,12 @@
 			"Select from Anchor to Cursor",
 			"Cancel Selection Anchor"
 		],
-		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
-			"Overview ruler marker color for matching brackets.",
-			"Go to Bracket",
-			"Select to Bracket",
-			"Remove Brackets",
-			"Go to &&Bracket"
+		"vs/platform/contextkey/common/scanner": [
+			"Did you mean {0}?",
+			"Did you mean {0} or {1}?",
+			"Did you mean {0}, {1} or {2}?",
+			"Did you forget to open or close the quote?",
+			"Did you forget to escape the '/' (slash) character? Put two backslashes before it to escape, e.g., '\\\\/'."
 		],
 		"vs/editor/browser/widget/diffEditorWidget": [
 			"Line decoration for inserts in the diff editor.",
@@ -21376,6 +21590,13 @@
 			" use Shift + F7 to navigate changes",
 			"Cannot compare files because one file is too large.",
 			"Click to revert change"
+		],
+		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
+			"Overview ruler marker color for matching brackets.",
+			"Go to Bracket",
+			"Select to Bracket",
+			"Remove Brackets",
+			"Go to &&Bracket"
 		],
 		"vs/editor/contrib/caretOperations/browser/caretOperations": [
 			"Move Selected Text Left",
@@ -21465,6 +21686,11 @@
 			"Replace",
 			"&&Replace"
 		],
+		"vs/editor/contrib/fontZoom/browser/fontZoom": [
+			"Editor Font Zoom In",
+			"Editor Font Zoom Out",
+			"Editor Font Zoom Reset"
+		],
 		"vs/editor/contrib/folding/browser/folding": [
 			"Unfold",
 			"Unfold Recursively",
@@ -21488,11 +21714,6 @@
 		"vs/editor/contrib/format/browser/formatActions": [
 			"Format Document",
 			"Format Selection"
-		],
-		"vs/editor/contrib/fontZoom/browser/fontZoom": [
-			"Editor Font Zoom In",
-			"Editor Font Zoom Out",
-			"Editor Font Zoom Reset"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/goToCommands": [
 			"Peek",
@@ -21535,6 +21756,9 @@
 			"No results for '{0}'",
 			"References"
 		],
+		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
+			"Click to show {0} definitions."
+		],
 		"vs/editor/contrib/gotoError/browser/gotoError": [
 			"Go to Next Problem (Error, Warning, Info)",
 			"Icon for goto next marker.",
@@ -21545,11 +21769,10 @@
 			"Go to Previous Problem in Files (Error, Warning, Info)",
 			"Previous &&Problem"
 		],
-		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
-			"Click to show {0} definitions."
-		],
 		"vs/editor/contrib/hover/browser/hover": [
 			"Show or Focus Hover",
+			"Inspect this in the accessible view with {0}",
+			"Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding",
 			"Show Definition Preview Hover",
 			"Scroll Up Hover",
 			"Scroll Down Hover",
@@ -21558,8 +21781,7 @@
 			"Page Up Hover",
 			"Page Down Hover",
 			"Go To Top Hover",
-			"Go To Bottom Hover",
-			"Escape Focus Hover"
+			"Go To Bottom Hover"
 		],
 		"vs/editor/contrib/indentation/browser/indentation": [
 			"Convert Indentation to Spaces",
@@ -21752,10 +21974,12 @@
 			"You are in a pane of a diff editor.",
 			"You are in a read-only code editor",
 			"You are in a code editor",
-			"To configure the editor to be optimized for usage with a Screen Reader press Command+E now.",
-			"To configure the editor to be optimized for usage with a Screen Reader press Control+E now.",
-			"The editor is configured to be optimized for usage with a Screen Reader.",
-			"The editor is configured to never be optimized for usage with a Screen Reader",
+			"To configure the application to be optimized for usage with a Screen Reader press Command+E now.",
+			"To configure the application to be optimized for usage with a Screen Reader press Control+E now.",
+			"The application is configured to be optimized for usage with a Screen Reader.",
+			"The application is configured to never be optimized for usage with a Screen Reader",
+			"Screen Reader Optimized Mode enabled.",
+			"Screen Reader Optimized Mode disabled.",
 			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
 			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
 			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
@@ -21843,20 +22067,6 @@
 			"'configuration.semanticTokenScopes.scopes' values must be an array of strings",
 			"configuration.semanticTokenScopes.scopes': Problems parsing selector {0}."
 		],
-		"vs/workbench/api/browser/statusBarExtensionPoint": [
-			"The identifier of the status bar entry. Must be unique within the extension. The same value must be used when calling the `vscode.window.createStatusBarItem(id, ...)`-API",
-			"The name of the entry, like 'Python Language Indicator', 'Git Status' etc. Try to keep the length of the name short, yet descriptive enough that users can understand what the status bar item is about.",
-			"The text to show for the entry. You can embed icons in the text by leveraging the `$(<name>)`-syntax, like 'Hello $(globe)!'",
-			"The tooltip text for the entry.",
-			"The command to execute when the status bar entry is clicked.",
-			"The alignment of the status bar entry.",
-			"The priority of the status bar entry. Higher value means the item should be shown more to the left.",
-			"Defines the role and aria label to be used when the status bar entry is focused.",
-			"The role of the status bar entry which defines how a screen reader interacts with it. More about aria roles can be found here https://w3c.github.io/aria/#widget_roles",
-			"The aria label of the status bar entry. Defaults to the entry's text.",
-			"Contributes items to the status bar.",
-			"Invalid status bar item contribution."
-		],
 		"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint": [
 			"Errors parsing {0}: {1}",
 			"{0}: Invalid format, JSON object expected.",
@@ -21922,6 +22132,20 @@
 			"Describes text to be appended after the new line and after the indentation.",
 			"Describes the number of characters to remove from the new line's indentation."
 		],
+		"vs/workbench/api/browser/statusBarExtensionPoint": [
+			"The identifier of the status bar entry. Must be unique within the extension. The same value must be used when calling the `vscode.window.createStatusBarItem(id, ...)`-API",
+			"The name of the entry, like 'Python Language Indicator', 'Git Status' etc. Try to keep the length of the name short, yet descriptive enough that users can understand what the status bar item is about.",
+			"The text to show for the entry. You can embed icons in the text by leveraging the `$(<name>)`-syntax, like 'Hello $(globe)!'",
+			"The tooltip text for the entry.",
+			"The command to execute when the status bar entry is clicked.",
+			"The alignment of the status bar entry.",
+			"The priority of the status bar entry. Higher value means the item should be shown more to the left.",
+			"Defines the role and aria label to be used when the status bar entry is focused.",
+			"The role of the status bar entry which defines how a screen reader interacts with it. More about aria roles can be found here https://w3c.github.io/aria/#widget_roles",
+			"The aria label of the status bar entry. Defaults to the entry's text.",
+			"Contributes items to the status bar.",
+			"Invalid status bar item contribution."
+		],
 		"vs/workbench/api/browser/mainThreadCLICommands": [
 			"Cannot install the '{0}' extension because it is declared to not run in this setup."
 		],
@@ -21960,15 +22184,15 @@
 			"Running 'File Write' participants...",
 			"Reset choice for 'File operation needs preview'"
 		],
-		"vs/workbench/api/browser/mainThreadProgress": [
-			"Manage Extension"
-		],
 		"vs/workbench/api/browser/mainThreadMessageService": [
 			"{0} (Extension)",
 			"Extension",
 			"Manage Extension",
 			"Cancel",
 			"&&OK"
+		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"Manage Extension"
 		],
 		"vs/workbench/api/browser/mainThreadSaveParticipant": [
 			"Aborted onWillSaveTextDocument-event after 1750ms"
@@ -21996,10 +22220,6 @@
 		"vs/workbench/api/browser/mainThreadTask": [
 			"{0}: {1}"
 		],
-		"vs/workbench/api/browser/mainThreadTunnelService": [
-			"The extension {0} has forwarded port {1}. You'll need to run as superuser to use port {2} locally.",
-			"Use Port {0} as Sudo..."
-		],
 		"vs/workbench/api/browser/mainThreadAuthentication": [
 			"This account has not been used by any extensions.",
 			"Cancel",
@@ -22015,60 +22235,9 @@
 			"The extension '{0}' wants to sign in using {1}.",
 			"&&Allow"
 		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
-			"Icon to toggle the auxiliary bar off in its right position.",
-			"Icon to toggle the auxiliary bar on in its right position.",
-			"Icon to toggle the auxiliary bar in its left position.",
-			"Icon to toggle the auxiliary bar on in its left position.",
-			"Toggle Secondary Side Bar Visibility",
-			"Secondary Side Bar",
-			"Secondary Si&&de Bar",
-			"Focus into Secondary Side Bar",
-			"Toggle Secondary Side Bar",
-			"Toggle Secondary Side Bar",
-			"Hide Secondary Side Bar"
-		],
-		"vs/workbench/browser/parts/panel/panelActions": [
-			"Icon to maximize a panel.",
-			"Icon to restore a panel.",
-			"Icon to close a panel.",
-			"Icon to toggle the panel off when it is on.",
-			"Icon to toggle the panel on when it is off.",
-			"Toggle Panel Visibility",
-			"Panel",
-			"&&Panel",
-			"Focus into Panel",
-			"Focus into Panel",
-			"Move Panel Left",
-			"Left",
-			"Move Panel Right",
-			"Right",
-			"Move Panel To Bottom",
-			"Bottom",
-			"Set Panel Alignment to Left",
-			"Left",
-			"Set Panel Alignment to Right",
-			"Right",
-			"Set Panel Alignment to Center",
-			"Center",
-			"Set Panel Alignment to Justify",
-			"Justify",
-			"Panel Position",
-			"Align Panel",
-			"Previous Panel View",
-			"Next Panel View",
-			"Toggle Maximized Panel",
-			"Maximize Panel Size",
-			"Restore Panel Size",
-			"Maximizing the panel is only supported when it is center aligned.",
-			"Close Panel",
-			"Close Secondary Side Bar",
-			"Toggle Panel",
-			"Hide Panel",
-			"Move Panel Views To Secondary Side Bar",
-			"Move Panel Views To Secondary Side Bar",
-			"Move Secondary Side Bar Views To Panel",
-			"Move Secondary Side Bar Views To Panel"
+		"vs/workbench/api/browser/mainThreadTunnelService": [
+			"The extension {0} has forwarded port {1}. You'll need to run as superuser to use port {2} locally.",
+			"Use Port {0} as Sudo..."
 		],
 		"vs/workbench/browser/quickaccess": [
 			"Whether keyboard focus is inside the quick open control"
@@ -22153,15 +22322,6 @@
 			"The relative path to a folder containing localization (bundle.l10n.*.json) files. Must be specified if you are using the vscode.l10n API.",
 			"API proposals that the respective extensions can freely use."
 		],
-		"vs/workbench/browser/parts/views/treeView": [
-			"There is no data provider registered that can provide view data.",
-			"Whether the the tree view with id {0} enables collapse all.",
-			"Whether the tree view with id {0} enables refresh.",
-			"Refresh",
-			"Collapse All",
-			"Whether collapse all is toggled for the tree view with id {0}.",
-			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
-		],
 		"vs/workbench/browser/parts/views/viewPaneContainer": [
 			"Views",
 			"Move View Up",
@@ -22225,6 +22385,70 @@
 			"Configured debug type '{0}' is installed but not supported in this environment.",
 			"Controls when the internal Debug Console should open."
 		],
+		"vs/workbench/browser/parts/views/treeView": [
+			"There is no data provider registered that can provide view data.",
+			"Whether the the tree view with id {0} enables collapse all.",
+			"Whether the tree view with id {0} enables refresh.",
+			"Refresh",
+			"Collapse All",
+			"Whether collapse all is toggled for the tree view with id {0}.",
+			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
+		],
+		"vs/workbench/contrib/remote/browser/remoteExplorer": [
+			"Ports",
+			"1 forwarded port",
+			"{0} forwarded ports",
+			"No Ports Forwarded",
+			"Forwarded Ports: {0}",
+			"Forwarded Ports",
+			"Your application running on port {0} is available.  ",
+			"[See all forwarded ports]({0})",
+			"You'll need to run as superuser to use port {0} locally.  ",
+			"Make Public",
+			"Use Port {0} as Sudo..."
+		],
+		"vs/workbench/browser/parts/panel/panelActions": [
+			"Icon to maximize a panel.",
+			"Icon to restore a panel.",
+			"Icon to close a panel.",
+			"Icon to toggle the panel off when it is on.",
+			"Icon to toggle the panel on when it is off.",
+			"Toggle Panel Visibility",
+			"Panel",
+			"&&Panel",
+			"Focus into Panel",
+			"Focus into Panel",
+			"Move Panel Left",
+			"Left",
+			"Move Panel Right",
+			"Right",
+			"Move Panel To Bottom",
+			"Bottom",
+			"Set Panel Alignment to Left",
+			"Left",
+			"Set Panel Alignment to Right",
+			"Right",
+			"Set Panel Alignment to Center",
+			"Center",
+			"Set Panel Alignment to Justify",
+			"Justify",
+			"Panel Position",
+			"Align Panel",
+			"Previous Panel View",
+			"Next Panel View",
+			"Toggle Maximized Panel",
+			"Maximize Panel Size",
+			"Restore Panel Size",
+			"Maximizing the panel is only supported when it is center aligned.",
+			"Close Panel",
+			"Close Secondary Side Bar",
+			"Toggle Panel",
+			"Hide Panel",
+			"Move Panel Views To Secondary Side Bar",
+			"Move Panel Views To Secondary Side Bar",
+			"Move Secondary Side Bar Views To Panel",
+			"Move Secondary Side Bar Views To Panel"
+		],
 		"vs/workbench/contrib/files/common/files": [
 			"True when the EXPLORER viewlet is visible.",
 			"True when the FOLDERS view (the file tree within the explorer view container) is visible.",
@@ -22241,19 +22465,6 @@
 			"True when the focus is inside a compact item's last part in the EXPLORER view.",
 			"True when a workspace in the EXPLORER view has some collapsible root child."
 		],
-		"vs/workbench/contrib/remote/browser/remoteExplorer": [
-			"Ports",
-			"1 forwarded port",
-			"{0} forwarded ports",
-			"No Ports Forwarded",
-			"Forwarded Ports: {0}",
-			"Forwarded Ports",
-			"Your application running on port {0} is available.  ",
-			"[See all forwarded ports]({0})",
-			"You'll need to run as superuser to use port {0} locally.  ",
-			"Make Public",
-			"Use Port {0} as Sudo..."
-		],
 		"vs/workbench/common/editor/sideBySideEditorInput": [
 			"{0} - {1}"
 		],
@@ -22262,6 +22473,19 @@
 		],
 		"vs/workbench/common/editor/diffEditorInput": [
 			"{0} ↔ {1}"
+		],
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
+			"Icon to toggle the auxiliary bar off in its right position.",
+			"Icon to toggle the auxiliary bar on in its right position.",
+			"Icon to toggle the auxiliary bar in its left position.",
+			"Icon to toggle the auxiliary bar on in its left position.",
+			"Toggle Secondary Side Bar Visibility",
+			"Secondary Side Bar",
+			"Secondary Si&&de Bar",
+			"Focus into Secondary Side Bar",
+			"Toggle Secondary Side Bar",
+			"Toggle Secondary Side Bar",
+			"Hide Secondary Side Bar"
 		],
 		"vs/workbench/browser/parts/editor/textDiffEditor": [
 			"Text Diff Editor",
@@ -22451,14 +22675,6 @@
 			"Toggle Editor Type",
 			"Reopen Editor With Text Editor"
 		],
-		"vs/editor/browser/editorExtensions": [
-			"&&Undo",
-			"Undo",
-			"&&Redo",
-			"Redo",
-			"&&Select All",
-			"Select All"
-		],
 		"vs/workbench/browser/parts/editor/editorCommands": [
 			"Move the active editor by tabs or groups",
 			"Active editor move argument",
@@ -22479,13 +22695,13 @@
 			"Lock Editor Group",
 			"Unlock Editor Group"
 		],
-		"vs/workbench/browser/parts/editor/editorConfiguration": [
-			"Interactive Window",
-			"Markdown Preview",
-			"If an editor matching one of the listed types is opened as the first in an editor group and more than one group is open, the group is automatically locked. Locked groups will only be used for opening editors when explicitly chosen by a user gesture (for example drag and drop), but not by default. Consequently, the active editor in a locked group is less likely to be replaced accidentally with a different editor.",
-			"The default editor for files detected as binary. If undefined, the user will be presented with a picker.",
-			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
-			"Controls the minimum size of a file in MB before asking for confirmation when opening in the editor. Note that this setting may not apply to all editor types and environments."
+		"vs/editor/browser/editorExtensions": [
+			"&&Undo",
+			"Undo",
+			"&&Redo",
+			"Redo",
+			"&&Select All",
+			"Select All"
 		],
 		"vs/workbench/browser/parts/editor/editorQuickAccess": [
 			"No matching editors",
@@ -22494,30 +22710,20 @@
 			"{0}, unsaved changes",
 			"Close Editor"
 		],
+		"vs/workbench/browser/parts/editor/editorConfiguration": [
+			"Interactive Window",
+			"Markdown Preview",
+			"If an editor matching one of the listed types is opened as the first in an editor group and more than one group is open, the group is automatically locked. Locked groups will only be used for opening editors when explicitly chosen by a user gesture (for example drag and drop), but not by default. Consequently, the active editor in a locked group is less likely to be replaced accidentally with a different editor.",
+			"The default editor for files detected as binary. If undefined, the user will be presented with a picker.",
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
+			"Controls the minimum size of a file in MB before asking for confirmation when opening in the editor. Note that this setting may not apply to all editor types and environments."
+		],
 		"vs/workbench/browser/parts/editor/accessibilityStatus": [
 			"Are you using a screen reader to operate VS Code?",
 			"Yes",
 			"No",
 			"Screen Reader Optimized",
 			"Screen Reader Mode"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
-			"Toggle Collapse Unchanged Regions",
-			"Show Unchanged Regions",
-			"Collapse Unchanged Regions",
-			"Toggle Show Moved Code Blocks",
-			"Show Moves"
-		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"Empty editor group actions",
-			"{0} (empty)",
-			"Group {0}",
-			"Editor Group {0}"
-		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
-			"Move Secondary Side Bar Left",
-			"Move Secondary Side Bar Right",
-			"Hide Secondary Side Bar"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
 			"Settings icon in the view bar.",
@@ -22533,6 +22739,19 @@
 			"Accounts",
 			"Accounts"
 		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
+			"Toggle Collapse Unchanged Regions",
+			"Show Unchanged Regions",
+			"Collapse Unchanged Regions",
+			"Toggle Show Moved Code Blocks",
+			"Diff Editor",
+			"Switch Side"
+		],
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
+			"Move Secondary Side Bar Left",
+			"Move Secondary Side Bar Right",
+			"Hide Secondary Side Bar"
+		],
 		"vs/workbench/browser/parts/panel/panelPart": [
 			"Reset Location",
 			"Reset Location",
@@ -22541,6 +22760,12 @@
 			"Panel Position",
 			"Align Panel",
 			"Hide Panel"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"Empty editor group actions",
+			"{0} (empty)",
+			"Group {0}",
+			"Editor Group {0}"
 		],
 		"vs/workbench/browser/parts/editor/editorDropTarget": [
 			"Hold __{0}__ to drop into editor"
@@ -22656,6 +22881,21 @@
 			"Problems parsing file icons file: {0}",
 			"Invalid format for file icons theme file: Object expected."
 		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"Colors and styles for the token.",
+			"Foreground color for the token.",
+			"Token background colors are currently not supported.",
+			"Font style of the rule: 'italic', 'bold', 'underline', 'strikethrough' or a combination. The empty string unsets inherited settings.",
+			"Font style must be 'italic', 'bold', 'underline', 'strikethrough' or a combination or the empty string.",
+			"None (clear inherited style)",
+			"Description of the rule.",
+			"Scope selector against which this rule matches.",
+			"Colors in the workbench",
+			"Path to a tmTheme file (relative to the current file).",
+			"Colors for syntax highlighting",
+			"Whether semantic highlighting should be enabled for this theme.",
+			"Colors for semantic tokens"
+		],
 		"vs/workbench/services/themes/common/themeExtensionPoints": [
 			"Contributes textmate color themes.",
 			"Id of the color theme as used in the user settings.",
@@ -22674,21 +22914,6 @@
 			"Expected string in `contributes.{0}.path`. Provided value: {1}",
 			"Expected string in `contributes.{0}.id`. Provided value: {1}",
 			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
-		],
-		"vs/workbench/services/themes/common/colorThemeSchema": [
-			"Colors and styles for the token.",
-			"Foreground color for the token.",
-			"Token background colors are currently not supported.",
-			"Font style of the rule: 'italic', 'bold', 'underline', 'strikethrough' or a combination. The empty string unsets inherited settings.",
-			"Font style must be 'italic', 'bold', 'underline', 'strikethrough' or a combination or the empty string.",
-			"None (clear inherited style)",
-			"Description of the rule.",
-			"Scope selector against which this rule matches.",
-			"Colors in the workbench",
-			"Path to a tmTheme file (relative to the current file).",
-			"Colors for syntax highlighting",
-			"Whether semantic highlighting should be enabled for this theme.",
-			"Colors for semantic tokens"
 		],
 		"vs/workbench/services/themes/common/themeConfiguration": [
 			"Specifies the color theme used in the workbench.",
@@ -22784,7 +23009,8 @@
 			"Keyboard Shortcuts"
 		],
 		"vs/workbench/services/userDataProfile/browser/snippetsResource": [
-			"Snippets"
+			"Snippets",
+			"Select Snippet {0}"
 		],
 		"vs/workbench/services/userDataProfile/browser/tasksResource": [
 			"User Tasks"
@@ -22792,6 +23018,7 @@
 		"vs/workbench/services/userDataProfile/browser/extensionsResource": [
 			"Extensions",
 			"Disabled",
+			"Select {0} Extension",
 			"Select {0} Extension"
 		],
 		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
@@ -22819,12 +23046,6 @@
 			"Invalid value in `contributes.{0}.tokenTypes`. Must be an object map from scope name to token type. Provided value: {1}",
 			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
 		],
-		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
-			"Press desired key combination and then press ENTER.",
-			"1 existing command has this keybinding",
-			"{0} existing commands have this keybinding",
-			"chord to"
-		],
 		"vs/editor/contrib/suggest/browser/suggest": [
 			"Whether any suggestion is focused",
 			"Whether suggestion details are visible",
@@ -22834,11 +23055,6 @@
 			"Whether the current suggestion has insert and replace behaviour",
 			"Whether the default behaviour is to insert or replace",
 			"Whether the current suggestion supports to resolve further details"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"Configure Language Specific Settings...",
-			"({0})",
-			"Select Language"
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"Record Keys",
@@ -22875,6 +23091,11 @@
 			"No when context",
 			"use space or enter to change the keybinding."
 		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"Configure Language Specific Settings...",
+			"({0})",
+			"Select Language"
+		],
 		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
 			"Icon for the folder dropdown button in the split JSON Settings editor.",
 			"Icon for the 'more actions' action in the Settings UI.",
@@ -22910,9 +23131,6 @@
 			"Turn on Settings Sync",
 			"Last synced: {0}"
 		],
-		"vs/workbench/contrib/performance/browser/perfviewEditor": [
-			"Startup Performance"
-		],
 		"vs/workbench/contrib/notebook/browser/notebookEditor": [
 			"Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed and enabled.",
 			"Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed and enabled.",
@@ -22933,13 +23151,13 @@
 		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
 			"Executing a notebook cell will run code from this workspace."
 		],
+		"vs/editor/common/languages/modesRegistry": [
+			"Plain Text"
+		],
 		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
 			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
 			"Yes",
 			"No"
-		],
-		"vs/editor/common/languages/modesRegistry": [
-			"Plain Text"
 		],
 		"vs/workbench/contrib/comments/browser/commentReply": [
 			"Reply...",
@@ -22958,19 +23176,17 @@
 			"Provide information about how to access the terminal accessibility help menu when the terminal is focused",
 			"Provide information about how to navigate changes in the diff editor when it is focused",
 			"Provide information about how to access the chat help menu when the chat input is focused",
-			"Provide information about how to access the inline editor chat accessibility help menu when the input is focused",
+			"Provide information about how to access the inline editor chat accessibility help menu and alert with hints which describe how to use the feature when the input is focused",
 			"Provide information about how to change a keybinding in the keybindings editor when a row is focused",
 			"Provide information about how to focus the cell container or inner editor when a notebook cell is focused.",
+			"Provide information about how to open the hover in an accessible view.",
+			"Provide information about how to open the notification in an accessible view.",
 			"Open Accessibility Help",
-			"Open Accessible View"
+			"Open Accessible View",
+			"Show Next in Accessible View",
+			"Show Previous in Accessible View"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
-			"Notebook",
-			"Insert Cell",
-			"Notebook Cell",
-			"Share"
-		],
-		"vs/workbench/contrib/notebook/browser/notebookAccessibilityHelp": [
+		"vs/workbench/contrib/notebook/browser/notebookAccessibility": [
 			"The notebook view is a collection of code and markdown cells. Code cells can be executed and will produce output directly below the cell.",
 			"The Edit Cell command ({0}) will focus on the cell input.",
 			"The Edit Cell command will focus on the cell input and is currently not triggerable by a keybinding.",
@@ -22982,7 +23198,26 @@
 			"The Execute Cell command ({0}) executes the cell that currently has focus.",
 			"The Execute Cell command executes the cell that currently has focus and is currently not triggerable by a keybinding.",
 			"The Insert Cell Above/Below commands will create new empty code cells",
-			"The Change Cell to Code/Markdown commands are used to switch between cell types."
+			"The Change Cell to Code/Markdown commands are used to switch between cell types.",
+			"Notebook Cell Output Accessible View"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibleView": [
+			"\nPress H now to open a browser window with more information related to accessibility.\n",
+			"\nTo disable the `accessibility.verbosity` hint for this feature, press D now.\n",
+			"Exit this dialog via the Escape key.",
+			"{0} {1}",
+			"{0}",
+			"{0} accessibility verbosity is now disabled",
+			"Show the next {0} or previous {1} item in the accessible view",
+			"Show the next or previous item in the accessible view by configuring keybindings for Show Next / Previous in Accessible View",
+			"Inspect this in the accessible view with {0}",
+			"Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
+			"Notebook",
+			"Insert Cell",
+			"Notebook Cell",
+			"Share"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/insertCellActions": [
 			"Insert Code Cell Above",
@@ -23033,45 +23268,6 @@
 			"Go to Most Recently Failed Cell",
 			"Go To"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/editActions": [
-			"Edit Cell",
-			"Stop Editing Cell",
-			"Delete Cell",
-			"Delete",
-			"This cell is running, are you sure you want to delete it?",
-			"Do not ask me again",
-			"Clear Cell Outputs",
-			"Clear All Outputs",
-			"Change Cell Language",
-			"Change Cell Language",
-			"({0}) - Current Language",
-			"({0})",
-			"Auto Detect",
-			"languages (identifier)",
-			"Select Language Mode",
-			"Accept Detected Language for Cell",
-			"Unable to detect cell language"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
-			"Select between Notebook Layouts",
-			"Customize Notebook Layout",
-			"Customize Notebook Layout",
-			"Customize Notebook...",
-			"Toggle Notebook Line Numbers",
-			"Notebook Line Numbers",
-			"Toggle Cell Toolbar Position",
-			"Toggle Breadcrumbs",
-			"Save Mimetype Display Order",
-			"Settings file to save in",
-			"User Settings",
-			"Workspace Settings",
-			"Reset Notebook Webview"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
-			"Fold Cell",
-			"Unfold Cell",
-			"Fold Cell"
-		],
 		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
 			"Copy Cell",
 			"Cut Cell",
@@ -23089,6 +23285,24 @@
 			"Format Cell",
 			"Format Cells"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
+			"Select between Notebook Layouts",
+			"Customize Notebook Layout",
+			"Customize Notebook Layout",
+			"Customize Notebook...",
+			"Toggle Notebook Line Numbers",
+			"Notebook Line Numbers",
+			"Toggle Cell Toolbar Position",
+			"Toggle Breadcrumbs",
+			"Save Mimetype Display Order",
+			"Settings file to save in",
+			"User Settings",
+			"Workspace Settings",
+			"Reset Notebook Webview"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
+			"Reset notebook getting started"
+		],
 		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
 			"Formatting",
 			"Format Notebook",
@@ -23100,27 +23314,9 @@
 		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
 			"Toggle Cell Toolbar Position"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
-			"Focus Next Cell Editor",
-			"Focus Previous Cell Editor",
-			"Focus First Cell",
-			"Focus Last Cell",
-			"Focus In Active Cell Output",
-			"Focus Out Active Cell Output",
-			"Center Active Cell",
-			"Cell Cursor Page Up",
-			"Cell Cursor Page Up Select",
-			"Cell Cursor Page Down",
-			"Cell Cursor Page Down Select",
-			"When enabled cursor can navigate to the next/previous cell when the current cursor in the cell editor is at the first/last line."
-		],
 		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
-			"empty cell",
 			"When enabled notebook outline shows code cells.",
 			"When enabled notebook breadcrumbs contain code cells."
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
-			"Reset notebook getting started"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
 			"Set Profile"
@@ -23136,6 +23332,11 @@
 			"Executing",
 			"Use the links above to file an issue using the issue reporter.",
 			"**Last Execution** {0}\n\n**Execution Time** {1}\n\n**Overhead Time** {2}\n\n**Render Times**\n\n{3}"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
+			"Fold Cell",
+			"Unfold Cell",
+			"Fold Cell"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar": [
 			"Notebook Kernel Info",
@@ -23170,6 +23371,20 @@
 			"Expand All Cell Outputs",
 			"Toggle Scroll Cell Output"
 		],
+		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
+			"Focus Next Cell Editor",
+			"Focus Previous Cell Editor",
+			"Focus First Cell",
+			"Focus Last Cell",
+			"Focus In Active Cell Output",
+			"Focus Out Active Cell Output",
+			"Center Active Cell",
+			"Cell Cursor Page Up",
+			"Cell Cursor Page Up Select",
+			"Cell Cursor Page Down",
+			"Cell Cursor Page Down Select",
+			"When enabled cursor can navigate to the next/previous cell when the current cursor in the cell editor is at the first/last line."
+		],
 		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
 			"Toggle Layout Troubleshoot",
 			"Inspect Notebook Layout",
@@ -23199,6 +23414,25 @@
 			"Delete",
 			"Select a chat session to restore"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/editActions": [
+			"Edit Cell",
+			"Stop Editing Cell",
+			"Delete Cell",
+			"Delete",
+			"This cell is running, are you sure you want to delete it?",
+			"Do not ask me again",
+			"Clear Cell Outputs",
+			"Clear All Outputs",
+			"Change Cell Language",
+			"Change Cell Language",
+			"({0}) - Current Language",
+			"({0})",
+			"Auto Detect",
+			"languages (identifier)",
+			"Select Language Mode",
+			"Accept Detected Language for Cell",
+			"Unable to detect cell language"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
 			"Copy",
 			"Insert at Cursor",
@@ -23214,10 +23448,6 @@
 		"vs/workbench/contrib/chat/browser/actions/chatExecuteActions": [
 			"Submit",
 			"Cancel"
-		],
-		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
-			"Ask Quick Question",
-			"Ask {0} a question..."
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
 			"Helpful",
@@ -23257,11 +23487,6 @@
 			"Clear",
 			"Clear"
 		],
-		"vs/workbench/contrib/accessibility/browser/accessibleView": [
-			"\nPress H now to open a browser window with more information related to accessibility.\n",
-			"\nTo disable the `accessibility.verbosity` hint for this feature, press D now.\n",
-			"Exit this menu via the Escape key."
-		],
 		"vs/workbench/contrib/chat/common/chatViewModel": [
 			"Thinking"
 		],
@@ -23276,13 +23501,13 @@
 			"True when focus is in the chat widget, false otherwise.",
 			"True when some chat provider has been registered."
 		],
-		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
-			"Ask a question or type '/' for topics",
-			"Ask a question"
-		],
 		"vs/workbench/contrib/chat/common/chatColors": [
 			"The background color of a chat request.",
 			"The border color of a chat request."
+		],
+		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
+			"Ask a question or type '/' for topics",
+			"Ask a question"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
 			"AI-generated code may be incorrect",
@@ -23318,8 +23543,10 @@
 			"Discard to New File",
 			"Helpful",
 			"Unhelpful",
-			"Toggle Diff",
-			"Show Inline Diff",
+			"Show Diff",
+			"&&Show Diff",
+			"Show Diff",
+			"&&Show Diff",
 			"Accept Changes",
 			"Accept",
 			"Cancel",
@@ -23333,14 +23560,16 @@
 			"Whether a provider for interactive editors exists",
 			"Whether the interactive editor input is visible",
 			"Whether the interactive editor input is focused",
+			"Whether the interactive widget's response is focused",
 			"Whether the interactive editor input is empty",
 			"Whether the cursor of the iteractive editor input is on the first line",
 			"Whether the cursor of the iteractive editor input is on the last line",
+			"Whether the cursor of the iteractive editor input is on the start of the input",
+			"Whether the cursor of the iteractive editor input is on the end of the input",
 			"Whether the interactive editor message is cropped, not cropped or expanded",
 			"Whether the cursor of the outer editor is above or below the interactive editor input",
 			"Whether interactive editor has an active request",
 			"Whether interactive editor has kept a session for quick restore",
-			"Whether interactive editor show diffs for changes",
 			"What type was the last response of the current interactive editor session",
 			"What type was the responses have been receieved",
 			"Whether interactive editor did change any code",
@@ -23360,7 +23589,8 @@
 			"Configure if changes crafted in the interactive editor are applied directly to the document or are previewed first.",
 			"Changes are applied directly to the document and are highlighted visually via inline or side-by-side diffs. Ending a session will keep the changes.",
 			"Changes are previewed only and need to be accepted via the apply button. Ending a session will discard the changes.",
-			"Changes are applied directly to the document but can be highlighted via inline diffs. Ending a session will keep the changes."
+			"Changes are applied directly to the document but can be highlighted via inline diffs. Ending a session will keep the changes.",
+			"Enable/disable showing the diff when edits are generated. Works only with inlineChat.mode equal to live or livePreview."
 		],
 		"vs/editor/contrib/peekView/browser/peekView": [
 			"Whether the current code editor is embedded inside peek",
@@ -23472,6 +23702,13 @@
 			"{0}, outdated result",
 			"Test Explorer"
 		],
+		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
+			"Running tests...",
+			"Running tests, {0}/{1} passed ({2}%)",
+			"Running tests, {0}/{1} tests passed ({2}%, {3} skipped)",
+			"{0}/{1} tests passed ({2}%)",
+			"{0}/{1} tests passed ({2}%, {3} skipped)"
+		],
 		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
 			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled.",
 			"Test Output",
@@ -23488,7 +23725,7 @@
 			"Show Result Output",
 			"Rerun Test Run",
 			"Debug Test Run",
-			"Go to File",
+			"Go to Source",
 			"Reveal in Test Explorer",
 			"Run Test",
 			"Debug Test",
@@ -23498,12 +23735,32 @@
 			"Open in Editor",
 			"Toggle Test History in Peek"
 		],
-		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
-			"Running tests...",
-			"Running tests, {0}/{1} passed ({2}%)",
-			"Running tests, {0}/{1} tests passed ({2}%, {3} skipped)",
-			"{0}/{1} tests passed ({2}%)",
-			"{0}/{1} tests passed ({2}%, {3} skipped)"
+		"vs/workbench/contrib/testing/common/configuration": [
+			"Testing",
+			"How long to wait, in milliseconds, after a test is marked as outdated and starting a new run.",
+			"Configures when the error Peek view is automatically opened.",
+			"Open automatically no matter where the failure is.",
+			"Open automatically when a test fails in a visible document.",
+			"Never automatically open.",
+			"Controls whether to show messages from all test runs.",
+			"Controls whether to automatically open the Peek view during continuous run mode.",
+			"Controls the count badge on the Testing icon on the Activity Bar.",
+			"Show the number of failed tests",
+			"Disable the testing count badge",
+			"Show the number of passed tests",
+			"Show the number of skipped tests",
+			"Controls whether the running test should be followed in the Test Explorer view.",
+			"Controls the action to take when left-clicking on a test decoration in the gutter.",
+			"Run the test.",
+			"Debug the test.",
+			"Open the context menu for more options.",
+			"Controls whether test decorations are shown in the editor gutter.",
+			"Control whether save all dirty editors before running a test.",
+			"Never automatically open the testing view",
+			"Open the testing view when tests start",
+			"Open the testing view on any test failure",
+			"Controls when the testing view should open.",
+			"Always reveal the executed test when `#testing.followRunningTest#` is on. If this setting is turned off, only failed tests will be revealed."
 		],
 		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
 			"Testing"
@@ -23534,6 +23791,10 @@
 			"ID of the current test item, set when creating or opening menus on test items",
 			"Boolean indicating whether the test item has a URI defined",
 			"Boolean indicating whether the test item is hidden"
+		],
+		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
+			"Pick a test profile to use",
+			"Update Test Configuration"
 		],
 		"vs/workbench/contrib/testing/browser/testExplorerActions": [
 			"Hide Test",
@@ -23587,37 +23848,6 @@
 			"Refresh Tests",
 			"Cancel Test Refresh"
 		],
-		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
-			"Pick a test profile to use",
-			"Update Test Configuration"
-		],
-		"vs/workbench/contrib/testing/common/configuration": [
-			"Testing",
-			"How long to wait, in milliseconds, after a test is marked as outdated and starting a new run.",
-			"Configures when the error Peek view is automatically opened.",
-			"Open automatically no matter where the failure is.",
-			"Open automatically when a test fails in a visible document.",
-			"Never automatically open.",
-			"Controls whether to show messages from all test runs.",
-			"Controls whether to automatically open the Peek view during continuous run mode.",
-			"Controls the count badge on the Testing icon on the Activity Bar.",
-			"Show the number of failed tests",
-			"Disable the testing count badge",
-			"Show the number of passed tests",
-			"Show the number of skipped tests",
-			"Controls whether the running test should be followed in the Test Explorer view.",
-			"Controls the action to take when left-clicking on a test decoration in the gutter.",
-			"Run the test.",
-			"Debug the test.",
-			"Open the context menu for more options.",
-			"Controls whether test decorations are shown in the editor gutter.",
-			"Control whether save all dirty editors before running a test.",
-			"Never automatically open the testing view",
-			"Open the testing view when tests start",
-			"Open the testing view on any test failure",
-			"Controls when the testing view should open.",
-			"Always reveal the executed test when `#testing.followRunningTest#` is on. If this setting is turned off, only failed tests will be revealed."
-		],
 		"vs/workbench/contrib/logs/common/logsActions": [
 			"Set Log Level...",
 			"All",
@@ -23639,8 +23869,30 @@
 			"Select Session",
 			"Select Log file"
 		],
-		"vs/platform/quickinput/browser/helpQuickAccess": [
-			"{0}, {1}"
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"Press desired key combination and then press ENTER.",
+			"1 existing command has this keybinding",
+			"{0} existing commands have this keybinding",
+			"chord to"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerView": [
+			"Explorer Section: {0}",
+			"New File...",
+			"New Folder...",
+			"Refresh Explorer",
+			"Collapse Folders in Explorer"
+		],
+		"vs/workbench/contrib/files/browser/views/openEditorsView": [
+			"Open Editors",
+			"{0} unsaved",
+			"Open Editors",
+			"Toggle Vertical/Horizontal Editor Layout",
+			"Flip Layout",
+			"Flip &&Layout",
+			"New Untitled Text File"
+		],
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"No Folder Opened"
 		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"No matching views",
@@ -23654,6 +23906,9 @@
 			"Open View",
 			"Quick Open View"
 		],
+		"vs/platform/quickinput/browser/helpQuickAccess": [
+			"{0}, {1}"
+		],
 		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
 			"No matching commands",
 			"Configure Keybinding",
@@ -23665,25 +23920,6 @@
 			"Do you want to clear the history of recently used commands?",
 			"This action is irreversible!",
 			"&&Clear"
-		],
-		"vs/workbench/contrib/files/browser/views/explorerView": [
-			"Explorer Section: {0}",
-			"New File...",
-			"New Folder...",
-			"Refresh Explorer",
-			"Collapse Folders in Explorer"
-		],
-		"vs/workbench/contrib/files/browser/views/emptyView": [
-			"No Folder Opened"
-		],
-		"vs/workbench/contrib/files/browser/views/openEditorsView": [
-			"Open Editors",
-			"{0} unsaved",
-			"Open Editors",
-			"Toggle Vertical/Horizontal Editor Layout",
-			"Flip Layout",
-			"Flip &&Layout",
-			"New Untitled Text File"
 		],
 		"vs/workbench/contrib/files/browser/fileActions": [
 			"New File...",
@@ -23851,6 +24087,10 @@
 			"Controls whether the diff editor uses the new or the old implementation.",
 			"Controls whether the diff editor shows empty decorations to see where characters got inserted or deleted."
 		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"1 unsaved file",
+			"{0} unsaved files"
+		],
 		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
 			"Text File Editor",
 			"Open Folder",
@@ -23861,31 +24101,12 @@
 			"The editor could not be opened because the file was not found.",
 			"Create File"
 		],
-		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
-			"1 unsaved file",
-			"{0} unsaved files"
-		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
-			"Other"
-		],
 		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
 			"Open a text editor first to go to a line.",
 			"Go to line {0} and character {1}.",
 			"Go to line {0}.",
 			"Current Line: {0}, Character: {1}. Type a line number between 1 and {2} to navigate to.",
 			"Current Line: {0}, Character: {1}. Type a line number to navigate to."
-		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
-			"Apply",
-			"Discard",
-			"Invoke a code action, like rename, to see a preview of its changes here.",
-			"Cannot apply refactoring because '{0}' has changed in the meantime.",
-			"Cannot apply refactoring because {0} other files have changed in the meantime.",
-			"{0} (delete, refactor preview)",
-			"rename",
-			"create",
-			"{0} ({1}, refactor preview)",
-			"{0} (refactor preview)"
 		],
 		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
 			"No matching entries",
@@ -23924,6 +24145,11 @@
 			"View icon of the search view.",
 			"Icon for the action to open a new search editor."
 		],
+		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
+			"No matching workspace symbols",
+			"Open to the Side",
+			"Open to the Bottom"
+		],
 		"vs/workbench/contrib/search/browser/searchWidget": [
 			"Replace All (Submit Search to Enable)",
 			"Replace All",
@@ -23933,11 +24159,6 @@
 			"Toggle Context Lines",
 			"Replace: Type replace term and press Enter to preview",
 			"Replace"
-		],
-		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
-			"No matching workspace symbols",
-			"Open to the Side",
-			"Open to the Bottom"
 		],
 		"vs/workbench/contrib/search/browser/searchActionsCopy": [
 			"Copy",
@@ -23995,6 +24216,21 @@
 			"View as Tree",
 			"View as List"
 		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
+			"Apply",
+			"Discard",
+			"Invoke a code action, like rename, to see a preview of its changes here.",
+			"Cannot apply refactoring because '{0}' has changed in the meantime.",
+			"Cannot apply refactoring because {0} other files have changed in the meantime.",
+			"{0} (delete, refactor preview)",
+			"rename",
+			"create",
+			"{0} ({1}, refactor preview)",
+			"{0} (refactor preview)"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
+			"Other"
+		],
 		"vs/workbench/contrib/search/browser/searchActionsBase": [
 			"Search"
 		],
@@ -24019,14 +24255,14 @@
 			"Icon for a collapsed view pane container.",
 			"{0} actions"
 		],
-		"vs/workbench/contrib/search/browser/searchMessage": [
-			"Unable to open command link from untrusted source: {0}",
-			"Unable to open unknown link: {0}"
-		],
 		"vs/workbench/contrib/search/browser/patternInputWidget": [
 			"input",
 			"Search only in Open Editors",
 			"Use Exclude Settings and Ignore Files"
+		],
+		"vs/workbench/contrib/search/browser/searchMessage": [
+			"Unable to open command link from untrusted source: {0}",
+			"Unable to open unknown link: {0}"
 		],
 		"vs/workbench/contrib/search/browser/searchResultsView": [
 			"Other files",
@@ -24076,6 +24312,13 @@
 		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
 			"Source Control"
 		],
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"Source Control Repositories"
+		],
+		"vs/workbench/contrib/workspace/common/workspace": [
+			"Whether the workspace trust feature is enabled.",
+			"Whether the current workspace has been trusted by the user."
+		],
 		"vs/workbench/contrib/scm/browser/scmViewPane": [
 			"Source Control Management",
 			"Source Control Input",
@@ -24094,12 +24337,38 @@
 			"Close",
 			"SCM Provider separator border."
 		],
-		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
-			"Source Control Repositories"
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			"Running",
+			"Show More Stack Frames",
+			"Session",
+			"Running",
+			"Restart Frame",
+			"Load More Stack Frames",
+			"Show {0} More: {1}",
+			"Show {0} More Stack Frames",
+			"Paused on {0}",
+			"Paused",
+			"Debug Call Stack",
+			"Thread {0} {1}",
+			"Stack Frame {0}, line {1}, {2}",
+			"Running",
+			"Session {0} {1}",
+			"Show {0} More Stack Frames",
+			"Collapse All"
 		],
-		"vs/workbench/contrib/workspace/common/workspace": [
-			"Whether the workspace trust feature is enabled.",
-			"Whether the current workspace has been trusted by the user."
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"Debug toolbar background color.",
+			"Debug toolbar border color.",
+			"Debug toolbar icon for start debugging.",
+			"Debug toolbar icon for pause.",
+			"Debug toolbar icon for stop.",
+			"Debug toolbar icon for disconnect.",
+			"Debug toolbar icon for restart.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for step into.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for continue.",
+			"Debug toolbar icon for step back."
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"Unverified Exception Breakpoint",
@@ -24154,72 +24423,6 @@
 			"Edit Hit Count...",
 			"Edit Function Breakpoint...",
 			"Edit Hit Count..."
-		],
-		"vs/workbench/contrib/debug/browser/debugColors": [
-			"Debug toolbar background color.",
-			"Debug toolbar border color.",
-			"Debug toolbar icon for start debugging.",
-			"Debug toolbar icon for pause.",
-			"Debug toolbar icon for stop.",
-			"Debug toolbar icon for disconnect.",
-			"Debug toolbar icon for restart.",
-			"Debug toolbar icon for step over.",
-			"Debug toolbar icon for step into.",
-			"Debug toolbar icon for step over.",
-			"Debug toolbar icon for continue.",
-			"Debug toolbar icon for step back."
-		],
-		"vs/workbench/contrib/debug/browser/callStackView": [
-			"Running",
-			"Show More Stack Frames",
-			"Session",
-			"Running",
-			"Restart Frame",
-			"Load More Stack Frames",
-			"Show {0} More: {1}",
-			"Show {0} More Stack Frames",
-			"Paused on {0}",
-			"Paused",
-			"Debug Call Stack",
-			"Thread {0} {1}",
-			"Stack Frame {0}, line {1}, {2}",
-			"Running",
-			"Session {0} {1}",
-			"Show {0} More Stack Frames",
-			"Collapse All"
-		],
-		"vs/workbench/contrib/debug/browser/debugCommands": [
-			"Debug",
-			"Restart",
-			"Step Over",
-			"Step Into",
-			"Step Into Target",
-			"Step Out",
-			"Pause",
-			"Disconnect",
-			"Disconnect and Suspend",
-			"Stop",
-			"Continue",
-			"Focus Session",
-			"Select and Start Debugging",
-			"Open '{0}'",
-			"Start Debugging",
-			"Start Without Debugging",
-			"Focus Next Debug Console",
-			"Focus Previous Debug Console",
-			"Open Loaded Script...",
-			"Navigate to Top of Call Stack",
-			"Navigate to Bottom of Call Stack",
-			"Navigate Up Call Stack",
-			"Navigate Down Call Stack",
-			"Select Debug Console",
-			"Select Debug Session",
-			"Choose the specific location",
-			"No executable code is associated at the current cursor position.",
-			"Jump to Cursor",
-			"No step targets available",
-			"Add Configuration...",
-			"Add Inline Breakpoint"
 		],
 		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
 			"Start a New Debug Session"
@@ -24314,6 +24517,39 @@
 			"Add Config ({0})...",
 			"Add Configuration..."
 		],
+		"vs/workbench/contrib/debug/browser/debugCommands": [
+			"Debug",
+			"Restart",
+			"Step Over",
+			"Step Into",
+			"Step Into Target",
+			"Step Out",
+			"Pause",
+			"Disconnect",
+			"Disconnect and Suspend",
+			"Stop",
+			"Continue",
+			"Focus Session",
+			"Select and Start Debugging",
+			"Open '{0}'",
+			"Start Debugging",
+			"Start Without Debugging",
+			"Focus Next Debug Console",
+			"Focus Previous Debug Console",
+			"Open Loaded Script...",
+			"Navigate to Top of Call Stack",
+			"Navigate to Bottom of Call Stack",
+			"Navigate Up Call Stack",
+			"Navigate Down Call Stack",
+			"Select Debug Console",
+			"Select Debug Session",
+			"Choose the specific location",
+			"No executable code is associated at the current cursor position.",
+			"Jump to Cursor",
+			"No step targets available",
+			"Add Configuration...",
+			"Add Inline Breakpoint"
+		],
 		"vs/workbench/contrib/debug/browser/debugStatus": [
 			"Debug",
 			"Debug: {0}",
@@ -24391,19 +24627,19 @@
 			"Add Expression",
 			"Remove All Expressions"
 		],
-		"vs/workbench/contrib/debug/browser/welcomeView": [
-			"Run",
-			"[Open a file](command:{0}) which can be debugged or run.",
-			"[Run and Debug{0}](command:{1})",
-			"[Show all automatic debug configurations](command:{0}).",
-			"To customize Run and Debug [create a launch.json file](command:{0}).",
-			"To customize Run and Debug, [open a folder](command:{0}) and create a launch.json file.",
-			"All debug extensions are disabled. Enable a debug extension or install a new one from the Marketplace."
-		],
 		"vs/workbench/contrib/debug/common/debugContentProvider": [
 			"Unable to resolve the resource without a debug session",
 			"Could not load source '{0}': {1}.",
 			"Could not load source '{0}'."
+		],
+		"vs/workbench/contrib/debug/browser/welcomeView": [
+			"Run",
+			"[Open a file](command:{0}) which can be debugged or run.",
+			"Run and Debug",
+			"Show all automatic debug configurations",
+			"To customize Run and Debug [create a launch.json file](command:{0}).",
+			"To customize Run and Debug, [open a folder](command:{0}) and create a launch.json file.",
+			"All debug extensions are disabled. Enable a debug extension or install a new one from the Marketplace."
 		],
 		"vs/workbench/contrib/debug/common/debugLifecycle": [
 			"There is an active debug session, are you sure you want to stop it?",
@@ -24435,16 +24671,13 @@
 			"Unverified breakpoint. File is modified, please restart debug session."
 		],
 		"vs/workbench/contrib/debug/browser/breakpointWidget": [
-			"Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.",
-			"Break when hit count condition is met. 'Enter' to accept, 'esc' to cancel.",
-			"Break when expression evaluates to true. 'Enter' to accept, 'esc' to cancel.",
+			"Message to log when breakpoint is hit. Expressions within {} are interpolated. '{0}' to accept, '{1}' to cancel.",
+			"Break when hit count condition is met. '{0}' to accept, '{1}' to cancel.",
+			"Break when expression evaluates to true. '{0}' to accept, '{1}' to cancel.",
 			"Expression",
 			"Hit Count",
 			"Log Message",
 			"Breakpoint Type"
-		],
-		"vs/platform/history/browser/contextScopedHistoryWidget": [
-			"Whether suggestion are visible"
 		],
 		"vs/workbench/contrib/debug/browser/debugActionViewItems": [
 			"Debug Launch Configurations",
@@ -24452,6 +24685,9 @@
 			"Add Config ({0})...",
 			"Add Configuration...",
 			"Debug Session"
+		],
+		"vs/platform/history/browser/contextScopedHistoryWidget": [
+			"Whether suggestion are visible"
 		],
 		"vs/workbench/contrib/debug/browser/linkDetector": [
 			"follow link using forwarded port",
@@ -24535,6 +24771,45 @@
 			"{0} problems in this file",
 			"Show Errors & Warnings on files and folder."
 		],
+		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+			"Startup Performance"
+		],
+		"vs/workbench/contrib/comments/browser/commentService": [
+			"Whether the open workspace has either comments or commenting ranges."
+		],
+		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
+			"Go to Next Comment Thread",
+			"Go to Previous Comment Thread",
+			"Toggle Editor Commenting",
+			"Add Comment on Current Selection",
+			"Collapse All Comments",
+			"Expand All Comments",
+			"Expand Unresolved Comments"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomains": [
+			"Manage Trusted Domains",
+			"Trust {0}",
+			"Trust {0} on all ports",
+			"Trust {0} and all its subdomains",
+			"Trust all domains (disables link protection)",
+			"Manage Trusted Domains"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
+			"Do you want {0} to open the external website?",
+			"&&Open",
+			"&&Copy",
+			"Configure &&Trusted Domains"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
+			"Show find",
+			"Stop find",
+			"Find next",
+			"Find previous",
+			"Reload Webviews"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
+			"The viewType of the currently active webview panel."
+		],
 		"vs/workbench/contrib/mergeEditor/browser/commands/commands": [
 			"Open Merge Editor",
 			"Mixed Layout",
@@ -24586,42 +24861,6 @@
 		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
 			"Text Merge Editor"
 		],
-		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
-			"Go to Next Comment Thread",
-			"Go to Previous Comment Thread",
-			"Toggle Editor Commenting",
-			"Add Comment on Current Selection",
-			"Collapse All Comments",
-			"Expand All Comments",
-			"Expand Unresolved Comments"
-		],
-		"vs/workbench/contrib/comments/browser/commentService": [
-			"Whether the open workspace has either comments or commenting ranges."
-		],
-		"vs/workbench/contrib/url/browser/trustedDomains": [
-			"Manage Trusted Domains",
-			"Trust {0}",
-			"Trust {0} on all ports",
-			"Trust {0} and all its subdomains",
-			"Trust all domains (disables link protection)",
-			"Manage Trusted Domains"
-		],
-		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
-			"Do you want {0} to open the external website?",
-			"&&Open",
-			"&&Copy",
-			"Configure &&Trusted Domains"
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
-			"The viewType of the currently active webview panel."
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
-			"Show find",
-			"Stop find",
-			"Find next",
-			"Find previous",
-			"Reload Webviews"
-		],
 		"vs/workbench/contrib/customEditor/common/customEditor": [
 			"The viewType of the currently active custom editor."
 		],
@@ -24630,6 +24869,12 @@
 			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
 			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
 			"Open using VS Code's standard opener."
+		],
+		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
+			"Open in new browser window",
+			"Open in default browser",
+			"Configure default opener...",
+			"How would you like to open: {0}"
 		],
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"Extension: {0}"
@@ -24644,8 +24889,6 @@
 			"Cancel",
 			"Error while updating '{0}' extension.",
 			"Error while installing '{0}' extension.",
-			"Would you like to install the release version?",
-			"Install Release Version",
 			"Please check the [log]({0}) for more details.",
 			"Try Downloading Manually...",
 			"Once downloaded, please manually install the downloaded VSIX of '{0}'.",
@@ -24797,65 +25040,12 @@
 			"Button foreground color for extension actions that stand out (e.g. install button).",
 			"Button background hover color for extension actions that stand out (e.g. install button)."
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViews": [
-			"Extensions",
-			"Unable to search the Marketplace when offline, please check your network connection.",
-			"Error while fetching extensions. {0}",
-			"No extensions found.",
-			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
-			"Open User Settings",
-			"There are no extensions to install.",
-			"Verified Publisher {0}",
-			"Publisher {0}",
-			"Deprecated",
-			"Rated {0} out of 5 stars by {1} users"
-		],
-		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
-			"Open in new browser window",
-			"Open in default browser",
-			"Configure default opener...",
-			"How would you like to open: {0}"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
-			"View icon of the extensions view.",
-			"Icon for the 'Manage' action in the extensions view.",
-			"Icon for the 'Clear Search Result' action in the extensions view.",
-			"Icon for the 'Refresh' action in the extensions view.",
-			"Icon for the 'Filter' action in the extensions view.",
-			"Icon for the 'Install Local Extension in Remote' action in the extensions view.",
-			"Icon for the 'Install Workspace Recommended Extensions' action in the extensions view.",
-			"Icon for the 'Configure Recommended Extensions' action in the extensions view.",
-			"Icon to indicate that an extension is synced.",
-			"Icon to indicate that an extension is ignored when syncing.",
-			"Icon to indicate that an extension is remote in the extensions view and editor.",
-			"Icon shown along with the install count in the extensions view and editor.",
-			"Icon shown along with the rating in the extensions view and editor.",
-			"Icon used for the verified extension publisher in the extensions view and editor.",
-			"Icon shown for extensions having pre-release versions in extensions view and editor.",
-			"Icon used for sponsoring extensions in the extensions view and editor.",
-			"Full star icon used for the rating in the extensions editor.",
-			"Half star icon used for the rating in the extensions editor.",
-			"Empty star icon used for the rating in the extensions editor.",
-			"Icon shown with a error message in the extensions editor.",
-			"Icon shown with a warning message in the extensions editor.",
-			"Icon shown with an info message in the extensions editor.",
-			"Icon shown with a workspace trust message in the extension editor.",
-			"Icon shown with a activation time message in the extension editor."
-		],
-		"vs/platform/dnd/browser/dnd": [
-			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
-		],
 		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
 			"Extensions",
 			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
 			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
 			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
 			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
-		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
-			"Yes",
-			"No"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionEditor": [
 			"Extension Version",
@@ -24972,21 +25162,13 @@
 			"Find Next",
 			"Find Previous"
 		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
+			"Yes",
+			"No"
+		],
 		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
 			"Activating Extensions..."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"Extensions",
-			"Install Missing Dependencies",
-			"Finished installing missing dependencies. Please reload the window now.",
-			"Reload Window",
-			"There are no missing dependencies to install."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"Type an extension name to install or search.",
-			"Press Enter to search for extension '{0}'.",
-			"Press Enter to install extension '{0}'.",
-			"Press Enter to manage your extensions."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
 			"Manifest is not found",
@@ -25046,6 +25228,39 @@
 		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
 			"Restarting extension host due to workspace trust change."
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"Extensions",
+			"Install Missing Dependencies",
+			"Finished installing missing dependencies. Please reload the window now.",
+			"Reload Window",
+			"There are no missing dependencies to install."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"View icon of the extensions view.",
+			"Icon for the 'Manage' action in the extensions view.",
+			"Icon for the 'Clear Search Result' action in the extensions view.",
+			"Icon for the 'Refresh' action in the extensions view.",
+			"Icon for the 'Filter' action in the extensions view.",
+			"Icon for the 'Install Local Extension in Remote' action in the extensions view.",
+			"Icon for the 'Install Workspace Recommended Extensions' action in the extensions view.",
+			"Icon for the 'Configure Recommended Extensions' action in the extensions view.",
+			"Icon to indicate that an extension is synced.",
+			"Icon to indicate that an extension is ignored when syncing.",
+			"Icon to indicate that an extension is remote in the extensions view and editor.",
+			"Icon shown along with the install count in the extensions view and editor.",
+			"Icon shown along with the rating in the extensions view and editor.",
+			"Icon used for the verified extension publisher in the extensions view and editor.",
+			"Icon shown for extensions having pre-release versions in extensions view and editor.",
+			"Icon used for sponsoring extensions in the extensions view and editor.",
+			"Full star icon used for the rating in the extensions editor.",
+			"Half star icon used for the rating in the extensions editor.",
+			"Empty star icon used for the rating in the extensions editor.",
+			"Icon shown with a error message in the extensions editor.",
+			"Icon shown with a warning message in the extensions editor.",
+			"Icon shown with an info message in the extensions editor.",
+			"Icon shown with a workspace trust message in the extension editor.",
+			"Icon shown with a activation time message in the extension editor."
+		],
 		"vs/workbench/contrib/extensions/browser/extensionsCompletionItemsProvider": [
 			"Example"
 		],
@@ -25054,8 +25269,84 @@
 			"Show Deprecated Extensions",
 			"Don't Show Again"
 		],
+		"vs/platform/dnd/browser/dnd": [
+			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"Extensions",
+			"Unable to search the Marketplace when offline, please check your network connection.",
+			"Error while fetching extensions. {0}",
+			"No extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"There are no extensions to install.",
+			"Verified Publisher {0}",
+			"Publisher {0}",
+			"Deprecated",
+			"Rated {0} out of 5 stars by {1} users"
+		],
 		"vs/workbench/contrib/output/browser/logViewer": [
 			"Log viewer"
+		],
+		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
+			"Type the name of a terminal to open.",
+			"Show All Opened Terminals",
+			"Terminal",
+			"Terminal",
+			"&&Terminal"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"Type an extension name to install or search.",
+			"Press Enter to search for extension '{0}'.",
+			"Press Enter to install extension '{0}'.",
+			"Press Enter to manage your extensions."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"Use 'monospace'",
+			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font.",
+			"Open Terminals.",
+			"Starting..."
+		],
+		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
+			"Show Terminal Texture Atlas",
+			"Write Data to Terminal",
+			"Enter data to write directly to the terminal, bypassing the pty",
+			"Restart Pty Host"
+		],
+		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
+			"Show Environment Contributions",
+			"Terminal Environment Changes",
+			"Extension: {0}",
+			"workspace"
+		],
+		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
+			"Focus Find",
+			"Hide Find",
+			"Toggle Find Using Regex",
+			"Toggle Find Using Whole Word",
+			"Toggle Find Using Case Sensitive",
+			"Find Next",
+			"Find Previous",
+			"Search Workspace"
+		],
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
+			"Focus Accessible Buffer",
+			"Navigate Accessible Buffer",
+			"Accessible Buffer Go to Next Command",
+			"Accessible Buffer Go to Previous Command"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
+			"Open Detected Link...",
+			"Open Last URL Link",
+			"Open Last Local File Link"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
+			"Show Terminal Quick Fixes"
+		],
+		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
+			"Manage Automatic Tasks",
+			"Allow Automatic Tasks",
+			"Disallow Automatic Tasks"
 		],
 		"vs/workbench/contrib/tasks/common/problemMatcher": [
 			"The problem pattern is missing a regular expression.",
@@ -25126,11 +25417,6 @@
 			"ESLint compact problems",
 			"ESLint stylish problems",
 			"Go problems"
-		],
-		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
-			"Manage Automatic Tasks",
-			"Allow Automatic Tasks",
-			"Disallow Automatic Tasks"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
 			"Task version 0.1.0 is deprecated. Please use 2.0.0",
@@ -25268,6 +25554,10 @@
 			"Cannot reconnect. Please reload the window.",
 			"&&Reload Window"
 		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"Emmet: Expand Abbreviation",
+			"Emmet: E&&xpand Abbreviation"
+		],
 		"vs/workbench/contrib/remote/browser/remoteIndicator": [
 			"Status bar background color when the workbench is offline. The status bar is shown in the bottom of the window",
 			"Status bar foreground color when the workbench is offline. The status bar is shown in the bottom of the window",
@@ -25287,92 +25577,25 @@
 			"Remote Host",
 			"Network appears to be offline, certain features might be unavailable.",
 			"Network appears to have high latency ({0}ms last, {1}ms average), certain features may be slow to respond.",
+			"Learn More",
+			"Install",
 			"Close Remote Connection",
 			"Reload Window",
 			"Close Remote Workspace",
-			"Learn More",
-			"Install",
 			"Select an option to open a Remote Window",
 			"Installing extension... "
 		],
-		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
-			"Type the name of a terminal to open.",
-			"Show All Opened Terminals",
-			"Terminal",
-			"Terminal",
-			"&&Terminal"
-		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
-			"Focus Accessible Buffer",
-			"Navigate Accessible Buffer",
-			"Accessible Buffer Go to Next Command",
-			"Accessible Buffer Go to Previous Command"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalView": [
-			"Use 'monospace'",
-			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font.",
-			"Open Terminals.",
-			"Starting..."
-		],
-		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
-			"Show Terminal Texture Atlas",
-			"Write Data to Terminal",
-			"Enter data to write directly to the terminal, bypassing the pty",
-			"Restart Pty Host"
-		],
-		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
-			"Show Environment Contributions",
-			"Terminal Environment Changes",
-			"Extension: {0}"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
-			"Show Terminal Quick Fixes"
-		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"Emmet: Expand Abbreviation",
-			"Emmet: E&&xpand Abbreviation"
-		],
 		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
-			"Accessibility Help",
-			"Now changing the setting `editor.accessibilitySupport` to 'on'.",
-			"Now opening the VS Code Accessibility documentation page.",
-			"Thank you for trying out VS Code's accessibility options.",
-			"Status:",
-			"To configure the editor to be permanently optimized for usage with a Screen Reader press Command+E now.",
-			"To configure the editor to be permanently optimized for usage with a Screen Reader press Control+E now.",
-			"The editor is configured to use platform APIs to detect when a Screen Reader is attached, but the current runtime does not support this.",
-			"The editor has automatically detected a Screen Reader is attached.",
-			"The editor is configured to automatically detect when a Screen Reader is attached, which is not the case at this time.",
-			"The editor is configured to be permanently optimized for usage with a Screen Reader - you can change this via the command `Toggle Screen Reader Accessibility Mode` or by editing the setting `editor.accessibilitySupport`",
-			"The editor is configured to never be optimized for usage with a Screen Reader.",
-			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
-			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
-			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
-			"Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.",
-			"Press Command+H now to open a browser window with more VS Code information related to Accessibility.",
-			"Press Control+H now to open a browser window with more VS Code information related to Accessibility.",
-			"You can dismiss this tooltip and return to the editor by pressing Escape or Shift+Escape.",
 			"Toggle Screen Reader Accessibility Mode"
 		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
-			"Open Detected Link...",
-			"Open Last URL Link",
-			"Open Last Local File Link"
-		],
 		"vs/workbench/contrib/codeEditor/browser/diffEditorHelper": [
+			"Show Whitespace Differences",
 			"The diff algorithm was stopped early (after {0} ms.)",
 			"Remove Limit",
-			"Show Whitespace Differences"
-		],
-		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
-			"Focus Find",
-			"Hide Find",
-			"Toggle Find Using Regex",
-			"Toggle Find Using Whole Word",
-			"Toggle Find Using Case Sensitive",
-			"Find Next",
-			"Find Previous",
-			"Search Workspace"
+			"You are in a diff editor.",
+			"Press {0} or {1} to view the next or previous diff in the diff review mode that is optimized for screen readers.",
+			"To control which audio cues should be played, the following settings can be configured: {0}.",
+			"Diff editor accessibility help"
 		],
 		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
 			"Inspect Key Mappings",
@@ -25412,14 +25635,6 @@
 			"Switch to Cmd+Click for Multi-Cursor",
 			"Switch to Ctrl+Click for Multi-Cursor"
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
-			"Toggle Control Characters",
-			"Render &&Control Characters"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
-			"Toggle Render Whitespace",
-			"&&Render Whitespace"
-		],
 		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
 			"Whether the editor is currently using word wrapping.",
 			"View: Toggle Word Wrap",
@@ -25427,8 +25642,16 @@
 			"Enable wrapping for this file",
 			"&&Word Wrap"
 		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
+			"Toggle Control Characters",
+			"Render &&Control Characters"
+		],
 		"vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint": [
 			"[[Select a language]], or [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don't show]] this again."
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"Toggle Render Whitespace",
+			"&&Render Whitespace"
 		],
 		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
 			"(global)",
@@ -25459,22 +25682,6 @@
 		],
 		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
 			"Surround With Snippet..."
-		],
-		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
-			"Surround With: {0}",
-			"Start with Snippet",
-			"Start with: {0}"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"Expected string in `contributes.{0}.path`. Provided value: {1}",
-			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
-			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
-			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
-			"Contributes snippets.",
-			"Language identifier for which this snippet is contributed to.",
-			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
-			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
-			"The snippet file \"{0}\" could not be read."
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
 			"None",
@@ -25510,6 +25717,8 @@
 			"This version of {0} does not have release notes online",
 			"Welcome to {0} v{1}! Would you like to read the Release Notes?",
 			"Release Notes",
+			"Updates are disabled because you are running the user-scope installation of {0} as Administrator.",
+			"Learn More",
 			"New {0} update available.",
 			"Checking for Updates...",
 			"Downloading...",
@@ -25534,6 +25743,7 @@
 			"Downloading Update...",
 			"Install Update... (1)",
 			"Installing Update...",
+			"Show Update Release Notes",
 			"Restart to Update (1)",
 			"Switch to Insiders Version...",
 			"Switch to Stable Version...",
@@ -25546,8 +25756,10 @@
 			"&&Insiders",
 			"&&Stable (current)"
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
-			"Welcome"
+		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
+			"Surround With: {0}",
+			"Start with Snippet",
+			"Start with: {0}"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
 			"Built-In",
@@ -25586,6 +25798,20 @@
 			"privacy statement",
 			"opt out",
 			"{0} collects usage data. Read our {1} and learn how to {2}."
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"Expected string in `contributes.{0}.path`. Provided value: {1}",
+			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
+			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
+			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"Contributes snippets.",
+			"Language identifier for which this snippet is contributed to.",
+			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
+			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
+			"The snippet file \"{0}\" could not be read."
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
+			"Welcome"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
 			"Welcome Page",
@@ -25634,33 +25860,7 @@
 			"{0} ({1})",
 			"1 problem in this element",
 			"{0} problems in this element",
-			"Contains elements with problems",
-			"array",
-			"boolean",
-			"class",
-			"constant",
-			"constructor",
-			"enumeration",
-			"enumeration member",
-			"event",
-			"field",
-			"file",
-			"function",
-			"interface",
-			"key",
-			"method",
-			"module",
-			"namespace",
-			"null",
-			"number",
-			"object",
-			"operator",
-			"package",
-			"property",
-			"string",
-			"struct",
-			"type parameter",
-			"variable"
+			"Contains elements with problems"
 		],
 		"vs/workbench/contrib/outline/browser/outlinePane": [
 			"The active editor cannot provide outline information.",
@@ -25762,39 +25962,28 @@
 			"Clear Data in Cloud..."
 		],
 		"vs/workbench/contrib/userDataProfile/browser/userDataProfile": [
-			"Create an Empty Profile...",
-			"Create from Current Profile...",
 			"Profiles ({0})",
 			"Switch Profile...",
 			"Select Profile",
-			"Rename...",
-			"Show Contents...",
+			"Edit Profile...",
+			"Show Profile Contents",
 			"Export Profile...",
 			"Export Profile ({0})...",
 			"Import Profile...",
-			"Create from profile template file",
-			"Create from profile template URL",
-			"Create Profile from Profile Template...",
-			"Provide profile template URL or select profile template file",
+			"Import from URL",
+			"Select File...",
+			"Profile Templates",
+			"Import from Profile Template...",
+			"Provide Profile Template URL",
 			"Error while creating profile: {0}",
 			"Select Profile Template File",
 			"Import Profile...",
-			"Profile name",
-			"Create from Current Profile...",
-			"Create an Empty Profile...",
-			"Profile with name {0} already exists.",
-			"Create Profile...",
-			"Empty Profile",
-			"Using Current Profile",
-			"Profile Templates",
+			"Save Current Profile As...",
 			"Create Profile...",
 			"Delete Profile...",
 			"Current",
 			"Delete Profile...",
-			"Select Profiles to Delete",
-			"Create Profile from Templates...",
-			"{0}: Create...",
-			"There are no templates to create from"
+			"Select Profiles to Delete"
 		],
 		"vs/workbench/contrib/userDataProfile/browser/userDataProfileActions": [
 			"Create a Temporary Profile",
@@ -25814,6 +26003,7 @@
 			"View icon of the cloud changes view."
 		],
 		"vs/workbench/contrib/editSessions/browser/editSessionsStorageService": [
+			"Select an account to restore your working changes from the cloud",
 			"Select an account to store your working changes in the cloud",
 			"Signed In",
 			"Others",
@@ -25843,13 +26033,6 @@
 			"Cloud Changes",
 			"Open File"
 		],
-		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
-			"Configure which editor to use for a resource.",
-			"Language modes that the code actions are enabled for.",
-			"`CodeActionKind` of the contributed code action.",
-			"Label for the code action used in the UI.",
-			"Description of what the code action does."
-		],
 		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
 			"Contributed documentation.",
 			"Contributed documentation for refactorings.",
@@ -25857,6 +26040,13 @@
 			"Label for the documentation used in the UI.",
 			"When clause.",
 			"Command executed."
+		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"Configure which editor to use for a resource.",
+			"Language modes that the code actions are enabled for.",
+			"`CodeActionKind` of the contributed code action.",
+			"Label for the code action used in the UI.",
+			"Description of what the code action does."
 		],
 		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
 			"Controls whether auto fix action should be run on file save.",
@@ -26046,13 +26236,8 @@
 			"Overwriting extension {0} with {1}.",
 			"Loading development extension at {0}"
 		],
-		"vs/workbench/contrib/localization/common/localizationsActions": [
-			"Configure Display Language",
-			"Select Display Language",
-			"Installed",
-			"Available",
-			"More Info",
-			"Clear Display Language Preference"
+		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
+			"Report Issue"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensionsSlowActions": [
 			"Performance Issue",
@@ -26063,11 +26248,56 @@
 			"Did you attach the CPU-Profile?",
 			"This is a reminder to make sure that you have not forgotten to attach '{0}' to an existing performance issue."
 		],
-		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
-			"Report Issue"
-		],
 		"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote": [
 			"Create New Integrated Terminal (Local)"
+		],
+		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
+			"Pty Host Status",
+			"Pty Host",
+			"The connection to the terminal's pty host process is unresponsive, terminals may stop working. Click to manually restart the pty host.",
+			"Pty Host is unresponsive"
+		],
+		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
+			"Task is running",
+			"Task succeeded",
+			"Task succeeded and waiting...",
+			"Task has errors",
+			"Task has errors and is waiting...",
+			"Task has warnings",
+			"Task has warnings and is waiting...",
+			"Task has infos",
+			"Task has infos and is waiting...",
+			"Beginning of detected errors for this run"
+		],
+		"vs/workbench/contrib/tasks/common/taskConfiguration": [
+			"Warning: options.cwd must be of type string. Ignoring value {0}\n",
+			"Error: command argument must either be a string or a quoted string. Provided value is:\n{0}",
+			"Warning: shell configuration is only supported when executing tasks in the terminal.",
+			"Error: Problem Matcher in declare scope must have a name:\n{0}\n",
+			"Warning: the defined problem matcher is unknown. Supported types are string | ProblemMatcher | Array<string | ProblemMatcher>.\n{0}\n",
+			"Error: Invalid problemMatcher reference: {0}\n",
+			"Error: tasks configuration must have a type property. The configuration will be ignored.\n{0}\n",
+			"Error: there is no registered task type '{0}'. Did you miss installing an extension that provides a corresponding task provider?",
+			"Error: the task configuration '{0}' is missing the required property 'type'. The task configuration will be ignored.",
+			"Error: the task configuration '{0}' is using an unknown type. The task configuration will be ignored.",
+			"Error: tasks is not declared as a custom task. The configuration will be ignored.\n{0}\n",
+			"Error: a task must provide a label property. The task will be ignored.\n{0}\n",
+			"Warning: {0} tasks are unavailable in the current environment.\n",
+			"Error: the task '{0}' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:\n{1}",
+			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
+			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
+		],
+		"vs/workbench/contrib/localHistory/browser/localHistory": [
+			"Icon for a local history entry in the timeline view.",
+			"Icon for restoring contents of a local history entry."
+		],
+		"vs/workbench/contrib/localization/common/localizationsActions": [
+			"Configure Display Language",
+			"Select Display Language",
+			"Installed",
+			"Available",
+			"More Info",
+			"Clear Display Language Preference"
 		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"Executes .NET Core build command",
@@ -26093,46 +26323,6 @@
 			"Go back ↩",
 			"No {0} tasks found. Go back ↩",
 			"There is no task provider registered for tasks of type \"{0}\"."
-		],
-		"vs/workbench/contrib/tasks/common/taskConfiguration": [
-			"Warning: options.cwd must be of type string. Ignoring value {0}\n",
-			"Error: command argument must either be a string or a quoted string. Provided value is:\n{0}",
-			"Warning: shell configuration is only supported when executing tasks in the terminal.",
-			"Error: Problem Matcher in declare scope must have a name:\n{0}\n",
-			"Warning: the defined problem matcher is unknown. Supported types are string | ProblemMatcher | Array<string | ProblemMatcher>.\n{0}\n",
-			"Error: Invalid problemMatcher reference: {0}\n",
-			"Error: tasks configuration must have a type property. The configuration will be ignored.\n{0}\n",
-			"Error: there is no registered task type '{0}'. Did you miss installing an extension that provides a corresponding task provider?",
-			"Error: the task configuration '{0}' is missing the required property 'type'. The task configuration will be ignored.",
-			"Error: the task configuration '{0}' is using an unknown type. The task configuration will be ignored.",
-			"Error: tasks is not declared as a custom task. The configuration will be ignored.\n{0}\n",
-			"Error: a task must provide a label property. The task will be ignored.\n{0}\n",
-			"Warning: {0} tasks are unavailable in the current environment.\n",
-			"Error: the task '{0}' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:\n{1}",
-			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
-			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
-		],
-		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
-			"Pty Host Status",
-			"Pty Host",
-			"The connection to the terminal's pty host process is unresponsive, terminals may stop working. Click to manually restart the pty host.",
-			"Pty Host is unresponsive"
-		],
-		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
-			"Task is running",
-			"Task succeeded",
-			"Task succeeded and waiting...",
-			"Task has errors",
-			"Task has errors and is waiting...",
-			"Task has warnings",
-			"Task has warnings and is waiting...",
-			"Task has infos",
-			"Task has infos and is waiting...",
-			"Beginning of detected errors for this run"
-		],
-		"vs/workbench/contrib/localHistory/browser/localHistory": [
-			"Icon for a local history entry in the timeline view.",
-			"Icon for restoring contents of a local history entry."
 		],
 		"vs/workbench/contrib/debug/common/abstractDebugAdapter": [
 			"Timeout after {0} ms for '{1}'"
@@ -26242,7 +26432,11 @@
 			"Cleared Input"
 		],
 		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"Inspect the response in the accessible view with {0}",
+			"Inspect the response in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding",
+			"{0}, notification, {1}",
 			"{0}, notification",
+			"{0}, source: {1}, notification, {2}",
 			"{0}, source: {1}, notification",
 			"Notifications List"
 		],
@@ -26269,6 +26463,17 @@
 		"vs/base/browser/ui/actionbar/actionViewItems": [
 			"{0} ({1})"
 		],
+		"vs/editor/browser/widget/inlineDiffMargin": [
+			"Copy deleted lines",
+			"Copy deleted line",
+			"Copy changed lines",
+			"Copy changed line",
+			"Copy deleted line ({0})",
+			"Copy changed line ({0})",
+			"Revert this change",
+			"Copy deleted line ({0})",
+			"Copy changed line ({0})"
+		],
 		"vs/editor/browser/widget/diffReview": [
 			"Icon for 'Insert' in diff review.",
 			"Icon for 'Remove' in diff review.",
@@ -26283,17 +26488,6 @@
 			"{0} original line {1} modified line {2}",
 			"+ {0} modified line {1}",
 			"- {0} original line {1}"
-		],
-		"vs/editor/browser/widget/inlineDiffMargin": [
-			"Copy deleted lines",
-			"Copy deleted line",
-			"Copy changed lines",
-			"Copy changed line",
-			"Copy deleted line ({0})",
-			"Copy changed line ({0})",
-			"Revert this change",
-			"Copy deleted line ({0})",
-			"Copy changed line ({0})"
 		],
 		"vs/editor/common/viewLayout/viewLineRenderer": [
 			"Show more ({0})",
@@ -26329,21 +26523,14 @@
 			"Auto Fix...",
 			"No auto fixes available"
 		],
-		"vs/editor/contrib/codeAction/browser/codeActionController": [
-			"Hide Disabled",
-			"Show Disabled"
-		],
 		"vs/editor/contrib/codeAction/browser/lightBulbWidget": [
 			"Show Code Actions. Preferred Quick Fix Available ({0})",
 			"Show Code Actions ({0})",
 			"Show Code Actions"
 		],
-		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
-			"Whether the paste widget is showing",
-			"Show paste options...",
-			"Running paste handlers. Click to cancel",
-			"Select Paste Action",
-			"Running paste handlers"
+		"vs/editor/contrib/codeAction/browser/codeActionController": [
+			"Hide Disabled",
+			"Show Disabled"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders": [
 			"Built-in",
@@ -26354,6 +26541,13 @@
 			"Insert Path",
 			"Insert Relative Paths",
 			"Insert Relative Path"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
+			"Whether the paste widget is showing",
+			"Show paste options...",
+			"Running paste handlers. Click to cancel",
+			"Select Paste Action",
+			"Running paste handlers"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController": [
 			"Whether the drop widget is showing",
@@ -26498,17 +26692,6 @@
 			"Overview ruler marker color for write-access symbol highlights. The color must not be opaque so as not to hide underlying decorations.",
 			"Overview ruler marker color of a textual occurrence for a symbol. The color must not be opaque so as not to hide underlying decorations."
 		],
-		"vs/editor/contrib/parameterHints/browser/parameterHintsWidget": [
-			"Icon for show next parameter hint.",
-			"Icon for show previous parameter hint.",
-			"{0}, hint",
-			"Foreground color of the active item in the parameter hint."
-		],
-		"vs/editor/contrib/rename/browser/renameInputField": [
-			"Whether the rename input widget is visible",
-			"Rename input. Type new name and press Enter to commit.",
-			"{0} to Rename, {1} to Preview"
-		],
 		"vs/editor/contrib/stickyScroll/browser/stickyScrollActions": [
 			"Toggle Sticky Scroll",
 			"&&Toggle Sticky Scroll",
@@ -26534,10 +26717,16 @@
 			"Loading...",
 			"No suggestions.",
 			"Suggest",
-			"{0}{1}, {2}",
-			"{0}{1}",
+			"{0} {1}, {2}",
+			"{0} {1}",
 			"{0}, {1}",
 			"{0}, docs: {1}"
+		],
+		"vs/editor/contrib/parameterHints/browser/parameterHintsWidget": [
+			"Icon for show next parameter hint.",
+			"Icon for show previous parameter hint.",
+			"{0}, hint",
+			"Foreground color of the active item in the parameter hint."
 		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
 			"Colors and styles for the token.",
@@ -26611,6 +26800,11 @@
 			"Collapse All",
 			"Expand All"
 		],
+		"vs/editor/contrib/rename/browser/renameInputField": [
+			"Whether the rename input widget is visible",
+			"Rename input. Type new name and press Enter to commit.",
+			"{0} to Rename, {1} to Preview"
+		],
 		"vs/workbench/contrib/comments/browser/commentsTreeViewer": [
 			"Comments",
 			"{0} comments",
@@ -26620,32 +26814,6 @@
 			"[Ln {0}]",
 			"[Ln {0}-{1}]",
 			"Last reply from {0}"
-		],
-		"vs/workbench/contrib/testing/common/testResult": [
-			"Test run at {0}"
-		],
-		"vs/workbench/browser/parts/compositeBarActions": [
-			"{0} ({1})",
-			"{0} - {1}",
-			"Additional Views",
-			"{0} ({1})",
-			"Manage Extension",
-			"Hide '{0}'",
-			"Keep '{0}'",
-			"Hide Badge",
-			"Show Badge",
-			"Toggle View Pinned",
-			"Toggle View Badge"
-		],
-		"vs/base/browser/ui/tree/treeDefaults": [
-			"Collapse All"
-		],
-		"vs/workbench/browser/parts/views/checkbox": [
-			"Checked",
-			"Unchecked"
-		],
-		"vs/base/browser/ui/splitview/paneview": [
-			"{0} Section"
 		],
 		"vs/workbench/contrib/remote/browser/tunnelView": [
 			"Whether the Ports view is enabled.",
@@ -26708,6 +26876,32 @@
 			"Change Port Protocol",
 			"The color of the icon for a port that has an associated running process."
 		],
+		"vs/workbench/contrib/testing/common/testResult": [
+			"Test run at {0}"
+		],
+		"vs/workbench/browser/parts/compositeBarActions": [
+			"{0} ({1})",
+			"{0} - {1}",
+			"Additional Views",
+			"{0} ({1})",
+			"Manage Extension",
+			"Hide '{0}'",
+			"Keep '{0}'",
+			"Hide Badge",
+			"Show Badge",
+			"Toggle View Pinned",
+			"Toggle View Badge"
+		],
+		"vs/base/browser/ui/splitview/paneview": [
+			"{0} Section"
+		],
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"Collapse All"
+		],
+		"vs/workbench/browser/parts/views/checkbox": [
+			"Checked",
+			"Unchecked"
+		],
 		"vs/workbench/contrib/remote/browser/remoteIcons": [
 			"Getting started icon in the remote explorer view.",
 			"Documentation icon in the remote explorer view.",
@@ -26734,30 +26928,6 @@
 			"Binary Viewer",
 			"The file is not displayed in the text editor because it is either binary or uses an unsupported text encoding.",
 			"Open Anyway"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/colors": [
-			"The border color for text that got moved in the diff editor."
-		],
-		"vs/workbench/browser/parts/editor/editorPanes": [
-			"Unable to open '{0}'",
-			"&&OK"
-		],
-		"vs/workbench/browser/parts/editor/tabsTitleControl": [
-			"Tab actions"
-		],
-		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
-			"Show All Commands",
-			"Go to File",
-			"Open File",
-			"Open Folder",
-			"Open File or Folder",
-			"Open Recent",
-			"New Untitled Text File",
-			"Find in Files",
-			"Toggle Terminal",
-			"Start Debugging",
-			"Toggle Full Screen",
-			"Show Settings"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
 			"Loading...",
@@ -26794,6 +26964,12 @@
 			"Installing Update...",
 			"Restart to &&Update"
 		],
+		"vs/editor/browser/widget/diffEditor.contribution": [
+			"Accessible Diff Viewer",
+			"Go to Next Difference",
+			"Open Accessible Diff Viewer",
+			"Go to Previous Difference"
+		],
 		"vs/workbench/browser/parts/compositePart": [
 			"{0} actions",
 			"Views and More Actions...",
@@ -26804,6 +26980,27 @@
 		],
 		"vs/workbench/browser/parts/sidebar/sidebarActions": [
 			"Focus into Primary Side Bar"
+		],
+		"vs/workbench/browser/parts/editor/tabsTitleControl": [
+			"Tab actions"
+		],
+		"vs/workbench/browser/parts/editor/editorPanes": [
+			"Unable to open '{0}'",
+			"&&OK"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
+			"Show All Commands",
+			"Go to File",
+			"Open File",
+			"Open Folder",
+			"Open File or Folder",
+			"Open Recent",
+			"New Untitled Text File",
+			"Find in Files",
+			"Toggle Terminal",
+			"Start Debugging",
+			"Toggle Full Screen",
+			"Show Settings"
 		],
 		"vs/base/browser/ui/iconLabel/iconLabelHover": [
 			"Loading..."
@@ -26850,6 +27047,9 @@
 		"vs/editor/common/model/editStack": [
 			"Typing"
 		],
+		"vs/base/browser/ui/selectBox/selectBoxCustom": [
+			"Select Box"
+		],
 		"vs/platform/quickinput/browser/quickInput": [
 			"Back",
 			"Press 'Enter' to confirm your input or 'Escape' to cancel",
@@ -26874,18 +27074,6 @@
 			"List of language scope names to which this grammar is injected to.",
 			"Defines which scope names contain balanced brackets.",
 			"Defines which scope names do not contain balanced brackets."
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
-			"User",
-			"Remote",
-			"Workspace",
-			"Folder",
-			"Settings Switcher",
-			"User",
-			"Remote",
-			"Workspace",
-			"User",
-			"Workspace"
 		],
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"Unbound"
@@ -26920,6 +27108,7 @@
 			"This setting cannot be applied because it is configured in the system policy.",
 			"This setting cannot be applied because it is not registered as language override setting.",
 			"This setting cannot be applied while a non-default profile is active. It will be applied when the default profile is active.",
+			"This setting cannot be applied because it is configured to be applied in all profiles using setting {0}. Value from the default profile will be used instead.",
 			"This setting cannot be applied in this window. It will be applied when you open a local window.",
 			"This setting cannot be applied in this workspace. It will be applied when you open the containing workspace folder directly.",
 			"This setting has an application scope and can be set only in the user settings file.",
@@ -26980,9 +27169,17 @@
 			"Security",
 			"Workspace"
 		],
-		"vs/workbench/contrib/preferences/browser/tocTree": [
-			"Settings Table of Contents",
-			"{0}, group"
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"User",
+			"Remote",
+			"Workspace",
+			"Folder",
+			"Settings Switcher",
+			"User",
+			"Remote",
+			"Workspace",
+			"User",
+			"Workspace"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsTree": [
 			"Extensions",
@@ -27001,7 +27198,12 @@
 			"Settings",
 			"Copy Setting ID",
 			"Copy Setting as JSON",
-			"Sync This Setting"
+			"Sync This Setting",
+			"Apply Setting to all Profiles"
+		],
+		"vs/workbench/contrib/preferences/browser/tocTree": [
+			"Settings Table of Contents",
+			"{0}, group"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
 			"Modified",
@@ -27053,6 +27255,8 @@
 			"Paths to additional resources that should be allowed in the webview."
 		],
 		"vs/workbench/contrib/notebook/browser/notebookEditorWidget": [
+			"Notebook\nUse {0} for accessibility help",
+			"Notebook\nRun the Open Accessibility Help command for more information",
 			"Notebook",
 			"The border color for notebook cells.",
 			"The color of the notebook cell editor border.",
@@ -27101,7 +27305,7 @@
 			"{0} - Currently Selected",
 			"Change kernel for '{0}'",
 			"Select kernel for '{0}'",
-			"Install suggested extensions",
+			"Install/Enable suggested extensions",
 			"Browse marketplace for kernel extensions",
 			"Select Another Kernel...",
 			"Select Kernel",
@@ -27133,9 +27337,14 @@
 		"vs/editor/contrib/codeAction/browser/codeAction": [
 			"An unknown error occurred while applying the code action"
 		],
+		"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider": [
+			"empty cell"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
 			"The chat view is comprised of an input box and a request/response list. The input box is used to make requests and the list is used to display responses.",
 			"In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.",
+			"In the input box, inspect the last response in the accessible view via {0}",
+			"With the input box focused, inspect the last response in the accessible view via the Open Accessible View command, which is currently not triggerable by a keybinding.",
 			"Chat responses will be announced as they come in. A response will indicate the number of code blocks, if any, and then the rest of the response.",
 			"To focus the chat request/response list, which can be navigated with up and down arrows, invoke The Focus Chat command ({0}).",
 			"To focus the chat request/response list, which can be navigated with up and down arrows, invoke The Focus Chat List command, which is currently not triggerable by a keybinding.",
@@ -27148,29 +27357,47 @@
 			"Inline chat occurs within a code editor and takes into account the current selection. It is useful for making changes to the current editor. For example, fixing diagnostics, documenting or refactoring code. Keep in mind that AI generated code may be incorrect.",
 			"It can be activated via code actions or directly using the command: Inline Chat: Start Code Chat ({0}).",
 			"In the input box, use {0} and {1} to navigate your request history. Edit input and use enter or the submit button to run a new request.",
-			"Context menu actions may run a request prefixed with /fix or /explain. Type / to discover more ready-made commands.",
-			"When a request is prefixed with /fix, a response will indicate the problem with the current code. A diff editor will be rendered and can be reached by tabbing.",
+			"In the input box, inspect the response in the accessible view via {0}",
+			"With the input box focused, inspect the response in the accessible view via the Open Accessible View command, which is currently not triggerable by a keybinding.",
+			"Context menu actions may run a request prefixed with a /. Type / to discover such ready-made commands.",
+			"If a fix action is invoked, a response will indicate the problem with the current code. A diff editor will be rendered and can be reached by tabbing.",
 			"Once in the diff editor, enter review mode with ({0}). Use up and down arrows to navigate lines with the proposed changes.",
 			"Tab again to enter the Diff editor with the changes and enter review mode with the Go to Next Difference Command. Use Up/DownArrow to navigate lines with the proposed changes.",
-			"When a request is prefixed with /explain, a response will explain the code in the current selection and the chat view will be focused.",
 			"Use tab to reach conditional parts like commands, status, message responses and more.",
 			"Audio cues can be changed via settings with a prefix of audioCues.chat. By default, if a request takes more than 4 seconds, you will hear an audio cue indicating that progress is still occurring.",
 			"Chat accessibility help",
 			"Inline chat accessibility help"
 		],
-		"vs/workbench/contrib/chat/browser/chatListRenderer": [
-			"Chat",
-			"1 code block: {0}",
-			"{0} code blocks: {1}",
-			"Code block",
-			"Toolbar for code block which can be reached via tab",
-			"Code block toolbar",
-			"Code block {0}"
+		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/quickQuestionAction": [
+			"Chat"
+		],
+		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/multipleByScrollQuickQuestionAction": [
+			"Clear",
+			"Open In Chat View"
+		],
+		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/singleQuickQuestionAction": [
+			"Ask {0} a question..."
 		],
 		"vs/workbench/contrib/chat/browser/chatInputPart": [
 			"Chat Input,  Type to ask questions or type / for topics, press enter to send out the request. Use {0} for Chat Accessibility Help.",
 			"Chat Input,  Type code here and press Enter to run. Use the Chat Accessibility Help command for more information.",
 			"Chat Input"
+		],
+		"vs/workbench/contrib/chat/browser/chatListRenderer": [
+			"Chat",
+			"{0} {1}",
+			"{0}",
+			"1 code block: {0} {1}",
+			"1 code block: {0}",
+			"{0} code blocks: {1}",
+			"{0} code blocks",
+			"Code block",
+			"Toolbar for code block which can be reached via tab",
+			"Code block toolbar",
+			"Code block {0}"
+		],
+		"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget": [
+			"Exited {0} mode"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
 			"Nothing changed",
@@ -27255,13 +27482,6 @@
 			"Border on the side of the terminal tab in the panel. This defaults to tab.activeBorder.",
 			"'{0}' ANSI color in the terminal."
 		],
-		"vs/platform/quickinput/browser/commandsQuickAccess": [
-			"recently used",
-			"commonly used",
-			"other commands",
-			"{0}, {1}",
-			"Command '{0}' resulted in an error"
-		],
 		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
 			"Unable to resolve workspace folder ({0})",
 			"Symbolic Link",
@@ -27283,6 +27503,13 @@
 			"Moving {0}",
 			"{0} folders",
 			"{0} files"
+		],
+		"vs/platform/quickinput/browser/commandsQuickAccess": [
+			"recently used",
+			"commonly used",
+			"other commands",
+			"{0}, {1}",
+			"Command '{0}' resulted in an error"
 		],
 		"vs/workbench/contrib/files/browser/fileImportExport": [
 			"Uploading",
@@ -27318,24 +27545,6 @@
 			"The following {0} files and/or folders already exist in the destination folder. Do you want to replace them?",
 			"This action is irreversible!",
 			"&&Replace"
-		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
-			"Bulk Edit",
-			"Renaming {0} to {1}, also making text edits",
-			"Creating {0}, also making text edits",
-			"Deleting {0}, also making text edits",
-			"{0}, making text edits",
-			"Renaming {0} to {1}",
-			"Creating {0}",
-			"Deleting {0}",
-			"line {0}, replacing {1} with {2}",
-			"line {0}, removing {1}",
-			"line {0}, inserting {1}",
-			"{0} → {1}",
-			"(renaming)",
-			"(creating)",
-			"(deleting)",
-			"{0} - {1}"
 		],
 		"vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess": [
 			"To go to a symbol, first open a text editor with symbol information.",
@@ -27378,6 +27587,24 @@
 		],
 		"vs/workbench/contrib/search/browser/searchFindInput": [
 			"Notebook Find Filters"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
+			"Bulk Edit",
+			"Renaming {0} to {1}, also making text edits",
+			"Creating {0}, also making text edits",
+			"Deleting {0}, also making text edits",
+			"{0}, making text edits",
+			"Renaming {0} to {1}",
+			"Creating {0}",
+			"Deleting {0}",
+			"line {0}, replacing {1} with {2}",
+			"line {0}, removing {1}",
+			"line {0}, inserting {1}",
+			"{0} → {1}",
+			"(renaming)",
+			"(creating)",
+			"(deleting)",
+			"{0} - {1}"
 		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization": [
 			"All backslashes in Query string must be escaped (\\\\)",
@@ -27448,6 +27675,9 @@
 			"The task '{0}' cannot be tracked. Make sure to have a problem matcher defined.",
 			"The task '{0}' cannot be tracked. Make sure to have a problem matcher defined."
 		],
+		"vs/workbench/contrib/debug/common/debugSource": [
+			"Unknown Source"
+		],
 		"vs/workbench/contrib/debug/browser/debugSession": [
 			"No debugger available, can not send '{0}'",
 			"No debugger available, can not send '{0}'",
@@ -27489,9 +27719,6 @@
 			"Debugging started.",
 			"Debugging stopped."
 		],
-		"vs/workbench/contrib/debug/common/debugSource": [
-			"Unknown Source"
-		],
 		"vs/base/browser/ui/findinput/replaceInput": [
 			"input",
 			"Preserve Case"
@@ -27508,6 +27735,10 @@
 			"Message",
 			"File",
 			"Source"
+		],
+		"vs/workbench/contrib/comments/browser/commentsController": [
+			"Whether the position at the active cursor has a commenting range",
+			"Select Comment Provider"
 		],
 		"vs/workbench/contrib/mergeEditor/common/mergeEditor": [
 			"The editor is a merge editor",
@@ -27550,11 +27781,6 @@
 			"&&Close",
 			"Don't ask again"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
-			"Base",
-			"Comparing with {0}",
-			"Differences are highlighted with a background color."
-		],
 		"vs/workbench/contrib/mergeEditor/browser/view/viewModel": [
 			"There is currently no conflict focused that can be toggled."
 		],
@@ -27593,16 +27819,8 @@
 			"The background color of decorations in input 1.",
 			"The background color of decorations in input 2."
 		],
-		"vs/workbench/contrib/comments/browser/commentsController": [
-			"Whether the position at the active cursor has a commenting range",
-			"Select Comment Provider"
-		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
 			"Built-in"
-		],
-		"vs/platform/files/browser/htmlFileSystemProvider": [
-			"Rename is only supported for files.",
-			"Insufficient permissions. Please retry and allow the operation."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"Average rating: {0} out of 5",
@@ -27630,10 +27848,19 @@
 			"The icon color for pre-release extension.",
 			"The icon color for extension sponsor."
 		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
+			"Base",
+			"Comparing with {0}",
+			"Differences are highlighted with a background color."
+		],
 		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
 			"Error",
 			"Unknown Extension:",
 			"Extensions"
+		],
+		"vs/platform/files/browser/htmlFileSystemProvider": [
+			"Rename is only supported for files.",
+			"Insufficient permissions. Please retry and allow the operation."
 		],
 		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
 			"This extension is recommended because you have {0} installed."
@@ -27648,79 +27875,16 @@
 			"The Marketplace has extensions that can help with '.{0}' files",
 			"Don't Show Again for '.{0}' files"
 		],
-		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
-			"This extension is recommended because of the current workspace configuration"
-		],
 		"vs/workbench/contrib/extensions/browser/webRecommendations": [
 			"This extension is recommended for {0} for the Web"
 		],
-		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
-			"Additional command options",
-			"The current working directory of the executed program or script. If omitted Code's current workspace root is used.",
-			"The environment of the executed program or shell. If omitted the parent process' environment is used.",
-			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
-			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
-			"Configures the shell to be used.",
-			"The shell to be used.",
-			"The shell arguments.",
-			"The command to be executed. Can be an external program or a shell command.",
-			"Arguments passed to the command when this task is invoked.",
-			"The task's name",
-			"The command to be executed. Can be an external program or a shell command.",
-			"Arguments passed to the command when this task is invoked.",
-			"Windows specific command configuration",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"Mac specific command configuration",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"Linux specific command configuration",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"Controls whether the task name is added as an argument to the command. If omitted the globally defined value is used.",
-			"Controls whether the output of the running task is shown or not. If omitted the globally defined value is used.",
-			"Controls whether the executed command is echoed to the output. Default is false.",
-			"Deprecated. Use isBackground instead.",
-			"Whether the executed task is kept alive and is watching the file system.",
-			"Whether the executed task is kept alive and is running in the background.",
-			"Whether the user is prompted when VS Code closes with a running task.",
-			"Maps this task to Code's default build command.",
-			"Maps this task to Code's default test command.",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"The command to be executed. Can be an external program or a shell command.",
-			"Additional arguments passed to the command.",
-			"Controls whether the output of the running task is shown or not. If omitted 'always' is used.",
-			"Deprecated. Use isBackground instead.",
-			"Whether the executed task is kept alive and is watching the file system.",
-			"Whether the executed task is kept alive and is running in the background.",
-			"Whether the user is prompted when VS Code closes with a running background task.",
-			"Controls whether the executed command is echoed to the output. Default is false.",
-			"Controls whether the task name is added as an argument to the command. Default is false.",
-			"Prefix to indicate that an argument is task.",
-			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
-			"The task configurations. Usually these are enrichments of task already defined in the external task runner."
+		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
+			"This extension is recommended because of the current workspace configuration"
 		],
-		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
-			"'env.', 'config.' and 'command.' are deprecated, use 'env:', 'config:' and 'command:' instead."
-		],
-		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
-			"The input's id is used to associate an input with a variable of the form ${input:id}.",
-			"The type of user input prompt to use.",
-			"The description is shown when the user is prompted for input.",
-			"The default value for the input.",
-			"User inputs. Used for defining user input prompts, such as free string input or a choice from several options.",
-			"The 'promptString' type opens an input box to ask the user for input.",
-			"Controls if a password input is shown. Password input hides the typed text.",
-			"The 'pickString' type shows a selection list.",
-			"An array of strings that defines the options for a quick pick.",
-			"Label for the option.",
-			"Value for the option.",
-			"The 'command' type executes a command.",
-			"The command to execute for this input variable.",
-			"Optional arguments passed to the command.",
-			"Optional arguments passed to the command.",
-			"Optional arguments passed to the command."
-		],
-		"vs/workbench/contrib/remote/browser/explorerViewItems": [
-			"Switch Remote",
-			"Switch Remote"
+		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
+			"Create New Terminal",
+			"Create New Terminal With Profile",
+			"Rename Terminal"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
 			"Show Tabs",
@@ -27803,18 +27967,6 @@
 			"(Overriden) {0}",
 			"Select current working directory for new terminal",
 			"Enter terminal name"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalService": [
-			"Do you want to terminate the active terminal session?",
-			"Do you want to terminate the {0} active terminal sessions?",
-			"&&Terminate",
-			"This shell is open to a {0}local{1} folder, NOT to the virtual folder",
-			"This shell is running on your {0}local{1} machine, NOT on the connected remote machine"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
-			"Create New Terminal",
-			"Create New Terminal With Profile",
-			"Rename Terminal"
 		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
 			"the terminal's current working directory",
@@ -27926,7 +28078,7 @@
 			"A new split terminal will use the working directory that the parent terminal started with.",
 			"On macOS and Linux, a new split terminal will use the working directory of the parent terminal. On Windows, this behaves the same as initial.",
 			"Whether to use ConPTY for Windows terminal process communication (requires Windows 10 build number 18309+). Winpty will be used if this is false.",
-			"A string containing all characters to be considered word separators by the double-click to select word feature.",
+			"A string containing all characters to be considered word separators when double-clicking to select word and in the fallback 'word' link detection. Since this is used for link detection, including characters such as `:` that are used when detecting links will cause the line and column part of links like `file:10:5` to be ignored.",
 			"Whether to enable file links in terminals. Links can be slow when working on a network drive in particular because each file link is verified against the file system. Changing this will take effect only in new terminals.",
 			"Always off.",
 			"Always on.",
@@ -27959,6 +28111,13 @@
 			"Enables experimental terminal Intellisense suggestions for supported shells when {0} is set to {1}. If shell integration is installed manually, {2} needs to be set to {3} before calling the script.",
 			"Controls whether the terminal will scroll using an animation.",
 			"Enables image support in the terminal, this will only work when {0} is enabled. Both sixel and iTerm's inline image protocol are supported on Linux and macOS, Windows support will light up automatically when ConPTY passes through the sequences. Images will currently not be restored between window reloads/reconnects."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"Do you want to terminate the active terminal session?",
+			"Do you want to terminate the {0} active terminal sessions?",
+			"&&Terminate",
+			"This shell is open to a {0}local{1} folder, NOT to the virtual folder",
+			"This shell is running on your {0}local{1} machine, NOT on the connected remote machine"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalIcons": [
 			"View icon of the terminal view.",
@@ -28037,17 +28196,17 @@
 		"vs/platform/terminal/common/terminalLogService": [
 			"Terminal"
 		],
+		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
+			"Move Tabs Right",
+			"Move Tabs Left",
+			"Hide Tabs"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
 			"Shell integration activated",
 			"The terminal process failed to launch. Disabling shell integration with terminal.integrated.shellIntegration.enabled might help.",
 			"Shell integration failed to activate",
 			"Process ID ({0}): {1}",
 			"Command line: {0}"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
-			"Move Tabs Right",
-			"Move Tabs Left",
-			"Hide Tabs"
 		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
 			"terminal accessibility help",
@@ -28077,22 +28236,6 @@
 			"Terminal buffer",
 			"{0}"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
-			"Free port {0}",
-			"Create PR {0}"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
-			"Run: {0}",
-			"Open: {0}",
-			"Quick Fix"
-		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
-			"Contributes terminal quick fixes.",
-			"The ID of the quick fix provider",
-			"A regular expression or string to test the command line against",
-			"A regular expression or string to match a single line of the output against, which provides groups to be referenced in terminalCommand and uri.\n\nFor example:\n\n `lineMatcher: /git push --set-upstream origin (?<branchName>[^s]+)/;`\n\n`terminalCommand: 'git push --set-upstream origin ${group:branchName}';`\n",
-			"The command exit result to match on"
-		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
 			"option + click",
 			"alt + click",
@@ -28109,8 +28252,97 @@
 			"Workspace Search",
 			"Show more links"
 		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
+			"Run: {0}",
+			"Open: {0}",
+			"Quick Fix"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
+			"Free port {0}",
+			"Create PR {0}"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
+			"Contributes terminal quick fixes.",
+			"The ID of the quick fix provider",
+			"A regular expression or string to test the command line against",
+			"A regular expression or string to match a single line of the output against, which provides groups to be referenced in terminalCommand and uri.\n\nFor example:\n\n `lineMatcher: /git push --set-upstream origin (?<branchName>[^s]+)/;`\n\n`terminalCommand: 'git push --set-upstream origin ${group:branchName}';`\n",
+			"The command exit result to match on"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
+			"Additional command options",
+			"The current working directory of the executed program or script. If omitted Code's current workspace root is used.",
+			"The environment of the executed program or shell. If omitted the parent process' environment is used.",
+			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
+			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
+			"Configures the shell to be used.",
+			"The shell to be used.",
+			"The shell arguments.",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Arguments passed to the command when this task is invoked.",
+			"The task's name",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Arguments passed to the command when this task is invoked.",
+			"Windows specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Mac specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Linux specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Controls whether the task name is added as an argument to the command. If omitted the globally defined value is used.",
+			"Controls whether the output of the running task is shown or not. If omitted the globally defined value is used.",
+			"Controls whether the executed command is echoed to the output. Default is false.",
+			"Deprecated. Use isBackground instead.",
+			"Whether the executed task is kept alive and is watching the file system.",
+			"Whether the executed task is kept alive and is running in the background.",
+			"Whether the user is prompted when VS Code closes with a running task.",
+			"Maps this task to Code's default build command.",
+			"Maps this task to Code's default test command.",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Additional arguments passed to the command.",
+			"Controls whether the output of the running task is shown or not. If omitted 'always' is used.",
+			"Deprecated. Use isBackground instead.",
+			"Whether the executed task is kept alive and is watching the file system.",
+			"Whether the executed task is kept alive and is running in the background.",
+			"Whether the user is prompted when VS Code closes with a running background task.",
+			"Controls whether the executed command is echoed to the output. Default is false.",
+			"Controls whether the task name is added as an argument to the command. Default is false.",
+			"Prefix to indicate that an argument is task.",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"The task configurations. Usually these are enrichments of task already defined in the external task runner."
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
+			"'env.', 'config.' and 'command.' are deprecated, use 'env:', 'config:' and 'command:' instead."
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
+			"The input's id is used to associate an input with a variable of the form ${input:id}.",
+			"The type of user input prompt to use.",
+			"The description is shown when the user is prompted for input.",
+			"The default value for the input.",
+			"User inputs. Used for defining user input prompts, such as free string input or a choice from several options.",
+			"The 'promptString' type opens an input box to ask the user for input.",
+			"Controls if a password input is shown. Password input hides the typed text.",
+			"The 'pickString' type shows a selection list.",
+			"An array of strings that defines the options for a quick pick.",
+			"Label for the option.",
+			"Value for the option.",
+			"The 'command' type executes a command.",
+			"The command to execute for this input variable.",
+			"Optional arguments passed to the command.",
+			"Optional arguments passed to the command.",
+			"Optional arguments passed to the command."
+		],
+		"vs/workbench/contrib/remote/browser/explorerViewItems": [
+			"Switch Remote",
+			"Switch Remote"
+		],
 		"vs/workbench/contrib/snippets/browser/commands/abstractSnippetsActions": [
 			"Snippets"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsFile": [
+			"Workspace Snippet",
+			"Global User Snippet",
+			"User Snippet"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetPicker": [
 			"User Snippets",
@@ -28120,11 +28352,6 @@
 			"Show in IntelliSense",
 			"Select a snippet",
 			"No snippet available"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsFile": [
-			"Workspace Snippet",
-			"Global User Snippet",
-			"User Snippet"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetCompletionProvider": [
 			"{0} ({1})",
@@ -28463,23 +28690,23 @@
 		"vs/platform/terminal/common/terminalProfiles": [
 			"Automatically detect the default"
 		],
+		"vs/workbench/contrib/webview/browser/webviewElement": [
+			"Error loading webview: {0}"
+		],
 		"vs/platform/quickinput/browser/quickPickPin": [
 			"pinned",
 			"Pin command",
 			"Pinned command"
 		],
-		"vs/workbench/contrib/webview/browser/webviewElement": [
-			"Error loading webview: {0}"
-		],
 		"vs/workbench/api/common/extHostDiagnostics": [
 			"Not showing {0} further errors and warnings."
-		],
-		"vs/workbench/api/common/extHostProgress": [
-			"{0} (Extension)"
 		],
 		"vs/workbench/api/common/extHostLanguageFeatures": [
 			"Paste using '{0}' extension",
 			"Drop using '{0}' extension"
+		],
+		"vs/workbench/api/common/extHostProgress": [
+			"{0} (Extension)"
 		],
 		"vs/workbench/api/common/extHostStatusBar": [
 			"{0} (Extension)",
@@ -28487,6 +28714,10 @@
 		],
 		"vs/workbench/api/common/extHostTreeViews": [
 			"Element with id {0} is already registered"
+		],
+		"vs/workbench/api/common/extHostNotebook": [
+			"Unable to modify read-only file '{0}'",
+			"File Modified Since"
 		],
 		"vs/workbench/api/common/extHostChat": [
 			"Provider returned null response",
@@ -28506,14 +28737,6 @@
 			"open",
 			"close",
 			"find"
-		],
-		"vs/editor/browser/controller/textAreaHandler": [
-			"editor",
-			"The editor is not accessible at this time. Press {0} for options."
-		],
-		"vs/editor/browser/widget/diffEditor.contribution": [
-			"Go to Next Difference",
-			"Go to Previous Difference"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionMenu": [
 			"More Actions...",
@@ -28594,13 +28817,20 @@
 		"vs/editor/contrib/suggest/browser/suggestWidgetStatus": [
 			"{0} ({1})"
 		],
-		"vs/editor/contrib/suggest/browser/suggestWidgetDetails": [
-			"Close",
-			"Loading..."
-		],
 		"vs/editor/contrib/suggest/browser/suggestWidgetRenderer": [
 			"Icon for more information in the suggest widget.",
 			"Read More"
+		],
+		"vs/editor/browser/controller/textAreaHandler": [
+			"editor",
+			"The editor is not accessible at this time.",
+			"{0} To enable screen reader optimized mode, use {1}",
+			"{0} To enable screen reader optimized mode, open the quick pick with {1} and run the command Toggle Screen Reader Accessibility Mode, which is currently not triggerable via keyboard.",
+			"{0} Please assign a keybinding for the command Toggle Screen Reader Accessibility Mode by accessing the keybindings editor with {1} and run it."
+		],
+		"vs/editor/contrib/suggest/browser/suggestWidgetDetails": [
+			"Close",
+			"Loading..."
 		],
 		"vs/workbench/contrib/comments/common/commentModel": [
 			"There are no comments in this workspace yet."
@@ -28626,11 +28856,18 @@
 			"Color of background for currently selected or hovered comment range.",
 			"Color of border for currently selected or hovered comment range."
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffReview": [
-			"Icon for 'Insert' in diff review.",
-			"Icon for 'Remove' in diff review.",
-			"Icon for 'Close' in diff review.",
+		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
+			"Fold Unchanged Region"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
+			" use {0} to open the accessibility help."
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer": [
+			"Icon for 'Insert' in accessible diff viewer.",
+			"Icon for 'Remove' in accessible diff viewer.",
+			"Icon for 'Close' in accessible diff viewer.",
 			"Close",
+			"Accessible Diff Viewer. Use arrow up and down to navigate.",
 			"no lines changed",
 			"1 line changed",
 			"{0} lines changed",
@@ -28641,11 +28878,8 @@
 			"+ {0} modified line {1}",
 			"- {0} original line {1}"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
-			"Fold Unchanged Region"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
-			" use Shift + F7 to navigate changes"
+		"vs/editor/browser/widget/diffEditorWidget2/colors": [
+			"The border color for text that got moved in the diff editor."
 		],
 		"vs/workbench/browser/parts/editor/editorPlaceholder": [
 			"Workspace Trust Required",
@@ -28657,6 +28891,10 @@
 			"The editor could not be opened due to an unexpected error: {0}",
 			"The editor could not be opened due to an unexpected error.",
 			"Try Again"
+		],
+		"vs/base/browser/ui/menu/menubar": [
+			"Application Menu",
+			"More"
 		],
 		"vs/workbench/browser/parts/editor/titleControl": [
 			"Editor actions",
@@ -28675,15 +28913,11 @@
 			"Focus and Select Breadcrumbs",
 			"Focus Breadcrumbs"
 		],
-		"vs/base/browser/ui/menu/menubar": [
-			"Application Menu",
-			"More"
+		"vs/platform/quickinput/browser/quickInputList": [
+			"Quick Input"
 		],
 		"vs/platform/quickinput/browser/quickInputUtils": [
 			"Click to execute command '{0}'"
-		],
-		"vs/platform/quickinput/browser/quickInputList": [
-			"Quick Input"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
 			"Setting value not applied",
@@ -28770,6 +29004,12 @@
 		],
 		"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer": [
 			"Execution Order"
+		],
+		"vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll": [
+			"Toggle Notebook Sticky Scroll",
+			"&&Toggle Notebook Sticky Scroll",
+			"Notebook Sticky Scroll",
+			"&&Notebook Sticky Scroll"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopyManager": [
 			"Saving working copies"
@@ -28874,23 +29114,43 @@
 			"No debugger available found. Can not send '{0}'.",
 			"More Info"
 		],
-		"vs/base/browser/ui/selectBox/selectBoxCustom": [
-			"Select Box"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
-			"1 Conflicting Line",
-			"{0} Conflicting Lines"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
-			"Set Input Handled",
-			"Undo Mark As Handled"
-		],
 		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
 			"Editor gutter decoration color for commenting ranges. This color should be opaque.",
 			"Editor overview ruler decoration color for resolved comments. This color should be opaque.",
 			"Editor overview ruler decoration color for unresolved comments. This color should be opaque.",
 			"Editor gutter decoration color for commenting glyphs.",
 			"Editor gutter decoration color for commenting glyphs for unresolved comment threads."
+		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
+			"1 Conflicting Line",
+			"{0} Conflicting Lines"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/conflictActions": [
+			"Accept {0}",
+			"Accept {0} in the result document.",
+			"Accept Combination ({0} First)",
+			"Accept Combination",
+			"Accept an automatic combination of both sides in the result document.",
+			"Append {0}",
+			"Append {0} to the result document.",
+			"Accept Combination",
+			"Accept an automatic combination of both sides in the result document.",
+			"Ignore",
+			"Don't take this side of the conflict.",
+			"Manual Resolution",
+			"This conflict has been resolved manually.",
+			"No Changes Accepted",
+			"The current resolution of this conflict equals the common ancestor of both the right and left changes.",
+			"Remove {0}",
+			"Remove {0} from the result document.",
+			"Remove {0}",
+			"Remove {0} from the result document.",
+			"Reset to base",
+			"Reset this conflict to the common ancestor of both the right and left changes."
+		],
+		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
+			"Set Input Handled",
+			"Undo Mark As Handled"
 		],
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"Contributed custom editors.",
@@ -28918,29 +29178,6 @@
 			"Yes",
 			"Cancel",
 			"Configure Terminal Profile"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/conflictActions": [
-			"Accept {0}",
-			"Accept {0} in the result document.",
-			"Accept Combination ({0} First)",
-			"Accept Combination",
-			"Accept an automatic combination of both sides in the result document.",
-			"Append {0}",
-			"Append {0} to the result document.",
-			"Accept Combination",
-			"Accept an automatic combination of both sides in the result document.",
-			"Ignore",
-			"Don't take this side of the conflict.",
-			"Manual Resolution",
-			"This conflict has been resolved manually.",
-			"No Changes Accepted",
-			"The current resolution of this conflict equals the common ancestor of both the right and left changes.",
-			"Remove {0}",
-			"Remove {0} from the result document.",
-			"Remove {0}",
-			"Remove {0} from the result document.",
-			"Reset to base",
-			"Reset this conflict to the common ancestor of both the right and left changes."
 		],
 		"vs/workbench/contrib/terminal/browser/terminalInstance": [
 			"Task",
@@ -28982,12 +29219,6 @@
 			"Terminal {0} {1}",
 			"Terminal"
 		],
-		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
-			"Show Command Actions",
-			"Command executed {0} and failed",
-			"Command executed {0} and failed (Exit Code {1})",
-			"Command executed {0}"
-		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
 			"Search workspace",
 			"Open file in editor",
@@ -29006,12 +29237,23 @@
 			"{0} found for '{1}'",
 			"{0} found for '{1}'"
 		],
+		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
+			"Show Command Actions",
+			"Command executed {0} and failed",
+			"Command executed {0} and failed (Exit Code {1})",
+			"Command executed {0}"
+		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/media/theme_picker": [
 			"Dark Modern",
 			"Light Modern",
 			"Dark High Contrast",
 			"Light High Contrast",
 			"See More Themes..."
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
+			"Default",
+			"Jupyter",
+			"Colab"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncConflictsView": [
 			"Please go through each entry and merge to resolve conflicts.",
@@ -29022,11 +29264,6 @@
 			"{0} (Local)",
 			"Theirs",
 			"Yours"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
-			"Default",
-			"Jupyter",
-			"Colab"
 		],
 		"vs/platform/actionWidget/browser/actionList": [
 			"{0} to apply, {1} to preview",
@@ -29154,6 +29391,12 @@
 			"Select a directory to go to (hold Option-key to edit the command)",
 			"Select a directory to go to (hold Alt-key to edit the command)"
 		],
+		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
+			"Success",
+			"Failed",
+			"Pending",
+			"Executing"
+		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput": [
 			"Cell has no output",
 			"No renderer could be found for output. It has the following mimetypes: {0}",
@@ -29164,21 +29407,10 @@
 			"Select mimetype to render for current output",
 			"renderer not available"
 		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
-			"Success",
-			"Failed",
-			"Pending",
-			"Executing"
-		],
 		"vs/workbench/contrib/comments/browser/commentThreadBody": [
 			"Comment thread with {0} comments on lines {1} through {2}. {3}.",
 			"Comment thread with {0} comments on the entire document. {1}.",
 			"Comment thread with {0} comments. {1}."
-		],
-		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
-			"Icon to collapse a review comment.",
-			"Collapse",
-			"Start discussion"
 		],
 		"vs/workbench/contrib/terminal/browser/environmentVariableInfo": [
 			"The following extensions want to relaunch the terminal to contribute to its environment:",
@@ -29186,6 +29418,11 @@
 			"The following extensions have contributed to this terminal's environment:",
 			"Show environment contributions",
 			"workspace"
+		],
+		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
+			"Icon to collapse a review comment.",
+			"Collapse",
+			"Start discussion"
 		],
 		"vs/workbench/contrib/comments/browser/commentNode": [
 			"Toggle Reaction",
@@ -29234,11 +29471,11 @@
 			"vs/editor/browser/widget/codeEditorWidget",
 			"vs/editor/browser/widget/diffEditor.contribution",
 			"vs/editor/browser/widget/diffEditorWidget",
+			"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer",
 			"vs/editor/browser/widget/diffEditorWidget2/colors",
 			"vs/editor/browser/widget/diffEditorWidget2/decorations",
 			"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors",
 			"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution",
-			"vs/editor/browser/widget/diffEditorWidget2/diffReview",
 			"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin",
 			"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges",
 			"vs/editor/browser/widget/diffReview",
@@ -29247,6 +29484,7 @@
 			"vs/editor/common/config/editorOptions",
 			"vs/editor/common/core/editorColorRegistry",
 			"vs/editor/common/editorContextKeys",
+			"vs/editor/common/languages",
 			"vs/editor/common/languages/modesRegistry",
 			"vs/editor/common/model/editStack",
 			"vs/editor/common/standaloneStrings",
@@ -29406,6 +29644,7 @@
 			"vs/workbench/api/browser/statusBarExtensionPoint",
 			"vs/workbench/api/browser/viewsExtensionPoint",
 			"vs/workbench/api/common/configurationExtensionPoint",
+			"vs/workbench/api/common/extHostTunnelService",
 			"vs/workbench/api/common/jsonValidationExtensionPoint",
 			"vs/workbench/browser/actions/developerActions",
 			"vs/workbench/browser/actions/helpActions",
@@ -29504,13 +29743,16 @@
 			"vs/workbench/contrib/chat/browser/actions/chatExecuteActions",
 			"vs/workbench/contrib/chat/browser/actions/chatImportExport",
 			"vs/workbench/contrib/chat/browser/actions/chatMoveActions",
-			"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions",
 			"vs/workbench/contrib/chat/browser/actions/chatTitleActions",
+			"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/multipleByScrollQuickQuestionAction",
+			"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/quickQuestionAction",
+			"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/singleQuickQuestionAction",
 			"vs/workbench/contrib/chat/browser/chat.contribution",
 			"vs/workbench/contrib/chat/browser/chatContributionServiceImpl",
 			"vs/workbench/contrib/chat/browser/chatEditorInput",
 			"vs/workbench/contrib/chat/browser/chatInputPart",
 			"vs/workbench/contrib/chat/browser/chatListRenderer",
+			"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget",
 			"vs/workbench/contrib/chat/browser/chatWidget",
 			"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib",
 			"vs/workbench/contrib/chat/common/chatColors",
@@ -29679,6 +29921,7 @@
 			"vs/workbench/contrib/format/browser/formatActionsNone",
 			"vs/workbench/contrib/format/browser/formatModified",
 			"vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty",
+			"vs/workbench/contrib/inlineChat/browser/inlineChat.contribution",
 			"vs/workbench/contrib/inlineChat/browser/inlineChatActions",
 			"vs/workbench/contrib/inlineChat/browser/inlineChatController",
 			"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies",
@@ -29752,7 +29995,7 @@
 			"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions",
 			"vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor",
 			"vs/workbench/contrib/notebook/browser/notebook.contribution",
-			"vs/workbench/contrib/notebook/browser/notebookAccessibilityHelp",
+			"vs/workbench/contrib/notebook/browser/notebookAccessibility",
 			"vs/workbench/contrib/notebook/browser/notebookEditor",
 			"vs/workbench/contrib/notebook/browser/notebookEditorWidget",
 			"vs/workbench/contrib/notebook/browser/notebookExtensionPoint",
@@ -29772,6 +30015,8 @@
 			"vs/workbench/contrib/notebook/browser/view/cellParts/markupCell",
 			"vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView",
 			"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer",
+			"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider",
+			"vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll",
 			"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy",
 			"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView",
 			"vs/workbench/contrib/notebook/common/notebookEditorInput",
@@ -30091,7 +30336,8 @@
 			"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService"
 		],
 		"vs/editor/common/services/editorSimpleWorker": [
-			"vs/base/common/platform"
+			"vs/base/common/platform",
+			"vs/editor/common/languages"
 		],
 		"vs/base/common/worker/simpleWorker": [
 			"vs/base/common/platform"
@@ -30115,11 +30361,13 @@
 			"vs/workbench/api/common/extHostExtensionService",
 			"vs/workbench/api/common/extHostLanguageFeatures",
 			"vs/workbench/api/common/extHostLogService",
+			"vs/workbench/api/common/extHostNotebook",
 			"vs/workbench/api/common/extHostProgress",
 			"vs/workbench/api/common/extHostStatusBar",
 			"vs/workbench/api/common/extHostTelemetry",
 			"vs/workbench/api/common/extHostTerminalService",
 			"vs/workbench/api/common/extHostTreeViews",
+			"vs/workbench/api/common/extHostTunnelService",
 			"vs/workbench/api/common/extHostWorkspace",
 			"vs/workbench/common/editor",
 			"vs/workbench/common/views",
@@ -30161,6 +30409,7 @@
 			"vs/base/common/errorMessage",
 			"vs/base/common/platform",
 			"vs/editor/common/config/editorOptions",
+			"vs/editor/common/languages",
 			"vs/platform/configuration/common/configurationRegistry",
 			"vs/platform/contextkey/common/contextkey",
 			"vs/platform/contextkey/common/scanner",
@@ -30178,14 +30427,15 @@
 			"vs/workbench/api/common/extHostExtensionService",
 			"vs/workbench/api/common/extHostLanguageFeatures",
 			"vs/workbench/api/common/extHostLogService",
+			"vs/workbench/api/common/extHostNotebook",
 			"vs/workbench/api/common/extHostProgress",
 			"vs/workbench/api/common/extHostStatusBar",
 			"vs/workbench/api/common/extHostTelemetry",
 			"vs/workbench/api/common/extHostTerminalService",
 			"vs/workbench/api/common/extHostTreeViews",
+			"vs/workbench/api/common/extHostTunnelService",
 			"vs/workbench/api/common/extHostWorkspace",
 			"vs/workbench/api/node/extHostDebugService",
-			"vs/workbench/api/node/extHostTunnelService",
 			"vs/workbench/common/editor",
 			"vs/workbench/common/views",
 			"vs/workbench/contrib/debug/common/abstractDebugAdapter",

--- a/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
@@ -274,13 +274,17 @@ export class DebugBreakpointWidget implements Disposable {
             .setDecorationsByType('Debug breakpoint placeholder', DebugBreakpointWidget.PLACEHOLDER_DECORATION, decorations);
     }
     protected get placeholder(): string {
+        const acceptString = 'Enter';
+        const closeString = 'Escape';
         if (this.context === 'logMessage') {
-            return nls.localizeByDefault("Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.");
+            return nls.localizeByDefault(
+                "Message to log when breakpoint is hit. Expressions within {} are interpolated. '{0}' to accept, '{1}' to cancel.", acceptString, closeString
+            );
         }
         if (this.context === 'hitCondition') {
-            return nls.localizeByDefault("Break when hit count condition is met. 'Enter' to accept, 'esc' to cancel.");
+            return nls.localizeByDefault("Break when hit count condition is met. '{0}' to accept, '{1}' to cancel.", acceptString, closeString);
         }
-        return nls.localizeByDefault("Break when expression evaluates to true. 'Enter' to accept, 'esc' to cancel.");
+        return nls.localizeByDefault("Break when expression evaluates to true. '{0}' to accept, '{1}' to cancel.", acceptString, closeString);
     }
 
 }

--- a/packages/getting-started/src/browser/getting-started-preferences.ts
+++ b/packages/getting-started/src/browser/getting-started-preferences.ts
@@ -35,8 +35,8 @@ export const GettingStartedPreferenceSchema: PreferenceSchema = {
                 nls.localizeByDefault('Start without an editor.'),
                 nls.localize('theia/getting-started/startup-editor/welcomePage', 'Open the Welcome page, with content to aid in getting started with {0} and extensions.',
                     FrontendApplicationConfigProvider.get().applicationName),
-                nls.localizeByDefault(`Open the README when opening a folder that contains one, fallback to \'welcomePage\' otherwise. 
-                Note: This is only observed as a global configuration, it will be ignored if set in a workspace or folder configuration.`),
+                // eslint-disable-next-line max-len
+                nls.localizeByDefault("Open the README when opening a folder that contains one, fallback to 'welcomePage' otherwise. Note: This is only observed as a global configuration, it will be ignored if set in a workspace or folder configuration."),
                 nls.localizeByDefault('Open a new untitled text file (only applies when opening an empty window).'),
                 nls.localizeByDefault('Open the Welcome page when opening an empty workbench.'),
             ],

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -103,7 +103,7 @@ export namespace TerminalCommands {
     export const TERMINAL_CONTEXT = Command.toDefaultLocalizedCommand({
         id: 'terminal:context',
         category: TERMINAL_CATEGORY,
-        label: 'Open in Terminal'
+        label: 'Open in Integrated Terminal'
     });
     export const SPLIT = Command.toDefaultLocalizedCommand({
         id: 'terminal:split',


### PR DESCRIPTION
#### What it does

Related to https://github.com/eclipse-theia/theia/pull/12949

Updates our localization file for VSCode API version 1.81.0.

#### How to test

CI is green, no warnings appear in the frontend console during startup about untranslated values.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
