### PR TITLE
vscode - proposed API evolution for TerminalQuickFixProvider for 1.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.43.0 - Unreleased
 
 - [vsode] evolve proposed API for dropDocument [#13009](https://github.com/eclipse-theia/theia/pull/13009) - contributed on behalf of STMicroelectronics
+- [vsode] evolve proposed API for terminalQuickFixProvider [#13006](https://github.com/eclipse-theia/theia/pull/13006) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.43.0">[Breaking Changes:](#breaking_changes_1.43.0)</a>
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -161,7 +161,6 @@ import {
     TerminalLocation,
     TerminalExitReason,
     TerminalProfile,
-    TerminalQuickFixType,
     InlayHint,
     InlayHintKind,
     InlayHintLabelPart,
@@ -199,7 +198,9 @@ import {
     DocumentPasteEdit,
     ExternalUriOpenerPriority,
     EditSessionIdentityMatch,
-    TerminalOutputAnchor
+    TerminalOutputAnchor,
+    TerminalQuickFixExecuteTerminalCommand,
+    TerminalQuickFixOpener
 } from './types-impl';
 import { AuthenticationExtImpl } from './authentication-ext';
 import { SymbolKind } from '../common/plugin-api-rpc-model';
@@ -1391,7 +1392,8 @@ export function createAPIFactory(
             TerminalExitReason,
             DocumentPasteEdit,
             ExternalUriOpenerPriority,
-            TerminalQuickFixType,
+            TerminalQuickFixExecuteTerminalCommand,
+            TerminalQuickFixOpener,
             EditSessionIdentityMatch
         };
     };

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2183,11 +2183,6 @@ export enum TerminalExitReason {
     Extension = 4,
 }
 
-export enum TerminalQuickFixType {
-    command = 'command',
-    opener = 'opener'
-}
-
 @es5ClassCompat
 export class FileDecoration {
 
@@ -3629,4 +3624,28 @@ export enum EditSessionIdentityMatch {
     Partial = 50,
     None = 0
 }
+// #endregion
+
+// #region terminalQuickFixProvider
+export class TerminalQuickFixExecuteTerminalCommand {
+    /**
+     * The terminal command to run
+     */
+    terminalCommand: string;
+    /**
+     * @stubbed
+     */
+    constructor(terminalCommand: string) { }
+}
+export class TerminalQuickFixOpener {
+    /**
+     * The uri to open
+     */
+    uri: theia.Uri;
+    /**
+     * @stubbed
+     */
+    constructor(uri: theia.Uri) { }
+}
+
 // #endregion

--- a/packages/plugin/src/theia.proposed.terminalQuickFixProvider.d.ts
+++ b/packages/plugin/src/theia.proposed.terminalQuickFixProvider.d.ts
@@ -22,6 +22,8 @@
 
 export module '@theia/plugin' {
 
+    export type SingleOrMany<T> = T[] | T;
+
     export namespace window {
         /**
          * @param provider A terminal quick fix provider
@@ -37,7 +39,8 @@ export module '@theia/plugin' {
          * @param token A cancellation token indicating the result is no longer needed
          * @return Terminal quick fix(es) if any
          */
-        provideTerminalQuickFixes(commandMatchResult: TerminalCommandMatchResult, token: CancellationToken): TerminalQuickFix[] | TerminalQuickFix | undefined;
+        provideTerminalQuickFixes(commandMatchResult: TerminalCommandMatchResult, token: CancellationToken):
+            ProviderResult<SingleOrMany<TerminalQuickFixExecuteTerminalCommand | TerminalQuickFixOpener | Command>>;
     }
 
     export interface TerminalCommandMatchResult {
@@ -49,13 +52,19 @@ export module '@theia/plugin' {
         };
     }
 
-    interface TerminalQuickFix {
-        type: TerminalQuickFixType;
+    export class TerminalQuickFixExecuteTerminalCommand {
+        /**
+         * The terminal command to run
+         */
+        terminalCommand: string;
+        constructor(terminalCommand: string);
     }
-
-    enum TerminalQuickFixType {
-        command = 'command',
-        opener = 'opener'
+    export class TerminalQuickFixOpener {
+        /**
+         * The uri to open
+         */
+        uri: Uri;
+        constructor(uri: Uri);
     }
 
     /**


### PR DESCRIPTION
#### What it does

Fix stubbed API with missing types and removed enums on 1.82.0 version for TerminalQuickFixProvider (used by _npm_ builtins) 

Fixes #12969

Contributed on behalf of ST Microelectronics

#### How to test 
Not much, as this is a stubbed API. 

#### Follow-ups

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

