### PR TITLE
fix: do not reject unknown schemes in WindowStateExt.asExternalUri

### DIFF
--- a/packages/plugin-ext/src/plugin/window-state.ts
+++ b/packages/plugin-ext/src/plugin/window-state.ts
@@ -19,7 +19,6 @@ import { WindowState } from '@theia/plugin';
 import { WindowStateExt, WindowMain, PLUGIN_RPC_CONTEXT } from '../common/plugin-api-rpc';
 import { Event, Emitter } from '@theia/core/lib/common/event';
 import { RPCProtocol } from '../common/rpc-protocol';
-import { Schemes } from '../common/uri-components';
 
 export class WindowStateExtImpl implements WindowStateExt {
 
@@ -50,15 +49,16 @@ export class WindowStateExtImpl implements WindowStateExt {
     }
 
     openUri(uri: URI): Promise<boolean> {
+        if (!uri.scheme.trim().length) {
+            throw new Error('Invalid scheme - cannot be empty');
+        }
+
         return this.proxy.$openUri(uri);
     }
 
     async asExternalUri(target: URI): Promise<URI> {
         if (!target.scheme.trim().length) {
             throw new Error('Invalid scheme - cannot be empty');
-        }
-        if (Schemes.http !== target.scheme && Schemes.https !== target.scheme) {
-            throw new Error(`Invalid scheme '${target.scheme}'`);
         }
 
         const uri = await this.proxy.$asExternalUri(target);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #12821

After testing the same workflow of the Gitlens extension in VS Code, I think URLs with unknown schemes were rejected prematurely in Theia.
When the `Connect to Github` action is triggered, the extension invokes two methods of the `WindowStateExtImpl`: first [asExternalUri](https://github.com/eclipse-theia/theia/blob/f33547ef9e2521b5a7e3507badaaf34b35da5d70/packages/plugin-ext/src/plugin/window-state.ts#L56) and at a later point [openUri](https://github.com/eclipse-theia/theia/blob/f33547ef9e2521b5a7e3507badaaf34b35da5d70/packages/plugin-ext/src/plugin/window-state.ts#L52).

The parameter passed to the `asExternalUri` method is an URI of the form `theia://...` and the existing code rejects it. 
In VS Code, the URI has an application specific schema as well (not http or https), but the code does not reject it. This allows the Github authentication to process the request and later on call the `openUri` method with a valid URI.

I modified the code and it now handles URIs similar to VS Code. This fixes the initial problem, which was reported for the gitlens extension, but I would love some feedback as I can't tell if this is generally safe for all extensions.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Install gitlens. I had to remove the vscode.git and vscode.github extensions from the [excluded plugins list](https://github.com/eclipse-theia/theia/blob/f33547ef9e2521b5a7e3507badaaf34b35da5d70/package.json#L114C4-L117C36) and removed the '@theia/git' package to make this work with the Theia examples.
2. Open an editor on a file in a github repo, for example theia itself.
3. When you hover at the end of a line, you get a hover that shows you information about the commit that last changed this line.
4. Scroll to the bottom of the hover
5. Observe: there is a link that says "Connect to Github".
6. Click the link
7. There's a popup that says "You have not yet finished authorizing this extension ...". Click 'Yes'.
8. Another popup shows up - click "Copy & Continue to Github".
9. A Github link should open in the browser.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Contributed on behalf of STMicroelectronics