### PR TITLE
fix: clear error message when group is undefined

### DIFF
--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -143,7 +143,7 @@ export class ToolbarImpl extends TabBarToolbar {
 
     protected renderGroupsInColumn(groups: ToolbarItem[][], alignment: ToolbarAlignment): React.ReactNode[] {
         const nodes: React.ReactNode[] = [];
-        groups.forEach((group, groupIndex) => {
+        groups?.forEach((group, groupIndex) => {
             if (nodes.length && group.length) {
                 nodes.push(<div key={`toolbar-separator-${groupIndex}`} className='separator' />);
             }


### PR DESCRIPTION
#### What it does

clear error message when group is undefined
![image](https://github.com/eclipse-theia/theia/assets/17584383/ed4ce75d-1d7d-4477-a077-55e102575580)

#### How to test

import @theia/toolbar on pakcage.json
#### Follow-ups

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
