### PR TITLE
fix: set `display: block` on plugin icon pseudo-element (#13096)

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
@@ -125,8 +125,9 @@ export class PluginSharedStyle {
             toDispose.push(this.insertRule('.' + iconClass + '::before', theme => `
                     content: "";
                     background-position: 2px;
-                    width: ${size}'px';
-                    height: ${size}'px';
+                    display: block;
+                    width: ${size}px;
+                    height: ${size}px;
                     background: center no-repeat url("${theme.type === 'light' ? lightIconUrl : darkIconUrl}");
                     background-size: ${size}px;
                 `));


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #13096

Fix the icon pseudo-element being displayed as `inline` by default. This meant that the `width` and `height` properties were being ignored and the icons displayed with 0 width.

Also fix css syntax for `width` and `height` properties.


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The most mainstream vscode extension I could reproduce the issue with was [ms-kubernetes-tools](https://open-vsx.org/extension/ms-kubernetes-tools/vscode-kubernetes-tools). If you have no Kubernetes clusters, you can have one displayed using this dummy kubeconfig:
```yaml
apiVersion: v1
kind: Config
current-context: dev
preferences: {}
clusters:
  - cluster:
      server: https://fake-k8s.com.local
    name: dev
users:
  - name: dev
    user:
      token: dummy
contexts:
  - name: dev
    context:
      cluster: dev
      user: dev
```
Just save it somewhere, then add it with the command *Kubernetes: Set Kubeconfig*.

Then just open the Kubernetes plugin view and note the no longer missing icon to the left of the cluster name.

I also found the issue reproduced in the [gitlens plugin](https://open-vsx.org/extension/eamodio/gitlens) list of commits, here's a before/after comparison:

![image](https://github.com/eclipse-theia/theia/assets/105274814/925d7222-7677-4c3d-b84e-c1dc83773bf7)

To reproduce this you can just install gitlens and open any git repository.

All this works on the Theia browser example.

#### Follow-ups

None that I can see.

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
