### PR TITLE
Support VS Code Default Language Icons

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -138,6 +138,7 @@ import { StylingParticipant, StylingService } from './styling-service';
 import { bindCommonStylingParticipants } from './common-styling-participants';
 import { HoverService } from './hover-service';
 import { AdditionalViewsMenuWidget, AdditionalViewsMenuWidgetFactory } from './shell/additional-views-menu-widget';
+import { LanguageIconLabelProvider } from './language-icon-provider';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -150,6 +151,8 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(IconThemeContribution).toService(DefaultFileIconThemeContribution);
     bind(IconThemeApplicationContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(IconThemeApplicationContribution);
+    bind(LanguageIconLabelProvider).toSelf().inSingletonScope();
+    bind(LabelProviderContribution).toService(LanguageIconLabelProvider);
 
     bind(ColorRegistry).toSelf().inSingletonScope();
     bindContributionProvider(bind, ColorContribution);

--- a/packages/core/src/browser/icon-theme-contribution.ts
+++ b/packages/core/src/browser/icon-theme-contribution.ts
@@ -50,6 +50,7 @@ export class DefaultFileIconThemeContribution implements IconTheme, IconThemeCon
     readonly label = 'File Icons (Theia)';
     readonly hasFileIcons = true;
     readonly hasFolderIcons = true;
+    readonly showLanguageModeIcons = true;
 
     registerIconThemes(iconThemes: IconThemeService): MaybePromise<void> {
         iconThemes.register(this);

--- a/packages/core/src/browser/icon-theme-service.ts
+++ b/packages/core/src/browser/icon-theme-service.ts
@@ -31,6 +31,7 @@ export interface IconThemeDefinition {
     readonly hasFileIcons?: boolean;
     readonly hasFolderIcons?: boolean;
     readonly hidesExplorerArrows?: boolean;
+    readonly showLanguageModeIcons?: boolean;
 }
 
 export interface IconTheme extends IconThemeDefinition {

--- a/packages/core/src/browser/language-icon-provider.ts
+++ b/packages/core/src/browser/language-icon-provider.ts
@@ -1,0 +1,36 @@
+// *****************************************************************************
+// Copyright (C) 2023 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from 'inversify';
+import { IconThemeService } from './icon-theme-service';
+import { LabelProviderContribution } from './label-provider';
+import { LanguageService } from './language-service';
+
+@injectable()
+export class LanguageIconLabelProvider implements LabelProviderContribution {
+    @inject(IconThemeService) protected readonly iconThemeService: IconThemeService;
+    @inject(LanguageService) protected readonly languageService: LanguageService;
+
+    canHandle(element: object): number {
+        const current = this.iconThemeService.getDefinition(this.iconThemeService.current);
+        return current?.showLanguageModeIcons === true && this.languageService.getIcon(element) ? Number.MAX_SAFE_INTEGER : 0;
+    }
+
+    getIcon(element: object): string | undefined {
+        const language = this.languageService.detectLanguage(element);
+        return this.languageService.getIcon(language!.id);
+    }
+}

--- a/packages/core/src/browser/language-service.ts
+++ b/packages/core/src/browser/language-service.ts
@@ -15,12 +15,14 @@
 // *****************************************************************************
 
 import { injectable } from 'inversify';
+import { Disposable } from '../common';
 
 export interface Language {
     readonly id: string;
     readonly name: string;
     readonly extensions: Set<string>;
     readonly filenames: Set<string>;
+    readonly iconClass?: string;
 }
 
 @injectable()
@@ -37,6 +39,27 @@ export class LanguageService {
      * It should be implemented by an extension, e.g. by the monaco extension.
      */
     getLanguage(languageId: string): Language | undefined {
+        return undefined;
+    }
+
+    /**
+     * It should be implemented by an extension, e.g. by the monaco extension.
+     */
+    detectLanguage(obj: unknown): Language | undefined {
+        return undefined;
+    }
+
+    /**
+     * It should be implemented by an extension, e.g. by the monaco extension.
+     */
+    registerIcon(languageId: string, iconClass: string): Disposable {
+        return Disposable.NULL;
+    }
+
+    /**
+     * It should be implemented by an extension, e.g. by the monaco extension.
+     */
+    getIcon(obj: unknown): string | undefined {
         return undefined;
     }
 

--- a/packages/core/src/browser/language-service.ts
+++ b/packages/core/src/browser/language-service.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable } from 'inversify';
-import { Disposable } from '../common';
+import { Disposable, Emitter, Event } from '../common';
 
 export interface Language {
     readonly id: string;
@@ -27,6 +27,7 @@ export interface Language {
 
 @injectable()
 export class LanguageService {
+    protected readonly onDidChangeIconEmitter = new Emitter<DidChangeIconEvent>();
 
     /**
      * It should be implemented by an extension, e.g. by the monaco extension.
@@ -63,4 +64,14 @@ export class LanguageService {
         return undefined;
     }
 
+    /**
+     * Emit when the icon of a particular language was changed.
+     */
+    get onDidChangeIcon(): Event<DidChangeIconEvent> {
+        return this.onDidChangeIconEmitter.event;
+    }
+}
+
+export interface DidChangeIconEvent {
+    languageId: string;
 }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -308,6 +308,7 @@ export interface PluginPackageLanguageContribution {
     aliases?: string[];
     mimetypes?: string[];
     configuration?: string;
+    icon?: IconUrl;
 }
 
 export interface PluginPackageLanguageContributionConfiguration {
@@ -715,6 +716,10 @@ export interface LanguageContribution {
     aliases?: string[];
     mimetypes?: string[];
     configuration?: LanguageConfiguration;
+    /**
+     * @internal
+     */
+    icon?: IconUrl;
 }
 
 export interface RegExpOptions {

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -371,7 +371,7 @@ export class TheiaPluginScanner implements PluginScanner {
         }
 
         const [languagesResult, grammarsResult] = await Promise.allSettled([
-            rawPlugin.contributes.languages ? this.readLanguages(rawPlugin.contributes.languages, rawPlugin.packagePath) : undefined,
+            rawPlugin.contributes.languages ? this.readLanguages(rawPlugin.contributes.languages, rawPlugin) : undefined,
             rawPlugin.contributes.grammars ? this.grammarsReader.readGrammars(rawPlugin.contributes.grammars, rawPlugin.packagePath) : undefined
         ]);
 
@@ -723,8 +723,8 @@ export class TheiaPluginScanner implements PluginScanner {
         return result;
     }
 
-    private async readLanguages(rawLanguages: PluginPackageLanguageContribution[], pluginPath: string): Promise<LanguageContribution[]> {
-        return Promise.all(rawLanguages.map(language => this.readLanguage(language, pluginPath)));
+    private async readLanguages(rawLanguages: PluginPackageLanguageContribution[], plugin: PluginPackage): Promise<LanguageContribution[]> {
+        return Promise.all(rawLanguages.map(language => this.readLanguage(language, plugin)));
     }
 
     private readSubmenus(rawSubmenus: PluginPackageSubmenu[], plugin: PluginPackage): Submenu[] {
@@ -741,8 +741,9 @@ export class TheiaPluginScanner implements PluginScanner {
 
     }
 
-    private async readLanguage(rawLang: PluginPackageLanguageContribution, pluginPath: string): Promise<LanguageContribution> {
+    private async readLanguage(rawLang: PluginPackageLanguageContribution, plugin: PluginPackage): Promise<LanguageContribution> {
         // TODO: add validation to all parameters
+        const icon = this.transformIconUrl(plugin, rawLang.icon);
         const result: LanguageContribution = {
             id: rawLang.id,
             aliases: rawLang.aliases,
@@ -750,10 +751,11 @@ export class TheiaPluginScanner implements PluginScanner {
             filenamePatterns: rawLang.filenamePatterns,
             filenames: rawLang.filenames,
             firstLine: rawLang.firstLine,
-            mimetypes: rawLang.mimetypes
+            mimetypes: rawLang.mimetypes,
+            icon: icon?.iconUrl ?? icon?.themeIcon
         };
         if (rawLang.configuration) {
-            const rawConfiguration = await this.readJson<PluginPackageLanguageContributionConfiguration>(path.resolve(pluginPath, rawLang.configuration));
+            const rawConfiguration = await this.readJson<PluginPackageLanguageContributionConfiguration>(path.resolve(plugin.packagePath, rawLang.configuration));
             if (rawConfiguration) {
                 const configuration: LanguageConfiguration = {
                     brackets: rawConfiguration.brackets,

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -53,6 +53,7 @@ import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { PluginTerminalRegistry } from './plugin-terminal-registry';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { LanguageService } from '@theia/core/lib/browser/language-service';
 
 @injectable()
 export class PluginContributionHandler {
@@ -88,6 +89,9 @@ export class PluginContributionHandler {
 
     @inject(CommandRegistry)
     protected readonly commands: CommandRegistry;
+
+    @inject(LanguageService)
+    protected readonly languageService: LanguageService;
 
     @inject(PluginSharedStyle)
     protected readonly style: PluginSharedStyle;
@@ -195,6 +199,11 @@ export class PluginContributionHandler {
                     firstLine: lang.firstLine,
                     mimetypes: lang.mimetypes
                 });
+                if (lang.icon) {
+                    const languageIcon = this.style.toFileIconClass(lang.icon);
+                    pushContribution(`language.${lang.id}.icon`, () => languageIcon);
+                    pushContribution(`language.${lang.id}.iconRegistration`, () => this.languageService.registerIcon(lang.id, languageIcon.object.iconClass));
+                }
                 const langConfiguration = lang.configuration;
                 if (langConfiguration) {
                     pushContribution(`language.${lang.id}.configuration`, () => monaco.languages.setLanguageConfiguration(lang.id, {


### PR DESCRIPTION
#### What it does

Add support for default language icons similar to VS Code:
- Extend language service with necessary methods
- Create CSS rules for contributed language icons
- Use language icons if theme sets 'showLanguageModeIcons'
- Ensure custom theme can override language icons

Fixes https://github.com/eclipse-theia/theia/issues/13013

#### How to test

- Provide a plugin with a language contribution that adds a custom default language icon, ideally a "known" language like python
- Install [Material Icon Theme](https://open-vsx.org/extension/PKief/material-icon-theme) which already provides custom icons for the same language.
- Switch file icon themes to see that everything is working as expected:
  - `None`: no icons shown
  - `File Icons (Theia)`: uses our default language icon
  - `Material Icon Theme`: uses icon from the theme

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
