### PR TITLE
Incorrect "Unsupported activation event" error in stdout #12953

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -234,6 +234,7 @@ export interface PluginManagerInitializeParams {
     extApi?: ExtPluginApi[]
     webview: WebviewInitData
     jsonValidation: PluginJsonValidationContribution[]
+    supportedActivationEvents?: string[]
 }
 
 export interface PluginManagerStartParams {

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -79,30 +79,6 @@ class ActivatedPlugin {
 
 export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
 
-    static BUILTIN_ACTIVATION_EVENTS = new Set([
-        '*',
-        'onLanguage',
-        'onCommand',
-        'onDebug',
-        'onDebugInitialConfigurations',
-        'onDebugResolve',
-        'onDebugAdapterProtocolTracker',
-        'onDebugDynamicConfigurations',
-        'onTaskType',
-        'workspaceContains',
-        'onView',
-        'onUri',
-        'onTerminalProfile',
-        'onWebviewPanel',
-        'onFileSystem',
-        'onCustomEditor',
-        'onStartupFinished',
-        'onAuthenticationRequest',
-        'onNotebook',
-        'onNotebookSerializer'
-    ]);
-    static ADDITIONAL_ACTIVATION_EVENTS_ENV = 'ADDITIONAL_ACTIVATION_EVENTS';
-
     private configStorage: ConfigStorage | undefined;
     private readonly registry = new Map<string, Plugin>();
     private readonly activations = new Map<string, (() => Promise<void>)[] | undefined>();
@@ -222,11 +198,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         this.webview.init(params.webview);
         this.jsonValidation = params.jsonValidation;
 
-        this.supportedActivationEvents = new Set(PluginManagerExtImpl.BUILTIN_ACTIVATION_EVENTS);
-        const additionalActivationEvents = await this.envExt.getEnvVariable(PluginManagerExtImpl.ADDITIONAL_ACTIVATION_EVENTS_ENV);
-        if (additionalActivationEvents) {
-            additionalActivationEvents.split(',').forEach(event => this.supportedActivationEvents.add(event));
-        }
+        this.supportedActivationEvents = new Set(params.supportedActivationEvents ?? []);
     }
 
     async $start(params: PluginManagerStartParams): Promise<void> {


### PR DESCRIPTION
#### What it does
In this PR we are adding a mechanism to add additional known activation events to avoid "Unsupported activation event" messages in the log. 

In my initial implementation the information is taken from an environment variable. 
For the browser application use case the environment may be set when building the container image for the app.
For the electron application use case a custom `main` script may be used, that sets the desired environment variable value and then hands over to the generated `electron-main.js`. 
Also the user/application may influence the environment variable further if required. 

Any additional plugin installed by the user may bring in new warnings, so I was not sure if a more programmatic approach, where the activation events have to be specified at compile/build time, is working for all use cases. 
A user preference might work, but it seems a bit weird to me to have this in the settings. 
So this is my reasoning for the initial environment variable approach. 

If you would prefer a different approach to specify the events, let me know and I will adjust the PR. 

Fixes #12953

#### How to test
Run Electron Example with downloaded plugins

```
yarn && yarn download:plugins && yarn electron build && clear && yarn electron start
```

With the default plugins you should get the following warnings:

```
Unsupported activation events: onProfile, onProfile:github, please open an issue: https://github.com/eclipse-theia/theia/issues/new
Unsupported activation events: onOpenExternalUri:http, onOpenExternalUri:https, please open an issue: https://github.com/eclipse-theia/theia/issues/new
Unsupported activation events: onWalkthrough:nodejsWelcome, please open an issue: https://github.com/eclipse-theia/theia/issues/new
```

Now run the same same application with the `ADDITIONAL_ACTIVATION_EVENTS` env variable. 

```
export ADDITIONAL_ACTIVATION_EVENTS=onProfile,onOpenExternalUri,onWalkthrough && clear && yarn electron start
```

This will remove the warnings/errors.

#### Follow-ups

-

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
