### PR TITLE
fix: allow all listener to be executed for AsyncEmitter

### DIFF
--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -456,7 +456,7 @@ export class AsyncEmitter<T extends WaitUntilEvent> extends Emitter<T> {
                 delete (asyncEvent as any)['waitUntil'];
             }
             if (!waitables.length) {
-                return;
+                continue;
             }
             try {
                 await Promise.all(waitables);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
With AsyncEmitters, if a listener callback does not call `event.waitUntil`, other listeners that are registered after this one will fail to be called due to early loop termination.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Register two separate callbacks without `waitUntil` for `FileService.onDidRunUserOperation` or any other `AsyncEmitter.event` and fire an event. Verify that both callbacks are called correctly.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
