### PR TITLE
Add option to copy `trash` dependency to bundle

### DIFF
--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -393,6 +393,7 @@ if (process.platform !== 'win32') {
 
 const nativePlugin = new NativeWebpackPlugin({
     out: 'native',
+    trash: ${this.ifPackage('@theia/filesystem', 'true', 'false')},
     ripgrep: ${this.ifPackage(['@theia/search-in-workspace', '@theia/file-search'], 'true', 'false')},
     pty: ${this.ifPackage('@theia/process', 'true', 'false')},
     nativeBindings: {

--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -27,6 +27,7 @@ const REQUIRE_KEYMAPPING = './build/Release/keymapping';
 
 export interface NativeWebpackPluginOptions {
     out: string;
+    trash: boolean;
     ripgrep: boolean;
     pty: boolean;
     replacements?: Record<string, string>;
@@ -95,7 +96,9 @@ export class NativeWebpackPlugin {
             }
         );
         compiler.hooks.afterEmit.tapPromise(NativeWebpackPlugin.name, async () => {
-            await this.copyTrashHelper(compiler);
+            if (this.options.trash) {
+                await this.copyTrashHelper(compiler);
+            }
             if (this.options.ripgrep) {
                 await this.copyRipgrep(compiler);
             }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13110

Only copies the `trash` native binaries in case the adopter has included `@theia/filesystem` in their build.

#### How to test

Create a minimal Theia app like in the issue above. The backend should be bundled successfully.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
