### PR TITLE
Ensure ApplicationShellOptions are properly used for shell init

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -272,6 +272,22 @@ export class ApplicationShell extends Widget {
         @inject(SecondaryWindowHandler) protected readonly secondaryWindowHandler: SecondaryWindowHandler,
     ) {
         super(options as Widget.IOptions);
+
+        // Merge the user-defined application options with the default options
+        this.options = {
+            bottomPanel: {
+                ...ApplicationShell.DEFAULT_OPTIONS.bottomPanel,
+                ...options?.bottomPanel || {}
+            },
+            leftPanel: {
+                ...ApplicationShell.DEFAULT_OPTIONS.leftPanel,
+                ...options?.leftPanel || {}
+            },
+            rightPanel: {
+                ...ApplicationShell.DEFAULT_OPTIONS.rightPanel,
+                ...options?.rightPanel || {}
+            }
+        };
     }
 
     @postConstruct()
@@ -303,21 +319,6 @@ export class ApplicationShell extends Widget {
     protected initializeShell(): void {
         this.addClass(APPLICATION_SHELL_CLASS);
         this.id = 'theia-app-shell';
-        // Merge the user-defined application options with the default options
-        this.options = {
-            bottomPanel: {
-                ...ApplicationShell.DEFAULT_OPTIONS.bottomPanel,
-                ...this.options?.bottomPanel || {}
-            },
-            leftPanel: {
-                ...ApplicationShell.DEFAULT_OPTIONS.leftPanel,
-                ...this.options?.leftPanel || {}
-            },
-            rightPanel: {
-                ...ApplicationShell.DEFAULT_OPTIONS.rightPanel,
-                ...this.options?.rightPanel || {}
-            }
-        };
 
         this.mainPanel = this.createMainPanel();
         this.topPanel = this.createTopPanel();


### PR DESCRIPTION

#### What it does
Ensure ApplicationShellOptions are properly used for shell init
Fixes https://github.com/eclipse-theia/theia/issues/12982

#### How to test

1. Use a custom re-binding in your application, e.g., `rebind(ApplicationShellOptions).toConstantValue(<ApplicationShell.Options>{ leftPanel: { initialSizeRatio: 0.5 } });` or replace the binding in Theia with something that has values (https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/frontend-application-module.ts#L163)
2. Ensure your workspace layout is reset to default.
3. Expand the left sidebar and see that the right ratio is used.

#### Follow-ups

None.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
