### PR TITLE
Add smoke test for production build

### DIFF
--- a/.github/workflows/production-smoke-test.yml
+++ b/.github/workflows/production-smoke-test.yml
@@ -28,10 +28,10 @@ jobs:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Use Python 3.x
+      - name: Use Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
 
       - name: Build Browser Example Application for Production
         shell: bash

--- a/.github/workflows/production-smoke-test.yml
+++ b/.github/workflows/production-smoke-test.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: "0 5 * * *" # Runs every day at 5am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
 
 jobs:
   build-and-test-playwright:

--- a/.github/workflows/production-smoke-test.yml
+++ b/.github/workflows/production-smoke-test.yml
@@ -1,0 +1,54 @@
+name: Production Build Smoke Test
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 5 * * *" # Runs every day at 5am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
+
+jobs:
+  build-and-test-playwright:
+    name: Smoke Test for Browser Example Production Build on ubuntu-latest with Node.js 18.x
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js "18.x"
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Build Browser Example Application for Production
+        shell: bash
+        run: |
+          yarn global add node-gyp
+          yarn --skip-integrity-check --network-timeout 100000
+          yarn browser build:production
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Build Playwright
+        shell: bash
+        run: |
+          yarn --cwd examples/playwright build
+
+      - name: Run Smoke Test (examples/playwright/src/tests/theia-app)
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn test:playwright theia-app

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -62,7 +62,9 @@
   "scripts": {
     "clean": "theia clean",
     "build": "yarn -s compile && yarn -s bundle",
+    "build:production": "yarn -s compile && yarn -s bundle:production",
     "bundle": "yarn rebuild && theia build --mode development",
+    "bundle:production": "yarn rebuild && theia build --mode production",
     "compile": "tsc -b",
     "coverage": "yarn -s test --test-coverage && yarn -s coverage:report",
     "coverage:clean": "rimraf .nyc_output && rimraf coverage",


### PR DESCRIPTION
#### What it does

Currently we don't seem to have any automated test that verifies whether the production build works as expected.
For a recent issue and its root cause, which remained unrevealed by the CI, see https://github.com/eclipse-theia/theia/issues/12962.

With this PR, we add a new Github workflow, which builds the example browser app in production mode and runs a simple smoke test. This smoke test just opens the app and awaits the loading spinner to disappear and expects the workbench to be visible within a certain timeframe.

Contributed on behalf of STMicroelectronics

#### How to test

The check should be green after https://github.com/eclipse-theia/theia/pull/12964 is merged.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
