### PR TITLE
Allow tree data providers to return null items

### DIFF
--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -34,6 +34,7 @@ import { PluginIconPath } from '../plugin-icon-path';
 import { URI } from '@theia/core/shared/vscode-uri';
 import { UriComponents } from '@theia/core/lib/common/uri';
 import { isObject } from '@theia/core';
+import { coalesce } from '../../common/arrays';
 
 export class TreeViewsExtImpl implements TreeViewsExt {
     private proxy: TreeViewsMain;
@@ -407,7 +408,7 @@ class TreeViewExtImpl<T> implements Disposable {
         // ask data provider for children for cached element
         const result = await this.options.treeDataProvider.getChildren(parent);
         if (result) {
-            const treeItemPromises = result.map(async value => {
+            const treeItemPromises = coalesce(result).map(async value => {
 
                 // Ask data provider for a tree item for the value
                 // Data provider must return theia.TreeItem


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13001

Some extensions return falsy values in their tree data providers. [VSCode first filters the results](https://github.com/microsoft/vscode/blob/cbd09078e6221fa1553c5a59dd25e63ad767911a/src/vs/workbench/api/common/extHostTreeViews.ts#L661) by using `coalesce`. This change aligns Theia to the behavior of vscode to also allow falsy values.

#### How to test

1. Install the SonarLint extension from open-vsx
2. Open the SonarLint Issues Location view in the explorer panel
3. Assert that the welcome view info is shown and no error is logged on the backend.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
