### PR TITLE
Perform remote backend copy via http

### DIFF
--- a/packages/remote/src/electron-browser/remote-preferences.ts
+++ b/packages/remote/src/electron-browser/remote-preferences.ts
@@ -18,7 +18,8 @@ import { interfaces } from '@theia/core/shared/inversify';
 import {
     PreferenceProxy,
     PreferenceSchema,
-    PreferenceContribution
+    PreferenceContribution,
+    PreferenceScope
 } from '@theia/core/lib/browser/preferences';
 import { nls } from '@theia/core/lib/common/nls';
 import { PreferenceProxyFactory } from '@theia/core/lib/browser/preferences/injectable-preference-proxy';
@@ -29,7 +30,6 @@ const nodeDownloadTemplateParts = [
     nls.localize('theia/remote/nodeDownloadTemplateArch', '`{arch}` for the remote system architecture.'),
     nls.localize('theia/remote/nodeDownloadTemplateExt', '`{ext}` for the file extension. Either `zip`, `tar.xz` or `tar.xz`, depending on the operating system.')
 ];
-
 export const RemotePreferenceSchema: PreferenceSchema = {
     'type': 'object',
     properties: {
@@ -41,11 +41,19 @@ export const RemotePreferenceSchema: PreferenceSchema = {
                 'Controls the template used to download the node.js binaries for the remote backend. Points to the official node.js website by default. Uses multiple placeholders:'
             ) + '\n- ' + nodeDownloadTemplateParts.join('\n- ')
         },
+        'remote.httpRemoteCopyPort': {
+            type: 'number',
+            description: 'The port used for copying the backend via http for connecting to remote systems (http is in most cases faster than sftp)',
+            default: 8080,
+            scope: PreferenceScope.Workspace
+        }
+
     }
 };
 
 export interface RemoteConfiguration {
     'remote.nodeDownloadTemplate': string;
+    'remote.httpRemoteCopyPort': number;
 }
 
 export const RemotePreferenceContribution = Symbol('RemotePreferenceContribution');

--- a/packages/remote/src/electron-browser/remote-ssh-contribution.ts
+++ b/packages/remote/src/electron-browser/remote-ssh-contribution.ts
@@ -96,7 +96,8 @@ export class RemoteSSHContribution extends AbstractRemoteRegistryContribution {
         return this.sshConnectionProvider.establishConnection({
             host,
             user,
-            nodeDownloadTemplate: this.remotePreferences['remote.nodeDownloadTemplate']
+            nodeDownloadTemplate: this.remotePreferences['remote.nodeDownloadTemplate'],
+            remoteHttpCopyPort: this.remotePreferences['remote.httpRemoteCopyPort']
         });
     }
 }

--- a/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
+++ b/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
@@ -22,6 +22,7 @@ export interface RemoteSSHConnectionProviderOptions {
     user: string;
     host: string;
     nodeDownloadTemplate?: string;
+    remoteHttpCopyPort?: number;
 }
 
 export interface RemoteSSHConnectionProvider {

--- a/packages/remote/src/electron-node/setup/http-copy-server.ts
+++ b/packages/remote/src/electron-node/setup/http-copy-server.ts
@@ -1,0 +1,48 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { IncomingMessage, ServerResponse } from 'http';
+import { AddressInfo } from 'net';
+
+declare function __require(module: string): unknown;
+
+export function launchNodeHttpCopyServer(destination: string, port: number): void {
+
+    const http = __require('http') as typeof import('http');
+    const fs = __require('fs') as typeof import('fs');
+
+    const server = http.createServer((req: IncomingMessage, res: ServerResponse) => {
+
+        const stream = req.pipe(fs.createWriteStream(destination));
+        stream.on('finish', () => {
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'text/plain');
+            res.end('Copyed successful');
+            server.close();
+        });
+        stream.on('error', (err: Error) => {
+            console.error(err.message);
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'text/plain');
+            res.end(`Copy failed: ${err.message}`);
+            server.close();
+        });
+    });
+
+    server.listen(port, () => {
+        console.log(`Port:${(server.address() as AddressInfo).port}`);
+    });
+}

--- a/packages/remote/src/electron-node/setup/remote-setup-script-service.ts
+++ b/packages/remote/src/electron-node/setup/remote-setup-script-service.ts
@@ -24,6 +24,7 @@ export interface RemoteScriptStrategy {
     unzip(file: string, directory: string): string;
     mkdir(path: string): string;
     home(): string;
+    tempFile(): string;
     joinPath(...segments: string[]): string;
     joinScript(...segments: string[]): string;
 }
@@ -33,6 +34,10 @@ export class RemoteWindowsScriptStrategy implements RemoteScriptStrategy {
 
     home(): string {
         return 'PowerShell -Command $HOME';
+    }
+
+    tempFile(): string {
+        return 'PowerShell -Command [System.IO.Path]::GetTempFileName()()';
     }
 
     exec(): string {
@@ -65,6 +70,10 @@ export class RemotePosixScriptStrategy implements RemoteScriptStrategy {
 
     home(): string {
         return 'eval echo ~';
+    }
+
+    tempFile(): string {
+        return 'mktemp';
     }
 
     exec(): string {
@@ -118,6 +127,10 @@ export class RemoteSetupScriptService {
 
     home(platform: RemotePlatform): string {
         return this.getStrategy(platform).home();
+    }
+
+    tempFile(platform: RemotePlatform): string {
+        return this.getStrategy(platform).tempFile();
     }
 
     exec(platform: RemotePlatform): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

There is a strong indication that copying the backend to remote systems via http is a faster than using sftp. 
On my local system copying the zipped theia backend, http was 2.5x faster then sftp. I sadly wasn't able to test it with an actual remote system.

#### How to test

i created a small docker container here https://hub.docker.com/repository/docker/jonahiden/remote-test-ubuntu-ssh/general
you can connect to it via ssh with user: test pass: test 
also open port 8080 or some other port (other ports need configuration in the theia settings) for the http copy

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
