### PR TITLE
evolution on proposed API  documentPaste with vs code 1.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.43.0 - Unreleased
 
 - [vsode] evolve proposed API for dropDocument [#13009](https://github.com/eclipse-theia/theia/pull/13009) - contributed on behalf of STMicroelectronics
+- [vsode] evolve proposed API for documentPaste (stubbed) [#13010](https://github.com/eclipse-theia/theia/pull/13010) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.43.0">[Breaking Changes:](#breaking_changes_1.43.0)</a>
 

--- a/packages/plugin/src/theia.proposed.documentPaste.d.ts
+++ b/packages/plugin/src/theia.proposed.documentPaste.d.ts
@@ -60,23 +60,17 @@ export module '@theia/plugin' {
      */
     class DocumentPasteEdit {
         /**
-         * Identifies the type of edit.
-         *
-         * This id should be unique within the extension but does not need to be unique across extensions.
-         */
-        id: string;
-
-        /**
          * Human readable label that describes the edit.
          */
         label: string;
 
         /**
-         * The relative priority of this edit. Higher priority items are shown first in the UI.
-         *
-         * Defaults to `0`.
+         * Controls the ordering or multiple paste edits. If this provider yield to edits, it will be shown lower in the list.
          */
-        priority?: number;
+        yieldTo?: ReadonlyArray<
+            | { readonly extensionId: string; readonly providerId: string }
+            | { readonly mimeType: string }
+        >;
 
         /**
          * The text or snippet to insert at the pasted locations.
@@ -97,6 +91,15 @@ export module '@theia/plugin' {
     }
 
     interface DocumentPasteProviderMetadata {
+        /**
+         * Identifies the provider.
+         *
+         * This id is used when users configure the default provider for paste.
+         *
+         * This id should be unique within the extension but does not need to be unique across extensions.
+         */
+        readonly id: string;
+
         /**
          * Mime types that {@link DocumentPasteEditProvider.prepareDocumentPaste provideDocumentPasteEdits} may add on copy.
          */


### PR DESCRIPTION
#### What it does

Some evolutions were done on proposed API  documentPaste with vs code 1.82:
- _DocumentPasteEdit_ lost _id_ and _priority_ , but gained _yieldTo_ 
- _DocumentPasteProviderMetadata_ gained _id_ attribute. 

This PR updated the proposal API, but the dcoumentPasteProvider API is still stubbed.

Fixes #12987

Contributed on behalf of ST Microelectronics

#### How to test 
 
There isn't anything to test, as behavior is stubbed.

#### Follow-ups

none

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

