### PR TITLE
Fix #12546: UI not updated upon editing breakpoint condition

### DIFF
--- a/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
@@ -75,7 +75,9 @@ export class BreakpointManager extends MarkerManager<SourceBreakpoint> {
                 added.push(newMarker);
             } else {
                 // We emit all existing markers as 'changed', but we only fire an event if something really did change.
-                didChangeMarkers ||= !!added.length || !deepEqual(oldMarker, newMarker);
+                // We also fire an event if oldMarker === newMarker, as we cannot actually detect a change in this case
+                // (https://github.com/eclipse-theia/theia/issues/12546).
+                didChangeMarkers ||= !!added.length || oldMarker === newMarker || !deepEqual(oldMarker, newMarker);
                 changed.push(newMarker);
             }
         }


### PR DESCRIPTION
#### What it does

Fixes #12546, which is a regression introduced by #12183, by ensuring that `BreakpointManager.setMarkers` fires a `SourceBreakpointsChangeEvent` when `oldMarker === newMarker`, as there is no way to actually detect a change in this case.

#### How to test

- Verify that #12546 is actually fixed by following the steps given in the issue description.

- Also verify that #11878, which was fixed by #12183, is still fixed after this patch is applied, and there are no other regressions in breakpoint management in general.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
