### PR TITLE
vscode support of editor.indentSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [vscode] added support for `autoClosingPairs` in the `LanguageConfiguration ` VS Code API [#13088](https://github.com/eclipse-theia/theia/pull/13088) - contributed on behalf of STMicroelectronics
 - [task] prevent task widget title from being changed by task process [#13003](https://github.com/eclipse-theia/theia/pull/13003)
 - [vscode] added Notebook CodeActionKind [#13093](https://github.com/eclipse-theia/theia/pull/13093) - contributed on behalf of STMicroelectronics
+- [vscode] added support for editor.indentSize API [#13105](https://github.com/eclipse-theia/theia/pull/13105) - contributed on behalf of STMicroelectronics
 - [vscode] added support to env.ondidChangeShell event [#13097](https://github.com/eclipse-theia/theia/pull/13097) - contributed on behalf of STMicroelectronics
 - [task] support `isDefault: false` in task group definition [#13075](https://github.com/eclipse-theia/theia/pull/13075) - contributed on behalf of STMicroelectronics
 

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -265,10 +265,12 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             ({
                 label: size === tabSize ? size + '   ' + nls.localizeByDefault('Configured Tab Size') : size.toString(),
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                execute: () => model.updateOptions({
-                    tabSize: size || tabSize,
-                    insertSpaces: useSpaces
-                })
+                execute: () =>
+                    model.updateOptions({
+                        tabSize: size || tabSize,
+                        indentSize: size || tabSize,
+                        insertSpaces: useSpaces
+                    })
             })
             );
             this.quickInputService?.showQuickPick(tabSizeOptions, { placeholder: nls.localizeByDefault('Select Tab Size for Current File') });

--- a/packages/monaco/src/browser/monaco-status-bar-contribution.ts
+++ b/packages/monaco/src/browser/monaco-status-bar-contribution.ts
@@ -67,8 +67,9 @@ export class MonacoStatusBarContribution implements FrontendApplicationContribut
         if (editor && editorModel) {
             const modelOptions = editorModel.getOptions();
             const tabSize = modelOptions.tabSize;
+            const indentSize = modelOptions.indentSize;
             const spaceOrTabSizeMessage = modelOptions.insertSpaces
-                ? nls.localizeByDefault('Spaces: {0}', tabSize)
+                ? nls.localizeByDefault('Spaces: {0}', indentSize)
                 : nls.localizeByDefault('Tab Size: {0}', tabSize);
             this.statusBar.setElement('editor-status-tabbing-config', {
                 text: spaceOrTabSizeMessage,

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -127,12 +127,15 @@ export class MonacoTextModelService implements ITextModelService {
 
     protected readonly modelOptions: { [name: string]: (keyof ITextModelUpdateOptions | undefined) } = {
         'editor.tabSize': 'tabSize',
-        'editor.insertSpaces': 'insertSpaces'
+        'editor.insertSpaces': 'insertSpaces',
+        'editor.indentSize': 'indentSize'
     };
 
     protected toModelOption(editorPreference: EditorPreferenceChange['preferenceName']): keyof ITextModelUpdateOptions | undefined {
         switch (editorPreference) {
             case 'editor.tabSize': return 'tabSize';
+            // @monaco-uplift: uncomment this line once 'editor.indentSize' preference is available
+            //  case 'editor.indentSize': return 'indentSize';
             case 'editor.insertSpaces': return 'insertSpaces';
             case 'editor.bracketPairColorization.enabled':
             case 'editor.bracketPairColorization.independentColorPoolPerBracketType':
@@ -170,6 +173,8 @@ export class MonacoTextModelService implements ITextModelService {
         const overrideIdentifier = typeof arg === 'string' ? undefined : arg.languageId;
         return {
             tabSize: this.editorPreferences.get({ preferenceName: 'editor.tabSize', overrideIdentifier }, undefined, uri),
+            // @monaco-uplift: when available, switch to 'editor.indentSize' preference.
+            indentSize: this.editorPreferences.get({ preferenceName: 'editor.tabSize', overrideIdentifier }, undefined, uri),
             insertSpaces: this.editorPreferences.get({ preferenceName: 'editor.insertSpaces', overrideIdentifier }, undefined, uri),
             bracketColorizationOptions: {
                 enabled: this.editorPreferences.get({ preferenceName: 'editor.bracketPairColorization.enabled', overrideIdentifier }, undefined, uri),

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1125,6 +1125,7 @@ export interface Selection {
 
 export interface TextEditorConfiguration {
     tabSize: number;
+    indentSize: number;
     insertSpaces: boolean;
     cursorStyle: TextEditorCursorStyle;
     lineNumbers: TextEditorLineNumbersStyle;
@@ -1132,6 +1133,7 @@ export interface TextEditorConfiguration {
 
 export interface TextEditorConfigurationUpdate {
     tabSize?: number | 'auto';
+    indentSize?: number | 'tabSize';
     insertSpaces?: boolean | 'auto';
     cursorStyle?: TextEditorCursorStyle;
     lineNumbers?: TextEditorLineNumbersStyle;

--- a/packages/plugin-ext/src/main/browser/text-editor-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-main.ts
@@ -194,6 +194,13 @@ export class TextEditorMain implements Disposable {
         if (typeof newConfiguration.tabSize !== 'undefined') {
             newOpts.tabSize = newConfiguration.tabSize;
         }
+        if (typeof newConfiguration.indentSize !== 'undefined') {
+            if (newConfiguration.indentSize === 'tabSize') {
+                newOpts.indentSize = newConfiguration.tabSize;
+            } else if (typeof newConfiguration.indentSize == 'number') {
+                newOpts.indentSize = newConfiguration.indentSize;
+            }
+        }
         this.model.updateOptions(newOpts);
     }
 
@@ -408,6 +415,7 @@ export class TextEditorPropertiesMain {
         const modelOptions = model.getOptions();
         return {
             insertSpaces: modelOptions.insertSpaces,
+            indentSize: modelOptions.indentSize,
             tabSize: modelOptions.tabSize,
             cursorStyle,
             lineNumbers,
@@ -443,6 +451,7 @@ export class TextEditorPropertiesMain {
         return (
             a.tabSize === b.tabSize
             && a.insertSpaces === b.insertSpaces
+            && a.indentSize === b.indentSize
             && a.cursorStyle === b.cursorStyle
             && a.lineNumbers === b.lineNumbers
         );

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1910,6 +1910,14 @@ export module '@theia/plugin' {
         tabSize?: number | string;
 
         /**
+         * The number of spaces to insert when {@link TextEditorOptions.insertSpaces insertSpaces} is true.
+         *
+         * When getting a text editor's options, this property will always be a number (resolved).
+         * When setting a text editor's options, this property is optional and it can be a number or `"tabSize"`.
+         */
+        indentSize?: number | string;
+
+        /**
          * When pressing Tab insert {@link TextEditorOptions.tabSize n} spaces.
          * When getting a text editor's options, this property will always be a boolean (resolved).
          * When setting a text editor's options, this property is optional and it can be a boolean or `"auto"`.


### PR DESCRIPTION
#### What it does

Fix missing API TextEditorOptions.indentSize made public on vscode 1.83 (was a proposed API before). 
The behavior is available, but the preference requires an uplift of the monaco version. It is not yet available in the generated preferences. 

Fixes #13058

Contributed on behalf of ST Microelectronics

#### How to test 
The test can be done on a text file, using "Indent using spaces" and "Indent using tabs" commands. The behavior should be the same as before. Only the internals have changed. 
The preferences test has to wait the monaco uplift.

The following provided extension can also show the value of identSize when the value has changed with an information message:
- zip: [indent-sample-0.0.1.zip](https://github.com/eclipse-theia/theia/files/13347091/indent-sample-0.0.1.zip)
- src: [indent-sample-src-0.01.zip](https://github.com/eclipse-theia/theia/files/13347093/indent-sample-src-0.01.zip)

#### Follow-ups

Preferences need to be supported once a monaco uplift has been performed.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)