### PR TITLE
Bump API version to 1.83.1

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.82.0';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.83.1';


### PR DESCRIPTION
#### What it does

Increase compatibility version to 1.83.0 as implementation tasks from task #13062  are closed.
Fixes https://github.com/eclipse-theia/theia/issues/13065

Contributed on behalf of ST Microelectronics

#### How to test
Make sure the system starts and built-ins work as expected as described in https://github.com/eclipse-theia/vscode-builtin-extensions/wiki/Produce-and-Publish-the-set-of-vscode-built-in-extensions#local-testing

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)