### PR TITLE
Improve language quick pick responsiveness

### DIFF
--- a/packages/core/src/browser/i18n/language-quick-pick-service.ts
+++ b/packages/core/src/browser/i18n/language-quick-pick-service.ts
@@ -80,6 +80,7 @@ export class LanguageQuickPickService {
                 } else {
                     resolve(undefined);
                 }
+                quickInput.hide();
             });
             quickInput.onDidHide(() => {
                 resolve(undefined);

--- a/packages/vsx-registry/src/browser/vsx-language-quick-pick-service.ts
+++ b/packages/vsx-registry/src/browser/vsx-language-quick-pick-service.ts
@@ -71,9 +71,12 @@ export class VSXLanguageQuickPickService extends LanguageQuickPickService {
                                 text: nls.localizeByDefault('Installing {0} language support...',
                                     localizationContribution.localizedLanguageName ?? localizationContribution.languageName ?? localizationContribution.languageId),
                             });
-                            const extensionUri = VSCodeExtensionUri.toUri(extension.extension.name, extension.extension.namespace).toString();
-                            await this.pluginServer.deploy(extensionUri);
-                            progress.cancel();
+                            try {
+                                const extensionUri = VSCodeExtensionUri.toUri(extension.extension.name, extension.extension.namespace).toString();
+                                await this.pluginServer.deploy(extensionUri);
+                            } finally {
+                                progress.cancel();
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12991

Improves the responsiveness of the quick pick that appears when executing the `Configure Display Language` command:

1. Correctly hides the quick pick when the current default language is selected (fix for https://github.com/eclipse-theia/theia/issues/12991)
2. Shows a notification that the language pack is currently being downloaded/installed.


#### How to test

1. Run the `Configure Display Languages` command.
3. Before the languages are fetched from open-vsx, press enter to select the default language.
4. The quick input should close as expected.

---

1. Install a language package from open-vsx via the `Configure Display Language` command.
2. During the plugin deployment, a notification appears in the application shell.
3. Once the plugin is installed, the notification disappears.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
