### PR TITLE
Update nls metadata for VSCode API 1.82.0

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -25,22 +25,22 @@ import { DefaultTheme } from '@theia/application-package/lib/application-props';
 
 /* eslint-disable max-len */
 const windowTitleDescription = [
-    'Controls the window title based on the active editor. Variables are substituted based on the context:',
-    '`${activeEditorShort}`: the file name (e.g. myFile.txt).',
-    '`${activeEditorMedium}`: the path of the file relative to the workspace folder (e.g. myFolder/myFileFolder/myFile.txt).',
-    '`${activeEditorLong}`: the full path of the file (e.g. /Users/Development/myFolder/myFileFolder/myFile.txt).',
-    '`${activeFolderShort}`: the name of the folder the file is contained in (e.g. myFileFolder).',
-    '`${activeFolderMedium}`: the path of the folder the file is contained in, relative to the workspace folder (e.g. myFolder/myFileFolder).',
-    '`${activeFolderLong}`: the full path of the folder the file is contained in (e.g. /Users/Development/myFolder/myFileFolder).',
-    '`${folderName}`: name of the workspace folder the file is contained in (e.g. myFolder).',
-    '`${folderPath}`: file path of the workspace folder the file is contained in (e.g. /Users/Development/myFolder).',
-    '`${rootName}`: name of the workspace with optional remote name and workspace indicator if applicable (e.g. myFolder, myRemoteFolder [SSH] or myWorkspace (Workspace)).',
-    '`${rootPath}`: file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace).',
-    '`${appName}`: e.g. VS Code.',
-    '`${remoteName}`: e.g. SSH',
-    '`${dirty}`: an indicator for when the active editor has unsaved changes.',
-    '`${separator}`: a conditional separator (" - ") that only shows when surrounded by variables with values or static text.'
-].map(e => nls.localizeByDefault(e)).join('\n- ');
+    nls.localizeByDefault('Controls the window title based on the current context such as the opened workspace or active editor. Variables are substituted based on the context:'),
+    nls.localizeByDefault('`${activeEditorShort}`: the file name (e.g. myFile.txt).'),
+    nls.localizeByDefault('`${activeEditorMedium}`: the path of the file relative to the workspace folder (e.g. myFolder/myFileFolder/myFile.txt).'),
+    nls.localizeByDefault('`${activeEditorLong}`: the full path of the file (e.g. /Users/Development/myFolder/myFileFolder/myFile.txt).'),
+    nls.localizeByDefault('`${activeFolderShort}`: the name of the folder the file is contained in (e.g. myFileFolder).'),
+    nls.localizeByDefault('`${activeFolderMedium}`: the path of the folder the file is contained in, relative to the workspace folder (e.g. myFolder/myFileFolder).'),
+    nls.localizeByDefault('`${activeFolderLong}`: the full path of the folder the file is contained in (e.g. /Users/Development/myFolder/myFileFolder).'),
+    nls.localizeByDefault('`${folderName}`: name of the workspace folder the file is contained in (e.g. myFolder).'),
+    nls.localizeByDefault('`${folderPath}`: file path of the workspace folder the file is contained in (e.g. /Users/Development/myFolder).'),
+    nls.localizeByDefault('`${rootName}`: name of the workspace with optional remote name and workspace indicator if applicable (e.g. myFolder, myRemoteFolder [SSH] or myWorkspace (Workspace)).'),
+    nls.localizeByDefault('`${rootPath}`: file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace).'),
+    nls.localizeByDefault('`${appName}`: e.g. VS Code.'),
+    nls.localizeByDefault('`${remoteName}`: e.g. SSH'),
+    nls.localizeByDefault('`${dirty}`: an indicator for when the active editor has unsaved changes.'),
+    nls.localizeByDefault('`${separator}`: a conditional separator (" - ") that only shows when surrounded by variables with values or static text.')
+].join('\n- ');
 
 export const corePreferenceSchema: PreferenceSchema = {
     'type': 'object',

--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -19,6 +19,12 @@
 				]
 			}
 		],
+		"vs/code/node/cliProcessMain": [
+			"cli"
+		],
+		"vs/code/node/sharedProcess/sharedProcessMain": [
+			"sharedLog"
+		],
 		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
 			"name",
 			"cpu",
@@ -30,14 +36,11 @@
 			"copyAll",
 			"debug"
 		],
-		"vs/code/node/cliProcessMain": [
-			"cli"
-		],
-		"vs/code/node/sharedProcess/sharedProcessMain": [
-			"sharedLog"
-		],
 		"vs/workbench/electron-sandbox/desktop.main": [
 			"join.closeStorage"
+		],
+		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
+			"join.textFiles"
 		],
 		"vs/workbench/electron-sandbox/desktop.contribution": [
 			"newTab",
@@ -74,7 +77,6 @@
 			"closeWhenEmpty",
 			"window.doubleClickIconToClose",
 			"titleBarStyle",
-			"windowControlsOverlay",
 			"nativeContextMenuLocation",
 			"dialogStyle",
 			"window.nativeTabs",
@@ -95,9 +97,6 @@
 			"argv.logLevel",
 			"argv.disableChromiumSandbox",
 			"argv.force-renderer-accessibility"
-		],
-		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
-			"join.textFiles"
 		],
 		"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService": [
 			"saveWorkspaceMessage",
@@ -151,6 +150,12 @@
 		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
 			"join.workingCopyBackups"
 		],
+		"vs/workbench/services/voiceRecognition/electron-sandbox/workbenchVoiceRecognitionService": [
+			"voiceTranscription",
+			"voiceTranscriptionGettingReady",
+			"voiceTranscriptionRecording",
+			"voiceTranscriptionError"
+		],
 		"vs/workbench/services/extensions/electron-sandbox/nativeExtensionService": [
 			"extensionService.versionMismatchCrash",
 			"relaunch",
@@ -168,6 +173,18 @@
 			"resolverExtensionNotFound",
 			"restartExtensionHost",
 			"restartExtensionHost.reason"
+		],
+		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
+			"updateLocale",
+			"changeAndRestart",
+			"neverAgain"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
+			"revealInWindows",
+			"revealInMac",
+			"openContainer",
+			"miShare",
+			"filesCategory"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution": [
 			"runtimeExtension"
@@ -328,18 +345,6 @@
 			"remoteTunnelAccess.machineNameRegex",
 			"remoteTunnelAccess.preventSleep"
 		],
-		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
-			"updateLocale",
-			"changeAndRestart",
-			"neverAgain"
-		],
-		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
-			"revealInWindows",
-			"revealInMac",
-			"openContainer",
-			"miShare",
-			"filesCategory"
-		],
 		"vs/base/common/platform": [
 			{
 				"key": "ensureLoaderPluginIsLoaded",
@@ -352,6 +357,7 @@
 			"optionsUpperCase",
 			"extensionsManagement",
 			"troubleshooting",
+			"cliDataDir",
 			"cliDataDir",
 			"diff",
 			"merge",
@@ -452,6 +458,7 @@
 			"editor.stickyScroll.enabled",
 			"editor.stickyScroll.maxLineCount",
 			"editor.stickyScroll.defaultModel",
+			"editor.stickyScroll.scrollWithEditor",
 			"inlayHints.enable",
 			"editor.inlayHints.on",
 			"editor.inlayHints.onUnlessPressed",
@@ -717,6 +724,7 @@
 			"snippetSuggestions.none",
 			"snippetSuggestions",
 			"smoothScrolling",
+			"inlineCompletionsAccessibilityVerbose",
 			"suggestFontSize",
 			"suggestLineHeight",
 			"suggestOnTriggerCharacters",
@@ -769,82 +777,6 @@
 			"defaultColorDecorators",
 			"tabFocusMode"
 		],
-		"vs/code/electron-sandbox/issue/issueReporterPage": [
-			"sendSystemInfo",
-			"sendProcessInfo",
-			"sendWorkspaceInfo",
-			"sendExtensions",
-			"sendExperiments",
-			{
-				"key": "reviewGuidanceLabel",
-				"comment": [
-					"{Locked=\"<a href=\"https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions\" target=\"_blank\">\"}",
-					"{Locked=\"</a>\"}"
-				]
-			},
-			"completeInEnglish",
-			"issueTypeLabel",
-			"issueSourceLabel",
-			"issueSourceEmptyValidation",
-			"disableExtensionsLabelText",
-			"disableExtensions",
-			"chooseExtension",
-			"extensionWithNonstandardBugsUrl",
-			"extensionWithNoBugsUrl",
-			"issueTitleLabel",
-			"issueTitleRequired",
-			"titleEmptyValidation",
-			"titleLengthValidation",
-			"details",
-			"descriptionEmptyValidation",
-			"show",
-			"show",
-			"show",
-			"show",
-			"show"
-		],
-		"vs/code/electron-sandbox/issue/issueReporterService": [
-			"hide",
-			"show",
-			"createOnGitHub",
-			"previewOnGitHub",
-			"loadingData",
-			"rateLimited",
-			"similarIssues",
-			"open",
-			"closed",
-			"open",
-			"closed",
-			"noSimilarIssues",
-			"bugReporter",
-			"featureRequest",
-			"performanceIssue",
-			"selectSource",
-			"vscode",
-			"extension",
-			"marketplace",
-			"unknown",
-			"handlesIssuesElsewhere",
-			"elsewhereDescription",
-			"openIssueReporter",
-			"stepsToReproduce",
-			"bugDescription",
-			"stepsToReproduce",
-			"performanceIssueDesciption",
-			"description",
-			"featureRequestDescription",
-			"pasteData",
-			"disabledExtensions",
-			"noCurrentExperiments"
-		],
-		"vs/platform/environment/node/argvHelper": [
-			"multipleValues",
-			"emptyValue",
-			"deprecatedArgument",
-			"unknownSubCommandOption",
-			"unknownOption",
-			"gotoValidation"
-		],
 		"vs/base/common/errorMessage": [
 			"stackTrace.format",
 			"nodeExceptionMessage",
@@ -868,6 +800,14 @@
 			},
 			"confirmOpenMessage",
 			"confirmOpenDetail"
+		],
+		"vs/platform/environment/node/argvHelper": [
+			"multipleValues",
+			"emptyValue",
+			"deprecatedArgument",
+			"unknownSubCommandOption",
+			"unknownOption",
+			"gotoValidation"
 		],
 		"vs/platform/files/common/files": [
 			"unknownError",
@@ -967,18 +907,77 @@
 			"enableWindowsBackgroundUpdates",
 			"showReleaseNotes"
 		],
+		"vs/code/electron-sandbox/issue/issueReporterPage": [
+			"sendSystemInfo",
+			"sendProcessInfo",
+			"sendWorkspaceInfo",
+			"sendExtensions",
+			"sendExperiments",
+			{
+				"key": "reviewGuidanceLabel",
+				"comment": [
+					"{Locked=\"<a href=\"https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions\" target=\"_blank\">\"}",
+					"{Locked=\"</a>\"}"
+				]
+			},
+			"completeInEnglish",
+			"issueTypeLabel",
+			"issueSourceLabel",
+			"issueSourceEmptyValidation",
+			"disableExtensionsLabelText",
+			"disableExtensions",
+			"chooseExtension",
+			"extensionWithNonstandardBugsUrl",
+			"extensionWithNoBugsUrl",
+			"issueTitleLabel",
+			"issueTitleRequired",
+			"titleEmptyValidation",
+			"titleLengthValidation",
+			"details",
+			"descriptionEmptyValidation",
+			"show",
+			"show",
+			"show",
+			"show",
+			"show"
+		],
+		"vs/code/electron-sandbox/issue/issueReporterService": [
+			"hide",
+			"show",
+			"createOnGitHub",
+			"previewOnGitHub",
+			"loadingData",
+			"rateLimited",
+			"similarIssues",
+			"open",
+			"closed",
+			"open",
+			"closed",
+			"noSimilarIssues",
+			"bugReporter",
+			"featureRequest",
+			"performanceIssue",
+			"selectSource",
+			"vscode",
+			"extension",
+			"marketplace",
+			"unknown",
+			"handlesIssuesElsewhere",
+			"elsewhereDescription",
+			"openIssueReporter",
+			"stepsToReproduce",
+			"bugDescription",
+			"stepsToReproduce",
+			"performanceIssueDesciption",
+			"description",
+			"featureRequestDescription",
+			"pasteData",
+			"disabledExtensions",
+			"noCurrentExperiments"
+		],
 		"vs/platform/extensionManagement/common/extensionManagement": [
 			"extensions",
 			"preferences"
-		],
-		"vs/platform/extensionManagement/common/extensionsScannerService": [
-			"fileReadFail",
-			"jsonParseFail",
-			"jsonParseInvalidType",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat"
 		],
 		"vs/platform/extensionManagement/common/extensionManagementCLI": [
 			"notFound",
@@ -1008,6 +1007,15 @@
 			"successUninstall",
 			"notInstalleddOnLocation",
 			"notInstalled"
+		],
+		"vs/platform/extensionManagement/common/extensionsScannerService": [
+			"fileReadFail",
+			"jsonParseFail",
+			"jsonParseInvalidType",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat"
 		],
 		"vs/platform/extensionManagement/node/extensionManagementService": [
 			"incompatible",
@@ -1046,6 +1054,16 @@
 		"vs/platform/userDataProfile/common/userDataProfile": [
 			"defaultProfile"
 		],
+		"vs/platform/telemetry/common/telemetryLogAppender": [
+			"telemetryLog"
+		],
+		"vs/platform/userDataSync/common/userDataSync": [
+			"settings sync",
+			"settingsSync.keybindingsPerPlatform",
+			"settingsSync.ignoredExtensions",
+			"app.extension.identifier.errorMessage",
+			"settingsSync.ignoredSettings"
+		],
 		"vs/platform/userDataSync/common/userDataSyncLog": [
 			"userDataSyncLog"
 		],
@@ -1054,16 +1072,6 @@
 		],
 		"vs/platform/remoteTunnel/common/remoteTunnel": [
 			"remoteTunnelLog"
-		],
-		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
-			"incompatible sync data"
-		],
-		"vs/platform/userDataSync/common/userDataSync": [
-			"settings sync",
-			"settingsSync.keybindingsPerPlatform",
-			"settingsSync.ignoredExtensions",
-			"app.extension.identifier.errorMessage",
-			"settingsSync.ignoredSettings"
 		],
 		"vs/platform/remoteTunnel/node/remoteTunnelService": [
 			"remoteTunnelService.building",
@@ -1082,8 +1090,37 @@
 			"remoteTunnelService.openTunnel",
 			"remoteTunnelService.serviceInstallFailed"
 		],
-		"vs/platform/telemetry/common/telemetryLogAppender": [
-			"telemetryLog"
+		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
+			"incompatible sync data"
+		],
+		"vs/editor/common/languages": [
+			"Array",
+			"Boolean",
+			"Class",
+			"Constant",
+			"Constructor",
+			"Enum",
+			"EnumMember",
+			"Event",
+			"Field",
+			"File",
+			"Function",
+			"Interface",
+			"Key",
+			"Method",
+			"Module",
+			"Namespace",
+			"Null",
+			"Number",
+			"Object",
+			"Operator",
+			"Package",
+			"Property",
+			"String",
+			"Struct",
+			"TypeParameter",
+			"Variable",
+			"symbolAriaLabel"
 		],
 		"vs/workbench/browser/workbench": [
 			"loaderErrorNative"
@@ -1146,13 +1183,9 @@
 			"loaderCycle",
 			"runningAsRoot",
 			"appRootWarning.banner",
-			"windowseolmessage",
+			"windows32eolmessage",
 			"windowseolBannerLearnMore",
 			"windowseolarialabel",
-			"learnMore",
-			"macoseolmessage",
-			"macoseolBannerLearnMore",
-			"macoseolarialabel",
 			"learnMore",
 			"resolveShellEnvironment",
 			"learnMore"
@@ -1161,6 +1194,9 @@
 			"configurationDefaults.description",
 			"experimental",
 			"setting description"
+		],
+		"vs/platform/workspace/common/workspace": [
+			"codeWorkspace"
 		],
 		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
 			"devTools",
@@ -1217,16 +1253,13 @@
 			"expand mode",
 			"typeNavigationMode"
 		],
-		"vs/platform/workspace/common/workspace": [
-			"codeWorkspace"
-		],
-		"vs/platform/contextkey/browser/contextKeyService": [
-			"getContextKeyInfo"
-		],
 		"vs/platform/markers/common/markers": [
 			"sev.error",
 			"sev.warning",
 			"sev.info"
+		],
+		"vs/platform/contextkey/browser/contextKeyService": [
+			"getContextKeyInfo"
 		],
 		"vs/platform/contextkey/common/contextkey": [
 			"contextkey.parser.error.emptyString",
@@ -1240,6 +1273,14 @@
 			"contextkey.parser.error.expectedButGot",
 			"contextkey.scanner.errorForLinterWithHint",
 			"contextkey.scanner.errorForLinter"
+		],
+		"vs/workbench/browser/actions/textInputActions": [
+			"undo",
+			"redo",
+			"cut",
+			"copy",
+			"paste",
+			"selectAll"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"workbench.editor.titleScrollbarSizing.default",
@@ -1322,6 +1363,11 @@
 				],
 				"key": "pinnedTabSizing"
 			},
+			"workbench.editor.preventPinnedEditorClose.always",
+			"workbench.editor.preventPinnedEditorClose.onlyKeyboard",
+			"workbench.editor.preventPinnedEditorClose.onlyMouse",
+			"workbench.editor.preventPinnedEditorClose.never",
+			"workbench.editor.preventPinnedEditorClose",
 			"workbench.editor.splitSizingAuto",
 			"workbench.editor.splitSizingDistribute",
 			"workbench.editor.splitSizingSplit",
@@ -1377,7 +1423,7 @@
 			"commandHistory",
 			"preserveInput",
 			"suggestCommands",
-			"useSemanticSimilarity",
+			"enableNaturalLanguageSearch",
 			"closeOnFocusLost",
 			"workbench.quickOpen.preserveInput",
 			"openDefaultSettings",
@@ -1436,6 +1482,7 @@
 			"appName",
 			"remoteName",
 			"dirty",
+			"focusedView",
 			"separator",
 			"windowConfigurationTitle",
 			"window.titleSeparator",
@@ -1490,14 +1537,6 @@
 			"zenMode.restore",
 			"zenMode.silentNotifications"
 		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"undo",
-			"redo",
-			"cut",
-			"copy",
-			"paste",
-			"selectAll"
-		],
 		"vs/workbench/browser/actions/helpActions": [
 			"keybindingsReference",
 			{
@@ -1528,9 +1567,9 @@
 				]
 			},
 			"newsletterSignup",
-			"openTwitterUrl",
+			"openYouTubeUrl",
 			{
-				"key": "miTwitter",
+				"key": "miYouTube",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
@@ -1579,6 +1618,7 @@
 			"screencastMode.fontSize",
 			"screencastMode.keyboardOptions.description",
 			"screencastMode.keyboardOptions.showKeys",
+			"screencastMode.keyboardOptions.showKeybindings",
 			"screencastMode.keyboardOptions.showCommands",
 			"screencastMode.keyboardOptions.showCommandGroups",
 			"screencastMode.keyboardOptions.showSingleEditorCursorMoves",
@@ -1818,6 +1858,17 @@
 				]
 			}
 		],
+		"vs/workbench/browser/actions/workspaceCommands": [
+			"addFolderToWorkspace",
+			{
+				"key": "add",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"addFolderToWorkspaceTitle",
+			"workspaceFolderPickerPlaceholder"
+		],
 		"vs/workbench/browser/actions/workspaceActions": [
 			"workspaces",
 			"openFile",
@@ -1881,16 +1932,57 @@
 				]
 			}
 		],
-		"vs/workbench/browser/actions/workspaceCommands": [
-			"addFolderToWorkspace",
-			{
-				"key": "add",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"addFolderToWorkspaceTitle",
-			"workspaceFolderPickerPlaceholder"
+		"vs/workbench/browser/actions/quickAccessActions": [
+			"quickOpen",
+			"quickOpenWithModes",
+			"quickNavigateNext",
+			"quickNavigatePrevious",
+			"quickSelectNext",
+			"quickSelectPrevious"
+		],
+		"vs/workbench/api/common/configurationExtensionPoint": [
+			"vscode.extension.contributes.configuration.title",
+			"vscode.extension.contributes.configuration.order",
+			"vscode.extension.contributes.configuration.properties",
+			"vscode.extension.contributes.configuration.property.empty",
+			"vscode.extension.contributes.configuration.properties.schema",
+			"scope.application.description",
+			"scope.machine.description",
+			"scope.window.description",
+			"scope.resource.description",
+			"scope.language-overridable.description",
+			"scope.machine-overridable.description",
+			"scope.description",
+			"scope.enumDescriptions",
+			"scope.markdownEnumDescriptions",
+			"scope.enumItemLabels",
+			"scope.markdownDescription",
+			"scope.deprecationMessage",
+			"scope.markdownDeprecationMessage",
+			"scope.singlelineText.description",
+			"scope.multilineText.description",
+			"scope.editPresentation",
+			"scope.order",
+			"scope.ignoreSync",
+			"config.property.defaultConfiguration.warning",
+			"vscode.extension.contributes.configuration",
+			"invalid.title",
+			"invalid.properties",
+			"config.property.duplicate",
+			"invalid.property",
+			"invalid.allOf",
+			"workspaceConfig.folders.description",
+			"workspaceConfig.path.description",
+			"workspaceConfig.name.description",
+			"workspaceConfig.uri.description",
+			"workspaceConfig.name.description",
+			"workspaceConfig.settings.description",
+			"workspaceConfig.launch.description",
+			"workspaceConfig.tasks.description",
+			"workspaceConfig.extensions.description",
+			"workspaceConfig.remoteAuthority",
+			"workspaceConfig.transient",
+			"unknownWorkspaceProperty"
 		],
 		"vs/workbench/services/actions/common/menusExtensionPoint": [
 			"menus.commandPalette",
@@ -1916,6 +2008,8 @@
 			"menus.resourceGroupContext",
 			"menus.changeTitle",
 			"menus.statusBarRemoteIndicator",
+			"menus.terminalContext",
+			"menus.terminalTabContext",
 			"view.viewTitle",
 			"view.itemContext",
 			"commentThread.editorActions",
@@ -1934,6 +2028,8 @@
 			"interactive.cell.title",
 			"testing.item.context",
 			"testing.item.gutter.title",
+			"testing.message.context.title",
+			"testing.message.content.title",
 			"menus.extensionContext",
 			"view.timelineTitle",
 			"view.timelineContext",
@@ -2012,14 +2108,6 @@
 			"missing.submenu",
 			"submenuItem.duplicate"
 		],
-		"vs/workbench/browser/actions/quickAccessActions": [
-			"quickOpen",
-			"quickOpenWithModes",
-			"quickNavigateNext",
-			"quickNavigatePrevious",
-			"quickSelectNext",
-			"quickSelectPrevious"
-		],
 		"vs/workbench/api/browser/viewsExtensionPoint": [
 			{
 				"key": "vscode.extension.contributes.views.containers.id",
@@ -2075,50 +2163,6 @@
 			"optstring",
 			"optstring",
 			"optenum"
-		],
-		"vs/workbench/api/common/configurationExtensionPoint": [
-			"vscode.extension.contributes.configuration.title",
-			"vscode.extension.contributes.configuration.order",
-			"vscode.extension.contributes.configuration.properties",
-			"vscode.extension.contributes.configuration.property.empty",
-			"vscode.extension.contributes.configuration.properties.schema",
-			"scope.application.description",
-			"scope.machine.description",
-			"scope.window.description",
-			"scope.resource.description",
-			"scope.language-overridable.description",
-			"scope.machine-overridable.description",
-			"scope.description",
-			"scope.enumDescriptions",
-			"scope.markdownEnumDescriptions",
-			"scope.enumItemLabels",
-			"scope.markdownDescription",
-			"scope.deprecationMessage",
-			"scope.markdownDeprecationMessage",
-			"scope.singlelineText.description",
-			"scope.multilineText.description",
-			"scope.editPresentation",
-			"scope.order",
-			"scope.ignoreSync",
-			"config.property.defaultConfiguration.warning",
-			"vscode.extension.contributes.configuration",
-			"invalid.title",
-			"invalid.properties",
-			"config.property.duplicate",
-			"invalid.property",
-			"invalid.allOf",
-			"workspaceConfig.folders.description",
-			"workspaceConfig.path.description",
-			"workspaceConfig.name.description",
-			"workspaceConfig.uri.description",
-			"workspaceConfig.name.description",
-			"workspaceConfig.settings.description",
-			"workspaceConfig.launch.description",
-			"workspaceConfig.tasks.description",
-			"workspaceConfig.extensions.description",
-			"workspaceConfig.remoteAuthority",
-			"workspaceConfig.transient",
-			"unknownWorkspaceProperty"
 		],
 		"vs/workbench/browser/parts/editor/editor.contribution": [
 			"textEditor",
@@ -2186,7 +2230,6 @@
 			"navigate.prev.label",
 			"navigate.next.label",
 			"ignoreTrimWhitespace.label",
-			"showTrimWhitespace.label",
 			"keepEditor",
 			"pinEditor",
 			"unpinEditor",
@@ -2586,35 +2629,6 @@
 				]
 			}
 		],
-		"vs/workbench/services/keybinding/common/keybindingEditing": [
-			"errorKeybindingsFileDirty",
-			"parseErrors",
-			"errorInvalidConfiguration",
-			"emptyKeybindingsHeader"
-		],
-		"vs/workbench/services/decorations/browser/decorationsService": [
-			"bubbleTitle"
-		],
-		"vs/workbench/services/progress/browser/progressService": [
-			"progress.text2",
-			"progress.title3",
-			"progress.title2",
-			"progress.title2",
-			"status.progress",
-			"cancel",
-			"cancel",
-			"dismiss"
-		],
-		"vs/workbench/services/preferences/browser/preferencesService": [
-			"openFolderFirst",
-			"emptyKeybindingsHeader",
-			"defaultKeybindings",
-			"defaultKeybindings",
-			"fail.createSettings"
-		],
-		"vs/workbench/services/configuration/common/jsonEditingService": [
-			"errorInvalidFile"
-		],
 		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
 			"confirmUrl",
 			"rememberConfirmUrl",
@@ -2649,6 +2663,35 @@
 			"manage",
 			"extensions",
 			"no"
+		],
+		"vs/workbench/services/keybinding/common/keybindingEditing": [
+			"errorKeybindingsFileDirty",
+			"parseErrors",
+			"errorInvalidConfiguration",
+			"emptyKeybindingsHeader"
+		],
+		"vs/workbench/services/decorations/browser/decorationsService": [
+			"bubbleTitle"
+		],
+		"vs/workbench/services/progress/browser/progressService": [
+			"progress.text2",
+			"progress.title3",
+			"progress.title2",
+			"progress.title2",
+			"status.progress",
+			"cancel",
+			"cancel",
+			"dismiss"
+		],
+		"vs/workbench/services/preferences/browser/preferencesService": [
+			"openFolderFirst",
+			"emptyKeybindingsHeader",
+			"defaultKeybindings",
+			"defaultKeybindings",
+			"fail.createSettings"
+		],
+		"vs/workbench/services/configuration/common/jsonEditingService": [
+			"errorInvalidFile"
 		],
 		"vs/workbench/services/editor/browser/editorResolverService": [
 			"editorResolver.conflictingDefaults",
@@ -2761,6 +2804,16 @@
 			"workspace folder",
 			"workspace"
 		],
+		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
+			"reload message when updated",
+			"reload message when removed",
+			"reload message when removed",
+			"cannotRenameDefaultProfile",
+			"cannotDeleteDefaultProfile",
+			"switch profile",
+			"reload message",
+			"reload button"
+		],
 		"vs/workbench/services/notification/common/notificationService": [
 			"neverShowAgain",
 			"neverShowAgain"
@@ -2867,22 +2920,6 @@
 			"export profile title",
 			"profile name required"
 		],
-		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
-			"reload message when updated",
-			"reload message when removed",
-			"reload message when removed",
-			"cannotRenameDefaultProfile",
-			"cannotDeleteDefaultProfile",
-			"switch profile",
-			"reload message",
-			"reload button"
-		],
-		"vs/workbench/services/remote/common/remoteExplorerService": [
-			"tunnel.source.user",
-			"tunnel.source.auto",
-			"remote.localPortMismatch.single",
-			"tunnel.staticallyForwarded"
-		],
 		"vs/workbench/services/filesConfiguration/common/filesConfigurationService": [
 			"providerReadonly",
 			{
@@ -2962,6 +2999,9 @@
 			"others",
 			"sign in using account"
 		],
+		"vs/workbench/services/assignment/common/assignmentService": [
+			"workbench.enableExperiments"
+		],
 		"vs/workbench/services/authentication/browser/authenticationService": [
 			"authentication.id",
 			"authentication.label",
@@ -3011,9 +3051,6 @@
 				]
 			}
 		],
-		"vs/workbench/services/assignment/common/assignmentService": [
-			"workbench.enableExperiments"
-		],
 		"vs/workbench/services/issue/browser/issueTroubleshoot": [
 			"troubleshoot issue",
 			"detail.start",
@@ -3044,6 +3081,23 @@
 			"troubleshootIssue",
 			"title.stop"
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"defineKeybinding.kbLayoutErrorMessage",
+			{
+				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
+					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			},
+			{
+				"key": "defineKeybinding.kbLayoutLocalMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
+					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			}
+		],
 		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
 			"settingsEditor2",
 			"keybindingsEditor",
@@ -3061,7 +3115,6 @@
 			"openSettings2",
 			"openGlobalSettings",
 			"openRawDefaultSettings",
-			"openSettingsJson",
 			"openWorkspaceSettings",
 			"openAccessibilitySettings",
 			"openWorkspaceSettingsFile",
@@ -3104,12 +3157,19 @@
 			"clear",
 			"clearHistory",
 			"defineKeybinding.start",
+			"openSettingsJson",
 			{
 				"key": "miPreferences",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"show.label",
+			"cycles",
+			"insta.trace",
+			"emitter"
 		],
 		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
 			"notebook.editorOptions.experimentalCustomization",
@@ -3164,17 +3224,9 @@
 			"interactiveSession.editor.fontWeight",
 			"interactiveSession.editor.wordWrap",
 			"interactiveSession.editor.lineHeight",
-			"interactiveSession.defaultMode.chatView",
-			"interactiveSession.defaultMode.quickQuestion",
-			"interactiveSession.defaultMode.both",
-			"interactiveSession.defaultMode",
-			"interactiveSession.quickQuestion.mode",
 			"chat",
 			"chat",
-			"chatAccessibleView"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChat.contribution": [
-			"inlineChatAccessibleView"
+			"clear"
 		],
 		"vs/workbench/contrib/interactive/browser/interactive.contribution": [
 			"interactiveWindow",
@@ -3192,6 +3244,12 @@
 			"interactive.inactiveCodeBorder",
 			"interactiveWindow.alwaysScrollOnNewCell"
 		],
+		"vs/workbench/contrib/logs/common/logs.contribution": [
+			"setDefaultLogLevel",
+			"remote name",
+			"remote name",
+			"show window log"
+		],
 		"vs/workbench/contrib/testing/browser/testing.contribution": [
 			"test",
 			{
@@ -3205,29 +3263,6 @@
 			"noTestProvidersRegistered",
 			"searchForAdditionalTestExtensions",
 			"testExplorer"
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"defineKeybinding.kbLayoutErrorMessage",
-			{
-				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
-					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			},
-			{
-				"key": "defineKeybinding.kbLayoutLocalMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
-					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			}
-		],
-		"vs/workbench/contrib/logs/common/logs.contribution": [
-			"setDefaultLogLevel",
-			"remote name",
-			"remote name",
-			"show window log"
 		],
 		"vs/workbench/contrib/files/browser/explorerViewlet": [
 			"explorerViewIcon",
@@ -3278,6 +3313,7 @@
 		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
 			"helpQuickAccessPlaceholder",
 			"helpQuickAccess",
+			"more",
 			"viewQuickAccessPlaceholder",
 			"viewQuickAccess",
 			"commandsQuickAccessPlaceholder",
@@ -3610,6 +3646,8 @@
 			"anythingQuickAccess",
 			"symbolsQuickAccessPlaceholder",
 			"symbolsQuickAccess",
+			"textSearchPickerPlaceholder",
+			"textSearchPickerHelp",
 			"searchConfigurationTitle",
 			"exclude",
 			"exclude.boolean",
@@ -3677,7 +3715,8 @@
 			"scm.defaultViewMode.tree",
 			"scm.defaultViewMode.list",
 			"search.defaultViewMode",
-			"search.experimental.closedNotebookResults"
+			"search.experimental.closedNotebookResults",
+			"search.experimental.quickAccess.preserveInput"
 		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
 			"overlap",
@@ -3703,32 +3742,6 @@
 			"refactorPreviewViewIcon",
 			"panel",
 			"panel"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
-			"searchEditor",
-			"promptOpenWith.searchEditor.displayName",
-			"search",
-			"searchEditor.deleteResultBlock",
-			"search.openNewSearchEditor",
-			"search.openSearchEditor",
-			"search.openNewEditorToSide",
-			"search.openResultsInEditor",
-			"search.rerunSearchInEditor",
-			"search.action.focusQueryEditorWidget",
-			"search.action.focusFilesToInclude",
-			"search.action.focusFilesToExclude",
-			"searchEditor.action.toggleSearchEditorCaseSensitive",
-			"searchEditor.action.toggleSearchEditorWholeWord",
-			"searchEditor.action.toggleSearchEditorRegex",
-			"searchEditor.action.toggleSearchEditorContextLines",
-			"searchEditor.action.increaseSearchEditorContextLines",
-			"searchEditor.action.decreaseSearchEditorContextLines",
-			"searchEditor.action.selectAllSearchEditorMatches",
-			"search.openNewEditor"
-		],
-		"vs/workbench/contrib/sash/browser/sash.contribution": [
-			"sashSize",
-			"sashHoverDelay"
 		],
 		"vs/workbench/contrib/search/browser/searchView": [
 			"searchCanceled",
@@ -3792,6 +3805,32 @@
 			"search.files.results",
 			"searchWithoutFolder",
 			"openFolder"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
+			"searchEditor",
+			"promptOpenWith.searchEditor.displayName",
+			"search",
+			"searchEditor.deleteResultBlock",
+			"search.openNewSearchEditor",
+			"search.openSearchEditor",
+			"search.openNewEditorToSide",
+			"search.openResultsInEditor",
+			"search.rerunSearchInEditor",
+			"search.action.focusQueryEditorWidget",
+			"search.action.focusFilesToInclude",
+			"search.action.focusFilesToExclude",
+			"searchEditor.action.toggleSearchEditorCaseSensitive",
+			"searchEditor.action.toggleSearchEditorWholeWord",
+			"searchEditor.action.toggleSearchEditorRegex",
+			"searchEditor.action.toggleSearchEditorContextLines",
+			"searchEditor.action.increaseSearchEditorContextLines",
+			"searchEditor.action.decreaseSearchEditorContextLines",
+			"searchEditor.action.selectAllSearchEditorMatches",
+			"search.openNewEditor"
+		],
+		"vs/workbench/contrib/sash/browser/sash.contribution": [
+			"sashSize",
+			"sashHoverDelay"
 		],
 		"vs/workbench/contrib/scm/browser/scm.contribution": [
 			"sourceControlViewIcon",
@@ -4096,10 +4135,6 @@
 			"debug.autoExpandLazyVariables",
 			"debug.enableStatusBarColor"
 		],
-		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
-			"editor.inlineValuesForeground",
-			"editor.inlineValuesBackground"
-		],
 		"vs/workbench/contrib/debug/browser/breakpointEditorContribution": [
 			"logPoint",
 			"breakpoint",
@@ -4154,6 +4189,14 @@
 			"debugIcon.breakpointUnverifiedForeground",
 			"debugIcon.breakpointCurrentStackframeForeground",
 			"debugIcon.breakpointStackframeForeground"
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"topStackFrameLineHighlight",
+			"focusedStackFrameLineHighlight"
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
+			"editor.inlineValuesForeground",
+			"editor.inlineValuesBackground"
 		],
 		"vs/workbench/contrib/debug/browser/debugViewlet": [
 			{
@@ -4242,11 +4285,10 @@
 			"manyProblems",
 			"totalProblems"
 		],
-		"vs/workbench/contrib/performance/browser/performance.contribution": [
-			"show.label",
-			"cycles",
-			"insta.trace",
-			"emitter"
+		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
+			"name",
+			"diffAlgorithm.legacy",
+			"diffAlgorithm.advanced"
 		],
 		"vs/workbench/contrib/commands/common/commands.contribution": [
 			"runCommands",
@@ -4254,10 +4296,6 @@
 			"runCommands.commands",
 			"runCommands.invalidArgs",
 			"runCommands.noCommandsToRun"
-		],
-		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
-			"topStackFrameLineHighlight",
-			"focusedStackFrameLineHighlight"
 		],
 		"vs/workbench/contrib/comments/browser/comments.contribution": [
 			"commentsConfigurationTitle",
@@ -4276,18 +4314,59 @@
 			"urlToOpen",
 			"workbench.trustedDomains.promptInTrustedWorkspace"
 		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
+			"webview.editor.label"
+		],
 		"vs/workbench/contrib/webview/browser/webview.contribution": [
 			"cut",
 			"copy",
 			"paste"
 		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
-			"webview.editor.label"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
-			"name",
-			"diffAlgorithm.legacy",
-			"diffAlgorithm.advanced"
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			{
+				"key": "remote",
+				"comment": [
+					"Remote as in remote machine"
+				]
+			},
+			"installed",
+			"select and install local extensions",
+			"install remote in local",
+			"popularExtensions",
+			"recommendedExtensions",
+			"enabledExtensions",
+			"disabledExtensions",
+			"marketPlace",
+			"installed",
+			"recently updated",
+			"enabled",
+			"disabled",
+			"availableUpdates",
+			"builtin",
+			"workspaceUnsupported",
+			"workspaceRecommendedExtensions",
+			"otherRecommendedExtensions",
+			"builtinFeatureExtensions",
+			"builtInThemesExtensions",
+			"builtinProgrammingLanguageExtensions",
+			"untrustedUnsupportedExtensions",
+			"untrustedPartiallySupportedExtensions",
+			"virtualUnsupportedExtensions",
+			"virtualPartiallySupportedExtensions",
+			"deprecated",
+			"searchExtensions",
+			"extensionFoundInSection",
+			"extensionFound",
+			"extensionsFoundInSection",
+			"extensionsFound",
+			"suggestProxyError",
+			"open user settings",
+			"extensionToUpdate",
+			"extensionsToUpdate",
+			"extensionToReload",
+			"extensionsToReload",
+			"malicious warning",
+			"reloadNow"
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
 			"manageExtensionsQuickAccessPlaceholder",
@@ -4441,52 +4520,6 @@
 			"extensions",
 			"extensions"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			{
-				"key": "remote",
-				"comment": [
-					"Remote as in remote machine"
-				]
-			},
-			"installed",
-			"select and install local extensions",
-			"install remote in local",
-			"popularExtensions",
-			"recommendedExtensions",
-			"enabledExtensions",
-			"disabledExtensions",
-			"marketPlace",
-			"installed",
-			"recently updated",
-			"enabled",
-			"disabled",
-			"availableUpdates",
-			"builtin",
-			"workspaceUnsupported",
-			"workspaceRecommendedExtensions",
-			"otherRecommendedExtensions",
-			"builtinFeatureExtensions",
-			"builtInThemesExtensions",
-			"builtinProgrammingLanguageExtensions",
-			"untrustedUnsupportedExtensions",
-			"untrustedPartiallySupportedExtensions",
-			"virtualUnsupportedExtensions",
-			"virtualPartiallySupportedExtensions",
-			"deprecated",
-			"searchExtensions",
-			"extensionFoundInSection",
-			"extensionFound",
-			"extensionsFoundInSection",
-			"extensionsFound",
-			"suggestProxyError",
-			"open user settings",
-			"extensionToUpdate",
-			"extensionsToUpdate",
-			"extensionToReload",
-			"extensionsToReload",
-			"malicious warning",
-			"reloadNow"
-		],
 		"vs/workbench/contrib/output/browser/output.contribution": [
 			"outputViewIcon",
 			"output",
@@ -4524,11 +4557,6 @@
 			"output",
 			"outputViewAriaLabel"
 		],
-		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
-			"scopedConsoleAction.Integrated",
-			"scopedConsoleAction.external",
-			"scopedConsoleAction.wt"
-		],
 		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
 			"relaunchSettingMessage",
 			"relaunchSettingMessageWeb",
@@ -4547,6 +4575,11 @@
 				]
 			},
 			"restartExtensionHost.reason"
+		],
+		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
+			"scopedConsoleAction.Integrated",
+			"scopedConsoleAction.external",
+			"scopedConsoleAction.wt"
 		],
 		"vs/workbench/contrib/tasks/browser/task.contribution": [
 			"building",
@@ -4799,16 +4832,16 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/surveys/browser/ces.contribution": [
+			"cesSurveyQuestion",
+			"giveFeedback",
+			"remindLater"
+		],
 		"vs/workbench/contrib/surveys/browser/nps.contribution": [
 			"surveyQuestion",
 			"takeSurvey",
 			"remindLater",
 			"neverAgain"
-		],
-		"vs/workbench/contrib/surveys/browser/ces.contribution": [
-			"cesSurveyQuestion",
-			"giveFeedback",
-			"remindLater"
 		],
 		"vs/workbench/contrib/surveys/browser/languageSurveys.contribution": [
 			"helpUs",
@@ -4911,6 +4944,13 @@
 		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
 			"document"
 		],
+		"vs/workbench/contrib/languageDetection/browser/languageDetection.contribution": [
+			"status.autoDetectLanguage",
+			"langDetection.name",
+			"langDetection.aria",
+			"detectlang",
+			"noDetection"
+		],
 		"vs/workbench/contrib/outline/browser/outline.contribution": [
 			"outlineViewIcon",
 			"name",
@@ -4948,13 +4988,6 @@
 			"filteredTypes.event",
 			"filteredTypes.operator",
 			"filteredTypes.typeParameter"
-		],
-		"vs/workbench/contrib/languageDetection/browser/languageDetection.contribution": [
-			"status.autoDetectLanguage",
-			"langDetection.name",
-			"langDetection.aria",
-			"detectlang",
-			"noDetection"
 		],
 		"vs/workbench/contrib/languageStatus/browser/languageStatus.contribution": [
 			"langStatus.name",
@@ -5056,6 +5089,38 @@
 			"files.openTimeline",
 			"timelineFilter",
 			"filterTimeline"
+		],
+		"vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExtensionMigrator.contribution": [
+			"bracketPairColorizer.notification",
+			"bracketPairColorizer.notification.action.uninstall",
+			"bracketPairColorizer.notification.action.enableNative",
+			"bracketPairColorizer.notification.action.showMoreInfo"
+		],
+		"vs/workbench/contrib/audioCues/browser/audioCues.contribution": [
+			"audioCues.enabled.auto",
+			"audioCues.enabled.on",
+			"audioCues.enabled.off",
+			"audioCues.volume",
+			"audioCues.debouncePositionChanges",
+			"audioCues.lineHasBreakpoint",
+			"audioCues.lineHasInlineSuggestion",
+			"audioCues.lineHasError",
+			"audioCues.lineHasFoldedArea",
+			"audioCues.lineHasWarning",
+			"audioCues.onDebugBreak",
+			"audioCues.noInlayHints",
+			"audioCues.taskCompleted",
+			"audioCues.taskFailed",
+			"audioCues.terminalCommandFailed",
+			"audioCues.terminalQuickFix",
+			"audioCues.diffLineInserted",
+			"audioCues.diffLineDeleted",
+			"audioCues.diffLineModified",
+			"audioCues.notebookCellCompleted",
+			"audioCues.notebookCellFailed",
+			"audioCues.chatRequestSent",
+			"audioCues.chatResponsePending",
+			"audioCues.chatResponseReceived"
 		],
 		"vs/workbench/contrib/workspace/browser/workspace.contribution": [
 			"openLooseFileWorkspaceDetails",
@@ -5176,53 +5241,6 @@
 			"workspace.trust.untrustedFiles.newWindow",
 			"workspace.trust.emptyWindow.description"
 		],
-		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
-			"workspaceFound",
-			"openWorkspace",
-			"workspacesFound",
-			"selectWorkspace",
-			"selectToOpen",
-			"openWorkspace",
-			"alreadyOpen"
-		],
-		"vs/workbench/contrib/audioCues/browser/audioCues.contribution": [
-			"audioCues.enabled.auto",
-			"audioCues.enabled.on",
-			"audioCues.enabled.off",
-			"audioCues.volume",
-			"audioCues.debouncePositionChanges",
-			"audioCues.lineHasBreakpoint",
-			"audioCues.lineHasInlineSuggestion",
-			"audioCues.lineHasError",
-			"audioCues.lineHasFoldedArea",
-			"audioCues.lineHasWarning",
-			"audioCues.onDebugBreak",
-			"audioCues.noInlayHints",
-			"audioCues.taskCompleted",
-			"audioCues.taskFailed",
-			"audioCues.terminalCommandFailed",
-			"audioCues.terminalQuickFix",
-			"audioCues.diffLineInserted",
-			"audioCues.diffLineDeleted",
-			"audioCues.diffLineModified",
-			"audioCues.notebookCellCompleted",
-			"audioCues.notebookCellFailed",
-			"audioCues.chatRequestSent",
-			"audioCues.chatResponsePending",
-			"audioCues.chatResponseReceived"
-		],
-		"vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExtensionMigrator.contribution": [
-			"bracketPairColorizer.notification",
-			"bracketPairColorizer.notification.action.uninstall",
-			"bracketPairColorizer.notification.action.enableNative",
-			"bracketPairColorizer.notification.action.showMoreInfo"
-		],
-		"vs/workbench/contrib/accessibility/browser/accessibility.contribution": [
-			"editor-help",
-			"hoverAccessibleView",
-			"notification.accessibleView",
-			"notification"
-		],
 		"vs/workbench/contrib/share/browser/share.contribution": [
 			"share",
 			"generating link",
@@ -5231,6 +5249,15 @@
 			"close",
 			"open link",
 			"experimental.share.enabled"
+		],
+		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
+			"workspaceFound",
+			"openWorkspace",
+			"workspacesFound",
+			"selectWorkspace",
+			"selectToOpen",
+			"openWorkspace",
+			"alreadyOpen"
 		],
 		"vs/workbench/browser/parts/dialogs/dialogHandler": [
 			"aboutDetail",
@@ -5256,6 +5283,23 @@
 				]
 			},
 			"okButton"
+		],
+		"vs/workbench/services/textfile/browser/textFileService": [
+			"textFileCreate.source",
+			"textFileOverwrite.source",
+			"textFileModelDecorations",
+			"readonlyAndDeleted",
+			"readonly",
+			"deleted",
+			"fileBinaryError",
+			"confirmOverwrite",
+			"irreversible",
+			{
+				"key": "replaceButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
 			"defaultLanguageConfigurationOverrides.title",
@@ -5312,6 +5356,13 @@
 			"switchWindow",
 			"quickSwitchWindow"
 		],
+		"vs/workbench/electron-sandbox/actions/installActions": [
+			"shellCommand",
+			"install",
+			"successIn",
+			"uninstall",
+			"successFrom"
+		],
 		"vs/platform/contextkey/common/contextkeys": [
 			"isMac",
 			"isLinux",
@@ -5322,13 +5373,6 @@
 			"isMobile",
 			"productQualityType",
 			"inputFocus"
-		],
-		"vs/workbench/electron-sandbox/actions/installActions": [
-			"shellCommand",
-			"install",
-			"successIn",
-			"uninstall",
-			"successFrom"
 		],
 		"vs/workbench/common/contextkeys": [
 			"workbenchState",
@@ -5399,23 +5443,6 @@
 			"security.allowedUNCHosts.patternErrorMessage",
 			"security.allowedUNCHosts",
 			"security.restrictUNCAccess"
-		],
-		"vs/workbench/services/textfile/browser/textFileService": [
-			"textFileCreate.source",
-			"textFileOverwrite.source",
-			"textFileModelDecorations",
-			"readonlyAndDeleted",
-			"readonly",
-			"deleted",
-			"fileBinaryError",
-			"confirmOverwrite",
-			"irreversible",
-			{
-				"key": "replaceButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
 		],
 		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
 			"saveChangesDetail",
@@ -5733,14 +5760,20 @@
 			"statusBarItemActiveBackground",
 			"statusBarItemFocusBorder",
 			"statusBarItemHoverBackground",
+			"statusBarItemHoverForeground",
 			"statusBarItemCompactHoverBackground",
 			"statusBarProminentItemForeground",
 			"statusBarProminentItemBackground",
+			"statusBarProminentItemHoverForeground",
 			"statusBarProminentItemHoverBackground",
 			"statusBarErrorItemBackground",
 			"statusBarErrorItemForeground",
+			"statusBarErrorItemHoverForeground",
+			"statusBarErrorItemHoverBackground",
 			"statusBarWarningItemBackground",
 			"statusBarWarningItemForeground",
+			"statusBarWarningItemHoverForeground",
+			"statusBarWarningItemHoverBackground",
 			"activityBarBackground",
 			"activityBarForeground",
 			"activityBarInActiveForeground",
@@ -5755,6 +5788,12 @@
 			"profileBadgeForeground",
 			"statusBarItemHostBackground",
 			"statusBarItemHostForeground",
+			"statusBarRemoteItemHoverForeground",
+			"statusBarRemoteItemHoverBackground",
+			"statusBarItemOfflineBackground",
+			"statusBarItemOfflineForeground",
+			"statusBarOfflineItemHoverForeground",
+			"statusBarOfflineItemHoverBackground",
 			"extensionBadge.remoteBackground",
 			"extensionBadge.remoteForeground",
 			"sideBarBackground",
@@ -5786,6 +5825,9 @@
 			"notificationsInfoIconForeground",
 			"windowActiveBorder",
 			"windowInactiveBorder"
+		],
+		"vs/base/common/actions": [
+			"submenu.empty"
 		],
 		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
 			"save",
@@ -5850,9 +5892,6 @@
 			"non web extensions detail",
 			"non web extensions"
 		],
-		"vs/base/common/actions": [
-			"submenu.empty"
-		],
 		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
 			"notFoundReleaseExtension",
 			"notFoundCompatibleDependency"
@@ -5898,25 +5937,78 @@
 			"extensionService.crash",
 			"restart"
 		],
-		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
-			"extensionCache.invalid",
-			"reloadWindow"
-		],
-		"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost": [
-			"extensionHost.startupFailDebug",
-			"extensionHost.startupFail",
-			"reloadWindow",
-			"join.extensionDevelopment"
-		],
 		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
 			"openLogsFolder",
 			"openExtensionLogsFolder"
 		],
-		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
-			"actions.pasteSelectionClipboard"
+		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
+			"showLanguagePackExtensions",
+			"searchMarketplace",
+			"installAndRestartMessage",
+			"installAndRestart"
+		],
+		"vs/workbench/contrib/localization/common/localization.contribution": [
+			"vscode.extension.contributes.localizations",
+			"vscode.extension.contributes.localizations.languageId",
+			"vscode.extension.contributes.localizations.languageName",
+			"vscode.extension.contributes.localizations.languageNameLocalized",
+			"vscode.extension.contributes.localizations.translations",
+			"vscode.extension.contributes.localizations.translations.id",
+			"vscode.extension.contributes.localizations.translations.id.pattern",
+			"vscode.extension.contributes.localizations.translations.path"
+		],
+		"vs/workbench/common/editor": [
+			"promptOpenWith.defaultEditor.displayName",
+			"builtinProviderDisplayName",
+			"openLargeFile",
+			"configureEditorLargeFileConfirmation"
+		],
+		"vs/editor/common/editorContextKeys": [
+			"editorTextFocus",
+			"editorFocus",
+			"textInputFocus",
+			"editorReadonly",
+			"inDiffEditor",
+			"isEmbeddedDiffEditor",
+			"comparingMovedCode",
+			"accessibleDiffViewerVisible",
+			"diffEditorRenderSideBySideInlineBreakpointReached",
+			"editorColumnSelection",
+			"editorHasSelection",
+			"editorHasMultipleSelections",
+			"editorTabMovesFocus",
+			"editorHoverVisible",
+			"editorHoverFocused",
+			"stickyScrollFocused",
+			"stickyScrollVisible",
+			"standaloneColorPickerVisible",
+			"standaloneColorPickerFocused",
+			"inCompositeEditor",
+			"editorLangId",
+			"editorHasCompletionItemProvider",
+			"editorHasCodeActionsProvider",
+			"editorHasCodeLensProvider",
+			"editorHasDefinitionProvider",
+			"editorHasDeclarationProvider",
+			"editorHasImplementationProvider",
+			"editorHasTypeDefinitionProvider",
+			"editorHasHoverProvider",
+			"editorHasDocumentHighlightProvider",
+			"editorHasDocumentSymbolProvider",
+			"editorHasReferenceProvider",
+			"editorHasRenameProvider",
+			"editorHasSignatureHelpProvider",
+			"editorHasInlayHintsProvider",
+			"editorHasDocumentFormattingProvider",
+			"editorHasDocumentSelectionFormattingProvider",
+			"editorHasMultipleDocumentFormattingProvider",
+			"editorHasMultipleDocumentSelectionFormattingProvider"
 		],
 		"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate": [
 			"startDebugTextMate"
+		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
+			"actions.pasteSelectionClipboard"
 		],
 		"vs/workbench/browser/editor": [
 			"preview",
@@ -5929,11 +6021,15 @@
 			"saveprofile.dialogTitle",
 			"saveprofile.saveButton"
 		],
-		"vs/workbench/common/editor": [
-			"promptOpenWith.defaultEditor.displayName",
-			"builtinProviderDisplayName",
-			"openLargeFile",
-			"configureEditorLargeFileConfirmation"
+		"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost": [
+			"extensionHost.startupFailDebug",
+			"extensionHost.startupFail",
+			"reloadWindow",
+			"join.extensionDevelopment"
+		],
+		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
+			"extensionCache.invalid",
+			"reloadWindow"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/debugExtensionHostAction": [
 			"debugExtensionHost",
@@ -6017,35 +6113,6 @@
 			"vscode.extension.contributes.terminal.types.icon.light",
 			"vscode.extension.contributes.terminal.types.icon.dark"
 		],
-		"vs/editor/common/languages": [
-			"Array",
-			"Boolean",
-			"Class",
-			"Constant",
-			"Constructor",
-			"Enum",
-			"EnumMember",
-			"Event",
-			"Field",
-			"File",
-			"Function",
-			"Interface",
-			"Key",
-			"Method",
-			"Module",
-			"Namespace",
-			"Null",
-			"Number",
-			"Object",
-			"Operator",
-			"Package",
-			"Property",
-			"String",
-			"Struct",
-			"TypeParameter",
-			"Variable",
-			"symbolAriaLabel"
-		],
 		"vs/workbench/services/userDataSync/common/userDataSync": [
 			"settings",
 			"keybindings",
@@ -6077,12 +6144,22 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"tasks.taskRunningContext",
+			"tasksCategory",
+			"TaskDefinition.missingRequiredProperty"
+		],
 		"vs/workbench/contrib/tasks/common/taskService": [
 			"tasks.customExecutionSupported",
 			"tasks.shellExecutionSupported",
 			"tasks.taskCommandsRegistered",
 			"tasks.processExecutionSupported",
 			"tasks.serverlessWebContext"
+		],
+		"vs/workbench/common/views": [
+			"defaultViewIcon",
+			"duplicateId",
+			"treeView.notRegistered"
 		],
 		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
 			"TerminalTaskSystem.unknownError",
@@ -6126,88 +6203,6 @@
 			"unknownProblemMatcher",
 			"closeTerminal",
 			"reuseTerminal"
-		],
-		"vs/workbench/contrib/tasks/common/tasks": [
-			"tasks.taskRunningContext",
-			"tasksCategory",
-			"TaskDefinition.missingRequiredProperty"
-		],
-		"vs/workbench/common/views": [
-			"defaultViewIcon",
-			"duplicateId",
-			"treeView.notRegistered"
-		],
-		"vs/platform/audioCues/browser/audioCueService": [
-			"audioCues.lineHasError.name",
-			"audioCues.lineHasWarning.name",
-			"audioCues.lineHasFoldedArea.name",
-			"audioCues.lineHasBreakpoint.name",
-			"audioCues.lineHasInlineSuggestion.name",
-			"audioCues.terminalQuickFix.name",
-			"audioCues.onDebugBreak.name",
-			"audioCues.noInlayHints",
-			"audioCues.taskCompleted",
-			"audioCues.taskFailed",
-			"audioCues.terminalCommandFailed",
-			"audioCues.terminalBell",
-			"audioCues.notebookCellCompleted",
-			"audioCues.notebookCellFailed",
-			"audioCues.diffLineInserted",
-			"audioCues.diffLineDeleted",
-			"audioCues.diffLineModified",
-			"audioCues.chatRequestSent",
-			"audioCues.chatResponseReceived",
-			"audioCues.chatResponsePending"
-		],
-		"vs/workbench/contrib/terminal/common/terminalContextKey": [
-			"terminalFocusContextKey",
-			"terminalFocusInAnyContextKey",
-			"terminalAccessibleBufferFocusContextKey",
-			"terminalEditorFocusContextKey",
-			"terminalCountContextKey",
-			"terminalTabsFocusContextKey",
-			"terminalShellTypeContextKey",
-			"terminalAltBufferActive",
-			"terminalSuggestWidgetVisible",
-			"terminalViewShowing",
-			"terminalTextSelectedContextKey",
-			"terminalTextSelectedInFocusedContextKey",
-			"terminalProcessSupportedContextKey",
-			"terminalTabsSingularSelectedContextKey",
-			"isSplitTerminalContextKey",
-			"inTerminalRunCommandPickerContextKey",
-			"terminalShellIntegrationEnabled"
-		],
-		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
-			"revealInWindows",
-			"revealInMac",
-			"openContainer"
-		],
-		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
-			"openToolsLabel",
-			"iframeWebviewAlert"
-		],
-		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
-			"mergeEditor",
-			"merge.dev.openState",
-			"mergeEditor.enterJSON",
-			"merge.dev.openSelectionInTemporaryMergeEditor"
-		],
-		"vs/workbench/contrib/localization/common/localization.contribution": [
-			"vscode.extension.contributes.localizations",
-			"vscode.extension.contributes.localizations.languageId",
-			"vscode.extension.contributes.localizations.languageName",
-			"vscode.extension.contributes.localizations.languageNameLocalized",
-			"vscode.extension.contributes.localizations.translations",
-			"vscode.extension.contributes.localizations.translations.id",
-			"vscode.extension.contributes.localizations.translations.id.pattern",
-			"vscode.extension.contributes.localizations.translations.path"
-		],
-		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
-			"showLanguagePackExtensions",
-			"searchMarketplace",
-			"installAndRestartMessage",
-			"installAndRestart"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"ConfigureTaskRunnerAction.label",
@@ -6309,44 +6304,80 @@
 			"taskService.openDiff",
 			"taskService.openDiffs"
 		],
-		"vs/editor/common/editorContextKeys": [
-			"editorTextFocus",
-			"editorFocus",
-			"textInputFocus",
-			"editorReadonly",
-			"inDiffEditor",
-			"isEmbeddedDiffEditor",
-			"accessibleDiffViewerVisible",
-			"editorColumnSelection",
-			"editorHasSelection",
-			"editorHasMultipleSelections",
-			"editorTabMovesFocus",
-			"editorHoverVisible",
-			"editorHoverFocused",
-			"stickyScrollFocused",
-			"stickyScrollVisible",
-			"standaloneColorPickerVisible",
-			"standaloneColorPickerFocused",
-			"inCompositeEditor",
-			"editorLangId",
-			"editorHasCompletionItemProvider",
-			"editorHasCodeActionsProvider",
-			"editorHasCodeLensProvider",
-			"editorHasDefinitionProvider",
-			"editorHasDeclarationProvider",
-			"editorHasImplementationProvider",
-			"editorHasTypeDefinitionProvider",
-			"editorHasHoverProvider",
-			"editorHasDocumentHighlightProvider",
-			"editorHasDocumentSymbolProvider",
-			"editorHasReferenceProvider",
-			"editorHasRenameProvider",
-			"editorHasSignatureHelpProvider",
-			"editorHasInlayHintsProvider",
-			"editorHasDocumentFormattingProvider",
-			"editorHasDocumentSelectionFormattingProvider",
-			"editorHasMultipleDocumentFormattingProvider",
-			"editorHasMultipleDocumentSelectionFormattingProvider"
+		"vs/platform/audioCues/browser/audioCueService": [
+			"audioCues.lineHasError.name",
+			"audioCues.lineHasWarning.name",
+			"audioCues.lineHasFoldedArea.name",
+			"audioCues.lineHasBreakpoint.name",
+			"audioCues.lineHasInlineSuggestion.name",
+			"audioCues.terminalQuickFix.name",
+			"audioCues.onDebugBreak.name",
+			"audioCues.noInlayHints",
+			"audioCues.taskCompleted",
+			"audioCues.taskFailed",
+			"audioCues.terminalCommandFailed",
+			"audioCues.terminalBell",
+			"audioCues.notebookCellCompleted",
+			"audioCues.notebookCellFailed",
+			"audioCues.diffLineInserted",
+			"audioCues.diffLineDeleted",
+			"audioCues.diffLineModified",
+			"audioCues.chatRequestSent",
+			"audioCues.chatResponseReceived",
+			"audioCues.chatResponsePending"
+		],
+		"vs/workbench/contrib/terminal/common/terminalContextKey": [
+			"terminalFocusContextKey",
+			"terminalFocusInAnyContextKey",
+			"terminalAccessibleBufferFocusContextKey",
+			"terminalAccessibleBufferOnLastLineContextKey",
+			"terminalEditorFocusContextKey",
+			"terminalCountContextKey",
+			"terminalTabsFocusContextKey",
+			"terminalShellTypeContextKey",
+			"terminalAltBufferActive",
+			"terminalSuggestWidgetVisible",
+			"terminalViewShowing",
+			"terminalTextSelectedContextKey",
+			"terminalTextSelectedInFocusedContextKey",
+			"terminalProcessSupportedContextKey",
+			"terminalTabsSingularSelectedContextKey",
+			"isSplitTerminalContextKey",
+			"inTerminalRunCommandPickerContextKey",
+			"terminalShellIntegrationEnabled"
+		],
+		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
+			"openToolsLabel",
+			"iframeWebviewAlert"
+		],
+		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
+			"revealInWindows",
+			"revealInMac",
+			"openContainer"
+		],
+		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
+			"mergeEditor",
+			"merge.dev.openState",
+			"mergeEditor.enterJSON",
+			"merge.dev.openSelectionInTemporaryMergeEditor"
+		],
+		"vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions": [
+			"voiceChatGettingReady",
+			"voiceChatInProgress",
+			"quickVoiceChatInProgress",
+			"inlineVoiceChatInProgress",
+			"voiceChatInViewInProgress",
+			"voiceChatInEditorInProgress",
+			"workbench.action.chat.voiceChatInView.label",
+			"workbench.action.chat.inlineVoiceChat",
+			"workbench.action.chat.quickVoiceChat.label",
+			"workbench.action.chat.startVoiceChat",
+			"workbench.action.chat.stopVoiceChat.label",
+			"workbench.action.chat.stopVoiceChatInChatView.label",
+			"workbench.action.chat.stopVoiceChatInChatEditor.label",
+			"workbench.action.chat.stopQuickVoiceChat.label",
+			"workbench.action.chat.stopInlineVoiceChat.label",
+			"workbench.action.chat.stopAndAcceptVoiceChat.label"
 		],
 		"vs/workbench/api/common/extHostExtensionService": [
 			"extensionTestError1",
@@ -6378,9 +6409,6 @@
 		],
 		"vs/workbench/api/node/extHostDebugService": [
 			"debug.terminal.title"
-		],
-		"vs/base/browser/ui/button/button": [
-			"button dropdown more actions"
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"open",
@@ -6461,6 +6489,24 @@
 			"cantUninstall",
 			"sourceMissing"
 		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"newWindow",
+			"newWindowDesc",
+			"recentFoldersAndWorkspaces",
+			"recentFolders",
+			"untitledWorkspace",
+			"workspaceName"
+		],
+		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
+			{
+				"key": "ok",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"workspaceOpenedMessage",
+			"workspaceOpenedDetail"
+		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			{
 				"key": "ok",
@@ -6494,42 +6540,11 @@
 			"confirmOpenDetail",
 			"doNotAskAgain"
 		],
-		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
-			"newWindow",
-			"newWindowDesc",
-			"recentFoldersAndWorkspaces",
-			"recentFolders",
-			"untitledWorkspace",
-			"workspaceName"
-		],
-		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
-			{
-				"key": "ok",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"workspaceOpenedMessage",
-			"workspaceOpenedDetail"
-		],
 		"vs/platform/files/common/io": [
 			"fileTooLargeError"
 		],
-		"vs/base/browser/ui/tree/abstractTree": [
-			"filter",
-			"fuzzySearch",
-			"type to filter",
-			"type to search",
-			"type to search",
-			"close",
-			"not found"
-		],
-		"vs/platform/theme/common/iconRegistry": [
-			"iconDefinition.fontId",
-			"iconDefinition.fontCharacter",
-			"widgetClose",
-			"previousChangeIcon",
-			"nextChangeIcon"
+		"vs/base/browser/ui/button/button": [
+			"button dropdown more actions"
 		],
 		"vs/platform/extensions/common/extensionValidator": [
 			"extensionDescription.publisher",
@@ -6643,21 +6658,12 @@
 			"date.fromNow.years.plural.fullWord",
 			"date.fromNow.years.plural"
 		],
-		"vs/platform/userDataSync/common/keybindingsSync": [
-			"errorInvalidSettings",
-			"errorInvalidSettings"
-		],
 		"vs/platform/userDataSync/common/settingsSync": [
 			"errorInvalidSettings"
 		],
-		"vs/platform/userDataSync/common/abstractSynchronizer": [
-			{
-				"key": "incompatible",
-				"comment": [
-					"This is an error while syncing a resource that its local version is not compatible with its remote version."
-				]
-			},
-			"incompatible sync data"
+		"vs/platform/userDataSync/common/keybindingsSync": [
+			"errorInvalidSettings",
+			"errorInvalidSettings"
 		],
 		"vs/platform/userDataSync/common/userDataAutoSyncService": [
 			"default service changed",
@@ -6668,10 +6674,36 @@
 			"session expired",
 			"turned off machine"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
-			"alertErrorMessage",
-			"alertWarningMessage",
-			"alertInfoMessage"
+		"vs/platform/userDataSync/common/abstractSynchronizer": [
+			{
+				"key": "incompatible",
+				"comment": [
+					"This is an error while syncing a resource that its local version is not compatible with its remote version."
+				]
+			},
+			"incompatible sync data"
+		],
+		"vs/base/browser/ui/tree/abstractTree": [
+			"filter",
+			"fuzzySearch",
+			"type to filter",
+			"type to search",
+			"type to search",
+			"close",
+			"not found"
+		],
+		"vs/platform/theme/common/iconRegistry": [
+			"iconDefinition.fontId",
+			"iconDefinition.fontCharacter",
+			"widgetClose",
+			"previousChangeIcon",
+			"nextChangeIcon"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"notificationsEmpty",
+			"notifications",
+			"notificationsToolbar",
+			"notificationsCenterWidgetAriaLabel"
 		],
 		"vs/workbench/browser/parts/notifications/notificationsStatus": [
 			"status.notifications",
@@ -6708,15 +6740,14 @@
 			},
 			"status.message"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"notificationsEmpty",
-			"notifications",
-			"notificationsToolbar",
-			"notificationsCenterWidgetAriaLabel"
-		],
 		"vs/workbench/browser/parts/notifications/notificationsToasts": [
 			"notificationAriaLabel",
 			"notificationWithSourceAriaLabel"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"alertErrorMessage",
+			"alertWarningMessage",
+			"alertInfoMessage"
 		],
 		"vs/workbench/browser/parts/notifications/notificationsCommands": [
 			"notifications",
@@ -6775,15 +6806,6 @@
 			"remoteUserTarget",
 			"workspaceTarget",
 			"folderTarget"
-		],
-		"vs/editor/browser/coreCommands": [
-			"stickydesc",
-			"stickydesc",
-			"removedCursor"
-		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"cursors.maximum",
-			"goToSetting"
 		],
 		"vs/editor/common/core/editorColorRegistry": [
 			"lineHighlight",
@@ -6854,6 +6876,22 @@
 			"editorUnicodeHighlight.border",
 			"editorUnicodeHighlight.background"
 		],
+		"vs/platform/contextkey/common/scanner": [
+			"contextkey.scanner.hint.didYouMean1",
+			"contextkey.scanner.hint.didYouMean2",
+			"contextkey.scanner.hint.didYouMean3",
+			"contextkey.scanner.hint.didYouForgetToOpenOrCloseQuote",
+			"contextkey.scanner.hint.didYouForgetToEscapeSlash"
+		],
+		"vs/editor/browser/coreCommands": [
+			"stickydesc",
+			"stickydesc",
+			"removedCursor"
+		],
+		"vs/editor/contrib/caretOperations/browser/caretOperations": [
+			"caret.moveLeft",
+			"caret.moveRight"
+		],
 		"vs/editor/contrib/anchorSelect/browser/anchorSelect": [
 			"selectionAnchor",
 			"anchorSet",
@@ -6862,19 +6900,12 @@
 			"selectFromAnchorToCursor",
 			"cancelSelectionAnchor"
 		],
-		"vs/platform/contextkey/common/scanner": [
-			"contextkey.scanner.hint.didYouMean1",
-			"contextkey.scanner.hint.didYouMean2",
-			"contextkey.scanner.hint.didYouMean3",
-			"contextkey.scanner.hint.didYouForgetToOpenOrCloseQuote",
-			"contextkey.scanner.hint.didYouForgetToEscapeSlash"
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"cursors.maximum",
+			"goToSetting"
 		],
-		"vs/editor/browser/widget/diffEditorWidget": [
-			"diffInsertIcon",
-			"diffRemoveIcon",
-			"diff-aria-navigation-tip",
-			"diff.tooLarge",
-			"revertChangeHoverMessage"
+		"vs/editor/contrib/caretOperations/browser/transpose": [
+			"transposeLetters.label"
 		],
 		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
 			"overviewRulerBracketMatchForeground",
@@ -6887,13 +6918,6 @@
 					"&& denotes a mnemonic"
 				]
 			}
-		],
-		"vs/editor/contrib/caretOperations/browser/caretOperations": [
-			"caret.moveLeft",
-			"caret.moveRight"
-		],
-		"vs/editor/contrib/caretOperations/browser/transpose": [
-			"transposeLetters.label"
 		],
 		"vs/editor/contrib/clipboard/browser/clipboard": [
 			{
@@ -6932,6 +6956,13 @@
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionContributions": [
 			"showCodeActionHeaders"
+		],
+		"vs/editor/browser/widget/diffEditorWidget": [
+			"diffInsertIcon",
+			"diffRemoveIcon",
+			"diff-aria-navigation-tip",
+			"diff.tooLarge",
+			"revertChangeHoverMessage"
 		],
 		"vs/editor/contrib/codelens/browser/codelensController": [
 			"showLensOnLine"
@@ -6991,10 +7022,6 @@
 			"cursor.undo",
 			"cursor.redo"
 		],
-		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution": [
-			"pasteAs",
-			"pasteAs.id"
-		],
 		"vs/editor/contrib/find/browser/findController": [
 			"startFindAction",
 			{
@@ -7031,6 +7058,9 @@
 			"EditorFontZoomOut.label",
 			"EditorFontZoomReset.label"
 		],
+		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution": [
+			"defaultProviderDescription"
+		],
 		"vs/editor/contrib/folding/browser/folding": [
 			"unfoldAction.label",
 			"unFoldRecursivelyAction.label",
@@ -7050,6 +7080,10 @@
 			"createManualFoldRange.label",
 			"removeManualFoldingRanges.label",
 			"foldLevelAction.label"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution": [
+			"pasteAs",
+			"pasteAs.id"
 		],
 		"vs/editor/contrib/format/browser/formatActions": [
 			"formatDocument.label",
@@ -7124,26 +7158,6 @@
 		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
 			"multipleResults"
 		],
-		"vs/editor/contrib/gotoError/browser/gotoError": [
-			"markerAction.next.label",
-			"nextMarkerIcon",
-			"markerAction.previous.label",
-			"previousMarkerIcon",
-			"markerAction.nextInFiles.label",
-			{
-				"key": "miGotoNextProblem",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"markerAction.previousInFiles.label",
-			{
-				"key": "miGotoPreviousProblem",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/editor/contrib/hover/browser/hover": [
 			{
 				"key": "showOrFocusHover",
@@ -7154,8 +7168,6 @@
 					"If the hover is already visible, it will take focus."
 				]
 			},
-			"chatAccessibleViewHint",
-			"chatAccessibleViewHintNoKb",
 			{
 				"key": "showDefinitionPreviewHover",
 				"comment": [
@@ -7212,6 +7224,26 @@
 				]
 			}
 		],
+		"vs/editor/contrib/gotoError/browser/gotoError": [
+			"markerAction.next.label",
+			"nextMarkerIcon",
+			"markerAction.previous.label",
+			"previousMarkerIcon",
+			"markerAction.nextInFiles.label",
+			{
+				"key": "miGotoNextProblem",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"markerAction.previousInFiles.label",
+			{
+				"key": "miGotoPreviousProblem",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/editor/contrib/indentation/browser/indentation": [
 			"indentationToSpaces",
 			"indentationToTabs",
@@ -7231,12 +7263,12 @@
 			"editor.reindentlines",
 			"editor.reindentselectedlines"
 		],
+		"vs/editor/contrib/lineSelection/browser/lineSelection": [
+			"expandLineSelection"
+		],
 		"vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace": [
 			"InPlaceReplaceAction.previous.label",
 			"InPlaceReplaceAction.next.label"
-		],
-		"vs/editor/contrib/lineSelection/browser/lineSelection": [
-			"expandLineSelection"
 		],
 		"vs/editor/contrib/linesOperations/browser/linesOperations": [
 			"lines.copyUp",
@@ -7294,10 +7326,6 @@
 			"editor.transformToCamelcase",
 			"editor.transformToKebabcase"
 		],
-		"vs/editor/contrib/linkedEditing/browser/linkedEditing": [
-			"linkedEditing.label",
-			"editorLinkedEditingBackground"
-		],
 		"vs/editor/contrib/links/browser/links": [
 			"invalid.url",
 			"missing.url",
@@ -7309,6 +7337,10 @@
 			"links.navigate.kb.alt",
 			"tooltip.explanation",
 			"label"
+		],
+		"vs/editor/contrib/linkedEditing/browser/linkedEditing": [
+			"linkedEditing.label",
+			"editorLinkedEditingBackground"
 		],
 		"vs/editor/contrib/multicursor/browser/multicursor": [
 			"cursorAdded",
@@ -7464,13 +7496,13 @@
 			},
 			"unusualLineTerminators.ignore"
 		],
+		"vs/editor/contrib/wordOperations/browser/wordOperations": [
+			"deleteInsideWord"
+		],
 		"vs/editor/contrib/wordHighlighter/browser/wordHighlighter": [
 			"wordHighlight.next.label",
 			"wordHighlight.previous.label",
 			"wordHighlight.trigger.label"
-		],
-		"vs/editor/contrib/wordOperations/browser/wordOperations": [
-			"deleteInsideWord"
 		],
 		"vs/editor/contrib/readOnlyMessage/browser/contribution": [
 			"editor.simple.readonly",
@@ -7491,6 +7523,8 @@
 			"screenReaderModeDisabled",
 			"tabFocusModeOnMsg",
 			"tabFocusModeOnMsgNoKb",
+			"stickScrollKb",
+			"stickScrollNoKb",
 			"tabFocusModeOffMsg",
 			"tabFocusModeOffMsgNoKb",
 			"showAccessibilityHelpAction",
@@ -7549,6 +7583,20 @@
 			"invalid.icons.default.fontPath.extension",
 			"invalid.icons.default.fontPath.path",
 			"invalid.icons.default"
+		],
+		"vs/workbench/api/browser/statusBarExtensionPoint": [
+			"id",
+			"name",
+			"text",
+			"tooltip",
+			"command",
+			"alignment",
+			"priority",
+			"accessibilityInformation",
+			"accessibilityInformation.role",
+			"accessibilityInformation.label",
+			"vscode.extension.contributes.statusBarItems",
+			"invalid"
 		],
 		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
 			"contributes.semanticTokenTypes",
@@ -7641,20 +7689,6 @@
 			"schema.onEnterRules.action.appendText",
 			"schema.onEnterRules.action.removeText"
 		],
-		"vs/workbench/api/browser/statusBarExtensionPoint": [
-			"id",
-			"name",
-			"text",
-			"tooltip",
-			"command",
-			"alignment",
-			"priority",
-			"accessibilityInformation",
-			"accessibilityInformation.role",
-			"accessibilityInformation.label",
-			"vscode.extension.contributes.statusBarItems",
-			"invalid"
-		],
 		"vs/workbench/api/browser/mainThreadCLICommands": [
 			"cannot be installed"
 		],
@@ -7723,6 +7757,9 @@
 			"msg-write",
 			"label"
 		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"manageExtension"
+		],
 		"vs/workbench/api/browser/mainThreadMessageService": [
 			"extensionSource",
 			"defaultSource",
@@ -7734,9 +7771,6 @@
 					"&& denotes a mnemonic"
 				]
 			}
-		],
-		"vs/workbench/api/browser/mainThreadProgress": [
-			"manageExtension"
 		],
 		"vs/workbench/api/browser/mainThreadSaveParticipant": [
 			"timeout.onWillSave"
@@ -7769,6 +7803,10 @@
 		"vs/workbench/api/browser/mainThreadTask": [
 			"task.label"
 		],
+		"vs/workbench/api/browser/mainThreadTunnelService": [
+			"remote.tunnel.openTunnel",
+			"remote.tunnelsView.elevationButton"
+		],
 		"vs/workbench/api/browser/mainThreadAuthentication": [
 			"noTrustedExtensions",
 			"manageTrustedExtensions.cancel",
@@ -7799,9 +7837,70 @@
 				]
 			}
 		],
-		"vs/workbench/api/browser/mainThreadTunnelService": [
-			"remote.tunnel.openTunnel",
-			"remote.tunnelsView.elevationButton"
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
+			"toggleAuxiliaryIconRight",
+			"toggleAuxiliaryIconRightOn",
+			"toggleAuxiliaryIconLeft",
+			"toggleAuxiliaryIconLeftOn",
+			"toggleAuxiliaryBar",
+			"secondary sidebar",
+			{
+				"key": "secondary sidebar mnemonic",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"focusAuxiliaryBar",
+			"toggleSecondarySideBar",
+			"toggleSecondarySideBar",
+			"hideAuxiliaryBar"
+		],
+		"vs/workbench/browser/parts/panel/panelActions": [
+			"maximizeIcon",
+			"restoreIcon",
+			"closeIcon",
+			"togglePanelOffIcon",
+			"togglePanelOnIcon",
+			"togglePanelVisibility",
+			"toggle panel",
+			{
+				"key": "toggle panel mnemonic",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"focusPanel",
+			"focusPanel",
+			"positionPanelLeft",
+			"positionPanelLeftShort",
+			"positionPanelRight",
+			"positionPanelRightShort",
+			"positionPanelBottom",
+			"positionPanelBottomShort",
+			"alignPanelLeft",
+			"alignPanelLeftShort",
+			"alignPanelRight",
+			"alignPanelRightShort",
+			"alignPanelCenter",
+			"alignPanelCenterShort",
+			"alignPanelJustify",
+			"alignPanelJustifyShort",
+			"positionPanel",
+			"alignPanel",
+			"previousPanelView",
+			"nextPanelView",
+			"toggleMaximizedPanel",
+			"maximizePanel",
+			"minimizePanel",
+			"panelMaxNotSupported",
+			"closePanel",
+			"closeSecondarySideBar",
+			"togglePanel",
+			"hidePanel",
+			"movePanelToSecondarySideBar",
+			"movePanelToSecondarySideBar",
+			"moveSidePanelToPanel",
+			"moveSidePanelToPanel"
 		],
 		"vs/workbench/browser/quickaccess": [
 			"inQuickOpen"
@@ -7890,15 +7989,17 @@
 					"{Locked=\"vscode.l10n API\"}"
 				]
 			},
+			"vscode.extension.pricing",
 			"product.extensionEnabledApiProposals"
 		],
-		"vs/workbench/browser/parts/views/viewPaneContainer": [
-			"views",
-			"viewMoveUp",
-			"viewMoveLeft",
-			"viewMoveDown",
-			"viewMoveRight",
-			"viewsMove"
+		"vs/workbench/browser/parts/views/treeView": [
+			"no-dataprovider",
+			"treeView.enableCollapseAll",
+			"treeView.enableRefresh",
+			"refresh",
+			"collapseAll",
+			"treeView.toggleCollapseAll",
+			"command-error"
 		],
 		"vs/workbench/contrib/debug/common/debug": [
 			"debugType",
@@ -7955,16 +8056,33 @@
 			"debuggerDisabled",
 			"internalConsoleOptions"
 		],
-		"vs/workbench/browser/parts/views/treeView": [
-			"no-dataprovider",
-			"treeView.enableCollapseAll",
-			"treeView.enableRefresh",
-			"refresh",
-			"collapseAll",
-			"treeView.toggleCollapseAll",
-			"command-error"
+		"vs/workbench/contrib/files/common/files": [
+			"explorerViewletVisible",
+			"foldersViewVisible",
+			"explorerResourceIsFolder",
+			"explorerResourceReadonly",
+			"explorerResourceIsRoot",
+			"explorerResourceCut",
+			"explorerResourceMoveableToTrash",
+			"filesExplorerFocus",
+			"openEditorsFocus",
+			"explorerViewletFocus",
+			"explorerViewletCompressedFocus",
+			"explorerViewletCompressedFirstFocus",
+			"explorerViewletCompressedLastFocus",
+			"viewHasSomeCollapsibleItem"
+		],
+		"vs/workbench/browser/parts/views/viewPaneContainer": [
+			"views",
+			"viewMoveUp",
+			"viewMoveLeft",
+			"viewMoveDown",
+			"viewMoveRight",
+			"viewsMove"
 		],
 		"vs/workbench/contrib/remote/browser/remoteExplorer": [
+			"remoteNoPorts",
+			"noRemoteNoPorts",
 			"ports",
 			"1forwardedPort",
 			"nForwardedPorts",
@@ -7982,71 +8100,14 @@
 			"remote.tunnelsView.makePublic",
 			"remote.tunnelsView.elevationButton"
 		],
-		"vs/workbench/browser/parts/panel/panelActions": [
-			"maximizeIcon",
-			"restoreIcon",
-			"closeIcon",
-			"togglePanelOffIcon",
-			"togglePanelOnIcon",
-			"togglePanelVisibility",
-			"toggle panel",
-			{
-				"key": "toggle panel mnemonic",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"focusPanel",
-			"focusPanel",
-			"positionPanelLeft",
-			"positionPanelLeftShort",
-			"positionPanelRight",
-			"positionPanelRightShort",
-			"positionPanelBottom",
-			"positionPanelBottomShort",
-			"alignPanelLeft",
-			"alignPanelLeftShort",
-			"alignPanelRight",
-			"alignPanelRightShort",
-			"alignPanelCenter",
-			"alignPanelCenterShort",
-			"alignPanelJustify",
-			"alignPanelJustifyShort",
-			"positionPanel",
-			"alignPanel",
-			"previousPanelView",
-			"nextPanelView",
-			"toggleMaximizedPanel",
-			"maximizePanel",
-			"minimizePanel",
-			"panelMaxNotSupported",
-			"closePanel",
-			"closeSecondarySideBar",
-			"togglePanel",
-			"hidePanel",
-			"movePanelToSecondarySideBar",
-			"movePanelToSecondarySideBar",
-			"moveSidePanelToPanel",
-			"moveSidePanelToPanel"
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"dropIntoEditorPrompt"
 		],
-		"vs/workbench/contrib/files/common/files": [
-			"explorerViewletVisible",
-			"foldersViewVisible",
-			"explorerResourceIsFolder",
-			"explorerResourceReadonly",
-			"explorerResourceIsRoot",
-			"explorerResourceCut",
-			"explorerResourceMoveableToTrash",
-			"filesExplorerFocus",
-			"openEditorsFocus",
-			"explorerViewletFocus",
-			"explorerViewletCompressedFocus",
-			"explorerViewletCompressedFirstFocus",
-			"explorerViewletCompressedLastFocus",
-			"viewHasSomeCollapsibleItem"
-		],
-		"vs/workbench/common/editor/sideBySideEditorInput": [
-			"sideBySideLabels"
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"ariaLabelGroupActions",
+			"emptyEditorGroup",
+			"groupLabel",
+			"groupAriaLabel"
 		],
 		"vs/workbench/browser/parts/editor/sideBySideEditor": [
 			"sideBySideEditor"
@@ -8054,31 +8115,13 @@
 		"vs/workbench/common/editor/diffEditorInput": [
 			"sideBySideLabels"
 		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
-			"toggleAuxiliaryIconRight",
-			"toggleAuxiliaryIconRightOn",
-			"toggleAuxiliaryIconLeft",
-			"toggleAuxiliaryIconLeftOn",
-			"toggleAuxiliaryBar",
-			"secondary sidebar",
-			{
-				"key": "secondary sidebar mnemonic",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"focusAuxiliaryBar",
-			"toggleSecondarySideBar",
-			"toggleSecondarySideBar",
-			"hideAuxiliaryBar"
+		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
+			"metadataDiff"
 		],
 		"vs/workbench/browser/parts/editor/textDiffEditor": [
 			"textDiffEditor",
 			"fileTooLargeForHeapErrorWithSize",
 			"fileTooLargeForHeapErrorWithoutSize"
-		],
-		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
-			"metadataDiff"
 		],
 		"vs/workbench/browser/parts/editor/editorStatus": [
 			"singleSelectionRange",
@@ -8285,26 +8328,6 @@
 			"toggleEditorType",
 			"reopenTextEditor"
 		],
-		"vs/workbench/browser/parts/editor/editorCommands": [
-			"editorCommand.activeEditorMove.description",
-			"editorCommand.activeEditorMove.arg.name",
-			"editorCommand.activeEditorMove.arg.description",
-			"editorCommand.activeEditorCopy.description",
-			"editorCommand.activeEditorCopy.arg.name",
-			"editorCommand.activeEditorCopy.arg.description",
-			"toggleInlineView",
-			"compare",
-			"splitEditorInGroup",
-			"joinEditorInGroup",
-			"toggleJoinEditorInGroup",
-			"toggleSplitEditorInGroupLayout",
-			"focusLeftSideEditor",
-			"focusRightSideEditor",
-			"focusOtherSideEditor",
-			"toggleEditorGroupLock",
-			"lockEditorGroup",
-			"unlockEditorGroup"
-		],
 		"vs/editor/browser/editorExtensions": [
 			{
 				"key": "miUndo",
@@ -8328,12 +8351,34 @@
 			},
 			"selectAll"
 		],
-		"vs/workbench/browser/parts/editor/editorQuickAccess": [
-			"noViewResults",
-			"entryAriaLabelWithGroupDirty",
-			"entryAriaLabelWithGroup",
-			"entryAriaLabelDirty",
-			"closeEditor"
+		"vs/workbench/browser/parts/editor/editorCommands": [
+			"editorCommand.activeEditorMove.description",
+			"editorCommand.activeEditorMove.arg.name",
+			"editorCommand.activeEditorMove.arg.description",
+			"editorCommand.activeEditorCopy.description",
+			"editorCommand.activeEditorCopy.arg.name",
+			"editorCommand.activeEditorCopy.arg.description",
+			"compare.nextChange",
+			"compare.previousChange",
+			"toggleInlineView",
+			"compare",
+			"splitEditorInGroup",
+			"joinEditorInGroup",
+			"toggleJoinEditorInGroup",
+			"toggleSplitEditorInGroupLayout",
+			"focusLeftSideEditor",
+			"focusRightSideEditor",
+			"focusOtherSideEditor",
+			"toggleEditorGroupLock",
+			"lockEditorGroup",
+			"unlockEditorGroup"
+		],
+		"vs/workbench/browser/parts/editor/accessibilityStatus": [
+			"screenReaderDetectedExplanation.question",
+			"screenReaderDetectedExplanation.answerYes",
+			"screenReaderDetectedExplanation.answerNo",
+			"screenReaderDetected",
+			"status.editor.screenReaderMode"
 		],
 		"vs/workbench/browser/parts/editor/editorConfiguration": [
 			"interactiveWindow",
@@ -8343,12 +8388,25 @@
 			"editor.editorAssociations",
 			"editorLargeFileSizeConfirmation"
 		],
-		"vs/workbench/browser/parts/editor/accessibilityStatus": [
-			"screenReaderDetectedExplanation.question",
-			"screenReaderDetectedExplanation.answerYes",
-			"screenReaderDetectedExplanation.answerNo",
-			"screenReaderDetected",
-			"status.editor.screenReaderMode"
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
+			"toggleCollapseUnchangedRegions",
+			"toggleShowMovedCodeBlocks",
+			"toggleUseInlineViewWhenSpaceIsLimited",
+			"useInlineViewWhenSpaceIsLimited",
+			"showMoves",
+			"diffEditor",
+			"switchSide",
+			"exitCompareMove",
+			"collapseAllUnchangedRegions",
+			"showAllUnchangedRegions"
+		],
+		"vs/workbench/common/editor/sideBySideEditorInput": [
+			"sideBySideLabels"
+		],
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
+			"move second side bar left",
+			"move second side bar right",
+			"hide second side bar"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
 			"settingsViewBarIcon",
@@ -8364,19 +8422,6 @@
 			"accounts",
 			"accounts"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
-			"toggleCollapseUnchangedRegions",
-			"collapseUnchangedRegions",
-			"showUnchangedRegions",
-			"toggleShowMovedCodeBlocks",
-			"diffEditor",
-			"switchSide"
-		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
-			"move second side bar left",
-			"move second side bar right",
-			"hide second side bar"
-		],
 		"vs/workbench/browser/parts/panel/panelPart": [
 			"resetLocation",
 			"resetLocation",
@@ -8386,18 +8431,12 @@
 			"align panel",
 			"hidePanel"
 		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"ariaLabelGroupActions",
-			"emptyEditorGroup",
-			"groupLabel",
-			"groupAriaLabel"
-		],
-		"vs/workbench/browser/parts/editor/editorDropTarget": [
-			"dropIntoEditorPrompt"
-		],
-		"vs/workbench/browser/parts/statusbar/statusbarActions": [
-			"hide",
-			"focusStatusBar"
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"noViewResults",
+			"entryAriaLabelWithGroupDirty",
+			"entryAriaLabelWithGroup",
+			"entryAriaLabelDirty",
+			"closeEditor"
 		],
 		"vs/platform/actions/common/menuResetAction": [
 			"title"
@@ -8422,6 +8461,10 @@
 		"vs/workbench/services/preferences/common/preferencesModels": [
 			"commonlyUsed",
 			"defaultKeybindingsHeader"
+		],
+		"vs/workbench/browser/parts/statusbar/statusbarActions": [
+			"hide",
+			"focusStatusBar"
 		],
 		"vs/workbench/services/textfile/common/textFileEditorModel": [
 			"textFileCreate.source"
@@ -8582,6 +8625,10 @@
 			"error.cannotparse",
 			"error.cannotload"
 		],
+		"vs/workbench/services/themes/browser/fileIconThemeData": [
+			"error.cannotparseicontheme",
+			"error.invalidformat"
+		],
 		"vs/workbench/services/themes/common/fileIconThemeSchema": [
 			"schema.folderExpanded",
 			"schema.folder",
@@ -8617,25 +8664,6 @@
 			"schema.hidesExplorerArrows",
 			"schema.showLanguageModeIcons"
 		],
-		"vs/workbench/services/themes/browser/fileIconThemeData": [
-			"error.cannotparseicontheme",
-			"error.invalidformat"
-		],
-		"vs/workbench/services/themes/common/colorThemeSchema": [
-			"schema.token.settings",
-			"schema.token.foreground",
-			"schema.token.background.warning",
-			"schema.token.fontStyle",
-			"schema.fontStyle.error",
-			"schema.token.fontStyle.none",
-			"schema.properties.name",
-			"schema.properties.scope",
-			"schema.workbenchColors",
-			"schema.tokenColors.path",
-			"schema.colors",
-			"schema.supportsSemanticHighlighting",
-			"schema.semanticTokenColors"
-		],
 		"vs/workbench/services/themes/common/themeExtensionPoints": [
 			"vscode.extension.contributes.themes",
 			"vscode.extension.contributes.themes.id",
@@ -8654,6 +8682,35 @@
 			"reqpath",
 			"reqid",
 			"invalid.path.1"
+		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"schema.token.settings",
+			"schema.token.foreground",
+			"schema.token.background.warning",
+			"schema.token.fontStyle",
+			"schema.fontStyle.error",
+			"schema.token.fontStyle.none",
+			"schema.properties.name",
+			"schema.properties.scope",
+			"schema.workbenchColors",
+			"schema.tokenColors.path",
+			"schema.colors",
+			"schema.supportsSemanticHighlighting",
+			"schema.semanticTokenColors"
+		],
+		"vs/workbench/services/themes/browser/productIconThemeData": [
+			"error.parseicondefs",
+			"defaultTheme",
+			"error.cannotparseicontheme",
+			"error.invalidformat",
+			"error.missingProperties",
+			"error.fontWeight",
+			"error.fontStyle",
+			"error.fontSrc",
+			"error.noFontSrc",
+			"error.fontId",
+			"error.icon.font",
+			"error.icon.fontCharacter"
 		],
 		"vs/workbench/services/themes/common/themeConfiguration": [
 			"colorTheme",
@@ -8727,20 +8784,6 @@
 			"editorColors.semanticHighlighting.enabled",
 			"editorColors.semanticHighlighting.rules",
 			"semanticTokenColors"
-		],
-		"vs/workbench/services/themes/browser/productIconThemeData": [
-			"error.parseicondefs",
-			"defaultTheme",
-			"error.cannotparseicontheme",
-			"error.invalidformat",
-			"error.missingProperties",
-			"error.fontWeight",
-			"error.fontStyle",
-			"error.fontSrc",
-			"error.noFontSrc",
-			"error.fontId",
-			"error.icon.font",
-			"error.icon.fontCharacter"
 		],
 		"vs/workbench/services/themes/common/productIconThemeSchema": [
 			"schema.id",
@@ -8817,17 +8860,24 @@
 			"snippets",
 			"exclude"
 		],
-		"vs/workbench/services/userDataProfile/browser/tasksResource": [
-			"tasks"
-		],
 		"vs/workbench/services/userDataProfile/browser/extensionsResource": [
 			"extensions",
 			"disabled",
 			"exclude",
 			"exclude"
 		],
+		"vs/workbench/services/userDataProfile/browser/tasksResource": [
+			"tasks"
+		],
 		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
 			"globalState"
+		],
+		"vs/workbench/services/remote/common/tunnelModel": [
+			"tunnel.forwardedPortsViewEnabled",
+			"tunnel.source.user",
+			"tunnel.source.auto",
+			"remote.localPortMismatch.single",
+			"tunnel.staticallyForwarded"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopySaveParticipant": [
 			"saveParticipants"
@@ -8851,6 +8901,12 @@
 			"invalid.tokenTypes",
 			"invalid.path.1"
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"defineKeybinding.initial",
+			"defineKeybinding.oneExists",
+			"defineKeybinding.existing",
+			"defineKeybinding.chordsTo"
+		],
 		"vs/editor/contrib/suggest/browser/suggest": [
 			"suggestWidgetHasSelection",
 			"suggestWidgetDetailsVisible",
@@ -8860,6 +8916,25 @@
 			"suggestionHasInsertAndReplaceRange",
 			"suggestionInsertMode",
 			"suggestionCanResolve"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"configureLanguageBasedSettings",
+			"languageDescriptionConfigured",
+			"pickLanguage"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
+			"settingsScopeDropDownIcon",
+			"settingsMoreActionIcon",
+			"keybindingsRecordKeysIcon",
+			"keybindingsSortIcon",
+			"keybindingsEditIcon",
+			"keybindingsAddIcon",
+			"settingsEditIcon",
+			"settingsRemoveIcon",
+			"preferencesDiscardIcon",
+			"preferencesClearInput",
+			"settingsFilter",
+			"preferencesOpenSettings"
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"recordKeysLabel",
@@ -8896,32 +8971,6 @@
 			"noWhen",
 			"keyboard shortcuts aria label"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"configureLanguageBasedSettings",
-			"languageDescriptionConfigured",
-			"pickLanguage"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
-			"settingsScopeDropDownIcon",
-			"settingsMoreActionIcon",
-			"keybindingsRecordKeysIcon",
-			"keybindingsSortIcon",
-			"keybindingsEditIcon",
-			"keybindingsAddIcon",
-			"settingsEditIcon",
-			"settingsRemoveIcon",
-			"preferencesDiscardIcon",
-			"preferencesClearInput",
-			"settingsFilter",
-			"preferencesOpenSettings"
-		],
-		"vs/workbench/contrib/preferences/common/preferencesContribution": [
-			"splitSettingsEditorLabel",
-			"enableNaturalLanguageSettingsSearch",
-			"settingsSearchTocBehavior.hide",
-			"settingsSearchTocBehavior.filter",
-			"settingsSearchTocBehavior"
-		],
 		"vs/workbench/contrib/preferences/browser/settingsEditor2": [
 			"SearchSettings.AriaLabel",
 			"clearInput",
@@ -8935,6 +8984,16 @@
 			"moreThanOneResult",
 			"turnOnSyncButton",
 			"lastSyncedLabel"
+		],
+		"vs/workbench/contrib/preferences/common/preferencesContribution": [
+			"splitSettingsEditorLabel",
+			"enableNaturalLanguageSettingsSearch",
+			"settingsSearchTocBehavior.hide",
+			"settingsSearchTocBehavior.filter",
+			"settingsSearchTocBehavior"
+		],
+		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+			"name"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookEditor": [
 			"fail.noEditor",
@@ -8956,13 +9015,13 @@
 		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
 			"notebookRunTrust"
 		],
-		"vs/editor/common/languages/modesRegistry": [
-			"plainText.alias"
-		],
 		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
 			"disableOtherKeymapsConfirmation",
 			"yes",
 			"no"
+		],
+		"vs/editor/common/languages/modesRegistry": [
+			"plainText.alias"
 		],
 		"vs/workbench/contrib/comments/browser/commentReply": [
 			"reply",
@@ -8976,21 +9035,6 @@
 		"vs/workbench/contrib/notebook/browser/services/notebookLoggingServiceImpl": [
 			"renderChannelName"
 		],
-		"vs/workbench/contrib/accessibility/browser/accessibilityContribution": [
-			"accessibilityConfigurationTitle",
-			"verbosity.terminal.description",
-			"verbosity.diffEditor.description",
-			"verbosity.chat.description",
-			"verbosity.interactiveEditor.description",
-			"verbosity.keybindingsEditor.description",
-			"verbosity.notebook",
-			"verbosity.hover",
-			"verbosity.notification",
-			"editor.action.accessibilityHelp",
-			"editor.action.accessibleView",
-			"editor.action.accessibleViewNext",
-			"editor.action.accessibleViewPrevious"
-		],
 		"vs/workbench/contrib/notebook/browser/notebookAccessibility": [
 			"notebook.overview",
 			"notebook.cell.edit",
@@ -9003,20 +9047,42 @@
 			"notebook.cell.executeAndFocusContainer",
 			"notebook.cell.executeAndFocusContainerNoKb",
 			"notebook.cell.insertCodeCellBelowAndFocusContainer",
-			"notebook.changeCellType",
-			"NotebookCellOutputAccessibleView"
+			"notebook.changeCellType"
 		],
 		"vs/workbench/contrib/accessibility/browser/accessibleView": [
-			"openDoc",
-			"disable-help-hint",
-			"exit-tip",
-			"accessibleViewAriaLabelWithNav",
-			"accessibleViewAriaLabel",
+			"symbolLabel",
+			"symbolLabelAria",
 			"disableAccessibilityHelp",
-			"chatAccessibleViewNextPreviousHint",
+			"openDoc",
+			"exit-tip",
+			"ariaAccessibleViewActions",
+			"accessibility-help",
+			"accessible-view",
+			"accessible-view-hint",
+			"accessibility-help-hint",
+			"accessibleHelpToolbar",
+			"accessibleViewToolbar",
+			"toolbar",
+			"intro",
+			"accessibleViewNextPreviousHint",
 			"chatAccessibleViewNextPreviousHintNoKb",
-			"chatAccessibleViewHint",
-			"chatAccessibleViewHintNoKb"
+			"acessibleViewDisableHint",
+			"accessibleViewDisableHintNoKb",
+			"goToSymbolHint",
+			"goToSymbolHintNoKb",
+			"acessibleViewHint",
+			"acessibleViewHintNoKbEither",
+			"accessibleViewSymbolQuickPickPlaceholder",
+			"accessibleViewSymbolQuickPickTitle"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibleViewActions": [
+			"editor.action.accessibleViewNext",
+			"editor.action.accessibleViewPrevious",
+			"editor.action.accessibleViewGoToSymbol",
+			"editor.action.accessibilityHelp",
+			"editor.action.accessibleView",
+			"editor.action.accessibleViewDisableHint",
+			"editor.action.accessibleViewAcceptInlineCompletionAction"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
 			"notebookActions.category",
@@ -9073,6 +9139,48 @@
 			"revealLastFailedCell",
 			"revealLastFailedCellShort"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
+			"workbench.notebook.layout.select.label",
+			"workbench.notebook.layout.configure.label",
+			"workbench.notebook.layout.configure.label",
+			"customizeNotebook",
+			"notebook.toggleLineNumbers",
+			"notebook.showLineNumbers",
+			"notebook.toggleCellToolbarPosition",
+			"notebook.toggleBreadcrumb",
+			"notebook.saveMimeTypeOrder",
+			"notebook.placeholder",
+			"saveTarget.machine",
+			"saveTarget.workspace",
+			"workbench.notebook.layout.webview.reset.label"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/editActions": [
+			"notebookActions.editCell",
+			"notebookActions.quitEdit",
+			"notebookActions.deleteCell",
+			"confirmDeleteButton",
+			"confirmDeleteButtonMessage",
+			"doNotAskAgain",
+			"clearCellOutputs",
+			"clearAllCellsOutputs",
+			"changeLanguage",
+			"changeLanguage",
+			"languageDescription",
+			"languageDescriptionConfigured",
+			"autoDetect",
+			"languagesPicks",
+			"pickLanguageToConfigure",
+			"detectLanguage",
+			"noDetection"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/cellOutputActions": [
+			"notebookActions.copyOutput"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
+			"fold.cell",
+			"unfold.cell",
+			"fold.cell"
+		],
 		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
 			"notebookActions.copy",
 			"notebookActions.cut",
@@ -9090,23 +9198,8 @@
 			"formatCell.label",
 			"formatCells.label"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
-			"workbench.notebook.layout.select.label",
-			"workbench.notebook.layout.configure.label",
-			"workbench.notebook.layout.configure.label",
-			"customizeNotebook",
-			"notebook.toggleLineNumbers",
-			"notebook.showLineNumbers",
-			"notebook.toggleCellToolbarPosition",
-			"notebook.toggleBreadcrumb",
-			"notebook.saveMimeTypeOrder",
-			"notebook.placeholder",
-			"saveTarget.machine",
-			"saveTarget.workspace",
-			"workbench.notebook.layout.webview.reset.label"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
-			"workbench.notebook.layout.gettingStarted.label"
+		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
+			"notebook.toggleCellToolbarPosition"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
 			"notebookFormatSave.formatting",
@@ -9121,19 +9214,34 @@
 			},
 			"codeAction.apply"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
-			"notebook.toggleCellToolbarPosition"
+		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
+			"workbench.notebook.layout.gettingStarted.label"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
 			"outline.showCodeCells",
 			"breadcrumbs.showCodeCells"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
-			"setProfileTitle"
+		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
+			"cursorMoveDown",
+			"cursorMoveUp",
+			"focusFirstCell",
+			"focusLastCell",
+			"focusOutput",
+			"focusOutputOut",
+			"notebookActions.centerActiveCell",
+			"cursorPageUp",
+			"cursorPageUpSelect",
+			"cursorPageDown",
+			"cursorPageDownSelect",
+			"notebook.navigation.allowNavigateToSurroundingCells"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders": [
+			"notebook.cell.status.searchLanguageExtensions",
 			"notebook.cell.status.language",
 			"notebook.cell.status.autoDetectLanguage"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
+			"setProfileTitle"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController": [
 			"notebook.cell.status.success",
@@ -9142,11 +9250,6 @@
 			"notebook.cell.status.executing",
 			"notebook.cell.statusBar.timerTooltip.reportIssueFootnote",
 			"notebook.cell.statusBar.timerTooltip"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
-			"fold.cell",
-			"unfold.cell",
-			"fold.cell"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar": [
 			"notebook.info",
@@ -9180,20 +9283,6 @@
 			"notebookActions.collapseAllCellOutput",
 			"notebookActions.expandAllCellOutput",
 			"notebookActions.toggleScrolling"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
-			"cursorMoveDown",
-			"cursorMoveUp",
-			"focusFirstCell",
-			"focusLastCell",
-			"focusOutput",
-			"focusOutputOut",
-			"notebookActions.centerActiveCell",
-			"cursorPageUp",
-			"cursorPageUpSelect",
-			"cursorPageDown",
-			"cursorPageDownSelect",
-			"notebook.navigation.allowNavigateToSurroundingCells"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
 			"workbench.notebook.toggleLayoutTroubleshoot",
@@ -9229,25 +9318,6 @@
 			"interactiveSession.history.delete",
 			"interactiveSession.history.pick"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/editActions": [
-			"notebookActions.editCell",
-			"notebookActions.quitEdit",
-			"notebookActions.deleteCell",
-			"confirmDeleteButton",
-			"confirmDeleteButtonMessage",
-			"doNotAskAgain",
-			"clearCellOutputs",
-			"clearAllCellsOutputs",
-			"changeLanguage",
-			"changeLanguage",
-			"languageDescription",
-			"languageDescriptionConfigured",
-			"autoDetect",
-			"languagesPicks",
-			"pickLanguageToConfigure",
-			"detectLanguage",
-			"noDetection"
-		],
 		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
 			"interactive.copyCodeBlock.label",
 			"interactive.insertCodeBlock.label",
@@ -9263,6 +9333,12 @@
 		"vs/workbench/contrib/chat/browser/actions/chatExecuteActions": [
 			"interactive.submit.label",
 			"interactive.cancel.label"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
+			"chat.openInChatView.label",
+			"chat.closeQuickChat.label",
+			"quickChat",
+			"interactiveSession.open"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
 			"interactive.helpful.label",
@@ -9286,9 +9362,6 @@
 		"vs/workbench/contrib/chat/browser/chatEditorInput": [
 			"chatEditorName"
 		],
-		"vs/workbench/contrib/chat/browser/chatWidget": [
-			"clear"
-		],
 		"vs/workbench/contrib/chat/common/chatServiceImpl": [
 			"emptyResponse"
 		],
@@ -9302,12 +9375,10 @@
 			"interactiveSession.clear.label",
 			"interactiveSession.clear.label"
 		],
-		"vs/workbench/contrib/chat/common/chatViewModel": [
-			"thinking"
-		],
 		"vs/workbench/contrib/chat/common/chatContextKeys": [
 			"interactiveSessionResponseHasProviderId",
 			"interactiveSessionResponseVote",
+			"chatResponseFiltered",
 			"interactiveSessionRequestInProgress",
 			"chatResponse",
 			"chatRequest",
@@ -9316,28 +9387,52 @@
 			"inChat",
 			"hasChatProvider"
 		],
-		"vs/workbench/contrib/chat/common/chatColors": [
-			"chat.requestBackground",
-			"chat.requestBorder"
+		"vs/workbench/contrib/chat/common/chatViewModel": [
+			"thinking"
+		],
+		"vs/workbench/contrib/chat/common/chatSlashCommands": [
+			"command",
+			"details",
+			"vscode.extension.contributes.slashes",
+			"invalid"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibilityContributions": [
+			"notification.accessibleViewSrc",
+			"notification.accessibleView",
+			"clearNotification",
+			"clearNotification"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions": [
+			"interactive.nextFileTree.label",
+			"interactive.previousFileTree.label"
 		],
 		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
 			"interactive.input.placeholderWithCommands",
 			"interactive.input.placeholderNoCommands"
 		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
-			"welcome.1",
-			"welcome.2",
-			"create.fail",
-			"create.fail.detail",
-			"welcome.1",
-			"default.placeholder",
-			"default.placeholder.history",
-			"thinking",
-			"empty",
-			"markdownResponseMessage",
-			"editResponseMessage",
-			"err.apply",
-			"err.discard"
+		"vs/workbench/contrib/chat/common/chatColors": [
+			"chat.requestBorder",
+			"chat.slashCommandBackground",
+			"chat.slashCommandForeground"
+		],
+		"vs/editor/contrib/peekView/browser/peekView": [
+			"inReferenceSearchEditor",
+			"label.close",
+			"peekViewTitleBackground",
+			"peekViewTitleForeground",
+			"peekViewTitleInfoForeground",
+			"peekViewBorder",
+			"peekViewResultsBackground",
+			"peekViewResultsMatchForeground",
+			"peekViewResultsFileForeground",
+			"peekViewResultsSelectionBackground",
+			"peekViewResultsSelectionForeground",
+			"peekViewEditorBackground",
+			"peekViewEditorGutterBackground",
+			"peekViewEditorStickScrollBackground",
+			"peekViewResultsMatchHighlight",
+			"peekViewEditorMatchHighlight",
+			"peekViewEditorMatchHighlightBorder"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
 			"run",
@@ -9381,6 +9476,37 @@
 			"expandMessage",
 			"contractMessage"
 		],
+		"vs/workbench/contrib/notebook/browser/notebookIcons": [
+			"selectKernelIcon",
+			"executeIcon",
+			"executeAboveIcon",
+			"executeBelowIcon",
+			"stopIcon",
+			"deleteCellIcon",
+			"executeAllIcon",
+			"editIcon",
+			"stopEditIcon",
+			"moveUpIcon",
+			"moveDownIcon",
+			"clearIcon",
+			"splitCellIcon",
+			"successStateIcon",
+			"errorStateIcon",
+			"pendingStateIcon",
+			"executingStateIcon",
+			"collapsedIcon",
+			"expandedIcon",
+			"openAsTextIcon",
+			"revertIcon",
+			"renderOutputIcon",
+			"mimetypeIcon",
+			"copyIcon",
+			"previousChangeIcon",
+			"nextChangeIcon"
+		],
+		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
+			"interactiveInputPlaceHolder"
+		],
 		"vs/workbench/contrib/inlineChat/common/inlineChat": [
 			"inlineChatHasProvider",
 			"inlineChatVisible",
@@ -9417,55 +9543,6 @@
 			"mode.live",
 			"showDiff"
 		],
-		"vs/editor/contrib/peekView/browser/peekView": [
-			"inReferenceSearchEditor",
-			"label.close",
-			"peekViewTitleBackground",
-			"peekViewTitleForeground",
-			"peekViewTitleInfoForeground",
-			"peekViewBorder",
-			"peekViewResultsBackground",
-			"peekViewResultsMatchForeground",
-			"peekViewResultsFileForeground",
-			"peekViewResultsSelectionBackground",
-			"peekViewResultsSelectionForeground",
-			"peekViewEditorBackground",
-			"peekViewEditorGutterBackground",
-			"peekViewEditorStickScrollBackground",
-			"peekViewResultsMatchHighlight",
-			"peekViewEditorMatchHighlight",
-			"peekViewEditorMatchHighlightBorder"
-		],
-		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
-			"interactiveInputPlaceHolder"
-		],
-		"vs/workbench/contrib/notebook/browser/notebookIcons": [
-			"selectKernelIcon",
-			"executeIcon",
-			"executeAboveIcon",
-			"executeBelowIcon",
-			"stopIcon",
-			"deleteCellIcon",
-			"executeAllIcon",
-			"editIcon",
-			"stopEditIcon",
-			"moveUpIcon",
-			"moveDownIcon",
-			"clearIcon",
-			"splitCellIcon",
-			"successStateIcon",
-			"errorStateIcon",
-			"pendingStateIcon",
-			"executingStateIcon",
-			"collapsedIcon",
-			"expandedIcon",
-			"openAsTextIcon",
-			"revertIcon",
-			"renderOutputIcon",
-			"mimetypeIcon",
-			"previousChangeIcon",
-			"nextChangeIcon"
-		],
 		"vs/workbench/contrib/files/browser/fileConstants": [
 			"saveAs",
 			"save",
@@ -9474,10 +9551,32 @@
 			"removeFolderFromWorkspace",
 			"newUntitledFile"
 		],
+		"vs/workbench/contrib/logs/common/logsActions": [
+			"setLogLevel",
+			"all",
+			"extensionLogs",
+			"loggers",
+			"selectlog",
+			"selectLogLevelFor",
+			"selectLogLevel",
+			"resetLogLevel",
+			"trace",
+			"debug",
+			"info",
+			"warn",
+			"err",
+			"off",
+			"default",
+			"openSessionLogFile",
+			"current",
+			"sessions placeholder",
+			"log placeholder"
+		],
 		"vs/workbench/contrib/testing/browser/icons": [
 			"testViewIcon",
 			"testingResultsIcon",
 			"testingRunIcon",
+			"testingRerunIcon",
 			"testingRunAllIcon",
 			"testingDebugAllIcon",
 			"testingDebugIcon",
@@ -9499,6 +9598,24 @@
 			"testingSkippedIcon",
 			"testingUnsetIcon"
 		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
+			"welcome.1",
+			"welcome.2",
+			"create.fail",
+			"create.fail.detail",
+			"welcome.1",
+			"default.placeholder",
+			"default.placeholder.history",
+			"thinking",
+			"empty",
+			"markdownResponseMessage",
+			"editResponseMessage",
+			"err.apply",
+			"err.discard"
+		],
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"testing"
+		],
 		"vs/workbench/contrib/testing/browser/testingDecorations": [
 			"peekTestOutout",
 			"expected.title",
@@ -9514,10 +9631,19 @@
 			"run all test",
 			"debug all test"
 		],
+		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
+			"testProgress.runningInitial",
+			"testProgress.running",
+			"testProgressWithSkip.running",
+			"testProgress.completed",
+			"testProgressWithSkip.completed"
+		],
 		"vs/workbench/contrib/testing/browser/testingExplorerView": [
 			"defaultTestProfile",
 			"selectDefaultConfigs",
 			"configureTestProfiles",
+			"noResults",
+			"testingContinuousBadge",
 			"testingCountBadgePassed",
 			"testingCountBadgeSkipped",
 			"testingCountBadgeFailed",
@@ -9537,20 +9663,13 @@
 			},
 			"testExplorer"
 		],
-		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
-			"testProgress.runningInitial",
-			"testProgress.running",
-			"testProgressWithSkip.running",
-			"testProgress.completed",
-			"testProgressWithSkip.completed"
-		],
 		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
 			"testing.markdownPeekError",
 			"testOutputTitle",
 			"testingOutputExpected",
 			"testingOutputActual",
-			"runNoOutout",
 			"runNoOutputForPast",
+			"runNoOutput",
 			"close",
 			"testUnnamedTask",
 			"messageMoreLinesN",
@@ -9561,6 +9680,7 @@
 			"testing.reRunLastRun",
 			"testing.debugLastRun",
 			"testing.goToFile",
+			"testing.showResultOutput",
 			"testing.revealInExplorer",
 			"run test",
 			"debug test",
@@ -9597,9 +9717,6 @@
 			"testing.openTesting",
 			"testing.alwaysRevealTestOnStateChange"
 		],
-		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
-			"testing"
-		],
 		"vs/workbench/contrib/testing/common/testServiceImpl": [
 			"testTrust",
 			"testError",
@@ -9625,11 +9742,9 @@
 			"testing.controllerId",
 			"testing.testId",
 			"testing.testItemHasUri",
-			"testing.testItemIsHidden"
-		],
-		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
-			"testConfigurationUi.pick",
-			"updateTestConfiguration"
+			"testing.testItemIsHidden",
+			"testing.testMessage",
+			"testing.testResultOutdated"
 		],
 		"vs/workbench/contrib/testing/browser/testExplorerActions": [
 			"hideTest",
@@ -9683,32 +9798,9 @@
 			"testing.refreshTests",
 			"testing.cancelTestRefresh"
 		],
-		"vs/workbench/contrib/logs/common/logsActions": [
-			"setLogLevel",
-			"all",
-			"extensionLogs",
-			"loggers",
-			"selectlog",
-			"selectLogLevelFor",
-			"selectLogLevel",
-			"resetLogLevel",
-			"trace",
-			"debug",
-			"info",
-			"warn",
-			"err",
-			"off",
-			"default",
-			"openSessionLogFile",
-			"current",
-			"sessions placeholder",
-			"log placeholder"
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
-			"defineKeybinding.initial",
-			"defineKeybinding.oneExists",
-			"defineKeybinding.existing",
-			"defineKeybinding.chordsTo"
+		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
+			"testConfigurationUi.pick",
+			"updateTestConfiguration"
 		],
 		"vs/workbench/contrib/files/browser/views/explorerView": [
 			"explorerSection",
@@ -9716,6 +9808,9 @@
 			"createNewFolder",
 			"refreshExplorer",
 			"collapseExplorerFolders"
+		],
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"noWorkspace"
 		],
 		"vs/workbench/contrib/files/browser/views/openEditorsView": [
 			{
@@ -9736,9 +9831,6 @@
 			},
 			"newUntitledFile"
 		],
-		"vs/workbench/contrib/files/browser/views/emptyView": [
-			"noWorkspace"
-		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"noViewResults",
 			"views",
@@ -9757,7 +9849,7 @@
 		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
 			"noCommandResults",
 			"configure keybinding",
-			"semanticSimilarity",
+			"similarCommands",
 			"askXInChat",
 			"commandWithCategory",
 			"showTriggerActions",
@@ -9770,6 +9862,34 @@
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
+			"userGuide",
+			"staleSaveError",
+			"readonlySaveErrorAdmin",
+			"readonlySaveErrorSudo",
+			"readonlySaveError",
+			"permissionDeniedSaveError",
+			"permissionDeniedSaveErrorSudo",
+			{
+				"key": "genericSaveError",
+				"comment": [
+					"{0} is the resource that failed to save and {1} the error message"
+				]
+			},
+			"learnMore",
+			"dontShowAgain",
+			"compareChanges",
+			"saveConflictDiffLabel",
+			"overwriteElevated",
+			"overwriteElevatedSudo",
+			"saveElevated",
+			"saveElevatedSudo",
+			"retry",
+			"discard",
+			"overwrite",
+			"overwrite",
+			"configure"
 		],
 		"vs/workbench/contrib/files/browser/fileActions": [
 			"newFile",
@@ -9932,34 +10052,6 @@
 			"toggleActiveEditorReadonlyInSession",
 			"resetActiveEditorReadonlyInSession"
 		],
-		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
-			"userGuide",
-			"staleSaveError",
-			"readonlySaveErrorAdmin",
-			"readonlySaveErrorSudo",
-			"readonlySaveError",
-			"permissionDeniedSaveError",
-			"permissionDeniedSaveErrorSudo",
-			{
-				"key": "genericSaveError",
-				"comment": [
-					"{0} is the resource that failed to save and {1} the error message"
-				]
-			},
-			"learnMore",
-			"dontShowAgain",
-			"compareChanges",
-			"saveConflictDiffLabel",
-			"overwriteElevated",
-			"overwriteElevatedSudo",
-			"saveElevated",
-			"saveElevatedSudo",
-			"retry",
-			"discard",
-			"overwrite",
-			"overwrite",
-			"configure"
-		],
 		"vs/workbench/contrib/files/browser/fileCommands": [
 			"modifiedLabel",
 			{
@@ -9981,6 +10073,10 @@
 			"learnMore",
 			"eshutdownError",
 			"reload"
+		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"dirtyFile",
+			"dirtyFiles"
 		],
 		"vs/editor/common/config/editorConfigurationSchema": [
 			"editorConfigurationTitle",
@@ -10013,6 +10109,8 @@
 			"maxComputationTime",
 			"maxFileSize",
 			"sideBySide",
+			"renderSideBySideInlineBreakpoint",
+			"useInlineViewWhenSpaceIsLimited",
 			"renderMarginRevertIcon",
 			"ignoreTrimWhitespace",
 			"renderIndicators",
@@ -10022,14 +10120,13 @@
 			"wordWrap.inherit",
 			"diffAlgorithm.legacy",
 			"diffAlgorithm.advanced",
-			"collapseUnchangedRegions",
+			"hideUnchangedRegions.enabled",
+			"hideUnchangedRegions.revealLineCount",
+			"hideUnchangedRegions.minimumLineCount",
+			"hideUnchangedRegions.contextLineCount",
 			"showMoves",
 			"useVersion2",
 			"showEmptyDecorations"
-		],
-		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
-			"dirtyFile",
-			"dirtyFiles"
 		],
 		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
 			"textFileEditor",
@@ -10048,25 +10145,13 @@
 			"gotoLineLabelEmptyWithLimit",
 			"gotoLineLabelEmpty"
 		],
-		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
-			"empty",
-			"gotoSymbol",
-			{
-				"key": "miGotoSymbolInEditor",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"gotoSymbolQuickAccessPlaceholder",
-			"gotoSymbolQuickAccess",
-			"gotoSymbolByCategoryQuickAccess"
-		],
 		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
 			"noAnythingResults",
 			"recentlyOpenedSeparator",
 			"fileAndSymbolResultsSeparator",
 			"fileResultsSeparator",
-			"more",
+			"helpPickAriaLabel",
+			"chat",
 			{
 				"key": "openToSide",
 				"comment": [
@@ -10081,6 +10166,19 @@
 			},
 			"closeEditor",
 			"filePickAriaLabelDirty"
+		],
+		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
+			"empty",
+			"gotoSymbol",
+			{
+				"key": "miGotoSymbolInEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"gotoSymbolQuickAccessPlaceholder",
+			"gotoSymbolQuickAccess",
+			"gotoSymbolByCategoryQuickAccess"
 		],
 		"vs/workbench/contrib/search/browser/searchIcons": [
 			"searchDetailsIcon",
@@ -10098,7 +10196,8 @@
 			"searchClearIcon",
 			"searchStopIcon",
 			"searchViewIcon",
-			"searchNewEditorIcon"
+			"searchNewEditorIcon",
+			"searchOpenInFile"
 		],
 		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
 			"noSymbolResults",
@@ -10114,6 +10213,11 @@
 			"showContext",
 			"label.Replace",
 			"search.replace.placeHolder"
+		],
+		"vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess": [
+			"QuickSearchSeeMoreFiles",
+			"QuickSearchOpenInFile",
+			"QuickSearchMore"
 		],
 		"vs/workbench/contrib/search/browser/searchActionsCopy": [
 			"copyMatchLabel",
@@ -10136,6 +10240,12 @@
 			"findInFolder",
 			"findInWorkspace"
 		],
+		"vs/workbench/contrib/search/browser/searchActionsRemoveReplace": [
+			"RemoveAction.label",
+			"match.replace.label",
+			"file.replaceAll.label",
+			"file.replaceAll.label"
+		],
 		"vs/workbench/contrib/search/browser/searchActionsNav": [
 			"ToggleQueryDetailsAction.label",
 			"CloseReplaceWidget.label",
@@ -10155,11 +10265,15 @@
 			"FocusPreviousSearchResult.label",
 			"replaceInFiles"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsRemoveReplace": [
-			"RemoveAction.label",
-			"match.replace.label",
-			"file.replaceAll.label",
-			"file.replaceAll.label"
+		"vs/workbench/contrib/search/browser/searchActionsTopBar": [
+			"clearSearchHistoryLabel",
+			"CancelSearchAction.label",
+			"RefreshAction.label",
+			"CollapseDeepestExpandedLevelAction.label",
+			"ExpandAllAction.label",
+			"ClearSearchResultsAction.label",
+			"ViewAsTreeAction.label",
+			"ViewAsListAction.label"
 		],
 		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
 			"showTriggerActions",
@@ -10171,15 +10285,8 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/search/browser/searchActionsTopBar": [
-			"clearSearchHistoryLabel",
-			"CancelSearchAction.label",
-			"RefreshAction.label",
-			"CollapseDeepestExpandedLevelAction.label",
-			"ExpandAllAction.label",
-			"ClearSearchResultsAction.label",
-			"ViewAsTreeAction.label",
-			"ViewAsListAction.label"
+		"vs/workbench/contrib/search/browser/searchActionsTextQuickAccess": [
+			"quickTextSearch"
 		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
 			"ok",
@@ -10199,35 +10306,22 @@
 		"vs/workbench/contrib/search/browser/searchActionsBase": [
 			"search"
 		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
-			"moreSearch",
-			"searchScope.includes",
-			"label.includes",
-			"searchScope.excludes",
-			"label.excludes",
-			"runSearch",
-			"searchResultItem",
-			"searchEditor",
-			"textInputBoxBorder"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
-			"searchTitle.withQuery",
-			"searchTitle.withQuery",
-			"searchTitle"
-		],
 		"vs/workbench/browser/parts/views/viewPane": [
 			"viewPaneContainerExpandedIcon",
 			"viewPaneContainerCollapsedIcon",
 			"viewToolbarAriaLabel"
+		],
+		"vs/workbench/contrib/search/browser/searchMessage": [
+			"unable to open trust",
+			"unable to open"
 		],
 		"vs/workbench/contrib/search/browser/patternInputWidget": [
 			"defaultLabel",
 			"onlySearchInOpenEditors",
 			"useExcludesAndIgnoreFilesDescription"
 		],
-		"vs/workbench/contrib/search/browser/searchMessage": [
-			"unable to open trust",
-			"unable to open"
+		"vs/workbench/services/search/common/queryBuilder": [
+			"search.noWorkspaceWithName"
 		],
 		"vs/workbench/contrib/search/browser/searchResultsView": [
 			"searchFolderMatch.other.label",
@@ -10245,12 +10339,28 @@
 			"replacePreviewResultAria",
 			"searchResultAria"
 		],
-		"vs/workbench/services/search/common/queryBuilder": [
-			"search.noWorkspaceWithName"
+		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
+			"moreSearch",
+			"searchScope.includes",
+			"label.includes",
+			"searchScope.excludes",
+			"label.excludes",
+			"runSearch",
+			"searchResultItem",
+			"searchEditor",
+			"textInputBoxBorder"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
+			"searchTitle.withQuery",
+			"searchTitle.withQuery",
+			"searchTitle"
 		],
 		"vs/workbench/contrib/scm/browser/activity": [
 			"status.scm",
 			"scmPendingChangesBadge"
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
+			"source control"
 		],
 		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
 			"changes",
@@ -10284,9 +10394,6 @@
 			"overviewRulerAddedForeground",
 			"overviewRulerDeletedForeground"
 		],
-		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
-			"source control"
-		],
 		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
 			"scm"
 		],
@@ -10311,79 +10418,6 @@
 			"expand all",
 			"label.close",
 			"scm.providerBorder"
-		],
-		"vs/workbench/contrib/debug/browser/callStackView": [
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"showMoreStackFrames2",
-			{
-				"key": "session",
-				"comment": [
-					"Session is a noun"
-				]
-			},
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"restartFrame",
-			"loadAllStackFrames",
-			"showMoreAndOrigin",
-			"showMoreStackFrames",
-			{
-				"key": "pausedOn",
-				"comment": [
-					"indicates reason for program being paused"
-				]
-			},
-			"paused",
-			{
-				"comment": [
-					"Debug is a noun in this context, not a verb."
-				],
-				"key": "callStackAriaLabel"
-			},
-			{
-				"key": "threadAriaLabel",
-				"comment": [
-					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
-				]
-			},
-			"stackFrameAriaLabel",
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			{
-				"key": "sessionLabel",
-				"comment": [
-					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
-				]
-			},
-			"showMoreStackFrames",
-			"collapse"
-		],
-		"vs/workbench/contrib/debug/browser/debugColors": [
-			"debugToolBarBackground",
-			"debugToolBarBorder",
-			"debugIcon.startForeground",
-			"debugIcon.pauseForeground",
-			"debugIcon.stopForeground",
-			"debugIcon.disconnectForeground",
-			"debugIcon.restartForeground",
-			"debugIcon.stepOverForeground",
-			"debugIcon.stepIntoForeground",
-			"debugIcon.stepOutForeground",
-			"debugIcon.continueForeground",
-			"debugIcon.stepBackForeground"
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"unverifiedExceptionBreakpoint",
@@ -10459,8 +10493,171 @@
 			"editBreakpoint",
 			"editHitCount"
 		],
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"debugToolBarBackground",
+			"debugToolBarBorder",
+			"debugIcon.startForeground",
+			"debugIcon.pauseForeground",
+			"debugIcon.stopForeground",
+			"debugIcon.disconnectForeground",
+			"debugIcon.restartForeground",
+			"debugIcon.stepOverForeground",
+			"debugIcon.stepIntoForeground",
+			"debugIcon.stepOutForeground",
+			"debugIcon.continueForeground",
+			"debugIcon.stepBackForeground"
+		],
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"showMoreStackFrames2",
+			{
+				"key": "session",
+				"comment": [
+					"Session is a noun"
+				]
+			},
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"restartFrame",
+			"loadAllStackFrames",
+			"showMoreAndOrigin",
+			"showMoreStackFrames",
+			{
+				"key": "pausedOn",
+				"comment": [
+					"indicates reason for program being paused"
+				]
+			},
+			"paused",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "callStackAriaLabel"
+			},
+			{
+				"key": "threadAriaLabel",
+				"comment": [
+					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
+				]
+			},
+			"stackFrameAriaLabel",
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			{
+				"key": "sessionLabel",
+				"comment": [
+					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
+				]
+			},
+			"showMoreStackFrames",
+			"collapse"
+		],
 		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
 			"workbench.action.debug.startDebug"
+		],
+		"vs/workbench/contrib/debug/browser/debugIcons": [
+			"debugConsoleViewIcon",
+			"runViewIcon",
+			"variablesViewIcon",
+			"watchViewIcon",
+			"callStackViewIcon",
+			"breakpointsViewIcon",
+			"loadedScriptsViewIcon",
+			"debugBreakpoint",
+			"debugBreakpointDisabled",
+			"debugBreakpointUnverified",
+			"debugBreakpointFunction",
+			"debugBreakpointFunctionDisabled",
+			"debugBreakpointFunctionUnverified",
+			"debugBreakpointConditional",
+			"debugBreakpointConditionalDisabled",
+			"debugBreakpointConditionalUnverified",
+			"debugBreakpointData",
+			"debugBreakpointDataDisabled",
+			"debugBreakpointDataUnverified",
+			"debugBreakpointLog",
+			"debugBreakpointLogDisabled",
+			"debugBreakpointLogUnverified",
+			"debugBreakpointHint",
+			"debugBreakpointUnsupported",
+			"debugStackframe",
+			"debugStackframeFocused",
+			"debugGripper",
+			"debugRestartFrame",
+			"debugStop",
+			"debugDisconnect",
+			"debugRestart",
+			"debugStepOver",
+			"debugStepInto",
+			"debugStepOut",
+			"debugStepBack",
+			"debugPause",
+			"debugContinue",
+			"debugReverseContinue",
+			"debugRun",
+			"debugStart",
+			"debugConfigure",
+			"debugConsole",
+			"debugRemoveConfig",
+			"debugCollapseAll",
+			"callstackViewSession",
+			"debugConsoleClearAll",
+			"watchExpressionsRemoveAll",
+			"watchExpressionRemove",
+			"watchExpressionsAdd",
+			"watchExpressionsAddFuncBreakpoint",
+			"breakpointsRemoveAll",
+			"breakpointsActivate",
+			"debugConsoleEvaluationInput",
+			"debugConsoleEvaluationPrompt",
+			"debugInspectMemory"
+		],
+		"vs/workbench/contrib/debug/browser/debugCommands": [
+			"debug",
+			"restartDebug",
+			"stepOverDebug",
+			"stepIntoDebug",
+			"stepIntoTargetDebug",
+			"stepOutDebug",
+			"pauseDebug",
+			"disconnect",
+			"disconnectSuspend",
+			"stop",
+			"continueDebug",
+			"focusSession",
+			"selectAndStartDebugging",
+			"openLaunchJson",
+			"startDebug",
+			"startWithoutDebugging",
+			"nextDebugConsole",
+			"prevDebugConsole",
+			"openLoadedScript",
+			"callStackTop",
+			"callStackBottom",
+			"callStackUp",
+			"callStackDown",
+			"selectDebugConsole",
+			"selectDebugSession",
+			"chooseLocation",
+			"noExecutableCode",
+			"jumpToCursor",
+			"editor.debug.action.stepIntoTargets.none",
+			"addConfiguration",
+			"addInlineBreakpoint"
 		],
 		"vs/workbench/contrib/debug/browser/debugEditorActions": [
 			"toggleBreakpointAction",
@@ -10520,63 +10717,6 @@
 			"goToPreviousBreakpoint",
 			"closeExceptionWidget"
 		],
-		"vs/workbench/contrib/debug/browser/debugIcons": [
-			"debugConsoleViewIcon",
-			"runViewIcon",
-			"variablesViewIcon",
-			"watchViewIcon",
-			"callStackViewIcon",
-			"breakpointsViewIcon",
-			"loadedScriptsViewIcon",
-			"debugBreakpoint",
-			"debugBreakpointDisabled",
-			"debugBreakpointUnverified",
-			"debugBreakpointFunction",
-			"debugBreakpointFunctionDisabled",
-			"debugBreakpointFunctionUnverified",
-			"debugBreakpointConditional",
-			"debugBreakpointConditionalDisabled",
-			"debugBreakpointConditionalUnverified",
-			"debugBreakpointData",
-			"debugBreakpointDataDisabled",
-			"debugBreakpointDataUnverified",
-			"debugBreakpointLog",
-			"debugBreakpointLogDisabled",
-			"debugBreakpointLogUnverified",
-			"debugBreakpointHint",
-			"debugBreakpointUnsupported",
-			"debugStackframe",
-			"debugStackframeFocused",
-			"debugGripper",
-			"debugRestartFrame",
-			"debugStop",
-			"debugDisconnect",
-			"debugRestart",
-			"debugStepOver",
-			"debugStepInto",
-			"debugStepOut",
-			"debugStepBack",
-			"debugPause",
-			"debugContinue",
-			"debugReverseContinue",
-			"debugRun",
-			"debugStart",
-			"debugConfigure",
-			"debugConsole",
-			"debugRemoveConfig",
-			"debugCollapseAll",
-			"callstackViewSession",
-			"debugConsoleClearAll",
-			"watchExpressionsRemoveAll",
-			"watchExpressionRemove",
-			"watchExpressionsAdd",
-			"watchExpressionsAddFuncBreakpoint",
-			"breakpointsRemoveAll",
-			"breakpointsActivate",
-			"debugConsoleEvaluationInput",
-			"debugConsoleEvaluationPrompt",
-			"debugInspectMemory"
-		],
 		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
 			"noDebugResults",
 			"customizeLaunchConfig",
@@ -10596,44 +10736,6 @@
 			"configure",
 			"addConfigTo",
 			"addConfiguration"
-		],
-		"vs/workbench/contrib/debug/browser/debugCommands": [
-			"debug",
-			"restartDebug",
-			"stepOverDebug",
-			"stepIntoDebug",
-			"stepIntoTargetDebug",
-			"stepOutDebug",
-			"pauseDebug",
-			"disconnect",
-			"disconnectSuspend",
-			"stop",
-			"continueDebug",
-			"focusSession",
-			"selectAndStartDebugging",
-			"openLaunchJson",
-			"startDebug",
-			"startWithoutDebugging",
-			"nextDebugConsole",
-			"prevDebugConsole",
-			"openLoadedScript",
-			"callStackTop",
-			"callStackBottom",
-			"callStackUp",
-			"callStackDown",
-			"selectDebugConsole",
-			"selectDebugSession",
-			"chooseLocation",
-			"noExecutableCode",
-			"jumpToCursor",
-			"editor.debug.action.stepIntoTargets.none",
-			"addConfiguration",
-			"addInlineBreakpoint"
-		],
-		"vs/workbench/contrib/debug/browser/debugStatus": [
-			"status.debug",
-			"debugTarget",
-			"selectAndStartDebug"
 		],
 		"vs/workbench/contrib/debug/browser/debugService": [
 			"1activeSession",
@@ -10674,19 +10776,15 @@
 			"breakpointAdded",
 			"breakpointRemoved"
 		],
+		"vs/workbench/contrib/debug/browser/debugStatus": [
+			"status.debug",
+			"debugTarget",
+			"selectAndStartDebug"
+		],
 		"vs/workbench/contrib/debug/browser/debugToolBar": [
 			"notebook.moreRunActionsLabel",
 			"stepBackDebug",
 			"reverseContinue"
-		],
-		"vs/workbench/contrib/debug/browser/disassemblyView": [
-			"instructionNotAvailable",
-			"disassemblyTableColumnLabel",
-			"editorOpenedFromDisassemblyDescription",
-			"disassemblyView",
-			"instructionAddress",
-			"instructionBytes",
-			"instructionText"
 		],
 		"vs/workbench/contrib/debug/browser/loadedScriptsView": [
 			"loadedScriptsSession",
@@ -10706,21 +10804,14 @@
 			"statusBarDebuggingForeground",
 			"statusBarDebuggingBorder"
 		],
-		"vs/workbench/contrib/debug/browser/variablesView": [
-			"variableValueAriaLabel",
-			"variablesAriaTreeLabel",
-			"variableScopeAriaLabel",
-			{
-				"key": "variableAriaLabel",
-				"comment": [
-					"Placeholders are variable name and variable value respectivly. They should not be translated."
-				]
-			},
-			"viewMemory.prompt",
-			"cancel",
-			"install",
-			"viewMemory.install.progress",
-			"collapse"
+		"vs/workbench/contrib/debug/browser/disassemblyView": [
+			"instructionNotAvailable",
+			"disassemblyTableColumnLabel",
+			"editorOpenedFromDisassemblyDescription",
+			"disassemblyView",
+			"instructionAddress",
+			"instructionBytes",
+			"instructionText"
 		],
 		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
 			"typeNewValue",
@@ -10737,11 +10828,6 @@
 			"collapse",
 			"addWatchExpression",
 			"removeAllWatchExpressions"
-		],
-		"vs/workbench/contrib/debug/common/debugContentProvider": [
-			"unable",
-			"canNotResolveSourceWithError",
-			"canNotResolveSource"
 		],
 		"vs/workbench/contrib/debug/browser/welcomeView": [
 			"run",
@@ -10770,6 +10856,27 @@
 			},
 			"allDebuggersDisabled"
 		],
+		"vs/workbench/contrib/debug/browser/variablesView": [
+			"variableValueAriaLabel",
+			"variablesAriaTreeLabel",
+			"variableScopeAriaLabel",
+			{
+				"key": "variableAriaLabel",
+				"comment": [
+					"Placeholders are variable name and variable value respectivly. They should not be translated."
+				]
+			},
+			"viewMemory.prompt",
+			"cancel",
+			"install",
+			"viewMemory.install.progress",
+			"collapse"
+		],
+		"vs/workbench/contrib/debug/common/debugContentProvider": [
+			"unable",
+			"canNotResolveSourceWithError",
+			"canNotResolveSource"
+		],
 		"vs/workbench/contrib/debug/common/debugLifecycle": [
 			"debug.debugSessionCloseConfirmationSingular",
 			"debug.debugSessionCloseConfirmationPlural",
@@ -10782,6 +10889,15 @@
 		],
 		"vs/workbench/contrib/debug/common/disassemblyViewInput": [
 			"disassemblyInputName"
+		],
+		"vs/workbench/contrib/debug/browser/breakpointWidget": [
+			"breakpointWidgetLogMessagePlaceholder",
+			"breakpointWidgetHitCountPlaceholder",
+			"breakpointWidgetExpressionPlaceholder",
+			"expression",
+			"hitCount",
+			"logMessage",
+			"breakpointType"
 		],
 		"vs/workbench/contrib/debug/browser/debugHover": [
 			{
@@ -10824,15 +10940,6 @@
 			},
 			"breakpointDirtydHover"
 		],
-		"vs/workbench/contrib/debug/browser/breakpointWidget": [
-			"breakpointWidgetLogMessagePlaceholder",
-			"breakpointWidgetHitCountPlaceholder",
-			"breakpointWidgetExpressionPlaceholder",
-			"expression",
-			"hitCount",
-			"logMessage",
-			"breakpointType"
-		],
 		"vs/workbench/contrib/debug/browser/debugActionViewItems": [
 			"debugLaunchConfigurations",
 			"noConfigurations",
@@ -10865,12 +10972,6 @@
 		],
 		"vs/workbench/contrib/debug/common/replModel": [
 			"consoleCleared"
-		],
-		"vs/workbench/contrib/markers/browser/markersView": [
-			"showing filtered problems",
-			"No problems filtered",
-			"problems filtered",
-			"clearFilter"
 		],
 		"vs/workbench/contrib/markers/browser/messages": [
 			"problems.view.toggle.label",
@@ -10921,17 +11022,76 @@
 			"problems.tree.aria.label.relatedinfo.message",
 			"errors.warnings.show.label"
 		],
-		"vs/workbench/browser/parts/views/viewFilter": [
-			"more filters"
-		],
 		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
 			"label",
 			"tooltip.1",
 			"tooltip.N",
 			"markers.showOnFile"
 		],
-		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"showing filtered problems",
+			"No problems filtered",
+			"problems filtered",
+			"clearFilter"
+		],
+		"vs/workbench/browser/parts/views/viewFilter": [
+			"more filters"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/commands/commands": [
+			"title",
+			"layout.mixed",
+			"layout.column",
+			"showNonConflictingChanges",
+			"layout.showBase",
+			"layout.showBaseTop",
+			"layout.showBaseCenter",
+			"mergeEditor",
+			"openfile",
+			"merge.goToNextUnhandledConflict",
+			"merge.goToPreviousUnhandledConflict",
+			"merge.toggleCurrentConflictFromLeft",
+			"merge.toggleCurrentConflictFromRight",
+			"mergeEditor.compareInput1WithBase",
+			"mergeEditor.compareWithBase",
+			"mergeEditor.compareInput2WithBase",
+			"mergeEditor.compareWithBase",
+			"merge.openBaseEditor",
+			"merge.acceptAllInput1",
+			"merge.acceptAllInput2",
+			"mergeEditor.resetResultToBaseAndAutoMerge",
+			"mergeEditor.resetResultToBaseAndAutoMerge.short",
+			"mergeEditor.resetChoice",
+			"mergeEditor.acceptMerge",
+			"mergeEditor.acceptMerge.unhandledConflicts.message",
+			"mergeEditor.acceptMerge.unhandledConflicts.detail",
+			{
+				"key": "mergeEditor.acceptMerge.unhandledConflicts.accept",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
 			"name"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/commands/devCommands": [
+			"mergeEditor",
+			"merge.dev.copyState",
+			"mergeEditor.name",
+			"mergeEditor.noActiveMergeEditor",
+			"mergeEditor.name",
+			"mergeEditor.successfullyCopiedMergeEditorContents",
+			"merge.dev.saveContentsToFolder",
+			"mergeEditor.name",
+			"mergeEditor.noActiveMergeEditor",
+			"mergeEditor.selectFolderToSaveTo",
+			"mergeEditor.name",
+			"mergeEditor.successfullySavedMergeEditorContentsToFolder",
+			"merge.dev.loadContentsFromFolder",
+			"mergeEditor.selectFolderToSaveTo"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
+			"mergeEditor"
 		],
 		"vs/workbench/contrib/comments/browser/commentService": [
 			"hasCommentingProvider"
@@ -10981,68 +11141,6 @@
 			"editor.action.webvieweditor.findPrevious",
 			"refreshWebviewLabel"
 		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
-			"context.activeWebviewId"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/commands/commands": [
-			"title",
-			"layout.mixed",
-			"layout.column",
-			"showNonConflictingChanges",
-			"layout.showBase",
-			"layout.showBaseTop",
-			"layout.showBaseCenter",
-			"mergeEditor",
-			"openfile",
-			"merge.goToNextUnhandledConflict",
-			"merge.goToPreviousUnhandledConflict",
-			"merge.toggleCurrentConflictFromLeft",
-			"merge.toggleCurrentConflictFromRight",
-			"mergeEditor.compareInput1WithBase",
-			"mergeEditor.compareWithBase",
-			"mergeEditor.compareInput2WithBase",
-			"mergeEditor.compareWithBase",
-			"merge.openBaseEditor",
-			"merge.acceptAllInput1",
-			"merge.acceptAllInput2",
-			"mergeEditor.resetResultToBaseAndAutoMerge",
-			"mergeEditor.resetResultToBaseAndAutoMerge.short",
-			"mergeEditor.resetChoice",
-			"mergeEditor.acceptMerge",
-			"mergeEditor.acceptMerge.unhandledConflicts.message",
-			"mergeEditor.acceptMerge.unhandledConflicts.detail",
-			{
-				"key": "mergeEditor.acceptMerge.unhandledConflicts.accept",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/mergeEditor/browser/commands/devCommands": [
-			"mergeEditor",
-			"merge.dev.copyState",
-			"mergeEditor.name",
-			"mergeEditor.noActiveMergeEditor",
-			"mergeEditor.name",
-			"mergeEditor.successfullyCopiedMergeEditorContents",
-			"merge.dev.saveContentsToFolder",
-			"mergeEditor.name",
-			"mergeEditor.noActiveMergeEditor",
-			"mergeEditor.selectFolderToSaveTo",
-			"mergeEditor.name",
-			"mergeEditor.successfullySavedMergeEditorContentsToFolder",
-			"merge.dev.loadContentsFromFolder",
-			"mergeEditor.selectFolderToSaveTo"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
-			"name"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
-			"mergeEditor"
-		],
-		"vs/workbench/contrib/customEditor/common/customEditor": [
-			"context.customEditor"
-		],
 		"vs/workbench/contrib/externalUriOpener/common/configuration": [
 			"externalUriOpeners",
 			"externalUriOpeners.uri",
@@ -11055,8 +11153,24 @@
 			"selectOpenerConfigureTitle",
 			"selectOpenerPlaceHolder"
 		],
+		"vs/workbench/contrib/customEditor/common/customEditor": [
+			"context.customEditor"
+		],
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"extensionsInputName"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"extensions",
+			"offline error",
+			"error",
+			"no extensions found",
+			"suggestProxyError",
+			"open user settings",
+			"no local extensions",
+			"extension.arialabel.verifiedPublisher",
+			"extension.arialabel.publisher",
+			"extension.arialabel.deprecated",
+			"extension.arialabel.rating"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"VS Code for Web",
@@ -11129,7 +11243,6 @@
 			"migrate to",
 			"migrate",
 			"manage",
-			"ManageExtensionAction.uninstallingTooltip",
 			"manage",
 			"switch to pre-release version",
 			"switch to pre-release version tooltip",
@@ -11239,12 +11352,52 @@
 			"extensionButtonProminentForeground",
 			"extensionButtonProminentHoverBackground"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"extensionsViewIcon",
+			"manageExtensionIcon",
+			"clearSearchResultsIcon",
+			"refreshIcon",
+			"filterIcon",
+			"installLocalInRemoteIcon",
+			"installWorkspaceRecommendedIcon",
+			"configureRecommendedIcon",
+			"syncEnabledIcon",
+			"syncIgnoredIcon",
+			"remoteIcon",
+			"installCountIcon",
+			"ratingIcon",
+			"verifiedPublisher",
+			"preReleaseIcon",
+			"sponsorIcon",
+			"starFullIcon",
+			"starHalfIcon",
+			"starEmptyIcon",
+			"errorIcon",
+			"warningIcon",
+			"infoIcon",
+			"trustIcon",
+			"activationtimeIcon"
+		],
+		"vs/platform/dnd/browser/dnd": [
+			"fileTooLarge"
+		],
 		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
 			"app.extensions.json.title",
 			"app.extensions.json.recommendations",
 			"app.extension.identifier.errorMessage",
 			"app.extensions.json.unwantedRecommendations",
 			"app.extension.identifier.errorMessage"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"disableOtherKeymapsConfirmation",
+			"yes",
+			"no"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
+			"context.activeWebviewId"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"activation"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionEditor": [
 			"extension version",
@@ -11361,13 +11514,18 @@
 			"find next",
 			"find previous"
 		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"disableOtherKeymapsConfirmation",
-			"yes",
-			"no"
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"extensions",
+			"auto install missing deps",
+			"finished installing missing deps",
+			"reload",
+			"no missing deps"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
-			"activation"
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"type",
+			"searchFor",
+			"install",
+			"manage"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
 			"Manifest is not found",
@@ -11416,6 +11574,9 @@
 			"install",
 			"install and do no sync",
 			"show recommendations"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
+			"restartExtensionHost.reason"
 		],
 		"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor": [
 			{
@@ -11468,42 +11629,6 @@
 			"disable",
 			"showRuntimeExtensions"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
-			"restartExtensionHost.reason"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"extensions",
-			"auto install missing deps",
-			"finished installing missing deps",
-			"reload",
-			"no missing deps"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
-			"extensionsViewIcon",
-			"manageExtensionIcon",
-			"clearSearchResultsIcon",
-			"refreshIcon",
-			"filterIcon",
-			"installLocalInRemoteIcon",
-			"installWorkspaceRecommendedIcon",
-			"configureRecommendedIcon",
-			"syncEnabledIcon",
-			"syncIgnoredIcon",
-			"remoteIcon",
-			"installCountIcon",
-			"ratingIcon",
-			"verifiedPublisher",
-			"preReleaseIcon",
-			"sponsorIcon",
-			"starFullIcon",
-			"starHalfIcon",
-			"starEmptyIcon",
-			"errorIcon",
-			"warningIcon",
-			"infoIcon",
-			"trustIcon",
-			"activationtimeIcon"
-		],
 		"vs/workbench/contrib/extensions/browser/extensionsCompletionItemsProvider": [
 			"exampleExtension"
 		],
@@ -11511,22 +11636,6 @@
 			"deprecated extensions",
 			"showDeprecated",
 			"neverShowAgain"
-		],
-		"vs/platform/dnd/browser/dnd": [
-			"fileTooLarge"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsViews": [
-			"extensions",
-			"offline error",
-			"error",
-			"no extensions found",
-			"suggestProxyError",
-			"open user settings",
-			"no local extensions",
-			"extension.arialabel.verifiedPublihser",
-			"extension.arialabel.publihser",
-			"extension.arialabel.deprecated",
-			"extension.arialabel.rating"
 		],
 		"vs/workbench/contrib/output/browser/logViewer": [
 			"logViewerAriaLabel"
@@ -11543,17 +11652,17 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"type",
-			"searchFor",
-			"install",
-			"manage"
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
+			"workbench.action.terminal.focusAccessibleBuffer",
+			"workbench.action.terminal.navigateAccessibleBuffer",
+			"workbench.action.terminal.accessibleBufferGoToNextCommand",
+			"workbench.action.terminal.accessibleBufferGoToPreviousCommand"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalView": [
-			"terminal.useMonospace",
-			"terminal.monospaceOnly",
-			"terminals",
-			"terminalConnectingLabel"
+		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
+			"workbench.action.terminal.showEnvironmentContributions",
+			"envChanges",
+			"extension",
+			"ScopedEnvironmentContributionInfo"
 		],
 		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
 			"workbench.action.terminal.showTextureAtlas",
@@ -11561,11 +11670,11 @@
 			"workbench.action.terminal.writeDataToTerminal.prompt",
 			"workbench.action.terminal.restartPtyHost"
 		],
-		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
-			"workbench.action.terminal.showEnvironmentContributions",
-			"envChanges",
-			"extension",
-			"ScopedEnvironmentContributionInfo"
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"terminal.useMonospace",
+			"terminal.monospaceOnly",
+			"terminals",
+			"terminalConnectingLabel"
 		],
 		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
 			"workbench.action.terminal.focusFind",
@@ -11576,12 +11685,6 @@
 			"workbench.action.terminal.findNext",
 			"workbench.action.terminal.findPrevious",
 			"workbench.action.terminal.searchWorkspace"
-		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
-			"workbench.action.terminal.focusAccessibleBuffer",
-			"workbench.action.terminal.navigateAccessibleBuffer",
-			"workbench.action.terminal.accessibleBufferGoToNextCommand",
-			"workbench.action.terminal.accessibleBufferGoToPreviousCommand"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
 			"workbench.action.terminal.openDetectedLink",
@@ -11595,76 +11698,6 @@
 			"workbench.action.tasks.manageAutomaticRunning",
 			"workbench.action.tasks.allowAutomaticTasks",
 			"workbench.action.tasks.disallowAutomaticTasks"
-		],
-		"vs/workbench/contrib/tasks/common/problemMatcher": [
-			"ProblemPatternParser.problemPattern.missingRegExp",
-			"ProblemPatternParser.loopProperty.notLast",
-			"ProblemPatternParser.problemPattern.kindProperty.notFirst",
-			"ProblemPatternParser.problemPattern.missingProperty",
-			"ProblemPatternParser.problemPattern.missingLocation",
-			"ProblemPatternParser.invalidRegexp",
-			"ProblemPatternSchema.regexp",
-			"ProblemPatternSchema.kind",
-			"ProblemPatternSchema.file",
-			"ProblemPatternSchema.location",
-			"ProblemPatternSchema.line",
-			"ProblemPatternSchema.column",
-			"ProblemPatternSchema.endLine",
-			"ProblemPatternSchema.endColumn",
-			"ProblemPatternSchema.severity",
-			"ProblemPatternSchema.code",
-			"ProblemPatternSchema.message",
-			"ProblemPatternSchema.loop",
-			"NamedProblemPatternSchema.name",
-			"NamedMultiLineProblemPatternSchema.name",
-			"NamedMultiLineProblemPatternSchema.patterns",
-			"ProblemPatternExtPoint",
-			"ProblemPatternRegistry.error",
-			"ProblemPatternRegistry.error",
-			"ProblemMatcherParser.noProblemMatcher",
-			"ProblemMatcherParser.noProblemPattern",
-			"ProblemMatcherParser.noOwner",
-			"ProblemMatcherParser.noFileLocation",
-			"ProblemMatcherParser.unknownSeverity",
-			"ProblemMatcherParser.noDefinedPatter",
-			"ProblemMatcherParser.noIdentifier",
-			"ProblemMatcherParser.noValidIdentifier",
-			"ProblemMatcherParser.problemPattern.watchingMatcher",
-			"ProblemMatcherParser.invalidRegexp",
-			"WatchingPatternSchema.regexp",
-			"WatchingPatternSchema.file",
-			"PatternTypeSchema.name",
-			"PatternTypeSchema.description",
-			"ProblemMatcherSchema.base",
-			"ProblemMatcherSchema.owner",
-			"ProblemMatcherSchema.source",
-			"ProblemMatcherSchema.severity",
-			"ProblemMatcherSchema.applyTo",
-			"ProblemMatcherSchema.fileLocation",
-			"ProblemMatcherSchema.background",
-			"ProblemMatcherSchema.background.activeOnStart",
-			"ProblemMatcherSchema.background.beginsPattern",
-			"ProblemMatcherSchema.background.endsPattern",
-			"ProblemMatcherSchema.watching.deprecated",
-			"ProblemMatcherSchema.watching",
-			"ProblemMatcherSchema.watching.activeOnStart",
-			"ProblemMatcherSchema.watching.beginsPattern",
-			"ProblemMatcherSchema.watching.endsPattern",
-			"LegacyProblemMatcherSchema.watchedBegin.deprecated",
-			"LegacyProblemMatcherSchema.watchedBegin",
-			"LegacyProblemMatcherSchema.watchedEnd.deprecated",
-			"LegacyProblemMatcherSchema.watchedEnd",
-			"NamedProblemMatcherSchema.name",
-			"NamedProblemMatcherSchema.label",
-			"ProblemMatcherExtPoint",
-			"msCompile",
-			"lessCompile",
-			"gulp-tsc",
-			"jshint",
-			"jshint-stylish",
-			"eslint-compact",
-			"eslint-stylish",
-			"go"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
 			"JsonSchema.version.deprecated",
@@ -11760,6 +11793,76 @@
 			"JsonSchema.mac",
 			"JsonSchema.linux"
 		],
+		"vs/workbench/contrib/tasks/common/problemMatcher": [
+			"ProblemPatternParser.problemPattern.missingRegExp",
+			"ProblemPatternParser.loopProperty.notLast",
+			"ProblemPatternParser.problemPattern.kindProperty.notFirst",
+			"ProblemPatternParser.problemPattern.missingProperty",
+			"ProblemPatternParser.problemPattern.missingLocation",
+			"ProblemPatternParser.invalidRegexp",
+			"ProblemPatternSchema.regexp",
+			"ProblemPatternSchema.kind",
+			"ProblemPatternSchema.file",
+			"ProblemPatternSchema.location",
+			"ProblemPatternSchema.line",
+			"ProblemPatternSchema.column",
+			"ProblemPatternSchema.endLine",
+			"ProblemPatternSchema.endColumn",
+			"ProblemPatternSchema.severity",
+			"ProblemPatternSchema.code",
+			"ProblemPatternSchema.message",
+			"ProblemPatternSchema.loop",
+			"NamedProblemPatternSchema.name",
+			"NamedMultiLineProblemPatternSchema.name",
+			"NamedMultiLineProblemPatternSchema.patterns",
+			"ProblemPatternExtPoint",
+			"ProblemPatternRegistry.error",
+			"ProblemPatternRegistry.error",
+			"ProblemMatcherParser.noProblemMatcher",
+			"ProblemMatcherParser.noProblemPattern",
+			"ProblemMatcherParser.noOwner",
+			"ProblemMatcherParser.noFileLocation",
+			"ProblemMatcherParser.unknownSeverity",
+			"ProblemMatcherParser.noDefinedPatter",
+			"ProblemMatcherParser.noIdentifier",
+			"ProblemMatcherParser.noValidIdentifier",
+			"ProblemMatcherParser.problemPattern.watchingMatcher",
+			"ProblemMatcherParser.invalidRegexp",
+			"WatchingPatternSchema.regexp",
+			"WatchingPatternSchema.file",
+			"PatternTypeSchema.name",
+			"PatternTypeSchema.description",
+			"ProblemMatcherSchema.base",
+			"ProblemMatcherSchema.owner",
+			"ProblemMatcherSchema.source",
+			"ProblemMatcherSchema.severity",
+			"ProblemMatcherSchema.applyTo",
+			"ProblemMatcherSchema.fileLocation",
+			"ProblemMatcherSchema.background",
+			"ProblemMatcherSchema.background.activeOnStart",
+			"ProblemMatcherSchema.background.beginsPattern",
+			"ProblemMatcherSchema.background.endsPattern",
+			"ProblemMatcherSchema.watching.deprecated",
+			"ProblemMatcherSchema.watching",
+			"ProblemMatcherSchema.watching.activeOnStart",
+			"ProblemMatcherSchema.watching.beginsPattern",
+			"ProblemMatcherSchema.watching.endsPattern",
+			"LegacyProblemMatcherSchema.watchedBegin.deprecated",
+			"LegacyProblemMatcherSchema.watchedBegin",
+			"LegacyProblemMatcherSchema.watchedEnd.deprecated",
+			"LegacyProblemMatcherSchema.watchedEnd",
+			"NamedProblemMatcherSchema.name",
+			"NamedProblemMatcherSchema.label",
+			"ProblemMatcherExtPoint",
+			"msCompile",
+			"lessCompile",
+			"gulp-tsc",
+			"jshint",
+			"jshint-stylish",
+			"eslint-compact",
+			"eslint-stylish",
+			"go"
+		],
 		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
 			"noTaskResults",
 			"TaskService.pickRunTask"
@@ -11807,18 +11910,7 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"expandAbbreviationAction",
-			{
-				"key": "miEmmetExpandAbbreviation",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/remote/browser/remoteIndicator": [
-			"statusBarOfflineBackground",
-			"statusBarOfflineForeground",
 			"remote.category",
 			"remote.showMenu",
 			"remote.close",
@@ -11863,6 +11955,15 @@
 			"remoteActions",
 			"remote.startActions.installingExtension"
 		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"expandAbbreviationAction",
+			{
+				"key": "miEmmetExpandAbbreviation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
 			"toggleScreenReaderMode"
 		],
@@ -11872,8 +11973,7 @@
 			"removeTimeout",
 			"msg1",
 			"msg2",
-			"msg3",
-			"chat-help-label"
+			"msg3"
 		],
 		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
 			"workbench.action.inspectKeyMap",
@@ -11897,6 +11997,15 @@
 			"gotoLine",
 			"gotoLineQuickAccessPlaceholder",
 			"gotoLineQuickAccess"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
+			"toggleMinimap",
+			{
+				"key": "miMinimap",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
 			{
@@ -11923,20 +12032,29 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
-			"toggleMinimap",
-			{
-				"key": "miMinimap",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
 			"toggleLocation",
 			"miMultiCursorAlt",
 			"miMultiCursorCmd",
 			"miMultiCursorCtrl"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
+			"toggleRenderControlCharacters",
+			{
+				"key": "miToggleRenderControlCharacters",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"toggleRenderWhitespace",
+			{
+				"key": "miToggleRenderWhitespace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
 			"editorWordWrap",
@@ -11950,32 +12068,24 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
-			"toggleRenderControlCharacters",
-			{
-				"key": "miToggleRenderControlCharacters",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint": [
+			"untitledText",
+			"untitledText2",
+			{
+				"key": "inlineChatHint",
+				"comment": [
+					"Preserve double-square brackets and their order"
+				]
+			},
 			{
 				"key": "message",
 				"comment": [
 					"Preserve double-square brackets and their order",
 					"language refers to a programming language"
 				]
-			}
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
-			"toggleRenderWhitespace",
-			{
-				"key": "miToggleRenderWhitespace",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
+			},
+			"defaultHintAriaLabel",
+			"disableHint"
 		],
 		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
 			"global.scope",
@@ -12002,15 +12112,31 @@
 			"new.global.sep",
 			"openSnippet.pickLanguage"
 		],
+		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
+			"snippet.suggestions.label"
+		],
 		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
 			"label",
 			"placeholder"
 		],
-		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
-			"snippet.suggestions.label"
-		],
 		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
 			"label"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
+			"codeAction",
+			"overflow.start.title",
+			"title"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"invalid.path.0",
+			"invalid.language.0",
+			"invalid.language",
+			"invalid.path.1",
+			"vscode.extension.contributes.snippets",
+			"vscode.extension.contributes.snippets-language",
+			"vscode.extension.contributes.snippets-path",
+			"badVariableUse",
+			"badFile"
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
 			"null",
@@ -12110,15 +12236,24 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
-			"codeAction",
-			"overflow.start.title",
-			"title"
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
+			"getStarted"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
 			"builtin",
 			"developer",
 			"resetWelcomePageWalkthroughProgress"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
+			"welcome.displayName",
+			"startupPage.markdownPreviewError"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons": [
+			"gettingStartedUnchecked",
+			"gettingStartedChecked"
+		],
+		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
+			"ViewsWelcomeExtensionPoint.proposedAPI"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted": [
 			"welcomeAriaLabel",
@@ -12168,39 +12303,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"invalid.path.0",
-			"invalid.language.0",
-			"invalid.language",
-			"invalid.path.1",
-			"vscode.extension.contributes.snippets",
-			"vscode.extension.contributes.snippets-language",
-			"vscode.extension.contributes.snippets-path",
-			"badVariableUse",
-			"badFile"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
-			"getStarted"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
-			"welcome.displayName",
-			"startupPage.markdownPreviewError"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons": [
-			"gettingStartedUnchecked",
-			"gettingStartedChecked"
-		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
-			"walkThrough.unboundCommand",
-			"walkThrough.gitNotFound"
-		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
-			"editorWalkThrough.title",
-			"editorWalkThrough"
-		],
-		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
-			"ViewsWelcomeExtensionPoint.proposedAPI"
-		],
 		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeExtensionPoint": [
 			"contributes.viewsWelcome",
 			"contributes.viewsWelcome.view",
@@ -12210,6 +12312,14 @@
 			"contributes.viewsWelcome.view.when",
 			"contributes.viewsWelcome.view.group",
 			"contributes.viewsWelcome.view.enablement"
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
+			"walkThrough.unboundCommand",
+			"walkThrough.gitNotFound"
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
+			"editorWalkThrough.title",
+			"editorWalkThrough"
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
 			"callFrom",
@@ -12244,12 +12354,6 @@
 			"sortByPosition",
 			"sortByName",
 			"sortByKind"
-		],
-		"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem": [
-			"status.feedback",
-			"status.feedback.name",
-			"status.feedback",
-			"status.feedback"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
 			"stop sync",
@@ -12364,6 +12468,13 @@
 			"delete specific profile",
 			"pick profile to delete"
 		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"contributes.codeActions",
+			"contributes.codeActions.languages",
+			"contributes.codeActions.kind",
+			"contributes.codeActions.title",
+			"contributes.codeActions.description"
+		],
 		"vs/workbench/contrib/userDataProfile/browser/userDataProfileActions": [
 			"create temporary profile",
 			"rename profile",
@@ -12375,6 +12486,19 @@
 			"mange",
 			"cleanup profile",
 			"reset workspaces"
+		],
+		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
+			"contributes.documentation",
+			"contributes.documentation.refactorings",
+			"contributes.documentation.refactoring",
+			"contributes.documentation.refactoring.title",
+			"contributes.documentation.refactoring.when",
+			"contributes.documentation.refactoring.command"
+		],
+		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
+			"codeActionsOnSave.fixAll",
+			"codeActionsOnSave",
+			"codeActionsOnSave.generic"
 		],
 		"vs/workbench/contrib/editSessions/common/editSessions": [
 			"cloud changes",
@@ -12411,26 +12535,6 @@
 			"local copy",
 			"cloud changes",
 			"open file"
-		],
-		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
-			"contributes.documentation",
-			"contributes.documentation.refactorings",
-			"contributes.documentation.refactoring",
-			"contributes.documentation.refactoring.title",
-			"contributes.documentation.refactoring.when",
-			"contributes.documentation.refactoring.command"
-		],
-		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
-			"contributes.codeActions",
-			"contributes.codeActions.languages",
-			"contributes.codeActions.kind",
-			"contributes.codeActions.title",
-			"contributes.codeActions.description"
-		],
-		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
-			"codeActionsOnSave.fixAll",
-			"codeActionsOnSave",
-			"codeActionsOnSave.generic"
 		],
 		"vs/workbench/contrib/timeline/browser/timelinePane": [
 			"timeline.loadingMore",
@@ -12504,6 +12608,12 @@
 			"localHistoryEditorLabel",
 			"localHistoryCompareToFileEditorLabel",
 			"localHistoryCompareToPreviousEditorLabel"
+		],
+		"vs/workbench/contrib/audioCues/browser/commands": [
+			"audioCues.help",
+			"disabled",
+			"audioCues.help.settings",
+			"audioCues.help.placeholder"
 		],
 		"vs/workbench/contrib/workspace/browser/workspaceTrustEditor": [
 			"shieldIcon",
@@ -12612,15 +12722,27 @@
 		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
 			"workspaceTrustEditorInputName"
 		],
-		"vs/workbench/contrib/audioCues/browser/commands": [
-			"audioCues.help",
-			"disabled",
-			"audioCues.help.settings",
-			"audioCues.help.placeholder"
-		],
 		"vs/workbench/contrib/share/browser/shareService": [
 			"shareProviderCount",
 			"type to filter"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibilityConfiguration": [
+			"accessibilityConfigurationTitle",
+			"verbosity.terminal.description",
+			"verbosity.diffEditor.description",
+			"verbosity.chat.description",
+			"verbosity.interactiveEditor.description",
+			"verbosity.inlineCompletions.description",
+			"verbosity.keybindingsEditor.description",
+			"verbosity.notebook",
+			"verbosity.hover",
+			"verbosity.notification",
+			"verbosity.untitledhint",
+			"dimUnfocusedEnabled",
+			"dimUnfocusedOpacity"
+		],
+		"vs/workbench/common/editor/textEditorModel": [
+			"languageAutoDetected"
 		],
 		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
 			{
@@ -12629,14 +12751,6 @@
 					"{0} is the resource that failed to save and {1} the error message"
 				]
 			}
-		],
-		"vs/workbench/common/editor/textEditorModel": [
-			"languageAutoDetected"
-		],
-		"vs/workbench/browser/parts/titlebar/titlebarPart": [
-			"focusTitleBar",
-			"toggle.commandCenter",
-			"toggle.layout"
 		],
 		"vs/workbench/services/configurationResolver/common/variableResolver": [
 			"canNotResolveFile",
@@ -12666,6 +12780,14 @@
 			"overwritingExtension",
 			"extensionUnderDevelopment"
 		],
+		"vs/workbench/contrib/localization/common/localizationsActions": [
+			"configureLocale",
+			"chooseLocale",
+			"installed",
+			"available",
+			"moreInfo",
+			"clearDisplayLanguage"
+		],
 		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
 			"reportExtensionIssue"
 		],
@@ -12680,6 +12802,11 @@
 		],
 		"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote": [
 			"workbench.action.terminal.newLocal"
+		],
+		"vs/workbench/browser/parts/titlebar/titlebarPart": [
+			"focusTitleBar",
+			"toggle.commandCenter",
+			"toggle.layout"
 		],
 		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
 			"ptyHostStatus",
@@ -12722,18 +12849,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/localHistory/browser/localHistory": [
-			"localHistoryIcon",
-			"localHistoryRestore"
-		],
-		"vs/workbench/contrib/localization/common/localizationsActions": [
-			"configureLocale",
-			"chooseLocale",
-			"installed",
-			"available",
-			"moreInfo",
-			"clearDisplayLanguage"
-		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"dotnetCore",
 			"msbuild",
@@ -12758,6 +12873,10 @@
 			"TaskQuickPick.goBack",
 			"TaskQuickPick.noTasksForType",
 			"noProviderForTask"
+		],
+		"vs/workbench/contrib/localHistory/browser/localHistory": [
+			"localHistoryIcon",
+			"localHistoryRestore"
 		],
 		"vs/workbench/contrib/debug/common/abstractDebugAdapter": [
 			"timeout"
@@ -12997,9 +13116,6 @@
 			"configureNotification",
 			"copyNotification"
 		],
-		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
-			"moreActions"
-		],
 		"vs/base/browser/ui/actionbar/actionViewItems": [
 			{
 				"key": "titleLabel",
@@ -13009,50 +13125,8 @@
 				]
 			}
 		],
-		"vs/editor/browser/widget/inlineDiffMargin": [
-			"diff.clipboard.copyDeletedLinesContent.label",
-			"diff.clipboard.copyDeletedLinesContent.single.label",
-			"diff.clipboard.copyChangedLinesContent.label",
-			"diff.clipboard.copyChangedLinesContent.single.label",
-			"diff.clipboard.copyDeletedLineContent.label",
-			"diff.clipboard.copyChangedLineContent.label",
-			"diff.inline.revertChange.label",
-			"diff.clipboard.copyDeletedLineContent.label",
-			"diff.clipboard.copyChangedLineContent.label"
-		],
-		"vs/editor/browser/widget/diffReview": [
-			"diffReviewInsertIcon",
-			"diffReviewRemoveIcon",
-			"diffReviewCloseIcon",
-			"label.close",
-			"no_lines_changed",
-			"one_line_changed",
-			"more_lines_changed",
-			{
-				"key": "header",
-				"comment": [
-					"This is the ARIA label for a git diff header.",
-					"A git diff header looks like this: @@ -154,12 +159,39 @@.",
-					"That encodes that at original line 154 (which is now line 159), 12 lines were removed/changed with 39 lines.",
-					"Variables 0 and 1 refer to the diff index out of total number of diffs.",
-					"Variables 2 and 4 will be numbers (a line number).",
-					"Variables 3 and 5 will be \"no lines changed\", \"1 line changed\" or \"X lines changed\", localized separately."
-				]
-			},
-			"blankLine",
-			{
-				"key": "unchangedLine",
-				"comment": [
-					"The placeholders are contents of the line and should not be translated."
-				]
-			},
-			"equalLine",
-			"insertLine",
-			"deleteLine"
-		],
-		"vs/editor/common/viewLayout/viewLineRenderer": [
-			"showMore",
-			"overflow.chars"
+		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
+			"moreActions"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionCommands": [
 			"args.schema.kind",
@@ -13093,15 +13167,50 @@
 			"hideMoreActions",
 			"showMoreActions"
 		],
-		"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders": [
-			"builtIn",
-			"text.label",
-			"defaultDropProvider.uriList.uris",
-			"defaultDropProvider.uriList.uri",
-			"defaultDropProvider.uriList.paths",
-			"defaultDropProvider.uriList.path",
-			"defaultDropProvider.uriList.relativePaths",
-			"defaultDropProvider.uriList.relativePath"
+		"vs/editor/browser/widget/diffReview": [
+			"diffReviewInsertIcon",
+			"diffReviewRemoveIcon",
+			"diffReviewCloseIcon",
+			"label.close",
+			"no_lines_changed",
+			"one_line_changed",
+			"more_lines_changed",
+			{
+				"key": "header",
+				"comment": [
+					"This is the ARIA label for a git diff header.",
+					"A git diff header looks like this: @@ -154,12 +159,39 @@.",
+					"That encodes that at original line 154 (which is now line 159), 12 lines were removed/changed with 39 lines.",
+					"Variables 0 and 1 refer to the diff index out of total number of diffs.",
+					"Variables 2 and 4 will be numbers (a line number).",
+					"Variables 3 and 5 will be \"no lines changed\", \"1 line changed\" or \"X lines changed\", localized separately."
+				]
+			},
+			"blankLine",
+			{
+				"key": "unchangedLine",
+				"comment": [
+					"The placeholders are contents of the line and should not be translated."
+				]
+			},
+			"equalLine",
+			"insertLine",
+			"deleteLine"
+		],
+		"vs/editor/browser/widget/inlineDiffMargin": [
+			"diff.clipboard.copyDeletedLinesContent.label",
+			"diff.clipboard.copyDeletedLinesContent.single.label",
+			"diff.clipboard.copyChangedLinesContent.label",
+			"diff.clipboard.copyChangedLinesContent.single.label",
+			"diff.clipboard.copyDeletedLineContent.label",
+			"diff.clipboard.copyChangedLineContent.label",
+			"diff.inline.revertChange.label",
+			"diff.clipboard.copyDeletedLineContent.label",
+			"diff.clipboard.copyChangedLineContent.label"
+		],
+		"vs/editor/common/viewLayout/viewLineRenderer": [
+			"showMore",
+			"overflow.chars"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
 			"pasteWidgetVisible",
@@ -13114,6 +13223,16 @@
 			"dropWidgetVisible",
 			"postDropWidgetTitle",
 			"dropIntoEditorProgress"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders": [
+			"builtIn",
+			"text.label",
+			"defaultDropProvider.uriList.uris",
+			"defaultDropProvider.uriList.uri",
+			"defaultDropProvider.uriList.paths",
+			"defaultDropProvider.uriList.path",
+			"defaultDropProvider.uriList.relativePaths",
+			"defaultDropProvider.uriList.relativePath"
 		],
 		"vs/editor/contrib/find/browser/findWidget": [
 			"findSelectionIcon",
@@ -13171,8 +13290,8 @@
 			"action.inlineSuggest.hide",
 			"action.inlineSuggest.alwaysShowToolbar"
 		],
-		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
-			"inlineSuggestionFollows"
+		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController": [
+			"showAccessibleViewHint"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/peek/referencesController": [
 			"referenceSearchVisible",
@@ -13194,13 +13313,36 @@
 			"aria.result.n1",
 			"aria.result.nm"
 		],
+		"vs/editor/contrib/message/browser/messageController": [
+			"messageVisible"
+		],
 		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
 			"hasSymbols",
 			"location.kb",
 			"location"
 		],
-		"vs/editor/contrib/message/browser/messageController": [
-			"messageVisible"
+		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
+			"inlineSuggestionFollows"
+		],
+		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget": [
+			"parameterHintsNextIcon",
+			"parameterHintsPreviousIcon",
+			{
+				"key": "content",
+				"comment": [
+					"A label",
+					"A keybinding"
+				]
+			},
+			"previous",
+			"next"
+		],
+		"vs/editor/contrib/hover/browser/markerHoverParticipant": [
+			"view problem",
+			"noQuickFixes",
+			"checkingForQuickFixes",
+			"noQuickFixes",
+			"quick fixes"
 		],
 		"vs/editor/contrib/gotoError/browser/gotoErrorWidget": [
 			"Error",
@@ -13223,25 +13365,22 @@
 			"stopped rendering",
 			"too many characters"
 		],
-		"vs/editor/contrib/hover/browser/markerHoverParticipant": [
-			"view problem",
-			"noQuickFixes",
-			"checkingForQuickFixes",
-			"noQuickFixes",
-			"quick fixes"
+		"vs/editor/contrib/wordHighlighter/browser/highlightDecorations": [
+			"wordHighlight",
+			"wordHighlightStrong",
+			"wordHighlightText",
+			"wordHighlightBorder",
+			"wordHighlightStrongBorder",
+			"wordHighlightTextBorder",
+			"overviewRulerWordHighlightForeground",
+			"overviewRulerWordHighlightStrongForeground",
+			"overviewRulerWordHighlightTextForeground"
 		],
-		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget": [
+		"vs/editor/contrib/parameterHints/browser/parameterHintsWidget": [
 			"parameterHintsNextIcon",
 			"parameterHintsPreviousIcon",
-			{
-				"key": "content",
-				"comment": [
-					"A label",
-					"A keybinding"
-				]
-			},
-			"previous",
-			"next"
+			"hint",
+			"editorHoverWidgetHighlightForeground"
 		],
 		"vs/editor/contrib/inlayHints/browser/inlayHintsHover": [
 			"hint.dbl",
@@ -13253,16 +13392,15 @@
 			"hint.def",
 			"hint.cmd"
 		],
-		"vs/editor/contrib/wordHighlighter/browser/highlightDecorations": [
-			"wordHighlight",
-			"wordHighlightStrong",
-			"wordHighlightText",
-			"wordHighlightBorder",
-			"wordHighlightStrongBorder",
-			"wordHighlightTextBorder",
-			"overviewRulerWordHighlightForeground",
-			"overviewRulerWordHighlightStrongForeground",
-			"overviewRulerWordHighlightTextForeground"
+		"vs/editor/contrib/rename/browser/renameInputField": [
+			"renameInputVisible",
+			"renameAriaLabel",
+			{
+				"key": "label",
+				"comment": [
+					"placeholders are keybindings, e.g \"F2 to Rename, Shift+F2 to Preview\""
+				]
+			}
 		],
 		"vs/editor/contrib/stickyScroll/browser/stickyScrollActions": [
 			"toggleStickyScroll",
@@ -13309,11 +13447,8 @@
 			"label.desc",
 			"ariaCurrenttSuggestionReadDetails"
 		],
-		"vs/editor/contrib/parameterHints/browser/parameterHintsWidget": [
-			"parameterHintsNextIcon",
-			"parameterHintsPreviousIcon",
-			"hint",
-			"editorHoverWidgetHighlightForeground"
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"errorMessage"
 		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
 			"schema.token.settings",
@@ -13359,9 +13494,6 @@
 			"async",
 			"readonly"
 		],
-		"vs/workbench/api/browser/mainThreadWebviews": [
-			"errorMessage"
-		],
 		"vs/workbench/browser/parts/editor/textEditor": [
 			"editor"
 		],
@@ -13392,16 +13524,6 @@
 			"collapseAll",
 			"expandAll"
 		],
-		"vs/editor/contrib/rename/browser/renameInputField": [
-			"renameInputVisible",
-			"renameAriaLabel",
-			{
-				"key": "label",
-				"comment": [
-					"placeholders are keybindings, e.g \"F2 to Rename, Shift+F2 to Preview\""
-				]
-			}
-		],
 		"vs/workbench/contrib/comments/browser/commentsTreeViewer": [
 			"comments.view.title",
 			"commentsCount",
@@ -13412,8 +13534,52 @@
 			"commentRange",
 			"lastReplyFrom"
 		],
+		"vs/workbench/contrib/testing/common/testResult": [
+			"runFinished"
+		],
+		"vs/workbench/browser/parts/compositeBarActions": [
+			"titleKeybinding",
+			"badgeTitle",
+			"additionalViews",
+			"numberBadge",
+			"manageExtension",
+			"hide",
+			"keep",
+			"hideBadge",
+			"showBadge",
+			"toggle",
+			"toggleBadge"
+		],
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"collapse all"
+		],
+		"vs/workbench/browser/parts/views/checkbox": [
+			"checked",
+			"unchecked"
+		],
+		"vs/base/browser/ui/splitview/paneview": [
+			"viewSection"
+		],
+		"vs/workbench/contrib/remote/browser/remoteIcons": [
+			"getStartedIcon",
+			"documentationIcon",
+			"feedbackIcon",
+			"reviewIssuesIcon",
+			"reportIssuesIcon",
+			"remoteExplorerViewIcon",
+			"portsViewIcon",
+			"portIcon",
+			"privatePortIcon",
+			"forwardPortIcon",
+			"stopForwardIcon",
+			"openBrowserIcon",
+			"openPreviewIcon",
+			"copyAddressIcon",
+			"labelPortIcon",
+			"forwardedPortWithoutProcessIcon",
+			"forwardedPortWithProcessIcon"
+		],
 		"vs/workbench/contrib/remote/browser/tunnelView": [
-			"tunnel.forwardedPortsViewEnabled",
 			"remote.tunnelsView.addPort",
 			"tunnelPrivacy.private",
 			"tunnel.portColumn.label",
@@ -13452,6 +13618,7 @@
 			"remote.tunnel.forwardItem",
 			"remote.tunnel.forwardPrompt",
 			"remote.tunnel.forwardError",
+			"remote.tunnel.forwardErrorProvided",
 			"remote.tunnel.closeNoPorts",
 			"remote.tunnel.close",
 			"remote.tunnel.closePlaceholder",
@@ -13473,50 +13640,32 @@
 			"tunnelContext.protocolMenu",
 			"portWithRunningProcess.foreground"
 		],
-		"vs/workbench/contrib/testing/common/testResult": [
-			"runFinished"
+		"vs/workbench/browser/parts/editor/tabsTitleControl": [
+			"ariaLabelTabActions"
 		],
-		"vs/workbench/browser/parts/compositeBarActions": [
-			"titleKeybinding",
-			"badgeTitle",
-			"additionalViews",
-			"numberBadge",
-			"manageExtension",
-			"hide",
-			"keep",
-			"hideBadge",
-			"showBadge",
-			"toggle",
-			"toggleBadge"
-		],
-		"vs/base/browser/ui/splitview/paneview": [
-			"viewSection"
-		],
-		"vs/base/browser/ui/tree/treeDefaults": [
-			"collapse all"
-		],
-		"vs/workbench/browser/parts/views/checkbox": [
-			"checked",
-			"unchecked"
-		],
-		"vs/workbench/contrib/remote/browser/remoteIcons": [
-			"getStartedIcon",
-			"documentationIcon",
-			"feedbackIcon",
-			"reviewIssuesIcon",
-			"reportIssuesIcon",
-			"remoteExplorerViewIcon",
-			"portsViewIcon",
-			"portIcon",
-			"privatePortIcon",
-			"forwardPortIcon",
-			"stopForwardIcon",
-			"openBrowserIcon",
-			"openPreviewIcon",
-			"copyAddressIcon",
-			"labelPortIcon",
-			"forwardedPortWithoutProcessIcon",
-			"forwardedPortWithProcessIcon"
+		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
+			"watermark.showCommands",
+			"watermark.quickAccess",
+			"watermark.openFile",
+			"watermark.openFolder",
+			"watermark.openFileFolder",
+			"watermark.openRecent",
+			"watermark.newUntitledFile",
+			"watermark.findInFiles",
+			{
+				"key": "watermark.toggleTerminal",
+				"comment": [
+					"toggle is a verb here"
+				]
+			},
+			"watermark.startDebugging",
+			{
+				"key": "watermark.toggleFullscreen",
+				"comment": [
+					"toggle is a verb here"
+				]
+			},
+			"watermark.showSettings"
 		],
 		"vs/workbench/browser/parts/editor/textCodeEditor": [
 			"textEditor"
@@ -13525,6 +13674,21 @@
 			"binaryEditor",
 			"binaryError",
 			"openAnyway"
+		],
+		"vs/workbench/browser/parts/editor/editorPanes": [
+			"editorOpenErrorDialog",
+			{
+				"key": "ok",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/browser/widget/diffEditor.contribution": [
+			"accessibleDiffViewer",
+			"editor.action.accessibleDiffViewer.next",
+			"Open Accessible Diff Viewer",
+			"editor.action.accessibleDiffViewer.prev"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
 			"loading",
@@ -13621,70 +13785,19 @@
 				]
 			}
 		],
-		"vs/editor/browser/widget/diffEditor.contribution": [
-			"accessibleDiffViewer",
-			"editor.action.accessibleDiffViewer.next",
-			"Open Accessible Diff Viewer",
-			"editor.action.accessibleDiffViewer.prev"
-		],
 		"vs/workbench/browser/parts/compositePart": [
 			"ariaCompositeToolbarLabel",
 			"viewsAndMoreActions",
 			"titleTooltip"
 		],
-		"vs/base/browser/ui/toolbar/toolbar": [
-			"moreActions"
-		],
 		"vs/workbench/browser/parts/sidebar/sidebarActions": [
 			"focusSideBar"
 		],
-		"vs/workbench/browser/parts/editor/tabsTitleControl": [
-			"ariaLabelTabActions"
-		],
-		"vs/workbench/browser/parts/editor/editorPanes": [
-			"editorOpenErrorDialog",
-			{
-				"key": "ok",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
-			"watermark.showCommands",
-			"watermark.quickAccess",
-			"watermark.openFile",
-			"watermark.openFolder",
-			"watermark.openFileFolder",
-			"watermark.openRecent",
-			"watermark.newUntitledFile",
-			"watermark.findInFiles",
-			{
-				"key": "watermark.toggleTerminal",
-				"comment": [
-					"toggle is a verb here"
-				]
-			},
-			"watermark.startDebugging",
-			{
-				"key": "watermark.toggleFullscreen",
-				"comment": [
-					"toggle is a verb here"
-				]
-			},
-			"watermark.showSettings"
+		"vs/base/browser/ui/toolbar/toolbar": [
+			"moreActions"
 		],
 		"vs/base/browser/ui/iconLabel/iconLabelHover": [
 			"iconLabel.loading"
-		],
-		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
-			"default",
-			"extension",
-			"user",
-			"cat.title",
-			"cat.title",
-			"option",
-			"meta"
 		],
 		"vs/workbench/services/preferences/common/preferencesValidation": [
 			"validations.booleanIncorrectType",
@@ -13716,6 +13829,15 @@
 			"validations.objectIncorrectType",
 			"validations.objectPattern"
 		],
+		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
+			"default",
+			"extension",
+			"user",
+			"cat.title",
+			"cat.title",
+			"option",
+			"meta"
+		],
 		"vs/editor/common/model/editStack": [
 			"edit"
 		],
@@ -13727,12 +13849,7 @@
 				]
 			}
 		],
-		"vs/platform/quickinput/browser/quickInput": [
-			"quickInput.back",
-			"inputModeEntry",
-			"quickInput.steps",
-			"quickInputBox.ariaLabel",
-			"inputModeEntryDescription",
+		"vs/platform/quickinput/browser/quickInputController": [
 			"quickInput.checkAll",
 			{
 				"key": "quickInput.visibleCount",
@@ -13751,6 +13868,10 @@
 			"quickInput.backWithKeybinding",
 			"quickInput.back"
 		],
+		"vs/base/browser/ui/hover/hoverWidget": [
+			"acessibleViewHint",
+			"acessibleViewHintNoKbOpen"
+		],
 		"vs/workbench/services/textMate/common/TMGrammars": [
 			"vscode.extension.contributes.grammars",
 			"vscode.extension.contributes.grammars.language",
@@ -13764,6 +13885,36 @@
 		],
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"unbound"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"folderSettings",
+			"settingsSwitcherBarAriaLabel",
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"userSettings",
+			"workspaceSettings"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
+			"editTtile",
+			"replaceDefaultValue",
+			"copyDefaultValue",
+			"unsupportedPolicySetting",
+			"unsupportLanguageOverrideSetting",
+			"defaultProfileSettingWhileNonDefaultActive",
+			"allProfileSettingWhileInNonDefaultProfileSetting",
+			"unsupportedRemoteMachineSetting",
+			"unsupportedWindowSetting",
+			"unsupportedApplicationSetting",
+			"unsupportedMachineSetting",
+			"untrustedSetting",
+			"unknown configuration setting",
+			"manage workspace trust",
+			"manage workspace trust",
+			"unsupportedProperty"
 		],
 		"vs/workbench/contrib/preferences/common/settingsEditorColorRegistry": [
 			"headerForeground",
@@ -13787,24 +13938,6 @@
 			"focusedRowBackground",
 			"settings.rowHoverBackground",
 			"settings.focusedRowBorder"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
-			"editTtile",
-			"replaceDefaultValue",
-			"copyDefaultValue",
-			"unsupportedPolicySetting",
-			"unsupportLanguageOverrideSetting",
-			"defaultProfileSettingWhileNonDefaultActive",
-			"allProfileSettingWhileInNonDefaultProfileSetting",
-			"unsupportedRemoteMachineSetting",
-			"unsupportedWindowSetting",
-			"unsupportedApplicationSetting",
-			"unsupportedMachineSetting",
-			"untrustedSetting",
-			"unknown configuration setting",
-			"manage workspace trust",
-			"manage workspace trust",
-			"unsupportedProperty"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsLayout": [
 			"commonlyUsed",
@@ -13856,38 +13989,6 @@
 			"security",
 			"workspace"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
-			"userSettings",
-			"userSettingsRemote",
-			"workspaceSettings",
-			"folderSettings",
-			"settingsSwitcherBarAriaLabel",
-			"userSettings",
-			"userSettingsRemote",
-			"workspaceSettings",
-			"userSettings",
-			"workspaceSettings"
-		],
-		"vs/workbench/contrib/preferences/browser/settingsTree": [
-			"extensions",
-			"modified",
-			"settingsContextMenuTitle",
-			"newExtensionsButtonLabel",
-			"editInSettingsJson",
-			"editLanguageSettingLabel",
-			"settings.Default",
-			"modified",
-			"showExtension",
-			"resetSettingLabel",
-			"validationError",
-			"validationError",
-			"settings.Modified",
-			"settings",
-			"copySettingIdLabel",
-			"copySettingAsJSONLabel",
-			"stopSyncingSetting",
-			"applyToAllProfiles"
-		],
 		"vs/workbench/contrib/preferences/browser/tocTree": [
 			{
 				"key": "settingsTOC",
@@ -13912,6 +14013,26 @@
 			"onlineSettingsSearchTooltip",
 			"policySettingsSearch",
 			"policySettingsSearchTooltip"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsTree": [
+			"extensions",
+			"modified",
+			"settingsContextMenuTitle",
+			"newExtensionsButtonLabel",
+			"editInSettingsJson",
+			"editLanguageSettingLabel",
+			"settings.Default",
+			"modified",
+			"showExtension",
+			"resetSettingLabel",
+			"validationError",
+			"validationError",
+			"settings.Modified",
+			"settings",
+			"copySettingIdLabel",
+			"copySettingAsJSONLabel",
+			"stopSyncingSetting",
+			"applyToAllProfiles"
 		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView": [
 			"notebookActions.selectKernel",
@@ -13991,22 +14112,6 @@
 			},
 			"webview title"
 		],
-		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
-			"fileWorkingCopyCreate.source",
-			"fileWorkingCopyReplace.source",
-			"fileWorkingCopyDecorations",
-			"readonlyAndDeleted",
-			"readonly",
-			"deleted",
-			"confirmOverwrite",
-			"irreversible",
-			{
-				"key": "replaceButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy": [
 			"current1",
 			"current2",
@@ -14025,12 +14130,25 @@
 			"kernels.detecting",
 			"select"
 		],
-		"vs/workbench/contrib/comments/common/commentContextKeys": [
-			"commentThreadIsEmpty",
-			"commentIsEmpty",
-			"comment",
-			"commentThread",
-			"commentController"
+		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
+			"fileWorkingCopyCreate.source",
+			"fileWorkingCopyReplace.source",
+			"fileWorkingCopyDecorations",
+			"readonlyAndDeleted",
+			"readonly",
+			"deleted",
+			"confirmOverwrite",
+			"irreversible",
+			{
+				"key": "replaceButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/platform/actions/browser/toolbar": [
+			"hide",
+			"resetThisMenu"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/cellOperations": [
 			"notebookActions.joinSelectedCells",
@@ -14047,6 +14165,13 @@
 		"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider": [
 			"empty"
 		],
+		"vs/workbench/contrib/comments/common/commentContextKeys": [
+			"commentThreadIsEmpty",
+			"commentIsEmpty",
+			"comment",
+			"commentThread",
+			"commentController"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
 			"chat.overview",
 			"chat.requestHistory",
@@ -14059,6 +14184,8 @@
 			"workbench.action.interactiveSession.focusInputNoKb",
 			"workbench.action.chat.nextCodeBlock",
 			"workbench.action.chat.nextCodeBlockNoKb",
+			"workbench.action.chat.nextFileTree",
+			"workbench.action.chat.nextFileTreeNoKb",
 			"workbench.action.chat.clear",
 			"workbench.action.chat.clearNoKb",
 			"inlineChat.overview",
@@ -14071,19 +14198,7 @@
 			"inlineChat.diff",
 			"inlineChat.diffNoKb",
 			"inlineChat.toolbar",
-			"chat.audioCues",
-			"chat-help-label",
-			"inline-chat-label"
-		],
-		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/quickQuestionAction": [
-			"chat"
-		],
-		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/multipleByScrollQuickQuestionAction": [
-			"clear",
-			"openInChat"
-		],
-		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/singleQuickQuestionAction": [
-			"askabot"
+			"chat.audioCues"
 		],
 		"vs/workbench/contrib/chat/browser/chatInputPart": [
 			"actions.chat.accessibiltyHelp",
@@ -14092,6 +14207,10 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatListRenderer": [
 			"chat",
+			"commandFollowUpInfo",
+			"commandFollowUpInfoMany",
+			"singleFileTreeHint",
+			"multiFileTreeHint",
 			"noCodeBlocksHint",
 			"noCodeBlocks",
 			"singleCodeBlockHint",
@@ -14101,23 +14220,17 @@
 			"chat.codeBlockHelp",
 			"chat.codeBlock.toolbarVerbose",
 			"chat.codeBlock.toolbar",
-			"chat.codeBlockLabel"
+			"chat.codeBlockLabel",
+			"treeAriaLabel"
+		],
+		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys": [
+			"inlineSuggestionVisible",
+			"inlineSuggestionHasIndentation",
+			"inlineSuggestionHasIndentationLessThanTabSize",
+			"suppressSuggestions"
 		],
 		"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget": [
 			"exited slash command mode"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
-			"lines.0",
-			"lines.1",
-			"lines.N"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
-			"aria-label",
-			"original",
-			"modified",
-			"inlineChat.accessibilityHelp",
-			"inlineChat.accessibilityHelpNoKb",
-			"inlineChatClosed"
 		],
 		"vs/workbench/contrib/testing/browser/theme": [
 			"testing.iconFailed",
@@ -14133,6 +14246,11 @@
 			"testing.message.error.marginBackground",
 			"testing.message.info.decorationForeground",
 			"testing.message.info.marginBackground"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
+			"lines.0",
+			"lines.1",
+			"lines.N"
 		],
 		"vs/workbench/contrib/testing/common/constants": [
 			"testState.errored",
@@ -14164,12 +14282,13 @@
 			"testing.filters.showExcludedTests",
 			"testing.filters.removeTestExclusions"
 		],
-		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
-			"terminal.integrated.copySelection.noSelection",
-			"yes",
-			"no",
-			"dontShowAgain",
-			"terminal.slowRendering"
+		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
+			"aria-label",
+			"original",
+			"modified",
+			"inlineChat.accessibilityHelp",
+			"inlineChat.accessibilityHelpNoKb",
+			"inlineChatClosed"
 		],
 		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
 			"terminal.background",
@@ -14193,6 +14312,13 @@
 			"terminal.dragAndDropBackground",
 			"terminal.tab.activeBorder",
 			"terminal.ansiColor"
+		],
+		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
+			"terminal.integrated.copySelection.noSelection",
+			"yes",
+			"no",
+			"dontShowAgain",
+			"terminal.slowRendering"
 		],
 		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
 			"canNotResolve",
@@ -14328,13 +14454,6 @@
 			"field",
 			"constant"
 		],
-		"vs/workbench/contrib/search/browser/replaceService": [
-			"searchReplace.source",
-			"fileReplaceChanges"
-		],
-		"vs/workbench/contrib/search/browser/searchFindInput": [
-			"searchFindInputNotebookFilter.label"
-		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
 			"bulkEdit",
 			"aria.renameAndEdit",
@@ -14362,10 +14481,6 @@
 			"noResults",
 			"searchMaxResultsWarning"
 		],
-		"vs/platform/actions/browser/toolbar": [
-			"hide",
-			"resetThisMenu"
-		],
 		"vs/workbench/contrib/scm/browser/dirtyDiffSwitcher": [
 			"remotes",
 			"quickDiff.base.switch"
@@ -14376,13 +14491,20 @@
 		"vs/workbench/contrib/debug/browser/baseDebugView": [
 			"debug.lazyButton.tooltip"
 		],
-		"vs/workbench/contrib/debug/common/loadedScriptsPicker": [
-			"moveFocusedView.selectView"
-		],
 		"vs/workbench/contrib/debug/browser/debugSessionPicker": [
 			"moveFocusedView.selectView",
 			"workbench.action.debug.startDebug",
 			"workbench.action.debug.spawnFrom"
+		],
+		"vs/workbench/contrib/search/browser/searchFindInput": [
+			"searchFindInputNotebookFilter.label"
+		],
+		"vs/workbench/contrib/debug/common/loadedScriptsPicker": [
+			"moveFocusedView.selectView"
+		],
+		"vs/workbench/contrib/search/browser/replaceService": [
+			"searchReplace.source",
+			"fileReplaceChanges"
 		],
 		"vs/workbench/contrib/debug/browser/debugAdapterManager": [
 			"debugNoType",
@@ -14442,9 +14564,6 @@
 			"taskNotTrackedWithTaskId",
 			"taskNotTracked"
 		],
-		"vs/workbench/contrib/debug/common/debugSource": [
-			"unknownSource"
-		],
 		"vs/workbench/contrib/debug/browser/debugSession": [
 			"noDebugAdapter",
 			"noDebugAdapter",
@@ -14486,6 +14605,9 @@
 			"debuggingStarted",
 			"debuggingStopped"
 		],
+		"vs/workbench/contrib/debug/common/debugSource": [
+			"unknownSource"
+		],
 		"vs/base/browser/ui/findinput/replaceInput": [
 			"defaultLabel",
 			"label.preserveCaseToggle"
@@ -14502,10 +14624,6 @@
 			"messageColumnLabel",
 			"fileColumnLabel",
 			"sourceColumnLabel"
-		],
-		"vs/workbench/contrib/comments/browser/commentsController": [
-			"hasCommentingRange",
-			"pickCommentService"
 		],
 		"vs/workbench/contrib/mergeEditor/common/mergeEditor": [
 			"is",
@@ -14593,15 +14711,13 @@
 			},
 			"noMoreWarn"
 		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
+			"base",
+			"compareWith",
+			"compareWithTooltip"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/view/viewModel": [
 			"noConflictMessage"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
-			"result",
-			"mergeEditor.remainingConflicts",
-			"mergeEditor.remainingConflict",
-			"goToNextConflict",
-			"allConflictHandled"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView": [
 			"input1",
@@ -14615,6 +14731,13 @@
 			"accept.conflicting",
 			"accept.first",
 			"accept.second"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
+			"result",
+			"mergeEditor.remainingConflicts",
+			"mergeEditor.remainingConflict",
+			"goToNextConflict",
+			"allConflictHandled"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/colors": [
 			"mergeEditor.change.background",
@@ -14631,8 +14754,21 @@
 			"mergeEditor.conflict.input1.background",
 			"mergeEditor.conflict.input2.background"
 		],
+		"vs/workbench/contrib/comments/browser/commentsController": [
+			"hasCommentingRange",
+			"pickCommentService"
+		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
 			"builtinProviderDisplayName"
+		],
+		"vs/platform/files/browser/htmlFileSystemProvider": [
+			"fileSystemRenameError",
+			"fileSystemNotAllowedError"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
+			"error",
+			"Unknown Extension",
+			"extensions"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"ratedLabel",
@@ -14660,19 +14796,9 @@
 			"extensionPreReleaseForeground",
 			"extensionIcon.sponsorForeground"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
-			"base",
-			"compareWith",
-			"compareWithTooltip"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
-			"error",
-			"Unknown Extension",
-			"extensions"
-		],
-		"vs/platform/files/browser/htmlFileSystemProvider": [
-			"fileSystemRenameError",
-			"fileSystemNotAllowedError"
+		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
+			"fileBasedRecommendation",
+			"languageName"
 		],
 		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
 			"exeBasedRecommendation"
@@ -14680,23 +14806,11 @@
 		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
 			"workspaceRecommendation"
 		],
-		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
-			"searchMarketplace",
-			"fileBasedRecommendation",
-			"languageName",
-			"showLanguageExtensions",
-			"dontShowAgainExtension"
-		],
-		"vs/workbench/contrib/extensions/browser/webRecommendations": [
-			"reason"
-		],
 		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
 			"exeBasedRecommendation"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
-			"workbench.action.terminal.newplus",
-			"workbench.action.terminal.newWithProfilePlus",
-			"renameTerminal"
+		"vs/workbench/contrib/extensions/browser/webRecommendations": [
+			"reason"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
 			"showTerminalTabs",
@@ -14706,7 +14820,6 @@
 			"workbench.action.terminal.createTerminalEditor",
 			"workbench.action.terminal.createTerminalEditor",
 			"workbench.action.terminal.createTerminalEditorSide",
-			"workbench.action.terminal.showTabs",
 			"workbench.action.terminal.focusPreviousPane",
 			"workbench.action.terminal.focusNextPane",
 			"workbench.action.terminal.runRecentCommand",
@@ -14780,6 +14893,37 @@
 			"workbench.action.terminal.newWorkspacePlaceholder",
 			"workbench.action.terminal.rename.prompt"
 		],
+		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
+			"workbench.action.terminal.newplus",
+			"workbench.action.terminal.newWithProfilePlus",
+			"renameTerminal"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalIcons": [
+			"terminalViewIcon",
+			"renameTerminalIcon",
+			"killTerminalIcon",
+			"newTerminalIcon",
+			"configureTerminalProfileIcon",
+			"terminalDecorationMark",
+			"terminalDecorationIncomplete",
+			"terminalDecorationError",
+			"terminalDecorationSuccess",
+			"terminalCommandHistoryRemove",
+			"terminalCommandHistoryOutput",
+			"terminalCommandHistoryFuzzySearch"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"terminalService.terminalCloseConfirmationSingular",
+			"terminalService.terminalCloseConfirmationPlural",
+			{
+				"key": "terminate",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"localTerminalVirtualWorkspace",
+			"localTerminalRemote"
+		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
 			"cwd",
 			"cwdFolder",
@@ -14842,6 +14986,7 @@
 			"terminal.integrated.fontWeightBold",
 			"terminal.integrated.cursorBlinking",
 			"terminal.integrated.cursorStyle",
+			"terminal.integrated.cursorStyleInactive",
 			"terminal.integrated.cursorWidth",
 			"terminal.integrated.scrollback",
 			"terminal.integrated.detectLocale",
@@ -14910,6 +15055,10 @@
 			"terminal.integrated.persistentSessionReviveProcess.onExit",
 			"terminal.integrated.persistentSessionReviveProcess.onExitAndWindowClose",
 			"terminal.integrated.persistentSessionReviveProcess.never",
+			"terminal.integrated.hideOnStartup",
+			"hideOnStartup.never",
+			"hideOnStartup.whenEmpty",
+			"hideOnStartup.always",
 			"terminal.integrated.customGlyphs",
 			"terminal.integrated.autoReplies",
 			"terminal.integrated.autoReplies.reply",
@@ -14922,33 +15071,12 @@
 			"terminal.integrated.shellIntegration.history",
 			"terminal.integrated.shellIntegration.suggestEnabled",
 			"terminal.integrated.smoothScrolling",
-			"terminal.integrated.enableImages"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalService": [
-			"terminalService.terminalCloseConfirmationSingular",
-			"terminalService.terminalCloseConfirmationPlural",
-			{
-				"key": "terminate",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"localTerminalVirtualWorkspace",
-			"localTerminalRemote"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalIcons": [
-			"terminalViewIcon",
-			"renameTerminalIcon",
-			"killTerminalIcon",
-			"newTerminalIcon",
-			"configureTerminalProfileIcon",
-			"terminalDecorationMark",
-			"terminalDecorationIncomplete",
-			"terminalDecorationError",
-			"terminalDecorationSuccess",
-			"terminalCommandHistoryRemove",
-			"terminalCommandHistoryOutput",
-			"terminalCommandHistoryFuzzySearch"
+			"terminal.integrated.ignoreBracketedPasteMode",
+			"terminal.integrated.enableImages",
+			"terminal.integrated.focusAfterRun",
+			"terminal.integrated.focusAfterRun.terminal",
+			"terminal.integrated.focusAfterRun.accessible-buffer",
+			"terminal.integrated.focusAfterRun.none"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalMenus": [
 			{
@@ -14979,7 +15107,6 @@
 			"workbench.action.terminal.copySelectionAsHtml",
 			"workbench.action.terminal.paste.short",
 			"workbench.action.terminal.clear",
-			"workbench.action.terminal.showsTabs",
 			"workbench.action.terminal.selectAll",
 			"workbench.action.terminal.copySelection.short",
 			"workbench.action.terminal.copySelectionAsHtml",
@@ -14995,7 +15122,6 @@
 			"workbench.action.terminal.clearLong",
 			"workbench.action.terminal.runActiveFile",
 			"workbench.action.terminal.runSelectedText",
-			"workbench.action.terminal.sizeToContentWidthInstance",
 			"workbench.action.terminal.renameInstance",
 			"workbench.action.terminal.changeIcon",
 			"workbench.action.terminal.changeColor",
@@ -15014,6 +15140,7 @@
 			"previousSessionCategory",
 			"terminalCategory",
 			"workbench.action.terminal.focus",
+			"workbench.action.terminal.focusAndHideAccessibleBuffer",
 			"killTerminal",
 			"killTerminal.short",
 			"moveToEditor",
@@ -15033,25 +15160,7 @@
 		"vs/platform/terminal/common/terminalLogService": [
 			"terminalLoggerName"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
-			"moveTabsRight",
-			"moveTabsLeft",
-			"hideTabs"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
-			"shellIntegration.enabled",
-			"launchFailed.exitCodeOnlyShellIntegration",
-			"shellIntegration.activationFailed",
-			{
-				"key": "shellProcessTooltip.processId",
-				"comment": [
-					"The first arg is \"PID\" which shouldn't be translated"
-				]
-			},
-			"shellProcessTooltip.commandLine"
-		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
-			"terminal-help-label",
 			"focusAccessibleBuffer",
 			"focusAccessibleBufferNoKb",
 			"commandPromptMigration",
@@ -15072,11 +15181,29 @@
 			"openDetectedLinkNoKb",
 			"newWithProfile",
 			"newWithProfileNoKb",
+			"focusAfterRun",
 			"accessibilitySettings"
 		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer": [
 			"terminal.integrated.accessibleBuffer",
 			"terminal.integrated.symbolQuickPick.labelNoExitCode"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
+			"moveTabsRight",
+			"moveTabsLeft",
+			"hideTabs"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
+			"shellIntegration.enabled",
+			"launchFailed.exitCodeOnlyShellIntegration",
+			"shellIntegration.activationFailed",
+			{
+				"key": "shellProcessTooltip.processId",
+				"comment": [
+					"The first arg is \"PID\" which shouldn't be translated"
+				]
+			},
+			"shellProcessTooltip.commandLine"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
 			"terminalLinkHandler.followLinkAlt.mac",
@@ -15088,27 +15215,28 @@
 			"followLinkUrl"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick": [
+			"terminal.integrated.urlLinks",
+			"terminal.integrated.localFileLinks",
+			"terminal.integrated.localFolderLinks",
+			"terminal.integrated.searchLinks",
 			"terminal.integrated.openDetectedLink",
 			"terminal.integrated.urlLinks",
 			"terminal.integrated.localFileLinks",
-			"terminal.integrated.searchLinks",
-			"terminal.integrated.showMoreLinks"
+			"terminal.integrated.localFolderLinks",
+			"terminal.integrated.searchLinks"
 		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
 			"quickFix.command",
 			"quickFix.opener",
 			"codeAction.widget.id.quickfix"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
-			"terminal.freePort",
-			"terminal.createPR"
-		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
 			"vscode.extension.contributes.terminalQuickFixes",
 			"vscode.extension.contributes.terminalQuickFixes.id",
 			"vscode.extension.contributes.terminalQuickFixes.commandLineMatcher",
 			"vscode.extension.contributes.terminalQuickFixes.outputMatcher",
-			"vscode.extension.contributes.terminalQuickFixes.commandExitResult"
+			"vscode.extension.contributes.terminalQuickFixes.commandExitResult",
+			"vscode.extension.contributes.terminalQuickFixes.kind"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
 			"JsonSchema.options",
@@ -15174,17 +15302,16 @@
 			"JsonSchema.input.command.args",
 			"JsonSchema.input.command.args"
 		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
+			"terminal.freePort",
+			"terminal.createPR"
+		],
 		"vs/workbench/contrib/remote/browser/explorerViewItems": [
 			"remotes",
 			"remote.explorer.switch"
 		],
 		"vs/workbench/contrib/snippets/browser/commands/abstractSnippetsActions": [
 			"snippets"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsFile": [
-			"source.workspaceSnippetGlobal",
-			"source.userSnippetGlobal",
-			"source.userSnippet"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetPicker": [
 			"sep.userSnippet",
@@ -15194,6 +15321,11 @@
 			"enable.snippet",
 			"pick.placeholder",
 			"pick.noSnippetAvailable"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsFile": [
+			"source.workspaceSnippetGlobal",
+			"source.userSnippetGlobal",
+			"source.userSnippet"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetCompletionProvider": [
 			"detail.snippet",
@@ -15341,6 +15473,18 @@
 			"gettingStarted.notebookProfile.title",
 			"gettingStarted.notebookProfile.description"
 		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
+			"gettingStarted.featuredTitle"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
+			"welcomePage.background",
+			"welcomePage.tileBackground",
+			"welcomePage.tileHoverBackground",
+			"welcomePage.tileBorder",
+			"welcomePage.progress.background",
+			"welcomePage.progress.foreground",
+			"walkthrough.stepTitle.foreground"
+		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedExtensionPoint": [
 			"title",
 			"walkthroughs",
@@ -15379,18 +15523,6 @@
 			"walkthroughs.steps.doneOn.deprecation",
 			"walkthroughs.steps.oneOn.command",
 			"walkthroughs.steps.when"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
-			"gettingStarted.featuredTitle"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
-			"welcomePage.background",
-			"welcomePage.tileBackground",
-			"welcomePage.tileHoverBackground",
-			"welcomePage.tileBorder",
-			"welcomePage.progress.background",
-			"welcomePage.progress.foreground",
-			"walkthrough.stepTitle.foreground"
 		],
 		"vs/workbench/contrib/welcomeWalkthrough/common/walkThroughUtils": [
 			"walkThrough.embeddedEditorBackground"
@@ -15439,27 +15571,6 @@
 			"symbolIcon.typeParameterForeground",
 			"symbolIcon.unitForeground",
 			"symbolIcon.variableForeground"
-		],
-		"vs/workbench/contrib/feedback/browser/feedback": [
-			"label.sendASmile",
-			"close",
-			"patchedVersion1",
-			"patchedVersion2",
-			"sentiment",
-			"smileCaption",
-			"smileCaption",
-			"frownCaption",
-			"frownCaption",
-			"other ways to contact us",
-			"submit a bug",
-			"request a missing feature",
-			"tell us why",
-			"feedbackTextInput",
-			"showFeedback",
-			"tweet",
-			"tweetFeedback",
-			"character left",
-			"characters left"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
 			"conflicts",
@@ -15530,11 +15641,6 @@
 		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
 			"saveParticipants"
 		],
-		"vs/workbench/browser/parts/titlebar/windowTitle": [
-			"userIsAdmin",
-			"userIsSudo",
-			"devExtensionWindowTitlePrefix"
-		],
 		"vs/workbench/browser/parts/titlebar/commandCenterControl": [
 			"label.dfl",
 			"label1",
@@ -15574,16 +15680,21 @@
 				]
 			}
 		],
+		"vs/workbench/browser/parts/titlebar/windowTitle": [
+			"userIsAdmin",
+			"userIsSudo",
+			"devExtensionWindowTitlePrefix"
+		],
 		"vs/platform/terminal/common/terminalProfiles": [
 			"terminalAutomaticProfile"
-		],
-		"vs/workbench/contrib/webview/browser/webviewElement": [
-			"fatalErrorMessage"
 		],
 		"vs/platform/quickinput/browser/quickPickPin": [
 			"terminal.commands.pinned",
 			"pinCommand",
 			"pinnedCommand"
+		],
+		"vs/workbench/contrib/webview/browser/webviewElement": [
+			"fatalErrorMessage"
 		],
 		"vs/workbench/api/common/extHostDiagnostics": [
 			{
@@ -15600,12 +15711,12 @@
 		"vs/workbench/api/common/extHostProgress": [
 			"extensionSource"
 		],
+		"vs/workbench/api/common/extHostTreeViews": [
+			"treeView.duplicateElement"
+		],
 		"vs/workbench/api/common/extHostStatusBar": [
 			"extensionLabel",
 			"status.extensionMessage"
-		],
-		"vs/workbench/api/common/extHostTreeViews": [
-			"treeView.duplicateElement"
 		],
 		"vs/workbench/api/common/extHostNotebook": [
 			"err.readonly",
@@ -15630,6 +15741,13 @@
 			"close",
 			"find"
 		],
+		"vs/editor/browser/controller/textAreaHandler": [
+			"editor",
+			"accessibilityModeOff",
+			"accessibilityOffAriaLabel",
+			"accessibilityOffAriaLabelNoKb",
+			"accessibilityOffAriaLabelNoKbs"
+		],
 		"vs/editor/contrib/codeAction/browser/codeActionMenu": [
 			"codeAction.widget.id.more",
 			"codeAction.widget.id.quickfix",
@@ -15641,6 +15759,7 @@
 			"codeAction.widget.id.source"
 		],
 		"vs/platform/actionWidget/browser/actionWidget": [
+			"actionBar.toggledBackground",
 			"codeActionMenuVisible",
 			"hideCodeActionWidget.title",
 			"selectPrevCodeAction.title",
@@ -15648,23 +15767,17 @@
 			"acceptSelected.title",
 			"previewSelected.title"
 		],
-		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
-			"clickToToggleColorOptions",
-			"closeIcon"
-		],
-		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys": [
-			"inlineSuggestionVisible",
-			"inlineSuggestionHasIndentation",
-			"inlineSuggestionHasIndentationLessThanTabSize",
-			"suppressSuggestions"
-		],
-		"vs/editor/contrib/editorState/browser/keybindingCancellation": [
-			"cancellableOperation"
-		],
 		"vs/editor/contrib/gotoSymbol/browser/peek/referencesWidget": [
 			"missingPreviewMessage",
 			"noResults",
 			"peekView.alternateTitle"
+		],
+		"vs/editor/contrib/editorState/browser/keybindingCancellation": [
+			"cancellableOperation"
+		],
+		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
+			"clickToToggleColorOptions",
+			"closeIcon"
 		],
 		"vs/editor/contrib/snippet/browser/snippetVariables": [
 			"Sunday",
@@ -15719,13 +15832,6 @@
 			"suggestMoreInfoIcon",
 			"readMore"
 		],
-		"vs/editor/browser/controller/textAreaHandler": [
-			"editor",
-			"accessibilityModeOff",
-			"accessibilityOffAriaLabel",
-			"accessibilityOffAriaLabelNoKb",
-			"accessibilityOffAriaLabelNoKbs"
-		],
 		"vs/editor/contrib/suggest/browser/suggestWidgetDetails": [
 			"details.close",
 			"loading"
@@ -15750,15 +15856,45 @@
 			"resolvedCommentBorder",
 			"unresolvedCommentBorder",
 			"commentThreadRangeBackground",
-			"commentThreadRangeBorder",
-			"commentThreadActiveRangeBackground",
-			"commentThreadActiveRangeBorder"
+			"commentThreadActiveRangeBackground"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
-			"foldUnchanged"
+		"vs/workbench/browser/parts/editor/titleControl": [
+			"ariaLabelEditorActions",
+			"draggedEditorGroup"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
-			"diff-aria-navigation-tip"
+		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
+			"separatorIcon",
+			"breadcrumbsPossible",
+			"breadcrumbsVisible",
+			"breadcrumbsActive",
+			"empty",
+			"cmd.toggle",
+			{
+				"key": "miBreadcrumbs",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cmd.toggle2",
+			{
+				"key": "miBreadcrumbs2",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cmd.focusAndSelect",
+			"cmd.focus"
+		],
+		"vs/workbench/browser/parts/editor/editorPlaceholder": [
+			"trustRequiredEditor",
+			"requiresFolderTrustText",
+			"requiresWorkspaceTrustText",
+			"manageTrust",
+			"errorEditor",
+			"unavailableResourceErrorEditorText",
+			"unknownErrorEditorTextWithError",
+			"unknownErrorEditorTextWithoutError",
+			"retry"
 		],
 		"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer": [
 			"accessibleDiffViewerInsertIcon",
@@ -15791,56 +15927,40 @@
 			"insertLine",
 			"deleteLine"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/colors": [
-			"diffEditor.move.border"
+		"vs/editor/browser/widget/diffEditorWidget2/movedBlocksLines": [
+			"codeMovedToWithChanges",
+			"codeMovedFromWithChanges",
+			"codeMovedTo",
+			"codeMovedFrom"
 		],
-		"vs/workbench/browser/parts/editor/editorPlaceholder": [
-			"trustRequiredEditor",
-			"requiresFolderTrustText",
-			"requiresWorkspaceTrustText",
-			"manageTrust",
-			"errorEditor",
-			"unavailableResourceErrorEditorText",
-			"unknownErrorEditorTextWithError",
-			"unknownErrorEditorTextWithoutError",
-			"retry"
+		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
+			"foldUnchanged",
+			"diff.hiddenLines.top",
+			"showAll",
+			"diff.bottom",
+			"hiddenLines",
+			"diff.hiddenLines.expandAll"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
+			"diff-aria-navigation-tip"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/colors": [
+			"diffEditor.move.border",
+			"diffEditor.moveActive.border"
 		],
 		"vs/base/browser/ui/menu/menubar": [
 			"mAppMenu",
 			"mMore"
 		],
-		"vs/workbench/browser/parts/editor/titleControl": [
-			"ariaLabelEditorActions",
-			"draggedEditorGroup"
-		],
-		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
-			"separatorIcon",
-			"breadcrumbsPossible",
-			"breadcrumbsVisible",
-			"breadcrumbsActive",
-			"empty",
-			"cmd.toggle",
-			{
-				"key": "miBreadcrumbs",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"cmd.toggle2",
-			{
-				"key": "miBreadcrumbs2",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"cmd.focusAndSelect",
-			"cmd.focus"
-		],
 		"vs/platform/quickinput/browser/quickInputList": [
 			"quickInput"
 		],
-		"vs/platform/quickinput/browser/quickInputUtils": [
-			"executeCommand"
+		"vs/platform/quickinput/browser/quickInput": [
+			"quickInput.back",
+			"inputModeEntry",
+			"quickInput.steps",
+			"quickInputBox.ariaLabel",
+			"inputModeEntryDescription"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
 			"workspaceUntrustedLabel",
@@ -16052,13 +16172,6 @@
 			"noDebugAdapter",
 			"moreInfo"
 		],
-		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
-			"editorGutterCommentRangeForeground",
-			"editorOverviewRuler.commentForeground",
-			"editorOverviewRuler.commentUnresolvedForeground",
-			"editorGutterCommentGlyphForeground",
-			"editorGutterCommentUnresolvedGlyphForeground"
-		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
 			"conflictingLine",
 			"conflictingLines"
@@ -16089,6 +16202,13 @@
 		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
 			"setInputHandled",
 			"undoMarkAsHandled"
+		],
+		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
+			"editorGutterCommentRangeForeground",
+			"editorOverviewRuler.commentForeground",
+			"editorOverviewRuler.commentUnresolvedForeground",
+			"editorGutterCommentGlyphForeground",
+			"editorGutterCommentUnresolvedGlyphForeground"
 		],
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"contributes.customEditors",
@@ -16155,6 +16275,9 @@
 			"terminated.exitCodeOnly",
 			"launchFailed.errorMessage"
 		],
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget": [
+			"terminalAccessibleBuffer"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalTabsList": [
 			"terminalInputAriaLabel",
 			"terminal.tabs",
@@ -16176,13 +16299,6 @@
 			},
 			"label"
 		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
-			"searchWorkspace",
-			"openFile",
-			"focusFolder",
-			"openFolder",
-			"followLink"
-		],
 		"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget": [
 			"label.find",
 			"placeholder.find",
@@ -16192,7 +16308,15 @@
 			"ariaSearchNoInput",
 			"ariaSearchNoResultEmpty",
 			"ariaSearchNoResult",
-			"ariaSearchNoResultWithLineNumNoCurrentMatch"
+			"ariaSearchNoResultWithLineNumNoCurrentMatch",
+			"simpleFindWidget.sashBorder"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
+			"searchWorkspace",
+			"openFile",
+			"focusFolder",
+			"openFolder",
+			"followLink"
 		],
 		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
 			"terminalPromptContextMenu",
@@ -16263,20 +16387,6 @@
 			"referenceCount",
 			"treeAriaLabel"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/decorations": [
-			"diffInsertIcon",
-			"diffRemoveIcon",
-			"revertChangeHoverMessage"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin": [
-			"diff.clipboard.copyDeletedLinesContent.label",
-			"diff.clipboard.copyDeletedLinesContent.single.label",
-			"diff.clipboard.copyChangedLinesContent.label",
-			"diff.clipboard.copyChangedLinesContent.single.label",
-			"diff.clipboard.copyDeletedLineContent.label",
-			"diff.clipboard.copyChangedLineContent.label",
-			"diff.inline.revertChange.label"
-		],
 		"vs/workbench/browser/parts/editor/breadcrumbs": [
 			"title",
 			"enabled",
@@ -16322,6 +16432,23 @@
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
 			"breadcrumbs"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/decorations": [
+			"diffInsertIcon",
+			"diffRemoveIcon",
+			"revertChangeHoverMessage"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin": [
+			"diff.clipboard.copyDeletedLinesContent.label",
+			"diff.clipboard.copyDeletedLinesContent.single.label",
+			"diff.clipboard.copyChangedLinesContent.label",
+			"diff.clipboard.copyChangedLinesContent.single.label",
+			"diff.clipboard.copyDeletedLineContent.label",
+			"diff.clipboard.copyChangedLineContent.label",
+			"diff.inline.revertChange.label"
+		],
+		"vs/platform/quickinput/browser/quickInputUtils": [
+			"executeCommand"
 		],
 		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
 			"mimeTypePicker",
@@ -16399,17 +16526,17 @@
 			"commentThreadAria.document",
 			"commentThreadAria"
 		],
+		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
+			"collapseIcon",
+			"label.collapse",
+			"startThread"
+		],
 		"vs/workbench/contrib/terminal/browser/environmentVariableInfo": [
 			"extensionEnvironmentContributionInfoStale",
 			"relaunchTerminalLabel",
 			"extensionEnvironmentContributionInfoActive",
 			"showEnvironmentContributions",
 			"ScopedEnvironmentContributionInfo"
-		],
-		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
-			"collapseIcon",
-			"label.collapse",
-			"startThread"
 		],
 		"vs/workbench/contrib/comments/browser/commentNode": [
 			"commentToggleReaction",
@@ -16463,6 +16590,12 @@
 			"{0}\n\nPlease make sure the following directories are writeable:\n\n{1}",
 			"&&Close"
 		],
+		"vs/code/node/cliProcessMain": [
+			"CLI"
+		],
+		"vs/code/node/sharedProcess/sharedProcessMain": [
+			"Shared"
+		],
 		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
 			"Process Name",
 			"CPU (%)",
@@ -16474,14 +16607,11 @@
 			"Copy All",
 			"Debug"
 		],
-		"vs/code/node/cliProcessMain": [
-			"CLI"
-		],
-		"vs/code/node/sharedProcess/sharedProcessMain": [
-			"Shared"
-		],
 		"vs/workbench/electron-sandbox/desktop.main": [
 			"Saving UI state"
+		],
+		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
+			"Saving text files"
 		],
 		"vs/workbench/electron-sandbox/desktop.contribution": [
 			"New Window Tab",
@@ -16513,7 +16643,6 @@
 			"Controls whether closing the last editor should also close the window. This setting only applies for windows that do not show folders.",
 			"If enabled, this setting will close the window when the application icon in the title bar is double-clicked. The window will not be able to be dragged by the icon. This setting is effective only if `#window.titleBarStyle#` is set to `custom`.",
 			"Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.",
-			"Use window controls provided by the platform instead of our HTML-based window controls. Changes require a full restart to apply.",
 			"Let the OS handle positioning of the context menu in cases where it should appear under the mouse.",
 			"Adjust the appearance of dialog windows.",
 			"Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured.",
@@ -16534,9 +16663,6 @@
 			"Log level to use. Default is 'info'. Allowed values are 'error', 'warn', 'info', 'debug', 'trace', 'off'.",
 			"Disables the Chromium sandbox. This is useful when running VS Code as elevated on Linux and running under Applocker on Windows.",
 			"Forces the renderer to be accessible. ONLY change this if you are using a screen reader on Linux. On other platforms the renderer will automatically be accessible. This flag is automatically set if you have editor.accessibilitySupport: on."
-		],
-		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
-			"Saving text files"
 		],
 		"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService": [
 			"Do you want to save your workspace configuration as a file?",
@@ -16575,6 +16701,12 @@
 		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
 			"Backup working copies"
 		],
+		"vs/workbench/services/voiceRecognition/electron-sandbox/workbenchVoiceRecognitionService": [
+			"Voice Transcription",
+			"Getting microphone ready...",
+			"Recording from microphone...",
+			"Voice transcription failed: {0}"
+		],
 		"vs/workbench/services/extensions/electron-sandbox/nativeExtensionService": [
 			"Extension host cannot start: version mismatch.",
 			"Relaunch VS Code",
@@ -16592,6 +16724,18 @@
 			"`{0}` not found on marketplace",
 			"Restart Extension Host",
 			"Restarting extension host on explicit request."
+		],
+		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
+			"Would you like to change {0}'s display language to {1} and restart?",
+			"Change Language and Restart",
+			"Don't Show Again"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
+			"Reveal in File Explorer",
+			"Reveal in Finder",
+			"Open Containing Folder",
+			"Share",
+			"File"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution": [
 			"Running Extensions"
@@ -16682,18 +16826,6 @@
 			"The name must only consist of letters, numbers, underscore and dash. It must not start with a dash.",
 			"Prevent the computer from sleeping when remote tunnel access is turned on."
 		],
-		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
-			"Would you like to change {0}'s display language to {1} and restart?",
-			"Change Language and Restart",
-			"Don't Show Again"
-		],
-		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
-			"Reveal in File Explorer",
-			"Reveal in Finder",
-			"Open Containing Folder",
-			"Share",
-			"File"
-		],
 		"vs/base/common/platform": [
 			"_"
 		],
@@ -16701,6 +16833,7 @@
 			"Options",
 			"Extensions Management",
 			"Troubleshooting",
+			"Directory where CLI metadata should be stored.",
 			"Directory where CLI metadata should be stored.",
 			"Compare two files with each other.",
 			"Perform a three-way merge by providing paths for two modified versions of a file, the common origin of both modified versions and the output file to save merge results.",
@@ -16801,6 +16934,7 @@
 			"Shows the nested current scopes during the scroll at the top of the editor.",
 			"Defines the maximum number of sticky lines to show.",
 			"Defines the model to use for determining which lines to stick. If the outline model does not exist, it will fall back on the folding provider model which falls back on the indentation model. This order is respected in all three cases.",
+			"Enable scrolling of the sticky scroll widget with the editor's horizontal scrollbar.",
 			"Enables the inlay hints in the editor.",
 			"Inlay hints are enabled",
 			"Inlay hints are showing by default and hide when holding {0}",
@@ -17060,6 +17194,7 @@
 			"Do not show snippet suggestions.",
 			"Controls whether snippets are shown with other suggestions and how they are sorted.",
 			"Controls whether the editor will scroll using an animation.",
+			"Controls whether the accessibility hint should be provided to screen reader users when an inline completion is shown.",
 			"Font size for the suggest widget. When set to {0}, the value of {1} is used.",
 			"Line height for the suggest widget. When set to {0}, the value of {1} is used. The minimum value is 8.",
 			"Controls whether suggestions should automatically show up when typing trigger characters.",
@@ -17089,76 +17224,6 @@
 			"Controls whether inline color decorations should be shown using the default document color provider",
 			"Controls whether the editor receives tabs or defers them to the workbench for navigation."
 		],
-		"vs/code/electron-sandbox/issue/issueReporterPage": [
-			"Include my system information",
-			"Include my currently running processes",
-			"Include my workspace metadata",
-			"Include my enabled extensions",
-			"Include A/B experiment info",
-			"Before you report an issue here please <a href=\"https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions\" target=\"_blank\">review the guidance we provide</a>.",
-			"Please complete the form in English.",
-			"This is a",
-			"File on",
-			"An issue source is required.",
-			"Try to reproduce the problem after {0}. If the problem only reproduces when extensions are active, it is likely an issue with an extension.",
-			"disabling all extensions and reloading the window",
-			"Extension",
-			"The issue reporter is unable to create issues for this extension. Please visit {0} to report an issue.",
-			"The issue reporter is unable to create issues for this extension, as it does not specify a URL for reporting issues. Please check the marketplace page of this extension to see if other instructions are available.",
-			"Title",
-			"Please enter a title.",
-			"A title is required.",
-			"The title is too long.",
-			"Please enter details.",
-			"A description is required.",
-			"show",
-			"show",
-			"show",
-			"show",
-			"show"
-		],
-		"vs/code/electron-sandbox/issue/issueReporterService": [
-			"hide",
-			"show",
-			"Create on GitHub",
-			"Preview on GitHub",
-			"Loading data...",
-			"GitHub query limit exceeded. Please wait.",
-			"Similar issues",
-			"Open",
-			"Closed",
-			"Open",
-			"Closed",
-			"No similar issues found",
-			"Bug Report",
-			"Feature Request",
-			"Performance Issue",
-			"Select source",
-			"Visual Studio Code",
-			"An extension",
-			"Extensions marketplace",
-			"Don't know",
-			"This extension handles issues outside of VS Code",
-			"The '{0}' extension prefers to use an external issue reporter. To be taken to that issue reporting experience, click the button below.",
-			"Open External Issue Reporter",
-			"Steps to Reproduce",
-			"Share the steps needed to reliably reproduce the problem. Please include actual and expected results. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
-			"Steps to Reproduce",
-			"When did this performance issue happen? Does it occur on startup or after a specific series of actions? We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
-			"Description",
-			"Please describe the feature you would like to see. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
-			"We have written the needed data into your clipboard because it was too large to send. Please paste.",
-			"Extensions are disabled",
-			"No current experiments."
-		],
-		"vs/platform/environment/node/argvHelper": [
-			"Option '{0}' is defined more than once. Using value '{1}'.",
-			"Option '{0}' requires a non empty value. Ignoring the option.",
-			"Option '{0}' is deprecated: {1}",
-			"Warning: '{0}' is not in the list of known options for subcommand '{1}'",
-			"Warning: '{0}' is not in the list of known options, but still passed to Electron/Chromium.",
-			"Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`."
-		],
 		"vs/base/common/errorMessage": [
 			"{0}: {1}",
 			"A system error occurred ({0})",
@@ -17172,6 +17237,14 @@
 			"&&No",
 			"An external application wants to open '{0}' in {1}. Do you want to open this file or folder?",
 			"If you did not initiate this request, it may represent an attempted attack on your system. Unless you took an explicit action to initiate this request, you should press 'No'"
+		],
+		"vs/platform/environment/node/argvHelper": [
+			"Option '{0}' is defined more than once. Using value '{1}'.",
+			"Option '{0}' requires a non empty value. Ignoring the option.",
+			"Option '{0}' is deprecated: {1}",
+			"Warning: '{0}' is not in the list of known options for subcommand '{1}'",
+			"Warning: '{0}' is not in the list of known options, but still passed to Electron/Chromium.",
+			"Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`."
 		],
 		"vs/platform/files/common/files": [
 			"Unknown Error",
@@ -17256,18 +17329,71 @@
 			"Enable to download and install new VS Code versions in the background on Windows.",
 			"Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."
 		],
+		"vs/code/electron-sandbox/issue/issueReporterPage": [
+			"Include my system information",
+			"Include my currently running processes",
+			"Include my workspace metadata",
+			"Include my enabled extensions",
+			"Include A/B experiment info",
+			"Before you report an issue here please <a href=\"https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions\" target=\"_blank\">review the guidance we provide</a>.",
+			"Please complete the form in English.",
+			"This is a",
+			"File on",
+			"An issue source is required.",
+			"Try to reproduce the problem after {0}. If the problem only reproduces when extensions are active, it is likely an issue with an extension.",
+			"disabling all extensions and reloading the window",
+			"Extension",
+			"The issue reporter is unable to create issues for this extension. Please visit {0} to report an issue.",
+			"The issue reporter is unable to create issues for this extension, as it does not specify a URL for reporting issues. Please check the marketplace page of this extension to see if other instructions are available.",
+			"Title",
+			"Please enter a title.",
+			"A title is required.",
+			"The title is too long.",
+			"Please enter details.",
+			"A description is required.",
+			"show",
+			"show",
+			"show",
+			"show",
+			"show"
+		],
+		"vs/code/electron-sandbox/issue/issueReporterService": [
+			"hide",
+			"show",
+			"Create on GitHub",
+			"Preview on GitHub",
+			"Loading data...",
+			"GitHub query limit exceeded. Please wait.",
+			"Similar issues",
+			"Open",
+			"Closed",
+			"Open",
+			"Closed",
+			"No similar issues found",
+			"Bug Report",
+			"Feature Request",
+			"Performance Issue",
+			"Select source",
+			"Visual Studio Code",
+			"An extension",
+			"Extensions marketplace",
+			"Don't know",
+			"This extension handles issues outside of VS Code",
+			"The '{0}' extension prefers to use an external issue reporter. To be taken to that issue reporting experience, click the button below.",
+			"Open External Issue Reporter",
+			"Steps to Reproduce",
+			"Share the steps needed to reliably reproduce the problem. Please include actual and expected results. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
+			"Steps to Reproduce",
+			"When did this performance issue happen? Does it occur on startup or after a specific series of actions? We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
+			"Description",
+			"Please describe the feature you would like to see. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
+			"We have written the needed data into your clipboard because it was too large to send. Please paste.",
+			"Extensions are disabled",
+			"No current experiments."
+		],
 		"vs/platform/extensionManagement/common/extensionManagement": [
 			"Extensions",
 			"Preferences"
-		],
-		"vs/platform/extensionManagement/common/extensionsScannerService": [
-			"Cannot read file {0}: {1}.",
-			"Failed to parse {0}: [{1}, {2}] {3}.",
-			"Invalid manifest file {0}: Not an JSON object.",
-			"Failed to parse {0}: {1}.",
-			"Invalid format {0}: JSON object expected.",
-			"Failed to parse {0}: {1}.",
-			"Invalid format {0}: JSON object expected."
 		],
 		"vs/platform/extensionManagement/common/extensionManagementCLI": [
 			"Extension '{0}' not found.",
@@ -17297,6 +17423,15 @@
 			"Extension '{0}' was successfully uninstalled!",
 			"Extension '{0}' is not installed on {1}.",
 			"Extension '{0}' is not installed."
+		],
+		"vs/platform/extensionManagement/common/extensionsScannerService": [
+			"Cannot read file {0}: {1}.",
+			"Failed to parse {0}: [{1}, {2}] {3}.",
+			"Invalid manifest file {0}: Not an JSON object.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected."
 		],
 		"vs/platform/extensionManagement/node/extensionManagementService": [
 			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.",
@@ -17335,6 +17470,16 @@
 		"vs/platform/userDataProfile/common/userDataProfile": [
 			"Default"
 		],
+		"vs/platform/telemetry/common/telemetryLogAppender": [
+			"Telemetry{0}"
+		],
+		"vs/platform/userDataSync/common/userDataSync": [
+			"Settings Sync",
+			"Synchronize keybindings for each platform.",
+			"List of extensions to be ignored while synchronizing. The identifier of an extension is always `${publisher}.${name}`. For example: `vscode.csharp`.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
+			"Configure settings to be ignored while synchronizing."
+		],
 		"vs/platform/userDataSync/common/userDataSyncLog": [
 			"Settings Sync"
 		],
@@ -17344,16 +17489,6 @@
 		"vs/platform/remoteTunnel/common/remoteTunnel": [
 			"Remote Tunnel Service"
 		],
-		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
-			"Cannot parse sync data as it is not compatible with the current version."
-		],
-		"vs/platform/userDataSync/common/userDataSync": [
-			"Settings Sync",
-			"Synchronize keybindings for each platform.",
-			"List of extensions to be ignored while synchronizing. The identifier of an extension is always `${publisher}.${name}`. For example: `vscode.csharp`.",
-			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
-			"Configure settings to be ignored while synchronizing."
-		],
 		"vs/platform/remoteTunnel/node/remoteTunnelService": [
 			"Building CLI from sources",
 			"Connecting as {0} ({1})",
@@ -17361,8 +17496,37 @@
 			"Opening tunnel",
 			"Failed to install tunnel as a service, starting in session..."
 		],
-		"vs/platform/telemetry/common/telemetryLogAppender": [
-			"Telemetry{0}"
+		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
+			"Cannot parse sync data as it is not compatible with the current version."
+		],
+		"vs/editor/common/languages": [
+			"array",
+			"boolean",
+			"class",
+			"constant",
+			"constructor",
+			"enumeration",
+			"enumeration member",
+			"event",
+			"field",
+			"file",
+			"function",
+			"interface",
+			"key",
+			"method",
+			"module",
+			"namespace",
+			"null",
+			"number",
+			"object",
+			"operator",
+			"package",
+			"property",
+			"string",
+			"struct",
+			"type parameter",
+			"variable",
+			"{0} ({1})"
 		],
 		"vs/workbench/browser/workbench": [
 			"Failed to load a required file. Please restart the application to try again. Details: {0}"
@@ -17405,11 +17569,7 @@
 			"There is a dependency cycle in the AMD modules that needs to be resolved!",
 			"It is not recommended to run {0} as root user.",
 			"Files you store within the installation folder ('{0}') may be OVERWRITTEN or DELETED IRREVERSIBLY without warning at update time.",
-			"{0} on {1} will soon stop receiving updates. Consider upgrading your windows version.",
-			"Learn More",
-			"{0}. Use navigation keys to access banner actions.",
-			"Learn More",
-			"{0} on {1} will soon stop receiving updates. Consider upgrading your macOS version.",
+			"{0} on Windows 32-bit will soon stop receiving updates. Consider upgrading to the 64-bit build.",
 			"Learn More",
 			"{0}. Use navigation keys to access banner actions.",
 			"Learn More",
@@ -17420,6 +17580,9 @@
 			"Contribute defaults for configurations",
 			"Experiments",
 			"Configure settings to be applied for all profiles."
+		],
+		"vs/platform/workspace/common/workspace": [
+			"Code Workspace"
 		],
 		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
 			"Open Developer Tools",
@@ -17465,16 +17628,13 @@
 			"Controls how tree folders are expanded when clicking the folder names. Note that some trees and lists might choose to ignore this setting if it is not applicable.",
 			"Controls the how type navigation works in lists and trees in the workbench. When set to 'trigger', type navigation begins once the 'list.triggerTypeNavigation' command is run."
 		],
-		"vs/platform/workspace/common/workspace": [
-			"Code Workspace"
-		],
-		"vs/platform/contextkey/browser/contextKeyService": [
-			"A command that returns information about context keys"
-		],
 		"vs/platform/markers/common/markers": [
 			"Error",
 			"Warning",
 			"Info"
+		],
+		"vs/platform/contextkey/browser/contextKeyService": [
+			"A command that returns information about context keys"
 		],
 		"vs/platform/contextkey/common/contextkey": [
 			"Empty context key expression",
@@ -17488,6 +17648,14 @@
 			"Expected: {0}\nReceived: '{1}'.",
 			"Unexpected token. Hint: {0}",
 			"Unexpected token."
+		],
+		"vs/workbench/browser/actions/textInputActions": [
+			"Undo",
+			"Redo",
+			"Cut",
+			"Copy",
+			"Paste",
+			"Select All"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"The default size.",
@@ -17525,12 +17693,17 @@
 			"A pinned tab will show in a compact form with only icon or first letter of the editor name.",
 			"A pinned tab shrinks to a compact fixed size showing parts of the editor name.",
 			"Controls the size of pinned editor tabs. Pinned tabs are sorted to the beginning of all opened tabs and typically do not close until unpinned. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"Always prevent closing the pinned editor when using mouse middle click or keyboard.",
+			"Prevent closing the pinned editor when using the keyboard.",
+			"Prevent closing the pinned editor when using mouse middle click.",
+			"Never prevent closing a pinned editor.",
+			"Controls whether pinned editors should close when keyboard or middle mouse click is used for closing.",
 			"Splits the active editor group to equal parts, unless all editor groups are already in equal parts. In that case, splits all the editor groups to equal parts.",
 			"Splits all the editor groups to equal parts.",
 			"Splits the active editor group to equal parts.",
 			"Controls the size of editor groups when splitting them.",
 			"Controls if editor groups can be split from drag and drop operations by dropping an editor or file on the edges of the editor area.",
-			"Controls whether tabs are closed in most recently used order or from left to right.",
+			"Controls whether editors are closed in most recently used order or from left to right.",
 			"Controls whether opened editors should show with an icon or not. This requires a file icon theme to be enabled as well.",
 			"Controls whether opened editors show as preview editors. Preview editors do not stay open, are reused until explicitly set to be kept open (via double-click or editing), and show file names in italics.",
 			"Controls whether editors opened from Quick Open show as preview editors. Preview editors do not stay open, and are reused until explicitly set to be kept open (via double-click or editing). When enabled, hold Ctrl before selection to open an editor as a non-preview. This value is ignored when `#workbench.editor.enablePreview#` is disabled.",
@@ -17565,7 +17738,7 @@
 			"Controls the number of recently used commands to keep in history for the command palette. Set to 0 to disable command history.",
 			"Controls whether the last typed input to the command palette should be restored when opening it the next time.",
 			"Controls whether the command palette should have a list of commonly used commands.",
-			"Controls whether the command palette should include similar commands. You must have an extension installed that provides Semantic Similarity.",
+			"Controls whether the command palette should include similar commands. You must have an extension installed that provides Natural Language support.",
 			"Controls whether Quick Open should close automatically once it loses focus.",
 			"Controls whether the last typed input to Quick Open should be restored when opening it the next time.",
 			"Controls whether opening settings also opens an editor showing all default settings.",
@@ -17603,7 +17776,7 @@
 			"Shows both the dropdown and toggle buttons.",
 			"Controls whether the layout control in the custom title bar is displayed as a single menu button or with multiple UI toggles.",
 			"When enabled, will show the watermark tips when no editor is open.",
-			"Controls the window title based on the active editor. Variables are substituted based on the context:",
+			"Controls the window title based on the current context such as the opened workspace or active editor. Variables are substituted based on the context:",
 			"`${activeEditorShort}`: the file name (e.g. myFile.txt).",
 			"`${activeEditorMedium}`: the path of the file relative to the workspace folder (e.g. myFolder/myFileFolder/myFile.txt).",
 			"`${activeEditorLong}`: the full path of the file (e.g. /Users/Development/myFolder/myFileFolder/myFile.txt).",
@@ -17619,6 +17792,7 @@
 			"`${appName}`: e.g. VS Code.",
 			"`${remoteName}`: e.g. SSH",
 			"`${dirty}`: an indicator for when the active editor has unsaved changes.",
+			"`${focusedView}`: the name of the view that is currently focused.",
 			"`${separator}`: a conditional separator (\" - \") that only shows when surrounded by variables with values or static text.",
 			"Window",
 			"Separator used by {0}.",
@@ -17663,14 +17837,6 @@
 			"Controls whether a window should restore to Zen Mode if it was exited in Zen Mode.",
 			"Controls whether notifications do not disturb mode should be enabled while in Zen Mode. If true, only error notifications will pop out."
 		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"Undo",
-			"Redo",
-			"Cut",
-			"Copy",
-			"Paste",
-			"Select All"
-		],
 		"vs/workbench/browser/actions/helpActions": [
 			"Keyboard Shortcuts Reference",
 			"&&Keyboard Shortcuts Reference",
@@ -17681,8 +17847,8 @@
 			"Documentation",
 			"&&Documentation",
 			"Signup for the VS Code Newsletter",
-			"Join Us on Twitter",
-			"&&Join Us on Twitter",
+			"Join Us on YouTube",
+			"&&Join Us on YouTube",
 			"Search Feature Requests",
 			"&&Search Feature Requests",
 			"View License",
@@ -17702,6 +17868,7 @@
 			"Controls the font size (in pixels) of the screencast mode keyboard.",
 			"Options for customizing the keyboard overlay in screencast mode.",
 			"Show raw keys.",
+			"Show keyboard shortcuts.",
 			"Show command names.",
 			"Show command group names, when commands are also shown.",
 			"Show single editor cursor move commands.",
@@ -17856,6 +18023,12 @@
 			"Confirm Before Close",
 			"Open &&Recent"
 		],
+		"vs/workbench/browser/actions/workspaceCommands": [
+			"Add Folder to Workspace...",
+			"&&Add",
+			"Add Folder to Workspace",
+			"Select workspace folder"
+		],
 		"vs/workbench/browser/actions/workspaceActions": [
 			"Workspaces",
 			"Open File...",
@@ -17879,11 +18052,57 @@
 			"Close &&Folder",
 			"Close &&Workspace"
 		],
-		"vs/workbench/browser/actions/workspaceCommands": [
-			"Add Folder to Workspace...",
-			"&&Add",
-			"Add Folder to Workspace",
-			"Select workspace folder"
+		"vs/workbench/browser/actions/quickAccessActions": [
+			"Go to File...",
+			"Quick Open",
+			"Navigate Next in Quick Open",
+			"Navigate Previous in Quick Open",
+			"Select Next in Quick Open",
+			"Select Previous in Quick Open"
+		],
+		"vs/workbench/api/common/configurationExtensionPoint": [
+			"A title for the current category of settings. This label will be rendered in the Settings editor as a subheading. If the title is the same as the extension display name, then the category will be grouped under the main extension heading.",
+			"When specified, gives the order of this category of settings relative to other categories.",
+			"Description of the configuration properties.",
+			"Property should not be empty.",
+			"Schema of the configuration property.",
+			"Configuration that can be configured only in the user settings.",
+			"Configuration that can be configured only in the user settings or only in the remote settings.",
+			"Configuration that can be configured in the user, remote or workspace settings.",
+			"Configuration that can be configured in the user, remote, workspace or folder settings.",
+			"Resource configuration that can be configured in language specific settings.",
+			"Machine configuration that can be configured also in workspace or folder settings.",
+			"Scope in which the configuration is applicable. Available scopes are `application`, `machine`, `window`, `resource`, and `machine-overridable`.",
+			"Descriptions for enum values",
+			"Descriptions for enum values in the markdown format.",
+			"Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.",
+			"The description in the markdown format.",
+			"If set, the property is marked as deprecated and the given message is shown as an explanation.",
+			"If set, the property is marked as deprecated and the given message is shown as an explanation in the markdown format.",
+			"The value will be shown in an inputbox.",
+			"The value will be shown in a textarea.",
+			"When specified, controls the presentation format of the string setting.",
+			"When specified, gives the order of this setting relative to other settings within the same category. Settings with an order property will be placed before settings without this property set.",
+			"When enabled, Settings Sync will not sync the user value of this configuration by default.",
+			"Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.",
+			"Contributes configuration settings.",
+			"'configuration.title' must be a string",
+			"'configuration.properties' must be an object",
+			"Cannot register '{0}'. This property is already registered.",
+			"configuration.properties property '{0}' must be an object",
+			"'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point.",
+			"List of folders to be loaded in the workspace.",
+			"A file path. e.g. `/root/folderA` or `./folderA` for a relative path that will be resolved against the location of the workspace file.",
+			"An optional name for the folder. ",
+			"URI of the folder",
+			"An optional name for the folder. ",
+			"Workspace settings",
+			"Workspace launch configurations",
+			"Workspace task configurations",
+			"Workspace extensions",
+			"The remote server where the workspace is located.",
+			"A transient workspace will disappear when restarting or reloading.",
+			"Unknown workspace configuration property"
 		],
 		"vs/workbench/services/actions/common/menusExtensionPoint": [
 			"The Command Palette",
@@ -17909,6 +18128,8 @@
 			"The Source Control resource group context menu",
 			"The Source Control inline change menu",
 			"The remote indicator menu in the status bar",
+			"The terminal context menu",
+			"The terminal tabs context menu",
 			"The contributed view title menu",
 			"The contributed view item context menu",
 			"The contributed comment editor actions",
@@ -17927,6 +18148,8 @@
 			"The contributed interactive cell title menu",
 			"The contributed test item menu",
 			"The menu for a gutter decoration for a test item",
+			"A prominent button overlaying editor content where the message is displayed",
+			"Context menu for the message in the results tree",
 			"The extension context menu",
 			"The Timeline view title menu",
 			"The Timeline view item context menu",
@@ -17995,14 +18218,6 @@
 			"Menu item references a submenu `{0}` which is not defined in the 'submenus' section.",
 			"The `{0}` submenu was already contributed to the `{1}` menu."
 		],
-		"vs/workbench/browser/actions/quickAccessActions": [
-			"Go to File...",
-			"Quick Open",
-			"Navigate Next in Quick Open",
-			"Navigate Previous in Quick Open",
-			"Select Next in Quick Open",
-			"Select Previous in Quick Open"
-		],
 		"vs/workbench/api/browser/viewsExtensionPoint": [
 			"Unique id used to identify the container in which views can be contributed using 'views' contribution point",
 			"Human readable string used to render the container",
@@ -18053,50 +18268,6 @@
 			"property `{0}` can be omitted or must be of type `string`",
 			"property `{0}` can be omitted or must be of type `string`",
 			"property `{0}` can be omitted or must be one of {1}"
-		],
-		"vs/workbench/api/common/configurationExtensionPoint": [
-			"A title for the current category of settings. This label will be rendered in the Settings editor as a subheading. If the title is the same as the extension display name, then the category will be grouped under the main extension heading.",
-			"When specified, gives the order of this category of settings relative to other categories.",
-			"Description of the configuration properties.",
-			"Property should not be empty.",
-			"Schema of the configuration property.",
-			"Configuration that can be configured only in the user settings.",
-			"Configuration that can be configured only in the user settings or only in the remote settings.",
-			"Configuration that can be configured in the user, remote or workspace settings.",
-			"Configuration that can be configured in the user, remote, workspace or folder settings.",
-			"Resource configuration that can be configured in language specific settings.",
-			"Machine configuration that can be configured also in workspace or folder settings.",
-			"Scope in which the configuration is applicable. Available scopes are `application`, `machine`, `window`, `resource`, and `machine-overridable`.",
-			"Descriptions for enum values",
-			"Descriptions for enum values in the markdown format.",
-			"Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.",
-			"The description in the markdown format.",
-			"If set, the property is marked as deprecated and the given message is shown as an explanation.",
-			"If set, the property is marked as deprecated and the given message is shown as an explanation in the markdown format.",
-			"The value will be shown in an inputbox.",
-			"The value will be shown in a textarea.",
-			"When specified, controls the presentation format of the string setting.",
-			"When specified, gives the order of this setting relative to other settings within the same category. Settings with an order property will be placed before settings without this property set.",
-			"When enabled, Settings Sync will not sync the user value of this configuration by default.",
-			"Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.",
-			"Contributes configuration settings.",
-			"'configuration.title' must be a string",
-			"'configuration.properties' must be an object",
-			"Cannot register '{0}'. This property is already registered.",
-			"configuration.properties property '{0}' must be an object",
-			"'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point.",
-			"List of folders to be loaded in the workspace.",
-			"A file path. e.g. `/root/folderA` or `./folderA` for a relative path that will be resolved against the location of the workspace file.",
-			"An optional name for the folder. ",
-			"URI of the folder",
-			"An optional name for the folder. ",
-			"Workspace settings",
-			"Workspace launch configurations",
-			"Workspace task configurations",
-			"Workspace extensions",
-			"The remote server where the workspace is located.",
-			"A transient workspace will disappear when restarting or reloading.",
-			"Unknown workspace configuration property"
 		],
 		"vs/workbench/browser/parts/editor/editor.contribution": [
 			"Text Editor",
@@ -18163,7 +18334,6 @@
 			"Icon for the toggle whitespace action in the diff editor.",
 			"Previous Change",
 			"Next Change",
-			"Ignore Leading/Trailing Whitespace Differences",
 			"Show Leading/Trailing Whitespace Differences",
 			"Keep Editor",
 			"Pin Editor",
@@ -18269,6 +18439,21 @@
 			"Could not redo '{0}' across all files because an undo or redo operation occurred in the meantime",
 			"Could not redo '{0}' because there is already an undo or redo operation running."
 		],
+		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
+			"Allow an extension to open this URI?",
+			"Don't ask again for this extension.",
+			"&&Open",
+			"Extension '{0}' is not installed. Would you like to install the extension and open this URL?",
+			"&&Install and Open",
+			"Installing Extension '{0}'...",
+			"Extension '{0}' is disabled. Would you like to enable the extension and open the URL?",
+			"&&Enable and Open",
+			"Extension '{0}' is not loaded. Would you like to reload the window to load the extension and open the URL?",
+			"&&Reload Window and Open",
+			"Manage Authorized Extension URIs...",
+			"Extensions",
+			"There are currently no authorized extension URIs."
+		],
 		"vs/workbench/services/keybinding/common/keybindingEditing": [
 			"Unable to write because the keybindings configuration file has unsaved changes. Please save it first and then try again.",
 			"Unable to write to the keybindings configuration file. Please open it to correct errors/warnings in the file and try again.",
@@ -18297,21 +18482,6 @@
 		],
 		"vs/workbench/services/configuration/common/jsonEditingService": [
 			"Unable to write into the file. Please open the file to correct errors/warnings in the file and try again."
-		],
-		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
-			"Allow an extension to open this URI?",
-			"Don't ask again for this extension.",
-			"&&Open",
-			"Extension '{0}' is not installed. Would you like to install the extension and open this URL?",
-			"&&Install and Open",
-			"Installing Extension '{0}'...",
-			"Extension '{0}' is disabled. Would you like to enable the extension and open the URL?",
-			"&&Enable and Open",
-			"Extension '{0}' is not loaded. Would you like to reload the window to load the extension and open the URL?",
-			"&&Reload Window and Open",
-			"Manage Authorized Extension URIs...",
-			"Extensions",
-			"There are currently no authorized extension URIs."
 		],
 		"vs/workbench/services/editor/browser/editorResolverService": [
 			"There are multiple default editors available for the resource.",
@@ -18424,6 +18594,16 @@
 			"Workspace Folder",
 			"Workspace"
 		],
+		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
+			"The current profile has been updated. Please reload to switch back to the updated profile",
+			"The current profile has been removed. Please reload to switch back to default profile",
+			"The current profile has been removed. Please reload to switch back to default profile",
+			"Cannot rename the default profile",
+			"Cannot delete the default profile",
+			"Switching to a profile.",
+			"Switching a profile requires reloading VS Code.",
+			"&&Reload"
+		],
 		"vs/workbench/services/notification/common/notificationService": [
 			"Don't Show Again",
 			"Don't Show Again"
@@ -18448,7 +18628,7 @@
 			"Profile with name {0} already exists.",
 			"The profile should contain at least one configuration.",
 			"Using Default Profile",
-			"Provide a name for the new profile",
+			"Profile name is required and must be a non-empty value.",
 			"Copy from:",
 			"None",
 			"Profile Templates",
@@ -18505,22 +18685,6 @@
 			"Export Profile",
 			"Profile name must be provided."
 		],
-		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
-			"The current profile has been updated. Please reload to switch back to the updated profile",
-			"The current profile has been removed. Please reload to switch back to default profile",
-			"The current profile has been removed. Please reload to switch back to default profile",
-			"Cannot rename the default profile",
-			"Cannot delete the default profile",
-			"Switching to a profile.",
-			"Switching a profile requires reloading VS Code.",
-			"&&Reload"
-		],
-		"vs/workbench/services/remote/common/remoteExplorerService": [
-			"User Forwarded",
-			"Auto Forwarded",
-			"Local port {0} could not be used for forwarding to remote port {1}.\n\nThis usually happens when there is already another process using local port {0}.\n\nPort number {2} has been used instead.",
-			"Statically Forwarded"
-		],
 		"vs/workbench/services/filesConfiguration/common/filesConfigurationService": [
 			"Editor is read-only because the file system of the file is read-only.",
 			"Editor is read-only because the file was set read-only in this session. [Click here](command:{0}) to set writeable.",
@@ -18557,6 +18721,9 @@
 			"Others",
 			"Sign in with {0}"
 		],
+		"vs/workbench/services/assignment/common/assignmentService": [
+			"Fetches experiments to run from a Microsoft online service."
+		],
 		"vs/workbench/services/authentication/browser/authenticationService": [
 			"The id of the authentication provider.",
 			"The human readable name of the authentication provider.",
@@ -18575,9 +18742,6 @@
 			"Select an account for '{0}' to use or Esc to cancel",
 			"Grant access to {0} for {1}... (1)",
 			"Sign in with {0} to use {1} (1)"
-		],
-		"vs/workbench/services/assignment/common/assignmentService": [
-			"Fetches experiments to run from a Microsoft online service."
 		],
 		"vs/workbench/services/issue/browser/issueTroubleshoot": [
 			"Troubleshoot Issue",
@@ -18604,6 +18768,11 @@
 			"Troubleshoot Issue...",
 			"Stop Troubleshoot Issue"
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"You won't be able to produce this key combination under your current keyboard layout.",
+			"**{0}** for your current keyboard layout (**{1}** for US standard).",
+			"**{0}** for your current keyboard layout."
+		],
 		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
 			"Settings Editor 2",
 			"Keybindings Editor",
@@ -18616,7 +18785,6 @@
 			"Open Settings (UI)",
 			"Open User Settings",
 			"Open Default Settings (JSON)",
-			"Open Settings (JSON)",
 			"Open Workspace Settings",
 			"Open Accessibility Settings",
 			"Open Workspace Settings (JSON)",
@@ -18649,7 +18817,14 @@
 			"Clear Search Results",
 			"Clear Keyboard Shortcuts Search History",
 			"Define Keybinding",
+			"Open Settings (JSON)",
 			"&&Preferences"
+		],
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"Startup Performance",
+			"Print Service Cycles",
+			"Print Service Traces",
+			"Print Emitter Profiles"
 		],
 		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
 			"Settings for code editors used in notebooks. This can be used to customize most editor.* settings.",
@@ -18704,17 +18879,9 @@
 			"Controls the font weight in chat codeblocks.",
 			"Controls whether lines should wrap in chat codeblocks.",
 			"Controls the line height in pixels in chat codeblocks. Use 0 to compute the line height from the font size.",
-			"Use the chat view as the default mode. Displays the chat icon in the Activity Bar.",
-			"Use the quick question as the default mode. Displays the chat icon in the Title Bar.",
-			"Displays the chat icon in the Activity Bar and the Title Bar which open their respective chat modes.",
-			"Controls the default mode of the chat experience.",
-			"Controls the mode of quick question chat experience.",
 			"Chat",
 			"Chat",
-			"Chat Accessible View"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChat.contribution": [
-			"Inline Chat Accessible View"
+			"Clear the session"
 		],
 		"vs/workbench/contrib/interactive/browser/interactive.contribution": [
 			"Interactive Window",
@@ -18732,6 +18899,12 @@
 			"The border color for the current interactive code cell when the editor does not have focus.",
 			"Automatically scroll the interactive window to show the output of the last statement executed. If this value is false, the window will only scroll if the last cell was already the one scrolled to."
 		],
+		"vs/workbench/contrib/logs/common/logs.contribution": [
+			"Set Default Log Level",
+			"{0} (Remote)",
+			"{0} (Remote)",
+			"Show Window Log"
+		],
 		"vs/workbench/contrib/testing/browser/testing.contribution": [
 			"Testing",
 			"T&&esting",
@@ -18740,17 +18913,6 @@
 			"No tests have been found in this workspace yet.",
 			"Install Additional Test Extensions...",
 			"Test Explorer"
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"You won't be able to produce this key combination under your current keyboard layout.",
-			"**{0}** for your current keyboard layout (**{1}** for US standard).",
-			"**{0}** for your current keyboard layout."
-		],
-		"vs/workbench/contrib/logs/common/logs.contribution": [
-			"Set Default Log Level",
-			"{0} (Remote)",
-			"{0} (Remote)",
-			"Show Window Log"
 		],
 		"vs/workbench/contrib/files/browser/explorerViewlet": [
 			"View icon of the explorer view.",
@@ -18771,6 +18933,7 @@
 		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
 			"Type '{0}' to get help on the actions you can take from here.",
 			"Show all Quick Access Providers",
+			"More",
 			"Type the name of a view, output channel or terminal to open.",
 			"Open View",
 			"Type the name of a command to run.",
@@ -18837,7 +19000,7 @@
 			"Disable the pattern.",
 			"The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.",
 			"Additional check on the siblings of a matching file. Use \\$(basename) as variable for the matching file name.",
-			"Configure file associations to languages (for example `\"*.extension\": \"html\"`). These have precedence over the default associations of the languages installed.",
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) of file associations to languages (for example `\"*.extension\": \"html\"`). Patterns will match on the absolute path of a file if they contain a path separator and will match on the name of the file otherwise. These have precedence over the default associations of the languages installed.",
 			"The default character set encoding to use when reading and writing files. This setting can also be configured per language.",
 			"When enabled, the editor will attempt to guess the character set encoding when opening files. This setting can also be configured per language. Note, this setting is not respected by text search. Only {0} is respected.",
 			"LF",
@@ -18953,6 +19116,8 @@
 			"Go to File",
 			"Type the name of a symbol to open.",
 			"Go to Symbol in Workspace",
+			"Search for text in your workspace files (experimental).",
+			"Search for Text (Experimental)",
 			"Search",
 			"Configure [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting.",
 			"The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.",
@@ -19010,7 +19175,8 @@
 			"Shows search results as a tree.",
 			"Shows search results as a list.",
 			"Controls the default search result view mode.",
-			"Show notebook editor rich content results for closed notebooks. Please refresh your search results after changing this setting."
+			"Show notebook editor rich content results for closed notebooks. Please refresh your search results after changing this setting.",
+			"Controls whether the last typed input to Quick Search should be restored when opening it the next time."
 		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
 			"Another refactoring is being previewed.",
@@ -19031,32 +19197,6 @@
 			"View icon of the refactor preview view.",
 			"Refactor Preview",
 			"Refactor Preview"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
-			"Search Editor",
-			"Search Editor",
-			"Search Editor",
-			"Delete File Results",
-			"New Search Editor",
-			"Open Search Editor",
-			"Open New Search Editor to the Side",
-			"Open Results in Editor",
-			"Search Again",
-			"Focus Search Editor Input",
-			"Focus Search Editor Files to Include",
-			"Focus Search Editor Files to Exclude",
-			"Toggle Match Case",
-			"Toggle Match Whole Word",
-			"Toggle Use Regular Expression",
-			"Toggle Context Lines",
-			"Increase Context Lines",
-			"Decrease Context Lines",
-			"Select All Matches",
-			"Open New Search Editor"
-		],
-		"vs/workbench/contrib/sash/browser/sash.contribution": [
-			"Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it's hard to resize views using the mouse.",
-			"Controls the hover feedback delay in milliseconds of the dragging area in between views/editors."
 		],
 		"vs/workbench/contrib/search/browser/searchView": [
 			"Search was canceled before any results could be found - ",
@@ -19115,6 +19255,32 @@
 			"{0} results in {1} files",
 			"You have not opened or specified a folder. Only open files are currently searched - ",
 			"Open Folder"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
+			"Search Editor",
+			"Search Editor",
+			"Search Editor",
+			"Delete File Results",
+			"New Search Editor",
+			"Open Search Editor",
+			"Open New Search Editor to the Side",
+			"Open Results in Editor",
+			"Search Again",
+			"Focus Search Editor Input",
+			"Focus Search Editor Files to Include",
+			"Focus Search Editor Files to Exclude",
+			"Toggle Match Case",
+			"Toggle Match Whole Word",
+			"Toggle Use Regular Expression",
+			"Toggle Context Lines",
+			"Increase Context Lines",
+			"Decrease Context Lines",
+			"Select All Matches",
+			"Open New Search Editor"
+		],
+		"vs/workbench/contrib/sash/browser/sash.contribution": [
+			"Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it's hard to resize views using the mouse.",
+			"Controls the hover feedback delay in milliseconds of the dragging area in between views/editors."
 		],
 		"vs/workbench/contrib/scm/browser/scm.contribution": [
 			"View icon of the Source Control view.",
@@ -19274,10 +19440,6 @@
 			"Automatically show values for variables that are lazily resolved by the debugger, such as getters.",
 			"Color status bar when debugger is active"
 		],
-		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
-			"Color for the debug inline value text.",
-			"Color for the debug inline value background."
-		],
 		"vs/workbench/contrib/debug/browser/breakpointEditorContribution": [
 			"Logpoint",
 			"Breakpoint",
@@ -19317,6 +19479,14 @@
 			"Icon color for unverified breakpoints.",
 			"Icon color for the current breakpoint stack frame.",
 			"Icon color for all breakpoint stack frames."
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"Background color for the highlight of line at the top stack frame position.",
+			"Background color for the highlight of line at focused stack frame position."
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
+			"Color for the debug inline value text.",
+			"Color for the debug inline value background."
 		],
 		"vs/workbench/contrib/debug/browser/debugViewlet": [
 			"Open &&Configurations",
@@ -19380,11 +19550,10 @@
 			"10K+",
 			"Total {0} Problems"
 		],
-		"vs/workbench/contrib/performance/browser/performance.contribution": [
-			"Startup Performance",
-			"Print Service Cycles",
-			"Print Service Traces",
-			"Print Emitter Profiles"
+		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
+			"Merge Editor",
+			"Uses the legacy diffing algorithm.",
+			"Uses the advanced diffing algorithm."
 		],
 		"vs/workbench/contrib/commands/common/commands.contribution": [
 			"Run Commands",
@@ -19392,10 +19561,6 @@
 			"Commands to run",
 			"'runCommands' has received an argument with incorrect type. Please, review the argument passed to the command.",
 			"'runCommands' has not received commands to run. Did you forget to pass commands in the 'runCommands' argument?"
-		],
-		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
-			"Background color for the highlight of line at the top stack frame position.",
-			"Background color for the highlight of line at focused stack frame position."
 		],
 		"vs/workbench/contrib/comments/browser/comments.contribution": [
 			"Comments",
@@ -19414,18 +19579,54 @@
 			"URL to open",
 			"When enabled, trusted domain prompts will appear when opening links in trusted workspaces."
 		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
+			"webview editor"
+		],
 		"vs/workbench/contrib/webview/browser/webview.contribution": [
 			"Cut",
 			"Copy",
 			"Paste"
 		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
-			"webview editor"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
-			"Merge Editor",
-			"Uses the legacy diffing algorithm.",
-			"Uses the advanced diffing algorithm."
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			"Remote",
+			"Installed",
+			"Install Local Extensions in '{0}'...",
+			"Install Remote Extensions Locally...",
+			"Popular",
+			"Recommended",
+			"Enabled",
+			"Disabled",
+			"Marketplace",
+			"Installed",
+			"Recently Updated",
+			"Enabled",
+			"Disabled",
+			"Available Updates",
+			"Builtin",
+			"Workspace Unsupported",
+			"Workspace Recommendations",
+			"Other Recommendations",
+			"Features",
+			"Themes",
+			"Programming Languages",
+			"Disabled in Restricted Mode",
+			"Limited in Restricted Mode",
+			"Disabled in Virtual Workspaces",
+			"Limited in Virtual Workspaces",
+			"Deprecated",
+			"Search Extensions in Marketplace",
+			"1 extension found in the {0} section.",
+			"1 extension found.",
+			"{0} extensions found in the {1} section.",
+			"{0} extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"{0} requires update",
+			"{0} require update",
+			"{0} requires reload",
+			"{0} require reload",
+			"We have uninstalled '{0}' which was reported to be problematic.",
+			"Reload Now"
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
 			"Press Enter to manage extensions.",
@@ -19564,47 +19765,6 @@
 			"Extensions",
 			"Extensions"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			"Remote",
-			"Installed",
-			"Install Local Extensions in '{0}'...",
-			"Install Remote Extensions Locally...",
-			"Popular",
-			"Recommended",
-			"Enabled",
-			"Disabled",
-			"Marketplace",
-			"Installed",
-			"Recently Updated",
-			"Enabled",
-			"Disabled",
-			"Available Updates",
-			"Builtin",
-			"Workspace Unsupported",
-			"Workspace Recommendations",
-			"Other Recommendations",
-			"Features",
-			"Themes",
-			"Programming Languages",
-			"Disabled in Restricted Mode",
-			"Limited in Restricted Mode",
-			"Disabled in Virtual Workspaces",
-			"Limited in Virtual Workspaces",
-			"Deprecated",
-			"Search Extensions in Marketplace",
-			"1 extension found in the {0} section.",
-			"1 extension found.",
-			"{0} extensions found in the {1} section.",
-			"{0} extensions found.",
-			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
-			"Open User Settings",
-			"{0} requires update",
-			"{0} require update",
-			"{0} requires reload",
-			"{0} require reload",
-			"We have uninstalled '{0}' which was reported to be problematic.",
-			"Reload Now"
-		],
 		"vs/workbench/contrib/output/browser/output.contribution": [
 			"View icon of the output view.",
 			"Output",
@@ -19637,11 +19797,6 @@
 			"Output",
 			"Output panel"
 		],
-		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
-			"Open in Integrated Terminal",
-			"Open in External Terminal",
-			"Open in Windows Terminal"
-		],
 		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
 			"A setting has changed that requires a restart to take effect.",
 			"A setting has changed that requires a reload to take effect.",
@@ -19650,6 +19805,11 @@
 			"&&Restart",
 			"&&Reload",
 			"Restarting extension host due to a workspace folder change."
+		],
+		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
+			"Open in Integrated Terminal",
+			"Open in External Terminal",
+			"Open in Windows Terminal"
 		],
 		"vs/workbench/contrib/tasks/browser/task.contribution": [
 			"Building...",
@@ -19837,16 +19997,16 @@
 			"Apply Update",
 			"&&Update"
 		],
+		"vs/workbench/contrib/surveys/browser/ces.contribution": [
+			"Got a moment to help the VS Code team? Please tell us about your experience with VS Code so far.",
+			"Give Feedback",
+			"Remind Me Later"
+		],
 		"vs/workbench/contrib/surveys/browser/nps.contribution": [
 			"Do you mind taking a quick feedback survey?",
 			"Take Survey",
 			"Remind Me Later",
 			"Don't Show Again"
-		],
-		"vs/workbench/contrib/surveys/browser/ces.contribution": [
-			"Got a moment to help the VS Code team? Please tell us about your experience with VS Code so far.",
-			"Give Feedback",
-			"Remind Me Later"
 		],
 		"vs/workbench/contrib/surveys/browser/languageSurveys.contribution": [
 			"Help us improve our support for {0}",
@@ -19919,6 +20079,13 @@
 		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
 			"Document Symbols"
 		],
+		"vs/workbench/contrib/languageDetection/browser/languageDetection.contribution": [
+			"Accept Detected Language: {0}",
+			"Language Detection",
+			"Change to Detected Language: {0}",
+			"Detect Language from Content",
+			"Unable to detect editor language"
+		],
 		"vs/workbench/contrib/outline/browser/outline.contribution": [
 			"View icon of the outline view.",
 			"Outline",
@@ -19956,13 +20123,6 @@
 			"When enabled, Outline shows `event`-symbols.",
 			"When enabled, Outline shows `operator`-symbols.",
 			"When enabled, Outline shows `typeParameter`-symbols."
-		],
-		"vs/workbench/contrib/languageDetection/browser/languageDetection.contribution": [
-			"Accept Detected Language: {0}",
-			"Language Detection",
-			"Change to Detected Language: {0}",
-			"Detect Language from Content",
-			"Unable to detect editor language"
 		],
 		"vs/workbench/contrib/languageStatus/browser/languageStatus.contribution": [
 			"Editor Language Status",
@@ -20050,6 +20210,38 @@
 			"Icon for the filter timeline action.",
 			"Filter Timeline"
 		],
+		"vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExtensionMigrator.contribution": [
+			"The extension 'Bracket pair Colorizer' got disabled because it was deprecated.",
+			"Uninstall Extension",
+			"Enable Native Bracket Pair Colorization",
+			"More Info"
+		],
+		"vs/workbench/contrib/audioCues/browser/audioCues.contribution": [
+			"Enable audio cue when a screen reader is attached.",
+			"Enable audio cue.",
+			"Disable audio cue.",
+			"The volume of the audio cues in percent (0-100).",
+			"Whether or not position changes should be debounced",
+			"Plays a sound when the active line has a breakpoint.",
+			"Plays a sound when the active line has an inline suggestion.",
+			"Plays a sound when the active line has an error.",
+			"Plays a sound when the active line has a folded area that can be unfolded.",
+			"Plays a sound when the active line has a warning.",
+			"Plays a sound when the debugger stopped on a breakpoint.",
+			"Plays a sound when trying to read a line with inlay hints that has no inlay hints.",
+			"Plays a sound when a task is completed.",
+			"Plays a sound when a task fails (non-zero exit code).",
+			"Plays a sound when a terminal command fails (non-zero exit code).",
+			"Plays a sound when terminal Quick Fixes are available.",
+			"Plays a sound when the focus moves to an inserted line in accessible diff viewer mode or to the next/previous change",
+			"Plays a sound when the focus moves to a deleted line in accessible diff viewer mode or to the next/previous change",
+			"Plays a sound when the focus moves to a modified line in accessible diff viewer mode or to the next/previous change",
+			"Plays a sound when a notebook cell execution is successfully completed.",
+			"Plays a sound when a notebook cell execution fails.",
+			"Plays a sound when a chat request is made.",
+			"Plays a sound on loop while the response is pending.",
+			"Plays a sound on loop while the response has been received."
+		],
 		"vs/workbench/contrib/workspace/browser/workspace.contribution": [
 			"You are trying to open untrusted files in a workspace which is trusted.",
 			"You are trying to open untrusted files in a window which is trusted.",
@@ -20119,53 +20311,6 @@
 			"Always open untrusted files in a separate window in restricted mode without prompting.",
 			"Controls whether or not the empty window is trusted by default within VS Code. When used with `#{0}#`, you can enable the full functionality of VS Code without prompting in an empty window."
 		],
-		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
-			"This folder contains a workspace file '{0}'. Do you want to open it? [Learn more]({1}) about workspace files.",
-			"Open Workspace",
-			"This folder contains multiple workspace files. Do you want to open one? [Learn more]({0}) about workspace files.",
-			"Select Workspace",
-			"Select a workspace to open",
-			"Open Workspace",
-			"This workspace is already open."
-		],
-		"vs/workbench/contrib/audioCues/browser/audioCues.contribution": [
-			"Enable audio cue when a screen reader is attached.",
-			"Enable audio cue.",
-			"Disable audio cue.",
-			"The volume of the audio cues in percent (0-100).",
-			"Whether or not position changes should be debounced",
-			"Plays a sound when the active line has a breakpoint.",
-			"Plays a sound when the active line has an inline suggestion.",
-			"Plays a sound when the active line has an error.",
-			"Plays a sound when the active line has a folded area that can be unfolded.",
-			"Plays a sound when the active line has a warning.",
-			"Plays a sound when the debugger stopped on a breakpoint.",
-			"Plays a sound when trying to read a line with inlay hints that has no inlay hints.",
-			"Plays a sound when a task is completed.",
-			"Plays a sound when a task fails (non-zero exit code).",
-			"Plays a sound when a terminal command fails (non-zero exit code).",
-			"Plays a sound when terminal Quick Fixes are available.",
-			"Plays a sound when the focus moves to an inserted line in accessible diff viewer mode or to the next/previous change",
-			"Plays a sound when the focus moves to a deleted line in accessible diff viewer mode or to the next/previous change",
-			"Plays a sound when the focus moves to a modified line in accessible diff viewer mode or to the next/previous change",
-			"Plays a sound when a notebook cell execution is successfully completed.",
-			"Plays a sound when a notebook cell execution fails.",
-			"Plays a sound when a chat request is made.",
-			"Plays a sound on loop while the response is pending.",
-			"Plays a sound on loop while the response has been received."
-		],
-		"vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExtensionMigrator.contribution": [
-			"The extension 'Bracket pair Colorizer' got disabled because it was deprecated.",
-			"Uninstall Extension",
-			"Enable Native Bracket Pair Colorization",
-			"More Info"
-		],
-		"vs/workbench/contrib/accessibility/browser/accessibility.contribution": [
-			"editor accessibility help",
-			"Hover Accessible View",
-			"{0} Source: {1}",
-			"Notification Accessible View"
-		],
 		"vs/workbench/contrib/share/browser/share.contribution": [
 			"Share...",
 			"Generating link...",
@@ -20174,6 +20319,15 @@
 			"Close",
 			"Open Link",
 			"Controls whether to render the Share action next to the command center when {0} is {1}."
+		],
+		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
+			"This folder contains a workspace file '{0}'. Do you want to open it? [Learn more]({1}) about workspace files.",
+			"Open Workspace",
+			"This folder contains multiple workspace files. Do you want to open one? [Learn more]({0}) about workspace files.",
+			"Select Workspace",
+			"Select a workspace to open",
+			"Open Workspace",
+			"This workspace is already open."
 		],
 		"vs/workbench/browser/parts/dialogs/dialogHandler": [
 			"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
@@ -20184,6 +20338,18 @@
 			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
 			"&&Copy",
 			"OK"
+		],
+		"vs/workbench/services/textfile/browser/textFileService": [
+			"File Created",
+			"File Replaced",
+			"Text File Model Decorations",
+			"Deleted, Read-only",
+			"Read-only",
+			"Deleted",
+			"File seems to be binary and cannot be opened as text",
+			"'{0}' already exists. Do you want to replace it?",
+			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
+			"&&Replace"
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
 			"Default Language Configuration Overrides",
@@ -20220,6 +20386,13 @@
 			"Switch Window...",
 			"Quick Switch Window..."
 		],
+		"vs/workbench/electron-sandbox/actions/installActions": [
+			"Shell Command",
+			"Install '{0}' command in PATH",
+			"Shell command '{0}' successfully installed in PATH.",
+			"Uninstall '{0}' command from PATH",
+			"Shell command '{0}' successfully uninstalled from PATH."
+		],
 		"vs/platform/contextkey/common/contextkeys": [
 			"Whether the operating system is macOS",
 			"Whether the operating system is Linux",
@@ -20230,13 +20403,6 @@
 			"Whether the platform is a mobile web browser",
 			"Quality type of VS Code",
 			"Whether keyboard focus is inside an input box"
-		],
-		"vs/workbench/electron-sandbox/actions/installActions": [
-			"Shell Command",
-			"Install '{0}' command in PATH",
-			"Shell command '{0}' successfully installed in PATH.",
-			"Uninstall '{0}' command from PATH",
-			"Shell command '{0}' successfully uninstalled from PATH."
 		],
 		"vs/workbench/common/contextkeys": [
 			"The kind of workspace opened in the window, either 'empty' (no workspace), 'folder' (single folder) or 'workspace' (multi-root workspace)",
@@ -20307,18 +20473,6 @@
 			"UNC host names must not contain backslashes.",
 			"A set of UNC host names (without leading or trailing backslash, for example `192.168.0.1` or `my-server`) to allow without user confirmation. If a UNC host is being accessed that is not allowed via this setting or has not been acknowledged via user confirmation, an error will occur and the operation stopped. A restart is required when changing this setting. Find out more about this setting at https://aka.ms/vscode-windows-unc.",
 			"If enabled, only allows access to UNC host names that are allowed by the `#security.allowedUNCHosts#` setting or after user confirmation. Find out more about this setting at https://aka.ms/vscode-windows-unc."
-		],
-		"vs/workbench/services/textfile/browser/textFileService": [
-			"File Created",
-			"File Replaced",
-			"Text File Model Decorations",
-			"Deleted, Read-only",
-			"Read-only",
-			"Deleted",
-			"File seems to be binary and cannot be opened as text",
-			"'{0}' already exists. Do you want to replace it?",
-			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
-			"&&Replace"
 		],
 		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
 			"Your changes will be lost if you don't save them.",
@@ -20621,14 +20775,20 @@
 			"Status bar item background color when clicking. The status bar is shown in the bottom of the window.",
 			"Status bar item border color when focused on keyboard navigation. The status bar is shown in the bottom of the window.",
 			"Status bar item background color when hovering. The status bar is shown in the bottom of the window.",
+			"Status bar item foreground color when hovering. The status bar is shown in the bottom of the window.",
 			"Status bar item background color when hovering an item that contains two hovers. The status bar is shown in the bottom of the window.",
-			"Status bar prominent items foreground color. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window.",
-			"Status bar prominent items background color. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window.",
-			"Status bar prominent items background color when hovering. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items foreground color. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items background color. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items foreground color when hovering. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items background color when hovering. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
 			"Status bar error items background color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
 			"Status bar error items foreground color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
+			"Status bar error items foreground color when hovering. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
+			"Status bar error items background color when hovering. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
 			"Status bar warning items background color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
 			"Status bar warning items foreground color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
+			"Status bar warning items foreground color when hovering. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
+			"Status bar warning items background color when hovering. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
 			"Activity bar background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
 			"Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
 			"Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
@@ -20643,6 +20803,12 @@
 			"Profile badge foreground color. The profile badge shows on top of the settings gear icon in the activity bar.",
 			"Background color for the remote indicator on the status bar.",
 			"Foreground color for the remote indicator on the status bar.",
+			"Foreground color for the remote indicator on the status bar when hovering.",
+			"Background color for the remote indicator on the status bar when hovering.",
+			"Status bar item background color when the workbench is offline.",
+			"Status bar item foreground color when the workbench is offline.",
+			"Status bar item foreground hover color when the workbench is offline.",
+			"Status bar item background hover color when the workbench is offline.",
 			"Background color for the remote badge in the extensions view.",
 			"Foreground color for the remote badge in the extensions view.",
 			"Side bar background color. The side bar is the container for views like explorer and search.",
@@ -20674,6 +20840,9 @@
 			"The color used for the icon of info notifications. Notifications slide in from the bottom right of the window.",
 			"The color used for the border of the window when it is active. Only supported in the macOS and Linux desktop client when using the custom title bar.",
 			"The color used for the border of the window when it is inactive. Only supported in the macOS and Linux desktop client when using the custom title bar."
+		],
+		"vs/base/common/actions": [
+			"(empty)"
 		],
 		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
 			"Save",
@@ -20718,9 +20887,6 @@
 			"Contains extensions which are not supported.",
 			"'{0}' contains extensions which are not supported in {1}."
 		],
-		"vs/base/common/actions": [
-			"(empty)"
-		],
 		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
 			"Can't install release version of '{0}' extension because it has no release version.",
 			"Can't install '{0}' extension because it is not compatible with the current version of {1} (version {2})."
@@ -20761,25 +20927,78 @@
 			"Remote Extension host terminated unexpectedly 3 times within the last 5 minutes.",
 			"Restart Remote Extension Host"
 		],
-		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
-			"Extensions have been modified on disk. Please reload the window.",
-			"Reload Window"
-		],
-		"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost": [
-			"Extension host did not start in 10 seconds, it might be stopped on the first line and needs a debugger to continue.",
-			"Extension host did not start in 10 seconds, that might be a problem.",
-			"Reload Window",
-			"Terminating extension debug session"
-		],
 		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
 			"Open Logs Folder",
 			"Open Extension Logs Folder"
 		],
-		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
-			"Paste Selection Clipboard"
+		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
+			"Search language packs in the Marketplace to change the display language to {0}.",
+			"Search Marketplace",
+			"Install language pack to change the display language to {0}.",
+			"Install and Restart"
+		],
+		"vs/workbench/contrib/localization/common/localization.contribution": [
+			"Contributes localizations to the editor",
+			"Id of the language into which the display strings are translated.",
+			"Name of the language in English.",
+			"Name of the language in contributed language.",
+			"List of translations associated to the language.",
+			"Id of VS Code or Extension for which this translation is contributed to. Id of VS Code is always `vscode` and of extension should be in format `publisherId.extensionName`.",
+			"Id should be `vscode` or in format `publisherId.extensionName` for translating VS code or an extension respectively.",
+			"A relative path to a file containing translations for the language."
+		],
+		"vs/workbench/common/editor": [
+			"Text Editor",
+			"Built-in",
+			"Open Anyway",
+			"Configure Limit"
+		],
+		"vs/editor/common/editorContextKeys": [
+			"Whether the editor text has focus (cursor is blinking)",
+			"Whether the editor or an editor widget has focus (e.g. focus is in the find widget)",
+			"Whether an editor or a rich text input has focus (cursor is blinking)",
+			"Whether the editor is read-only",
+			"Whether the context is a diff editor",
+			"Whether the context is an embedded diff editor",
+			"Whether a moved code block is selected for comparison",
+			"Whether the accessible diff viewer is visible",
+			"Whether the diff editor render side by side inline breakpoint is reached",
+			"Whether `editor.columnSelection` is enabled",
+			"Whether the editor has text selected",
+			"Whether the editor has multiple selections",
+			"Whether `Tab` will move focus out of the editor",
+			"Whether the editor hover is visible",
+			"Whether the editor hover is focused",
+			"Whether the sticky scroll is focused",
+			"Whether the sticky scroll is visible",
+			"Whether the standalone color picker is visible",
+			"Whether the standalone color picker is focused",
+			"Whether the editor is part of a larger editor (e.g. notebooks)",
+			"The language identifier of the editor",
+			"Whether the editor has a completion item provider",
+			"Whether the editor has a code actions provider",
+			"Whether the editor has a code lens provider",
+			"Whether the editor has a definition provider",
+			"Whether the editor has a declaration provider",
+			"Whether the editor has an implementation provider",
+			"Whether the editor has a type definition provider",
+			"Whether the editor has a hover provider",
+			"Whether the editor has a document highlight provider",
+			"Whether the editor has a document symbol provider",
+			"Whether the editor has a reference provider",
+			"Whether the editor has a rename provider",
+			"Whether the editor has a signature help provider",
+			"Whether the editor has an inline hints provider",
+			"Whether the editor has a document formatting provider",
+			"Whether the editor has a document selection formatting provider",
+			"Whether the editor has multiple document formatting providers",
+			"Whether the editor has multiple document selection formatting providers"
 		],
 		"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate": [
 			"Start Text Mate Syntax Grammar Logging"
+		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
+			"Paste Selection Clipboard"
 		],
 		"vs/workbench/browser/editor": [
 			"{0}, preview",
@@ -20792,11 +21011,15 @@
 			"Save Extension Host Profile",
 			"Save"
 		],
-		"vs/workbench/common/editor": [
-			"Text Editor",
-			"Built-in",
-			"Open Anyway",
-			"Configure Limit"
+		"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost": [
+			"Extension host did not start in 10 seconds, it might be stopped on the first line and needs a debugger to continue.",
+			"Extension host did not start in 10 seconds, that might be a problem.",
+			"Reload Window",
+			"Terminating extension debug session"
+		],
+		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
+			"Extensions have been modified on disk. Please reload the window.",
+			"Reload Window"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/debugExtensionHostAction": [
 			"Start Debugging Extension Host",
@@ -20859,35 +21082,6 @@
 			"Icon path when a light theme is used",
 			"Icon path when a dark theme is used"
 		],
-		"vs/editor/common/languages": [
-			"array",
-			"boolean",
-			"class",
-			"constant",
-			"constructor",
-			"enumeration",
-			"enumeration member",
-			"event",
-			"field",
-			"file",
-			"function",
-			"interface",
-			"key",
-			"method",
-			"module",
-			"namespace",
-			"null",
-			"number",
-			"object",
-			"operator",
-			"package",
-			"property",
-			"string",
-			"struct",
-			"type parameter",
-			"variable",
-			"{0} ({1})"
-		],
 		"vs/workbench/services/userDataSync/common/userDataSync": [
 			"Settings",
 			"Keyboard Shortcuts",
@@ -20909,12 +21103,22 @@
 			"A final restart is required to continue to use '{0}'. Again, thank you for your contribution.",
 			"&&Restart"
 		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"Whether a task is currently running.",
+			"Tasks",
+			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
+		],
 		"vs/workbench/contrib/tasks/common/taskService": [
 			"Whether CustomExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
 			"Whether ShellExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
 			"Whether the task commands have been registered yet",
 			"Whether ProcessExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
 			"True when in the web with no remote authority."
+		],
+		"vs/workbench/common/views": [
+			"Default view icon.",
+			"A view with id '{0}' is already registered",
+			"No tree view with id '{0}' registered."
 		],
 		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
 			"A unknown error has occurred while executing a task. See task output log for details.",
@@ -20931,88 +21135,6 @@
 			"Problem matcher {0} can't be resolved. The matcher will be ignored",
 			"Press any key to close the terminal.",
 			"Terminal will be reused by tasks, press any key to close it."
-		],
-		"vs/workbench/contrib/tasks/common/tasks": [
-			"Whether a task is currently running.",
-			"Tasks",
-			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
-		],
-		"vs/workbench/common/views": [
-			"Default view icon.",
-			"A view with id '{0}' is already registered",
-			"No tree view with id '{0}' registered."
-		],
-		"vs/platform/audioCues/browser/audioCueService": [
-			"Error on Line",
-			"Warning on Line",
-			"Folded Area on Line",
-			"Breakpoint on Line",
-			"Inline Suggestion on Line",
-			"Terminal Quick Fix",
-			"Debugger Stopped on Breakpoint",
-			"No Inlay Hints on Line",
-			"Task Completed",
-			"Task Failed",
-			"Terminal Command Failed",
-			"Terminal Bell",
-			"Notebook Cell Completed",
-			"Notebook Cell Failed",
-			"Diff Line Inserted",
-			"Diff Line Deleted",
-			"Diff Line Modified",
-			"Chat Request Sent",
-			"Chat Response Received",
-			"Chat Response Pending"
-		],
-		"vs/workbench/contrib/terminal/common/terminalContextKey": [
-			"Whether the terminal is focused.",
-			"Whether any terminal is focused, including detached terminals used in other UI.",
-			"Whether the terminal accessible buffer is focused.",
-			"Whether a terminal in the editor area is focused.",
-			"The current number of terminals.",
-			"Whether the terminal tabs widget is focused.",
-			"The shell type of the active terminal, this is set to the last known value when no terminals exist.",
-			"Whether the terminal's alt buffer is active.",
-			"Whether the terminal's suggest widget is visible.",
-			"Whether the terminal view is showing",
-			"Whether text is selected in the active terminal.",
-			"Whether text is selected in a focused terminal.",
-			"Whether terminal processes can be launched in the current workspace.",
-			"Whether one terminal is selected in the terminal tabs list.",
-			"Whether the focused tab's terminal is a split terminal.",
-			"Whether the terminal run command picker is currently open.",
-			"Whether shell integration is enabled in the active terminal"
-		],
-		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
-			"Reveal in File Explorer",
-			"Reveal in Finder",
-			"Open Containing Folder"
-		],
-		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
-			"Open Webview Developer Tools",
-			"Using standard dev tools to debug iframe based webview"
-		],
-		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
-			"Merge Editor (Dev)",
-			"Open Merge Editor State from JSON",
-			"Enter JSON",
-			"Open Selection In Temporary Merge Editor"
-		],
-		"vs/workbench/contrib/localization/common/localization.contribution": [
-			"Contributes localizations to the editor",
-			"Id of the language into which the display strings are translated.",
-			"Name of the language in English.",
-			"Name of the language in contributed language.",
-			"List of translations associated to the language.",
-			"Id of VS Code or Extension for which this translation is contributed to. Id of VS Code is always `vscode` and of extension should be in format `publisherId.extensionName`.",
-			"Id should be `vscode` or in format `publisherId.extensionName` for translating VS code or an extension respectively.",
-			"A relative path to a file containing translations for the language."
-		],
-		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
-			"Search language packs in the Marketplace to change the display language to {0}.",
-			"Search Marketplace",
-			"Install language pack to change the display language to {0}.",
-			"Install and Restart"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"Configure Task",
@@ -21104,44 +21226,80 @@
 			"Open diff",
 			"Open diffs"
 		],
-		"vs/editor/common/editorContextKeys": [
-			"Whether the editor text has focus (cursor is blinking)",
-			"Whether the editor or an editor widget has focus (e.g. focus is in the find widget)",
-			"Whether an editor or a rich text input has focus (cursor is blinking)",
-			"Whether the editor is read-only",
-			"Whether the context is a diff editor",
-			"Whether the context is an embedded diff editor",
-			"Whether the accessible diff viewer is visible",
-			"Whether `editor.columnSelection` is enabled",
-			"Whether the editor has text selected",
-			"Whether the editor has multiple selections",
-			"Whether `Tab` will move focus out of the editor",
-			"Whether the editor hover is visible",
-			"Whether the editor hover is focused",
-			"Whether the sticky scroll is focused",
-			"Whether the sticky scroll is visible",
-			"Whether the standalone color picker is visible",
-			"Whether the standalone color picker is focused",
-			"Whether the editor is part of a larger editor (e.g. notebooks)",
-			"The language identifier of the editor",
-			"Whether the editor has a completion item provider",
-			"Whether the editor has a code actions provider",
-			"Whether the editor has a code lens provider",
-			"Whether the editor has a definition provider",
-			"Whether the editor has a declaration provider",
-			"Whether the editor has an implementation provider",
-			"Whether the editor has a type definition provider",
-			"Whether the editor has a hover provider",
-			"Whether the editor has a document highlight provider",
-			"Whether the editor has a document symbol provider",
-			"Whether the editor has a reference provider",
-			"Whether the editor has a rename provider",
-			"Whether the editor has a signature help provider",
-			"Whether the editor has an inline hints provider",
-			"Whether the editor has a document formatting provider",
-			"Whether the editor has a document selection formatting provider",
-			"Whether the editor has multiple document formatting providers",
-			"Whether the editor has multiple document selection formatting providers"
+		"vs/platform/audioCues/browser/audioCueService": [
+			"Error on Line",
+			"Warning on Line",
+			"Folded Area on Line",
+			"Breakpoint on Line",
+			"Inline Suggestion on Line",
+			"Terminal Quick Fix",
+			"Debugger Stopped on Breakpoint",
+			"No Inlay Hints on Line",
+			"Task Completed",
+			"Task Failed",
+			"Terminal Command Failed",
+			"Terminal Bell",
+			"Notebook Cell Completed",
+			"Notebook Cell Failed",
+			"Diff Line Inserted",
+			"Diff Line Deleted",
+			"Diff Line Modified",
+			"Chat Request Sent",
+			"Chat Response Received",
+			"Chat Response Pending"
+		],
+		"vs/workbench/contrib/terminal/common/terminalContextKey": [
+			"Whether the terminal is focused.",
+			"Whether any terminal is focused, including detached terminals used in other UI.",
+			"Whether the terminal accessible buffer is focused.",
+			"Whether the accessible buffer focus is on the last line.",
+			"Whether a terminal in the editor area is focused.",
+			"The current number of terminals.",
+			"Whether the terminal tabs widget is focused.",
+			"The shell type of the active terminal, this is set to the last known value when no terminals exist.",
+			"Whether the terminal's alt buffer is active.",
+			"Whether the terminal's suggest widget is visible.",
+			"Whether the terminal view is showing",
+			"Whether text is selected in the active terminal.",
+			"Whether text is selected in a focused terminal.",
+			"Whether terminal processes can be launched in the current workspace.",
+			"Whether one terminal is selected in the terminal tabs list.",
+			"Whether the focused tab's terminal is a split terminal.",
+			"Whether the terminal run command picker is currently open.",
+			"Whether shell integration is enabled in the active terminal"
+		],
+		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
+			"Open Webview Developer Tools",
+			"Using standard dev tools to debug iframe based webview"
+		],
+		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
+			"Reveal in File Explorer",
+			"Reveal in Finder",
+			"Open Containing Folder"
+		],
+		"vs/workbench/contrib/mergeEditor/electron-sandbox/devCommands": [
+			"Merge Editor (Dev)",
+			"Open Merge Editor State from JSON",
+			"Enter JSON",
+			"Open Selection In Temporary Merge Editor"
+		],
+		"vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions": [
+			"True when getting ready for receiving voice input from the microphone for voice chat.",
+			"True when voice recording from microphone is in progress for voice chat.",
+			"True when voice recording from microphone is in progress for quick chat.",
+			"True when voice recording from microphone is in progress for inline chat.",
+			"True when voice recording from microphone is in progress in the chat view.",
+			"True when voice recording from microphone is in progress in the chat editor.",
+			"Voice Chat in Chat View",
+			"Inline Voice Chat",
+			"Quick Voice Chat",
+			"Start Voice Chat",
+			"Stop Voice Chat",
+			"Stop Voice Chat (Chat View)",
+			"Stop Voice Chat (Chat Editor)",
+			"Stop Voice Chat (Quick Chat)",
+			"Stop Voice Chat (Inline Editor)",
+			"Stop Voice Chat and Submit"
 		],
 		"vs/workbench/api/common/extHostExtensionService": [
 			"Cannot load test runner.",
@@ -21173,9 +21331,6 @@
 		],
 		"vs/workbench/api/node/extHostDebugService": [
 			"Debug Process"
-		],
-		"vs/base/browser/ui/button/button": [
-			"More Actions..."
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"Open",
@@ -21226,19 +21381,6 @@
 			"Unable to uninstall the shell command '{0}'.",
 			"Unable to find shell script in '{0}'"
 		],
-		"vs/platform/windows/electron-main/windowsMainService": [
-			"&&OK",
-			"Path does not exist",
-			"URI can not be opened",
-			"The path '{0}' does not exist on this computer.",
-			"The URI '{0}' is not valid and can not be opened.",
-			"&&Allow",
-			"&&Cancel",
-			"&&Learn More",
-			"The host '{0}' was not found in the list of allowed hosts. Do you want to allow it anyway?",
-			"The path '{0}' uses a host that is not allowed. Unless you trust the host, you should press 'Cancel'",
-			"Permanently allow host '{0}'"
-		],
 		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
 			"New Window",
 			"Opens a new window",
@@ -21252,24 +21394,24 @@
 			"Unable to save workspace '{0}'",
 			"The workspace is already opened in another window. Please close that window first and then try again."
 		],
+		"vs/platform/windows/electron-main/windowsMainService": [
+			"&&OK",
+			"Path does not exist",
+			"URI can not be opened",
+			"The path '{0}' does not exist on this computer.",
+			"The URI '{0}' is not valid and can not be opened.",
+			"&&Allow",
+			"&&Cancel",
+			"&&Learn More",
+			"The host '{0}' was not found in the list of allowed hosts. Do you want to allow it anyway?",
+			"The path '{0}' uses a host that is not allowed. Unless you trust the host, you should press 'Cancel'",
+			"Permanently allow host '{0}'"
+		],
 		"vs/platform/files/common/io": [
 			"File is too large to open"
 		],
-		"vs/base/browser/ui/tree/abstractTree": [
-			"Filter",
-			"Fuzzy Match",
-			"Type to filter",
-			"Type to search",
-			"Type to search",
-			"Close",
-			"No elements found."
-		],
-		"vs/platform/theme/common/iconRegistry": [
-			"The id of the font to use. If not set, the font that is defined first is used.",
-			"The font character associated with the icon definition.",
-			"Icon for the close action in widgets.",
-			"Icon for goto previous editor location.",
-			"Icon for goto next editor location."
+		"vs/base/browser/ui/button/button": [
+			"More Actions..."
 		],
 		"vs/platform/extensions/common/extensionValidator": [
 			"property publisher must be of type `string`.",
@@ -21383,16 +21525,12 @@
 			"{0} years",
 			"{0} yrs"
 		],
-		"vs/platform/userDataSync/common/keybindingsSync": [
-			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it.",
-			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it."
-		],
 		"vs/platform/userDataSync/common/settingsSync": [
 			"Unable to sync settings as there are errors/warning in settings file."
 		],
-		"vs/platform/userDataSync/common/abstractSynchronizer": [
-			"Cannot sync {0} as its local version {1} is not compatible with its remote version {2}",
-			"Cannot parse sync data as it is not compatible with the current version."
+		"vs/platform/userDataSync/common/keybindingsSync": [
+			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it.",
+			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it."
 		],
 		"vs/platform/userDataSync/common/userDataAutoSyncService": [
 			"Cannot sync because default service has changed",
@@ -21403,10 +21541,31 @@
 			"Cannot sync because current session is expired",
 			"Cannot sync because syncing is turned off on this machine from another machine."
 		],
-		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
-			"Error: {0}",
-			"Warning: {0}",
-			"Info: {0}"
+		"vs/platform/userDataSync/common/abstractSynchronizer": [
+			"Cannot sync {0} as its local version {1} is not compatible with its remote version {2}",
+			"Cannot parse sync data as it is not compatible with the current version."
+		],
+		"vs/base/browser/ui/tree/abstractTree": [
+			"Filter",
+			"Fuzzy Match",
+			"Type to filter",
+			"Type to search",
+			"Type to search",
+			"Close",
+			"No elements found."
+		],
+		"vs/platform/theme/common/iconRegistry": [
+			"The id of the font to use. If not set, the font that is defined first is used.",
+			"The font character associated with the icon definition.",
+			"Icon for the close action in widgets.",
+			"Icon for goto previous editor location.",
+			"Icon for goto next editor location."
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"No new notifications",
+			"Notifications",
+			"Notification Center Actions",
+			"Notifications Center"
 		],
 		"vs/workbench/browser/parts/notifications/notificationsStatus": [
 			"Notifications",
@@ -21423,15 +21582,14 @@
 			"{0} New Notifications ({1} in progress)",
 			"Status Message"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"No new notifications",
-			"Notifications",
-			"Notification Center Actions",
-			"Notifications Center"
-		],
 		"vs/workbench/browser/parts/notifications/notificationsToasts": [
 			"{0}, notification",
 			"{0}, source: {1}, notification"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"Error: {0}",
+			"Warning: {0}",
+			"Info: {0}"
 		],
 		"vs/workbench/browser/parts/notifications/notificationsCommands": [
 			"Notifications",
@@ -21490,15 +21648,6 @@
 			"Remote User Settings",
 			"Workspace Settings",
 			"Folder Settings"
-		],
-		"vs/editor/browser/coreCommands": [
-			"Stick to the end even when going to longer lines",
-			"Stick to the end even when going to longer lines",
-			"Removed secondary cursors"
-		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"The number of cursors has been limited to {0}. Consider using [find and replace](https://code.visualstudio.com/docs/editor/codebasics#_find-and-replace) for larger changes or increase the editor multi cursor limit setting.",
-			"Increase Multi Cursor Limit"
 		],
 		"vs/editor/common/core/editorColorRegistry": [
 			"Background color for the highlight of line at the cursor position.",
@@ -21569,6 +21718,22 @@
 			"Border color used to highlight unicode characters.",
 			"Background color used to highlight unicode characters."
 		],
+		"vs/platform/contextkey/common/scanner": [
+			"Did you mean {0}?",
+			"Did you mean {0} or {1}?",
+			"Did you mean {0}, {1} or {2}?",
+			"Did you forget to open or close the quote?",
+			"Did you forget to escape the '/' (slash) character? Put two backslashes before it to escape, e.g., '\\\\/'."
+		],
+		"vs/editor/browser/coreCommands": [
+			"Stick to the end even when going to longer lines",
+			"Stick to the end even when going to longer lines",
+			"Removed secondary cursors"
+		],
+		"vs/editor/contrib/caretOperations/browser/caretOperations": [
+			"Move Selected Text Left",
+			"Move Selected Text Right"
+		],
 		"vs/editor/contrib/anchorSelect/browser/anchorSelect": [
 			"Selection Anchor",
 			"Anchor set at {0}:{1}",
@@ -21577,19 +21742,12 @@
 			"Select from Anchor to Cursor",
 			"Cancel Selection Anchor"
 		],
-		"vs/platform/contextkey/common/scanner": [
-			"Did you mean {0}?",
-			"Did you mean {0} or {1}?",
-			"Did you mean {0}, {1} or {2}?",
-			"Did you forget to open or close the quote?",
-			"Did you forget to escape the '/' (slash) character? Put two backslashes before it to escape, e.g., '\\\\/'."
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"The number of cursors has been limited to {0}. Consider using [find and replace](https://code.visualstudio.com/docs/editor/codebasics#_find-and-replace) for larger changes or increase the editor multi cursor limit setting.",
+			"Increase Multi Cursor Limit"
 		],
-		"vs/editor/browser/widget/diffEditorWidget": [
-			"Line decoration for inserts in the diff editor.",
-			"Line decoration for removals in the diff editor.",
-			" use Shift + F7 to navigate changes",
-			"Cannot compare files because one file is too large.",
-			"Click to revert change"
+		"vs/editor/contrib/caretOperations/browser/transpose": [
+			"Transpose Letters"
 		],
 		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
 			"Overview ruler marker color for matching brackets.",
@@ -21597,13 +21755,6 @@
 			"Select to Bracket",
 			"Remove Brackets",
 			"Go to &&Bracket"
-		],
-		"vs/editor/contrib/caretOperations/browser/caretOperations": [
-			"Move Selected Text Left",
-			"Move Selected Text Right"
-		],
-		"vs/editor/contrib/caretOperations/browser/transpose": [
-			"Transpose Letters"
 		],
 		"vs/editor/contrib/clipboard/browser/clipboard": [
 			"Cu&&t",
@@ -21627,6 +21778,13 @@
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionContributions": [
 			"Enable/disable showing group headers in the Code Action menu."
+		],
+		"vs/editor/browser/widget/diffEditorWidget": [
+			"Line decoration for inserts in the diff editor.",
+			"Line decoration for removals in the diff editor.",
+			" use Shift + F7 to navigate changes",
+			"Cannot compare files because one file is too large.",
+			"Click to revert change"
 		],
 		"vs/editor/contrib/codelens/browser/codelensController": [
 			"Show CodeLens Commands For Current Line"
@@ -21661,10 +21819,6 @@
 			"Cursor Undo",
 			"Cursor Redo"
 		],
-		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution": [
-			"Paste As...",
-			"The id of the paste edit to try applying. If not provided, the editor will show a picker."
-		],
 		"vs/editor/contrib/find/browser/findController": [
 			"Find",
 			"&&Find",
@@ -21691,6 +21845,9 @@
 			"Editor Font Zoom Out",
 			"Editor Font Zoom Reset"
 		],
+		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution": [
+			"Configures the default drop provider to use for content of a given mime type."
+		],
 		"vs/editor/contrib/folding/browser/folding": [
 			"Unfold",
 			"Unfold Recursively",
@@ -21700,8 +21857,8 @@
 			"Fold All Block Comments",
 			"Fold All Regions",
 			"Unfold All Regions",
-			"Fold All Regions Except Selected",
-			"Unfold All Regions Except Selected",
+			"Fold All Except Selected",
+			"Unfold All Except Selected",
 			"Fold All",
 			"Unfold All",
 			"Go to Parent Fold",
@@ -21710,6 +21867,10 @@
 			"Create Folding Range from Selection",
 			"Remove Manual Folding Ranges",
 			"Fold Level {0}"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution": [
+			"Paste As...",
+			"The id of the paste edit to try applying. If not provided, the editor will show a picker."
 		],
 		"vs/editor/contrib/format/browser/formatActions": [
 			"Format Document",
@@ -21759,20 +21920,8 @@
 		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
 			"Click to show {0} definitions."
 		],
-		"vs/editor/contrib/gotoError/browser/gotoError": [
-			"Go to Next Problem (Error, Warning, Info)",
-			"Icon for goto next marker.",
-			"Go to Previous Problem (Error, Warning, Info)",
-			"Icon for goto previous marker.",
-			"Go to Next Problem in Files (Error, Warning, Info)",
-			"Next &&Problem",
-			"Go to Previous Problem in Files (Error, Warning, Info)",
-			"Previous &&Problem"
-		],
 		"vs/editor/contrib/hover/browser/hover": [
 			"Show or Focus Hover",
-			"Inspect this in the accessible view with {0}",
-			"Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding",
 			"Show Definition Preview Hover",
 			"Scroll Up Hover",
 			"Scroll Down Hover",
@@ -21782,6 +21931,16 @@
 			"Page Down Hover",
 			"Go To Top Hover",
 			"Go To Bottom Hover"
+		],
+		"vs/editor/contrib/gotoError/browser/gotoError": [
+			"Go to Next Problem (Error, Warning, Info)",
+			"Icon for goto next marker.",
+			"Go to Previous Problem (Error, Warning, Info)",
+			"Icon for goto previous marker.",
+			"Go to Next Problem in Files (Error, Warning, Info)",
+			"Next &&Problem",
+			"Go to Previous Problem in Files (Error, Warning, Info)",
+			"Previous &&Problem"
 		],
 		"vs/editor/contrib/indentation/browser/indentation": [
 			"Convert Indentation to Spaces",
@@ -21797,12 +21956,12 @@
 			"Reindent Lines",
 			"Reindent Selected Lines"
 		],
+		"vs/editor/contrib/lineSelection/browser/lineSelection": [
+			"Expand Line Selection"
+		],
 		"vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace": [
 			"Replace with Previous Value",
 			"Replace with Next Value"
-		],
-		"vs/editor/contrib/lineSelection/browser/lineSelection": [
-			"Expand Line Selection"
 		],
 		"vs/editor/contrib/linesOperations/browser/linesOperations": [
 			"Copy Line Up",
@@ -21827,17 +21986,13 @@
 			"Delete All Left",
 			"Delete All Right",
 			"Join Lines",
-			"Transpose characters around the cursor",
+			"Transpose Characters around the Cursor",
 			"Transform to Uppercase",
 			"Transform to Lowercase",
 			"Transform to Title Case",
 			"Transform to Snake Case",
 			"Transform to Camel Case",
 			"Transform to Kebab Case"
-		],
-		"vs/editor/contrib/linkedEditing/browser/linkedEditing": [
-			"Start Linked Editing",
-			"Background color when the editor auto renames on type."
 		],
 		"vs/editor/contrib/links/browser/links": [
 			"Failed to open this link because it is not well-formed: {0}",
@@ -21850,6 +22005,10 @@
 			"alt + click",
 			"Execute command {0}",
 			"Open Link"
+		],
+		"vs/editor/contrib/linkedEditing/browser/linkedEditing": [
+			"Start Linked Editing",
+			"Background color when the editor auto renames on type."
 		],
 		"vs/editor/contrib/multicursor/browser/multicursor": [
 			"Cursor added: {0}",
@@ -21955,13 +22114,13 @@
 			"&&Remove Unusual Line Terminators",
 			"Ignore"
 		],
+		"vs/editor/contrib/wordOperations/browser/wordOperations": [
+			"Delete Word"
+		],
 		"vs/editor/contrib/wordHighlighter/browser/wordHighlighter": [
 			"Go to Next Symbol Highlight",
 			"Go to Previous Symbol Highlight",
 			"Trigger Symbol Highlight"
-		],
-		"vs/editor/contrib/wordOperations/browser/wordOperations": [
-			"Delete Word"
 		],
 		"vs/editor/contrib/readOnlyMessage/browser/contribution": [
 			"Cannot edit in read-only input",
@@ -21972,16 +22131,18 @@
 			"Now opening the Accessibility documentation page.",
 			"You are in a read-only pane of a diff editor.",
 			"You are in a pane of a diff editor.",
-			"You are in a read-only code editor",
-			"You are in a code editor",
+			"You are in a read-only code editor.",
+			"You are in a code editor.",
 			"To configure the application to be optimized for usage with a Screen Reader press Command+E now.",
 			"To configure the application to be optimized for usage with a Screen Reader press Control+E now.",
 			"The application is configured to be optimized for usage with a Screen Reader.",
-			"The application is configured to never be optimized for usage with a Screen Reader",
+			"The application is configured to never be optimized for usage with a Screen Reader.",
 			"Screen Reader Optimized Mode enabled.",
 			"Screen Reader Optimized Mode disabled.",
 			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
 			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
+			"Run the command: Focus Sticky Scroll ({0}) to focus the currently nested scopes.",
+			"Run the command: Focus Sticky Scroll to focus the currently nested scopes. It is currently not triggerable by a keybinding.",
 			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
 			"Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.",
 			"Show Accessibility Help",
@@ -22040,6 +22201,20 @@
 			"Expected `contributes.icons.default.fontPath` to have file extension 'woff', woff2' or 'ttf', is '{0}'.",
 			"Expected `contributes.icons.default.fontPath` ({0}) to be included inside extension's folder ({0}).",
 			"'configuration.icons.default' must be either a reference to the id of an other theme icon (string) or a icon definition (object) with properties `fontPath` and `fontCharacter`."
+		],
+		"vs/workbench/api/browser/statusBarExtensionPoint": [
+			"The identifier of the status bar entry. Must be unique within the extension. The same value must be used when calling the `vscode.window.createStatusBarItem(id, ...)`-API",
+			"The name of the entry, like 'Python Language Indicator', 'Git Status' etc. Try to keep the length of the name short, yet descriptive enough that users can understand what the status bar item is about.",
+			"The text to show for the entry. You can embed icons in the text by leveraging the `$(<name>)`-syntax, like 'Hello $(globe)!'",
+			"The tooltip text for the entry.",
+			"The command to execute when the status bar entry is clicked.",
+			"The alignment of the status bar entry.",
+			"The priority of the status bar entry. Higher value means the item should be shown more to the left.",
+			"Defines the role and aria label to be used when the status bar entry is focused.",
+			"The role of the status bar entry which defines how a screen reader interacts with it. More about aria roles can be found here https://w3c.github.io/aria/#widget_roles",
+			"The aria label of the status bar entry. Defaults to the entry's text.",
+			"Contributes items to the status bar.",
+			"Invalid status bar item contribution."
 		],
 		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
 			"Contributes semantic token types.",
@@ -22132,20 +22307,6 @@
 			"Describes text to be appended after the new line and after the indentation.",
 			"Describes the number of characters to remove from the new line's indentation."
 		],
-		"vs/workbench/api/browser/statusBarExtensionPoint": [
-			"The identifier of the status bar entry. Must be unique within the extension. The same value must be used when calling the `vscode.window.createStatusBarItem(id, ...)`-API",
-			"The name of the entry, like 'Python Language Indicator', 'Git Status' etc. Try to keep the length of the name short, yet descriptive enough that users can understand what the status bar item is about.",
-			"The text to show for the entry. You can embed icons in the text by leveraging the `$(<name>)`-syntax, like 'Hello $(globe)!'",
-			"The tooltip text for the entry.",
-			"The command to execute when the status bar entry is clicked.",
-			"The alignment of the status bar entry.",
-			"The priority of the status bar entry. Higher value means the item should be shown more to the left.",
-			"Defines the role and aria label to be used when the status bar entry is focused.",
-			"The role of the status bar entry which defines how a screen reader interacts with it. More about aria roles can be found here https://w3c.github.io/aria/#widget_roles",
-			"The aria label of the status bar entry. Defaults to the entry's text.",
-			"Contributes items to the status bar.",
-			"Invalid status bar item contribution."
-		],
 		"vs/workbench/api/browser/mainThreadCLICommands": [
 			"Cannot install the '{0}' extension because it is declared to not run in this setup."
 		],
@@ -22184,15 +22345,15 @@
 			"Running 'File Write' participants...",
 			"Reset choice for 'File operation needs preview'"
 		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"Manage Extension"
+		],
 		"vs/workbench/api/browser/mainThreadMessageService": [
 			"{0} (Extension)",
 			"Extension",
 			"Manage Extension",
 			"Cancel",
 			"&&OK"
-		],
-		"vs/workbench/api/browser/mainThreadProgress": [
-			"Manage Extension"
 		],
 		"vs/workbench/api/browser/mainThreadSaveParticipant": [
 			"Aborted onWillSaveTextDocument-event after 1750ms"
@@ -22220,6 +22381,10 @@
 		"vs/workbench/api/browser/mainThreadTask": [
 			"{0}: {1}"
 		],
+		"vs/workbench/api/browser/mainThreadTunnelService": [
+			"The extension {0} has forwarded port {1}. You'll need to run as superuser to use port {2} locally.",
+			"Use Port {0} as Sudo..."
+		],
 		"vs/workbench/api/browser/mainThreadAuthentication": [
 			"This account has not been used by any extensions.",
 			"Cancel",
@@ -22235,9 +22400,60 @@
 			"The extension '{0}' wants to sign in using {1}.",
 			"&&Allow"
 		],
-		"vs/workbench/api/browser/mainThreadTunnelService": [
-			"The extension {0} has forwarded port {1}. You'll need to run as superuser to use port {2} locally.",
-			"Use Port {0} as Sudo..."
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
+			"Icon to toggle the auxiliary bar off in its right position.",
+			"Icon to toggle the auxiliary bar on in its right position.",
+			"Icon to toggle the auxiliary bar in its left position.",
+			"Icon to toggle the auxiliary bar on in its left position.",
+			"Toggle Secondary Side Bar Visibility",
+			"Secondary Side Bar",
+			"Secondary Si&&de Bar",
+			"Focus into Secondary Side Bar",
+			"Toggle Secondary Side Bar",
+			"Toggle Secondary Side Bar",
+			"Hide Secondary Side Bar"
+		],
+		"vs/workbench/browser/parts/panel/panelActions": [
+			"Icon to maximize a panel.",
+			"Icon to restore a panel.",
+			"Icon to close a panel.",
+			"Icon to toggle the panel off when it is on.",
+			"Icon to toggle the panel on when it is off.",
+			"Toggle Panel Visibility",
+			"Panel",
+			"&&Panel",
+			"Focus into Panel",
+			"Focus into Panel",
+			"Move Panel Left",
+			"Left",
+			"Move Panel Right",
+			"Right",
+			"Move Panel To Bottom",
+			"Bottom",
+			"Set Panel Alignment to Left",
+			"Left",
+			"Set Panel Alignment to Right",
+			"Right",
+			"Set Panel Alignment to Center",
+			"Center",
+			"Set Panel Alignment to Justify",
+			"Justify",
+			"Panel Position",
+			"Align Panel",
+			"Previous Panel View",
+			"Next Panel View",
+			"Toggle Maximized Panel",
+			"Maximize Panel Size",
+			"Restore Panel Size",
+			"Maximizing the panel is only supported when it is center aligned.",
+			"Close Panel",
+			"Close Secondary Side Bar",
+			"Toggle Panel",
+			"Hide Panel",
+			"Move Panel Views To Secondary Side Bar",
+			"Move Panel Views To Secondary Side Bar",
+			"Move Secondary Side Bar Views To Panel",
+			"Move Secondary Side Bar Views To Panel"
 		],
 		"vs/workbench/browser/quickaccess": [
 			"Whether keyboard focus is inside the quick open control"
@@ -22320,15 +22536,17 @@
 			"Uninstall hook for VS Code extension. Script that gets executed when the extension is completely uninstalled from VS Code which is when VS Code is restarted (shutdown and start) after the extension is uninstalled. Only Node scripts are supported.",
 			"The path to a 128x128 pixel icon.",
 			"The relative path to a folder containing localization (bundle.l10n.*.json) files. Must be specified if you are using the vscode.l10n API.",
+			"The pricing information for the extension. Can be Free (default) or Trial. For more details visit: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#extension-pricing-label",
 			"API proposals that the respective extensions can freely use."
 		],
-		"vs/workbench/browser/parts/views/viewPaneContainer": [
-			"Views",
-			"Move View Up",
-			"Move View Left",
-			"Move View Down",
-			"Move View Right",
-			"Move Views"
+		"vs/workbench/browser/parts/views/treeView": [
+			"There is no data provider registered that can provide view data.",
+			"Whether the the tree view with id {0} enables collapse all.",
+			"Whether the tree view with id {0} enables refresh.",
+			"Refresh",
+			"Collapse All",
+			"Whether collapse all is toggled for the tree view with id {0}.",
+			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
 		],
 		"vs/workbench/contrib/debug/common/debug": [
 			"Debug type of the active debug session. For example 'python'.",
@@ -22385,70 +22603,6 @@
 			"Configured debug type '{0}' is installed but not supported in this environment.",
 			"Controls when the internal Debug Console should open."
 		],
-		"vs/workbench/browser/parts/views/treeView": [
-			"There is no data provider registered that can provide view data.",
-			"Whether the the tree view with id {0} enables collapse all.",
-			"Whether the tree view with id {0} enables refresh.",
-			"Refresh",
-			"Collapse All",
-			"Whether collapse all is toggled for the tree view with id {0}.",
-			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
-		],
-		"vs/workbench/contrib/remote/browser/remoteExplorer": [
-			"Ports",
-			"1 forwarded port",
-			"{0} forwarded ports",
-			"No Ports Forwarded",
-			"Forwarded Ports: {0}",
-			"Forwarded Ports",
-			"Your application running on port {0} is available.  ",
-			"[See all forwarded ports]({0})",
-			"You'll need to run as superuser to use port {0} locally.  ",
-			"Make Public",
-			"Use Port {0} as Sudo..."
-		],
-		"vs/workbench/browser/parts/panel/panelActions": [
-			"Icon to maximize a panel.",
-			"Icon to restore a panel.",
-			"Icon to close a panel.",
-			"Icon to toggle the panel off when it is on.",
-			"Icon to toggle the panel on when it is off.",
-			"Toggle Panel Visibility",
-			"Panel",
-			"&&Panel",
-			"Focus into Panel",
-			"Focus into Panel",
-			"Move Panel Left",
-			"Left",
-			"Move Panel Right",
-			"Right",
-			"Move Panel To Bottom",
-			"Bottom",
-			"Set Panel Alignment to Left",
-			"Left",
-			"Set Panel Alignment to Right",
-			"Right",
-			"Set Panel Alignment to Center",
-			"Center",
-			"Set Panel Alignment to Justify",
-			"Justify",
-			"Panel Position",
-			"Align Panel",
-			"Previous Panel View",
-			"Next Panel View",
-			"Toggle Maximized Panel",
-			"Maximize Panel Size",
-			"Restore Panel Size",
-			"Maximizing the panel is only supported when it is center aligned.",
-			"Close Panel",
-			"Close Secondary Side Bar",
-			"Toggle Panel",
-			"Hide Panel",
-			"Move Panel Views To Secondary Side Bar",
-			"Move Panel Views To Secondary Side Bar",
-			"Move Secondary Side Bar Views To Panel",
-			"Move Secondary Side Bar Views To Panel"
-		],
 		"vs/workbench/contrib/files/common/files": [
 			"True when the EXPLORER viewlet is visible.",
 			"True when the FOLDERS view (the file tree within the explorer view container) is visible.",
@@ -22465,8 +22619,37 @@
 			"True when the focus is inside a compact item's last part in the EXPLORER view.",
 			"True when a workspace in the EXPLORER view has some collapsible root child."
 		],
-		"vs/workbench/common/editor/sideBySideEditorInput": [
-			"{0} - {1}"
+		"vs/workbench/browser/parts/views/viewPaneContainer": [
+			"Views",
+			"Move View Up",
+			"Move View Left",
+			"Move View Down",
+			"Move View Right",
+			"Move Views"
+		],
+		"vs/workbench/contrib/remote/browser/remoteExplorer": [
+			"No forwarded ports. Forward a port to access your running services locally.\n[Forward a Port]({0})",
+			"No forwarded ports. Forward a port to access your locally running services over the internet.\n[Forward a Port]({0})",
+			"Ports",
+			"1 forwarded port",
+			"{0} forwarded ports",
+			"No Ports Forwarded",
+			"Forwarded Ports: {0}",
+			"Forwarded Ports",
+			"Your application running on port {0} is available.  ",
+			"[See all forwarded ports]({0})",
+			"You'll need to run as superuser to use port {0} locally.  ",
+			"Make Public",
+			"Use Port {0} as Sudo..."
+		],
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"Hold __{0}__ to drop into editor"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"Empty editor group actions",
+			"{0} (empty)",
+			"Group {0}",
+			"Editor Group {0}"
 		],
 		"vs/workbench/browser/parts/editor/sideBySideEditor": [
 			"Side by Side Editor"
@@ -22474,26 +22657,13 @@
 		"vs/workbench/common/editor/diffEditorInput": [
 			"{0} ↔ {1}"
 		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
-			"Icon to toggle the auxiliary bar off in its right position.",
-			"Icon to toggle the auxiliary bar on in its right position.",
-			"Icon to toggle the auxiliary bar in its left position.",
-			"Icon to toggle the auxiliary bar on in its left position.",
-			"Toggle Secondary Side Bar Visibility",
-			"Secondary Side Bar",
-			"Secondary Si&&de Bar",
-			"Focus into Secondary Side Bar",
-			"Toggle Secondary Side Bar",
-			"Toggle Secondary Side Bar",
-			"Hide Secondary Side Bar"
+		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
+			"{0} ↔ {1}"
 		],
 		"vs/workbench/browser/parts/editor/textDiffEditor": [
 			"Text Diff Editor",
 			"At least one file is not displayed in the text compare editor because it is very large ({0}).",
 			"At least one file is not displayed in the text compare editor because it is very large."
-		],
-		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
-			"{0} ↔ {1}"
 		],
 		"vs/workbench/browser/parts/editor/editorStatus": [
 			"Ln {0}, Col {1} ({2} selected)",
@@ -22675,6 +22845,14 @@
 			"Toggle Editor Type",
 			"Reopen Editor With Text Editor"
 		],
+		"vs/editor/browser/editorExtensions": [
+			"&&Undo",
+			"Undo",
+			"&&Redo",
+			"Redo",
+			"&&Select All",
+			"Select All"
+		],
 		"vs/workbench/browser/parts/editor/editorCommands": [
 			"Move the active editor by tabs or groups",
 			"Active editor move argument",
@@ -22682,6 +22860,8 @@
 			"Copy the active editor by groups",
 			"Active editor copy argument",
 			"Argument Properties:\n\t* 'to': String value providing where to copy.\n\t* 'value': Number value providing how many positions or an absolute position to copy.",
+			"Go to Next Change",
+			"Go to Previous Change",
 			"Toggle Inline View",
 			"Compare",
 			"Split Editor in Group",
@@ -22695,20 +22875,12 @@
 			"Lock Editor Group",
 			"Unlock Editor Group"
 		],
-		"vs/editor/browser/editorExtensions": [
-			"&&Undo",
-			"Undo",
-			"&&Redo",
-			"Redo",
-			"&&Select All",
-			"Select All"
-		],
-		"vs/workbench/browser/parts/editor/editorQuickAccess": [
-			"No matching editors",
-			"{0}, unsaved changes, {1}",
-			"{0}, {1}",
-			"{0}, unsaved changes",
-			"Close Editor"
+		"vs/workbench/browser/parts/editor/accessibilityStatus": [
+			"Are you using a screen reader to operate VS Code?",
+			"Yes",
+			"No",
+			"Screen Reader Optimized",
+			"Screen Reader Mode"
 		],
 		"vs/workbench/browser/parts/editor/editorConfiguration": [
 			"Interactive Window",
@@ -22718,12 +22890,25 @@
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
 			"Controls the minimum size of a file in MB before asking for confirmation when opening in the editor. Note that this setting may not apply to all editor types and environments."
 		],
-		"vs/workbench/browser/parts/editor/accessibilityStatus": [
-			"Are you using a screen reader to operate VS Code?",
-			"Yes",
-			"No",
-			"Screen Reader Optimized",
-			"Screen Reader Mode"
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
+			"Toggle Collapse Unchanged Regions",
+			"Toggle Show Moved Code Blocks",
+			"Toggle Use Inline View When Space Is Limited",
+			"Use Inline View When Space Is Limited",
+			"Show Moved Code Blocks",
+			"Diff Editor",
+			"Switch Side",
+			"Exit Compare Move",
+			"Collapse All Unchanged Regions",
+			"Show All Unchanged Regions"
+		],
+		"vs/workbench/common/editor/sideBySideEditorInput": [
+			"{0} - {1}"
+		],
+		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
+			"Move Secondary Side Bar Left",
+			"Move Secondary Side Bar Right",
+			"Hide Secondary Side Bar"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
 			"Settings icon in the view bar.",
@@ -22739,19 +22924,6 @@
 			"Accounts",
 			"Accounts"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
-			"Toggle Collapse Unchanged Regions",
-			"Show Unchanged Regions",
-			"Collapse Unchanged Regions",
-			"Toggle Show Moved Code Blocks",
-			"Diff Editor",
-			"Switch Side"
-		],
-		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
-			"Move Secondary Side Bar Left",
-			"Move Secondary Side Bar Right",
-			"Hide Secondary Side Bar"
-		],
 		"vs/workbench/browser/parts/panel/panelPart": [
 			"Reset Location",
 			"Reset Location",
@@ -22761,18 +22933,12 @@
 			"Align Panel",
 			"Hide Panel"
 		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"Empty editor group actions",
-			"{0} (empty)",
-			"Group {0}",
-			"Editor Group {0}"
-		],
-		"vs/workbench/browser/parts/editor/editorDropTarget": [
-			"Hold __{0}__ to drop into editor"
-		],
-		"vs/workbench/browser/parts/statusbar/statusbarActions": [
-			"Hide '{0}'",
-			"Focus Status Bar"
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"No matching editors",
+			"{0}, unsaved changes, {1}",
+			"{0}, {1}",
+			"{0}, unsaved changes",
+			"Close Editor"
 		],
 		"vs/platform/actions/common/menuResetAction": [
 			"Reset All Menus"
@@ -22797,6 +22963,10 @@
 		"vs/workbench/services/preferences/common/preferencesModels": [
 			"Commonly Used",
 			"Override key bindings by placing them into your key bindings file."
+		],
+		"vs/workbench/browser/parts/statusbar/statusbarActions": [
+			"Hide '{0}'",
+			"Focus Status Bar"
 		],
 		"vs/workbench/services/textfile/common/textFileEditorModel": [
 			"File Encoding Changed"
@@ -22842,6 +23012,10 @@
 			"Problems parsing tmTheme file: {0}",
 			"Problems loading tmTheme file {0}: {1}"
 		],
+		"vs/workbench/services/themes/browser/fileIconThemeData": [
+			"Problems parsing file icons file: {0}",
+			"Invalid format for file icons theme file: Object expected."
+		],
 		"vs/workbench/services/themes/common/fileIconThemeSchema": [
 			"The folder icon for expanded folders. The expanded folder icon is optional. If not set, the icon defined for folder will be shown.",
 			"The folder icon for collapsed folders, and if folderExpanded is not set, also for expanded folders.",
@@ -22877,25 +23051,6 @@
 			"Configures whether the file explorer's arrows should be hidden when this theme is active.",
 			"Configures whether the default language icons should be used if the theme does not define an icon for a language."
 		],
-		"vs/workbench/services/themes/browser/fileIconThemeData": [
-			"Problems parsing file icons file: {0}",
-			"Invalid format for file icons theme file: Object expected."
-		],
-		"vs/workbench/services/themes/common/colorThemeSchema": [
-			"Colors and styles for the token.",
-			"Foreground color for the token.",
-			"Token background colors are currently not supported.",
-			"Font style of the rule: 'italic', 'bold', 'underline', 'strikethrough' or a combination. The empty string unsets inherited settings.",
-			"Font style must be 'italic', 'bold', 'underline', 'strikethrough' or a combination or the empty string.",
-			"None (clear inherited style)",
-			"Description of the rule.",
-			"Scope selector against which this rule matches.",
-			"Colors in the workbench",
-			"Path to a tmTheme file (relative to the current file).",
-			"Colors for syntax highlighting",
-			"Whether semantic highlighting should be enabled for this theme.",
-			"Colors for semantic tokens"
-		],
 		"vs/workbench/services/themes/common/themeExtensionPoints": [
 			"Contributes textmate color themes.",
 			"Id of the color theme as used in the user settings.",
@@ -22914,6 +23069,35 @@
 			"Expected string in `contributes.{0}.path`. Provided value: {1}",
 			"Expected string in `contributes.{0}.id`. Provided value: {1}",
 			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
+		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"Colors and styles for the token.",
+			"Foreground color for the token.",
+			"Token background colors are currently not supported.",
+			"Font style of the rule: 'italic', 'bold', 'underline', 'strikethrough' or a combination. The empty string unsets inherited settings.",
+			"Font style must be 'italic', 'bold', 'underline', 'strikethrough' or a combination or the empty string.",
+			"None (clear inherited style)",
+			"Description of the rule.",
+			"Scope selector against which this rule matches.",
+			"Colors in the workbench",
+			"Path to a tmTheme file (relative to the current file).",
+			"Colors for syntax highlighting",
+			"Whether semantic highlighting should be enabled for this theme.",
+			"Colors for semantic tokens"
+		],
+		"vs/workbench/services/themes/browser/productIconThemeData": [
+			"Problems processing product icons definitions in {0}:\n{1}",
+			"Default",
+			"Problems parsing product icons file: {0}",
+			"Invalid format for product icons theme file: Object expected.",
+			"Invalid format for product icons theme file: Must contain iconDefinitions and fonts.",
+			"Invalid font weight in font '{0}'. Ignoring setting.",
+			"Invalid font style in font '{0}'. Ignoring setting.",
+			"Invalid font source in font '{0}'. Ignoring source.",
+			"No valid font source in font '{0}'. Ignoring font definition.",
+			"Missing or invalid font id '{0}'. Skipping font definition.",
+			"Skipping icon definition '{0}'. Unknown font.",
+			"Skipping icon definition '{0}'. Unknown fontCharacter."
 		],
 		"vs/workbench/services/themes/common/themeConfiguration": [
 			"Specifies the color theme used in the workbench.",
@@ -22952,20 +23136,6 @@
 			"Whether semantic highlighting is enabled or disabled for this theme",
 			"Semantic token styling rules for this theme.",
 			"Overrides editor semantic token color and styles from the currently selected color theme."
-		],
-		"vs/workbench/services/themes/browser/productIconThemeData": [
-			"Problems processing product icons definitions in {0}:\n{1}",
-			"Default",
-			"Problems parsing product icons file: {0}",
-			"Invalid format for product icons theme file: Object expected.",
-			"Invalid format for product icons theme file: Must contain iconDefinitions and fonts.",
-			"Invalid font weight in font '{0}'. Ignoring setting.",
-			"Invalid font style in font '{0}'. Ignoring setting.",
-			"Invalid font source in font '{0}'. Ignoring source.",
-			"No valid font source in font '{0}'. Ignoring font definition.",
-			"Missing or invalid font id '{0}'. Skipping font definition.",
-			"Skipping icon definition '{0}'. Unknown font.",
-			"Skipping icon definition '{0}'. Unknown fontCharacter."
 		],
 		"vs/workbench/services/themes/common/productIconThemeSchema": [
 			"The ID of the font.",
@@ -23012,17 +23182,24 @@
 			"Snippets",
 			"Select Snippet {0}"
 		],
-		"vs/workbench/services/userDataProfile/browser/tasksResource": [
-			"User Tasks"
-		],
 		"vs/workbench/services/userDataProfile/browser/extensionsResource": [
 			"Extensions",
 			"Disabled",
 			"Select {0} Extension",
 			"Select {0} Extension"
 		],
+		"vs/workbench/services/userDataProfile/browser/tasksResource": [
+			"User Tasks"
+		],
 		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
 			"UI State"
+		],
+		"vs/workbench/services/remote/common/tunnelModel": [
+			"Whether the Ports view is enabled.",
+			"User Forwarded",
+			"Auto Forwarded",
+			"Local port {0} could not be used for forwarding to remote port {1}.\n\nThis usually happens when there is already another process using local port {0}.\n\nPort number {2} has been used instead.",
+			"Statically Forwarded"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopySaveParticipant": [
 			"Saving '{0}'"
@@ -23046,6 +23223,12 @@
 			"Invalid value in `contributes.{0}.tokenTypes`. Must be an object map from scope name to token type. Provided value: {1}",
 			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"Press desired key combination and then press ENTER.",
+			"1 existing command has this keybinding",
+			"{0} existing commands have this keybinding",
+			"chord to"
+		],
 		"vs/editor/contrib/suggest/browser/suggest": [
 			"Whether any suggestion is focused",
 			"Whether suggestion details are visible",
@@ -23055,6 +23238,25 @@
 			"Whether the current suggestion has insert and replace behaviour",
 			"Whether the default behaviour is to insert or replace",
 			"Whether the current suggestion supports to resolve further details"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"Configure Language Specific Settings...",
+			"({0})",
+			"Select Language"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
+			"Icon for the folder dropdown button in the split JSON Settings editor.",
+			"Icon for the 'more actions' action in the Settings UI.",
+			"Icon for the 'record keys' action in the keybinding UI.",
+			"Icon for the 'sort by precedence' toggle in the keybinding UI.",
+			"Icon for the edit action in the keybinding UI.",
+			"Icon for the add action in the keybinding UI.",
+			"Icon for the edit action in the Settings UI.",
+			"Icon for the remove action in the Settings UI.",
+			"Icon for the discard action in the Settings UI.",
+			"Icon for clear input in the Settings and keybinding UI.",
+			"Icon for the button that suggests filters for the Settings UI.",
+			"Icon for open settings commands."
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"Record Keys",
@@ -23091,32 +23293,6 @@
 			"No when context",
 			"use space or enter to change the keybinding."
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"Configure Language Specific Settings...",
-			"({0})",
-			"Select Language"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
-			"Icon for the folder dropdown button in the split JSON Settings editor.",
-			"Icon for the 'more actions' action in the Settings UI.",
-			"Icon for the 'record keys' action in the keybinding UI.",
-			"Icon for the 'sort by precedence' toggle in the keybinding UI.",
-			"Icon for the edit action in the keybinding UI.",
-			"Icon for the add action in the keybinding UI.",
-			"Icon for the edit action in the Settings UI.",
-			"Icon for the remove action in the Settings UI.",
-			"Icon for the discard action in the Settings UI.",
-			"Icon for clear input in the Settings and keybinding UI.",
-			"Icon for the button that suggests filters for the Settings UI.",
-			"Icon for open settings commands."
-		],
-		"vs/workbench/contrib/preferences/common/preferencesContribution": [
-			"Split Settings Editor",
-			"Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service.",
-			"Hide the Table of Contents while searching.",
-			"Filter the Table of Contents to just categories that have matching settings. Clicking a category will filter the results to that category.",
-			"Controls the behavior of the settings editor Table of Contents while searching."
-		],
 		"vs/workbench/contrib/preferences/browser/settingsEditor2": [
 			"Search settings",
 			"Clear Settings Search Input",
@@ -23130,6 +23306,16 @@
 			"{0} Settings Found",
 			"Turn on Settings Sync",
 			"Last synced: {0}"
+		],
+		"vs/workbench/contrib/preferences/common/preferencesContribution": [
+			"Split Settings Editor",
+			"Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service.",
+			"Hide the Table of Contents while searching.",
+			"Filter the Table of Contents to just categories that have matching settings. Clicking a category will filter the results to that category.",
+			"Controls the behavior of the settings editor Table of Contents while searching."
+		],
+		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+			"Startup Performance"
 		],
 		"vs/workbench/contrib/notebook/browser/notebookEditor": [
 			"Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed and enabled.",
@@ -23151,13 +23337,13 @@
 		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
 			"Executing a notebook cell will run code from this workspace."
 		],
-		"vs/editor/common/languages/modesRegistry": [
-			"Plain Text"
-		],
 		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
 			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
 			"Yes",
 			"No"
+		],
+		"vs/editor/common/languages/modesRegistry": [
+			"Plain Text"
 		],
 		"vs/workbench/contrib/comments/browser/commentReply": [
 			"Reply...",
@@ -23171,21 +23357,6 @@
 		"vs/workbench/contrib/notebook/browser/services/notebookLoggingServiceImpl": [
 			"Notebook rendering"
 		],
-		"vs/workbench/contrib/accessibility/browser/accessibilityContribution": [
-			"Accessibility",
-			"Provide information about how to access the terminal accessibility help menu when the terminal is focused",
-			"Provide information about how to navigate changes in the diff editor when it is focused",
-			"Provide information about how to access the chat help menu when the chat input is focused",
-			"Provide information about how to access the inline editor chat accessibility help menu and alert with hints which describe how to use the feature when the input is focused",
-			"Provide information about how to change a keybinding in the keybindings editor when a row is focused",
-			"Provide information about how to focus the cell container or inner editor when a notebook cell is focused.",
-			"Provide information about how to open the hover in an accessible view.",
-			"Provide information about how to open the notification in an accessible view.",
-			"Open Accessibility Help",
-			"Open Accessible View",
-			"Show Next in Accessible View",
-			"Show Previous in Accessible View"
-		],
 		"vs/workbench/contrib/notebook/browser/notebookAccessibility": [
 			"The notebook view is a collection of code and markdown cells. Code cells can be executed and will produce output directly below the cell.",
 			"The Edit Cell command ({0}) will focus on the cell input.",
@@ -23198,20 +23369,42 @@
 			"The Execute Cell command ({0}) executes the cell that currently has focus.",
 			"The Execute Cell command executes the cell that currently has focus and is currently not triggerable by a keybinding.",
 			"The Insert Cell Above/Below commands will create new empty code cells",
-			"The Change Cell to Code/Markdown commands are used to switch between cell types.",
-			"Notebook Cell Output Accessible View"
+			"The Change Cell to Code/Markdown commands are used to switch between cell types."
 		],
 		"vs/workbench/contrib/accessibility/browser/accessibleView": [
-			"\nPress H now to open a browser window with more information related to accessibility.\n",
-			"\nTo disable the `accessibility.verbosity` hint for this feature, press D now.\n",
-			"Exit this dialog via the Escape key.",
-			"{0} {1}",
-			"{0}",
+			"({0}) {1}",
+			"({0}) {1}",
 			"{0} accessibility verbosity is now disabled",
-			"Show the next {0} or previous {1} item in the accessible view",
-			"Show the next or previous item in the accessible view by configuring keybindings for Show Next / Previous in Accessible View",
+			"\n\nPress H now to open a browser window with more information related to accessibility.\n\n",
+			"\nExit this dialog via the Escape key.",
+			"Use Shift+Tab to explore actions such as disabling this hint.",
+			"Accessibility Help",
+			"Accessible View",
+			"Accessible View, {0}",
+			"Accessibility Help, {0}",
+			"Accessibility Help",
+			"Accessible View",
+			"Navigate to the toolbar (Shift+Tab))",
+			"In the accessible view, you can:\n",
+			"Show the next ({0}) or previous ({1}) item",
+			"Show the next or previous item by configuring keybindings for the Show Next & Previous in Accessible View commands",
+			"Disable accessibility verbosity for this feature ({0}). This will disable the hint to open the accessible view for example.\n",
+			"Add a keybinding for the command Disable Accessible View Hint, which disables accessibility verbosity for this feature.\n",
+			"Go to a symbol ({0})",
+			"To go to a symbol, configure a keybinding for the command Go To Symbol in Accessible View",
 			"Inspect this in the accessible view with {0}",
-			"Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding"
+			"Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding.",
+			"Type to search symbols",
+			"Go to Symbol Accessible View"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibleViewActions": [
+			"Show Next in Accessible View",
+			"Show Previous in Accessible View",
+			"Go To Symbol in Accessible View",
+			"Open Accessibility Help",
+			"Open Accessible View",
+			"Disable Accessible View Hint",
+			"Accept Inline Completion"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
 			"Notebook",
@@ -23268,6 +23461,48 @@
 			"Go to Most Recently Failed Cell",
 			"Go To"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
+			"Select between Notebook Layouts",
+			"Customize Notebook Layout",
+			"Customize Notebook Layout",
+			"Customize Notebook...",
+			"Toggle Notebook Line Numbers",
+			"Notebook Line Numbers",
+			"Toggle Cell Toolbar Position",
+			"Toggle Breadcrumbs",
+			"Save Mimetype Display Order",
+			"Settings file to save in",
+			"User Settings",
+			"Workspace Settings",
+			"Reset Notebook Webview"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/editActions": [
+			"Edit Cell",
+			"Stop Editing Cell",
+			"Delete Cell",
+			"Delete",
+			"This cell is running, are you sure you want to delete it?",
+			"Do not ask me again",
+			"Clear Cell Outputs",
+			"Clear All Outputs",
+			"Change Cell Language",
+			"Change Cell Language",
+			"({0}) - Current Language",
+			"({0})",
+			"Auto Detect",
+			"languages (identifier)",
+			"Select Language Mode",
+			"Accept Detected Language for Cell",
+			"Unable to detect cell language"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/cellOutputActions": [
+			"Copy Output"
+		],
+		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
+			"Fold Cell",
+			"Unfold Cell",
+			"Fold Cell"
+		],
 		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
 			"Copy Cell",
 			"Cut Cell",
@@ -23285,23 +23520,8 @@
 			"Format Cell",
 			"Format Cells"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
-			"Select between Notebook Layouts",
-			"Customize Notebook Layout",
-			"Customize Notebook Layout",
-			"Customize Notebook...",
-			"Toggle Notebook Line Numbers",
-			"Notebook Line Numbers",
-			"Toggle Cell Toolbar Position",
-			"Toggle Breadcrumbs",
-			"Save Mimetype Display Order",
-			"Settings file to save in",
-			"User Settings",
-			"Workspace Settings",
-			"Reset Notebook Webview"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
-			"Reset notebook getting started"
+		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
+			"Toggle Cell Toolbar Position"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
 			"Formatting",
@@ -23311,19 +23531,34 @@
 			"Getting code actions from '{0}' ([configure]({1})).",
 			"Applying code action '{0}'."
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
-			"Toggle Cell Toolbar Position"
+		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
+			"Reset notebook getting started"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
 			"When enabled notebook outline shows code cells.",
 			"When enabled notebook breadcrumbs contain code cells."
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
-			"Set Profile"
+		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
+			"Focus Next Cell Editor",
+			"Focus Previous Cell Editor",
+			"Focus First Cell",
+			"Focus Last Cell",
+			"Focus In Active Cell Output",
+			"Focus Out Active Cell Output",
+			"Center Active Cell",
+			"Cell Cursor Page Up",
+			"Cell Cursor Page Up Select",
+			"Cell Cursor Page Down",
+			"Cell Cursor Page Down Select",
+			"When enabled cursor can navigate to the next/previous cell when the current cursor in the cell editor is at the first/last line."
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders": [
+			"Unknown cell language. Click to search for '{0}' extensions",
 			"Select Cell Language Mode",
 			"Accept Detected Language: {0}"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
+			"Set Profile"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController": [
 			"Success",
@@ -23332,11 +23567,6 @@
 			"Executing",
 			"Use the links above to file an issue using the issue reporter.",
 			"**Last Execution** {0}\n\n**Execution Time** {1}\n\n**Overhead Time** {2}\n\n**Render Times**\n\n{3}"
-		],
-		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
-			"Fold Cell",
-			"Unfold Cell",
-			"Fold Cell"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar": [
 			"Notebook Kernel Info",
@@ -23371,20 +23601,6 @@
 			"Expand All Cell Outputs",
 			"Toggle Scroll Cell Output"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
-			"Focus Next Cell Editor",
-			"Focus Previous Cell Editor",
-			"Focus First Cell",
-			"Focus Last Cell",
-			"Focus In Active Cell Output",
-			"Focus Out Active Cell Output",
-			"Center Active Cell",
-			"Cell Cursor Page Up",
-			"Cell Cursor Page Up Select",
-			"Cell Cursor Page Down",
-			"Cell Cursor Page Down Select",
-			"When enabled cursor can navigate to the next/previous cell when the current cursor in the cell editor is at the first/last line."
-		],
 		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
 			"Toggle Layout Troubleshoot",
 			"Inspect Notebook Layout",
@@ -23414,25 +23630,6 @@
 			"Delete",
 			"Select a chat session to restore"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/editActions": [
-			"Edit Cell",
-			"Stop Editing Cell",
-			"Delete Cell",
-			"Delete",
-			"This cell is running, are you sure you want to delete it?",
-			"Do not ask me again",
-			"Clear Cell Outputs",
-			"Clear All Outputs",
-			"Change Cell Language",
-			"Change Cell Language",
-			"({0}) - Current Language",
-			"({0})",
-			"Auto Detect",
-			"languages (identifier)",
-			"Select Language Mode",
-			"Accept Detected Language for Cell",
-			"Unable to detect cell language"
-		],
 		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
 			"Copy",
 			"Insert at Cursor",
@@ -23448,6 +23645,12 @@
 		"vs/workbench/contrib/chat/browser/actions/chatExecuteActions": [
 			"Submit",
 			"Cancel"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
+			"Open in Chat View",
+			"Close Quick Chat",
+			"Quick Chat",
+			"Open Quick Chat ({0})"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
 			"Helpful",
@@ -23471,9 +23674,6 @@
 		"vs/workbench/contrib/chat/browser/chatEditorInput": [
 			"Chat"
 		],
-		"vs/workbench/contrib/chat/browser/chatWidget": [
-			"Clear the session"
-		],
 		"vs/workbench/contrib/chat/common/chatServiceImpl": [
 			"Provider returned null response"
 		],
@@ -23487,12 +23687,10 @@
 			"Clear",
 			"Clear"
 		],
-		"vs/workbench/contrib/chat/common/chatViewModel": [
-			"Thinking"
-		],
 		"vs/workbench/contrib/chat/common/chatContextKeys": [
 			"True when the provider has assigned an id to this response.",
 			"When the response has been voted up, is set to 'up'. When voted down, is set to 'down'. Otherwise an empty string.",
+			"True when the chat response was filtered out by the server.",
 			"True when the current request is still in progress.",
 			"The chat item is a response.",
 			"The chat item is a request",
@@ -23501,28 +23699,52 @@
 			"True when focus is in the chat widget, false otherwise.",
 			"True when some chat provider has been registered."
 		],
-		"vs/workbench/contrib/chat/common/chatColors": [
-			"The background color of a chat request.",
-			"The border color of a chat request."
+		"vs/workbench/contrib/chat/common/chatViewModel": [
+			"Thinking"
+		],
+		"vs/workbench/contrib/chat/common/chatSlashCommands": [
+			"The name of the slash command which will be used as prefix.",
+			"The details of the slash command.",
+			"Contributes slash commands to chat",
+			"Invalid {0}: {1}"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibilityContributions": [
+			"{0} Source: {1}",
+			"{0}",
+			"Clear Notification",
+			"Clear Notification"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions": [
+			"Next File Tree",
+			"Previous File Tree"
 		],
 		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
 			"Ask a question or type '/' for topics",
 			"Ask a question"
 		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
-			"AI-generated code may be incorrect",
-			"Getting ready...",
-			"Failed to start editor chat",
-			"Please consult the error log and try again later.",
-			"AI-generated code may be incorrect",
-			"Ask a question",
-			"{0} ({1}, {2} for history)",
-			"Thinking…",
-			"No results, please refine your input and try again",
-			"{0}",
-			"Use tab to navigate to the diff editor and review proposed changes.",
-			"Failed to apply changes.",
-			"Failed to discard changes."
+		"vs/workbench/contrib/chat/common/chatColors": [
+			"The border color of a chat request.",
+			"The background color of a chat slash command.",
+			"The foreground color of a chat slash command."
+		],
+		"vs/editor/contrib/peekView/browser/peekView": [
+			"Whether the current code editor is embedded inside peek",
+			"Close",
+			"Background color of the peek view title area.",
+			"Color of the peek view title.",
+			"Color of the peek view title info.",
+			"Color of the peek view borders and arrow.",
+			"Background color of the peek view result list.",
+			"Foreground color for line nodes in the peek view result list.",
+			"Foreground color for file nodes in the peek view result list.",
+			"Background color of the selected entry in the peek view result list.",
+			"Foreground color of the selected entry in the peek view result list.",
+			"Background color of the peek view editor.",
+			"Background color of the gutter in the peek view editor.",
+			"Background color of sticky scroll in the peek view editor.",
+			"Match highlight color in the peek view result list.",
+			"Match highlight color in the peek view editor.",
+			"Match highlight border in the peek view editor."
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
 			"Start Code Chat",
@@ -23555,6 +23777,37 @@
 			"View in Chat",
 			"Show More",
 			"Show Less"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookIcons": [
+			"Configure icon to select a kernel in notebook editors.",
+			"Icon to execute in notebook editors.",
+			"Icon to execute above cells in notebook editors.",
+			"Icon to execute below cells in notebook editors.",
+			"Icon to stop an execution in notebook editors.",
+			"Icon to delete a cell in notebook editors.",
+			"Icon to execute all cells in notebook editors.",
+			"Icon to edit a cell in notebook editors.",
+			"Icon to stop editing a cell in notebook editors.",
+			"Icon to move up a cell in notebook editors.",
+			"Icon to move down a cell in notebook editors.",
+			"Icon to clear cell outputs in notebook editors.",
+			"Icon to split a cell in notebook editors.",
+			"Icon to indicate a success state in notebook editors.",
+			"Icon to indicate an error state in notebook editors.",
+			"Icon to indicate a pending state in notebook editors.",
+			"Icon to indicate an executing state in notebook editors.",
+			"Icon to annotate a collapsed section in notebook editors.",
+			"Icon to annotate an expanded section in notebook editors.",
+			"Icon to open the notebook in a text editor.",
+			"Icon to revert in notebook editors.",
+			"Icon to render output in diff editor.",
+			"Icon for a mime type in notebook editors.",
+			"Icon to copy content to clipboard",
+			"Icon for the previous change action in the diff editor.",
+			"Icon for the next change action in the diff editor."
+		],
+		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
+			"Type '{0}' code here and press {1} to run"
 		],
 		"vs/workbench/contrib/inlineChat/common/inlineChat": [
 			"Whether a provider for interactive editors exists",
@@ -23592,55 +23845,6 @@
 			"Changes are applied directly to the document but can be highlighted via inline diffs. Ending a session will keep the changes.",
 			"Enable/disable showing the diff when edits are generated. Works only with inlineChat.mode equal to live or livePreview."
 		],
-		"vs/editor/contrib/peekView/browser/peekView": [
-			"Whether the current code editor is embedded inside peek",
-			"Close",
-			"Background color of the peek view title area.",
-			"Color of the peek view title.",
-			"Color of the peek view title info.",
-			"Color of the peek view borders and arrow.",
-			"Background color of the peek view result list.",
-			"Foreground color for line nodes in the peek view result list.",
-			"Foreground color for file nodes in the peek view result list.",
-			"Background color of the selected entry in the peek view result list.",
-			"Foreground color of the selected entry in the peek view result list.",
-			"Background color of the peek view editor.",
-			"Background color of the gutter in the peek view editor.",
-			"Background color of sticky scroll in the peek view editor.",
-			"Match highlight color in the peek view result list.",
-			"Match highlight color in the peek view editor.",
-			"Match highlight border in the peek view editor."
-		],
-		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
-			"Type '{0}' code here and press {1} to run"
-		],
-		"vs/workbench/contrib/notebook/browser/notebookIcons": [
-			"Configure icon to select a kernel in notebook editors.",
-			"Icon to execute in notebook editors.",
-			"Icon to execute above cells in notebook editors.",
-			"Icon to execute below cells in notebook editors.",
-			"Icon to stop an execution in notebook editors.",
-			"Icon to delete a cell in notebook editors.",
-			"Icon to execute all cells in notebook editors.",
-			"Icon to edit a cell in notebook editors.",
-			"Icon to stop editing a cell in notebook editors.",
-			"Icon to move up a cell in notebook editors.",
-			"Icon to move down a cell in notebook editors.",
-			"Icon to clear cell outputs in notebook editors.",
-			"Icon to split a cell in notebook editors.",
-			"Icon to indicate a success state in notebook editors.",
-			"Icon to indicate an error state in notebook editors.",
-			"Icon to indicate a pending state in notebook editors.",
-			"Icon to indicate an executing state in notebook editors.",
-			"Icon to annotate a collapsed section in notebook editors.",
-			"Icon to annotate an expanded section in notebook editors.",
-			"Icon to open the notebook in a text editor.",
-			"Icon to revert in notebook editors.",
-			"Icon to render output in diff editor.",
-			"Icon for a mime type in notebook editors.",
-			"Icon for the previous change action in the diff editor.",
-			"Icon for the next change action in the diff editor."
-		],
 		"vs/workbench/contrib/files/browser/fileConstants": [
 			"Save As...",
 			"Save",
@@ -23649,10 +23853,32 @@
 			"Remove Folder from Workspace",
 			"New Untitled Text File"
 		],
+		"vs/workbench/contrib/logs/common/logsActions": [
+			"Set Log Level...",
+			"All",
+			"Extension Logs",
+			"Logs",
+			"Set Log Level",
+			" {0}: Select log level",
+			"Select log level",
+			"Set as Default Log Level",
+			"Trace",
+			"Debug",
+			"Info",
+			"Warning",
+			"Error",
+			"Off",
+			"Default",
+			"Open Window Log File (Session)...",
+			"Current",
+			"Select Session",
+			"Select Log file"
+		],
 		"vs/workbench/contrib/testing/browser/icons": [
 			"View icon of the test view.",
 			"Icons for test results.",
 			"Icon of the \"run test\" action.",
+			"Icon of the \"rerun tests\" action.",
 			"Icon of the \"run all tests\" action.",
 			"Icon of the \"debug all tests\" action.",
 			"Icon of the \"debug test\" action.",
@@ -23674,6 +23900,24 @@
 			"Icon shown for tests that are skipped.",
 			"Icon shown for tests that are in an unset state."
 		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
+			"AI-generated code may be incorrect",
+			"Getting ready...",
+			"Failed to start editor chat",
+			"Please consult the error log and try again later.",
+			"AI-generated code may be incorrect",
+			"Ask a question",
+			"{0} ({1}, {2} for history)",
+			"Thinking…",
+			"No results, please refine your input and try again",
+			"{0}",
+			"Use tab to navigate to the diff editor and review proposed changes.",
+			"Failed to apply changes.",
+			"Failed to discard changes."
+		],
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"Testing"
+		],
 		"vs/workbench/contrib/testing/browser/testingDecorations": [
 			"Peek Test Output",
 			"Expected",
@@ -23689,10 +23933,19 @@
 			"Run All Tests",
 			"Debug All Tests"
 		],
+		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
+			"Running tests...",
+			"Running tests, {0}/{1} passed ({2}%)",
+			"Running tests, {0}/{1} tests passed ({2}%, {3} skipped)",
+			"{0}/{1} tests passed ({2}%)",
+			"{0}/{1} tests passed ({2}%, {3} skipped)"
+		],
 		"vs/workbench/contrib/testing/browser/testingExplorerView": [
 			"{0} (Default)",
 			"Select Default Profile",
 			"Configure Test Profiles",
+			"No test results yet.",
+			"Tests are being watched for changes",
 			"{0} passed tests",
 			"{0} skipped tests",
 			"{0} failed tests",
@@ -23702,20 +23955,13 @@
 			"{0}, outdated result",
 			"Test Explorer"
 		],
-		"vs/workbench/contrib/testing/browser/testingProgressUiService": [
-			"Running tests...",
-			"Running tests, {0}/{1} passed ({2}%)",
-			"Running tests, {0}/{1} tests passed ({2}%, {3} skipped)",
-			"{0}/{1} tests passed ({2}%)",
-			"{0}/{1} tests passed ({2}%, {3} skipped)"
-		],
 		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
 			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled.",
 			"Test Output",
 			"Expected result",
 			"Actual result",
-			"The test run did not record any output.",
 			"Test output is only available for new test runs.",
+			"The test run did not record any output.",
 			"Close",
 			"Unnamed Task",
 			"+ {0} more lines",
@@ -23726,6 +23972,7 @@
 			"Rerun Test Run",
 			"Debug Test Run",
 			"Go to Source",
+			"Show Result Output",
 			"Reveal in Test Explorer",
 			"Run Test",
 			"Debug Test",
@@ -23762,9 +24009,6 @@
 			"Controls when the testing view should open.",
 			"Always reveal the executed test when `#testing.followRunningTest#` is on. If this setting is turned off, only failed tests will be revealed."
 		],
-		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
-			"Testing"
-		],
 		"vs/workbench/contrib/testing/common/testServiceImpl": [
 			"Running tests may execute code in your workspace.",
 			"An error occurred attempting to run tests: {0}",
@@ -23790,11 +24034,9 @@
 			"Controller ID of the current test item",
 			"ID of the current test item, set when creating or opening menus on test items",
 			"Boolean indicating whether the test item has a URI defined",
-			"Boolean indicating whether the test item is hidden"
-		],
-		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
-			"Pick a test profile to use",
-			"Update Test Configuration"
+			"Boolean indicating whether the test item is hidden",
+			"Value set in `testMessage.contextValue`, available in editor/content and testing/message/context",
+			"Value available in editor/content and testing/message/context when the result is outdated"
 		],
 		"vs/workbench/contrib/testing/browser/testExplorerActions": [
 			"Hide Test",
@@ -23848,32 +24090,9 @@
 			"Refresh Tests",
 			"Cancel Test Refresh"
 		],
-		"vs/workbench/contrib/logs/common/logsActions": [
-			"Set Log Level...",
-			"All",
-			"Extension Logs",
-			"Logs",
-			"Set Log Level",
-			" {0}: Select log level",
-			"Select log level",
-			"Set as Default Log Level",
-			"Trace",
-			"Debug",
-			"Info",
-			"Warning",
-			"Error",
-			"Off",
-			"Default",
-			"Open Window Log File (Session)...",
-			"Current",
-			"Select Session",
-			"Select Log file"
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
-			"Press desired key combination and then press ENTER.",
-			"1 existing command has this keybinding",
-			"{0} existing commands have this keybinding",
-			"chord to"
+		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
+			"Pick a test profile to use",
+			"Update Test Configuration"
 		],
 		"vs/workbench/contrib/files/browser/views/explorerView": [
 			"Explorer Section: {0}",
@@ -23881,6 +24100,9 @@
 			"New Folder...",
 			"Refresh Explorer",
 			"Collapse Folders in Explorer"
+		],
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"No Folder Opened"
 		],
 		"vs/workbench/contrib/files/browser/views/openEditorsView": [
 			"Open Editors",
@@ -23890,9 +24112,6 @@
 			"Flip Layout",
 			"Flip &&Layout",
 			"New Untitled Text File"
-		],
-		"vs/workbench/contrib/files/browser/views/emptyView": [
-			"No Folder Opened"
 		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"No matching views",
@@ -23920,6 +24139,29 @@
 			"Do you want to clear the history of recently used commands?",
 			"This action is irreversible!",
 			"&&Clear"
+		],
+		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
+			"Use the actions in the editor tool bar to either undo your changes or overwrite the content of the file with your changes.",
+			"Failed to save '{0}': The content of the file is newer. Please compare your version with the file contents or overwrite the content of the file with your changes.",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite as Admin' to retry as administrator.",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite as Sudo' to retry as superuser.",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite' to attempt to make it writeable.",
+			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Admin' to retry as administrator.",
+			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Sudo' to retry as superuser.",
+			"Failed to save '{0}': {1}",
+			"Learn More",
+			"Don't Show Again",
+			"Compare",
+			"{0} (in file) ↔ {1} (in {2}) - Resolve save conflict",
+			"Overwrite as Admin...",
+			"Overwrite as Sudo...",
+			"Retry as Admin...",
+			"Retry as Sudo...",
+			"Retry",
+			"Discard",
+			"Overwrite",
+			"Overwrite",
+			"Configure"
 		],
 		"vs/workbench/contrib/files/browser/fileActions": [
 			"New File...",
@@ -24002,29 +24244,6 @@
 			"Toggle Active Editor Read-only in Session",
 			"Reset Active Editor Read-only in Session"
 		],
-		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
-			"Use the actions in the editor tool bar to either undo your changes or overwrite the content of the file with your changes.",
-			"Failed to save '{0}': The content of the file is newer. Please compare your version with the file contents or overwrite the content of the file with your changes.",
-			"Failed to save '{0}': File is read-only. Select 'Overwrite as Admin' to retry as administrator.",
-			"Failed to save '{0}': File is read-only. Select 'Overwrite as Sudo' to retry as superuser.",
-			"Failed to save '{0}': File is read-only. Select 'Overwrite' to attempt to make it writeable.",
-			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Admin' to retry as administrator.",
-			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Sudo' to retry as superuser.",
-			"Failed to save '{0}': {1}",
-			"Learn More",
-			"Don't Show Again",
-			"Compare",
-			"{0} (in file) ↔ {1} (in {2}) - Resolve save conflict",
-			"Overwrite as Admin...",
-			"Overwrite as Sudo...",
-			"Retry as Admin...",
-			"Retry as Sudo...",
-			"Retry",
-			"Discard",
-			"Overwrite",
-			"Overwrite",
-			"Configure"
-		],
 		"vs/workbench/contrib/files/browser/fileCommands": [
 			"{0} (in file) ↔ {1}",
 			"Failed to save '{0}': {1}",
@@ -24041,6 +24260,10 @@
 			"Instructions",
 			"File changes watcher stopped unexpectedly. A reload of the window may enable the watcher again unless the workspace cannot be watched for file changes.",
 			"Reload"
+		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"1 unsaved file",
+			"{0} unsaved files"
 		],
 		"vs/editor/common/config/editorConfigurationSchema": [
 			"Editor",
@@ -24073,6 +24296,8 @@
 			"Timeout in milliseconds after which diff computation is cancelled. Use 0 for no timeout.",
 			"Maximum file size in MB for which to compute diffs. Use 0 for no limit.",
 			"Controls whether the diff editor shows the diff side by side or inline.",
+			"If the diff editor width is smaller than this value, the inline view is used.",
+			"If enabled and the editor width is too small, the inline view is used.",
 			"When enabled, the diff editor shows arrows in its glyph margin to revert changes.",
 			"When enabled, the diff editor ignores changes in leading or trailing whitespace.",
 			"Controls whether the diff editor shows +/- indicators for added/removed changes.",
@@ -24083,13 +24308,12 @@
 			"Uses the legacy diffing algorithm.",
 			"Uses the advanced diffing algorithm.",
 			"Controls whether the diff editor shows unchanged regions. Only works when {0} is set.",
+			"Controls how many lines are used for unchanged regions. Only works when {0} is set.",
+			"Controls how many lines are used as a minimum for unchanged regions. Only works when {0} is set.",
+			"Controls how many lines are used as context when comparing unchanged regions. Only works when {0} is set.",
 			"Controls whether the diff editor should show detected code moves. Only works when {0} is set.",
 			"Controls whether the diff editor uses the new or the old implementation.",
 			"Controls whether the diff editor shows empty decorations to see where characters got inserted or deleted."
-		],
-		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
-			"1 unsaved file",
-			"{0} unsaved files"
 		],
 		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
 			"Text File Editor",
@@ -24108,6 +24332,18 @@
 			"Current Line: {0}, Character: {1}. Type a line number between 1 and {2} to navigate to.",
 			"Current Line: {0}, Character: {1}. Type a line number to navigate to."
 		],
+		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
+			"No matching results",
+			"recently opened",
+			"file and symbol results",
+			"file results",
+			"{0}, {1}",
+			"Open Quick Chat",
+			"Open to the Side",
+			"Open to the Bottom",
+			"Remove from Recently Opened",
+			"{0} unsaved changes"
+		],
 		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
 			"No matching entries",
 			"Go to Symbol in Editor...",
@@ -24115,17 +24351,6 @@
 			"Type the name of a symbol to go to.",
 			"Go to Symbol in Editor",
 			"Go to Symbol in Editor by Category"
-		],
-		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
-			"No matching results",
-			"recently opened",
-			"file and symbol results",
-			"file results",
-			"More",
-			"Open to the Side",
-			"Open to the Bottom",
-			"Remove from Recently Opened",
-			"{0} unsaved changes"
 		],
 		"vs/workbench/contrib/search/browser/searchIcons": [
 			"Icon to make search details visible.",
@@ -24143,7 +24368,8 @@
 			"Icon for clear results in the search view.",
 			"Icon for stop in the search view.",
 			"View icon of the search view.",
-			"Icon for the action to open a new search editor."
+			"Icon for the action to open a new search editor.",
+			"Icon for the action to go to the file of the current search result."
 		],
 		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
 			"No matching workspace symbols",
@@ -24160,6 +24386,11 @@
 			"Replace: Type replace term and press Enter to preview",
 			"Replace"
 		],
+		"vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess": [
+			"See More Files",
+			"Open File",
+			"More"
+		],
 		"vs/workbench/contrib/search/browser/searchActionsCopy": [
 			"Copy",
 			"Copy Path",
@@ -24175,6 +24406,12 @@
 			"A set of options for the search",
 			"Find in Folder...",
 			"Find in Workspace..."
+		],
+		"vs/workbench/contrib/search/browser/searchActionsRemoveReplace": [
+			"Dismiss",
+			"Replace",
+			"Replace All",
+			"Replace All"
 		],
 		"vs/workbench/contrib/search/browser/searchActionsNav": [
 			"Toggle Query Details",
@@ -24195,17 +24432,6 @@
 			"Focus Previous Search Result",
 			"Replace in Files"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsRemoveReplace": [
-			"Dismiss",
-			"Replace",
-			"Replace All",
-			"Replace All"
-		],
-		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
-			"Go to Symbol in Workspace...",
-			"Go to Symbol in Workspace...",
-			"Go to Symbol in &&Workspace..."
-		],
 		"vs/workbench/contrib/search/browser/searchActionsTopBar": [
 			"Clear Search History",
 			"Cancel Search",
@@ -24215,6 +24441,14 @@
 			"Clear Search Results",
 			"View as Tree",
 			"View as List"
+		],
+		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
+			"Go to Symbol in Workspace...",
+			"Go to Symbol in Workspace...",
+			"Go to Symbol in &&Workspace..."
+		],
+		"vs/workbench/contrib/search/browser/searchActionsTextQuickAccess": [
+			"Quick Text Search (Experimental)"
 		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
 			"Apply",
@@ -24234,35 +24468,22 @@
 		"vs/workbench/contrib/search/browser/searchActionsBase": [
 			"Search"
 		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
-			"Toggle Search Details",
-			"files to include",
-			"Search Include Patterns",
-			"files to exclude",
-			"Search Exclude Patterns",
-			"Run Search",
-			"Matched {0} at {1} in file {2}",
-			"Search",
-			"Search editor text input box border."
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
-			"Search: {0}",
-			"Search: {0}",
-			"Search"
-		],
 		"vs/workbench/browser/parts/views/viewPane": [
 			"Icon for an expanded view pane container.",
 			"Icon for a collapsed view pane container.",
 			"{0} actions"
+		],
+		"vs/workbench/contrib/search/browser/searchMessage": [
+			"Unable to open command link from untrusted source: {0}",
+			"Unable to open unknown link: {0}"
 		],
 		"vs/workbench/contrib/search/browser/patternInputWidget": [
 			"input",
 			"Search only in Open Editors",
 			"Use Exclude Settings and Ignore Files"
 		],
-		"vs/workbench/contrib/search/browser/searchMessage": [
-			"Unable to open command link from untrusted source: {0}",
-			"Unable to open unknown link: {0}"
+		"vs/workbench/services/search/common/queryBuilder": [
+			"Workspace folder does not exist: {0}"
 		],
 		"vs/workbench/contrib/search/browser/searchResultsView": [
 			"Other files",
@@ -24280,12 +24501,28 @@
 			"'{0}' at column {1} replace {2} with {3}",
 			"'{0}' at column {1} found {2}"
 		],
-		"vs/workbench/services/search/common/queryBuilder": [
-			"Workspace folder does not exist: {0}"
+		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
+			"Toggle Search Details",
+			"files to include",
+			"Search Include Patterns",
+			"files to exclude",
+			"Search Exclude Patterns",
+			"Run Search",
+			"Matched {0} at {1} in file {2}",
+			"Search",
+			"Search editor text input box border."
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
+			"Search: {0}",
+			"Search: {0}",
+			"Search"
 		],
 		"vs/workbench/contrib/scm/browser/activity": [
 			"Source Control",
 			"{0} pending changes"
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
+			"Source Control"
 		],
 		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
 			"{0} - {1} of {2} changes",
@@ -24308,9 +24545,6 @@
 			"Overview ruler marker color for modified content.",
 			"Overview ruler marker color for added content.",
 			"Overview ruler marker color for deleted content."
-		],
-		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
-			"Source Control"
 		],
 		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
 			"Source Control Repositories"
@@ -24336,39 +24570,6 @@
 			"Expand All Repositories",
 			"Close",
 			"SCM Provider separator border."
-		],
-		"vs/workbench/contrib/debug/browser/callStackView": [
-			"Running",
-			"Show More Stack Frames",
-			"Session",
-			"Running",
-			"Restart Frame",
-			"Load More Stack Frames",
-			"Show {0} More: {1}",
-			"Show {0} More Stack Frames",
-			"Paused on {0}",
-			"Paused",
-			"Debug Call Stack",
-			"Thread {0} {1}",
-			"Stack Frame {0}, line {1}, {2}",
-			"Running",
-			"Session {0} {1}",
-			"Show {0} More Stack Frames",
-			"Collapse All"
-		],
-		"vs/workbench/contrib/debug/browser/debugColors": [
-			"Debug toolbar background color.",
-			"Debug toolbar border color.",
-			"Debug toolbar icon for start debugging.",
-			"Debug toolbar icon for pause.",
-			"Debug toolbar icon for stop.",
-			"Debug toolbar icon for disconnect.",
-			"Debug toolbar icon for restart.",
-			"Debug toolbar icon for step over.",
-			"Debug toolbar icon for step into.",
-			"Debug toolbar icon for step over.",
-			"Debug toolbar icon for continue.",
-			"Debug toolbar icon for step back."
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"Unverified Exception Breakpoint",
@@ -24424,31 +24625,41 @@
 			"Edit Function Breakpoint...",
 			"Edit Hit Count..."
 		],
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"Debug toolbar background color.",
+			"Debug toolbar border color.",
+			"Debug toolbar icon for start debugging.",
+			"Debug toolbar icon for pause.",
+			"Debug toolbar icon for stop.",
+			"Debug toolbar icon for disconnect.",
+			"Debug toolbar icon for restart.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for step into.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for continue.",
+			"Debug toolbar icon for step back."
+		],
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			"Running",
+			"Show More Stack Frames",
+			"Session",
+			"Running",
+			"Restart Frame",
+			"Load More Stack Frames",
+			"Show {0} More: {1}",
+			"Show {0} More Stack Frames",
+			"Paused on {0}",
+			"Paused",
+			"Debug Call Stack",
+			"Thread {0} {1}",
+			"Stack Frame {0}, line {1}, {2}",
+			"Running",
+			"Session {0} {1}",
+			"Show {0} More Stack Frames",
+			"Collapse All"
+		],
 		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
 			"Start a New Debug Session"
-		],
-		"vs/workbench/contrib/debug/browser/debugEditorActions": [
-			"Debug: Toggle Breakpoint",
-			"Toggle &&Breakpoint",
-			"Debug: Add Conditional Breakpoint...",
-			"&&Conditional Breakpoint...",
-			"Debug: Add Logpoint...",
-			"&&Logpoint...",
-			"Debug: Edit Breakpoint",
-			"&&Edit Breakpoint",
-			"Open Disassembly View",
-			"&&DisassemblyView",
-			"Toggle Source Code in Disassembly View",
-			"&&ToggleSource",
-			"Run to Cursor",
-			"Evaluate in Debug Console",
-			"Add to Watch",
-			"Debug: Show Hover",
-			"Step targets are not available here",
-			"Step Into Target",
-			"Debug: Go to Next Breakpoint",
-			"Debug: Go to Previous Breakpoint",
-			"Close Exception Widget"
 		],
 		"vs/workbench/contrib/debug/browser/debugIcons": [
 			"View icon of the debug console view.",
@@ -24507,16 +24718,6 @@
 			"Icon for the debug evaluation prompt.",
 			"Icon for the inspect memory action."
 		],
-		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
-			"No matching launch configurations",
-			"Configure Launch Configuration",
-			"contributed",
-			"Remove Launch Configuration",
-			"{0} contributed configurations",
-			"configure",
-			"Add Config ({0})...",
-			"Add Configuration..."
-		],
 		"vs/workbench/contrib/debug/browser/debugCommands": [
 			"Debug",
 			"Restart",
@@ -24550,10 +24751,38 @@
 			"Add Configuration...",
 			"Add Inline Breakpoint"
 		],
-		"vs/workbench/contrib/debug/browser/debugStatus": [
-			"Debug",
-			"Debug: {0}",
-			"Select and start debug configuration"
+		"vs/workbench/contrib/debug/browser/debugEditorActions": [
+			"Debug: Toggle Breakpoint",
+			"Toggle &&Breakpoint",
+			"Debug: Add Conditional Breakpoint...",
+			"&&Conditional Breakpoint...",
+			"Debug: Add Logpoint...",
+			"&&Logpoint...",
+			"Debug: Edit Breakpoint",
+			"&&Edit Breakpoint",
+			"Open Disassembly View",
+			"&&DisassemblyView",
+			"Toggle Source Code in Disassembly View",
+			"&&ToggleSource",
+			"Run to Cursor",
+			"Evaluate in Debug Console",
+			"Add to Watch",
+			"Debug: Show Hover",
+			"Step targets are not available here",
+			"Step Into Target",
+			"Debug: Go to Next Breakpoint",
+			"Debug: Go to Previous Breakpoint",
+			"Close Exception Widget"
+		],
+		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
+			"No matching launch configurations",
+			"Configure Launch Configuration",
+			"contributed",
+			"Remove Launch Configuration",
+			"{0} contributed configurations",
+			"configure",
+			"Add Config ({0})...",
+			"Add Configuration..."
 		],
 		"vs/workbench/contrib/debug/browser/debugService": [
 			"1 active session",
@@ -24578,19 +24807,15 @@
 			"Added breakpoint, line {0}, file {1}",
 			"Removed breakpoint, line {0}, file {1}"
 		],
+		"vs/workbench/contrib/debug/browser/debugStatus": [
+			"Debug",
+			"Debug: {0}",
+			"Select and start debug configuration"
+		],
 		"vs/workbench/contrib/debug/browser/debugToolBar": [
 			"More...",
 			"Step Back",
 			"Reverse"
-		],
-		"vs/workbench/contrib/debug/browser/disassemblyView": [
-			"Disassembly not available.",
-			"instructions",
-			"from disassembly",
-			"Disassembly View",
-			"Address",
-			"Bytes",
-			"Instruction"
 		],
 		"vs/workbench/contrib/debug/browser/loadedScriptsView": [
 			"Debug Session",
@@ -24605,16 +24830,14 @@
 			"Status bar foreground color when a program is being debugged. The status bar is shown in the bottom of the window",
 			"Status bar border color separating to the sidebar and editor when a program is being debugged. The status bar is shown in the bottom of the window"
 		],
-		"vs/workbench/contrib/debug/browser/variablesView": [
-			"Type new variable value",
-			"Debug Variables",
-			"Scope {0}",
-			"{0}, value {1}",
-			"Inspecting binary data requires the Hex Editor extension. Would you like to install it now?",
-			"Cancel",
-			"Install",
-			"Installing the Hex Editor...",
-			"Collapse All"
+		"vs/workbench/contrib/debug/browser/disassemblyView": [
+			"Disassembly not available.",
+			"instructions",
+			"from disassembly",
+			"Disassembly View",
+			"Address",
+			"Bytes",
+			"Instruction"
 		],
 		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
 			"Type new value",
@@ -24627,11 +24850,6 @@
 			"Add Expression",
 			"Remove All Expressions"
 		],
-		"vs/workbench/contrib/debug/common/debugContentProvider": [
-			"Unable to resolve the resource without a debug session",
-			"Could not load source '{0}': {1}.",
-			"Could not load source '{0}'."
-		],
 		"vs/workbench/contrib/debug/browser/welcomeView": [
 			"Run",
 			"[Open a file](command:{0}) which can be debugged or run.",
@@ -24641,6 +24859,22 @@
 			"To customize Run and Debug, [open a folder](command:{0}) and create a launch.json file.",
 			"All debug extensions are disabled. Enable a debug extension or install a new one from the Marketplace."
 		],
+		"vs/workbench/contrib/debug/browser/variablesView": [
+			"Type new variable value",
+			"Debug Variables",
+			"Scope {0}",
+			"{0}, value {1}",
+			"Inspecting binary data requires the Hex Editor extension. Would you like to install it now?",
+			"Cancel",
+			"Install",
+			"Installing the Hex Editor...",
+			"Collapse All"
+		],
+		"vs/workbench/contrib/debug/common/debugContentProvider": [
+			"Unable to resolve the resource without a debug session",
+			"Could not load source '{0}': {1}.",
+			"Could not load source '{0}'."
+		],
 		"vs/workbench/contrib/debug/common/debugLifecycle": [
 			"There is an active debug session, are you sure you want to stop it?",
 			"There are active debug sessions, are you sure you want to stop them?",
@@ -24648,6 +24882,15 @@
 		],
 		"vs/workbench/contrib/debug/common/disassemblyViewInput": [
 			"Disassembly"
+		],
+		"vs/workbench/contrib/debug/browser/breakpointWidget": [
+			"Message to log when breakpoint is hit. Expressions within {} are interpolated. '{0}' to accept, '{1}' to cancel.",
+			"Break when hit count condition is met. '{0}' to accept, '{1}' to cancel.",
+			"Break when expression evaluates to true. '{0}' to accept, '{1}' to cancel.",
+			"Expression",
+			"Hit Count",
+			"Log Message",
+			"Breakpoint Type"
 		],
 		"vs/workbench/contrib/debug/browser/debugHover": [
 			"Hold {0} key to switch to editor language hover",
@@ -24669,15 +24912,6 @@
 			"Paused",
 			"Running",
 			"Unverified breakpoint. File is modified, please restart debug session."
-		],
-		"vs/workbench/contrib/debug/browser/breakpointWidget": [
-			"Message to log when breakpoint is hit. Expressions within {} are interpolated. '{0}' to accept, '{1}' to cancel.",
-			"Break when hit count condition is met. '{0}' to accept, '{1}' to cancel.",
-			"Break when expression evaluates to true. '{0}' to accept, '{1}' to cancel.",
-			"Expression",
-			"Hit Count",
-			"Log Message",
-			"Breakpoint Type"
 		],
 		"vs/workbench/contrib/debug/browser/debugActionViewItems": [
 			"Debug Launch Configurations",
@@ -24706,12 +24940,6 @@
 		],
 		"vs/workbench/contrib/debug/common/replModel": [
 			"Console was cleared"
-		],
-		"vs/workbench/contrib/markers/browser/markersView": [
-			"Showing {0} of {1}",
-			"Showing {0} problems",
-			"Showing {0} of {1} problems",
-			"Clear Filters"
 		],
 		"vs/workbench/contrib/markers/browser/messages": [
 			"Toggle Problems (Errors, Warnings, Infos)",
@@ -24762,17 +24990,71 @@
 			"{0} at line {1} and character {2} in {3}",
 			"Show Errors and Warnings"
 		],
-		"vs/workbench/browser/parts/views/viewFilter": [
-			"More Filters..."
-		],
 		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
 			"Problems",
 			"1 problem in this file",
 			"{0} problems in this file",
 			"Show Errors & Warnings on files and folder."
 		],
-		"vs/workbench/contrib/performance/browser/perfviewEditor": [
-			"Startup Performance"
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"Showing {0} of {1}",
+			"Showing {0} problems",
+			"Showing {0} of {1} problems",
+			"Clear Filters"
+		],
+		"vs/workbench/browser/parts/views/viewFilter": [
+			"More Filters..."
+		],
+		"vs/workbench/contrib/mergeEditor/browser/commands/commands": [
+			"Open Merge Editor",
+			"Mixed Layout",
+			"Column Layout",
+			"Show Non-Conflicting Changes",
+			"Show Base",
+			"Show Base Top",
+			"Show Base Center",
+			"Merge Editor",
+			"Open File",
+			"Go to Next Unhandled Conflict",
+			"Go to Previous Unhandled Conflict",
+			"Toggle Current Conflict from Left",
+			"Toggle Current Conflict from Right",
+			"Compare Input 1 With Base",
+			"Compare With Base",
+			"Compare Input 2 With Base",
+			"Compare With Base",
+			"Open Base File",
+			"Accept All Changes from Left",
+			"Accept All Changes from Right",
+			"Reset Result",
+			"Reset",
+			"Reset Choice for 'Close with Conflicts'",
+			"Complete Merge",
+			"Do you want to complete the merge of {0}?",
+			"The file contains unhandled conflicts.",
+			"&&Complete with Conflicts"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
+			"Merging: {0}"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/commands/devCommands": [
+			"Merge Editor (Dev)",
+			"Copy Merge Editor State as JSON",
+			"Merge Editor",
+			"No active merge editor",
+			"Merge Editor",
+			"Successfully copied merge editor state",
+			"Save Merge Editor State to Folder",
+			"Merge Editor",
+			"No active merge editor",
+			"Select folder to save to",
+			"Merge Editor",
+			"Successfully saved merge editor state to folder",
+			"Load Merge Editor State from Folder",
+			"Select folder to save to"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
+			"Text Merge Editor"
 		],
 		"vs/workbench/contrib/comments/browser/commentService": [
 			"Whether the open workspace has either comments or commenting ranges."
@@ -24807,63 +25089,6 @@
 			"Find previous",
 			"Reload Webviews"
 		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
-			"The viewType of the currently active webview panel."
-		],
-		"vs/workbench/contrib/mergeEditor/browser/commands/commands": [
-			"Open Merge Editor",
-			"Mixed Layout",
-			"Column Layout",
-			"Show Non-Conflicting Changes",
-			"Show Base",
-			"Show Base Top",
-			"Show Base Center",
-			"Merge Editor",
-			"Open File",
-			"Go to Next Unhandled Conflict",
-			"Go to Previous Unhandled Conflict",
-			"Toggle Current Conflict from Left",
-			"Toggle Current Conflict from Right",
-			"Compare Input 1 With Base",
-			"Compare With Base",
-			"Compare Input 2 With Base",
-			"Compare With Base",
-			"Open Base File",
-			"Accept All Changes from Left",
-			"Accept All Changes from Right",
-			"Reset Result",
-			"Reset",
-			"Reset Choice for 'Close with Conflicts'",
-			"Complete Merge",
-			"Do you want to complete the merge of {0}?",
-			"The file contains unhandled conflicts.",
-			"&&Complete with Conflicts"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/commands/devCommands": [
-			"Merge Editor (Dev)",
-			"Copy Merge Editor State as JSON",
-			"Merge Editor",
-			"No active merge editor",
-			"Merge Editor",
-			"Successfully copied merge editor state",
-			"Save Merge Editor State to Folder",
-			"Merge Editor",
-			"No active merge editor",
-			"Select folder to save to",
-			"Merge Editor",
-			"Successfully saved merge editor state to folder",
-			"Load Merge Editor State from Folder",
-			"Select folder to save to"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
-			"Merging: {0}"
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
-			"Text Merge Editor"
-		],
-		"vs/workbench/contrib/customEditor/common/customEditor": [
-			"The viewType of the currently active custom editor."
-		],
 		"vs/workbench/contrib/externalUriOpener/common/configuration": [
 			"Configure the opener to use for external URIs (http, https).",
 			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
@@ -24876,8 +25101,24 @@
 			"Configure default opener...",
 			"How would you like to open: {0}"
 		],
+		"vs/workbench/contrib/customEditor/common/customEditor": [
+			"The viewType of the currently active custom editor."
+		],
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"Extension: {0}"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"Extensions",
+			"Unable to search the Marketplace when offline, please check your network connection.",
+			"Error while fetching extensions. {0}",
+			"No extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"There are no extensions to install.",
+			"Verified Publisher {0}",
+			"Publisher {0}",
+			"Deprecated",
+			"Rated {0} out of 5 stars by {1} users"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"{0} for the Web",
@@ -24930,7 +25171,6 @@
 			"Migrate to {0}",
 			"Migrate",
 			"Manage",
-			"Uninstalling",
 			"Manage",
 			"Switch to Pre-Release Version",
 			"Switch to Pre-Release version of this extension",
@@ -25040,12 +25280,52 @@
 			"Button foreground color for extension actions that stand out (e.g. install button).",
 			"Button background hover color for extension actions that stand out (e.g. install button)."
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"View icon of the extensions view.",
+			"Icon for the 'Manage' action in the extensions view.",
+			"Icon for the 'Clear Search Result' action in the extensions view.",
+			"Icon for the 'Refresh' action in the extensions view.",
+			"Icon for the 'Filter' action in the extensions view.",
+			"Icon for the 'Install Local Extension in Remote' action in the extensions view.",
+			"Icon for the 'Install Workspace Recommended Extensions' action in the extensions view.",
+			"Icon for the 'Configure Recommended Extensions' action in the extensions view.",
+			"Icon to indicate that an extension is synced.",
+			"Icon to indicate that an extension is ignored when syncing.",
+			"Icon to indicate that an extension is remote in the extensions view and editor.",
+			"Icon shown along with the install count in the extensions view and editor.",
+			"Icon shown along with the rating in the extensions view and editor.",
+			"Icon used for the verified extension publisher in the extensions view and editor.",
+			"Icon shown for extensions having pre-release versions in extensions view and editor.",
+			"Icon used for sponsoring extensions in the extensions view and editor.",
+			"Full star icon used for the rating in the extensions editor.",
+			"Half star icon used for the rating in the extensions editor.",
+			"Empty star icon used for the rating in the extensions editor.",
+			"Icon shown with a error message in the extensions editor.",
+			"Icon shown with a warning message in the extensions editor.",
+			"Icon shown with an info message in the extensions editor.",
+			"Icon shown with a workspace trust message in the extension editor.",
+			"Icon shown with a activation time message in the extension editor."
+		],
+		"vs/platform/dnd/browser/dnd": [
+			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
+		],
 		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
 			"Extensions",
 			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
 			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
 			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
 			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
+		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
+			"Yes",
+			"No"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
+			"The viewType of the currently active webview panel."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"Activating Extensions..."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionEditor": [
 			"Extension Version",
@@ -25162,13 +25442,18 @@
 			"Find Next",
 			"Find Previous"
 		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
-			"Yes",
-			"No"
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"Extensions",
+			"Install Missing Dependencies",
+			"Finished installing missing dependencies. Please reload the window now.",
+			"Reload Window",
+			"There are no missing dependencies to install."
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
-			"Activating Extensions..."
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"Type an extension name to install or search.",
+			"Press Enter to search for extension '{0}'.",
+			"Press Enter to install extension '{0}'.",
+			"Press Enter to manage your extensions."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
 			"Manifest is not found",
@@ -25208,6 +25493,9 @@
 			"Install (Do not sync)",
 			"Show Recommendations"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
+			"Restarting extension host due to workspace trust change."
+		],
 		"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor": [
 			"Activated by {0} on start-up",
 			"Activated by {1} because a file matching {0} exists in your workspace",
@@ -25225,42 +25513,6 @@
 			"Disable",
 			"Show Running Extensions"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
-			"Restarting extension host due to workspace trust change."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"Extensions",
-			"Install Missing Dependencies",
-			"Finished installing missing dependencies. Please reload the window now.",
-			"Reload Window",
-			"There are no missing dependencies to install."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
-			"View icon of the extensions view.",
-			"Icon for the 'Manage' action in the extensions view.",
-			"Icon for the 'Clear Search Result' action in the extensions view.",
-			"Icon for the 'Refresh' action in the extensions view.",
-			"Icon for the 'Filter' action in the extensions view.",
-			"Icon for the 'Install Local Extension in Remote' action in the extensions view.",
-			"Icon for the 'Install Workspace Recommended Extensions' action in the extensions view.",
-			"Icon for the 'Configure Recommended Extensions' action in the extensions view.",
-			"Icon to indicate that an extension is synced.",
-			"Icon to indicate that an extension is ignored when syncing.",
-			"Icon to indicate that an extension is remote in the extensions view and editor.",
-			"Icon shown along with the install count in the extensions view and editor.",
-			"Icon shown along with the rating in the extensions view and editor.",
-			"Icon used for the verified extension publisher in the extensions view and editor.",
-			"Icon shown for extensions having pre-release versions in extensions view and editor.",
-			"Icon used for sponsoring extensions in the extensions view and editor.",
-			"Full star icon used for the rating in the extensions editor.",
-			"Half star icon used for the rating in the extensions editor.",
-			"Empty star icon used for the rating in the extensions editor.",
-			"Icon shown with a error message in the extensions editor.",
-			"Icon shown with a warning message in the extensions editor.",
-			"Icon shown with an info message in the extensions editor.",
-			"Icon shown with a workspace trust message in the extension editor.",
-			"Icon shown with a activation time message in the extension editor."
-		],
 		"vs/workbench/contrib/extensions/browser/extensionsCompletionItemsProvider": [
 			"Example"
 		],
@@ -25268,22 +25520,6 @@
 			"You have deprecated extensions installed. We recommend to review them and migrate to alternatives.",
 			"Show Deprecated Extensions",
 			"Don't Show Again"
-		],
-		"vs/platform/dnd/browser/dnd": [
-			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsViews": [
-			"Extensions",
-			"Unable to search the Marketplace when offline, please check your network connection.",
-			"Error while fetching extensions. {0}",
-			"No extensions found.",
-			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
-			"Open User Settings",
-			"There are no extensions to install.",
-			"Verified Publisher {0}",
-			"Publisher {0}",
-			"Deprecated",
-			"Rated {0} out of 5 stars by {1} users"
 		],
 		"vs/workbench/contrib/output/browser/logViewer": [
 			"Log viewer"
@@ -25295,17 +25531,17 @@
 			"Terminal",
 			"&&Terminal"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"Type an extension name to install or search.",
-			"Press Enter to search for extension '{0}'.",
-			"Press Enter to install extension '{0}'.",
-			"Press Enter to manage your extensions."
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
+			"Focus Accessible Buffer",
+			"Navigate Accessible Buffer",
+			"Accessible Buffer Go to Next Command",
+			"Accessible Buffer Go to Previous Command"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalView": [
-			"Use 'monospace'",
-			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font.",
-			"Open Terminals.",
-			"Starting..."
+		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
+			"Show Environment Contributions",
+			"Terminal Environment Changes",
+			"Extension: {0}",
+			"workspace"
 		],
 		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
 			"Show Terminal Texture Atlas",
@@ -25313,11 +25549,11 @@
 			"Enter data to write directly to the terminal, bypassing the pty",
 			"Restart Pty Host"
 		],
-		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
-			"Show Environment Contributions",
-			"Terminal Environment Changes",
-			"Extension: {0}",
-			"workspace"
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"Use 'monospace'",
+			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font.",
+			"Open Terminals.",
+			"Starting..."
 		],
 		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
 			"Focus Find",
@@ -25328,12 +25564,6 @@
 			"Find Next",
 			"Find Previous",
 			"Search Workspace"
-		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
-			"Focus Accessible Buffer",
-			"Navigate Accessible Buffer",
-			"Accessible Buffer Go to Next Command",
-			"Accessible Buffer Go to Previous Command"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
 			"Open Detected Link...",
@@ -25347,76 +25577,6 @@
 			"Manage Automatic Tasks",
 			"Allow Automatic Tasks",
 			"Disallow Automatic Tasks"
-		],
-		"vs/workbench/contrib/tasks/common/problemMatcher": [
-			"The problem pattern is missing a regular expression.",
-			"The loop property is only supported on the last line matcher.",
-			"The problem pattern is invalid. The kind property must be provided only in the first element",
-			"The problem pattern is invalid. It must have at least have a file and a message.",
-			"The problem pattern is invalid. It must either have kind: \"file\" or have a line or location match group.",
-			"Error: The string {0} is not a valid regular expression.\n",
-			"The regular expression to find an error, warning or info in the output.",
-			"whether the pattern matches a location (file and line) or only a file.",
-			"The match group index of the filename. If omitted 1 is used.",
-			"The match group index of the problem's location. Valid location patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn). If omitted (line,column) is assumed.",
-			"The match group index of the problem's line. Defaults to 2",
-			"The match group index of the problem's line character. Defaults to 3",
-			"The match group index of the problem's end line. Defaults to undefined",
-			"The match group index of the problem's end line character. Defaults to undefined",
-			"The match group index of the problem's severity. Defaults to undefined",
-			"The match group index of the problem's code. Defaults to undefined",
-			"The match group index of the message. If omitted it defaults to 4 if location is specified. Otherwise it defaults to 5.",
-			"In a multi line matcher loop indicated whether this pattern is executed in a loop as long as it matches. Can only specified on a last pattern in a multi line pattern.",
-			"The name of the problem pattern.",
-			"The name of the problem multi line problem pattern.",
-			"The actual patterns.",
-			"Contributes problem patterns",
-			"Invalid problem pattern. The pattern will be ignored.",
-			"Invalid problem pattern. The pattern will be ignored.",
-			"Error: the description can't be converted into a problem matcher:\n{0}\n",
-			"Error: the description doesn't define a valid problem pattern:\n{0}\n",
-			"Error: the description doesn't define an owner:\n{0}\n",
-			"Error: the description doesn't define a file location:\n{0}\n",
-			"Info: unknown severity {0}. Valid values are error, warning and info.\n",
-			"Error: the pattern with the identifier {0} doesn't exist.",
-			"Error: the pattern property refers to an empty identifier.",
-			"Error: the pattern property {0} is not a valid pattern variable name.",
-			"A problem matcher must define both a begin pattern and an end pattern for watching.",
-			"Error: The string {0} is not a valid regular expression.\n",
-			"The regular expression to detect the begin or end of a background task.",
-			"The match group index of the filename. Can be omitted.",
-			"The name of a contributed or predefined pattern",
-			"A problem pattern or the name of a contributed or predefined problem pattern. Can be omitted if base is specified.",
-			"The name of a base problem matcher to use.",
-			"The owner of the problem inside Code. Can be omitted if base is specified. Defaults to 'external' if omitted and base is not specified.",
-			"A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.",
-			"The default severity for captures problems. Is used if the pattern doesn't define a match group for severity.",
-			"Controls if a problem reported on a text document is applied only to open, closed or all documents.",
-			"Defines how file names reported in a problem pattern should be interpreted. A relative fileLocation may be an array, where the second element of the array is the path of the relative file location. The search fileLocation mode, performs a deep (and, possibly, heavy) file system search within the directories specified by the include/exclude properties of the second element (or the current workspace directory if not specified).",
-			"Patterns to track the begin and end of a matcher active on a background task.",
-			"If set to true the background monitor is in active mode when the task starts. This is equals of issuing a line that matches the beginsPattern",
-			"If matched in the output the start of a background task is signaled.",
-			"If matched in the output the end of a background task is signaled.",
-			"The watching property is deprecated. Use background instead.",
-			"Patterns to track the begin and end of a watching matcher.",
-			"If set to true the watcher is in active mode when the task starts. This is equals of issuing a line that matches the beginPattern",
-			"If matched in the output the start of a watching task is signaled.",
-			"If matched in the output the end of a watching task is signaled.",
-			"This property is deprecated. Use the watching property instead.",
-			"A regular expression signaling that a watched tasks begins executing triggered through file watching.",
-			"This property is deprecated. Use the watching property instead.",
-			"A regular expression signaling that a watched tasks ends executing.",
-			"The name of the problem matcher used to refer to it.",
-			"A human readable label of the problem matcher.",
-			"Contributes problem matchers",
-			"Microsoft compiler problems",
-			"Less problems",
-			"Gulp TSC Problems",
-			"JSHint problems",
-			"JSHint stylish problems",
-			"ESLint compact problems",
-			"ESLint stylish problems",
-			"Go problems"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
 			"Task version 0.1.0 is deprecated. Please use 2.0.0",
@@ -25512,6 +25672,76 @@
 			"Mac specific command configuration",
 			"Linux specific command configuration"
 		],
+		"vs/workbench/contrib/tasks/common/problemMatcher": [
+			"The problem pattern is missing a regular expression.",
+			"The loop property is only supported on the last line matcher.",
+			"The problem pattern is invalid. The kind property must be provided only in the first element",
+			"The problem pattern is invalid. It must have at least have a file and a message.",
+			"The problem pattern is invalid. It must either have kind: \"file\" or have a line or location match group.",
+			"Error: The string {0} is not a valid regular expression.\n",
+			"The regular expression to find an error, warning or info in the output.",
+			"whether the pattern matches a location (file and line) or only a file.",
+			"The match group index of the filename. If omitted 1 is used.",
+			"The match group index of the problem's location. Valid location patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn). If omitted (line,column) is assumed.",
+			"The match group index of the problem's line. Defaults to 2",
+			"The match group index of the problem's line character. Defaults to 3",
+			"The match group index of the problem's end line. Defaults to undefined",
+			"The match group index of the problem's end line character. Defaults to undefined",
+			"The match group index of the problem's severity. Defaults to undefined",
+			"The match group index of the problem's code. Defaults to undefined",
+			"The match group index of the message. If omitted it defaults to 4 if location is specified. Otherwise it defaults to 5.",
+			"In a multi line matcher loop indicated whether this pattern is executed in a loop as long as it matches. Can only specified on a last pattern in a multi line pattern.",
+			"The name of the problem pattern.",
+			"The name of the problem multi line problem pattern.",
+			"The actual patterns.",
+			"Contributes problem patterns",
+			"Invalid problem pattern. The pattern will be ignored.",
+			"Invalid problem pattern. The pattern will be ignored.",
+			"Error: the description can't be converted into a problem matcher:\n{0}\n",
+			"Error: the description doesn't define a valid problem pattern:\n{0}\n",
+			"Error: the description doesn't define an owner:\n{0}\n",
+			"Error: the description doesn't define a file location:\n{0}\n",
+			"Info: unknown severity {0}. Valid values are error, warning and info.\n",
+			"Error: the pattern with the identifier {0} doesn't exist.",
+			"Error: the pattern property refers to an empty identifier.",
+			"Error: the pattern property {0} is not a valid pattern variable name.",
+			"A problem matcher must define both a begin pattern and an end pattern for watching.",
+			"Error: The string {0} is not a valid regular expression.\n",
+			"The regular expression to detect the begin or end of a background task.",
+			"The match group index of the filename. Can be omitted.",
+			"The name of a contributed or predefined pattern",
+			"A problem pattern or the name of a contributed or predefined problem pattern. Can be omitted if base is specified.",
+			"The name of a base problem matcher to use.",
+			"The owner of the problem inside Code. Can be omitted if base is specified. Defaults to 'external' if omitted and base is not specified.",
+			"A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.",
+			"The default severity for captures problems. Is used if the pattern doesn't define a match group for severity.",
+			"Controls if a problem reported on a text document is applied only to open, closed or all documents.",
+			"Defines how file names reported in a problem pattern should be interpreted. A relative fileLocation may be an array, where the second element of the array is the path of the relative file location. The search fileLocation mode, performs a deep (and, possibly, heavy) file system search within the directories specified by the include/exclude properties of the second element (or the current workspace directory if not specified).",
+			"Patterns to track the begin and end of a matcher active on a background task.",
+			"If set to true the background monitor is in active mode when the task starts. This is equals of issuing a line that matches the beginsPattern",
+			"If matched in the output the start of a background task is signaled.",
+			"If matched in the output the end of a background task is signaled.",
+			"The watching property is deprecated. Use background instead.",
+			"Patterns to track the begin and end of a watching matcher.",
+			"If set to true the watcher is in active mode when the task starts. This is equals of issuing a line that matches the beginPattern",
+			"If matched in the output the start of a watching task is signaled.",
+			"If matched in the output the end of a watching task is signaled.",
+			"This property is deprecated. Use the watching property instead.",
+			"A regular expression signaling that a watched tasks begins executing triggered through file watching.",
+			"This property is deprecated. Use the watching property instead.",
+			"A regular expression signaling that a watched tasks ends executing.",
+			"The name of the problem matcher used to refer to it.",
+			"A human readable label of the problem matcher.",
+			"Contributes problem matchers",
+			"Microsoft compiler problems",
+			"Less problems",
+			"Gulp TSC Problems",
+			"JSHint problems",
+			"JSHint stylish problems",
+			"ESLint compact problems",
+			"ESLint stylish problems",
+			"Go problems"
+		],
 		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
 			"No matching tasks",
 			"Select the task to run"
@@ -25554,13 +25784,7 @@
 			"Cannot reconnect. Please reload the window.",
 			"&&Reload Window"
 		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"Emmet: Expand Abbreviation",
-			"Emmet: E&&xpand Abbreviation"
-		],
 		"vs/workbench/contrib/remote/browser/remoteIndicator": [
-			"Status bar background color when the workbench is offline. The status bar is shown in the bottom of the window",
-			"Status bar foreground color when the workbench is offline. The status bar is shown in the bottom of the window",
 			"Remote",
 			"Show Remote Menu",
 			"Close Remote Connection",
@@ -25585,6 +25809,10 @@
 			"Select an option to open a Remote Window",
 			"Installing extension... "
 		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"Emmet: Expand Abbreviation",
+			"Emmet: E&&xpand Abbreviation"
+		],
 		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
 			"Toggle Screen Reader Accessibility Mode"
 		],
@@ -25594,15 +25822,14 @@
 			"Remove Limit",
 			"You are in a diff editor.",
 			"Press {0} or {1} to view the next or previous diff in the diff review mode that is optimized for screen readers.",
-			"To control which audio cues should be played, the following settings can be configured: {0}.",
-			"Diff editor accessibility help"
+			"To control which audio cues should be played, the following settings can be configured: {0}."
 		],
 		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
 			"Inspect Key Mappings",
 			"Inspect Key Mappings (JSON)"
 		],
 		"vs/workbench/contrib/codeEditor/browser/largeFileOptimizations": [
-			"{0}: tokenization, wrapping and folding have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
+			"{0}: tokenization, wrapping, folding and sticky scroll have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
 			"Forcefully Enable Features",
 			"Please reopen file in order for this setting to take effect."
 		],
@@ -25615,6 +25842,10 @@
 			"Type the line number and optional column to go to (e.g. 42:5 for line 42 and column 5).",
 			"Go to Line/Column"
 		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
+			"Toggle Minimap",
+			"&&Minimap"
+		],
 		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
 			"Running '{0}' Formatter ([configure]({1})).",
 			"Quick Fixes",
@@ -25625,15 +25856,19 @@
 			"Toggle Column Selection Mode",
 			"Column &&Selection Mode"
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
-			"Toggle Minimap",
-			"&&Minimap"
-		],
 		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
 			"Toggle Multi-Cursor Modifier",
 			"Switch to Alt+Click for Multi-Cursor",
 			"Switch to Cmd+Click for Multi-Cursor",
 			"Switch to Ctrl+Click for Multi-Cursor"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
+			"Toggle Control Characters",
+			"Render &&Control Characters"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"Toggle Render Whitespace",
+			"&&Render Whitespace"
 		],
 		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
 			"Whether the editor is currently using word wrapping.",
@@ -25642,16 +25877,13 @@
 			"Enable wrapping for this file",
 			"&&Word Wrap"
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
-			"Toggle Control Characters",
-			"Render &&Control Characters"
-		],
 		"vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint": [
-			"[[Select a language]], or [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don't show]] this again."
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
-			"Toggle Render Whitespace",
-			"&&Render Whitespace"
+			"Press {0} to ask {1} to do something. ",
+			"Start typing to dismiss.",
+			"[[Ask {0} to do something]] or start typing to dismiss.",
+			"[[Select a language]], or [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don't show]] this again.",
+			"Execute {0} to select a language, execute {1} to fill with template, or execute {2} to open a different editor and get started. Start typing to dismiss.",
+			" Toggle {0} in settings to disable this hint."
 		],
 		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
 			"(global)",
@@ -25673,15 +25905,31 @@
 			"New Snippets",
 			"Select Snippets File or Create Snippets"
 		],
+		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
+			"Insert Snippet"
+		],
 		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
 			"Fill File with Snippet",
 			"Select a snippet"
 		],
-		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
-			"Insert Snippet"
-		],
 		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
 			"Surround With Snippet..."
+		],
+		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
+			"Surround With: {0}",
+			"Start with Snippet",
+			"Start with: {0}"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"Expected string in `contributes.{0}.path`. Provided value: {1}",
+			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
+			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
+			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"Contributes snippets.",
+			"Language identifier for which this snippet is contributed to.",
+			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
+			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
+			"The snippet file \"{0}\" could not be read."
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
 			"None",
@@ -25756,15 +26004,24 @@
 			"&&Insiders",
 			"&&Stable (current)"
 		],
-		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
-			"Surround With: {0}",
-			"Start with Snippet",
-			"Start with: {0}"
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
+			"Welcome"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
 			"Built-In",
 			"Developer",
 			"Reset Welcome Page Walkthrough Progress"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
+			"Welcome Page",
+			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled."
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons": [
+			"Used to represent walkthrough steps which have not been completed",
+			"Used to represent walkthrough steps which have been completed"
+		],
+		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
+			"The viewsWelcome contribution in '{0}' requires 'enabledApiProposals: [\"contribViewsWelcome\"]' in order to use the 'group' proposed property."
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted": [
 			"Overview of how to get up to speed with your editor.",
@@ -25799,39 +26056,6 @@
 			"opt out",
 			"{0} collects usage data. Read our {1} and learn how to {2}."
 		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"Expected string in `contributes.{0}.path`. Provided value: {1}",
-			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
-			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
-			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
-			"Contributes snippets.",
-			"Language identifier for which this snippet is contributed to.",
-			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
-			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
-			"The snippet file \"{0}\" could not be read."
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
-			"Welcome"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
-			"Welcome Page",
-			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled."
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons": [
-			"Used to represent walkthrough steps which have not been completed",
-			"Used to represent walkthrough steps which have been completed"
-		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
-			"unbound",
-			"It looks like Git is not installed on your system."
-		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
-			"Editor Playground",
-			"Interactive Editor Playground"
-		],
-		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
-			"The viewsWelcome contribution in '{0}' requires 'enabledApiProposals: [\"contribViewsWelcome\"]' in order to use the 'group' proposed property."
-		],
 		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeExtensionPoint": [
 			"Contributed views welcome content. Welcome content will be rendered in tree based views whenever they have no meaningful content to display, ie. the File Explorer when no folder is open. Such content is useful as in-product documentation to drive users to use certain features before they are available. A good example would be a `Clone Repository` button in the File Explorer welcome view.",
 			"Contributed welcome content for a specific view.",
@@ -25841,6 +26065,14 @@
 			"Condition when the welcome content should be displayed.",
 			"Group to which this welcome content belongs. Proposed API.",
 			"Condition when the welcome content buttons and command links should be enabled."
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
+			"unbound",
+			"It looks like Git is not installed on your system."
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
+			"Editor Playground",
+			"Interactive Editor Playground"
 		],
 		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
 			"Calls from '{0}'",
@@ -25875,12 +26107,6 @@
 			"Sort By: Position",
 			"Sort By: Name",
 			"Sort By: Category"
-		],
-		"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem": [
-			"Tweet Feedback",
-			"Feedback",
-			"Tweet Feedback",
-			"Tweet Feedback"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
 			"Turn Off",
@@ -25985,6 +26211,13 @@
 			"Delete Profile...",
 			"Select Profiles to Delete"
 		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"Configure which editor to use for a resource.",
+			"Language modes that the code actions are enabled for.",
+			"`CodeActionKind` of the contributed code action.",
+			"Label for the code action used in the UI.",
+			"Description of what the code action does."
+		],
 		"vs/workbench/contrib/userDataProfile/browser/userDataProfileActions": [
 			"Create a Temporary Profile",
 			"Rename...",
@@ -25996,6 +26229,19 @@
 			"Manage...",
 			"Cleanup Profiles",
 			"Reset Workspace Profiles Associations"
+		],
+		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
+			"Contributed documentation.",
+			"Contributed documentation for refactorings.",
+			"Contributed documentation for refactoring.",
+			"Label for the documentation used in the UI.",
+			"When clause.",
+			"Command executed."
+		],
+		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
+			"Controls whether auto fix action should be run on file save.",
+			"Code Action kinds to be run on save.",
+			"Controls whether '{0}' actions should be run on file save."
 		],
 		"vs/workbench/contrib/editSessions/common/editSessions": [
 			"Cloud Changes",
@@ -26032,26 +26278,6 @@
 			"Local Copy",
 			"Cloud Changes",
 			"Open File"
-		],
-		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
-			"Contributed documentation.",
-			"Contributed documentation for refactorings.",
-			"Contributed documentation for refactoring.",
-			"Label for the documentation used in the UI.",
-			"When clause.",
-			"Command executed."
-		],
-		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
-			"Configure which editor to use for a resource.",
-			"Language modes that the code actions are enabled for.",
-			"`CodeActionKind` of the contributed code action.",
-			"Label for the code action used in the UI.",
-			"Description of what the code action does."
-		],
-		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
-			"Controls whether auto fix action should be run on file save.",
-			"Code Action kinds to be run on save.",
-			"Controls whether '{0}' actions should be run on file save."
 		],
 		"vs/workbench/contrib/timeline/browser/timelinePane": [
 			"Loading...",
@@ -26110,6 +26336,12 @@
 			"{0} ({1} • {2})",
 			"{0} ({1} • {2}) ↔ {3}",
 			"{0} ({1} • {2}) ↔ {3} ({4} • {5})"
+		],
+		"vs/workbench/contrib/audioCues/browser/commands": [
+			"Help: List Audio Cues",
+			"Disabled",
+			"Enable/Disable Audio Cue",
+			"Select an audio cue to play"
 		],
 		"vs/workbench/contrib/workspace/browser/workspaceTrustEditor": [
 			"Icon for workspace trust ion the banner.",
@@ -26187,26 +26419,30 @@
 		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
 			"Workspace Trust"
 		],
-		"vs/workbench/contrib/audioCues/browser/commands": [
-			"Help: List Audio Cues",
-			"Disabled",
-			"Enable/Disable Audio Cue",
-			"Select an audio cue to play"
-		],
 		"vs/workbench/contrib/share/browser/shareService": [
 			"The number of available share providers",
 			"Choose how to share {0}"
 		],
-		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
-			"Failed to save '{0}': {1}"
+		"vs/workbench/contrib/accessibility/browser/accessibilityConfiguration": [
+			"Accessibility",
+			"Provide information about how to access the terminal accessibility help menu when the terminal is focused",
+			"Provide information about how to navigate changes in the diff editor when it is focused",
+			"Provide information about how to access the chat help menu when the chat input is focused",
+			"Provide information about how to access the inline editor chat accessibility help menu and alert with hints which describe how to use the feature when the input is focused",
+			"Provide information about how to access the inline completions hover and accessible view",
+			"Provide information about how to change a keybinding in the keybindings editor when a row is focused",
+			"Provide information about how to focus the cell container or inner editor when a notebook cell is focused.",
+			"Provide information about how to open the hover in an accessible view.",
+			"Provide information about how to open the notification in an accessible view.",
+			"Provide information about relevant actions in an untitled text editor.",
+			"Whether to dim unfocused editors and terminals, which makes it more clear where typed input will go to. This works with the majority of editors with the notable exceptions of those that utilize iframes like notebooks and extension webview editors.",
+			"The opacity fraction (0.2 to 1.0) to use for unfocused editors and terminals. This will only take effect when {0} is enabled."
 		],
 		"vs/workbench/common/editor/textEditorModel": [
 			"Language {0} was automatically detected and set as the language mode."
 		],
-		"vs/workbench/browser/parts/titlebar/titlebarPart": [
-			"Focus Title Bar",
-			"Command Center",
-			"Layout Controls"
+		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
+			"Failed to save '{0}': {1}"
 		],
 		"vs/workbench/services/configurationResolver/common/variableResolver": [
 			"Variable {0} can not be resolved. Please open an editor.",
@@ -26236,6 +26472,14 @@
 			"Overwriting extension {0} with {1}.",
 			"Loading development extension at {0}"
 		],
+		"vs/workbench/contrib/localization/common/localizationsActions": [
+			"Configure Display Language",
+			"Select Display Language",
+			"Installed",
+			"Available",
+			"More Info",
+			"Clear Display Language Preference"
+		],
 		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
 			"Report Issue"
 		],
@@ -26250,6 +26494,11 @@
 		],
 		"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote": [
 			"Create New Integrated Terminal (Local)"
+		],
+		"vs/workbench/browser/parts/titlebar/titlebarPart": [
+			"Focus Title Bar",
+			"Command Center",
+			"Layout Controls"
 		],
 		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
 			"Pty Host Status",
@@ -26287,18 +26536,6 @@
 			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
 			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
 		],
-		"vs/workbench/contrib/localHistory/browser/localHistory": [
-			"Icon for a local history entry in the timeline view.",
-			"Icon for restoring contents of a local history entry."
-		],
-		"vs/workbench/contrib/localization/common/localizationsActions": [
-			"Configure Display Language",
-			"Select Display Language",
-			"Installed",
-			"Available",
-			"More Info",
-			"Clear Display Language Preference"
-		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"Executes .NET Core build command",
 			"Executes the build target",
@@ -26323,6 +26560,10 @@
 			"Go back ↩",
 			"No {0} tasks found. Go back ↩",
 			"There is no task provider registered for tasks of type \"{0}\"."
+		],
+		"vs/workbench/contrib/localHistory/browser/localHistory": [
+			"Icon for a local history entry in the timeline view.",
+			"Icon for restoring contents of a local history entry."
 		],
 		"vs/workbench/contrib/debug/common/abstractDebugAdapter": [
 			"Timeout after {0} ms for '{1}'"
@@ -26454,44 +26695,14 @@
 			"Hide Notifications",
 			"Expand Notification",
 			"Collapse Notification",
-			"Configure Notification",
+			"More Actions...",
 			"Copy Text"
-		],
-		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
-			"More Actions..."
 		],
 		"vs/base/browser/ui/actionbar/actionViewItems": [
 			"{0} ({1})"
 		],
-		"vs/editor/browser/widget/inlineDiffMargin": [
-			"Copy deleted lines",
-			"Copy deleted line",
-			"Copy changed lines",
-			"Copy changed line",
-			"Copy deleted line ({0})",
-			"Copy changed line ({0})",
-			"Revert this change",
-			"Copy deleted line ({0})",
-			"Copy changed line ({0})"
-		],
-		"vs/editor/browser/widget/diffReview": [
-			"Icon for 'Insert' in diff review.",
-			"Icon for 'Remove' in diff review.",
-			"Icon for 'Close' in diff review.",
-			"Close",
-			"no lines changed",
-			"1 line changed",
-			"{0} lines changed",
-			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
-			"blank",
-			"{0} unchanged line {1}",
-			"{0} original line {1} modified line {2}",
-			"+ {0} modified line {1}",
-			"- {0} original line {1}"
-		],
-		"vs/editor/common/viewLayout/viewLineRenderer": [
-			"Show more ({0})",
-			"{0} chars"
+		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
+			"More Actions..."
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionCommands": [
 			"Kind of the code action to run.",
@@ -26532,15 +26743,35 @@
 			"Hide Disabled",
 			"Show Disabled"
 		],
-		"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders": [
-			"Built-in",
-			"Insert Plain Text",
-			"Insert Uris",
-			"Insert Uri",
-			"Insert Paths",
-			"Insert Path",
-			"Insert Relative Paths",
-			"Insert Relative Path"
+		"vs/editor/browser/widget/diffReview": [
+			"Icon for 'Insert' in diff review.",
+			"Icon for 'Remove' in diff review.",
+			"Icon for 'Close' in diff review.",
+			"Close",
+			"no lines changed",
+			"1 line changed",
+			"{0} lines changed",
+			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
+			"blank",
+			"{0} unchanged line {1}",
+			"{0} original line {1} modified line {2}",
+			"+ {0} modified line {1}",
+			"- {0} original line {1}"
+		],
+		"vs/editor/browser/widget/inlineDiffMargin": [
+			"Copy deleted lines",
+			"Copy deleted line",
+			"Copy changed lines",
+			"Copy changed line",
+			"Copy deleted line ({0})",
+			"Copy changed line ({0})",
+			"Revert this change",
+			"Copy deleted line ({0})",
+			"Copy changed line ({0})"
+		],
+		"vs/editor/common/viewLayout/viewLineRenderer": [
+			"Show more ({0})",
+			"{0} chars"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
 			"Whether the paste widget is showing",
@@ -26553,6 +26784,16 @@
 			"Whether the drop widget is showing",
 			"Show drop options...",
 			"Running drop handlers. Click to cancel"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders": [
+			"Built-in",
+			"Insert Plain Text",
+			"Insert Uris",
+			"Insert Uri",
+			"Insert Paths",
+			"Insert Path",
+			"Insert Relative Paths",
+			"Insert Relative Path"
 		],
 		"vs/editor/contrib/find/browser/findWidget": [
 			"Icon for 'Find in Selection' in the editor find widget.",
@@ -26610,8 +26851,8 @@
 			"Hide Inline Suggestion",
 			"Always Show Toolbar"
 		],
-		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
-			"Suggestion:"
+		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController": [
+			"Inspect this in the accessible view ({0})"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/peek/referencesController": [
 			"Whether reference peek is visible, like 'Peek References' or 'Peek Definition'",
@@ -26628,13 +26869,30 @@
 			"Found {0} symbols in {1}",
 			"Found {0} symbols in {1} files"
 		],
+		"vs/editor/contrib/message/browser/messageController": [
+			"Whether the editor is currently showing an inline message"
+		],
 		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
 			"Whether there are symbol locations that can be navigated via keyboard-only.",
 			"Symbol {0} of {1}, {2} for next",
 			"Symbol {0} of {1}"
 		],
-		"vs/editor/contrib/message/browser/messageController": [
-			"Whether the editor is currently showing an inline message"
+		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
+			"Suggestion:"
+		],
+		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget": [
+			"Icon for show next parameter hint.",
+			"Icon for show previous parameter hint.",
+			"{0} ({1})",
+			"Previous",
+			"Next"
+		],
+		"vs/editor/contrib/hover/browser/markerHoverParticipant": [
+			"View Problem",
+			"No quick fixes available",
+			"Checking for quick fixes...",
+			"No quick fixes available",
+			"Quick Fix..."
 		],
 		"vs/editor/contrib/gotoError/browser/gotoErrorWidget": [
 			"Error",
@@ -26657,19 +26915,22 @@
 			"Rendering paused for long line for performance reasons. This can be configured via `editor.stopRenderingLineAfter`.",
 			"Tokenization is skipped for long lines for performance reasons. This can be configured via `editor.maxTokenizationLineLength`."
 		],
-		"vs/editor/contrib/hover/browser/markerHoverParticipant": [
-			"View Problem",
-			"No quick fixes available",
-			"Checking for quick fixes...",
-			"No quick fixes available",
-			"Quick Fix..."
+		"vs/editor/contrib/wordHighlighter/browser/highlightDecorations": [
+			"Background color of a symbol during read-access, like reading a variable. The color must not be opaque so as not to hide underlying decorations.",
+			"Background color of a symbol during write-access, like writing to a variable. The color must not be opaque so as not to hide underlying decorations.",
+			"Background color of a textual occurrence for a symbol. The color must not be opaque so as not to hide underlying decorations.",
+			"Border color of a symbol during read-access, like reading a variable.",
+			"Border color of a symbol during write-access, like writing to a variable.",
+			"Border color of a textual occurrence for a symbol.",
+			"Overview ruler marker color for symbol highlights. The color must not be opaque so as not to hide underlying decorations.",
+			"Overview ruler marker color for write-access symbol highlights. The color must not be opaque so as not to hide underlying decorations.",
+			"Overview ruler marker color of a textual occurrence for a symbol. The color must not be opaque so as not to hide underlying decorations."
 		],
-		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget": [
+		"vs/editor/contrib/parameterHints/browser/parameterHintsWidget": [
 			"Icon for show next parameter hint.",
 			"Icon for show previous parameter hint.",
-			"{0} ({1})",
-			"Previous",
-			"Next"
+			"{0}, hint",
+			"Foreground color of the active item in the parameter hint."
 		],
 		"vs/editor/contrib/inlayHints/browser/inlayHintsHover": [
 			"Double-click to insert",
@@ -26681,16 +26942,10 @@
 			"Go to Definition ({0})",
 			"Execute Command"
 		],
-		"vs/editor/contrib/wordHighlighter/browser/highlightDecorations": [
-			"Background color of a symbol during read-access, like reading a variable. The color must not be opaque so as not to hide underlying decorations.",
-			"Background color of a symbol during write-access, like writing to a variable. The color must not be opaque so as not to hide underlying decorations.",
-			"Background color of a textual occurrence for a symbol. The color must not be opaque so as not to hide underlying decorations.",
-			"Border color of a symbol during read-access, like reading a variable.",
-			"Border color of a symbol during write-access, like writing to a variable.",
-			"Border color of a textual occurrence for a symbol.",
-			"Overview ruler marker color for symbol highlights. The color must not be opaque so as not to hide underlying decorations.",
-			"Overview ruler marker color for write-access symbol highlights. The color must not be opaque so as not to hide underlying decorations.",
-			"Overview ruler marker color of a textual occurrence for a symbol. The color must not be opaque so as not to hide underlying decorations."
+		"vs/editor/contrib/rename/browser/renameInputField": [
+			"Whether the rename input widget is visible",
+			"Rename input. Type new name and press Enter to commit.",
+			"{0} to Rename, {1} to Preview"
 		],
 		"vs/editor/contrib/stickyScroll/browser/stickyScrollActions": [
 			"Toggle Sticky Scroll",
@@ -26722,11 +26977,8 @@
 			"{0}, {1}",
 			"{0}, docs: {1}"
 		],
-		"vs/editor/contrib/parameterHints/browser/parameterHintsWidget": [
-			"Icon for show next parameter hint.",
-			"Icon for show previous parameter hint.",
-			"{0}, hint",
-			"Foreground color of the active item in the parameter hint."
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"An error occurred while loading view: {0}"
 		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
 			"Colors and styles for the token.",
@@ -26772,9 +27024,6 @@
 			"Style to use for symbols that are async.",
 			"Style to use for symbols that are read-only."
 		],
-		"vs/workbench/api/browser/mainThreadWebviews": [
-			"An error occurred while loading view: {0}"
-		],
 		"vs/workbench/browser/parts/editor/textEditor": [
 			"Editor"
 		],
@@ -26800,11 +27049,6 @@
 			"Collapse All",
 			"Expand All"
 		],
-		"vs/editor/contrib/rename/browser/renameInputField": [
-			"Whether the rename input widget is visible",
-			"Rename input. Type new name and press Enter to commit.",
-			"{0} to Rename, {1} to Preview"
-		],
 		"vs/workbench/contrib/comments/browser/commentsTreeViewer": [
 			"Comments",
 			"{0} comments",
@@ -26815,14 +27059,58 @@
 			"[Ln {0}-{1}]",
 			"Last reply from {0}"
 		],
+		"vs/workbench/contrib/testing/common/testResult": [
+			"Test run at {0}"
+		],
+		"vs/workbench/browser/parts/compositeBarActions": [
+			"{0} ({1})",
+			"{0} - {1}",
+			"Additional Views",
+			"{0} ({1})",
+			"Manage Extension",
+			"Hide '{0}'",
+			"Keep '{0}'",
+			"Hide Badge",
+			"Show Badge",
+			"Toggle View Pinned",
+			"Toggle View Badge"
+		],
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"Collapse All"
+		],
+		"vs/workbench/browser/parts/views/checkbox": [
+			"Checked",
+			"Unchecked"
+		],
+		"vs/base/browser/ui/splitview/paneview": [
+			"{0} Section"
+		],
+		"vs/workbench/contrib/remote/browser/remoteIcons": [
+			"Getting started icon in the remote explorer view.",
+			"Documentation icon in the remote explorer view.",
+			"Feedback icon in the remote explorer view.",
+			"Review issue icon in the remote explorer view.",
+			"Report issue icon in the remote explorer view.",
+			"View icon of the remote explorer view.",
+			"View icon of the remote ports view.",
+			"Icon representing a remote port.",
+			"Icon representing a private remote port.",
+			"Icon for the forward action.",
+			"Icon for the stop forwarding action.",
+			"Icon for the open browser action.",
+			"Icon for the open preview action.",
+			"Icon for the copy local address action.",
+			"Icon for the label port action.",
+			"Icon for forwarded ports that don't have a running process.",
+			"Icon for forwarded ports that do have a running process."
+		],
 		"vs/workbench/contrib/remote/browser/tunnelView": [
-			"Whether the Ports view is enabled.",
 			"Add Port",
 			"Private",
 			"Port",
 			"The label and remote port number of the forwarded port.",
-			"Local Address",
-			"The address that the forwarded port is available at locally.",
+			"Forwarded Address",
+			"The address that the forwarded port is available at.",
 			"option + click",
 			"alt + click",
 			"cmd + click",
@@ -26855,6 +27143,7 @@
 			"Forward Port",
 			"Port number or address (eg. 3000 or 10.10.10.10:2000).",
 			"Unable to forward {0}:{1}. The host may not be available or that remote port may already be forwarded",
+			"Unable to forward {0}:{1}. {2}",
 			"No ports currently forwarded. Try running the {0} command",
 			"Stop Forwarding Port",
 			"Choose a port to stop forwarding",
@@ -26876,50 +27165,22 @@
 			"Change Port Protocol",
 			"The color of the icon for a port that has an associated running process."
 		],
-		"vs/workbench/contrib/testing/common/testResult": [
-			"Test run at {0}"
+		"vs/workbench/browser/parts/editor/tabsTitleControl": [
+			"Tab actions"
 		],
-		"vs/workbench/browser/parts/compositeBarActions": [
-			"{0} ({1})",
-			"{0} - {1}",
-			"Additional Views",
-			"{0} ({1})",
-			"Manage Extension",
-			"Hide '{0}'",
-			"Keep '{0}'",
-			"Hide Badge",
-			"Show Badge",
-			"Toggle View Pinned",
-			"Toggle View Badge"
-		],
-		"vs/base/browser/ui/splitview/paneview": [
-			"{0} Section"
-		],
-		"vs/base/browser/ui/tree/treeDefaults": [
-			"Collapse All"
-		],
-		"vs/workbench/browser/parts/views/checkbox": [
-			"Checked",
-			"Unchecked"
-		],
-		"vs/workbench/contrib/remote/browser/remoteIcons": [
-			"Getting started icon in the remote explorer view.",
-			"Documentation icon in the remote explorer view.",
-			"Feedback icon in the remote explorer view.",
-			"Review issue icon in the remote explorer view.",
-			"Report issue icon in the remote explorer view.",
-			"View icon of the remote explorer view.",
-			"View icon of the remote ports view.",
-			"Icon representing a remote port.",
-			"Icon representing a private remote port.",
-			"Icon for the forward action.",
-			"Icon for the stop forwarding action.",
-			"Icon for the open browser action.",
-			"Icon for the open preview action.",
-			"Icon for the copy local address action.",
-			"Icon for the label port action.",
-			"Icon for forwarded ports that don't have a running process.",
-			"Icon for forwarded ports that do have a running process."
+		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
+			"Show All Commands",
+			"Go to File",
+			"Open File",
+			"Open Folder",
+			"Open File or Folder",
+			"Open Recent",
+			"New Untitled Text File",
+			"Find in Files",
+			"Toggle Terminal",
+			"Start Debugging",
+			"Toggle Full Screen",
+			"Show Settings"
 		],
 		"vs/workbench/browser/parts/editor/textCodeEditor": [
 			"Text Editor"
@@ -26928,6 +27189,16 @@
 			"Binary Viewer",
 			"The file is not displayed in the text editor because it is either binary or uses an unsupported text encoding.",
 			"Open Anyway"
+		],
+		"vs/workbench/browser/parts/editor/editorPanes": [
+			"Unable to open '{0}'",
+			"&&OK"
+		],
+		"vs/editor/browser/widget/diffEditor.contribution": [
+			"Accessible Diff Viewer",
+			"Go to Next Difference",
+			"Open Accessible Diff Viewer",
+			"Go to Previous Difference"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
 			"Loading...",
@@ -26964,55 +27235,19 @@
 			"Installing Update...",
 			"Restart to &&Update"
 		],
-		"vs/editor/browser/widget/diffEditor.contribution": [
-			"Accessible Diff Viewer",
-			"Go to Next Difference",
-			"Open Accessible Diff Viewer",
-			"Go to Previous Difference"
-		],
 		"vs/workbench/browser/parts/compositePart": [
 			"{0} actions",
 			"Views and More Actions...",
 			"{0} ({1})"
 		],
-		"vs/base/browser/ui/toolbar/toolbar": [
-			"More Actions..."
-		],
 		"vs/workbench/browser/parts/sidebar/sidebarActions": [
 			"Focus into Primary Side Bar"
 		],
-		"vs/workbench/browser/parts/editor/tabsTitleControl": [
-			"Tab actions"
-		],
-		"vs/workbench/browser/parts/editor/editorPanes": [
-			"Unable to open '{0}'",
-			"&&OK"
-		],
-		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
-			"Show All Commands",
-			"Go to File",
-			"Open File",
-			"Open Folder",
-			"Open File or Folder",
-			"Open Recent",
-			"New Untitled Text File",
-			"Find in Files",
-			"Toggle Terminal",
-			"Start Debugging",
-			"Toggle Full Screen",
-			"Show Settings"
+		"vs/base/browser/ui/toolbar/toolbar": [
+			"More Actions..."
 		],
 		"vs/base/browser/ui/iconLabel/iconLabelHover": [
 			"Loading..."
-		],
-		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
-			"System",
-			"Extension",
-			"User",
-			"{0}: {1}",
-			"{0}: {1}",
-			"option",
-			"meta"
 		],
 		"vs/workbench/services/preferences/common/preferencesValidation": [
 			"Incorrect type. Expected \"boolean\".",
@@ -27044,18 +27279,22 @@
 			"Incorrect type. Expected an object.",
 			"Property {0} is not allowed.\n"
 		],
+		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
+			"System",
+			"Extension",
+			"User",
+			"{0}: {1}",
+			"{0}: {1}",
+			"option",
+			"meta"
+		],
 		"vs/editor/common/model/editStack": [
 			"Typing"
 		],
 		"vs/base/browser/ui/selectBox/selectBoxCustom": [
 			"Select Box"
 		],
-		"vs/platform/quickinput/browser/quickInput": [
-			"Back",
-			"Press 'Enter' to confirm your input or 'Escape' to cancel",
-			"{0}/{1}",
-			"Type to narrow down results.",
-			"{0} (Press 'Enter' to confirm or 'Escape' to cancel)",
+		"vs/platform/quickinput/browser/quickInputController": [
 			"Toggle all checkboxes",
 			"{0} Results",
 			"{0} Selected",
@@ -27063,6 +27302,10 @@
 			"Custom",
 			"Back ({0})",
 			"Back"
+		],
+		"vs/base/browser/ui/hover/hoverWidget": [
+			"Inspect this in the accessible view with {0}.",
+			"Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding."
 		],
 		"vs/workbench/services/textMate/common/TMGrammars": [
 			"Contributes textmate tokenizers.",
@@ -27077,6 +27320,36 @@
 		],
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"Unbound"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"User",
+			"Remote",
+			"Workspace",
+			"Folder",
+			"Settings Switcher",
+			"User",
+			"Remote",
+			"Workspace",
+			"User",
+			"Workspace"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
+			"Edit",
+			"Replace in Settings",
+			"Copy to Settings",
+			"This setting cannot be applied because it is configured in the system policy.",
+			"This setting cannot be applied because it is not registered as language override setting.",
+			"This setting cannot be applied while a non-default profile is active. It will be applied when the default profile is active.",
+			"This setting cannot be applied because it is configured to be applied in all profiles using setting {0}. Value from the default profile will be used instead.",
+			"This setting cannot be applied in this window. It will be applied when you open a local window.",
+			"This setting cannot be applied in this workspace. It will be applied when you open the containing workspace folder directly.",
+			"This setting has an application scope and can be set only in the user settings file.",
+			"This setting can only be applied in user settings in local window or in remote settings in remote window.",
+			"This setting can only be applied in a trusted workspace.",
+			"Unknown Configuration Setting",
+			"Manage Workspace Trust",
+			"Manage Workspace Trust",
+			"Unsupported Property"
 		],
 		"vs/workbench/contrib/preferences/common/settingsEditorColorRegistry": [
 			"The foreground color for a section header or active title.",
@@ -27100,24 +27373,6 @@
 			"The background color of a settings row when focused.",
 			"The background color of a settings row when hovered.",
 			"The color of the row's top and bottom border when the row is focused."
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
-			"Edit",
-			"Replace in Settings",
-			"Copy to Settings",
-			"This setting cannot be applied because it is configured in the system policy.",
-			"This setting cannot be applied because it is not registered as language override setting.",
-			"This setting cannot be applied while a non-default profile is active. It will be applied when the default profile is active.",
-			"This setting cannot be applied because it is configured to be applied in all profiles using setting {0}. Value from the default profile will be used instead.",
-			"This setting cannot be applied in this window. It will be applied when you open a local window.",
-			"This setting cannot be applied in this workspace. It will be applied when you open the containing workspace folder directly.",
-			"This setting has an application scope and can be set only in the user settings file.",
-			"This setting can only be applied in user settings in local window or in remote settings in remote window.",
-			"This setting can only be applied in a trusted workspace.",
-			"Unknown Configuration Setting",
-			"Manage Workspace Trust",
-			"Manage Workspace Trust",
-			"Unsupported Property"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsLayout": [
 			"Commonly Used",
@@ -27169,17 +27424,25 @@
 			"Security",
 			"Workspace"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
-			"User",
-			"Remote",
-			"Workspace",
-			"Folder",
-			"Settings Switcher",
-			"User",
-			"Remote",
-			"Workspace",
-			"User",
-			"Workspace"
+		"vs/workbench/contrib/preferences/browser/tocTree": [
+			"Settings Table of Contents",
+			"{0}, group"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
+			"Modified",
+			"Add or remove modified settings filter",
+			"Extension ID...",
+			"Add extension ID filter",
+			"Feature...",
+			"Add feature filter",
+			"Tag...",
+			"Add tag filter",
+			"Language...",
+			"Add language ID filter",
+			"Online services",
+			"Show settings for online services",
+			"Policy services",
+			"Show settings for policy services"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsTree": [
 			"Extensions",
@@ -27200,26 +27463,6 @@
 			"Copy Setting as JSON",
 			"Sync This Setting",
 			"Apply Setting to all Profiles"
-		],
-		"vs/workbench/contrib/preferences/browser/tocTree": [
-			"Settings Table of Contents",
-			"{0}, group"
-		],
-		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
-			"Modified",
-			"Add or remove modified settings filter",
-			"Extension ID...",
-			"Add extension ID filter",
-			"Feature...",
-			"Add feature filter",
-			"Tag...",
-			"Add tag filter",
-			"Language...",
-			"Add language ID filter",
-			"Online services",
-			"Show settings for online services",
-			"Policy services",
-			"Show settings for policy services"
 		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView": [
 			"Select Notebook Kernel",
@@ -27289,17 +27532,6 @@
 			"Could not render content for '$0'",
 			"Notebook webview content"
 		],
-		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
-			"File Created",
-			"File Replaced",
-			"File Working Copy Decorations",
-			"Deleted, Read-only",
-			"Read-only",
-			"Deleted",
-			"'{0}' already exists. Do you want to replace it?",
-			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
-			"&&Replace"
-		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy": [
 			"Currently Selected",
 			"{0} - Currently Selected",
@@ -27318,12 +27550,20 @@
 			"Detecting Kernels",
 			"Select Kernel"
 		],
-		"vs/workbench/contrib/comments/common/commentContextKeys": [
-			"Set when the comment thread has no comments",
-			"Set when the comment has no input",
-			"The context value of the comment",
-			"The context value of the comment thread",
-			"The comment controller id associated with a comment thread"
+		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
+			"File Created",
+			"File Replaced",
+			"File Working Copy Decorations",
+			"Deleted, Read-only",
+			"Read-only",
+			"Deleted",
+			"'{0}' already exists. Do you want to replace it?",
+			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
+			"&&Replace"
+		],
+		"vs/platform/actions/browser/toolbar": [
+			"Hide",
+			"Reset Menu"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/cellOperations": [
 			"Cannot join cells of different kinds",
@@ -27340,18 +27580,27 @@
 		"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider": [
 			"empty cell"
 		],
+		"vs/workbench/contrib/comments/common/commentContextKeys": [
+			"Set when the comment thread has no comments",
+			"Set when the comment has no input",
+			"The context value of the comment",
+			"The context value of the comment thread",
+			"The comment controller id associated with a comment thread"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
 			"The chat view is comprised of an input box and a request/response list. The input box is used to make requests and the list is used to display responses.",
 			"In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.",
 			"In the input box, inspect the last response in the accessible view via {0}",
 			"With the input box focused, inspect the last response in the accessible view via the Open Accessible View command, which is currently not triggerable by a keybinding.",
 			"Chat responses will be announced as they come in. A response will indicate the number of code blocks, if any, and then the rest of the response.",
-			"To focus the chat request/response list, which can be navigated with up and down arrows, invoke The Focus Chat command ({0}).",
+			"To focus the chat request/response list, which can be navigated with up and down arrows, invoke the Focus Chat command ({0}).",
 			"To focus the chat request/response list, which can be navigated with up and down arrows, invoke The Focus Chat List command, which is currently not triggerable by a keybinding.",
 			"To focus the input box for chat requests, invoke the Focus Chat Input command ({0})",
 			"To focus the input box for chat requests, invoke the Focus Chat Input command, which is currently not triggerable by a keybinding.",
 			"To focus the next code block within a response, invoke the Chat: Next Code Block command ({0}).",
 			"To focus the next code block within a response, invoke the Chat: Next Code Block command, which is currently not triggerable by a keybinding.",
+			"To focus the next file tree within a response, invoke the Chat: Next File Tree command ({0}).",
+			"To focus the next file tree within a response, invoke the Chat: Next File Tree command, which is currently not triggerable by a keybinding.",
 			"To clear the request/response list, invoke the Chat Clear command ({0}).",
 			"To clear the request/response list, invoke the Chat Clear command, which is currently not triggerable by a keybinding.",
 			"Inline chat occurs within a code editor and takes into account the current selection. It is useful for making changes to the current editor. For example, fixing diagnostics, documenting or refactoring code. Keep in mind that AI generated code may be incorrect.",
@@ -27364,19 +27613,7 @@
 			"Once in the diff editor, enter review mode with ({0}). Use up and down arrows to navigate lines with the proposed changes.",
 			"Tab again to enter the Diff editor with the changes and enter review mode with the Go to Next Difference Command. Use Up/DownArrow to navigate lines with the proposed changes.",
 			"Use tab to reach conditional parts like commands, status, message responses and more.",
-			"Audio cues can be changed via settings with a prefix of audioCues.chat. By default, if a request takes more than 4 seconds, you will hear an audio cue indicating that progress is still occurring.",
-			"Chat accessibility help",
-			"Inline chat accessibility help"
-		],
-		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/quickQuestionAction": [
-			"Chat"
-		],
-		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/multipleByScrollQuickQuestionAction": [
-			"Clear",
-			"Open In Chat View"
-		],
-		"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/singleQuickQuestionAction": [
-			"Ask {0} a question..."
+			"Audio cues can be changed via settings with a prefix of audioCues.chat. By default, if a request takes more than 4 seconds, you will hear an audio cue indicating that progress is still occurring."
 		],
 		"vs/workbench/contrib/chat/browser/chatInputPart": [
 			"Chat Input,  Type to ask questions or type / for topics, press enter to send out the request. Use {0} for Chat Accessibility Help.",
@@ -27385,32 +27622,30 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatListRenderer": [
 			"Chat",
+			"Command: {0}",
+			"Commands: {0}",
+			"1 file tree",
+			"{0} file trees",
+			"{0} {1} {2}",
 			"{0} {1}",
-			"{0}",
-			"1 code block: {0} {1}",
-			"1 code block: {0}",
-			"{0} code blocks: {1}",
-			"{0} code blocks",
+			"{0} 1 code block: {1} {2}",
+			"{0} 1 code block: {1}",
+			"{0} {1} code blocks: {2}",
+			"{0} {1} code blocks",
 			"Code block",
 			"Toolbar for code block which can be reached via tab",
 			"Code block toolbar",
-			"Code block {0}"
+			"Code block {0}",
+			"File Tree"
+		],
+		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys": [
+			"Whether an inline suggestion is visible",
+			"Whether the inline suggestion starts with whitespace",
+			"Whether the inline suggestion starts with whitespace that is less than what would be inserted by tab",
+			"Whether suggestions should be suppressed for the current suggestion"
 		],
 		"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget": [
 			"Exited {0} mode"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
-			"Nothing changed",
-			"Changed 1 line",
-			"Changed {0} lines"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
-			"Inline Chat Input",
-			"Original",
-			"Modified",
-			"Inline Chat Input, Use {0} for Inline Chat Accessibility Help.",
-			"Inline Chat Input, Run the Inline Chat Accessibility Help command for more information.",
-			"Closed inline chat widget"
 		],
 		"vs/workbench/contrib/testing/browser/theme": [
 			"Color for the 'failed' icon in the test explorer.",
@@ -27426,6 +27661,11 @@
 			"Margin color beside error messages shown inline in the editor.",
 			"Text color of test info messages shown inline in the editor.",
 			"Margin color beside info messages shown inline in the editor."
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
+			"Nothing changed",
+			"Changed 1 line",
+			"Changed {0} lines"
 		],
 		"vs/workbench/contrib/testing/common/constants": [
 			"Errored",
@@ -27452,12 +27692,13 @@
 			"Show Hidden Tests",
 			"Unhide All Tests"
 		],
-		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
-			"The terminal has no selection to copy",
-			"Yes",
-			"No",
-			"Don't Show Again",
-			"Terminal GPU acceleration appears to be slow on your computer. Would you like to switch to disable it which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered)."
+		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
+			"Inline Chat Input",
+			"Original",
+			"Modified",
+			"Inline Chat Input, Use {0} for Inline Chat Accessibility Help.",
+			"Inline Chat Input, Run the Inline Chat Accessibility Help command for more information.",
+			"Closed inline chat widget"
 		],
 		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
 			"The background color of the terminal, this allows coloring the terminal differently to the panel.",
@@ -27481,6 +27722,13 @@
 			"Background color when dragging on top of terminals. The color should have transparency so that the terminal contents can still shine through.",
 			"Border on the side of the terminal tab in the panel. This defaults to tab.activeBorder.",
 			"'{0}' ANSI color in the terminal."
+		],
+		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
+			"The terminal has no selection to copy",
+			"Yes",
+			"No",
+			"Don't Show Again",
+			"Terminal GPU acceleration appears to be slow on your computer. Would you like to switch to disable it which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered)."
 		],
 		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
 			"Unable to resolve workspace folder ({0})",
@@ -27581,13 +27829,6 @@
 			"fields ({0})",
 			"constants ({0})"
 		],
-		"vs/workbench/contrib/search/browser/replaceService": [
-			"Search and Replace",
-			"{0} ↔ {1} (Replace Preview)"
-		],
-		"vs/workbench/contrib/search/browser/searchFindInput": [
-			"Notebook Find Filters"
-		],
 		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
 			"Bulk Edit",
 			"Renaming {0} to {1}, also making text edits",
@@ -27615,10 +27856,6 @@
 			"No Results",
 			"The result set only contains a subset of all matches. Be more specific in your search to narrow down the results."
 		],
-		"vs/platform/actions/browser/toolbar": [
-			"Hide",
-			"Reset Menu"
-		],
 		"vs/workbench/contrib/scm/browser/dirtyDiffSwitcher": [
 			"Switch quick diff base",
 			"Switch Quick Diff Base"
@@ -27629,13 +27866,20 @@
 		"vs/workbench/contrib/debug/browser/baseDebugView": [
 			"Click to expand"
 		],
-		"vs/workbench/contrib/debug/common/loadedScriptsPicker": [
-			"Search loaded scripts by name"
-		],
 		"vs/workbench/contrib/debug/browser/debugSessionPicker": [
 			"Search debug sessions by name",
 			"Start a New Debug Session",
 			"Session {0} spawned from {1}"
+		],
+		"vs/workbench/contrib/search/browser/searchFindInput": [
+			"Notebook Find Filters"
+		],
+		"vs/workbench/contrib/debug/common/loadedScriptsPicker": [
+			"Search loaded scripts by name"
+		],
+		"vs/workbench/contrib/search/browser/replaceService": [
+			"Search and Replace",
+			"{0} ↔ {1} (Replace Preview)"
 		],
 		"vs/workbench/contrib/debug/browser/debugAdapterManager": [
 			"Debugger 'type' can not be omitted and must be of type 'string'.",
@@ -27674,9 +27918,6 @@
 			"Could not find the specified task.",
 			"The task '{0}' cannot be tracked. Make sure to have a problem matcher defined.",
 			"The task '{0}' cannot be tracked. Make sure to have a problem matcher defined."
-		],
-		"vs/workbench/contrib/debug/common/debugSource": [
-			"Unknown Source"
 		],
 		"vs/workbench/contrib/debug/browser/debugSession": [
 			"No debugger available, can not send '{0}'",
@@ -27719,6 +27960,9 @@
 			"Debugging started.",
 			"Debugging stopped."
 		],
+		"vs/workbench/contrib/debug/common/debugSource": [
+			"Unknown Source"
+		],
 		"vs/base/browser/ui/findinput/replaceInput": [
 			"input",
 			"Preserve Case"
@@ -27735,10 +27979,6 @@
 			"Message",
 			"File",
 			"Source"
-		],
-		"vs/workbench/contrib/comments/browser/commentsController": [
-			"Whether the position at the active cursor has a commenting range",
-			"Select Comment Provider"
 		],
 		"vs/workbench/contrib/mergeEditor/common/mergeEditor": [
 			"The editor is a merge editor",
@@ -27781,15 +28021,13 @@
 			"&&Close",
 			"Don't ask again"
 		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
+			"Base",
+			"Comparing with {0}",
+			"Differences are highlighted with a background color."
+		],
 		"vs/workbench/contrib/mergeEditor/browser/view/viewModel": [
 			"There is currently no conflict focused that can be toggled."
-		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
-			"Result",
-			"{0} Conflict Remaining",
-			"{0} Conflicts Remaining ",
-			"Go to next conflict",
-			"All conflicts handled, the merge can be completed now."
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView": [
 			"Input 1",
@@ -27803,6 +28041,13 @@
 			"Accept (result is dirty)",
 			"Undo accept",
 			"Undo accept (currently second)"
+		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
+			"Result",
+			"{0} Conflict Remaining",
+			"{0} Conflicts Remaining ",
+			"Go to next conflict",
+			"All conflicts handled, the merge can be completed now."
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/colors": [
 			"The background color for changes.",
@@ -27819,8 +28064,21 @@
 			"The background color of decorations in input 1.",
 			"The background color of decorations in input 2."
 		],
+		"vs/workbench/contrib/comments/browser/commentsController": [
+			"Whether the position at the active cursor has a commenting range",
+			"Select Comment Provider"
+		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
 			"Built-in"
+		],
+		"vs/platform/files/browser/htmlFileSystemProvider": [
+			"Rename is only supported for files.",
+			"Insufficient permissions. Please retry and allow the operation."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
+			"Error",
+			"Unknown Extension:",
+			"Extensions"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"Average rating: {0} out of 5",
@@ -27848,19 +28106,9 @@
 			"The icon color for pre-release extension.",
 			"The icon color for extension sponsor."
 		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView": [
-			"Base",
-			"Comparing with {0}",
-			"Differences are highlighted with a background color."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
-			"Error",
-			"Unknown Extension:",
-			"Extensions"
-		],
-		"vs/platform/files/browser/htmlFileSystemProvider": [
-			"Rename is only supported for files.",
-			"Insufficient permissions. Please retry and allow the operation."
+		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
+			"This extension is recommended based on the files you recently opened.",
+			"the {0} language"
 		],
 		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
 			"This extension is recommended because you have {0} installed."
@@ -27868,23 +28116,11 @@
 		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
 			"This extension is recommended by users of the current workspace."
 		],
-		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
-			"Search Marketplace",
-			"This extension is recommended based on the files you recently opened.",
-			"{0} language",
-			"The Marketplace has extensions that can help with '.{0}' files",
-			"Don't Show Again for '.{0}' files"
-		],
-		"vs/workbench/contrib/extensions/browser/webRecommendations": [
-			"This extension is recommended for {0} for the Web"
-		],
 		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
 			"This extension is recommended because of the current workspace configuration"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
-			"Create New Terminal",
-			"Create New Terminal With Profile",
-			"Rename Terminal"
+		"vs/workbench/contrib/extensions/browser/webRecommendations": [
+			"This extension is recommended for {0} for the Web"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
 			"Show Tabs",
@@ -27894,7 +28130,6 @@
 			"Create New Terminal in Editor Area",
 			"Create New Terminal in Editor Area",
 			"Create New Terminal in Editor Area to the Side",
-			"Show Tabs",
 			"Focus Previous Terminal in Terminal Group",
 			"Focus Next Terminal in Terminal Group",
 			"Run Recent Command...",
@@ -27968,6 +28203,32 @@
 			"Select current working directory for new terminal",
 			"Enter terminal name"
 		],
+		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
+			"Create New Terminal",
+			"Create New Terminal With Profile",
+			"Rename Terminal"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalIcons": [
+			"View icon of the terminal view.",
+			"Icon for rename in the terminal quick menu.",
+			"Icon for killing a terminal instance.",
+			"Icon for creating a new terminal instance.",
+			"Icon for creating a new terminal profile.",
+			"Icon for a terminal decoration mark.",
+			"Icon for a terminal decoration of a command that was incomplete.",
+			"Icon for a terminal decoration of a command that errored.",
+			"Icon for a terminal decoration of a command that was successful.",
+			"Icon for removing a terminal command from command history.",
+			"Icon for viewing output of a terminal command.",
+			"Icon for toggling fuzzy search of command history."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"Do you want to terminate the active terminal session?",
+			"Do you want to terminate the {0} active terminal sessions?",
+			"&&Terminate",
+			"This shell is open to a {0}local{1} folder, NOT to the virtual folder",
+			"This shell is running on your {0}local{1} machine, NOT on the connected remote machine"
+		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
 			"the terminal's current working directory",
 			"the terminal's current working directory, displayed for multi-root workspaces or in a single root workspace when the value differs from the initial working directory. On Windows, this will only be displayed when shell integration is enabled.",
@@ -28029,7 +28290,8 @@
 			"Only \"normal\" and \"bold\" keywords or numbers between 1 and 1000 are allowed.",
 			"The font weight to use within the terminal for bold text. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000.",
 			"Controls whether the terminal cursor blinks.",
-			"Controls the style of terminal cursor.",
+			"Controls the style of terminal cursor when the terminal is focused.",
+			"Controls the style of terminal cursor when the terminal is not focused.",
 			"Controls the width of the cursor when {0} is set to {1}.",
 			"Controls the maximum number of lines the terminal keeps in its buffer. We pre-allocate memory based on this value in order to ensure a smooth experience. As such, as the value increases, so will the amount of memory.",
 			"Controls whether to detect and set the `$LANG` environment variable to a UTF-8 compliant option since VS Code's terminal only supports UTF-8 encoded data coming from the shell.",
@@ -28098,6 +28360,10 @@
 			"Revive the processes after the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu).",
 			"Revive the processes after the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu), or when the window is closed.",
 			"Never restore the terminal buffers or recreate the process.",
+			"Whether to hide the terminal view on startup, avoiding creating a terminal when there are no persistent sessions.",
+			"Never hide the terminal view on startup.",
+			"Only hide the terminal when there are no persistent sessions restored.",
+			"Always hide the terminal, even when there are persistent sessions restored.",
 			"Whether to draw custom glyphs for block element and box drawing characters instead of using the font, which typically yields better rendering with continuous lines. Note that this doesn't work when {0} is disabled.",
 			"A set of messages that, when encountered in the terminal, will be automatically responded to. Provided the message is specific enough, this can help automate away common responses.\n\nRemarks:\n\n- Use {0} to automatically respond to the terminate batch job prompt on Windows.\n- The message includes escape sequences so the reply might not happen with styled text.\n- Each reply can only happen once every second.\n- Use {1} in the reply to mean the enter key.\n- To unset a default key, set the value to null.\n- Restart VS Code if new don't apply.",
 			"The reply to send to the process.",
@@ -28110,28 +28376,12 @@
 			"Controls the number of recently used commands to keep in the terminal command history. Set to 0 to disable terminal command history.",
 			"Enables experimental terminal Intellisense suggestions for supported shells when {0} is set to {1}. If shell integration is installed manually, {2} needs to be set to {3} before calling the script.",
 			"Controls whether the terminal will scroll using an animation.",
-			"Enables image support in the terminal, this will only work when {0} is enabled. Both sixel and iTerm's inline image protocol are supported on Linux and macOS, Windows support will light up automatically when ConPTY passes through the sequences. Images will currently not be restored between window reloads/reconnects."
-		],
-		"vs/workbench/contrib/terminal/browser/terminalService": [
-			"Do you want to terminate the active terminal session?",
-			"Do you want to terminate the {0} active terminal sessions?",
-			"&&Terminate",
-			"This shell is open to a {0}local{1} folder, NOT to the virtual folder",
-			"This shell is running on your {0}local{1} machine, NOT on the connected remote machine"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalIcons": [
-			"View icon of the terminal view.",
-			"Icon for rename in the terminal quick menu.",
-			"Icon for killing a terminal instance.",
-			"Icon for creating a new terminal instance.",
-			"Icon for creating a new terminal profile.",
-			"Icon for a terminal decoration mark.",
-			"Icon for a terminal decoration of a command that was incomplete.",
-			"Icon for a terminal decoration of a command that errored.",
-			"Icon for a terminal decoration of a command that was successful.",
-			"Icon for removing a terminal command from command history.",
-			"Icon for viewing output of a terminal command.",
-			"Icon for toggling fuzzy search of command history."
+			"Controls whether the terminal will ignore bracketed paste mode even if the terminal was put into the mode, omitting the {0} and {1} sequences when pasting. This is useful when the shell is not respecting the mode which can happen in sub-shells for example.",
+			"Enables image support in the terminal, this will only work when {0} is enabled. Both sixel and iTerm's inline image protocol are supported on Linux and macOS, Windows support will light up automatically when ConPTY passes through the sequences. Images will currently not be restored between window reloads/reconnects.",
+			"Controls whether the terminal, accessible buffer, or neither will be focused after `Terminal: Run Selected Text In Active Terminal` has been run.",
+			"Always focus the terminal.",
+			"Always focus the accessible buffer.",
+			"Do nothing."
 		],
 		"vs/workbench/contrib/terminal/browser/terminalMenus": [
 			"&&New Terminal",
@@ -28142,7 +28392,6 @@
 			"Copy as HTML",
 			"Paste",
 			"Clear",
-			"Show Tabs",
 			"Select All",
 			"Copy",
 			"Copy as HTML",
@@ -28158,7 +28407,6 @@
 			"Clear Terminal",
 			"Run Active File",
 			"Run Selected Text",
-			"Toggle Size to Content Width",
 			"Rename...",
 			"Change Icon...",
 			"Change Color...",
@@ -28177,6 +28425,7 @@
 			"previous session",
 			"Terminal",
 			"Focus Terminal",
+			"Focus Terminal and Hide Accessible Buffer",
 			"Kill Terminal",
 			"Kill",
 			"Move Terminal into Editor Area",
@@ -28196,20 +28445,7 @@
 		"vs/platform/terminal/common/terminalLogService": [
 			"Terminal"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
-			"Move Tabs Right",
-			"Move Tabs Left",
-			"Hide Tabs"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
-			"Shell integration activated",
-			"The terminal process failed to launch. Disabling shell integration with terminal.integrated.shellIntegration.enabled might help.",
-			"Shell integration failed to activate",
-			"Process ID ({0}): {1}",
-			"Command line: {0}"
-		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
-			"terminal accessibility help",
 			"The Focus Accessible Buffer ({0}) command enables screen readers to read terminal contents.",
 			"The Focus Accessible Buffer command enables screen readers to read terminal contents and is currently not triggerable by a keybinding.",
 			"Consider using powershell instead of command prompt for an improved experience",
@@ -28230,11 +28466,24 @@
 			"The Open Detected Link command enables screen readers to easily open links found in the terminal and is currently not triggerable by a keybinding.",
 			"The Create New Terminal (With Profile) ({0}) command allows for easy terminal creation using a specific profile.",
 			"The Create New Terminal (With Profile) command allows for easy terminal creation using a specific profile and is currently not triggerable by a keybinding.",
+			"Configure what gets focused after running selected text in the terminal with `{0}`.",
 			"Access accessibility settings such as `terminal.integrated.tabFocusMode` via the Preferences: Open Accessibility Settings command."
 		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer": [
 			"Terminal buffer",
 			"{0}"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
+			"Move Tabs Right",
+			"Move Tabs Left",
+			"Hide Tabs"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
+			"Shell integration activated",
+			"The terminal process failed to launch. Disabling shell integration with terminal.integrated.shellIntegration.enabled might help.",
+			"Shell integration failed to activate",
+			"Process ID ({0}): {1}",
+			"Command line: {0}"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
 			"option + click",
@@ -28246,27 +28495,28 @@
 			"Link"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick": [
-			"Select the link to open",
 			"Url",
-			"Local File",
+			"File",
+			"Folder",
 			"Workspace Search",
-			"Show more links"
+			"Select the link to open, type to filter all links",
+			"Url",
+			"File",
+			"Folder",
+			"Workspace Search"
 		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
 			"Run: {0}",
 			"Open: {0}",
 			"Quick Fix"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
-			"Free port {0}",
-			"Create PR {0}"
-		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
 			"Contributes terminal quick fixes.",
 			"The ID of the quick fix provider",
 			"A regular expression or string to test the command line against",
 			"A regular expression or string to match a single line of the output against, which provides groups to be referenced in terminalCommand and uri.\n\nFor example:\n\n `lineMatcher: /git push --set-upstream origin (?<branchName>[^s]+)/;`\n\n`terminalCommand: 'git push --set-upstream origin ${group:branchName}';`\n",
-			"The command exit result to match on"
+			"The command exit result to match on",
+			"The kind of the resulting quick fix. This changes how the quick fix is presented. Defaults to {0}."
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
 			"Additional command options",
@@ -28332,17 +28582,16 @@
 			"Optional arguments passed to the command.",
 			"Optional arguments passed to the command."
 		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
+			"Free port {0}",
+			"Create PR {0}"
+		],
 		"vs/workbench/contrib/remote/browser/explorerViewItems": [
 			"Switch Remote",
 			"Switch Remote"
 		],
 		"vs/workbench/contrib/snippets/browser/commands/abstractSnippetsActions": [
 			"Snippets"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsFile": [
-			"Workspace Snippet",
-			"Global User Snippet",
-			"User Snippet"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetPicker": [
 			"User Snippets",
@@ -28352,6 +28601,11 @@
 			"Show in IntelliSense",
 			"Select a snippet",
 			"No snippet available"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsFile": [
+			"Workspace Snippet",
+			"Global User Snippet",
+			"User Snippet"
 		],
 		"vs/workbench/contrib/snippets/browser/snippetCompletionProvider": [
 			"{0} ({1})",
@@ -28494,6 +28748,18 @@
 			"Select the layout for your notebooks",
 			"Get notebooks to feel just the way you prefer"
 		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
+			"Recommended"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
+			"Background color for the Welcome page.",
+			"Background color for the tiles on the Welcome page.",
+			"Hover background color for the tiles on the Welcome.",
+			"Border color for the tiles on the Welcome page.",
+			"Foreground color for the Welcome page progress bars.",
+			"Background color for the Welcome page progress bars.",
+			"Foreground color of the heading of each walkthrough step"
+		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedExtensionPoint": [
 			"Title",
 			"Contribute walkthroughs to help users getting started with your extension.",
@@ -28532,18 +28798,6 @@
 			"doneOn is deprecated. By default steps will be checked off when their buttons are clicked, to configure further use completionEvents",
 			"Mark step done when the specified command is executed.",
 			"Context key expression to control the visibility of this step."
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
-			"Recommended"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
-			"Background color for the Welcome page.",
-			"Background color for the tiles on the Welcome page.",
-			"Hover background color for the tiles on the Welcome.",
-			"Border color for the tiles on the Welcome page.",
-			"Foreground color for the Welcome page progress bars.",
-			"Background color for the Welcome page progress bars.",
-			"Foreground color of the heading of each walkthrough step"
 		],
 		"vs/workbench/contrib/welcomeWalkthrough/common/walkThroughUtils": [
 			"Background color for the embedded editors on the Interactive Playground."
@@ -28593,27 +28847,6 @@
 			"The foreground color for unit symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
 			"The foreground color for variable symbols. These symbols appear in the outline, breadcrumb, and suggest widget."
 		],
-		"vs/workbench/contrib/feedback/browser/feedback": [
-			"Tweet us your feedback.",
-			"Close",
-			"Your installation is corrupt.",
-			"Please specify this if you submit a bug.",
-			"How was your experience?",
-			"Happy Feedback Sentiment",
-			"Happy Feedback Sentiment",
-			"Sad Feedback Sentiment",
-			"Sad Feedback Sentiment",
-			"Other ways to contact us",
-			"Submit a bug",
-			"Request a missing feature",
-			"Tell us why?",
-			"Tell us your feedback",
-			"Show Feedback Icon in Status Bar",
-			"Tweet",
-			"Tweet Feedback",
-			"character left",
-			"characters left"
-		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
 			"Conflicts",
 			"Synced Machines",
@@ -28647,11 +28880,6 @@
 		],
 		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
 			"Saving '{0}'"
-		],
-		"vs/workbench/browser/parts/titlebar/windowTitle": [
-			"[Administrator]",
-			"[Superuser]",
-			"[Extension Development Host]"
 		],
 		"vs/workbench/browser/parts/titlebar/commandCenterControl": [
 			"Search",
@@ -28687,16 +28915,21 @@
 			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Sudo' to retry as superuser.",
 			"Failed to save '{0}': {1}"
 		],
+		"vs/workbench/browser/parts/titlebar/windowTitle": [
+			"[Administrator]",
+			"[Superuser]",
+			"[Extension Development Host]"
+		],
 		"vs/platform/terminal/common/terminalProfiles": [
 			"Automatically detect the default"
-		],
-		"vs/workbench/contrib/webview/browser/webviewElement": [
-			"Error loading webview: {0}"
 		],
 		"vs/platform/quickinput/browser/quickPickPin": [
 			"pinned",
 			"Pin command",
 			"Pinned command"
+		],
+		"vs/workbench/contrib/webview/browser/webviewElement": [
+			"Error loading webview: {0}"
 		],
 		"vs/workbench/api/common/extHostDiagnostics": [
 			"Not showing {0} further errors and warnings."
@@ -28708,12 +28941,12 @@
 		"vs/workbench/api/common/extHostProgress": [
 			"{0} (Extension)"
 		],
+		"vs/workbench/api/common/extHostTreeViews": [
+			"Element with id {0} is already registered"
+		],
 		"vs/workbench/api/common/extHostStatusBar": [
 			"{0} (Extension)",
 			"Extension Status"
-		],
-		"vs/workbench/api/common/extHostTreeViews": [
-			"Element with id {0} is already registered"
 		],
 		"vs/workbench/api/common/extHostNotebook": [
 			"Unable to modify read-only file '{0}'",
@@ -28738,17 +28971,25 @@
 			"close",
 			"find"
 		],
+		"vs/editor/browser/controller/textAreaHandler": [
+			"editor",
+			"The editor is not accessible at this time.",
+			"{0} To enable screen reader optimized mode, use {1}",
+			"{0} To enable screen reader optimized mode, open the quick pick with {1} and run the command Toggle Screen Reader Accessibility Mode, which is currently not triggerable via keyboard.",
+			"{0} Please assign a keybinding for the command Toggle Screen Reader Accessibility Mode by accessing the keybindings editor with {1} and run it."
+		],
 		"vs/editor/contrib/codeAction/browser/codeActionMenu": [
 			"More Actions...",
-			"Quick Fix...",
-			"Extract...",
-			"Inline...",
-			"Rewrite...",
-			"Move...",
-			"Surround With...",
-			"Source Action..."
+			"Quick Fix",
+			"Extract",
+			"Inline",
+			"Rewrite",
+			"Move",
+			"Surround With",
+			"Source Action"
 		],
 		"vs/platform/actionWidget/browser/actionWidget": [
+			"Background color for toggled action items in action bar.",
 			"Whether the action widget list is visible",
 			"Hide action widget",
 			"Select previous action",
@@ -28756,23 +28997,17 @@
 			"Accept selected action",
 			"Preview selected action"
 		],
-		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
-			"Click to toggle color options (rgb/hsl/hex)",
-			"Icon to close the color picker"
-		],
-		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys": [
-			"Whether an inline suggestion is visible",
-			"Whether the inline suggestion starts with whitespace",
-			"Whether the inline suggestion starts with whitespace that is less than what would be inserted by tab",
-			"Whether suggestions should be suppressed for the current suggestion"
-		],
-		"vs/editor/contrib/editorState/browser/keybindingCancellation": [
-			"Whether the editor runs a cancellable operation, e.g. like 'Peek References'"
-		],
 		"vs/editor/contrib/gotoSymbol/browser/peek/referencesWidget": [
 			"no preview available",
 			"No results",
 			"References"
+		],
+		"vs/editor/contrib/editorState/browser/keybindingCancellation": [
+			"Whether the editor runs a cancellable operation, e.g. like 'Peek References'"
+		],
+		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
+			"Click to toggle color options (rgb/hsl/hex)",
+			"Icon to close the color picker"
 		],
 		"vs/editor/contrib/snippet/browser/snippetVariables": [
 			"Sunday",
@@ -28821,13 +29056,6 @@
 			"Icon for more information in the suggest widget.",
 			"Read More"
 		],
-		"vs/editor/browser/controller/textAreaHandler": [
-			"editor",
-			"The editor is not accessible at this time.",
-			"{0} To enable screen reader optimized mode, use {1}",
-			"{0} To enable screen reader optimized mode, open the quick pick with {1} and run the command Toggle Screen Reader Accessibility Mode, which is currently not triggerable via keyboard.",
-			"{0} Please assign a keybinding for the command Toggle Screen Reader Accessibility Mode by accessing the keybindings editor with {1} and run it."
-		],
 		"vs/editor/contrib/suggest/browser/suggestWidgetDetails": [
 			"Close",
 			"Loading..."
@@ -28852,49 +29080,7 @@
 			"Color of borders and arrow for resolved comments.",
 			"Color of borders and arrow for unresolved comments.",
 			"Color of background for comment ranges.",
-			"Color of border for comment ranges.",
-			"Color of background for currently selected or hovered comment range.",
-			"Color of border for currently selected or hovered comment range."
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
-			"Fold Unchanged Region"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
-			" use {0} to open the accessibility help."
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer": [
-			"Icon for 'Insert' in accessible diff viewer.",
-			"Icon for 'Remove' in accessible diff viewer.",
-			"Icon for 'Close' in accessible diff viewer.",
-			"Close",
-			"Accessible Diff Viewer. Use arrow up and down to navigate.",
-			"no lines changed",
-			"1 line changed",
-			"{0} lines changed",
-			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
-			"blank",
-			"{0} unchanged line {1}",
-			"{0} original line {1} modified line {2}",
-			"+ {0} modified line {1}",
-			"- {0} original line {1}"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/colors": [
-			"The border color for text that got moved in the diff editor."
-		],
-		"vs/workbench/browser/parts/editor/editorPlaceholder": [
-			"Workspace Trust Required",
-			"The file is not displayed in the editor because trust has not been granted to the folder.",
-			"The file is not displayed in the editor because trust has not been granted to the workspace.",
-			"Manage Workspace Trust",
-			"Error Editor",
-			"The editor could not be opened because the file was not found.",
-			"The editor could not be opened due to an unexpected error: {0}",
-			"The editor could not be opened due to an unexpected error.",
-			"Try Again"
-		],
-		"vs/base/browser/ui/menu/menubar": [
-			"Application Menu",
-			"More"
+			"Color of background for currently selected or hovered comment range."
 		],
 		"vs/workbench/browser/parts/editor/titleControl": [
 			"Editor actions",
@@ -28913,11 +29099,67 @@
 			"Focus and Select Breadcrumbs",
 			"Focus Breadcrumbs"
 		],
+		"vs/workbench/browser/parts/editor/editorPlaceholder": [
+			"Workspace Trust Required",
+			"The file is not displayed in the editor because trust has not been granted to the folder.",
+			"The file is not displayed in the editor because trust has not been granted to the workspace.",
+			"Manage Workspace Trust",
+			"Error Editor",
+			"The editor could not be opened because the file was not found.",
+			"The editor could not be opened due to an unexpected error: {0}",
+			"The editor could not be opened due to an unexpected error.",
+			"Try Again"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer": [
+			"Icon for 'Insert' in accessible diff viewer.",
+			"Icon for 'Remove' in accessible diff viewer.",
+			"Icon for 'Close' in accessible diff viewer.",
+			"Close",
+			"Accessible Diff Viewer. Use arrow up and down to navigate.",
+			"no lines changed",
+			"1 line changed",
+			"{0} lines changed",
+			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
+			"blank",
+			"{0} unchanged line {1}",
+			"{0} original line {1} modified line {2}",
+			"+ {0} modified line {1}",
+			"- {0} original line {1}"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/movedBlocksLines": [
+			"Code moved with changes to line {0}-{1}",
+			"Code moved with changes from line {0}-{1}",
+			"Code moved to line {0}-{1}",
+			"Code moved from line {0}-{1}"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
+			"Fold Unchanged Region",
+			"Click or drag to show more above",
+			"Show all",
+			"Click or drag to show more below",
+			"{0} hidden lines",
+			"Double click to unfold"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
+			" use {0} to open the accessibility help."
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/colors": [
+			"The border color for text that got moved in the diff editor.",
+			"The active border color for text that got moved in the diff editor."
+		],
+		"vs/base/browser/ui/menu/menubar": [
+			"Application Menu",
+			"More"
+		],
 		"vs/platform/quickinput/browser/quickInputList": [
 			"Quick Input"
 		],
-		"vs/platform/quickinput/browser/quickInputUtils": [
-			"Click to execute command '{0}'"
+		"vs/platform/quickinput/browser/quickInput": [
+			"Back",
+			"Press 'Enter' to confirm your input or 'Escape' to cancel",
+			"{0}/{1}",
+			"Type to narrow down results.",
+			"{0} (Press 'Enter' to confirm or 'Escape' to cancel)"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
 			"Setting value not applied",
@@ -29114,13 +29356,6 @@
 			"No debugger available found. Can not send '{0}'.",
 			"More Info"
 		],
-		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
-			"Editor gutter decoration color for commenting ranges. This color should be opaque.",
-			"Editor overview ruler decoration color for resolved comments. This color should be opaque.",
-			"Editor overview ruler decoration color for unresolved comments. This color should be opaque.",
-			"Editor gutter decoration color for commenting glyphs.",
-			"Editor gutter decoration color for commenting glyphs for unresolved comment threads."
-		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
 			"1 Conflicting Line",
 			"{0} Conflicting Lines"
@@ -29151,6 +29386,13 @@
 		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
 			"Set Input Handled",
 			"Undo Mark As Handled"
+		],
+		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
+			"Editor gutter decoration color for commenting ranges. This color should be opaque.",
+			"Editor overview ruler decoration color for resolved comments. This color should be opaque.",
+			"Editor overview ruler decoration color for unresolved comments. This color should be opaque.",
+			"Editor gutter decoration color for commenting glyphs.",
+			"Editor gutter decoration color for commenting glyphs for unresolved comment threads."
 		],
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"Contributed custom editors.",
@@ -29212,19 +29454,15 @@
 			"The terminal process terminated with exit code: {0}.",
 			"The terminal process failed to launch: {0}."
 		],
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget": [
+			"Terminal Buffer"
+		],
 		"vs/workbench/contrib/terminal/browser/terminalTabsList": [
 			"Type terminal name. Press Enter to confirm or Escape to cancel.",
 			"Terminal tabs",
 			"Terminal {0} {1}, split {2} of {3}",
 			"Terminal {0} {1}",
 			"Terminal"
-		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
-			"Search workspace",
-			"Open file in editor",
-			"Focus folder in explorer",
-			"Open folder in new window",
-			"Follow link"
 		],
 		"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget": [
 			"Find",
@@ -29235,7 +29473,15 @@
 			"Enter search input",
 			"{0} found",
 			"{0} found for '{1}'",
-			"{0} found for '{1}'"
+			"{0} found for '{1}'",
+			"Border color of the sash border."
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
+			"Search workspace",
+			"Open file in editor",
+			"Focus folder in explorer",
+			"Open folder in new window",
+			"Follow link"
 		],
 		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
 			"Show Command Actions",
@@ -29275,20 +29521,6 @@
 			"{0} references",
 			"{0} reference",
 			"References"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/decorations": [
-			"Line decoration for inserts in the diff editor.",
-			"Line decoration for removals in the diff editor.",
-			"Click to revert change"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin": [
-			"Copy deleted lines",
-			"Copy deleted line",
-			"Copy changed lines",
-			"Copy changed line",
-			"Copy deleted line ({0})",
-			"Copy changed line ({0})",
-			"Revert this change"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbs": [
 			"Breadcrumb Navigation",
@@ -29335,6 +29567,23 @@
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
 			"Breadcrumbs"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/decorations": [
+			"Line decoration for inserts in the diff editor.",
+			"Line decoration for removals in the diff editor.",
+			"Click to revert change"
+		],
+		"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin": [
+			"Copy deleted lines",
+			"Copy deleted line",
+			"Copy changed lines",
+			"Copy changed line",
+			"Copy deleted line ({0})",
+			"Copy changed line ({0})",
+			"Revert this change"
+		],
+		"vs/platform/quickinput/browser/quickInputUtils": [
+			"Click to execute command '{0}'"
 		],
 		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
 			"Choose a different output mimetype, available mimetypes: {0}",
@@ -29412,17 +29661,17 @@
 			"Comment thread with {0} comments on the entire document. {1}.",
 			"Comment thread with {0} comments. {1}."
 		],
+		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
+			"Icon to collapse a review comment.",
+			"Collapse",
+			"Start discussion"
+		],
 		"vs/workbench/contrib/terminal/browser/environmentVariableInfo": [
 			"The following extensions want to relaunch the terminal to contribute to its environment:",
 			"Relaunch terminal",
 			"The following extensions have contributed to this terminal's environment:",
 			"Show environment contributions",
 			"workspace"
-		],
-		"vs/workbench/contrib/comments/browser/commentThreadHeader": [
-			"Icon to collapse a review comment.",
-			"Collapse",
-			"Start discussion"
 		],
 		"vs/workbench/contrib/comments/browser/commentNode": [
 			"Toggle Reaction",
@@ -29450,6 +29699,7 @@
 			"vs/base/browser/ui/findinput/findInput",
 			"vs/base/browser/ui/findinput/findInputToggles",
 			"vs/base/browser/ui/findinput/replaceInput",
+			"vs/base/browser/ui/hover/hoverWidget",
 			"vs/base/browser/ui/iconLabel/iconLabelHover",
 			"vs/base/browser/ui/inputbox/inputBox",
 			"vs/base/browser/ui/keybindingLabel/keybindingLabel",
@@ -29477,6 +29727,7 @@
 			"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors",
 			"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution",
 			"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin",
+			"vs/editor/browser/widget/diffEditorWidget2/movedBlocksLines",
 			"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges",
 			"vs/editor/browser/widget/diffReview",
 			"vs/editor/browser/widget/inlineDiffMargin",
@@ -29509,6 +29760,7 @@
 			"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution",
 			"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController",
 			"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders",
+			"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution",
 			"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController",
 			"vs/editor/contrib/editorState/browser/keybindingCancellation",
 			"vs/editor/contrib/find/browser/findController",
@@ -29536,6 +29788,7 @@
 			"vs/editor/contrib/inlineCompletions/browser/commands",
 			"vs/editor/contrib/inlineCompletions/browser/hoverParticipant",
 			"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys",
+			"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController",
 			"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget",
 			"vs/editor/contrib/lineSelection/browser/lineSelection",
 			"vs/editor/contrib/linesOperations/browser/linesOperations",
@@ -29604,6 +29857,7 @@
 			"vs/platform/quickinput/browser/commandsQuickAccess",
 			"vs/platform/quickinput/browser/helpQuickAccess",
 			"vs/platform/quickinput/browser/quickInput",
+			"vs/platform/quickinput/browser/quickInputController",
 			"vs/platform/quickinput/browser/quickInputList",
 			"vs/platform/quickinput/browser/quickInputUtils",
 			"vs/platform/quickinput/browser/quickPickPin",
@@ -29722,9 +29976,10 @@
 			"vs/workbench/common/editor/textEditorModel",
 			"vs/workbench/common/theme",
 			"vs/workbench/common/views",
-			"vs/workbench/contrib/accessibility/browser/accessibility.contribution",
-			"vs/workbench/contrib/accessibility/browser/accessibilityContribution",
+			"vs/workbench/contrib/accessibility/browser/accessibilityConfiguration",
+			"vs/workbench/contrib/accessibility/browser/accessibilityContributions",
 			"vs/workbench/contrib/accessibility/browser/accessibleView",
+			"vs/workbench/contrib/accessibility/browser/accessibleViewActions",
 			"vs/workbench/contrib/audioCues/browser/audioCues.contribution",
 			"vs/workbench/contrib/audioCues/browser/commands",
 			"vs/workbench/contrib/bulkEdit/browser/bulkEditService",
@@ -29741,24 +29996,24 @@
 			"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions",
 			"vs/workbench/contrib/chat/browser/actions/chatCopyActions",
 			"vs/workbench/contrib/chat/browser/actions/chatExecuteActions",
+			"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions",
 			"vs/workbench/contrib/chat/browser/actions/chatImportExport",
 			"vs/workbench/contrib/chat/browser/actions/chatMoveActions",
+			"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions",
 			"vs/workbench/contrib/chat/browser/actions/chatTitleActions",
-			"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/multipleByScrollQuickQuestionAction",
-			"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/quickQuestionAction",
-			"vs/workbench/contrib/chat/browser/actions/quickQuestionActions/singleQuickQuestionAction",
 			"vs/workbench/contrib/chat/browser/chat.contribution",
 			"vs/workbench/contrib/chat/browser/chatContributionServiceImpl",
 			"vs/workbench/contrib/chat/browser/chatEditorInput",
 			"vs/workbench/contrib/chat/browser/chatInputPart",
 			"vs/workbench/contrib/chat/browser/chatListRenderer",
 			"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget",
-			"vs/workbench/contrib/chat/browser/chatWidget",
 			"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib",
 			"vs/workbench/contrib/chat/common/chatColors",
 			"vs/workbench/contrib/chat/common/chatContextKeys",
 			"vs/workbench/contrib/chat/common/chatServiceImpl",
+			"vs/workbench/contrib/chat/common/chatSlashCommands",
 			"vs/workbench/contrib/chat/common/chatViewModel",
+			"vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions",
 			"vs/workbench/contrib/codeActions/browser/codeActionsContribution",
 			"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint",
 			"vs/workbench/contrib/codeActions/common/documentationExtensionPoint",
@@ -29895,8 +30150,6 @@
 			"vs/workbench/contrib/externalTerminal/electron-sandbox/externalTerminal.contribution",
 			"vs/workbench/contrib/externalUriOpener/common/configuration",
 			"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService",
-			"vs/workbench/contrib/feedback/browser/feedback",
-			"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem",
 			"vs/workbench/contrib/files/browser/editors/binaryFileEditor",
 			"vs/workbench/contrib/files/browser/editors/textFileEditor",
 			"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler",
@@ -29921,7 +30174,6 @@
 			"vs/workbench/contrib/format/browser/formatActionsNone",
 			"vs/workbench/contrib/format/browser/formatModified",
 			"vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty",
-			"vs/workbench/contrib/inlineChat/browser/inlineChat.contribution",
 			"vs/workbench/contrib/inlineChat/browser/inlineChatActions",
 			"vs/workbench/contrib/inlineChat/browser/inlineChatController",
 			"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies",
@@ -29985,6 +30237,7 @@
 			"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants",
 			"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout",
 			"vs/workbench/contrib/notebook/browser/controller/cellOperations",
+			"vs/workbench/contrib/notebook/browser/controller/cellOutputActions",
 			"vs/workbench/contrib/notebook/browser/controller/coreActions",
 			"vs/workbench/contrib/notebook/browser/controller/editActions",
 			"vs/workbench/contrib/notebook/browser/controller/executeActions",
@@ -30072,6 +30325,7 @@
 			"vs/workbench/contrib/scm/browser/scmViewPaneContainer",
 			"vs/workbench/contrib/search/browser/anythingQuickAccess",
 			"vs/workbench/contrib/search/browser/patternInputWidget",
+			"vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess",
 			"vs/workbench/contrib/search/browser/replaceService",
 			"vs/workbench/contrib/search/browser/search.contribution",
 			"vs/workbench/contrib/search/browser/searchActionsBase",
@@ -30080,6 +30334,7 @@
 			"vs/workbench/contrib/search/browser/searchActionsNav",
 			"vs/workbench/contrib/search/browser/searchActionsRemoveReplace",
 			"vs/workbench/contrib/search/browser/searchActionsSymbol",
+			"vs/workbench/contrib/search/browser/searchActionsTextQuickAccess",
 			"vs/workbench/contrib/search/browser/searchActionsTopBar",
 			"vs/workbench/contrib/search/browser/searchFindInput",
 			"vs/workbench/contrib/search/browser/searchIcons",
@@ -30155,6 +30410,7 @@
 			"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution",
 			"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp",
 			"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer",
+			"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget",
 			"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution",
 			"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution",
 			"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution",
@@ -30286,7 +30542,7 @@
 			"vs/workbench/services/preferences/common/preferencesModels",
 			"vs/workbench/services/preferences/common/preferencesValidation",
 			"vs/workbench/services/progress/browser/progressService",
-			"vs/workbench/services/remote/common/remoteExplorerService",
+			"vs/workbench/services/remote/common/tunnelModel",
 			"vs/workbench/services/remote/electron-sandbox/remoteAgentService",
 			"vs/workbench/services/search/common/queryBuilder",
 			"vs/workbench/services/secrets/electron-sandbox/secretStorageService",
@@ -30323,6 +30579,7 @@
 			"vs/workbench/services/userDataSync/common/userDataSync",
 			"vs/workbench/services/views/browser/viewDescriptorService",
 			"vs/workbench/services/views/common/viewContainerModel",
+			"vs/workbench/services/voiceRecognition/electron-sandbox/workbenchVoiceRecognitionService",
 			"vs/workbench/services/workingCopy/common/fileWorkingCopyManager",
 			"vs/workbench/services/workingCopy/common/storedFileWorkingCopy",
 			"vs/workbench/services/workingCopy/common/storedFileWorkingCopyManager",

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -66,7 +66,8 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
         'files.associations': {
             type: 'object',
             markdownDescription: nls.localizeByDefault(
-                'Configure file associations to languages (for example `"*.extension": "html"`). These have precedence over the default associations of the languages installed.'
+                // eslint-disable-next-line max-len
+                'Configure [glob patterns](https://aka.ms/vscode-glob-patterns) of file associations to languages (for example `\"*.extension\": \"html\"`). Patterns will match on the absolute path of a file if they contain a path separator and will match on the name of the file otherwise. These have precedence over the default associations of the languages installed.'
             )
         },
         'files.autoGuessEncoding': {

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -147,7 +147,7 @@ export const TerminalConfigSchema: PreferenceSchema = {
             default: false
         },
         'terminal.integrated.cursorStyle': {
-            description: nls.localizeByDefault('Controls the style of terminal cursor.'),
+            description: nls.localizeByDefault('Controls the style of terminal cursor when the terminal is focused.'),
             enum: ['block', 'underline', 'line'],
             default: 'block'
         },


### PR DESCRIPTION
#### What it does

Updates the nls metadata for the latest API bump https://github.com/eclipse-theia/theia/pull/13025.

#### How to test

CI is green, no translation warnings are displayed on application startup.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
