### PR TITLE
[vscode] Support env.onDidChangeShell event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ## v1.44.0
 
 - [task] prevent task widget title from being changed by task process [#13003](https://github.com/eclipse-theia/theia/pull/13003)
-- [vscode] Added Notebook CodeActionKind [#13093](https://github.com/eclipse-theia/theia/pull/13093) - contributed on behalf of STMicroelectronics
+- [vscode] added Notebook CodeActionKind [#13093](https://github.com/eclipse-theia/theia/pull/13093) - contributed on behalf of STMicroelectronics
+- [vscode] added support to env.ondidChangeShell event [#13097](https://github.com/eclipse-theia/theia/pull/13097) - contributed on behalf of STMicroelectronics
 
 ## v1.43.0 - 10/26/2023
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -296,6 +296,7 @@ export interface TerminalServiceExt {
     $provideTerminalLinks(line: string, terminalId: string, token: theia.CancellationToken): Promise<ProvidedTerminalLink[]>;
     $handleTerminalLink(link: ProvidedTerminalLink): Promise<void>;
     getEnvironmentVariableCollection(extensionIdentifier: string): theia.GlobalEnvironmentVariableCollection;
+    $setShell(shell: string): void;
 }
 export interface OutputChannelRegistryExt {
     createOutputChannel(name: string, pluginInfo: PluginInfo): theia.OutputChannel,

--- a/packages/plugin-ext/src/plugin/env.ts
+++ b/packages/plugin-ext/src/plugin/env.ts
@@ -25,7 +25,6 @@ export abstract class EnvExtImpl {
     private queryParameters: QueryParameters;
     private lang: string;
     private applicationName: string;
-    private defaultShell: string;
     private ui: theia.UIKind;
     private envMachineId: string;
     private envSessionId: string;
@@ -68,10 +67,6 @@ export abstract class EnvExtImpl {
         this.lang = lang;
     }
 
-    setShell(shell: string): void {
-        this.defaultShell = shell;
-    }
-
     setUIKind(uiKind: theia.UIKind): void {
         this.ui = uiKind;
     }
@@ -111,9 +106,6 @@ export abstract class EnvExtImpl {
     }
     get uriScheme(): string {
         return 'theia';
-    }
-    get shell(): string {
-        return this.defaultShell;
     }
     get uiKind(): theia.UIKind {
         return this.ui;

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -796,7 +796,10 @@ export function createAPIFactory(
             get machineId(): string { return envExt.machineId; },
             get sessionId(): string { return envExt.sessionId; },
             get uriScheme(): string { return envExt.uriScheme; },
-            get shell(): string { return envExt.shell; },
+            get shell(): string { return terminalExt.defaultShell; },
+            get onDidChangeShell(): theia.Event<string> {
+                return terminalExt.onDidChangeShell;
+            },
             get uiKind(): theia.UIKind { return envExt.uiKind; },
             clipboard,
             getEnvVariable(envVarName: string): PromiseLike<string | undefined> {

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -206,7 +206,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
 
         this.envExt.setQueryParameters(params.env.queryParams);
         this.envExt.setLanguage(params.env.language);
-        this.envExt.setShell(params.env.shell);
+        this.terminalService.$setShell(params.env.shell);
         this.envExt.setUIKind(params.env.uiKind);
         this.envExt.setApplicationName(params.env.appName);
         this.envExt.setAppHost(params.env.appHost);

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -71,12 +71,27 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
 
     protected environmentVariableCollections: MultiKeyMap<string, EnvironmentVariableCollectionImpl> = new MultiKeyMap(2);
 
+    private shell: string;
+    private readonly onDidChangeShellEmitter = new Emitter<string>();
+    readonly onDidChangeShell: theia.Event<string> = this.onDidChangeShellEmitter.event;
+
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.TERMINAL_MAIN);
     }
 
     get terminals(): TerminalExtImpl[] {
         return [...this._terminals.values()];
+    }
+
+    get defaultShell(): string {
+        return this.shell || '';
+    }
+
+    async $setShell(shell: string): Promise<void> {
+        if (this.shell !== shell) {
+            this.shell = shell;
+            this.onDidChangeShellEmitter.fire(shell);
+        }
     }
 
     createTerminal(

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7721,6 +7721,12 @@ export module '@theia/plugin' {
         export const isTelemetryEnabled: boolean;
 
         /**
+         * An {@link Event} which fires when the default shell changes. This fires with the new
+         * shell path.
+         */
+        export const onDidChangeShell: Event<string>;
+
+        /**
          * An {@link Event} which fires when the user enabled or disables telemetry.
          * `true` if the user has enabled telemetry or `false` if the user has disabled telemetry.
          */
@@ -7747,7 +7753,9 @@ export module '@theia/plugin' {
         export const remoteName: string | undefined;
 
         /**
-         * The detected default shell for the extension host.
+         * The detected default shell for the extension host, this is overridden by the
+         * `terminal.integrated.defaultProfile` setting for the extension host's platform. Note that in
+         * environments that do not support a shell the value is the empty string.
          */
         export const shell: string;
 

--- a/packages/terminal/src/browser/shell-terminal-profile.ts
+++ b/packages/terminal/src/browser/shell-terminal-profile.ts
@@ -20,6 +20,11 @@ import { TerminalWidget, TerminalWidgetOptions } from './base/terminal-widget';
 import { TerminalProfile } from './terminal-profile-service';
 
 export class ShellTerminalProfile implements TerminalProfile {
+
+    get shellPath(): string | undefined {
+        return this.options.shellPath;
+    }
+
     constructor(protected readonly terminalService: TerminalService, protected readonly options: TerminalWidgetOptions) { }
 
     async start(): Promise<TerminalWidget> {


### PR DESCRIPTION
#### What it does

Add env.onDidChangeShell event made public on vscode 1.83.
The documentation of this one was not obvious, and the doc was updated after testing on vscode side (see https://github.com/microsoft/vscode/issues/194229). This event is triggered when the default profile change, it sends the shell used by this new terminal profile. 

I added a sample extension to test this new API. The behavior is now similar to the one present on vscode. It provides a notification message as soon as the event is sent.

Fixes #13061 

Contributed on behalf of ST Microelectronics

#### How to test 
1. Install the following extension on Theia master:
- zip: [shell-change-event-0.0.1.zip](https://github.com/eclipse-theia/theia/files/13452364/shell-change-event-0.0.1.zip)
- src: [shell-change-event-0.0.1-src.zip](https://github.com/eclipse-theia/theia/files/13452360/shell-change-event-0.0.1-src.zip)

2. Start browser theia
3. On activation, an error is shown that the API is not available
4. Switch to the branch and rebuild
5. Starting with the extension,  no more errors shall popup
6. When using the action : `Terminal: Choose the default terminal profile`. A popup with the shell path for the new default profile shall popup.

#### Follow-ups

- no specific follow ups

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)