### PR TITLE
Fix SiW result line styling

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -239,6 +239,10 @@
   margin-left: 3px;
 }
 
+.t-siw-search-container .resultLine {
+  flex-grow: 1;
+}
+
 .t-siw-search-container .resultLine .match {
   white-space: pre;
   background: var(--theia-editor-findMatchHighlightBackground);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR fixes a minor visual regression that was most likely introduced with https://github.com/eclipse-theia/theia/pull/12868, where search result lines do not grow to full width and action buttons therefore do not get aligned on the right side.

Here's a comparison.

<img width="1528" alt="BeforeAfter" src="https://github.com/eclipse-theia/theia/assets/2768706/3b3515dd-8595-43ac-a537-e1bf7915d3c2">

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
