### PR TITLE
license: update baseline

### DIFF
--- a/dependency-check-baseline.json
+++ b/dependency-check-baseline.json
@@ -1,11 +1,9 @@
 {
   "npm/npmjs/-/allure-commandline/2.23.0": "Approved https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/9379",
-  "npm/npmjs/-/clone/2.1.2": "Under review, license believed to be MIT: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/7971",
   "npm/npmjs/-/eslint-plugin-deprecation/1.2.1": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22573",
   "npm/npmjs/-/jschardet/2.3.0": "Approved for Eclipse Theia: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22481",
   "npm/npmjs/-/jsdom/11.12.0": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640",
   "npm/npmjs/-/lzma-native/8.0.6": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/1850",
-  "npm/npmjs/-/playwright-core/1.22.2": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/2734",
-  "npm/npmjs/@octokit/openapi-types/12.11.0": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/7693",
-  "npm/npmjs/@octokit/openapi-types/16.0.0": "Under review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/7694"
+  "npm/npmjs/-/normalize-package-data/3.0.3": "Under review, licence believed to be BSD-2-Clause: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/11614",
+  "npm/npmjs/-/playwright-core/1.22.2": "Approved as 'works-with': https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/2734"
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates our `dependency-check-baseline.json` to reflect the latest state of the repository.
The updates include:
- Removing past entries which have been approved and are no longer needed in the baseline
- Add `normalize-package-data` as a dependency which is currently under-review (the dependency was manually verified as being license compatible)

The changes are necessary to ensure the `license:check` passes and we can better identify actual problems with dependencies going forward.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Confirm that the `3PP License Check` CI step is passing (can run `yarn license:check` locally as well)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
