### PR TITLE
Update `vscode-textmate` dependency

### DIFF
--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -13,7 +13,7 @@
     "idb": "^4.0.5",
     "jsonc-parser": "^2.2.0",
     "vscode-oniguruma": "1.6.1",
-    "vscode-textmate": "^7.0.3"
+    "vscode-textmate": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
+++ b/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
@@ -14,21 +14,21 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { INITIAL, IGrammar, StackElement } from 'vscode-textmate';
+import { INITIAL, IGrammar, StateStack } from 'vscode-textmate';
 import * as monaco from '@theia/monaco-editor-core';
 
 export class TokenizerState implements monaco.languages.IState {
 
     constructor(
-        public readonly stackElement: StackElement
+        public readonly stateStack: StateStack
     ) { }
 
     clone(): monaco.languages.IState {
-        return new TokenizerState(this.stackElement);
+        return new TokenizerState(this.stateStack);
     }
 
     equals(other: monaco.languages.IState): boolean {
-        return other instanceof TokenizerState && (other === this || other.stackElement === this.stackElement);
+        return other instanceof TokenizerState && (other === this || other.stateStack === this.stateStack);
     }
 
 }
@@ -58,9 +58,9 @@ export function createTextmateTokenizer(grammar: IGrammar, options: TokenizerOpt
         tokenizeEncoded(line: string, state: TokenizerState): monaco.languages.IEncodedLineTokens {
             if (options.lineLimit !== undefined && line.length > options.lineLimit) {
                 // Skip tokenizing the line if it exceeds the line limit.
-                return { endState: state.stackElement, tokens: new Uint32Array() };
+                return { endState: state.stateStack, tokens: new Uint32Array() };
             }
-            const result = grammar.tokenizeLine2(line, state.stackElement, 500);
+            const result = grammar.tokenizeLine2(line, state.stateStack, 500);
             return {
                 endState: new TokenizerState(result.ruleStack),
                 tokens: result.tokens
@@ -69,9 +69,9 @@ export function createTextmateTokenizer(grammar: IGrammar, options: TokenizerOpt
         tokenize(line: string, state: TokenizerState): monaco.languages.ILineTokens {
             if (options.lineLimit !== undefined && line.length > options.lineLimit) {
                 // Skip tokenizing the line if it exceeds the line limit.
-                return { endState: state.stackElement, tokens: [] };
+                return { endState: state.stateStack, tokens: [] };
             }
-            const result = grammar.tokenizeLine(line, state.stackElement, 500);
+            const result = grammar.tokenizeLine(line, state.stateStack, 500);
             return {
                 endState: new TokenizerState(result.ruleStack),
                 tokens: result.tokens.map(t => ({

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -47,7 +47,7 @@
     "semver": "^7.5.4",
     "uuid": "^8.0.0",
     "vhost": "^3.0.2",
-    "vscode-textmate": "^7.0.3"
+    "vscode-textmate": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11220,10 +11220,10 @@ vscode-textmate@5.2.0:
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
   integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
-vscode-textmate@^7.0.3:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-7.0.4.tgz#a30df59ce573e998e4e2ffbca5ab82d57bc3126f"
-  integrity sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==
+vscode-textmate@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-9.0.0.tgz#313c6c8792b0507aef35aeb81b6b370b37c44d6c"
+  integrity sha512-Cl65diFGxz7gpwbav10HqiY/eVYTO1sjQpmRmV991Bj7wAoOAjGQ97PpQcXorDE2Uc4hnGWLY17xme+5t6MlSg==
 
 vscode-uri@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12960.

Updates our `vscode-textmate` dependency to fix an issue in plist xml parsing that only seems to appear in newer versions of Chrome.

#### How to test

1. Open Theia in Chrome (version >= 117.0)
2. Install the [Twig Language](https://open-vsx.org/extension/mblode/twig-language) extension.
3. Open a `.twig` file, the highlighting should work as expected:
```twig
{% for user in users %}
* {{ user.name }}
{% else %}
No users have been found.
{% endfor %}
```

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
