### PR TITLE
Fix preload application package import

### DIFF
--- a/packages/core/src/browser/preload/theme-preload-contribution.ts
+++ b/packages/core/src/browser/preload/theme-preload-contribution.ts
@@ -17,7 +17,7 @@
 import { PreloadContribution } from './preloader';
 import { DEFAULT_BACKGROUND_COLOR_STORAGE_KEY } from '../frontend-application-config-provider';
 import { injectable } from 'inversify';
-import { DefaultTheme } from '@theia/application-package';
+import { DefaultTheme } from '@theia/application-package/lib/application-props';
 
 @injectable()
 export class ThemePreloadContribution implements PreloadContribution {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12962

Fixes the import to use one that doesn't rely on node.js dependencies.

#### How to test

Confirm that the preload functionality behaves as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
