### PR TITLE
Use description field as thread stopped status. fixes #13049

### DIFF
--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -238,18 +238,18 @@ export class DebugThread extends DebugThreadData implements TreeElement {
     }
 
     protected threadStatus(): string {
-        
+
         if (!this.stoppedDetails) {
             return nls.localizeByDefault('Running');
         }
-        
+
         const description = this.stoppedDetails.description;
-        
+
         if (description) {
             // According to DAP we must show description as is. Translation is made by debug adapter
             return description;
         }
-        
+
         const reason = this.stoppedDetails.reason;
         const localizedReason = this.getLocalizedReason(reason);
 

--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -229,20 +229,33 @@ export class DebugThread extends DebugThreadData implements TreeElement {
     }
 
     render(): React.ReactNode {
-        const reason = this.stoppedDetails && this.stoppedDetails.reason;
-        const localizedReason = this.getLocalizedReason(reason);
-
-        const status = this.stoppedDetails
-            ? reason
-                ? nls.localizeByDefault('Paused on {0}', localizedReason)
-                : nls.localizeByDefault('Paused')
-            : nls.localizeByDefault('Running');
         return (
             <div className="theia-debug-thread" title={nls.localizeByDefault('Session')}>
                 <span className="label">{this.raw.name}</span>
-                <span className="status">{status}</span>
+                <span className="status">{this.threadStatus()}</span>
             </div>
         );
+    }
+
+    protected threadStatus(): string {
+        
+        if (!this.stoppedDetails) {
+            return nls.localizeByDefault('Running');
+        }
+        
+        const description = this.stoppedDetails.description;
+        
+        if (description) {
+            // According to DAP we must show description as is. Translation is made by debug adapter
+            return description;
+        }
+        
+        const reason = this.stoppedDetails.reason;
+        const localizedReason = this.getLocalizedReason(reason);
+
+        return reason
+                ? nls.localizeByDefault('Paused on {0}', localizedReason)
+                : nls.localizeByDefault('Paused');
     }
 
     protected getLocalizedReason(reason: string | undefined): string {
@@ -269,5 +282,4 @@ export class DebugThread extends DebugThreadData implements TreeElement {
                 return '';
         }
     }
-
 }


### PR DESCRIPTION
If thread Stopped event contains description field, UI must show description as is

#### What it does

Fixes #13049

#### How to test

1. Create debug adapter which sets "Description" field of Stopped event of DAP
2. See that description is shown in UI

#### Follow-ups

It would be nice to localize "Paused on {0}" text, but I'm not sure how it translates in other languages. Should it be two separate NLS keys _"Paused on {0}"_ + _"reason"_ (like now) or should it be single NLS key _"paused on step"_ where word order depends on specific language.

#### Review checklist

- [ x ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
