### PR TITLE
Support string argument in `vscode.open`

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -229,7 +229,10 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(VscodeCommands.OPEN, {
             isVisible: () => false,
-            execute: async (resource: URI, columnOrOptions?: ViewColumn | TextDocumentShowOptions) => {
+            execute: async (resource: URI | string, columnOrOptions?: ViewColumn | TextDocumentShowOptions) => {
+                if (typeof resource === 'string') {
+                    resource = URI.parse(resource);
+                }
                 try {
                     await this.openWith(VscodeCommands.OPEN.id, resource, columnOrOptions);
                 } catch (error) {


### PR DESCRIPTION
#### What it does

Closes #12996

#### How to test

1. Install the [CodeGPT Chat](https://open-vsx.org/extension/DanielSanMedium/dscodegpt) extension
2. Open the webview and click on the "Connect to CodeGPT Plus" button
3. Theia should open the URL provided in an external browser window

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
