### PR TITLE
fix: omit proxy path prefix from socket.io base path

### DIFF
--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -119,7 +119,7 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
     protected createWebSocketUrl(path: string): string {
         // Since we are using Socket.io, the path should look like the following:
         // proto://domain.com/{path}
-        return this.createEndpoint(path).getWebSocketUrl().toString();
+        return this.createEndpoint(path).getWebSocketUrl().withPath(path).toString();
     }
 
     protected createHttpWebSocketUrl(path: string): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes an issue causing socket.io to use the wrong basepath when accessing the backend from a reverse proxy. #13055

#### How to test

This can be tested by running the browser example and accessing via a local nginx proxy:

- Build/run the browser example with `yarn && yarn browser build && yarn browser start` (Theia will run on port 3000)
- Run nginx using the following `nginx.conf`
  ```nginx
  http {
      server { 
          listen 3300;
  
          location ~* /proxy/(.*)? {
              proxy_set_header Host $host;
              proxy_set_header X-Real-IP $remote_addr;
              proxy_set_header X-Forwarded-For $remote_addr;
              proxy_set_header Upgrade $http_upgrade;
              proxy_set_header Connection "Upgrade";
              proxy_ssl_verify off;
  
              if ($args) {
                  proxy_pass http://127.0.0.1:3000/$1?$args;
              }
  
              proxy_pass http://127.0.0.1:3000/$1;
          }
      }
  }
  events {}
  ```
- Access theia via http://localhost:3300/proxy/


#### Follow-ups

Nothing major that i can see.

The first `path` argument [here](https://github.com/eclipse-theia/theia/commit/5107942562e2c2c9efb2afeb39f027ab8f0d27f5#diff-4bce5ab557626597cf9f000f9841f01f8ebf30c1bec36544fc4074cfe922711dR122) is now redundant; probably not really worth worrying about considering the severity of the issue.

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
