### PR TITLE
outputs now updating correctly when output items are updated.

### DIFF
--- a/packages/notebook/src/browser/service/notebook-execution-state-service.ts
+++ b/packages/notebook/src/browser/service/notebook-execution-state-service.ts
@@ -293,6 +293,7 @@ export function updateToEdit(update: CellExecuteUpdate, cellHandle: number): Cel
         return {
             editType: CellEditType.OutputItems,
             items: update.items,
+            outputId: update.outputId,
             append: update.append,
         };
     } else if (update.editType === CellExecutionUpdateType.ExecutionState) {

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -223,6 +223,8 @@ export class NotebookModel implements Saveable, Disposable {
                 cellIndex = edit.index;
             } else if ('handle' in edit) {
                 cellIndex = this.getCellIndexByHandle(edit.handle);
+            } else if ('outputId' in edit) {
+                cellIndex = this.cells.findIndex(cell => cell.outputs.some(output => output.outputId === edit.outputId));
             }
 
             return {
@@ -254,6 +256,7 @@ export class NotebookModel implements Saveable, Disposable {
                     break;
                 }
                 case CellEditType.OutputItems:
+                    cell.changeOutputItems(edit.outputId, !!edit.append, edit.items);
                     break;
                 case CellEditType.Metadata:
                     this.updateNotebookMetadata(edit.metadata, computeUndoRedo);

--- a/packages/notebook/src/common/notebook-common.ts
+++ b/packages/notebook/src/common/notebook-common.ts
@@ -98,7 +98,7 @@ export interface NotebookCell {
     internalMetadata: NotebookCellInternalMetadata;
     text: string;
     onDidChangeOutputs?: Event<NotebookCellOutputsSplice>;
-    onDidChangeOutputItems?: Event<void>;
+    onDidChangeOutputItems?: Event<CellOutput>;
     onDidChangeLanguage: Event<string>;
     onDidChangeMetadata: Event<void>;
     onDidChangeInternalMetadata: Event<CellInternalMetadataChangedEvent>;
@@ -309,6 +309,7 @@ export interface CellExecuteOutputEdit {
 export interface CellExecuteOutputItemEdit {
     editType: CellExecutionUpdateType.OutputItems;
     append?: boolean;
+    outputId: string,
     items: CellOutputItem[];
 }
 
@@ -337,6 +338,7 @@ export interface CellOutputEditByHandle {
 export interface CellOutputItemEdit {
     editType: CellEditType.OutputItems;
     items: CellOutputItem[];
+    outputId: string;
     append?: boolean;
 }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2423,6 +2423,7 @@ export interface CellExecuteOutputEditDto {
 export interface CellExecuteOutputItemEditDto {
     editType: CellExecutionUpdateType.OutputItems;
     append?: boolean;
+    outputId: string;
     items: NotebookOutputItemDto[];
 }
 

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -75,6 +75,9 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     @postConstruct()
     protected async init(): Promise<void> {
         this.cell.onDidChangeOutputs(outputChange => this.updateOutput(outputChange));
+        this.cell.onDidChangeOutputItems(output => {
+            this.updateOutput({start: this.cell.outputs.findIndex(o => o.getData().outputId === o.outputId), deleteCount: 1, newOutputs: [output]});
+        });
 
         this.webviewWidget = await this.widgetManager.getOrCreateWidget(WebviewWidget.FACTORY_ID, { id: this.id });
         this.webviewWidget.setContentOptions({ allowScripts: true });

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -381,6 +381,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
     function clearOutput(outputId: string): void {
         outputs.get(outputId)?.clear();
         outputs.delete(outputId);
+        document.getElementById(outputId)?.remove();
     }
 
     function outputsChanged(changedEvent: webviewCommunication.OutputChangedMessage): void {

--- a/packages/plugin-ext/src/plugin/notebook/notebook-kernels.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebook-kernels.ts
@@ -483,11 +483,13 @@ class NotebookCellExecutionTask implements Disposable {
             });
     }
 
-    private async updateOutputItems(items: theia.NotebookCellOutputItem | theia.NotebookCellOutputItem[], output: theia.NotebookCellOutput, append: boolean): Promise<void> {
+    private async updateOutputItems(items: theia.NotebookCellOutputItem | theia.NotebookCellOutputItem[],
+        output: theia.NotebookCellOutput, append: boolean): Promise<void> {
         items = NotebookCellOutputConverter.ensureUniqueMimeTypes(Array.isArray(items) ? items : [items], true);
         return this.updateSoon({
             editType: CellExecutionUpdateType.OutputItems,
             items: items.map(NotebookCellOutputItem.from),
+            outputId: output instanceof NotebookCellOutput ? output.outputId : '',
             append
         });
     }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -1722,6 +1722,7 @@ export namespace NotebookDto {
             return {
                 editType: data.editType,
                 append: data.append,
+                outputId: data.outputId,
                 items: data.items.map(fromNotebookOutputItemDto)
             };
         } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #13019

Firstly this fixes that output rendering is updated correctly when ouptut items changed.
Secondly this adds vscodes feature which concatinates stdOut and stdErr output items together.
The compression vscode is doing there is not implemented though.

#### How to test
create a notebook with a code cell like the following

```python
import time
print('1')

time.sleep(1)

print('2')

time.sleep(1)

print('3')
```

execute the cell and see how all outputs appear one after the other

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
