### PR TITLE
evolution on proposed API  dropMetadata with vs code 1.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## v1.43.0 - Unreleased
 
+- [vsode] evolve proposed API for dropDocument [#13009](https://github.com/eclipse-theia/theia/pull/13009) - contributed on behalf of STMicroelectronics
+
 <a name="breaking_changes_1.43.0">[Breaking Changes:](#breaking_changes_1.43.0)</a>
 
 - [core] removed `SETTINGS_OPEN` menupath constant - replaced by `MANAGE_GENERAL` [#12803](https://github.com/eclipse-theia/theia/pull/12803)

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -330,6 +330,7 @@ export interface DocumentDropEdit {
 }
 
 export interface DocumentDropEditProviderMetadata {
+    readonly id: string;
     readonly dropMimeTypes: readonly string[];
 }
 

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -740,7 +740,8 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
 
     createDocumentDropEditProvider(handle: number, _metadata?: DocumentDropEditProviderMetadata): DocumentOnDropEditProvider {
         return {
-            // @monaco-uplift dropMimeTypes should be supported by the monaco drop editor provider after 1.79.0
+            // @monaco-uplift id and dropMimeTypes should be supported by the monaco drop editor provider after 1.82.0
+            // id?: string;
             // dropMimeTypes: metadata?.dropMimeTypes ?? ['*/*'],
             provideDocumentOnDropEdits: async (model, position, dataTransfer, token) => this.provideDocumentDropEdits(handle, model, position, dataTransfer, token)
         };
@@ -752,10 +753,11 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         const edit = await this.proxy.$provideDocumentDropEdits(handle, model.uri, position, await DataTransfer.toDataTransferDTO(dataTransfer), token);
         if (edit) {
             return {
-                // @monaco-uplift id, priority and label should be supported by monaco after 1.79.0. The implementation relies on a copy of the plugin data
-                // id: edit.id ? plugin.identifier.value + '.' + edit.id : plugin.identifier.value,
-                // label: edit.label ?? nls.localizeByDefault("Drop using '{0}' extension", plugin.displayName || plugin.name),
-                // priority: edit.priority ?? 0,
+                // @monaco-uplift label and yieldTo should be supported by monaco after 1.82.0. The implementation relies on a copy of the plugin data
+                // label: label: edit.label ?? localize('defaultDropLabel', "Drop using '{0}' extension", this._extension.displayName || this._extension.name),,
+                // yieldTo: edit.yieldTo?.map(yTo => {
+                //      return 'mimeType' in yTo ? yTo : { providerId: DocumentOnDropEditAdapter.toInternalProviderId(yTo.extensionId, yTo.providerId) };
+                // }),
                 insertText: edit.insertText instanceof SnippetString ? { snippet: edit.insertText.value } : edit.insertText,
                 additionalEdit: toMonacoWorkspaceEdit(edit?.additionalEdit)
             };

--- a/packages/plugin/src/theia.proposed.dropMetadata.d.ts
+++ b/packages/plugin/src/theia.proposed.dropMetadata.d.ts
@@ -25,27 +25,36 @@ export module '@theia/plugin' {
     // https://github.com/microsoft/vscode/issues/179430
 
     export interface DocumentDropEdit {
-        /**
-         * Identifies the type of edit.
-         *
-         * This id should be unique within the extension but does not need to be unique across extensions.
-         */
-        id?: string;
-
-        /**
-         * The relative priority of this edit. Higher priority items are shown first in the UI.
-         *
-         * Defaults to `0`.
-         */
-        priority?: number;
 
         /**
          * Human readable label that describes the edit.
          */
         label?: string;
+
+        /**
+         * The mime type from the {@link DataTransfer} that this edit applies.
+         */
+        handledMimeType?: string;
+
+        /**
+         * Controls the ordering or multiple paste edits. If this provider yield to edits, it will be shown lower in the list.
+         */
+        yieldTo?: ReadonlyArray<
+            | { readonly extensionId: string; readonly providerId: string }
+            | { readonly mimeType: string }
+        >;
     }
 
     export interface DocumentDropEditProviderMetadata {
+        /**
+         * Identifies the provider.
+         *
+         * This id is used when users configure the default provider for drop.
+         *
+         * This id should be unique within the extension but does not need to be unique across extensions.
+         */
+        readonly id: string;
+
         /**
          * List of data transfer types that the provider supports.
          *


### PR DESCRIPTION
#### What it does

Some evolutions were done on proposed API  dropMetadata with vs code 1.82:
- _DocumentDropEdit_ lost _id_ and _priority_ , but gain _yieldTo_ and _handledMimeType_ 
- _DocumentDropEditProviderMetadata_ gained _id_ attribute. 

This PR updated the proposal API and also the comments on the code where the code shall be updated on next monaco uplift.

Fixes #12986 

Contributed on behalf of ST Microelectronics

#### How to test 
 
There isn't anything to test, no behavior should have changed, as current Monaco version does not provide support to optional properties. Confirm that the changes in https://github.com/eclipse-theia/theia/pull/12125 still work as expected.

#### Follow-ups

Monaco uplift tag has been updated for when the monaco version is uplifted.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

