### PR TITLE
Forward webview console log messages to browser console

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/host.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/host.js
@@ -36,7 +36,7 @@
                         break;
                     }
                 }
-                if (sourceIsChildFrame && e.data && (e.data.command === 'onmessage' || e.data.command === 'do-update-state')) {
+                if (sourceIsChildFrame && e.data && (e.data.command === 'onmessage' || e.data.command === 'do-update-state' || e.data.command === 'onconsole')) {
                     this.postMessage(e.data.command, e.data.data);
                 } else if (sourceIsChildFrame || sourceIsSelfOrParentFrame) {
                     const channel = e.data.channel;

--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -144,14 +144,39 @@
      * @param {*} [state]
      * @return {string}
      */
-    function getVsCodeApiScript(state) {
+    function getDefaultScript(state) {
         return `
         const acquireVsCodeApi = (function() {
             const originalPostMessage = window.parent.postMessage.bind(window.parent);
+            const originalConsole = {...console};
             const targetOrigin = '*';
             let acquired = false;
 
             let state = ${state ? `JSON.parse(${JSON.stringify(state)})` : undefined};
+
+            const forwardConsoleLog= (level,msg,args)=> {
+                let message, optionalParams;
+                try{
+                  if (msg) {
+                    message= JSON.stringify(msg) ?? null;
+                  }
+                  if (args){
+                    optionalParams= JSON.stringify(args) ?? null;
+                  }
+                } catch(e){
+                    // Log non serializable objects inside of view
+                    originalConsole[level](msg,args);
+                    return;
+                }
+                originalPostMessage({ command: 'onconsole', data: { level, message,optionalParams} }, targetOrigin);
+            };
+
+            console.log= (message,args)=> forwardConsoleLog('log',message,args);
+            console.info= (message,args)=> forwardConsoleLog('info',message,args);
+            console.warn= (message,args)=> forwardConsoleLog('warn',message,args);
+            console.error= (message,args)=> forwardConsoleLog('error',message,args);
+            console.debug= (message,args)=> forwardConsoleLog('debug',message,args);
+            console.trace= (message,args)=> forwardConsoleLog('trace',message,args);
 
             return () => {
                 if (acquired) {
@@ -369,7 +394,7 @@
             // apply default script
             if (options.allowScripts) {
                 const defaultScript = newDocument.createElement('script');
-                defaultScript.textContent = getVsCodeApiScript(data.state);
+                defaultScript.textContent = getDefaultScript(data.state);
                 newDocument.head.prepend(defaultScript);
             }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This ensures that webview console logs are correctly propagated to the backend logger.
Webview are rendered inside of an IFrame this means console logs are isolated and are not forwarded to the backend logger 
(in contrast to console logs of the main frontend process).

This change extends the default script injected into webviews to override the global console and send a log message via the `postMessage` API instead. This event is than handled by the `Webview´ base class and forwarded to the browser console.
In addition to forwarding to the backend logger this also makes it easier to identify log messages that are coming from webviews as they are now prefixed with [webview: <id>]

Contributed on behalf of STMicroelectronics

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
This can be tested with any vsocde-extension that provides a webview with console logs.
I used the  CatCoding [webview sample](https://github.com/microsoft/vscode-extension-samples/tree/main/webview-sample) and added the following console logs to the webview main script:
```ts
    console.log("Test extension webview  is ready!")
    console.debug("Debug test message")
    console.error("Error test message")
    console.warn("Warn test message")
    console.info("Info test message")
    console.trace("Trace test message")
    const foo=()=>{console.log("foo")};
    console.log("Function foo",foo);
   ```
The `vsix` for this customized cat coder can be found here:
[cat-coding-0.0.1.zip](https://github.com/eclipse-theia/theia/files/13426995/cat-coding-0.0.1.zip)

To test, add it to the plugin folder,
open the Theia application and then use the `Cat  Coding: Start coding session` command to open the webview.

Expected result: The console logs mentioned above should show up in the browser console and the backend console.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
