### PR TITLE
Implement EnvironmentVariableMutatorOptions API.

### DIFF
--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -372,16 +372,16 @@ export class EnvironmentVariableCollection implements theia.EnvironmentVariableC
         return this.map.size;
     }
 
-    replace(variable: string, value: string): void {
-        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Replace });
+    replace(variable: string, value: string, options?: theia.EnvironmentVariableMutatorOptions): void {
+        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Replace, options: options ?? { applyAtProcessCreation: true } });
     }
 
-    append(variable: string, value: string): void {
-        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Append });
+    append(variable: string, value: string, options?: theia.EnvironmentVariableMutatorOptions): void {
+        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Append, options: options ?? { applyAtProcessCreation: true } });
     }
 
-    prepend(variable: string, value: string): void {
-        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Prepend });
+    prepend(variable: string, value: string, options?: theia.EnvironmentVariableMutatorOptions): void {
+        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Prepend, options: options ?? { applyAtProcessCreation: true } });
     }
 
     private _setIfDiffers(variable: string, mutator: theia.EnvironmentVariableMutator): void {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3575,6 +3575,24 @@ export module '@theia/plugin' {
     }
 
     /**
+     * Options applied to the mutator.
+     */
+    export interface EnvironmentVariableMutatorOptions {
+        /**
+         * Apply to the environment just before the process is created. Defaults to true
+         */
+        applyAtProcessCreation?: boolean;
+
+        /**
+         * Apply to the environment in the shell integration script. Note that this _will not_ apply
+         * the mutator if shell integration is disabled or not working for some reason. Defaults to
+         * false.
+         * @stubbed
+         */
+        applyAtShellIntegration?: boolean;
+    }
+
+    /**
      * A type of mutation and its value to be applied to an environment variable.
      */
     export interface EnvironmentVariableMutator {
@@ -3587,6 +3605,11 @@ export module '@theia/plugin' {
          * The value to use for the variable.
          */
         readonly value: string;
+
+        /**
+         * Options applied to the mutator.
+         */
+        readonly options: EnvironmentVariableMutatorOptions;
     }
 
     /**
@@ -3617,7 +3640,7 @@ export module '@theia/plugin' {
          * @param variable The variable to replace.
          * @param value The value to replace the variable with.
          */
-        replace(variable: string, value: string): void;
+        replace(variable: string, value: string, options?: EnvironmentVariableMutatorOptions): void;
 
         /**
          * Append a value to an environment variable.
@@ -3628,7 +3651,7 @@ export module '@theia/plugin' {
          * @param variable The variable to append to.
          * @param value The value to append to the variable.
          */
-        append(variable: string, value: string): void;
+        append(variable: string, value: string, options?: EnvironmentVariableMutatorOptions): void;
 
         /**
          * Prepend a value to an environment variable.
@@ -3639,7 +3662,7 @@ export module '@theia/plugin' {
          * @param variable The variable to prepend.
          * @param value The value to prepend to the variable.
          */
-        prepend(variable: string, value: string): void;
+        prepend(variable: string, value: string, options?: EnvironmentVariableMutatorOptions): void;
 
         /**
          * Gets the mutator that this collection applies to a variable, if any.

--- a/packages/terminal/src/common/base-terminal-protocol.ts
+++ b/packages/terminal/src/common/base-terminal-protocol.ts
@@ -168,9 +168,14 @@ export enum EnvironmentVariableMutatorType {
     Prepend = 3
 }
 
+export interface EnvironmentVariableMutatorOptions {
+    applyAtProcessCreation?: boolean;
+}
+
 export interface EnvironmentVariableMutator {
     readonly value: string;
     readonly type: EnvironmentVariableMutatorType;
+    readonly options: EnvironmentVariableMutatorOptions;
 }
 
 export interface ExtensionOwnedEnvironmentVariableMutator extends EnvironmentVariableMutator {

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -274,7 +274,8 @@ export class MergedEnvironmentVariableCollectionImpl implements MergedEnvironmen
                 entry.unshift({
                     extensionIdentifier,
                     value: mutator.value,
-                    type: mutator.type
+                    type: mutator.type,
+                    options: mutator.options
                 });
 
                 next = it.next();
@@ -291,16 +292,18 @@ export class MergedEnvironmentVariableCollectionImpl implements MergedEnvironmen
         this.map.forEach((mutators, variable) => {
             const actualVariable = isWindows ? lowerToActualVariableNames![variable.toLowerCase()] || variable : variable;
             mutators.forEach(mutator => {
-                switch (mutator.type) {
-                    case EnvironmentVariableMutatorType.Append:
-                        env[actualVariable] = (env[actualVariable] || '') + mutator.value;
-                        break;
-                    case EnvironmentVariableMutatorType.Prepend:
-                        env[actualVariable] = mutator.value + (env[actualVariable] || '');
-                        break;
-                    case EnvironmentVariableMutatorType.Replace:
-                        env[actualVariable] = mutator.value;
-                        break;
+                if (mutator.options?.applyAtProcessCreation ?? true) {
+                    switch (mutator.type) {
+                        case EnvironmentVariableMutatorType.Append:
+                            env[actualVariable] = (env[actualVariable] || '') + mutator.value;
+                            break;
+                        case EnvironmentVariableMutatorType.Prepend:
+                            env[actualVariable] = mutator.value + (env[actualVariable] || '');
+                            break;
+                        case EnvironmentVariableMutatorType.Replace:
+                            env[actualVariable] = mutator.value;
+                            break;
+                    }
                 }
             });
         });


### PR DESCRIPTION


#### What it does
Implements options when mutating `EnvironmentVariableCollection`s. Since Theia does not support shell integration scripts, one of the options is stubbed. See the related issue for details.

 Fixes #12941

Contributed on behalf of STMicroelectronics

#### How to test

Install the attached extension. It exercises the various cases like so:

```
    context.environmentVariableCollection.append('MUTATED_DEFAULT', 'a string');
    context.environmentVariableCollection.append('MUTATED_TRUE', 'a string', { applyAtProcessCreation: true });
    context.environmentVariableCollection.append('MUTATED_FALSE', 'a string', { applyAtProcessCreation: false });
    context.environmentVariableCollection.append('MUTATED_INT_TRUE', 'a string', { applyAtShellIntegration: true, applyAtProcessCreation: false });
```` 
After startup, open a terminal. My expectation is that THE `MUTATED_DEFAULT` and `MUTATED_TRUE` are set in the terminal shell.

#### Follow-ups
If we ever decide to implement shell integration scripts, we need to honor the corresponding flag.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
