### PR TITLE
Improve default translation using preferred keys

### DIFF
--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -81,6 +81,10 @@ interface NlsInfo {
 
 class LocalizationKeyProvider {
 
+    private preferredKeys = new Set([
+        // We only want the `File` translation used in the menu
+        'vscode/fileActions.contribution/filesCategory'
+    ]);
     private data = this.buildData();
 
     get(defaultValue: string): string | undefined {
@@ -100,9 +104,16 @@ class LocalizationKeyProvider {
         const keys: NlsKeys = bundles.keys;
         const messages: Record<string, string[]> = bundles.messages;
         const data = new Map<string, string>();
+        const foundPreferredKeys = new Set<string>();
         const keysAndMessages = this.buildKeyMessageTuples(keys, messages);
         for (const { key, message } of keysAndMessages) {
-            data.set(message, key);
+            if (!foundPreferredKeys.has(message)) {
+                data.set(message, key);
+                if (this.preferredKeys.has(key)) {
+                    // Prevent messages with preferred keys to be overriden
+                    foundPreferredKeys.add(message);
+                }
+            }
         }
         // Second pass adds each message again in upper case, if the message doesn't already exist in upper case
         // The second pass is needed to not accidentally override any translations which actually use the upper case message


### PR DESCRIPTION
#### What it does

Related to a comment in https://github.com/eclipse-theia/theia/pull/13028.

Adds support for entering preferred translation keys for the nls.metadata.json translation process. This issue in particular is seen because there are ~5 different entries that translate to `File` in the metadata file. The last one is translated differently compared all others. This isn't an issue usually, since all entries that use the same english value translate to the same value in any other language.

For this case, we now have a set of "preferred keys" that have priority over other keys. This currently only seems to be necessary for the `File` entry, but contributors can any keys in there to improve localization.

#### How to test

1. Change the locale of the application to something other than English
2. The "File" menu entry should be translated to whatever "File" in your selected language is. It shouldn't show the translation for "local file".

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
