### PR TITLE
Update nls metadata for vscode API 1.83

### DIFF
--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -39,9 +39,6 @@
 		"vs/workbench/electron-sandbox/desktop.main": [
 			"join.closeStorage"
 		],
-		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
-			"join.textFiles"
-		],
 		"vs/workbench/electron-sandbox/desktop.contribution": [
 			"newTab",
 			"showPreviousTab",
@@ -77,7 +74,6 @@
 			"closeWhenEmpty",
 			"window.doubleClickIconToClose",
 			"titleBarStyle",
-			"nativeContextMenuLocation",
 			"dialogStyle",
 			"window.nativeTabs",
 			"window.nativeFullScreen",
@@ -97,6 +93,9 @@
 			"argv.logLevel",
 			"argv.disableChromiumSandbox",
 			"argv.force-renderer-accessibility"
+		],
+		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
+			"join.textFiles"
 		],
 		"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService": [
 			"saveWorkspaceMessage",
@@ -147,14 +146,21 @@
 			"integrity.moreInformation",
 			"integrity.dontShowAgain"
 		],
-		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
-			"join.workingCopyBackups"
+		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
+			"revealInWindows",
+			"revealInMac",
+			"openContainer",
+			"miShare",
+			"filesCategory"
 		],
 		"vs/workbench/services/voiceRecognition/electron-sandbox/workbenchVoiceRecognitionService": [
 			"voiceTranscription",
 			"voiceTranscriptionGettingReady",
 			"voiceTranscriptionRecording",
 			"voiceTranscriptionError"
+		],
+		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
+			"join.workingCopyBackups"
 		],
 		"vs/workbench/services/extensions/electron-sandbox/nativeExtensionService": [
 			"extensionService.versionMismatchCrash",
@@ -174,20 +180,18 @@
 			"restartExtensionHost",
 			"restartExtensionHost.reason"
 		],
+		"vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution": [
+			"runtimeExtension"
+		],
 		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
 			"updateLocale",
 			"changeAndRestart",
 			"neverAgain"
 		],
-		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
-			"revealInWindows",
-			"revealInMac",
-			"openContainer",
-			"miShare",
-			"filesCategory"
-		],
-		"vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution": [
-			"runtimeExtension"
+		"vs/workbench/contrib/remote/electron-sandbox/remote.contribution": [
+			"wslFeatureInstalled",
+			"remote",
+			"remote.downloadExtensionsLocally"
 		],
 		"vs/workbench/contrib/issue/electron-sandbox/issue.contribution": [
 			{
@@ -214,17 +218,11 @@
 			"stopTracing.title",
 			"stopTracing.detail"
 		],
-		"vs/workbench/contrib/remote/electron-sandbox/remote.contribution": [
-			"wslFeatureInstalled",
-			"remote",
-			"remote.downloadExtensionsLocally"
-		],
 		"vs/workbench/contrib/userDataSync/electron-sandbox/userDataSync.contribution": [
 			"Open Backup folder",
-			"no backups"
-		],
-		"vs/workbench/contrib/performance/electron-sandbox/performance.contribution": [
-			"experimental.rendererProfiling"
+			"no backups",
+			"download sync activity complete",
+			"open"
 		],
 		"vs/workbench/contrib/tasks/electron-sandbox/taskService": [
 			"TaskSystem.runningTask",
@@ -241,6 +239,9 @@
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/workbench/contrib/performance/electron-sandbox/performance.contribution": [
+			"experimental.rendererProfiling"
 		],
 		"vs/workbench/contrib/externalTerminal/electron-sandbox/externalTerminal.contribution": [
 			"globalConsoleAction",
@@ -353,57 +354,6 @@
 				]
 			}
 		],
-		"vs/platform/environment/node/argv": [
-			"optionsUpperCase",
-			"extensionsManagement",
-			"troubleshooting",
-			"cliDataDir",
-			"cliDataDir",
-			"diff",
-			"merge",
-			"add",
-			"goto",
-			"newWindow",
-			"reuseWindow",
-			"wait",
-			"locale",
-			"userDataDir",
-			"profileName",
-			"help",
-			"extensionHomePath",
-			"listExtensions",
-			"showVersions",
-			"category",
-			"installExtension",
-			"install prerelease",
-			"uninstallExtension",
-			"experimentalApis",
-			"version",
-			"verbose",
-			"log",
-			"status",
-			"prof-startup",
-			"disableExtensions",
-			"disableExtension",
-			"turn sync",
-			"inspect-extensions",
-			"inspect-brk-extensions",
-			"disableGPU",
-			"disableChromiumSandbox",
-			"telemetry",
-			"deprecated.useInstead",
-			"paths",
-			"usage",
-			"options",
-			"stdinWindows",
-			"stdinUnix",
-			"subcommands",
-			"unknownVersion",
-			"unknownCommit"
-		],
-		"vs/platform/terminal/node/ptyService": [
-			"terminal-history-restored"
-		],
 		"vs/editor/common/config/editorOptions": [
 			"accessibilitySupport.auto",
 			"accessibilitySupport.on",
@@ -450,6 +400,7 @@
 			"hover.enabled",
 			"hover.delay",
 			"hover.sticky",
+			"hover.hidingDelay",
 			"hover.above",
 			"wrappingStrategy.simple",
 			"wrappingStrategy.advanced",
@@ -609,6 +560,9 @@
 			"editor.autoClosingBrackets.languageDefined",
 			"editor.autoClosingBrackets.beforeWhitespace",
 			"autoClosingBrackets",
+			"editor.autoClosingComments.languageDefined",
+			"editor.autoClosingComments.beforeWhitespace",
+			"autoClosingComments",
 			"editor.autoClosingDelete.auto",
 			"autoClosingDelete",
 			"editor.autoClosingOvertype.auto",
@@ -777,6 +731,57 @@
 			"defaultColorDecorators",
 			"tabFocusMode"
 		],
+		"vs/platform/environment/node/argv": [
+			"optionsUpperCase",
+			"extensionsManagement",
+			"troubleshooting",
+			"cliDataDir",
+			"cliDataDir",
+			"diff",
+			"merge",
+			"add",
+			"goto",
+			"newWindow",
+			"reuseWindow",
+			"wait",
+			"locale",
+			"userDataDir",
+			"profileName",
+			"help",
+			"extensionHomePath",
+			"listExtensions",
+			"showVersions",
+			"category",
+			"installExtension",
+			"install prerelease",
+			"uninstallExtension",
+			"experimentalApis",
+			"version",
+			"verbose",
+			"log",
+			"status",
+			"prof-startup",
+			"disableExtensions",
+			"disableExtension",
+			"turn sync",
+			"inspect-extensions",
+			"inspect-brk-extensions",
+			"disableGPU",
+			"disableChromiumSandbox",
+			"telemetry",
+			"deprecated.useInstead",
+			"paths",
+			"usage",
+			"options",
+			"stdinWindows",
+			"stdinUnix",
+			"subcommands",
+			"unknownVersion",
+			"unknownCommit"
+		],
+		"vs/platform/terminal/node/ptyService": [
+			"terminal-history-restored"
+		],
 		"vs/base/common/errorMessage": [
 			"stackTrace.format",
 			"nodeExceptionMessage",
@@ -801,14 +806,6 @@
 			"confirmOpenMessage",
 			"confirmOpenDetail"
 		],
-		"vs/platform/environment/node/argvHelper": [
-			"multipleValues",
-			"emptyValue",
-			"deprecatedArgument",
-			"unknownSubCommandOption",
-			"unknownOption",
-			"gotoValidation"
-		],
 		"vs/platform/files/common/files": [
 			"unknownError",
 			"sizeB",
@@ -817,6 +814,23 @@
 			"sizeGB",
 			"sizeTB"
 		],
+		"vs/platform/environment/node/argvHelper": [
+			"multipleValues",
+			"emptyValue",
+			"deprecatedArgument",
+			"unknownSubCommandOption",
+			"unknownOption",
+			"gotoValidation"
+		],
+		"vs/platform/files/node/diskFileSystemProvider": [
+			"fileExists",
+			"fileNotExists",
+			"moveError",
+			"copyError",
+			"fileCopyErrorPathCase",
+			"fileMoveCopyErrorNotFound",
+			"fileMoveCopyErrorExists"
+		],
 		"vs/platform/files/common/fileService": [
 			"invalidPath",
 			"noProviderFound",
@@ -824,7 +838,8 @@
 			"fileExists",
 			"err.write",
 			"writeFailedUnlockUnsupported",
-			"writeFailedAtomicUnsupported",
+			"writeFailedAtomicUnsupported1",
+			"writeFailedAtomicUnsupported2",
 			"writeFailedAtomicUnlock",
 			"fileIsDirectoryWriteError",
 			"fileModifiedError",
@@ -845,15 +860,6 @@
 			"err.readonly",
 			"err.readonly"
 		],
-		"vs/platform/files/node/diskFileSystemProvider": [
-			"fileExists",
-			"fileNotExists",
-			"moveError",
-			"copyError",
-			"fileCopyErrorPathCase",
-			"fileMoveCopyErrorNotFound",
-			"fileMoveCopyErrorExists"
-		],
 		"vs/platform/request/common/request": [
 			"request",
 			"httpConfigurationTitle",
@@ -866,7 +872,8 @@
 			"proxySupportFallback",
 			"proxySupportOverride",
 			"proxySupport",
-			"systemCertificates"
+			"systemCertificates",
+			"systemCertificatesV2"
 		],
 		"vs/platform/dialogs/common/dialogs": [
 			{
@@ -972,12 +979,25 @@
 			"description",
 			"featureRequestDescription",
 			"pasteData",
+			"selectExtension",
 			"disabledExtensions",
 			"noCurrentExperiments"
 		],
 		"vs/platform/extensionManagement/common/extensionManagement": [
 			"extensions",
 			"preferences"
+		],
+		"vs/platform/extensionManagement/common/extensionsScannerService": [
+			"fileReadFail",
+			"jsonParseFail",
+			"jsonParseInvalidType",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat"
+		],
+		"vs/platform/languagePacks/common/languagePacks": [
+			"currentDisplayLanguage"
 		],
 		"vs/platform/extensionManagement/common/extensionManagementCLI": [
 			"notFound",
@@ -1008,15 +1028,6 @@
 			"notInstalleddOnLocation",
 			"notInstalled"
 		],
-		"vs/platform/extensionManagement/common/extensionsScannerService": [
-			"fileReadFail",
-			"jsonParseFail",
-			"jsonParseInvalidType",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat",
-			"jsonsParseReportErrors",
-			"jsonInvalidFormat"
-		],
 		"vs/platform/extensionManagement/node/extensionManagementService": [
 			"incompatible",
 			"MarketPlaceDisabled",
@@ -1027,9 +1038,6 @@
 			"cannot read",
 			"restartCode",
 			"restartCode"
-		],
-		"vs/platform/languagePacks/common/languagePacks": [
-			"currentDisplayLanguage"
 		],
 		"vs/platform/telemetry/common/telemetryService": [
 			"telemetry.telemetryLevelMd",
@@ -1064,11 +1072,14 @@
 			"app.extension.identifier.errorMessage",
 			"settingsSync.ignoredSettings"
 		],
+		"vs/platform/userDataSync/common/userDataSyncMachines": [
+			"error incompatible"
+		],
 		"vs/platform/userDataSync/common/userDataSyncLog": [
 			"userDataSyncLog"
 		],
-		"vs/platform/userDataSync/common/userDataSyncMachines": [
-			"error incompatible"
+		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
+			"incompatible sync data"
 		],
 		"vs/platform/remoteTunnel/common/remoteTunnel": [
 			"remoteTunnelLog"
@@ -1089,131 +1100,6 @@
 			},
 			"remoteTunnelService.openTunnel",
 			"remoteTunnelService.serviceInstallFailed"
-		],
-		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
-			"incompatible sync data"
-		],
-		"vs/editor/common/languages": [
-			"Array",
-			"Boolean",
-			"Class",
-			"Constant",
-			"Constructor",
-			"Enum",
-			"EnumMember",
-			"Event",
-			"Field",
-			"File",
-			"Function",
-			"Interface",
-			"Key",
-			"Method",
-			"Module",
-			"Namespace",
-			"Null",
-			"Number",
-			"Object",
-			"Operator",
-			"Package",
-			"Property",
-			"String",
-			"Struct",
-			"TypeParameter",
-			"Variable",
-			"symbolAriaLabel"
-		],
-		"vs/workbench/browser/workbench": [
-			"loaderErrorNative"
-		],
-		"vs/workbench/electron-sandbox/window": [
-			"restart",
-			"configure",
-			"learnMore",
-			"keychainWriteError",
-			"troubleshooting",
-			"runningTranslated",
-			"downloadArmBuild",
-			"proxyAuthRequired",
-			{
-				"key": "loginButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"username",
-			"password",
-			"proxyDetail",
-			"rememberCredentials",
-			"quitMessageMac",
-			"quitMessage",
-			"closeWindowMessage",
-			{
-				"key": "quitButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "exitButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			{
-				"key": "closeWindowButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"doNotAskAgain",
-			"shutdownErrorDetail",
-			"willShutdownDetail",
-			"shutdownErrorClose",
-			"shutdownErrorQuit",
-			"shutdownErrorReload",
-			"shutdownErrorLoad",
-			"shutdownTitleClose",
-			"shutdownTitleQuit",
-			"shutdownTitleReload",
-			"shutdownTitleLoad",
-			"shutdownForceClose",
-			"shutdownForceQuit",
-			"shutdownForceReload",
-			"shutdownForceLoad",
-			"loaderCycle",
-			"runningAsRoot",
-			"appRootWarning.banner",
-			"windows32eolmessage",
-			"windowseolBannerLearnMore",
-			"windowseolarialabel",
-			"learnMore",
-			"resolveShellEnvironment",
-			"learnMore"
-		],
-		"vs/workbench/services/configuration/browser/configurationService": [
-			"configurationDefaults.description",
-			"experimental",
-			"setting description"
-		],
-		"vs/platform/workspace/common/workspace": [
-			"codeWorkspace"
-		],
-		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
-			"devTools",
-			"directUrl",
-			"connectionError"
-		],
-		"vs/workbench/services/log/electron-sandbox/logService": [
-			"rendererLog"
-		],
-		"vs/platform/workspace/common/workspaceTrust": [
-			"trusted",
-			"untrusted"
-		],
-		"vs/workbench/services/userDataProfile/common/userDataProfile": [
-			"defaultProfileIcon",
-			"profiles",
-			"profile"
 		],
 		"vs/platform/list/browser/listService": [
 			"workbenchConfigurationTitle",
@@ -1251,7 +1137,7 @@
 			"defaultFindMatchTypeSettingKey.contiguous",
 			"defaultFindMatchTypeSettingKey",
 			"expand mode",
-			"typeNavigationMode"
+			"typeNavigationMode2"
 		],
 		"vs/platform/markers/common/markers": [
 			"sev.error",
@@ -1273,14 +1159,6 @@
 			"contextkey.parser.error.expectedButGot",
 			"contextkey.scanner.errorForLinterWithHint",
 			"contextkey.scanner.errorForLinter"
-		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"undo",
-			"redo",
-			"cut",
-			"copy",
-			"paste",
-			"selectAll"
 		],
 		"vs/workbench/browser/workbench.contribution": [
 			"workbench.editor.titleScrollbarSizing.default",
@@ -1319,7 +1197,7 @@
 				"comment": [
 					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
 				],
-				"key": "untitledHint"
+				"key": "emptyEditorHint"
 			},
 			"workbench.editor.languageDetection",
 			"workbench.editor.historyBasedLanguageDetection",
@@ -1354,6 +1232,12 @@
 				],
 				"key": "workbench.editor.tabSizingFixedMaxWidth"
 			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.editor.tabHeight"
+			},
 			"workbench.editor.pinnedTabSizing.normal",
 			"workbench.editor.pinnedTabSizing.compact",
 			"workbench.editor.pinnedTabSizing.shrink",
@@ -1363,6 +1247,7 @@
 				],
 				"key": "pinnedTabSizing"
 			},
+			"workbench.editor.pinnedTabsOnSeparateRow",
 			"workbench.editor.preventPinnedEditorClose.always",
 			"workbench.editor.preventPinnedEditorClose.onlyKeyboard",
 			"workbench.editor.preventPinnedEditorClose.onlyMouse",
@@ -1423,6 +1308,9 @@
 			"commandHistory",
 			"preserveInput",
 			"suggestCommands",
+			"askChatLocation",
+			"askChatLocation.chatView",
+			"askChatLocation.quickChat",
 			"enableNaturalLanguageSearch",
 			"closeOnFocusLost",
 			"workbench.quickOpen.preserveInput",
@@ -1537,6 +1425,65 @@
 			"zenMode.restore",
 			"zenMode.silentNotifications"
 		],
+		"vs/workbench/browser/actions/textInputActions": [
+			"undo",
+			"redo",
+			"cut",
+			"copy",
+			"paste",
+			"selectAll"
+		],
+		"vs/workbench/browser/actions/developerActions": [
+			"inspect context keys",
+			"toggle screencast mode",
+			{
+				"key": "logStorage",
+				"comment": [
+					"A developer only action to log the contents of the storage for the current window."
+				]
+			},
+			"storageLogDialogMessage",
+			"storageLogDialogDetails",
+			{
+				"key": "logWorkingCopies",
+				"comment": [
+					"A developer only action to log the working copies that exist."
+				]
+			},
+			"removeLargeStorageDatabaseEntries",
+			"largeStorageItemDetail",
+			"global",
+			"profile",
+			"workspace",
+			"machine",
+			"user",
+			"removeLargeStorageEntriesPickerButton",
+			"removeLargeStorageEntriesPickerPlaceholder",
+			"removeLargeStorageEntriesPickerDescriptionNoEntries",
+			"removeLargeStorageEntriesConfirmRemove",
+			"removeLargeStorageEntriesConfirmRemoveDetail",
+			{
+				"key": "removeLargeStorageEntriesButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"startTrackDisposables",
+			"snapshotTrackedDisposables",
+			"stopTrackDisposables",
+			"screencastModeConfigurationTitle",
+			"screencastMode.location.verticalPosition",
+			"screencastMode.fontSize",
+			"screencastMode.keyboardOptions.description",
+			"screencastMode.keyboardOptions.showKeys",
+			"screencastMode.keyboardOptions.showKeybindings",
+			"screencastMode.keyboardOptions.showCommands",
+			"screencastMode.keyboardOptions.showCommandGroups",
+			"screencastMode.keyboardOptions.showSingleEditorCursorMoves",
+			"screencastMode.keyboardOverlayTimeout",
+			"screencastMode.mouseIndicatorColor",
+			"screencastMode.mouseIndicatorSize"
+		],
 		"vs/workbench/browser/actions/helpActions": [
 			"keybindingsReference",
 			{
@@ -1595,36 +1542,6 @@
 					"&& denotes a mnemonic"
 				]
 			}
-		],
-		"vs/workbench/browser/actions/developerActions": [
-			"inspect context keys",
-			"toggle screencast mode",
-			{
-				"key": "logStorage",
-				"comment": [
-					"A developer only action to log the contents of the storage for the current window."
-				]
-			},
-			"storageLogDialogMessage",
-			"storageLogDialogDetails",
-			{
-				"key": "logWorkingCopies",
-				"comment": [
-					"A developer only action to log the working copies that exist."
-				]
-			},
-			"screencastModeConfigurationTitle",
-			"screencastMode.location.verticalPosition",
-			"screencastMode.fontSize",
-			"screencastMode.keyboardOptions.description",
-			"screencastMode.keyboardOptions.showKeys",
-			"screencastMode.keyboardOptions.showKeybindings",
-			"screencastMode.keyboardOptions.showCommands",
-			"screencastMode.keyboardOptions.showCommandGroups",
-			"screencastMode.keyboardOptions.showSingleEditorCursorMoves",
-			"screencastMode.keyboardOverlayTimeout",
-			"screencastMode.mouseIndicatorColor",
-			"screencastMode.mouseIndicatorSize"
 		],
 		"vs/workbench/browser/actions/layoutActions": [
 			"menuBarIcon",
@@ -1717,6 +1634,7 @@
 				]
 			},
 			"toggleTabs",
+			"toggleSeparatePinnedEditorTabs",
 			"toggleZenMode",
 			{
 				"key": "miToggleZenMode",
@@ -1858,17 +1776,6 @@
 				]
 			}
 		],
-		"vs/workbench/browser/actions/workspaceCommands": [
-			"addFolderToWorkspace",
-			{
-				"key": "add",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"addFolderToWorkspaceTitle",
-			"workspaceFolderPickerPlaceholder"
-		],
 		"vs/workbench/browser/actions/workspaceActions": [
 			"workspaces",
 			"openFile",
@@ -1932,6 +1839,17 @@
 				]
 			}
 		],
+		"vs/workbench/browser/actions/workspaceCommands": [
+			"addFolderToWorkspace",
+			{
+				"key": "add",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"addFolderToWorkspaceTitle",
+			"workspaceFolderPickerPlaceholder"
+		],
 		"vs/workbench/browser/actions/quickAccessActions": [
 			"quickOpen",
 			"quickOpenWithModes",
@@ -1939,50 +1857,6 @@
 			"quickNavigatePrevious",
 			"quickSelectNext",
 			"quickSelectPrevious"
-		],
-		"vs/workbench/api/common/configurationExtensionPoint": [
-			"vscode.extension.contributes.configuration.title",
-			"vscode.extension.contributes.configuration.order",
-			"vscode.extension.contributes.configuration.properties",
-			"vscode.extension.contributes.configuration.property.empty",
-			"vscode.extension.contributes.configuration.properties.schema",
-			"scope.application.description",
-			"scope.machine.description",
-			"scope.window.description",
-			"scope.resource.description",
-			"scope.language-overridable.description",
-			"scope.machine-overridable.description",
-			"scope.description",
-			"scope.enumDescriptions",
-			"scope.markdownEnumDescriptions",
-			"scope.enumItemLabels",
-			"scope.markdownDescription",
-			"scope.deprecationMessage",
-			"scope.markdownDeprecationMessage",
-			"scope.singlelineText.description",
-			"scope.multilineText.description",
-			"scope.editPresentation",
-			"scope.order",
-			"scope.ignoreSync",
-			"config.property.defaultConfiguration.warning",
-			"vscode.extension.contributes.configuration",
-			"invalid.title",
-			"invalid.properties",
-			"config.property.duplicate",
-			"invalid.property",
-			"invalid.allOf",
-			"workspaceConfig.folders.description",
-			"workspaceConfig.path.description",
-			"workspaceConfig.name.description",
-			"workspaceConfig.uri.description",
-			"workspaceConfig.name.description",
-			"workspaceConfig.settings.description",
-			"workspaceConfig.launch.description",
-			"workspaceConfig.tasks.description",
-			"workspaceConfig.extensions.description",
-			"workspaceConfig.remoteAuthority",
-			"workspaceConfig.transient",
-			"unknownWorkspaceProperty"
 		],
 		"vs/workbench/services/actions/common/menusExtensionPoint": [
 			"menus.commandPalette",
@@ -2108,6 +1982,50 @@
 			"missing.submenu",
 			"submenuItem.duplicate"
 		],
+		"vs/workbench/api/common/configurationExtensionPoint": [
+			"vscode.extension.contributes.configuration.title",
+			"vscode.extension.contributes.configuration.order",
+			"vscode.extension.contributes.configuration.properties",
+			"vscode.extension.contributes.configuration.property.empty",
+			"vscode.extension.contributes.configuration.properties.schema",
+			"scope.application.description",
+			"scope.machine.description",
+			"scope.window.description",
+			"scope.resource.description",
+			"scope.language-overridable.description",
+			"scope.machine-overridable.description",
+			"scope.description",
+			"scope.enumDescriptions",
+			"scope.markdownEnumDescriptions",
+			"scope.enumItemLabels",
+			"scope.markdownDescription",
+			"scope.deprecationMessage",
+			"scope.markdownDeprecationMessage",
+			"scope.singlelineText.description",
+			"scope.multilineText.description",
+			"scope.editPresentation",
+			"scope.order",
+			"scope.ignoreSync",
+			"config.property.defaultConfiguration.warning",
+			"vscode.extension.contributes.configuration",
+			"invalid.title",
+			"invalid.properties",
+			"config.property.duplicate",
+			"invalid.property",
+			"invalid.allOf",
+			"workspaceConfig.folders.description",
+			"workspaceConfig.path.description",
+			"workspaceConfig.name.description",
+			"workspaceConfig.uri.description",
+			"workspaceConfig.name.description",
+			"workspaceConfig.settings.description",
+			"workspaceConfig.launch.description",
+			"workspaceConfig.tasks.description",
+			"workspaceConfig.extensions.description",
+			"workspaceConfig.remoteAuthority",
+			"workspaceConfig.transient",
+			"unknownWorkspaceProperty"
+		],
 		"vs/workbench/api/browser/viewsExtensionPoint": [
 			{
 				"key": "vscode.extension.contributes.views.containers.id",
@@ -2188,6 +2106,7 @@
 			"splitLeft",
 			"splitRight",
 			"toggleTabs",
+			"toggleSeparatePinnedEditorTabs",
 			"close",
 			"closeOthers",
 			"closeRight",
@@ -2207,7 +2126,6 @@
 			"showOpenedEditors",
 			"closeAll",
 			"closeAllSaved",
-			"toggleTabs",
 			"togglePreviewMode",
 			"lockGroup",
 			"splitEditorRight",
@@ -2503,11 +2421,11 @@
 				]
 			}
 		],
-		"vs/workbench/browser/parts/banner/bannerPart": [
-			"focusBanner"
-		],
 		"vs/workbench/browser/parts/statusbar/statusbarPart": [
 			"hideStatusBar"
+		],
+		"vs/workbench/browser/parts/banner/bannerPart": [
+			"focusBanner"
 		],
 		"vs/workbench/browser/parts/views/viewsService": [
 			"show view",
@@ -2639,6 +2557,7 @@
 				]
 			},
 			"installAndHandle",
+			"installDetail",
 			{
 				"key": "install and open",
 				"comment": [
@@ -2804,6 +2723,10 @@
 			"workspace folder",
 			"workspace"
 		],
+		"vs/workbench/services/notification/common/notificationService": [
+			"neverShowAgain",
+			"neverShowAgain"
+		],
 		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
 			"reload message when updated",
 			"reload message when removed",
@@ -2813,10 +2736,6 @@
 			"switch profile",
 			"reload message",
 			"reload button"
-		],
-		"vs/workbench/services/notification/common/notificationService": [
-			"neverShowAgain",
-			"neverShowAgain"
 		],
 		"vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService": [
 			"profile import error",
@@ -2839,10 +2758,14 @@
 			"invalid configurations",
 			"use default profile",
 			"name required",
+			"icon",
+			"select icon",
+			"select icon",
 			"create from",
 			"empty profile",
 			"from templates",
 			"from existing profiles",
+			"copy profile from",
 			"create profile",
 			"export",
 			"close",
@@ -2993,14 +2916,13 @@
 					"&& denotes a mnemonic"
 				]
 			},
+			"download sync activity dialog title",
+			"download sync activity dialog open label",
 			"choose account placeholder",
 			"signed in",
 			"last used",
 			"others",
 			"sign in using account"
-		],
-		"vs/workbench/services/assignment/common/assignmentService": [
-			"workbench.enableExperiments"
 		],
 		"vs/workbench/services/authentication/browser/authenticationService": [
 			"authentication.id",
@@ -3051,52 +2973,8 @@
 				]
 			}
 		],
-		"vs/workbench/services/issue/browser/issueTroubleshoot": [
-			"troubleshoot issue",
-			"detail.start",
-			{
-				"key": "msg",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"profile.extensions.disabled",
-			"empty.profile",
-			"issue is with configuration",
-			"issue is in core",
-			"I cannot reproduce",
-			"This is Bad",
-			"Stop",
-			"troubleshoot issue",
-			"use insiders",
-			"troubleshoot issue",
-			"download insiders",
-			"report anyway",
-			"ask to download insiders",
-			"troubleshoot issue",
-			"good",
-			"bad",
-			"stop",
-			"ask to reproduce issue",
-			"troubleshootIssue",
-			"title.stop"
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"defineKeybinding.kbLayoutErrorMessage",
-			{
-				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
-					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			},
-			{
-				"key": "defineKeybinding.kbLayoutLocalMessage",
-				"comment": [
-					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
-					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
-				]
-			}
+		"vs/workbench/services/assignment/common/assignmentService": [
+			"workbench.enableExperiments"
 		],
 		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
 			"settingsEditor2",
@@ -3165,6 +3043,53 @@
 				]
 			}
 		],
+		"vs/workbench/services/issue/browser/issueTroubleshoot": [
+			"troubleshoot issue",
+			"detail.start",
+			{
+				"key": "msg",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"profile.extensions.disabled",
+			"empty.profile",
+			"issue is with configuration",
+			"issue is in core",
+			"I cannot reproduce",
+			"This is Bad",
+			"Stop",
+			"troubleshoot issue",
+			"use insiders",
+			"troubleshoot issue",
+			"download insiders",
+			"report anyway",
+			"ask to download insiders",
+			"troubleshoot issue",
+			"good",
+			"bad",
+			"stop",
+			"ask to reproduce issue",
+			"troubleshootIssue",
+			"title.stop"
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"defineKeybinding.kbLayoutErrorMessage",
+			{
+				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
+					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			},
+			{
+				"key": "defineKeybinding.kbLayoutLocalMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
+					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			}
+		],
 		"vs/workbench/contrib/performance/browser/performance.contribution": [
 			"show.label",
 			"cycles",
@@ -3212,10 +3137,22 @@
 			"notebook.outputWordWrap",
 			"notebook.formatOnSave",
 			"notebook.codeActionsOnSave",
+			"explicit",
+			"never",
+			"explicitBoolean",
+			"neverBoolean",
 			"notebook.formatOnCellExecution",
 			"notebook.confirmDeleteRunningCell",
 			"notebook.findScope",
-			"notebook.remoteSaving"
+			"notebook.remoteSaving",
+			"notebook.scrolling.revealNextCellOnExecute.description",
+			"notebook.scrolling.revealNextCellOnExecute.fullCell.description",
+			"notebook.scrolling.revealNextCellOnExecute.firstLine.description",
+			"notebook.scrolling.revealNextCellOnExecute.none.description",
+			"notebook.scrolling.anchorToFocusedCell.description",
+			"notebook.scrolling.anchorToFocusedCell.auto.description",
+			"notebook.scrolling.anchorToFocusedCell.on.description",
+			"notebook.scrolling.anchorToFocusedCell.off.description"
 		],
 		"vs/workbench/contrib/chat/browser/chat.contribution": [
 			"interactiveSessionConfigurationTitle",
@@ -3227,6 +3164,25 @@
 			"chat",
 			"chat",
 			"clear"
+		],
+		"vs/workbench/contrib/testing/browser/testing.contribution": [
+			"test",
+			{
+				"key": "miViewTesting",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"testResultsPanelName",
+			"testResultsPanelName",
+			"noTestProvidersRegistered",
+			"searchForAdditionalTestExtensions",
+			"testExplorer"
+		],
+		"vs/workbench/contrib/logs/common/logs.contribution": [
+			"setDefaultLogLevel",
+			"remote name",
+			"show window log"
 		],
 		"vs/workbench/contrib/interactive/browser/interactive.contribution": [
 			"interactiveWindow",
@@ -3243,72 +3199,6 @@
 			"interactive.activeCodeBorder",
 			"interactive.inactiveCodeBorder",
 			"interactiveWindow.alwaysScrollOnNewCell"
-		],
-		"vs/workbench/contrib/logs/common/logs.contribution": [
-			"setDefaultLogLevel",
-			"remote name",
-			"remote name",
-			"show window log"
-		],
-		"vs/workbench/contrib/testing/browser/testing.contribution": [
-			"test",
-			{
-				"key": "miViewTesting",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"testResultsPanelName",
-			"testResultsPanelName",
-			"noTestProvidersRegistered",
-			"searchForAdditionalTestExtensions",
-			"testExplorer"
-		],
-		"vs/workbench/contrib/files/browser/explorerViewlet": [
-			"explorerViewIcon",
-			"openEditorsIcon",
-			"folders",
-			"explore",
-			"explore",
-			{
-				"key": "miViewExplorer",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"openFolder",
-			"addAFolder",
-			"openRecent",
-			{
-				"key": "noWorkspaceHelp",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			},
-			{
-				"key": "noFolderHelpWeb",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			},
-			{
-				"key": "remoteNoFolderHelp",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			},
-			{
-				"key": "noFolderButEditorsHelp",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			},
-			{
-				"key": "noFolderHelp",
-				"comment": [
-					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
-				]
-			}
 		],
 		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
 			"helpQuickAccessPlaceholder",
@@ -3421,6 +3311,52 @@
 				"key": "miGotoFile",
 				"comment": [
 					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/files/browser/explorerViewlet": [
+			"explorerViewIcon",
+			"openEditorsIcon",
+			"folders",
+			"explore",
+			"explore",
+			{
+				"key": "miViewExplorer",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"openFolder",
+			"addAFolder",
+			"openRecent",
+			{
+				"key": "noWorkspaceHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "noFolderHelpWeb",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "remoteNoFolderHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "noFolderButEditorsHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "noFolderHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
 				]
 			}
 		],
@@ -3633,6 +3569,53 @@
 			"fileOperation",
 			"refactoring.autoSave"
 		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
+			"overlap",
+			"detail",
+			{
+				"key": "continue",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"apply",
+			"cat",
+			"Discard",
+			"cat",
+			"toogleSelection",
+			"cat",
+			"groupByFile",
+			"cat",
+			"groupByType",
+			"cat",
+			"groupByType",
+			"cat",
+			"refactorPreviewViewIcon",
+			"panel",
+			"panel"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
+			"searchEditor",
+			"promptOpenWith.searchEditor.displayName",
+			"search",
+			"searchEditor.deleteResultBlock",
+			"search.openNewSearchEditor",
+			"search.openSearchEditor",
+			"search.openNewEditorToSide",
+			"search.openResultsInEditor",
+			"search.rerunSearchInEditor",
+			"search.action.focusQueryEditorWidget",
+			"search.action.focusFilesToInclude",
+			"search.action.focusFilesToExclude",
+			"searchEditor.action.toggleSearchEditorCaseSensitive",
+			"searchEditor.action.toggleSearchEditorWholeWord",
+			"searchEditor.action.toggleSearchEditorRegex",
+			"searchEditor.action.toggleSearchEditorContextLines",
+			"searchEditor.action.increaseSearchEditorContextLines",
+			"searchEditor.action.decreaseSearchEditorContextLines",
+			"searchEditor.action.selectAllSearchEditorMatches",
+			"search.openNewEditor"
+		],
 		"vs/workbench/contrib/search/browser/search.contribution": [
 			"name",
 			"search",
@@ -3718,31 +3701,6 @@
 			"search.experimental.closedNotebookResults",
 			"search.experimental.quickAccess.preserveInput"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
-			"overlap",
-			"detail",
-			{
-				"key": "continue",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"apply",
-			"cat",
-			"Discard",
-			"cat",
-			"toogleSelection",
-			"cat",
-			"groupByFile",
-			"cat",
-			"groupByType",
-			"cat",
-			"groupByType",
-			"cat",
-			"refactorPreviewViewIcon",
-			"panel",
-			"panel"
-		],
 		"vs/workbench/contrib/search/browser/searchView": [
 			"searchCanceled",
 			"moreSearch",
@@ -3806,98 +3764,9 @@
 			"searchWithoutFolder",
 			"openFolder"
 		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
-			"searchEditor",
-			"promptOpenWith.searchEditor.displayName",
-			"search",
-			"searchEditor.deleteResultBlock",
-			"search.openNewSearchEditor",
-			"search.openSearchEditor",
-			"search.openNewEditorToSide",
-			"search.openResultsInEditor",
-			"search.rerunSearchInEditor",
-			"search.action.focusQueryEditorWidget",
-			"search.action.focusFilesToInclude",
-			"search.action.focusFilesToExclude",
-			"searchEditor.action.toggleSearchEditorCaseSensitive",
-			"searchEditor.action.toggleSearchEditorWholeWord",
-			"searchEditor.action.toggleSearchEditorRegex",
-			"searchEditor.action.toggleSearchEditorContextLines",
-			"searchEditor.action.increaseSearchEditorContextLines",
-			"searchEditor.action.decreaseSearchEditorContextLines",
-			"searchEditor.action.selectAllSearchEditorMatches",
-			"search.openNewEditor"
-		],
 		"vs/workbench/contrib/sash/browser/sash.contribution": [
 			"sashSize",
 			"sashHoverDelay"
-		],
-		"vs/workbench/contrib/scm/browser/scm.contribution": [
-			"sourceControlViewIcon",
-			"source control",
-			"no open repo",
-			"no open repo in an untrusted workspace",
-			"manageWorkspaceTrustAction",
-			"source control",
-			{
-				"key": "miViewSCM",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"source control repositories",
-			"scmConfigurationTitle",
-			"scm.diffDecorations.all",
-			"scm.diffDecorations.gutter",
-			"scm.diffDecorations.overviewRuler",
-			"scm.diffDecorations.minimap",
-			"scm.diffDecorations.none",
-			"diffDecorations",
-			"diffGutterWidth",
-			"scm.diffDecorationsGutterVisibility.always",
-			"scm.diffDecorationsGutterVisibility.hover",
-			"scm.diffDecorationsGutterVisibility",
-			"scm.diffDecorationsGutterAction.diff",
-			"scm.diffDecorationsGutterAction.none",
-			"scm.diffDecorationsGutterAction",
-			"diffGutterPattern",
-			"diffGutterPatternAdded",
-			"diffGutterPatternModifed",
-			"scm.diffDecorationsIgnoreTrimWhitespace.true",
-			"scm.diffDecorationsIgnoreTrimWhitespace.false",
-			"scm.diffDecorationsIgnoreTrimWhitespace.inherit",
-			"diffDecorationsIgnoreTrimWhitespace",
-			"alwaysShowActions",
-			"scm.countBadge.all",
-			"scm.countBadge.focused",
-			"scm.countBadge.off",
-			"scm.countBadge",
-			"scm.providerCountBadge.hidden",
-			"scm.providerCountBadge.auto",
-			"scm.providerCountBadge.visible",
-			"scm.providerCountBadge",
-			"scm.defaultViewMode.tree",
-			"scm.defaultViewMode.list",
-			"scm.defaultViewMode",
-			"scm.defaultViewSortKey.name",
-			"scm.defaultViewSortKey.path",
-			"scm.defaultViewSortKey.status",
-			"scm.defaultViewSortKey",
-			"autoReveal",
-			"inputFontFamily",
-			"inputFontSize",
-			"alwaysShowRepository",
-			"scm.repositoriesSortOrder.discoveryTime",
-			"scm.repositoriesSortOrder.name",
-			"scm.repositoriesSortOrder.path",
-			"repositoriesSortOrder",
-			"providersVisible",
-			"showActionButton",
-			"scm accept",
-			"scm view next commit",
-			"scm view previous commit",
-			"open in external terminal",
-			"open in integrated terminal"
 		],
 		"vs/workbench/contrib/debug/browser/debug.contribution": [
 			"debugCategory",
@@ -4069,6 +3938,10 @@
 				],
 				"key": "toolBarLocation"
 			},
+			"debugToolBar.floating",
+			"debugToolBar.docked",
+			"debugToolBar.commandCenter",
+			"debugToolBar.hidden",
 			"never",
 			"always",
 			"onFirstSessionStart",
@@ -4190,29 +4063,78 @@
 			"debugIcon.breakpointCurrentStackframeForeground",
 			"debugIcon.breakpointStackframeForeground"
 		],
-		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
-			"topStackFrameLineHighlight",
-			"focusedStackFrameLineHighlight"
-		],
-		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
-			"editor.inlineValuesForeground",
-			"editor.inlineValuesBackground"
-		],
-		"vs/workbench/contrib/debug/browser/debugViewlet": [
+		"vs/workbench/contrib/scm/browser/scm.contribution": [
+			"sourceControlViewIcon",
+			"source control",
+			"no open repo",
+			"no open repo in an untrusted workspace",
+			"manageWorkspaceTrustAction",
+			"source control",
 			{
-				"key": "miOpenConfigurations",
+				"key": "miViewSCM",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
 			},
-			{
-				"key": "selectWorkspaceFolder",
-				"comment": [
-					"User picks a workspace folder or a workspace configuration file here. Workspace configuration files can contain settings and thus a launch.json configuration can be written into one."
-				]
-			},
-			"debugPanel",
-			"startAdditionalSession"
+			"source control repositories",
+			"source control sync",
+			"scmConfigurationTitle",
+			"scm.diffDecorations.all",
+			"scm.diffDecorations.gutter",
+			"scm.diffDecorations.overviewRuler",
+			"scm.diffDecorations.minimap",
+			"scm.diffDecorations.none",
+			"diffDecorations",
+			"diffGutterWidth",
+			"scm.diffDecorationsGutterVisibility.always",
+			"scm.diffDecorationsGutterVisibility.hover",
+			"scm.diffDecorationsGutterVisibility",
+			"scm.diffDecorationsGutterAction.diff",
+			"scm.diffDecorationsGutterAction.none",
+			"scm.diffDecorationsGutterAction",
+			"diffGutterPattern",
+			"diffGutterPatternAdded",
+			"diffGutterPatternModifed",
+			"scm.diffDecorationsIgnoreTrimWhitespace.true",
+			"scm.diffDecorationsIgnoreTrimWhitespace.false",
+			"scm.diffDecorationsIgnoreTrimWhitespace.inherit",
+			"diffDecorationsIgnoreTrimWhitespace",
+			"alwaysShowActions",
+			"scm.countBadge.all",
+			"scm.countBadge.focused",
+			"scm.countBadge.off",
+			"scm.countBadge",
+			"scm.providerCountBadge.hidden",
+			"scm.providerCountBadge.auto",
+			"scm.providerCountBadge.visible",
+			"scm.providerCountBadge",
+			"scm.defaultViewMode.tree",
+			"scm.defaultViewMode.list",
+			"scm.defaultViewMode",
+			"scm.defaultViewSortKey.name",
+			"scm.defaultViewSortKey.path",
+			"scm.defaultViewSortKey.status",
+			"scm.defaultViewSortKey",
+			"autoReveal",
+			"inputFontFamily",
+			"inputFontSize",
+			"alwaysShowRepository",
+			"scm.repositoriesSortOrder.discoveryTime",
+			"scm.repositoriesSortOrder.name",
+			"scm.repositoriesSortOrder.path",
+			"repositoriesSortOrder",
+			"providersVisible",
+			"showActionButton",
+			"showSyncView",
+			"scm accept",
+			"scm view next commit",
+			"scm view previous commit",
+			"open in external terminal",
+			"open in integrated terminal"
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
+			"editor.inlineValuesForeground",
+			"editor.inlineValuesBackground"
 		],
 		"vs/workbench/contrib/debug/browser/repl": [
 			{
@@ -4239,6 +4161,10 @@
 			"paste",
 			"copyAll",
 			"copy"
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"topStackFrameLineHighlight",
+			"focusedStackFrameLineHighlight"
 		],
 		"vs/workbench/contrib/markers/browser/markers.contribution": [
 			"markersViewIcon",
@@ -4285,6 +4211,22 @@
 			"manyProblems",
 			"totalProblems"
 		],
+		"vs/workbench/contrib/debug/browser/debugViewlet": [
+			{
+				"key": "miOpenConfigurations",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "selectWorkspaceFolder",
+				"comment": [
+					"User picks a workspace folder or a workspace configuration file here. Workspace configuration files can contain settings and thus a launch.json configuration can be written into one."
+				]
+			},
+			"debugPanel",
+			"startAdditionalSession"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
 			"name",
 			"diffAlgorithm.legacy",
@@ -4304,69 +4246,42 @@
 			"comments.openView.never",
 			"comments.openView.file",
 			"comments.openView.firstFile",
+			"comments.openView.firstFileUnresolved",
 			"comments.openView",
 			"useRelativeTime",
 			"comments.visible",
-			"comments.maxHeight"
+			"comments.maxHeight",
+			"collapseOnResolve",
+			"intro",
+			"introWidget",
+			"introWidgetNoKb",
+			"commentCommands",
+			"escape",
+			"next",
+			"nextNoKb",
+			"previous",
+			"previousNoKb",
+			"nextCommentThreadKb",
+			"nextCommentThreadNoKb",
+			"previousCommentThreadKb",
+			"previousCommentThreadNoKb",
+			"addComment",
+			"addCommentNoKb",
+			"submitComment",
+			"submitCommentNoKb"
 		],
 		"vs/workbench/contrib/url/browser/url.contribution": [
 			"openUrl",
 			"urlToOpen",
 			"workbench.trustedDomains.promptInTrustedWorkspace"
 		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
-			"webview.editor.label"
-		],
 		"vs/workbench/contrib/webview/browser/webview.contribution": [
 			"cut",
 			"copy",
 			"paste"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			{
-				"key": "remote",
-				"comment": [
-					"Remote as in remote machine"
-				]
-			},
-			"installed",
-			"select and install local extensions",
-			"install remote in local",
-			"popularExtensions",
-			"recommendedExtensions",
-			"enabledExtensions",
-			"disabledExtensions",
-			"marketPlace",
-			"installed",
-			"recently updated",
-			"enabled",
-			"disabled",
-			"availableUpdates",
-			"builtin",
-			"workspaceUnsupported",
-			"workspaceRecommendedExtensions",
-			"otherRecommendedExtensions",
-			"builtinFeatureExtensions",
-			"builtInThemesExtensions",
-			"builtinProgrammingLanguageExtensions",
-			"untrustedUnsupportedExtensions",
-			"untrustedPartiallySupportedExtensions",
-			"virtualUnsupportedExtensions",
-			"virtualPartiallySupportedExtensions",
-			"deprecated",
-			"searchExtensions",
-			"extensionFoundInSection",
-			"extensionFound",
-			"extensionsFoundInSection",
-			"extensionsFound",
-			"suggestProxyError",
-			"open user settings",
-			"extensionToUpdate",
-			"extensionsToUpdate",
-			"extensionToReload",
-			"extensionsToReload",
-			"malicious warning",
-			"reloadNow"
+		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
+			"webview.editor.label"
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
 			"manageExtensionsQuickAccessPlaceholder",
@@ -4429,6 +4344,7 @@
 				]
 			},
 			"showExtensions",
+			"focusExtensions",
 			"installExtensions",
 			"showRecommendedKeymapExtensionsShort",
 			"importKeyboardShortcutsFroms",
@@ -4520,6 +4436,52 @@
 			"extensions",
 			"extensions"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			{
+				"key": "remote",
+				"comment": [
+					"Remote as in remote machine"
+				]
+			},
+			"installed",
+			"select and install local extensions",
+			"install remote in local",
+			"popularExtensions",
+			"recommendedExtensions",
+			"enabledExtensions",
+			"disabledExtensions",
+			"marketPlace",
+			"installed",
+			"recently updated",
+			"enabled",
+			"disabled",
+			"availableUpdates",
+			"builtin",
+			"workspaceUnsupported",
+			"workspaceRecommendedExtensions",
+			"otherRecommendedExtensions",
+			"builtinFeatureExtensions",
+			"builtInThemesExtensions",
+			"builtinProgrammingLanguageExtensions",
+			"untrustedUnsupportedExtensions",
+			"untrustedPartiallySupportedExtensions",
+			"virtualUnsupportedExtensions",
+			"virtualPartiallySupportedExtensions",
+			"deprecated",
+			"searchExtensions",
+			"extensionFoundInSection",
+			"extensionFound",
+			"extensionsFoundInSection",
+			"extensionsFound",
+			"suggestProxyError",
+			"open user settings",
+			"extensionToUpdate",
+			"extensionsToUpdate",
+			"extensionToReload",
+			"extensionsToReload",
+			"malicious warning",
+			"reloadNow"
+		],
 		"vs/workbench/contrib/output/browser/output.contribution": [
 			"outputViewIcon",
 			"output",
@@ -4530,7 +4492,6 @@
 					"&& denotes a mnemonic"
 				]
 			},
-			"logViewer",
 			"switchBetweenOutputs.label",
 			"switchToOutput.label",
 			"showOutputChannels",
@@ -4557,6 +4518,11 @@
 			"output",
 			"outputViewAriaLabel"
 		],
+		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
+			"scopedConsoleAction.Integrated",
+			"scopedConsoleAction.external",
+			"scopedConsoleAction.wt"
+		],
 		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
 			"relaunchSettingMessage",
 			"relaunchSettingMessageWeb",
@@ -4575,11 +4541,6 @@
 				]
 			},
 			"restartExtensionHost.reason"
-		],
-		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
-			"scopedConsoleAction.Integrated",
-			"scopedConsoleAction.external",
-			"scopedConsoleAction.wt"
 		],
 		"vs/workbench/contrib/tasks/browser/task.contribution": [
 			"building",
@@ -4716,9 +4677,6 @@
 			"remote.portsAttributes.defaults",
 			"remote.localPortHost"
 		],
-		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
-			"toggleKeybindingsLog"
-		],
 		"vs/workbench/contrib/snippets/browser/snippets.contribution": [
 			"editor.snippets.codeActions.enabled",
 			"snippetSchema.json.prefix",
@@ -4736,6 +4694,9 @@
 			"nullFormatterDescription",
 			"formatter.default"
 		],
+		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
+			"toggleKeybindingsLog"
+		],
 		"vs/workbench/contrib/limitIndicator/browser/limitIndicator.contribution": [
 			"status.button.configure",
 			"colorDecoratorsStatusItem.name",
@@ -4751,6 +4712,29 @@
 			"description",
 			"read.title",
 			"stop.title"
+		],
+		"vs/workbench/contrib/update/browser/update.contribution": [
+			"showReleaseNotes",
+			{
+				"key": "mshowReleaseNotes",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"update.noReleaseNotesOnline",
+			"checkForUpdates",
+			"downloadUpdate",
+			"installUpdate",
+			"restartToUpdate",
+			"openDownloadPage",
+			"applyUpdate",
+			"pickUpdate",
+			{
+				"key": "updateButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/workbench/contrib/themes/browser/themes.contribution": [
 			"manageExtensionIcon",
@@ -4781,6 +4765,7 @@
 			"manage extension",
 			"generateColorTheme.label",
 			"toggleLightDarkThemes.label",
+			"browseColorThemeInMarketPlace.label",
 			"themes",
 			{
 				"key": "miSelectTheme",
@@ -4809,34 +4794,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/update/browser/update.contribution": [
-			"showReleaseNotes",
-			{
-				"key": "mshowReleaseNotes",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"update.noReleaseNotesOnline",
-			"checkForUpdates",
-			"downloadUpdate",
-			"installUpdate",
-			"restartToUpdate",
-			"openDownloadPage",
-			"applyUpdate",
-			"pickUpdate",
-			{
-				"key": "updateButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/surveys/browser/ces.contribution": [
-			"cesSurveyQuestion",
-			"giveFeedback",
-			"remindLater"
-		],
 		"vs/workbench/contrib/surveys/browser/nps.contribution": [
 			"surveyQuestion",
 			"takeSurvey",
@@ -4848,6 +4805,11 @@
 			"takeShortSurvey",
 			"remindLater",
 			"neverAgain"
+		],
+		"vs/workbench/contrib/surveys/browser/ces.contribution": [
+			"cesSurveyQuestion",
+			"giveFeedback",
+			"remindLater"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution": [
 			"miWelcome",
@@ -4915,19 +4877,8 @@
 			"miNewFileWithName",
 			"miNewFile2"
 		],
-		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
-			"editorHasCallHierarchyProvider",
-			"callHierarchyVisible",
-			"callHierarchyDirection",
-			"no.item",
-			"error",
-			"title",
-			"title.incoming",
-			"showIncomingCallsIcons",
-			"title.outgoing",
-			"showOutgoingCallsIcon",
-			"title.refocus",
-			"close"
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
+			"document"
 		],
 		"vs/workbench/contrib/typeHierarchy/browser/typeHierarchy.contribution": [
 			"editorHasTypeHierarchyProvider",
@@ -4941,8 +4892,19 @@
 			"title.refocusTypeHierarchy",
 			"close"
 		],
-		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
-			"document"
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
+			"editorHasCallHierarchyProvider",
+			"callHierarchyVisible",
+			"callHierarchyDirection",
+			"no.item",
+			"error",
+			"title",
+			"title.incoming",
+			"showIncomingCallsIcons",
+			"title.outgoing",
+			"showOutgoingCallsIcon",
+			"title.refocus",
+			"close"
 		],
 		"vs/workbench/contrib/languageDetection/browser/languageDetection.contribution": [
 			"status.autoDetectLanguage",
@@ -4988,16 +4950,6 @@
 			"filteredTypes.event",
 			"filteredTypes.operator",
 			"filteredTypes.typeParameter"
-		],
-		"vs/workbench/contrib/languageStatus/browser/languageStatus.contribution": [
-			"langStatus.name",
-			"langStatus.aria",
-			"pin",
-			"unpin",
-			"aria.1",
-			"aria.2",
-			"name.pattern",
-			"reset"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution": [
 			{
@@ -5090,37 +5042,30 @@
 			"timelineFilter",
 			"filterTimeline"
 		],
+		"vs/workbench/contrib/languageStatus/browser/languageStatus.contribution": [
+			"langStatus.name",
+			"langStatus.aria",
+			"pin",
+			"unpin",
+			"aria.1",
+			"aria.2",
+			"name.pattern",
+			"reset"
+		],
+		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
+			"workspaceFound",
+			"openWorkspace",
+			"workspacesFound",
+			"selectWorkspace",
+			"selectToOpen",
+			"openWorkspace",
+			"alreadyOpen"
+		],
 		"vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExtensionMigrator.contribution": [
 			"bracketPairColorizer.notification",
 			"bracketPairColorizer.notification.action.uninstall",
 			"bracketPairColorizer.notification.action.enableNative",
 			"bracketPairColorizer.notification.action.showMoreInfo"
-		],
-		"vs/workbench/contrib/audioCues/browser/audioCues.contribution": [
-			"audioCues.enabled.auto",
-			"audioCues.enabled.on",
-			"audioCues.enabled.off",
-			"audioCues.volume",
-			"audioCues.debouncePositionChanges",
-			"audioCues.lineHasBreakpoint",
-			"audioCues.lineHasInlineSuggestion",
-			"audioCues.lineHasError",
-			"audioCues.lineHasFoldedArea",
-			"audioCues.lineHasWarning",
-			"audioCues.onDebugBreak",
-			"audioCues.noInlayHints",
-			"audioCues.taskCompleted",
-			"audioCues.taskFailed",
-			"audioCues.terminalCommandFailed",
-			"audioCues.terminalQuickFix",
-			"audioCues.diffLineInserted",
-			"audioCues.diffLineDeleted",
-			"audioCues.diffLineModified",
-			"audioCues.notebookCellCompleted",
-			"audioCues.notebookCellFailed",
-			"audioCues.chatRequestSent",
-			"audioCues.chatResponsePending",
-			"audioCues.chatResponseReceived"
 		],
 		"vs/workbench/contrib/workspace/browser/workspace.contribution": [
 			"openLooseFileWorkspaceDetails",
@@ -5241,6 +5186,32 @@
 			"workspace.trust.untrustedFiles.newWindow",
 			"workspace.trust.emptyWindow.description"
 		],
+		"vs/workbench/contrib/audioCues/browser/audioCues.contribution": [
+			"audioCues.enabled.auto",
+			"audioCues.enabled.on",
+			"audioCues.enabled.off",
+			"audioCues.volume",
+			"audioCues.debouncePositionChanges",
+			"audioCues.lineHasBreakpoint",
+			"audioCues.lineHasInlineSuggestion",
+			"audioCues.lineHasError",
+			"audioCues.lineHasFoldedArea",
+			"audioCues.lineHasWarning",
+			"audioCues.onDebugBreak",
+			"audioCues.noInlayHints",
+			"audioCues.taskCompleted",
+			"audioCues.taskFailed",
+			"audioCues.terminalCommandFailed",
+			"audioCues.terminalQuickFix",
+			"audioCues.diffLineInserted",
+			"audioCues.diffLineDeleted",
+			"audioCues.diffLineModified",
+			"audioCues.notebookCellCompleted",
+			"audioCues.notebookCellFailed",
+			"audioCues.chatRequestSent",
+			"audioCues.chatResponsePending",
+			"audioCues.chatResponseReceived"
+		],
 		"vs/workbench/contrib/share/browser/share.contribution": [
 			"share",
 			"generating link",
@@ -5250,56 +5221,102 @@
 			"open link",
 			"experimental.share.enabled"
 		],
-		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
-			"workspaceFound",
-			"openWorkspace",
-			"workspacesFound",
-			"selectWorkspace",
-			"selectToOpen",
-			"openWorkspace",
-			"alreadyOpen"
+		"vs/workbench/browser/workbench": [
+			"loaderErrorNative"
 		],
-		"vs/workbench/browser/parts/dialogs/dialogHandler": [
-			"aboutDetail",
+		"vs/workbench/services/configuration/browser/configurationService": [
+			"configurationDefaults.description",
+			"experimental",
+			"setting description"
+		],
+		"vs/platform/workspace/common/workspace": [
+			"codeWorkspace"
+		],
+		"vs/workbench/electron-sandbox/window": [
+			"restart",
+			"configure",
+			"learnMore",
+			"keychainWriteError",
+			"troubleshooting",
+			"runningTranslated",
+			"downloadArmBuild",
+			"proxyAuthRequired",
 			{
-				"key": "copy",
+				"key": "loginButton",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
 			},
-			"ok"
-		],
-		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
+			"username",
+			"password",
+			"proxyDetail",
+			"rememberCredentials",
+			"quitMessageMac",
+			"quitMessage",
+			"closeWindowMessage",
 			{
-				"key": "aboutDetail",
-				"comment": [
-					"Electron, Chromium, Node.js and V8 are product names that need no translation"
-				]
-			},
-			{
-				"key": "copy",
+				"key": "quitButtonLabel",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
 			},
-			"okButton"
-		],
-		"vs/workbench/services/textfile/browser/textFileService": [
-			"textFileCreate.source",
-			"textFileOverwrite.source",
-			"textFileModelDecorations",
-			"readonlyAndDeleted",
-			"readonly",
-			"deleted",
-			"fileBinaryError",
-			"confirmOverwrite",
-			"irreversible",
 			{
-				"key": "replaceButtonLabel",
+				"key": "exitButtonLabel",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
-			}
+			},
+			{
+				"key": "closeWindowButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"doNotAskAgain",
+			"shutdownErrorDetail",
+			"willShutdownDetail",
+			"shutdownErrorClose",
+			"shutdownErrorQuit",
+			"shutdownErrorReload",
+			"shutdownErrorLoad",
+			"shutdownTitleClose",
+			"shutdownTitleQuit",
+			"shutdownTitleReload",
+			"shutdownTitleLoad",
+			"shutdownForceClose",
+			"shutdownForceQuit",
+			"shutdownForceReload",
+			"shutdownForceLoad",
+			"loaderCycle",
+			"runningAsRoot",
+			"appRootWarning.banner",
+			"windows32eolmessage",
+			"windowseolBannerLearnMore",
+			"windowseolarialabel",
+			"learnMore",
+			"macoseolmessage",
+			"macoseolBannerLearnMore",
+			"macoseolarialabel",
+			"learnMore",
+			"resolveShellEnvironment",
+			"learnMore"
+		],
+		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
+			"devTools",
+			"directUrl",
+			"connectionError"
+		],
+		"vs/platform/workspace/common/workspaceTrust": [
+			"trusted",
+			"untrusted"
+		],
+		"vs/workbench/services/userDataProfile/common/userDataProfile": [
+			"defaultProfileIcon",
+			"profiles",
+			"profile"
+		],
+		"vs/workbench/services/log/electron-sandbox/logService": [
+			"rendererLog"
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
 			"defaultLanguageConfigurationOverrides.title",
@@ -5356,13 +5373,6 @@
 			"switchWindow",
 			"quickSwitchWindow"
 		],
-		"vs/workbench/electron-sandbox/actions/installActions": [
-			"shellCommand",
-			"install",
-			"successIn",
-			"uninstall",
-			"successFrom"
-		],
 		"vs/platform/contextkey/common/contextkeys": [
 			"isMac",
 			"isLinux",
@@ -5373,6 +5383,14 @@
 			"isMobile",
 			"productQualityType",
 			"inputFocus"
+		],
+		"vs/workbench/common/configuration": [
+			"applicationConfigurationTitle",
+			"workbenchConfigurationTitle",
+			"securityConfigurationTitle",
+			"security.allowedUNCHosts.patternErrorMessage",
+			"security.allowedUNCHosts",
+			"security.restrictUNCAccess"
 		],
 		"vs/workbench/common/contextkeys": [
 			"workbenchState",
@@ -5436,14 +5454,6 @@
 			"resourceSet",
 			"isFileSystemResource"
 		],
-		"vs/workbench/common/configuration": [
-			"applicationConfigurationTitle",
-			"workbenchConfigurationTitle",
-			"securityConfigurationTitle",
-			"security.allowedUNCHosts.patternErrorMessage",
-			"security.allowedUNCHosts",
-			"security.restrictUNCAccess"
-		],
 		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
 			"saveChangesDetail",
 			"saveChangesMessage",
@@ -5475,6 +5485,193 @@
 			"saveAsTitle",
 			"allFiles",
 			"noExt"
+		],
+		"vs/workbench/electron-sandbox/actions/installActions": [
+			"shellCommand",
+			"install",
+			"successIn",
+			"uninstall",
+			"successFrom"
+		],
+		"vs/workbench/services/textfile/browser/textFileService": [
+			"textFileCreate.source",
+			"textFileOverwrite.source",
+			"textFileModelDecorations",
+			"readonlyAndDeleted",
+			"readonly",
+			"deleted",
+			"fileBinaryError",
+			"confirmOverwrite",
+			"irreversible",
+			{
+				"key": "replaceButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/browser/parts/dialogs/dialogHandler": [
+			"aboutDetail",
+			{
+				"key": "copy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"ok"
+		],
+		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
+			{
+				"key": "aboutDetail",
+				"comment": [
+					"Electron, Chromium, Node.js and V8 are product names that need no translation"
+				]
+			},
+			{
+				"key": "copy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"okButton"
+		],
+		"vs/workbench/common/theme": [
+			"tabActiveBackground",
+			"tabUnfocusedActiveBackground",
+			"tabInactiveBackground",
+			"tabUnfocusedInactiveBackground",
+			"tabActiveForeground",
+			"tabInactiveForeground",
+			"tabUnfocusedActiveForeground",
+			"tabUnfocusedInactiveForeground",
+			"tabHoverBackground",
+			"tabUnfocusedHoverBackground",
+			"tabHoverForeground",
+			"tabUnfocusedHoverForeground",
+			"tabBorder",
+			"lastPinnedTabBorder",
+			"tabActiveBorder",
+			"tabActiveUnfocusedBorder",
+			"tabActiveBorderTop",
+			"tabActiveUnfocusedBorderTop",
+			"tabHoverBorder",
+			"tabUnfocusedHoverBorder",
+			"tabActiveModifiedBorder",
+			"tabInactiveModifiedBorder",
+			"unfocusedActiveModifiedBorder",
+			"unfocusedINactiveModifiedBorder",
+			"editorPaneBackground",
+			"editorGroupEmptyBackground",
+			"editorGroupFocusedEmptyBorder",
+			"tabsContainerBackground",
+			"tabsContainerBorder",
+			"editorGroupHeaderBackground",
+			"editorTitleContainerBorder",
+			"editorGroupBorder",
+			"editorDragAndDropBackground",
+			"editorDropIntoPromptForeground",
+			"editorDropIntoPromptBackground",
+			"editorDropIntoPromptBorder",
+			"sideBySideEditor.horizontalBorder",
+			"sideBySideEditor.verticalBorder",
+			"panelBackground",
+			"panelBorder",
+			"panelActiveTitleForeground",
+			"panelInactiveTitleForeground",
+			"panelActiveTitleBorder",
+			"panelInputBorder",
+			"panelDragAndDropBorder",
+			"panelSectionDragAndDropBackground",
+			"panelSectionHeaderBackground",
+			"panelSectionHeaderForeground",
+			"panelSectionHeaderBorder",
+			"panelSectionBorder",
+			"banner.background",
+			"banner.foreground",
+			"banner.iconForeground",
+			"statusBarForeground",
+			"statusBarNoFolderForeground",
+			"statusBarBackground",
+			"statusBarNoFolderBackground",
+			"statusBarBorder",
+			"statusBarFocusBorder",
+			"statusBarNoFolderBorder",
+			"statusBarItemActiveBackground",
+			"statusBarItemFocusBorder",
+			"statusBarItemHoverBackground",
+			"statusBarItemHoverForeground",
+			"statusBarItemCompactHoverBackground",
+			"statusBarProminentItemForeground",
+			"statusBarProminentItemBackground",
+			"statusBarProminentItemHoverForeground",
+			"statusBarProminentItemHoverBackground",
+			"statusBarErrorItemBackground",
+			"statusBarErrorItemForeground",
+			"statusBarErrorItemHoverForeground",
+			"statusBarErrorItemHoverBackground",
+			"statusBarWarningItemBackground",
+			"statusBarWarningItemForeground",
+			"statusBarWarningItemHoverForeground",
+			"statusBarWarningItemHoverBackground",
+			"activityBarBackground",
+			"activityBarForeground",
+			"activityBarInActiveForeground",
+			"activityBarBorder",
+			"activityBarActiveBorder",
+			"activityBarActiveFocusBorder",
+			"activityBarActiveBackground",
+			"activityBarDragAndDropBorder",
+			"activityBarBadgeBackground",
+			"activityBarBadgeForeground",
+			"profileBadgeBackground",
+			"profileBadgeForeground",
+			"statusBarItemHostBackground",
+			"statusBarItemHostForeground",
+			"statusBarRemoteItemHoverForeground",
+			"statusBarRemoteItemHoverBackground",
+			"statusBarItemOfflineBackground",
+			"statusBarItemOfflineForeground",
+			"statusBarOfflineItemHoverForeground",
+			"statusBarOfflineItemHoverBackground",
+			"extensionBadge.remoteBackground",
+			"extensionBadge.remoteForeground",
+			"sideBarBackground",
+			"sideBarForeground",
+			"sideBarBorder",
+			"sideBarTitleForeground",
+			"sideBarDragAndDropBackground",
+			"sideBarSectionHeaderBackground",
+			"sideBarSectionHeaderForeground",
+			"sideBarSectionHeaderBorder",
+			"titleBarActiveForeground",
+			"titleBarInactiveForeground",
+			"titleBarActiveBackground",
+			"titleBarInactiveBackground",
+			"titleBarBorder",
+			"menubarSelectionForeground",
+			"menubarSelectionBackground",
+			"menubarSelectionBorder",
+			"commandCenter-foreground",
+			"commandCenter-activeForeground",
+			"commandCenter-inactiveForeground",
+			"commandCenter-background",
+			"commandCenter-activeBackground",
+			"commandCenter-border",
+			"commandCenter-activeBorder",
+			"commandCenter-inactiveBorder",
+			"notificationCenterBorder",
+			"notificationToastBorder",
+			"notificationsForeground",
+			"notificationsBackground",
+			"notificationsLink",
+			"notificationCenterHeaderForeground",
+			"notificationCenterHeaderBackground",
+			"notificationsBorder",
+			"notificationsErrorIconForeground",
+			"notificationsWarningIconForeground",
+			"notificationsInfoIconForeground",
+			"windowActiveBorder",
+			"windowInactiveBorder"
 		],
 		"vs/platform/theme/common/colorRegistry": [
 			"foreground",
@@ -5677,8 +5874,9 @@
 			"minimapFindMatchHighlight",
 			"minimapSelectionOccurrenceHighlight",
 			"minimapSelectionHighlight",
-			"minimapError",
+			"minimapInfo",
 			"overviewRuleWarning",
+			"minimapError",
 			"minimapBackground",
 			"minimapForegroundOpacity",
 			"minimapSliderBackground",
@@ -5696,136 +5894,6 @@
 			"chartsGreen",
 			"chartsPurple"
 		],
-		"vs/workbench/common/theme": [
-			"tabActiveBackground",
-			"tabUnfocusedActiveBackground",
-			"tabInactiveBackground",
-			"tabUnfocusedInactiveBackground",
-			"tabActiveForeground",
-			"tabInactiveForeground",
-			"tabUnfocusedActiveForeground",
-			"tabUnfocusedInactiveForeground",
-			"tabHoverBackground",
-			"tabUnfocusedHoverBackground",
-			"tabHoverForeground",
-			"tabUnfocusedHoverForeground",
-			"tabBorder",
-			"lastPinnedTabBorder",
-			"tabActiveBorder",
-			"tabActiveUnfocusedBorder",
-			"tabActiveBorderTop",
-			"tabActiveUnfocusedBorderTop",
-			"tabHoverBorder",
-			"tabUnfocusedHoverBorder",
-			"tabActiveModifiedBorder",
-			"tabInactiveModifiedBorder",
-			"unfocusedActiveModifiedBorder",
-			"unfocusedINactiveModifiedBorder",
-			"editorPaneBackground",
-			"editorGroupEmptyBackground",
-			"editorGroupFocusedEmptyBorder",
-			"tabsContainerBackground",
-			"tabsContainerBorder",
-			"editorGroupHeaderBackground",
-			"editorTitleContainerBorder",
-			"editorGroupBorder",
-			"editorDragAndDropBackground",
-			"editorDropIntoPromptForeground",
-			"editorDropIntoPromptBackground",
-			"editorDropIntoPromptBorder",
-			"sideBySideEditor.horizontalBorder",
-			"sideBySideEditor.verticalBorder",
-			"panelBackground",
-			"panelBorder",
-			"panelActiveTitleForeground",
-			"panelInactiveTitleForeground",
-			"panelActiveTitleBorder",
-			"panelInputBorder",
-			"panelDragAndDropBorder",
-			"panelSectionDragAndDropBackground",
-			"panelSectionHeaderBackground",
-			"panelSectionHeaderForeground",
-			"panelSectionHeaderBorder",
-			"panelSectionBorder",
-			"banner.background",
-			"banner.foreground",
-			"banner.iconForeground",
-			"statusBarForeground",
-			"statusBarNoFolderForeground",
-			"statusBarBackground",
-			"statusBarNoFolderBackground",
-			"statusBarBorder",
-			"statusBarFocusBorder",
-			"statusBarNoFolderBorder",
-			"statusBarItemActiveBackground",
-			"statusBarItemFocusBorder",
-			"statusBarItemHoverBackground",
-			"statusBarItemHoverForeground",
-			"statusBarItemCompactHoverBackground",
-			"statusBarProminentItemForeground",
-			"statusBarProminentItemBackground",
-			"statusBarProminentItemHoverForeground",
-			"statusBarProminentItemHoverBackground",
-			"statusBarErrorItemBackground",
-			"statusBarErrorItemForeground",
-			"statusBarErrorItemHoverForeground",
-			"statusBarErrorItemHoverBackground",
-			"statusBarWarningItemBackground",
-			"statusBarWarningItemForeground",
-			"statusBarWarningItemHoverForeground",
-			"statusBarWarningItemHoverBackground",
-			"activityBarBackground",
-			"activityBarForeground",
-			"activityBarInActiveForeground",
-			"activityBarBorder",
-			"activityBarActiveBorder",
-			"activityBarActiveFocusBorder",
-			"activityBarActiveBackground",
-			"activityBarDragAndDropBorder",
-			"activityBarBadgeBackground",
-			"activityBarBadgeForeground",
-			"profileBadgeBackground",
-			"profileBadgeForeground",
-			"statusBarItemHostBackground",
-			"statusBarItemHostForeground",
-			"statusBarRemoteItemHoverForeground",
-			"statusBarRemoteItemHoverBackground",
-			"statusBarItemOfflineBackground",
-			"statusBarItemOfflineForeground",
-			"statusBarOfflineItemHoverForeground",
-			"statusBarOfflineItemHoverBackground",
-			"extensionBadge.remoteBackground",
-			"extensionBadge.remoteForeground",
-			"sideBarBackground",
-			"sideBarForeground",
-			"sideBarBorder",
-			"sideBarTitleForeground",
-			"sideBarDragAndDropBackground",
-			"sideBarSectionHeaderBackground",
-			"sideBarSectionHeaderForeground",
-			"sideBarSectionHeaderBorder",
-			"titleBarActiveForeground",
-			"titleBarInactiveForeground",
-			"titleBarActiveBackground",
-			"titleBarInactiveBackground",
-			"titleBarBorder",
-			"menubarSelectionForeground",
-			"menubarSelectionBackground",
-			"menubarSelectionBorder",
-			"notificationCenterBorder",
-			"notificationToastBorder",
-			"notificationsForeground",
-			"notificationsBackground",
-			"notificationsLink",
-			"notificationCenterHeaderForeground",
-			"notificationCenterHeaderBackground",
-			"notificationsBorder",
-			"notificationsErrorIconForeground",
-			"notificationsWarningIconForeground",
-			"notificationsInfoIconForeground",
-			"windowActiveBorder",
-			"windowInactiveBorder"
-		],
 		"vs/base/common/actions": [
 			"submenu.empty"
 		],
@@ -5835,6 +5903,11 @@
 			"errorInvalidTaskConfiguration",
 			"openWorkspaceConfigurationFile"
 		],
+		"vs/platform/keyboardLayout/common/keyboardConfig": [
+			"keyboardConfigurationTitle",
+			"dispatch",
+			"mapAltGrToCtrlAlt"
+		],
 		"vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService": [
 			"commandVariable.noStringType",
 			"inputVariable.noInputSection",
@@ -5843,11 +5916,6 @@
 			"inputVariable.command.noStringType",
 			"inputVariable.unknownType",
 			"inputVariable.undefinedVariable"
-		],
-		"vs/platform/keyboardLayout/common/keyboardConfig": [
-			"keyboardConfigurationTitle",
-			"dispatch",
-			"mapAltGrToCtrlAlt"
 		],
 		"vs/workbench/services/extensionManagement/common/extensionManagementService": [
 			"singleDependentError",
@@ -5892,76 +5960,15 @@
 			"non web extensions detail",
 			"non web extensions"
 		],
-		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
-			"notFoundReleaseExtension",
-			"notFoundCompatibleDependency"
-		],
-		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupTracker": [
-			"backupTrackerBackupFailed",
-			"backupTrackerConfirmFailed",
-			"backupErrorDetails",
-			"backupBeforeShutdownMessage",
-			"backupBeforeShutdownDetail",
-			"saveBeforeShutdown",
-			"revertBeforeShutdown",
-			"discardBackupsBeforeShutdown"
-		],
 		"vs/workbench/services/workingCopy/common/workingCopyHistoryService": [
 			"default.source",
 			"moved.source",
 			"renamed.source",
 			"join.workingCopyHistory"
 		],
-		"vs/platform/action/common/actionCommonCategories": [
-			"view",
-			"help",
-			"test",
-			"file",
-			"preferences",
-			{
-				"key": "developer",
-				"comment": [
-					"A developer on Code itself or someone diagnosing issues in Code"
-				]
-			}
-		],
-		"vs/workbench/services/extensions/common/abstractExtensionService": [
-			"looping",
-			"looping",
-			"extensionTestError",
-			"extensionStopVetoError",
-			"extensionStopVetoMessage",
-			"extensionStopVetoDetailsOne",
-			"extensionStopVetoDetailsMany",
-			"extensionService.autoRestart",
-			"extensionService.crash",
-			"restart"
-		],
-		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
-			"openLogsFolder",
-			"openExtensionLogsFolder"
-		],
-		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
-			"showLanguagePackExtensions",
-			"searchMarketplace",
-			"installAndRestartMessage",
-			"installAndRestart"
-		],
-		"vs/workbench/contrib/localization/common/localization.contribution": [
-			"vscode.extension.contributes.localizations",
-			"vscode.extension.contributes.localizations.languageId",
-			"vscode.extension.contributes.localizations.languageName",
-			"vscode.extension.contributes.localizations.languageNameLocalized",
-			"vscode.extension.contributes.localizations.translations",
-			"vscode.extension.contributes.localizations.translations.id",
-			"vscode.extension.contributes.localizations.translations.id.pattern",
-			"vscode.extension.contributes.localizations.translations.path"
-		],
-		"vs/workbench/common/editor": [
-			"promptOpenWith.defaultEditor.displayName",
-			"builtinProviderDisplayName",
-			"openLargeFile",
-			"configureEditorLargeFileConfirmation"
+		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
+			"notFoundReleaseExtension",
+			"notFoundCompatibleDependency"
 		],
 		"vs/editor/common/editorContextKeys": [
 			"editorTextFocus",
@@ -6004,8 +6011,60 @@
 			"editorHasMultipleDocumentFormattingProvider",
 			"editorHasMultipleDocumentSelectionFormattingProvider"
 		],
-		"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate": [
-			"startDebugTextMate"
+		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupTracker": [
+			"backupTrackerBackupFailed",
+			"backupTrackerConfirmFailed",
+			"backupErrorDetails",
+			"backupBeforeShutdownMessage",
+			"backupBeforeShutdownDetail",
+			"saveBeforeShutdown",
+			"revertBeforeShutdown",
+			"discardBackupsBeforeShutdown"
+		],
+		"vs/workbench/common/editor": [
+			"promptOpenWith.defaultEditor.displayName",
+			"builtinProviderDisplayName",
+			"openLargeFile",
+			"configureEditorLargeFileConfirmation"
+		],
+		"vs/platform/action/common/actionCommonCategories": [
+			"view",
+			"help",
+			"test",
+			"file",
+			"preferences",
+			{
+				"key": "developer",
+				"comment": [
+					"A developer on Code itself or someone diagnosing issues in Code"
+				]
+			}
+		],
+		"vs/workbench/services/extensions/common/abstractExtensionService": [
+			"looping",
+			"looping",
+			"extensionTestError",
+			"extensionStopVetoError",
+			"extensionStopVetoMessage",
+			"extensionStopVetoDetailsOne",
+			"extensionStopVetoDetailsMany",
+			"extensionService.autoRestart",
+			"extensionService.crash",
+			"restart"
+		],
+		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
+			"openLogsFolder",
+			"openExtensionLogsFolder"
+		],
+		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
+			"extensionCache.invalid",
+			"reloadWindow"
+		],
+		"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost": [
+			"extensionHost.startupFailDebug",
+			"extensionHost.startupFail",
+			"reloadWindow",
+			"join.extensionDevelopment"
 		],
 		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
 			"actions.pasteSelectionClipboard"
@@ -6014,22 +6073,18 @@
 			"preview",
 			"pinned"
 		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate": [
+			"startDebugTextMate"
+		],
+		"vs/workbench/contrib/extensions/common/runtimeExtensionsInput": [
+			"extensionsInputName"
+		],
 		"vs/workbench/contrib/extensions/electron-sandbox/runtimeExtensionsEditor": [
 			"extensionHostProfileStart",
 			"stopExtensionHostProfileStart",
 			"saveExtensionHostProfile",
 			"saveprofile.dialogTitle",
 			"saveprofile.saveButton"
-		],
-		"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost": [
-			"extensionHost.startupFailDebug",
-			"extensionHost.startupFail",
-			"reloadWindow",
-			"join.extensionDevelopment"
-		],
-		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
-			"extensionCache.invalid",
-			"reloadWindow"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/debugExtensionHostAction": [
 			"debugExtensionHost",
@@ -6042,9 +6097,6 @@
 				]
 			},
 			"debugExtensionHost.launch.name"
-		],
-		"vs/workbench/contrib/extensions/common/runtimeExtensionsInput": [
-			"extensionsInputName"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensionsActions": [
 			"openExtensionsFolder",
@@ -6069,20 +6121,21 @@
 			"unresponsive-exthost",
 			"show"
 		],
-		"vs/workbench/contrib/issue/common/issue.contribution": [
-			{
-				"key": "reportIssueInEnglish",
-				"comment": [
-					"Translate this to \"Report Issue in English\" in all languages please!"
-				]
-			},
-			{
-				"key": "miReportIssue",
-				"comment": [
-					"&& denotes a mnemonic",
-					"Translate this to \"Report Issue in English\" in all languages please!"
-				]
-			}
+		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
+			"showLanguagePackExtensions",
+			"searchMarketplace",
+			"installAndRestartMessage",
+			"installAndRestart"
+		],
+		"vs/workbench/contrib/localization/common/localization.contribution": [
+			"vscode.extension.contributes.localizations",
+			"vscode.extension.contributes.localizations.languageId",
+			"vscode.extension.contributes.localizations.languageName",
+			"vscode.extension.contributes.localizations.languageNameLocalized",
+			"vscode.extension.contributes.localizations.translations",
+			"vscode.extension.contributes.localizations.translations.id",
+			"vscode.extension.contributes.localizations.translations.id.pattern",
+			"vscode.extension.contributes.localizations.translations.path"
 		],
 		"vs/workbench/services/dialogs/browser/simpleFileDialog": [
 			"openLocalFile",
@@ -6099,10 +6152,26 @@
 			"remoteFileDialog.validateBadFilename",
 			"remoteFileDialog.validateCreateDirectory",
 			"remoteFileDialog.validateNonexistentDir",
+			"remoteFileDialog.validateReadonlyFolder",
 			"remoteFileDialog.validateNonexistentDir",
 			"remoteFileDialog.windowsDriveLetter",
 			"remoteFileDialog.validateFileOnly",
 			"remoteFileDialog.validateFolderOnly"
+		],
+		"vs/workbench/contrib/issue/common/issue.contribution": [
+			{
+				"key": "reportIssueInEnglish",
+				"comment": [
+					"Translate this to \"Report Issue in English\" in all languages please!"
+				]
+			},
+			{
+				"key": "miReportIssue",
+				"comment": [
+					"&& denotes a mnemonic",
+					"Translate this to \"Report Issue in English\" in all languages please!"
+				]
+			}
 		],
 		"vs/workbench/contrib/terminal/common/terminal": [
 			"vscode.extension.contributes.terminal",
@@ -6112,6 +6181,35 @@
 			"vscode.extension.contributes.terminal.types.icon",
 			"vscode.extension.contributes.terminal.types.icon.light",
 			"vscode.extension.contributes.terminal.types.icon.dark"
+		],
+		"vs/editor/common/languages": [
+			"Array",
+			"Boolean",
+			"Class",
+			"Constant",
+			"Constructor",
+			"Enum",
+			"EnumMember",
+			"Event",
+			"Field",
+			"File",
+			"Function",
+			"Interface",
+			"Key",
+			"Method",
+			"Module",
+			"Namespace",
+			"Null",
+			"Number",
+			"Object",
+			"Operator",
+			"Package",
+			"Property",
+			"String",
+			"Struct",
+			"TypeParameter",
+			"Variable",
+			"symbolAriaLabel"
 		],
 		"vs/workbench/services/userDataSync/common/userDataSync": [
 			"settings",
@@ -6123,7 +6221,13 @@
 			"profiles",
 			"workspace state label",
 			"sync category",
-			"syncViewIcon"
+			"syncViewIcon",
+			"download sync activity title"
+		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"tasks.taskRunningContext",
+			"tasksCategory",
+			"TaskDefinition.missingRequiredProperty"
 		],
 		"vs/workbench/contrib/performance/electron-sandbox/startupProfiler": [
 			"prof.message",
@@ -6144,11 +6248,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/tasks/common/tasks": [
-			"tasks.taskRunningContext",
-			"tasksCategory",
-			"TaskDefinition.missingRequiredProperty"
-		],
 		"vs/workbench/contrib/tasks/common/taskService": [
 			"tasks.customExecutionSupported",
 			"tasks.shellExecutionSupported",
@@ -6160,49 +6259,6 @@
 			"defaultViewIcon",
 			"duplicateId",
 			"treeView.notRegistered"
-		],
-		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
-			"TerminalTaskSystem.unknownError",
-			"TerminalTaskSystem.taskLoadReporting",
-			"dependencyCycle",
-			"dependencyFailed",
-			"TerminalTaskSystem.nonWatchingMatcher",
-			{
-				"key": "task.executingInFolder",
-				"comment": [
-					"The workspace folder the task is running in",
-					"The task command line or label"
-				]
-			},
-			{
-				"key": "task.executing.shellIntegration",
-				"comment": [
-					"The task command line or label"
-				]
-			},
-			{
-				"key": "task.executingInFolder",
-				"comment": [
-					"The workspace folder the task is running in",
-					"The task command line or label"
-				]
-			},
-			{
-				"key": "task.executing.shell-integration",
-				"comment": [
-					"The task command line or label"
-				]
-			},
-			{
-				"key": "task.executing",
-				"comment": [
-					"The task command line or label"
-				]
-			},
-			"TerminalTaskSystem",
-			"unknownProblemMatcher",
-			"closeTerminal",
-			"reuseTerminal"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"ConfigureTaskRunnerAction.label",
@@ -6304,6 +6360,49 @@
 			"taskService.openDiff",
 			"taskService.openDiffs"
 		],
+		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+			"TerminalTaskSystem.unknownError",
+			"TerminalTaskSystem.taskLoadReporting",
+			"dependencyCycle",
+			"dependencyFailed",
+			"TerminalTaskSystem.nonWatchingMatcher",
+			{
+				"key": "task.executingInFolder",
+				"comment": [
+					"The workspace folder the task is running in",
+					"The task command line or label"
+				]
+			},
+			{
+				"key": "task.executing.shellIntegration",
+				"comment": [
+					"The task command line or label"
+				]
+			},
+			{
+				"key": "task.executingInFolder",
+				"comment": [
+					"The workspace folder the task is running in",
+					"The task command line or label"
+				]
+			},
+			{
+				"key": "task.executing.shell-integration",
+				"comment": [
+					"The task command line or label"
+				]
+			},
+			{
+				"key": "task.executing",
+				"comment": [
+					"The task command line or label"
+				]
+			},
+			"TerminalTaskSystem",
+			"unknownProblemMatcher",
+			"closeTerminal",
+			"reuseTerminal"
+		],
 		"vs/platform/audioCues/browser/audioCueService": [
 			"audioCues.lineHasError.name",
 			"audioCues.lineHasWarning.name",
@@ -6326,11 +6425,13 @@
 			"audioCues.chatResponseReceived",
 			"audioCues.chatResponsePending"
 		],
+		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
+			"openToolsLabel",
+			"iframeWebviewAlert"
+		],
 		"vs/workbench/contrib/terminal/common/terminalContextKey": [
 			"terminalFocusContextKey",
 			"terminalFocusInAnyContextKey",
-			"terminalAccessibleBufferFocusContextKey",
-			"terminalAccessibleBufferOnLastLineContextKey",
 			"terminalEditorFocusContextKey",
 			"terminalCountContextKey",
 			"terminalTabsFocusContextKey",
@@ -6345,10 +6446,6 @@
 			"isSplitTerminalContextKey",
 			"inTerminalRunCommandPickerContextKey",
 			"terminalShellIntegrationEnabled"
-		],
-		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
-			"openToolsLabel",
-			"iframeWebviewAlert"
 		],
 		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
 			"revealInWindows",
@@ -6401,14 +6498,19 @@
 			"worker",
 			"local"
 		],
+		"vs/workbench/api/node/extHostDebugService": [
+			"debug.terminal.title"
+		],
 		"vs/platform/terminal/node/terminalProcess": [
 			"launchFail.cwdNotDirectory",
 			"launchFail.cwdDoesNotExist",
 			"launchFail.executableDoesNotExist",
 			"launchFail.executableIsNotFileOrSymlink"
 		],
-		"vs/workbench/api/node/extHostDebugService": [
-			"debug.terminal.title"
+		"vs/platform/shell/node/shellEnv": [
+			"resolveShellEnvTimeout",
+			"resolveShellEnvError",
+			"resolveShellEnvExitError"
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"open",
@@ -6421,11 +6523,6 @@
 					"&& denotes a mnemonic"
 				]
 			}
-		],
-		"vs/platform/shell/node/shellEnv": [
-			"resolveShellEnvTimeout",
-			"resolveShellEnvError",
-			"resolveShellEnvExitError"
 		],
 		"vs/platform/externalTerminal/node/externalTerminalService": [
 			"console.title",
@@ -6489,24 +6586,6 @@
 			"cantUninstall",
 			"sourceMissing"
 		],
-		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
-			"newWindow",
-			"newWindowDesc",
-			"recentFoldersAndWorkspaces",
-			"recentFolders",
-			"untitledWorkspace",
-			"workspaceName"
-		],
-		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
-			{
-				"key": "ok",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"workspaceOpenedMessage",
-			"workspaceOpenedDetail"
-		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			{
 				"key": "ok",
@@ -6539,6 +6618,24 @@
 			"confirmOpenMessage",
 			"confirmOpenDetail",
 			"doNotAskAgain"
+		],
+		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
+			{
+				"key": "ok",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"workspaceOpenedMessage",
+			"workspaceOpenedDetail"
+		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"newWindow",
+			"newWindowDesc",
+			"recentFoldersAndWorkspaces",
+			"recentFolders",
+			"untitledWorkspace",
+			"workspaceName"
 		],
 		"vs/platform/files/common/io": [
 			"fileTooLargeError"
@@ -6599,9 +6696,6 @@
 			"twoIndirectDependentsError",
 			"multipleIndirectDependentsError"
 		],
-		"vs/platform/extensionManagement/node/extensionManagementUtil": [
-			"invalidManifest"
-		],
 		"vs/base/common/date": [
 			"date.fromNow.in",
 			"date.fromNow.now",
@@ -6658,21 +6752,15 @@
 			"date.fromNow.years.plural.fullWord",
 			"date.fromNow.years.plural"
 		],
-		"vs/platform/userDataSync/common/settingsSync": [
-			"errorInvalidSettings"
+		"vs/platform/extensionManagement/node/extensionManagementUtil": [
+			"invalidManifest"
 		],
 		"vs/platform/userDataSync/common/keybindingsSync": [
 			"errorInvalidSettings",
 			"errorInvalidSettings"
 		],
-		"vs/platform/userDataSync/common/userDataAutoSyncService": [
-			"default service changed",
-			"service changed",
-			"turned off",
-			"default service changed",
-			"service changed",
-			"session expired",
-			"turned off machine"
+		"vs/platform/userDataSync/common/settingsSync": [
+			"errorInvalidSettings"
 		],
 		"vs/platform/userDataSync/common/abstractSynchronizer": [
 			{
@@ -6682,6 +6770,15 @@
 				]
 			},
 			"incompatible sync data"
+		],
+		"vs/platform/userDataSync/common/userDataAutoSyncService": [
+			"default service changed",
+			"service changed",
+			"turned off",
+			"default service changed",
+			"service changed",
+			"session expired",
+			"turned off machine"
 		],
 		"vs/base/browser/ui/tree/abstractTree": [
 			"filter",
@@ -6698,114 +6795,6 @@
 			"widgetClose",
 			"previousChangeIcon",
 			"nextChangeIcon"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"notificationsEmpty",
-			"notifications",
-			"notificationsToolbar",
-			"notificationsCenterWidgetAriaLabel"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsStatus": [
-			"status.notifications",
-			"status.notifications",
-			"status.doNotDisturb",
-			"status.doNotDisturbTooltip",
-			"hideNotifications",
-			"zeroNotifications",
-			"noNotifications",
-			"oneNotification",
-			{
-				"key": "notifications",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "noNotificationsWithProgress",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "oneNotificationWithProgress",
-				"comment": [
-					"{0} will be replaced by a number"
-				]
-			},
-			{
-				"key": "notificationsWithProgress",
-				"comment": [
-					"{0} and {1} will be replaced by a number"
-				]
-			},
-			"status.message"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsToasts": [
-			"notificationAriaLabel",
-			"notificationWithSourceAriaLabel"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
-			"alertErrorMessage",
-			"alertWarningMessage",
-			"alertInfoMessage"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCommands": [
-			"notifications",
-			"showNotifications",
-			"hideNotifications",
-			"clearAllNotifications",
-			"acceptNotificationPrimaryAction",
-			"toggleDoNotDisturbMode",
-			"focusNotificationToasts"
-		],
-		"vs/platform/actions/browser/menuEntryActionViewItem": [
-			"titleAndKb",
-			"titleAndKb",
-			"titleAndKbAndAlt"
-		],
-		"vs/workbench/services/configuration/common/configurationEditing": [
-			"fsError",
-			"openTasksConfiguration",
-			"openLaunchConfiguration",
-			"open",
-			"openTasksConfiguration",
-			"openLaunchConfiguration",
-			"saveAndRetry",
-			"saveAndRetry",
-			"open",
-			"errorPolicyConfiguration",
-			"errorUnknownKey",
-			"errorInvalidWorkspaceConfigurationApplication",
-			"errorInvalidWorkspaceConfigurationMachine",
-			"errorInvalidFolderConfiguration",
-			"errorInvalidUserTarget",
-			"errorInvalidWorkspaceTarget",
-			"errorInvalidFolderTarget",
-			"errorInvalidResourceLanguageConfiguration",
-			"errorNoWorkspaceOpened",
-			"errorInvalidTaskConfiguration",
-			"errorInvalidLaunchConfiguration",
-			"errorInvalidConfiguration",
-			"errorInvalidRemoteConfiguration",
-			"errorInvalidConfigurationWorkspace",
-			"errorInvalidConfigurationFolder",
-			"errorTasksConfigurationFileDirty",
-			"errorLaunchConfigurationFileDirty",
-			"errorConfigurationFileDirty",
-			"errorRemoteConfigurationFileDirty",
-			"errorConfigurationFileDirtyWorkspace",
-			"errorConfigurationFileDirtyFolder",
-			"errorTasksConfigurationFileModifiedSince",
-			"errorLaunchConfigurationFileModifiedSince",
-			"errorConfigurationFileModifiedSince",
-			"errorRemoteConfigurationFileModifiedSince",
-			"errorConfigurationFileModifiedSinceWorkspace",
-			"errorConfigurationFileModifiedSinceFolder",
-			"errorUnknown",
-			"userTarget",
-			"remoteUserTarget",
-			"workspaceTarget",
-			"folderTarget"
 		],
 		"vs/editor/common/core/editorColorRegistry": [
 			"lineHighlight",
@@ -6876,6 +6865,22 @@
 			"editorUnicodeHighlight.border",
 			"editorUnicodeHighlight.background"
 		],
+		"vs/editor/browser/widget/diffEditor/diffEditor.contribution": [
+			"toggleCollapseUnchangedRegions",
+			"toggleShowMovedCodeBlocks",
+			"toggleUseInlineViewWhenSpaceIsLimited",
+			"useInlineViewWhenSpaceIsLimited",
+			"showMoves",
+			"diffEditor",
+			"switchSide",
+			"exitCompareMove",
+			"collapseAllUnchangedRegions",
+			"showAllUnchangedRegions",
+			"accessibleDiffViewer",
+			"editor.action.accessibleDiffViewer.next",
+			"Open Accessible Diff Viewer",
+			"editor.action.accessibleDiffViewer.prev"
+		],
 		"vs/platform/contextkey/common/scanner": [
 			"contextkey.scanner.hint.didYouMean1",
 			"contextkey.scanner.hint.didYouMean2",
@@ -6888,10 +6893,6 @@
 			"stickydesc",
 			"removedCursor"
 		],
-		"vs/editor/contrib/caretOperations/browser/caretOperations": [
-			"caret.moveLeft",
-			"caret.moveRight"
-		],
 		"vs/editor/contrib/anchorSelect/browser/anchorSelect": [
 			"selectionAnchor",
 			"anchorSet",
@@ -6900,12 +6901,9 @@
 			"selectFromAnchorToCursor",
 			"cancelSelectionAnchor"
 		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"cursors.maximum",
-			"goToSetting"
-		],
-		"vs/editor/contrib/caretOperations/browser/transpose": [
-			"transposeLetters.label"
+		"vs/editor/contrib/caretOperations/browser/caretOperations": [
+			"caret.moveLeft",
+			"caret.moveRight"
 		],
 		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
 			"overviewRulerBracketMatchForeground",
@@ -6918,6 +6916,13 @@
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"cursors.maximum",
+			"goToSetting"
+		],
+		"vs/editor/contrib/caretOperations/browser/transpose": [
+			"transposeLetters.label"
 		],
 		"vs/editor/contrib/clipboard/browser/clipboard": [
 			{
@@ -6955,17 +6960,12 @@
 			"actions.clipboard.copyWithSyntaxHighlightingLabel"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionContributions": [
-			"showCodeActionHeaders"
-		],
-		"vs/editor/browser/widget/diffEditorWidget": [
-			"diffInsertIcon",
-			"diffRemoveIcon",
-			"diff-aria-navigation-tip",
-			"diff.tooLarge",
-			"revertChangeHoverMessage"
+			"showCodeActionHeaders",
+			"includeNearbyQuickfixes"
 		],
 		"vs/editor/contrib/codelens/browser/codelensController": [
-			"showLensOnLine"
+			"showLensOnLine",
+			"placeHolder"
 		],
 		"vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions": [
 			"showOrFocusStandaloneColorPicker",
@@ -7022,7 +7022,15 @@
 			"cursor.undo",
 			"cursor.redo"
 		],
+		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution": [
+			"pasteAs",
+			"pasteAs.id"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution": [
+			"defaultProviderDescription"
+		],
 		"vs/editor/contrib/find/browser/findController": [
+			"too.large.for.replaceall",
 			"startFindAction",
 			{
 				"key": "miFind",
@@ -7058,9 +7066,6 @@
 			"EditorFontZoomOut.label",
 			"EditorFontZoomReset.label"
 		],
-		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution": [
-			"defaultProviderDescription"
-		],
 		"vs/editor/contrib/folding/browser/folding": [
 			"unfoldAction.label",
 			"unFoldRecursivelyAction.label",
@@ -7080,10 +7085,6 @@
 			"createManualFoldRange.label",
 			"removeManualFoldingRanges.label",
 			"foldLevelAction.label"
-		],
-		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution": [
-			"pasteAs",
-			"pasteAs.id"
 		],
 		"vs/editor/contrib/format/browser/formatActions": [
 			"formatDocument.label",
@@ -7158,6 +7159,45 @@
 		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
 			"multipleResults"
 		],
+		"vs/editor/contrib/gotoError/browser/gotoError": [
+			"markerAction.next.label",
+			"nextMarkerIcon",
+			"markerAction.previous.label",
+			"previousMarkerIcon",
+			"markerAction.nextInFiles.label",
+			{
+				"key": "miGotoNextProblem",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"markerAction.previousInFiles.label",
+			{
+				"key": "miGotoPreviousProblem",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/indentation/browser/indentation": [
+			"indentationToSpaces",
+			"indentationToTabs",
+			"configuredTabSize",
+			"defaultTabSize",
+			"currentTabSize",
+			{
+				"key": "selectTabWidth",
+				"comment": [
+					"Tab corresponds to the tab key"
+				]
+			},
+			"indentUsingTabs",
+			"indentUsingSpaces",
+			"changeTabDisplaySize",
+			"detectIndentation",
+			"editor.reindentlines",
+			"editor.reindentselectedlines"
+		],
 		"vs/editor/contrib/hover/browser/hover": [
 			{
 				"key": "showOrFocusHover",
@@ -7224,51 +7264,28 @@
 				]
 			}
 		],
-		"vs/editor/contrib/gotoError/browser/gotoError": [
-			"markerAction.next.label",
-			"nextMarkerIcon",
-			"markerAction.previous.label",
-			"previousMarkerIcon",
-			"markerAction.nextInFiles.label",
-			{
-				"key": "miGotoNextProblem",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"markerAction.previousInFiles.label",
-			{
-				"key": "miGotoPreviousProblem",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/editor/contrib/indentation/browser/indentation": [
-			"indentationToSpaces",
-			"indentationToTabs",
-			"configuredTabSize",
-			"defaultTabSize",
-			"currentTabSize",
-			{
-				"key": "selectTabWidth",
-				"comment": [
-					"Tab corresponds to the tab key"
-				]
-			},
-			"indentUsingTabs",
-			"indentUsingSpaces",
-			"changeTabDisplaySize",
-			"detectIndentation",
-			"editor.reindentlines",
-			"editor.reindentselectedlines"
-		],
 		"vs/editor/contrib/lineSelection/browser/lineSelection": [
 			"expandLineSelection"
+		],
+		"vs/editor/contrib/linkedEditing/browser/linkedEditing": [
+			"linkedEditing.label",
+			"editorLinkedEditingBackground"
 		],
 		"vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace": [
 			"InPlaceReplaceAction.previous.label",
 			"InPlaceReplaceAction.next.label"
+		],
+		"vs/editor/contrib/links/browser/links": [
+			"invalid.url",
+			"missing.url",
+			"links.navigate.executeCmd",
+			"links.navigate.follow",
+			"links.navigate.kb.meta.mac",
+			"links.navigate.kb.meta",
+			"links.navigate.kb.alt.mac",
+			"links.navigate.kb.alt",
+			"tooltip.explanation",
+			"label"
 		],
 		"vs/editor/contrib/linesOperations/browser/linesOperations": [
 			"lines.copyUp",
@@ -7325,22 +7342,6 @@
 			"editor.transformToSnakecase",
 			"editor.transformToCamelcase",
 			"editor.transformToKebabcase"
-		],
-		"vs/editor/contrib/links/browser/links": [
-			"invalid.url",
-			"missing.url",
-			"links.navigate.executeCmd",
-			"links.navigate.follow",
-			"links.navigate.kb.meta.mac",
-			"links.navigate.kb.meta",
-			"links.navigate.kb.alt.mac",
-			"links.navigate.kb.alt",
-			"tooltip.explanation",
-			"label"
-		],
-		"vs/editor/contrib/linkedEditing/browser/linkedEditing": [
-			"linkedEditing.label",
-			"editorLinkedEditingBackground"
 		],
 		"vs/editor/contrib/multicursor/browser/multicursor": [
 			"cursorAdded",
@@ -7458,6 +7459,18 @@
 			"toggle.tabMovesFocus.on",
 			"toggle.tabMovesFocus.off"
 		],
+		"vs/editor/contrib/unusualLineTerminators/browser/unusualLineTerminators": [
+			"unusualLineTerminators.title",
+			"unusualLineTerminators.message",
+			"unusualLineTerminators.detail",
+			{
+				"key": "unusualLineTerminators.fix",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"unusualLineTerminators.ignore"
+		],
 		"vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter": [
 			"warningIcon",
 			"unicodeHighlighting.thisDocumentHasManyNonBasicAsciiUnicodeCharacters",
@@ -7484,25 +7497,13 @@
 			"unicodeHighlight.allowCommonCharactersInLanguage",
 			"unicodeHighlight.configureUnicodeHighlightOptions"
 		],
-		"vs/editor/contrib/unusualLineTerminators/browser/unusualLineTerminators": [
-			"unusualLineTerminators.title",
-			"unusualLineTerminators.message",
-			"unusualLineTerminators.detail",
-			{
-				"key": "unusualLineTerminators.fix",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"unusualLineTerminators.ignore"
-		],
-		"vs/editor/contrib/wordOperations/browser/wordOperations": [
-			"deleteInsideWord"
-		],
 		"vs/editor/contrib/wordHighlighter/browser/wordHighlighter": [
 			"wordHighlight.next.label",
 			"wordHighlight.previous.label",
 			"wordHighlight.trigger.label"
+		],
+		"vs/editor/contrib/wordOperations/browser/wordOperations": [
+			"deleteInsideWord"
 		],
 		"vs/editor/contrib/readOnlyMessage/browser/contribution": [
 			"editor.simple.readonly",
@@ -7583,20 +7584,6 @@
 			"invalid.icons.default.fontPath.extension",
 			"invalid.icons.default.fontPath.path",
 			"invalid.icons.default"
-		],
-		"vs/workbench/api/browser/statusBarExtensionPoint": [
-			"id",
-			"name",
-			"text",
-			"tooltip",
-			"command",
-			"alignment",
-			"priority",
-			"accessibilityInformation",
-			"accessibilityInformation.role",
-			"accessibilityInformation.label",
-			"vscode.extension.contributes.statusBarItems",
-			"invalid"
 		],
 		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
 			"contributes.semanticTokenTypes",
@@ -7689,6 +7676,20 @@
 			"schema.onEnterRules.action.appendText",
 			"schema.onEnterRules.action.removeText"
 		],
+		"vs/workbench/api/browser/statusBarExtensionPoint": [
+			"id",
+			"name",
+			"text",
+			"tooltip",
+			"command",
+			"alignment",
+			"priority",
+			"accessibilityInformation",
+			"accessibilityInformation.role",
+			"accessibilityInformation.label",
+			"vscode.extension.contributes.statusBarItems",
+			"invalid"
+		],
 		"vs/workbench/api/browser/mainThreadCLICommands": [
 			"cannot be installed"
 		],
@@ -7757,9 +7758,6 @@
 			"msg-write",
 			"label"
 		],
-		"vs/workbench/api/browser/mainThreadProgress": [
-			"manageExtension"
-		],
 		"vs/workbench/api/browser/mainThreadMessageService": [
 			"extensionSource",
 			"defaultSource",
@@ -7771,6 +7769,9 @@
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"manageExtension"
 		],
 		"vs/workbench/api/browser/mainThreadSaveParticipant": [
 			"timeout.onWillSave"
@@ -7992,15 +7993,6 @@
 			"vscode.extension.pricing",
 			"product.extensionEnabledApiProposals"
 		],
-		"vs/workbench/browser/parts/views/treeView": [
-			"no-dataprovider",
-			"treeView.enableCollapseAll",
-			"treeView.enableRefresh",
-			"refresh",
-			"collapseAll",
-			"treeView.toggleCollapseAll",
-			"command-error"
-		],
 		"vs/workbench/contrib/debug/common/debug": [
 			"debugType",
 			"debugConfigurationType",
@@ -8100,28 +8092,31 @@
 			"remote.tunnelsView.makePublic",
 			"remote.tunnelsView.elevationButton"
 		],
-		"vs/workbench/browser/parts/editor/editorDropTarget": [
-			"dropIntoEditorPrompt"
+		"vs/workbench/browser/parts/views/treeView": [
+			"no-dataprovider",
+			"treeView.enableCollapseAll",
+			"treeView.enableRefresh",
+			"refresh",
+			"collapseAll",
+			"treeView.toggleCollapseAll",
+			"command-error"
 		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"ariaLabelGroupActions",
-			"emptyEditorGroup",
-			"groupLabel",
-			"groupAriaLabel"
-		],
-		"vs/workbench/browser/parts/editor/sideBySideEditor": [
-			"sideBySideEditor"
+		"vs/workbench/common/editor/sideBySideEditorInput": [
+			"sideBySideLabels"
 		],
 		"vs/workbench/common/editor/diffEditorInput": [
 			"sideBySideLabels"
 		],
-		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
-			"metadataDiff"
+		"vs/workbench/browser/parts/editor/sideBySideEditor": [
+			"sideBySideEditor"
 		],
 		"vs/workbench/browser/parts/editor/textDiffEditor": [
 			"textDiffEditor",
 			"fileTooLargeForHeapErrorWithSize",
 			"fileTooLargeForHeapErrorWithoutSize"
+		],
+		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
+			"metadataDiff"
 		],
 		"vs/workbench/browser/parts/editor/editorStatus": [
 			"singleSelectionRange",
@@ -8373,12 +8368,12 @@
 			"lockEditorGroup",
 			"unlockEditorGroup"
 		],
-		"vs/workbench/browser/parts/editor/accessibilityStatus": [
-			"screenReaderDetectedExplanation.question",
-			"screenReaderDetectedExplanation.answerYes",
-			"screenReaderDetectedExplanation.answerNo",
-			"screenReaderDetected",
-			"status.editor.screenReaderMode"
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"noViewResults",
+			"entryAriaLabelWithGroupDirty",
+			"entryAriaLabelWithGroup",
+			"entryAriaLabelDirty",
+			"closeEditor"
 		],
 		"vs/workbench/browser/parts/editor/editorConfiguration": [
 			"interactiveWindow",
@@ -8388,28 +8383,12 @@
 			"editor.editorAssociations",
 			"editorLargeFileSizeConfirmation"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
-			"toggleCollapseUnchangedRegions",
-			"toggleShowMovedCodeBlocks",
-			"toggleUseInlineViewWhenSpaceIsLimited",
-			"useInlineViewWhenSpaceIsLimited",
-			"showMoves",
-			"diffEditor",
-			"switchSide",
-			"exitCompareMove",
-			"collapseAllUnchangedRegions",
-			"showAllUnchangedRegions"
-		],
-		"vs/workbench/common/editor/sideBySideEditorInput": [
-			"sideBySideLabels"
-		],
 		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
 			"move second side bar left",
 			"move second side bar right",
 			"hide second side bar"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
-			"settingsViewBarIcon",
 			"accountsViewBarIcon",
 			"menu",
 			"hideMenu",
@@ -8418,8 +8397,8 @@
 			"resetLocation",
 			"resetLocation",
 			"manage",
-			"manage",
 			"accounts",
+			"manage",
 			"accounts"
 		],
 		"vs/workbench/browser/parts/panel/panelPart": [
@@ -8431,18 +8410,28 @@
 			"align panel",
 			"hidePanel"
 		],
-		"vs/workbench/browser/parts/editor/editorQuickAccess": [
-			"noViewResults",
-			"entryAriaLabelWithGroupDirty",
-			"entryAriaLabelWithGroup",
-			"entryAriaLabelDirty",
-			"closeEditor"
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"ariaLabelGroupActions",
+			"emptyEditorGroup",
+			"groupLabel",
+			"groupAriaLabel"
+		],
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"dropIntoEditorPrompt"
+		],
+		"vs/workbench/browser/parts/statusbar/statusbarActions": [
+			"hide",
+			"focusStatusBar"
 		],
 		"vs/platform/actions/common/menuResetAction": [
 			"title"
 		],
 		"vs/platform/actions/common/menuService": [
 			"hide.label"
+		],
+		"vs/base/browser/ui/icons/iconSelectBox": [
+			"iconSelect.placeholder",
+			"iconSelect.noResults"
 		],
 		"vs/base/browser/ui/dialog/dialog": [
 			"ok",
@@ -8462,15 +8451,11 @@
 			"commonlyUsed",
 			"defaultKeybindingsHeader"
 		],
-		"vs/workbench/browser/parts/statusbar/statusbarActions": [
-			"hide",
-			"focusStatusBar"
+		"vs/workbench/services/editor/common/editorResolverService": [
+			"editor.editorAssociations"
 		],
 		"vs/workbench/services/textfile/common/textFileEditorModel": [
 			"textFileCreate.source"
-		],
-		"vs/workbench/services/editor/common/editorResolverService": [
-			"editor.editorAssociations"
 		],
 		"vs/base/common/keybindingLabels": [
 			{
@@ -8594,41 +8579,6 @@
 				]
 			}
 		],
-		"vs/platform/keybinding/common/abstractKeybindingService": [
-			"first.chord",
-			"next.chord",
-			"missing.chord",
-			"missing.chord"
-		],
-		"vs/workbench/services/themes/common/colorThemeData": [
-			"error.cannotparsejson",
-			"error.invalidformat",
-			{
-				"key": "error.invalidformat.colors",
-				"comment": [
-					"{0} will be replaced by a path. Values in quotes should not be translated."
-				]
-			},
-			{
-				"key": "error.invalidformat.tokenColors",
-				"comment": [
-					"{0} will be replaced by a path. Values in quotes should not be translated."
-				]
-			},
-			{
-				"key": "error.invalidformat.semanticTokenColors",
-				"comment": [
-					"{0} will be replaced by a path. Values in quotes should not be translated."
-				]
-			},
-			"error.plist.invalidformat",
-			"error.cannotparse",
-			"error.cannotload"
-		],
-		"vs/workbench/services/themes/browser/fileIconThemeData": [
-			"error.cannotparseicontheme",
-			"error.invalidformat"
-		],
 		"vs/workbench/services/themes/common/fileIconThemeSchema": [
 			"schema.folderExpanded",
 			"schema.folder",
@@ -8664,6 +8614,56 @@
 			"schema.hidesExplorerArrows",
 			"schema.showLanguageModeIcons"
 		],
+		"vs/workbench/services/themes/browser/fileIconThemeData": [
+			"error.cannotparseicontheme",
+			"error.invalidformat"
+		],
+		"vs/workbench/services/themes/common/colorThemeData": [
+			"error.cannotparsejson",
+			"error.invalidformat",
+			{
+				"key": "error.invalidformat.colors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			{
+				"key": "error.invalidformat.tokenColors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			{
+				"key": "error.invalidformat.semanticTokenColors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			"error.plist.invalidformat",
+			"error.cannotparse",
+			"error.cannotload"
+		],
+		"vs/platform/keybinding/common/abstractKeybindingService": [
+			"first.chord",
+			"next.chord",
+			"missing.chord",
+			"missing.chord"
+		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"schema.token.settings",
+			"schema.token.foreground",
+			"schema.token.background.warning",
+			"schema.token.fontStyle",
+			"schema.fontStyle.error",
+			"schema.token.fontStyle.none",
+			"schema.properties.name",
+			"schema.properties.scope",
+			"schema.workbenchColors",
+			"schema.tokenColors.path",
+			"schema.colors",
+			"schema.supportsSemanticHighlighting",
+			"schema.semanticTokenColors"
+		],
 		"vs/workbench/services/themes/common/themeExtensionPoints": [
 			"vscode.extension.contributes.themes",
 			"vscode.extension.contributes.themes.id",
@@ -8683,21 +8683,6 @@
 			"reqid",
 			"invalid.path.1"
 		],
-		"vs/workbench/services/themes/common/colorThemeSchema": [
-			"schema.token.settings",
-			"schema.token.foreground",
-			"schema.token.background.warning",
-			"schema.token.fontStyle",
-			"schema.fontStyle.error",
-			"schema.token.fontStyle.none",
-			"schema.properties.name",
-			"schema.properties.scope",
-			"schema.workbenchColors",
-			"schema.tokenColors.path",
-			"schema.colors",
-			"schema.supportsSemanticHighlighting",
-			"schema.semanticTokenColors"
-		],
 		"vs/workbench/services/themes/browser/productIconThemeData": [
 			"error.parseicondefs",
 			"defaultTheme",
@@ -8711,6 +8696,16 @@
 			"error.fontId",
 			"error.icon.font",
 			"error.icon.fontCharacter"
+		],
+		"vs/workbench/services/themes/common/productIconThemeSchema": [
+			"schema.id",
+			"schema.id.formatError",
+			"schema.src",
+			"schema.font-path",
+			"schema.font-format",
+			"schema.font-weight",
+			"schema.font-style",
+			"schema.iconDefinitions"
 		],
 		"vs/workbench/services/themes/common/themeConfiguration": [
 			"colorTheme",
@@ -8785,16 +8780,6 @@
 			"editorColors.semanticHighlighting.rules",
 			"semanticTokenColors"
 		],
-		"vs/workbench/services/themes/common/productIconThemeSchema": [
-			"schema.id",
-			"schema.id.formatError",
-			"schema.src",
-			"schema.font-path",
-			"schema.font-format",
-			"schema.font-weight",
-			"schema.font-style",
-			"schema.iconDefinitions"
-		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
 			"I cannot reproduce",
 			"This is Bad",
@@ -8860,6 +8845,9 @@
 			"snippets",
 			"exclude"
 		],
+		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
+			"globalState"
+		],
 		"vs/workbench/services/userDataProfile/browser/extensionsResource": [
 			"extensions",
 			"disabled",
@@ -8869,8 +8857,8 @@
 		"vs/workbench/services/userDataProfile/browser/tasksResource": [
 			"tasks"
 		],
-		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
-			"globalState"
+		"vs/workbench/services/userDataProfile/common/userDataProfileIcons": [
+			"settingsViewBarIcon"
 		],
 		"vs/workbench/services/remote/common/tunnelModel": [
 			"tunnel.forwardedPortsViewEnabled",
@@ -8901,12 +8889,6 @@
 			"invalid.tokenTypes",
 			"invalid.path.1"
 		],
-		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
-			"defineKeybinding.initial",
-			"defineKeybinding.oneExists",
-			"defineKeybinding.existing",
-			"defineKeybinding.chordsTo"
-		],
 		"vs/editor/contrib/suggest/browser/suggest": [
 			"suggestWidgetHasSelection",
 			"suggestWidgetDetailsVisible",
@@ -8916,25 +8898,6 @@
 			"suggestionHasInsertAndReplaceRange",
 			"suggestionInsertMode",
 			"suggestionCanResolve"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"configureLanguageBasedSettings",
-			"languageDescriptionConfigured",
-			"pickLanguage"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
-			"settingsScopeDropDownIcon",
-			"settingsMoreActionIcon",
-			"keybindingsRecordKeysIcon",
-			"keybindingsSortIcon",
-			"keybindingsEditIcon",
-			"keybindingsAddIcon",
-			"settingsEditIcon",
-			"settingsRemoveIcon",
-			"preferencesDiscardIcon",
-			"preferencesClearInput",
-			"settingsFilter",
-			"preferencesOpenSettings"
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"recordKeysLabel",
@@ -8971,6 +8934,25 @@
 			"noWhen",
 			"keyboard shortcuts aria label"
 		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"configureLanguageBasedSettings",
+			"languageDescriptionConfigured",
+			"pickLanguage"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
+			"settingsScopeDropDownIcon",
+			"settingsMoreActionIcon",
+			"keybindingsRecordKeysIcon",
+			"keybindingsSortIcon",
+			"keybindingsEditIcon",
+			"keybindingsAddIcon",
+			"settingsEditIcon",
+			"settingsRemoveIcon",
+			"preferencesDiscardIcon",
+			"preferencesClearInput",
+			"settingsFilter",
+			"preferencesOpenSettings"
+		],
 		"vs/workbench/contrib/preferences/browser/settingsEditor2": [
 			"SearchSettings.AriaLabel",
 			"clearInput",
@@ -8992,6 +8974,12 @@
 			"settingsSearchTocBehavior.filter",
 			"settingsSearchTocBehavior"
 		],
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"defineKeybinding.initial",
+			"defineKeybinding.oneExists",
+			"defineKeybinding.existing",
+			"defineKeybinding.chordsTo"
+		],
 		"vs/workbench/contrib/performance/browser/perfviewEditor": [
 			"name"
 		],
@@ -9012,13 +9000,13 @@
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor": [
 			"notebookTreeAriaLabel"
 		],
-		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
-			"notebookRunTrust"
-		],
 		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
 			"disableOtherKeymapsConfirmation",
 			"yes",
 			"no"
+		],
+		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
+			"notebookRunTrust"
 		],
 		"vs/editor/common/languages/modesRegistry": [
 			"plainText.alias"
@@ -9049,12 +9037,22 @@
 			"notebook.cell.insertCodeCellBelowAndFocusContainer",
 			"notebook.changeCellType"
 		],
+		"vs/workbench/contrib/accessibility/browser/accessibleViewActions": [
+			"editor.action.accessibleViewNext",
+			"editor.action.accessibleViewPrevious",
+			"editor.action.accessibleViewGoToSymbol",
+			"editor.action.accessibilityHelp",
+			"editor.action.accessibleView",
+			"editor.action.accessibleViewDisableHint",
+			"editor.action.accessibleViewAcceptInlineCompletionAction"
+		],
 		"vs/workbench/contrib/accessibility/browser/accessibleView": [
 			"symbolLabel",
 			"symbolLabelAria",
 			"disableAccessibilityHelp",
 			"openDoc",
-			"exit-tip",
+			"exit",
+			"ariaAccessibleViewActionsBottom",
 			"ariaAccessibleViewActions",
 			"accessibility-help",
 			"accessible-view",
@@ -9074,15 +9072,6 @@
 			"acessibleViewHintNoKbEither",
 			"accessibleViewSymbolQuickPickPlaceholder",
 			"accessibleViewSymbolQuickPickTitle"
-		],
-		"vs/workbench/contrib/accessibility/browser/accessibleViewActions": [
-			"editor.action.accessibleViewNext",
-			"editor.action.accessibleViewPrevious",
-			"editor.action.accessibleViewGoToSymbol",
-			"editor.action.accessibilityHelp",
-			"editor.action.accessibleView",
-			"editor.action.accessibleViewDisableHint",
-			"editor.action.accessibleViewAcceptInlineCompletionAction"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
 			"notebookActions.category",
@@ -9139,6 +9128,9 @@
 			"revealLastFailedCell",
 			"revealLastFailedCellShort"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/cellOutputActions": [
+			"notebookActions.copyOutput"
+		],
 		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
 			"workbench.notebook.layout.select.label",
 			"workbench.notebook.layout.configure.label",
@@ -9173,13 +9165,22 @@
 			"detectLanguage",
 			"noDetection"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/cellOutputActions": [
-			"notebookActions.copyOutput"
-		],
 		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
 			"fold.cell",
 			"unfold.cell",
 			"fold.cell"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
+			"format.title",
+			"label",
+			"formatCell.label",
+			"formatCells.label"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
+			"workbench.notebook.layout.gettingStarted.label"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
+			"notebook.toggleCellToolbarPosition"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
 			"notebookActions.copy",
@@ -9191,35 +9192,6 @@
 		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFind": [
 			"notebookActions.hideFind",
 			"notebookActions.findInNotebook"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
-			"format.title",
-			"label",
-			"formatCell.label",
-			"formatCells.label"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
-			"notebook.toggleCellToolbarPosition"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
-			"notebookFormatSave.formatting",
-			"label",
-			"notebookSaveParticipants.notebookCodeActions",
-			"notebookSaveParticipants.cellCodeActions",
-			{
-				"key": "codeaction.get2",
-				"comment": [
-					"[configure]({1}) is a link. Only translate `configure`. Do not change brackets and parentheses or {1}"
-				]
-			},
-			"codeAction.apply"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
-			"workbench.notebook.layout.gettingStarted.label"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
-			"outline.showCodeCells",
-			"breadcrumbs.showCodeCells"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
 			"cursorMoveDown",
@@ -9235,13 +9207,34 @@
 			"cursorPageDownSelect",
 			"notebook.navigation.allowNavigateToSurroundingCells"
 		],
+		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
+			"notebookFormatSave.formatting",
+			"formatNotebook",
+			"trimNotebookWhitespace",
+			"trimNotebookNewlines",
+			"insertFinalNewLine",
+			"notebookSaveParticipants.notebookCodeActions",
+			"notebookSaveParticipants.cellCodeActions",
+			{
+				"key": "codeaction.get2",
+				"comment": [
+					"[configure]({1}) is a link. Only translate `configure`. Do not change brackets and parentheses or {1}"
+				]
+			},
+			"codeAction.apply"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
+			"outline.showCodeCells",
+			"breadcrumbs.showCodeCells",
+			"notebook.gotoSymbols.showAllSymbols"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
+			"setProfileTitle"
+		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders": [
 			"notebook.cell.status.searchLanguageExtensions",
 			"notebook.cell.status.language",
 			"notebook.cell.status.autoDetectLanguage"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
-			"setProfileTitle"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController": [
 			"notebook.cell.status.success",
@@ -9260,6 +9253,11 @@
 			"notebook.activeCellStatusName",
 			"notebook.multiActiveCellIndicator",
 			"notebook.singleActiveCellIndicator"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
+			"workbench.notebook.toggleLayoutTroubleshoot",
+			"workbench.notebook.inspectLayout",
+			"workbench.notebook.clearNotebookEdtitorTypeCache"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands": [
 			"notebookActions.moveCellUp",
@@ -9284,11 +9282,6 @@
 			"notebookActions.expandAllCellOutput",
 			"notebookActions.toggleScrolling"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
-			"workbench.notebook.toggleLayoutTroubleshoot",
-			"workbench.notebook.inspectLayout",
-			"workbench.notebook.clearNotebookEdtitorTypeCache"
-		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions": [
 			"notebook.diff.switchToText",
 			"notebook.diff.cell.revertMetadata",
@@ -9304,6 +9297,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatActions": [
 			"chat.category",
+			"quickChat",
 			{
 				"key": "actions.chat.acceptInput",
 				"comment": [
@@ -9318,14 +9312,6 @@
 			"interactiveSession.history.delete",
 			"interactiveSession.history.pick"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
-			"interactive.copyCodeBlock.label",
-			"interactive.insertCodeBlock.label",
-			"interactive.insertIntoNewFile.label",
-			"interactive.runInTerminal.label",
-			"interactive.nextCodeBlock.label",
-			"interactive.previousCodeBlock.label"
-		],
 		"vs/workbench/contrib/chat/browser/actions/chatCopyActions": [
 			"interactive.copyAll.label",
 			"interactive.copyItem.label"
@@ -9334,17 +9320,25 @@
 			"interactive.submit.label",
 			"interactive.cancel.label"
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
+			"interactive.helpful.label",
+			"interactive.unhelpful.label",
+			"interactive.insertIntoNotebook.label",
+			"chat.remove.label"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
 			"chat.openInChatView.label",
 			"chat.closeQuickChat.label",
 			"quickChat",
 			"interactiveSession.open"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
-			"interactive.helpful.label",
-			"interactive.unhelpful.label",
-			"interactive.insertIntoNotebook.label",
-			"chat.remove.label"
+		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
+			"interactive.copyCodeBlock.label",
+			"interactive.insertCodeBlock.label",
+			"interactive.insertIntoNewFile.label",
+			"interactive.runInTerminal.label",
+			"interactive.nextCodeBlock.label",
+			"interactive.previousCodeBlock.label"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatImportExport": [
 			"chat.file.label",
@@ -9370,11 +9364,6 @@
 			"interactiveSession.openInEditor.label",
 			"interactiveSession.openInSidebar.label"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatClearActions": [
-			"interactiveSession.clear.label",
-			"interactiveSession.clear.label",
-			"interactiveSession.clear.label"
-		],
 		"vs/workbench/contrib/chat/common/chatContextKeys": [
 			"interactiveSessionResponseHasProviderId",
 			"interactiveSessionResponseVote",
@@ -9387,6 +9376,11 @@
 			"inChat",
 			"hasChatProvider"
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatClearActions": [
+			"interactiveSession.clear.label",
+			"interactiveSession.clear.label",
+			"interactiveSession.clear.label"
+		],
 		"vs/workbench/contrib/chat/common/chatViewModel": [
 			"thinking"
 		],
@@ -9396,43 +9390,81 @@
 			"vscode.extension.contributes.slashes",
 			"invalid"
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions": [
+			"interactive.nextFileTree.label",
+			"interactive.previousFileTree.label"
+		],
 		"vs/workbench/contrib/accessibility/browser/accessibilityContributions": [
 			"notification.accessibleViewSrc",
 			"notification.accessibleView",
 			"clearNotification",
 			"clearNotification"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions": [
-			"interactive.nextFileTree.label",
-			"interactive.previousFileTree.label"
-		],
-		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
-			"interactive.input.placeholderWithCommands",
-			"interactive.input.placeholderNoCommands"
+		"vs/workbench/contrib/chat/common/chatAgents": [
+			"agent",
+			"details",
+			"vscode.extension.contributes.slashes",
+			"invalid"
 		],
 		"vs/workbench/contrib/chat/common/chatColors": [
 			"chat.requestBorder",
 			"chat.slashCommandBackground",
 			"chat.slashCommandForeground"
 		],
-		"vs/editor/contrib/peekView/browser/peekView": [
-			"inReferenceSearchEditor",
-			"label.close",
-			"peekViewTitleBackground",
-			"peekViewTitleForeground",
-			"peekViewTitleInfoForeground",
-			"peekViewBorder",
-			"peekViewResultsBackground",
-			"peekViewResultsMatchForeground",
-			"peekViewResultsFileForeground",
-			"peekViewResultsSelectionBackground",
-			"peekViewResultsSelectionForeground",
-			"peekViewEditorBackground",
-			"peekViewEditorGutterBackground",
-			"peekViewEditorStickScrollBackground",
-			"peekViewResultsMatchHighlight",
-			"peekViewEditorMatchHighlight",
-			"peekViewEditorMatchHighlightBorder"
+		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
+			"interactive.input.placeholderWithCommands",
+			"interactive.input.placeholderNoCommands"
+		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
+			"welcome.1",
+			"welcome.2",
+			"create.fail",
+			"create.fail.detail",
+			"welcome.1",
+			"default.placeholder",
+			"default.placeholder.history",
+			"thinking",
+			"empty",
+			"markdownResponseMessage",
+			"editResponseMessage",
+			"err.apply",
+			"err.discard"
+		],
+		"vs/workbench/contrib/inlineChat/common/inlineChat": [
+			"inlineChatHasProvider",
+			"inlineChatVisible",
+			"inlineChatFocused",
+			"inlineChatResponseFocused",
+			"inlineChatEmpty",
+			"inlineChatInnerCursorFirst",
+			"inlineChatInnerCursorLast",
+			"inlineChatInnerCursorStart",
+			"inlineChatInnerCursorEnd",
+			"inlineChatMarkdownMessageCropState",
+			"inlineChatOuterCursorPosition",
+			"inlineChatHasActiveRequest",
+			"inlineChatHasStashedSession",
+			"inlineChatResponseType",
+			"inlineChatResponseTypes",
+			"inlineChatDidEdit",
+			"inlineChatUserDidEdit",
+			"inlineChatLastFeedbackKind",
+			"inlineChatDocumentChanged",
+			"inlineChat.background",
+			"inlineChat.border",
+			"inlineChat.shadow",
+			"inlineChat.regionHighlight",
+			"inlineChatInput.border",
+			"inlineChatInput.focusBorder",
+			"inlineChatInput.placeholderForeground",
+			"inlineChatInput.background",
+			"inlineChatDiff.inserted",
+			"inlineChatDiff.removed",
+			"mode",
+			"mode.livePreview",
+			"mode.preview",
+			"mode.live",
+			"showDiff"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
 			"run",
@@ -9476,73 +9508,6 @@
 			"expandMessage",
 			"contractMessage"
 		],
-		"vs/workbench/contrib/notebook/browser/notebookIcons": [
-			"selectKernelIcon",
-			"executeIcon",
-			"executeAboveIcon",
-			"executeBelowIcon",
-			"stopIcon",
-			"deleteCellIcon",
-			"executeAllIcon",
-			"editIcon",
-			"stopEditIcon",
-			"moveUpIcon",
-			"moveDownIcon",
-			"clearIcon",
-			"splitCellIcon",
-			"successStateIcon",
-			"errorStateIcon",
-			"pendingStateIcon",
-			"executingStateIcon",
-			"collapsedIcon",
-			"expandedIcon",
-			"openAsTextIcon",
-			"revertIcon",
-			"renderOutputIcon",
-			"mimetypeIcon",
-			"copyIcon",
-			"previousChangeIcon",
-			"nextChangeIcon"
-		],
-		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
-			"interactiveInputPlaceHolder"
-		],
-		"vs/workbench/contrib/inlineChat/common/inlineChat": [
-			"inlineChatHasProvider",
-			"inlineChatVisible",
-			"inlineChatFocused",
-			"inlineChatResponseFocused",
-			"inlineChatEmpty",
-			"inlineChatInnerCursorFirst",
-			"inlineChatInnerCursorLast",
-			"inlineChatInnerCursorStart",
-			"inlineChatInnerCursorEnd",
-			"inlineChatMarkdownMessageCropState",
-			"inlineChatOuterCursorPosition",
-			"inlineChatHasActiveRequest",
-			"inlineChatHasStashedSession",
-			"inlineChatResponseType",
-			"inlineChatResponseTypes",
-			"inlineChatDidEdit",
-			"inlineChatUserDidEdit",
-			"inlineChatLastFeedbackKind",
-			"inlineChatDocumentChanged",
-			"inlineChat.background",
-			"inlineChat.border",
-			"inlineChat.shadow",
-			"inlineChat.regionHighlight",
-			"inlineChatInput.border",
-			"inlineChatInput.focusBorder",
-			"inlineChatInput.placeholderForeground",
-			"inlineChatInput.background",
-			"inlineChatDiff.inserted",
-			"inlineChatDiff.removed",
-			"mode",
-			"mode.livePreview",
-			"mode.preview",
-			"mode.live",
-			"showDiff"
-		],
 		"vs/workbench/contrib/files/browser/fileConstants": [
 			"saveAs",
 			"save",
@@ -9550,27 +9515,6 @@
 			"saveAll",
 			"removeFolderFromWorkspace",
 			"newUntitledFile"
-		],
-		"vs/workbench/contrib/logs/common/logsActions": [
-			"setLogLevel",
-			"all",
-			"extensionLogs",
-			"loggers",
-			"selectlog",
-			"selectLogLevelFor",
-			"selectLogLevel",
-			"resetLogLevel",
-			"trace",
-			"debug",
-			"info",
-			"warn",
-			"err",
-			"off",
-			"default",
-			"openSessionLogFile",
-			"current",
-			"sessions placeholder",
-			"log placeholder"
 		],
 		"vs/workbench/contrib/testing/browser/icons": [
 			"testViewIcon",
@@ -9597,24 +9541,6 @@
 			"testingQueuedIcon",
 			"testingSkippedIcon",
 			"testingUnsetIcon"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
-			"welcome.1",
-			"welcome.2",
-			"create.fail",
-			"create.fail.detail",
-			"welcome.1",
-			"default.placeholder",
-			"default.placeholder.history",
-			"thinking",
-			"empty",
-			"markdownResponseMessage",
-			"editResponseMessage",
-			"err.apply",
-			"err.discard"
-		],
-		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
-			"testing"
 		],
 		"vs/workbench/contrib/testing/browser/testingDecorations": [
 			"peekTestOutout",
@@ -9663,32 +9589,8 @@
 			},
 			"testExplorer"
 		],
-		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
-			"testing.markdownPeekError",
-			"testOutputTitle",
-			"testingOutputExpected",
-			"testingOutputActual",
-			"runNoOutputForPast",
-			"runNoOutput",
-			"close",
-			"testUnnamedTask",
-			"messageMoreLinesN",
-			"messageMoreLines1",
-			"testingPeekLabel",
-			"testing.showResultOutput",
-			"testing.showResultOutput",
-			"testing.reRunLastRun",
-			"testing.debugLastRun",
-			"testing.goToFile",
-			"testing.showResultOutput",
-			"testing.revealInExplorer",
-			"run test",
-			"debug test",
-			"testing.goToError",
-			"testing.goToNextMessage",
-			"testing.goToPreviousMessage",
-			"testing.openMessageInEditor",
-			"testing.toggleTestingPeekHistory"
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"testing"
 		],
 		"vs/workbench/contrib/testing/common/configuration": [
 			"testConfigurationTitle",
@@ -9714,17 +9616,45 @@
 			"testing.openTesting.neverOpen",
 			"testing.openTesting.openOnTestStart",
 			"testing.openTesting.openOnTestFailure",
+			"testing.openTesting.openExplorerOnTestStart",
 			"testing.openTesting",
 			"testing.alwaysRevealTestOnStateChange"
+		],
+		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
+			"testing.markdownPeekError",
+			"testOutputTitle",
+			"testingOutputExpected",
+			"testingOutputActual",
+			"runNoOutputForPast",
+			"runNoOutput",
+			"close",
+			"testUnnamedTask",
+			"messageMoreLinesN",
+			"messageMoreLines1",
+			"testingPeekLabel",
+			"testing.showResultOutput",
+			"testing.showResultOutput",
+			"testing.reRunLastRun",
+			"testing.debugLastRun",
+			"testing.showResultOutput",
+			"testing.revealInExplorer",
+			"run test",
+			"debug test",
+			"testing.goToFile",
+			"testing.goToError",
+			"testing.goToNextMessage",
+			"testing.goToPreviousMessage",
+			"testing.openMessageInEditor",
+			"testing.toggleTestingPeekHistory"
+		],
+		"vs/workbench/contrib/testing/common/testingContentProvider": [
+			"runNoOutout"
 		],
 		"vs/workbench/contrib/testing/common/testServiceImpl": [
 			"testTrust",
 			"testError",
 			"testTrust",
 			"testError"
-		],
-		"vs/workbench/contrib/testing/common/testingContentProvider": [
-			"runNoOutout"
 		],
 		"vs/workbench/contrib/testing/common/testingContextKeys": [
 			"testing.canRefresh",
@@ -9745,6 +9675,31 @@
 			"testing.testItemIsHidden",
 			"testing.testMessage",
 			"testing.testResultOutdated"
+		],
+		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
+			"testConfigurationUi.pick",
+			"updateTestConfiguration"
+		],
+		"vs/workbench/contrib/logs/common/logsActions": [
+			"setLogLevel",
+			"all",
+			"extensionLogs",
+			"loggers",
+			"selectlog",
+			"selectLogLevelFor",
+			"selectLogLevel",
+			"resetLogLevel",
+			"trace",
+			"debug",
+			"info",
+			"warn",
+			"err",
+			"off",
+			"default",
+			"openSessionLogFile",
+			"current",
+			"sessions placeholder",
+			"log placeholder"
 		],
 		"vs/workbench/contrib/testing/browser/testExplorerActions": [
 			"hideTest",
@@ -9798,38 +9753,74 @@
 			"testing.refreshTests",
 			"testing.cancelTestRefresh"
 		],
-		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
-			"testConfigurationUi.pick",
-			"updateTestConfiguration"
+		"vs/editor/contrib/peekView/browser/peekView": [
+			"inReferenceSearchEditor",
+			"label.close",
+			"peekViewTitleBackground",
+			"peekViewTitleForeground",
+			"peekViewTitleInfoForeground",
+			"peekViewBorder",
+			"peekViewResultsBackground",
+			"peekViewResultsMatchForeground",
+			"peekViewResultsFileForeground",
+			"peekViewResultsSelectionBackground",
+			"peekViewResultsSelectionForeground",
+			"peekViewEditorBackground",
+			"peekViewEditorGutterBackground",
+			"peekViewEditorStickScrollBackground",
+			"peekViewResultsMatchHighlight",
+			"peekViewEditorMatchHighlight",
+			"peekViewEditorMatchHighlightBorder"
 		],
-		"vs/workbench/contrib/files/browser/views/explorerView": [
-			"explorerSection",
-			"createNewFile",
-			"createNewFolder",
-			"refreshExplorer",
-			"collapseExplorerFolders"
+		"vs/workbench/contrib/notebook/browser/notebookIcons": [
+			"selectKernelIcon",
+			"executeIcon",
+			"executeAboveIcon",
+			"executeBelowIcon",
+			"stopIcon",
+			"deleteCellIcon",
+			"executeAllIcon",
+			"editIcon",
+			"stopEditIcon",
+			"moveUpIcon",
+			"moveDownIcon",
+			"clearIcon",
+			"splitCellIcon",
+			"successStateIcon",
+			"errorStateIcon",
+			"pendingStateIcon",
+			"executingStateIcon",
+			"collapsedIcon",
+			"expandedIcon",
+			"openAsTextIcon",
+			"revertIcon",
+			"renderOutputIcon",
+			"mimetypeIcon",
+			"copyIcon",
+			"previousChangeIcon",
+			"nextChangeIcon"
 		],
-		"vs/workbench/contrib/files/browser/views/emptyView": [
-			"noWorkspace"
+		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
+			"interactiveInputPlaceHolder"
 		],
-		"vs/workbench/contrib/files/browser/views/openEditorsView": [
+		"vs/platform/quickinput/browser/helpQuickAccess": [
+			"helpPickAriaLabel"
+		],
+		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
+			"noCommandResults",
+			"configure keybinding",
+			"askXInChat",
+			"commandWithCategory",
+			"showTriggerActions",
+			"clearCommandHistory",
+			"confirmClearMessage",
+			"confirmClearDetail",
 			{
-				"key": "openEditors",
-				"comment": [
-					"Open is an adjective"
-				]
-			},
-			"dirtyCounter",
-			"openEditors",
-			"flipLayout",
-			"miToggleEditorLayoutWithoutMnemonic",
-			{
-				"key": "miToggleEditorLayout",
+				"key": "clearButtonLabel",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
-			},
-			"newUntitledFile"
+			}
 		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"noViewResults",
@@ -9843,25 +9834,18 @@
 			"openView",
 			"quickOpenView"
 		],
-		"vs/platform/quickinput/browser/helpQuickAccess": [
-			"helpPickAriaLabel"
-		],
-		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
-			"noCommandResults",
-			"configure keybinding",
-			"similarCommands",
-			"askXInChat",
-			"commandWithCategory",
-			"showTriggerActions",
-			"clearCommandHistory",
-			"confirmClearMessage",
-			"confirmClearDetail",
+		"vs/workbench/contrib/files/browser/fileCommands": [
+			"modifiedLabel",
 			{
-				"key": "clearButtonLabel",
+				"key": "genericSaveError",
 				"comment": [
-					"&& denotes a mnemonic"
+					"{0} is the resource that failed to save and {1} the error message"
 				]
-			}
+			},
+			"retry",
+			"discard",
+			"genericRevertError",
+			"newFileCommand.saveLabel"
 		],
 		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
 			"userGuide",
@@ -10052,31 +10036,37 @@
 			"toggleActiveEditorReadonlyInSession",
 			"resetActiveEditorReadonlyInSession"
 		],
-		"vs/workbench/contrib/files/browser/fileCommands": [
-			"modifiedLabel",
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"noWorkspace"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerView": [
+			"explorerSection",
+			"createNewFile",
+			"createNewFolder",
+			"refreshExplorer",
+			"collapseExplorerFolders"
+		],
+		"vs/workbench/contrib/files/browser/views/openEditorsView": [
 			{
-				"key": "genericSaveError",
+				"key": "openEditors",
 				"comment": [
-					"{0} is the resource that failed to save and {1} the error message"
+					"Open is an adjective"
 				]
 			},
-			"retry",
-			"discard",
-			"genericRevertError",
-			"newFileCommand.saveLabel"
+			"dirtyCounter",
+			"openEditors",
+			"flipLayout",
+			"miToggleEditorLayoutWithoutMnemonic",
+			{
+				"key": "miToggleEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"newUntitledFile"
 		],
 		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
 			"binaryFileEditor"
-		],
-		"vs/workbench/contrib/files/browser/workspaceWatcher": [
-			"enospcError",
-			"learnMore",
-			"eshutdownError",
-			"reload"
-		],
-		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
-			"dirtyFile",
-			"dirtyFiles"
 		],
 		"vs/editor/common/config/editorConfigurationSchema": [
 			"editorConfigurationTitle",
@@ -10125,8 +10115,17 @@
 			"hideUnchangedRegions.minimumLineCount",
 			"hideUnchangedRegions.contextLineCount",
 			"showMoves",
-			"useVersion2",
 			"showEmptyDecorations"
+		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"dirtyFile",
+			"dirtyFiles"
+		],
+		"vs/workbench/contrib/files/browser/workspaceWatcher": [
+			"enospcError",
+			"learnMore",
+			"eshutdownError",
+			"reload"
 		],
 		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
 			"textFileEditor",
@@ -10138,12 +10137,126 @@
 			"unavailableResourceErrorEditorText",
 			"createFile"
 		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
+			"ok",
+			"cancel",
+			"empty.msg",
+			"conflict.1",
+			"conflict.N",
+			"edt.title.del",
+			"rename",
+			"create",
+			"edt.title.2",
+			"edt.title.1"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
+			"default"
+		],
+		"vs/workbench/contrib/search/browser/searchActionsBase": [
+			"search"
+		],
+		"vs/workbench/contrib/search/browser/searchIcons": [
+			"searchDetailsIcon",
+			"searchShowContextIcon",
+			"searchHideReplaceIcon",
+			"searchShowReplaceIcon",
+			"searchReplaceAllIcon",
+			"searchReplaceIcon",
+			"searchRemoveIcon",
+			"searchRefreshIcon",
+			"searchCollapseAllIcon",
+			"searchExpandAllIcon",
+			"searchShowAsTree",
+			"searchShowAsList",
+			"searchClearIcon",
+			"searchStopIcon",
+			"searchViewIcon",
+			"searchNewEditorIcon",
+			"searchOpenInFile"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
+			"moreSearch",
+			"searchScope.includes",
+			"label.includes",
+			"searchScope.excludes",
+			"label.excludes",
+			"runSearch",
+			"searchResultItem",
+			"searchEditor",
+			"textInputBoxBorder"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
+			"searchTitle.withQuery",
+			"searchTitle.withQuery",
+			"searchTitle"
+		],
+		"vs/workbench/contrib/search/browser/patternInputWidget": [
+			"defaultLabel",
+			"onlySearchInOpenEditors",
+			"useExcludesAndIgnoreFilesDescription"
+		],
+		"vs/workbench/contrib/search/browser/searchMessage": [
+			"unable to open trust",
+			"unable to open"
+		],
+		"vs/workbench/browser/parts/views/viewPane": [
+			"viewPaneContainerExpandedIcon",
+			"viewPaneContainerCollapsedIcon",
+			"viewToolbarAriaLabel"
+		],
+		"vs/workbench/contrib/search/browser/searchResultsView": [
+			"searchFolderMatch.other.label",
+			"searchFolderMatch.other.label",
+			"searchFileMatches",
+			"searchFileMatch",
+			"searchMatches",
+			"searchMatch",
+			"lineNumStr",
+			"numLinesStr",
+			"search",
+			"folderMatchAriaLabel",
+			"otherFilesAriaLabel",
+			"fileMatchAriaLabel",
+			"replacePreviewResultAria",
+			"searchResultAria"
+		],
 		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
 			"cannotRunGotoLine",
 			"gotoLineColumnLabel",
 			"gotoLineLabel",
 			"gotoLineLabelEmptyWithLimit",
 			"gotoLineLabelEmpty"
+		],
+		"vs/workbench/contrib/search/browser/searchWidget": [
+			"search.action.replaceAll.disabled.label",
+			"search.action.replaceAll.enabled.label",
+			"search.replace.toggle.button.title",
+			"label.Search",
+			"search.placeHolder",
+			"showContext",
+			"label.Replace",
+			"search.replace.placeHolder"
+		],
+		"vs/workbench/services/search/common/queryBuilder": [
+			"search.noWorkspaceWithName"
+		],
+		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
+			"empty",
+			"gotoSymbol",
+			{
+				"key": "miGotoSymbolInEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"gotoSymbolQuickAccessPlaceholder",
+			"gotoSymbolQuickAccess",
+			"gotoSymbolByCategoryQuickAccess"
+		],
+		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
+			"noSymbolResults",
+			"openToSide",
+			"openToBottom"
 		],
 		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
 			"noAnythingResults",
@@ -10166,53 +10279,6 @@
 			},
 			"closeEditor",
 			"filePickAriaLabelDirty"
-		],
-		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
-			"empty",
-			"gotoSymbol",
-			{
-				"key": "miGotoSymbolInEditor",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"gotoSymbolQuickAccessPlaceholder",
-			"gotoSymbolQuickAccess",
-			"gotoSymbolByCategoryQuickAccess"
-		],
-		"vs/workbench/contrib/search/browser/searchIcons": [
-			"searchDetailsIcon",
-			"searchShowContextIcon",
-			"searchHideReplaceIcon",
-			"searchShowReplaceIcon",
-			"searchReplaceAllIcon",
-			"searchReplaceIcon",
-			"searchRemoveIcon",
-			"searchRefreshIcon",
-			"searchCollapseAllIcon",
-			"searchExpandAllIcon",
-			"searchShowAsTree",
-			"searchShowAsList",
-			"searchClearIcon",
-			"searchStopIcon",
-			"searchViewIcon",
-			"searchNewEditorIcon",
-			"searchOpenInFile"
-		],
-		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
-			"noSymbolResults",
-			"openToSide",
-			"openToBottom"
-		],
-		"vs/workbench/contrib/search/browser/searchWidget": [
-			"search.action.replaceAll.disabled.label",
-			"search.action.replaceAll.enabled.label",
-			"search.replace.toggle.button.title",
-			"label.Search",
-			"search.placeHolder",
-			"showContext",
-			"label.Replace",
-			"search.replace.placeHolder"
 		],
 		"vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess": [
 			"QuickSearchSeeMoreFiles",
@@ -10240,12 +10306,6 @@
 			"findInFolder",
 			"findInWorkspace"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsRemoveReplace": [
-			"RemoveAction.label",
-			"match.replace.label",
-			"file.replaceAll.label",
-			"file.replaceAll.label"
-		],
 		"vs/workbench/contrib/search/browser/searchActionsNav": [
 			"ToggleQueryDetailsAction.label",
 			"CloseReplaceWidget.label",
@@ -10265,15 +10325,11 @@
 			"FocusPreviousSearchResult.label",
 			"replaceInFiles"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsTopBar": [
-			"clearSearchHistoryLabel",
-			"CancelSearchAction.label",
-			"RefreshAction.label",
-			"CollapseDeepestExpandedLevelAction.label",
-			"ExpandAllAction.label",
-			"ClearSearchResultsAction.label",
-			"ViewAsTreeAction.label",
-			"ViewAsListAction.label"
+		"vs/workbench/contrib/search/browser/searchActionsRemoveReplace": [
+			"RemoveAction.label",
+			"match.replace.label",
+			"file.replaceAll.label",
+			"file.replaceAll.label"
 		],
 		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
 			"showTriggerActions",
@@ -10285,139 +10341,127 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/search/browser/searchActionsTopBar": [
+			"clearSearchHistoryLabel",
+			"CancelSearchAction.label",
+			"RefreshAction.label",
+			"CollapseDeepestExpandedLevelAction.label",
+			"ExpandAllAction.label",
+			"ClearSearchResultsAction.label",
+			"ViewAsTreeAction.label",
+			"ViewAsListAction.label"
+		],
 		"vs/workbench/contrib/search/browser/searchActionsTextQuickAccess": [
 			"quickTextSearch"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
-			"ok",
-			"cancel",
-			"empty.msg",
-			"conflict.1",
-			"conflict.N",
-			"edt.title.del",
-			"rename",
-			"create",
-			"edt.title.2",
-			"edt.title.1"
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"debugToolBarBackground",
+			"debugToolBarBorder",
+			"debugIcon.startForeground",
+			"debugIcon.pauseForeground",
+			"debugIcon.stopForeground",
+			"debugIcon.disconnectForeground",
+			"debugIcon.restartForeground",
+			"debugIcon.stepOverForeground",
+			"debugIcon.stepIntoForeground",
+			"debugIcon.stepOutForeground",
+			"debugIcon.continueForeground",
+			"debugIcon.stepBackForeground"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
-			"default"
+		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
+			"workbench.action.debug.startDebug"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsBase": [
-			"search"
-		],
-		"vs/workbench/browser/parts/views/viewPane": [
-			"viewPaneContainerExpandedIcon",
-			"viewPaneContainerCollapsedIcon",
-			"viewToolbarAriaLabel"
-		],
-		"vs/workbench/contrib/search/browser/searchMessage": [
-			"unable to open trust",
-			"unable to open"
-		],
-		"vs/workbench/contrib/search/browser/patternInputWidget": [
-			"defaultLabel",
-			"onlySearchInOpenEditors",
-			"useExcludesAndIgnoreFilesDescription"
-		],
-		"vs/workbench/services/search/common/queryBuilder": [
-			"search.noWorkspaceWithName"
-		],
-		"vs/workbench/contrib/search/browser/searchResultsView": [
-			"searchFolderMatch.other.label",
-			"searchFolderMatch.other.label",
-			"searchFileMatches",
-			"searchFileMatch",
-			"searchMatches",
-			"searchMatch",
-			"lineNumStr",
-			"numLinesStr",
-			"search",
-			"folderMatchAriaLabel",
-			"otherFilesAriaLabel",
-			"fileMatchAriaLabel",
-			"replacePreviewResultAria",
-			"searchResultAria"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
-			"moreSearch",
-			"searchScope.includes",
-			"label.includes",
-			"searchScope.excludes",
-			"label.excludes",
-			"runSearch",
-			"searchResultItem",
-			"searchEditor",
-			"textInputBoxBorder"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
-			"searchTitle.withQuery",
-			"searchTitle.withQuery",
-			"searchTitle"
-		],
-		"vs/workbench/contrib/scm/browser/activity": [
-			"status.scm",
-			"scmPendingChangesBadge"
-		],
-		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
-			"source control"
-		],
-		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
-			"changes",
-			"change",
-			"multiChanges",
-			"multiChange",
-			"label.close",
-			"show previous change",
-			"show next change",
+		"vs/workbench/contrib/debug/browser/callStackView": [
 			{
-				"key": "miGotoNextChange",
+				"key": "running",
 				"comment": [
-					"&& denotes a mnemonic"
+					"indicates state"
+				]
+			},
+			"showMoreStackFrames2",
+			{
+				"key": "session",
+				"comment": [
+					"Session is a noun"
 				]
 			},
 			{
-				"key": "miGotoPreviousChange",
+				"key": "running",
 				"comment": [
-					"&& denotes a mnemonic"
+					"indicates state"
 				]
 			},
-			"move to previous change",
-			"move to next change",
-			"editorGutterModifiedBackground",
-			"editorGutterAddedBackground",
-			"editorGutterDeletedBackground",
-			"minimapGutterModifiedBackground",
-			"minimapGutterAddedBackground",
-			"minimapGutterDeletedBackground",
-			"overviewRulerModifiedForeground",
-			"overviewRulerAddedForeground",
-			"overviewRulerDeletedForeground"
+			"restartFrame",
+			"loadAllStackFrames",
+			"showMoreAndOrigin",
+			"showMoreStackFrames",
+			{
+				"key": "pausedOn",
+				"comment": [
+					"indicates reason for program being paused"
+				]
+			},
+			"paused",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "callStackAriaLabel"
+			},
+			{
+				"key": "threadAriaLabel",
+				"comment": [
+					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
+				]
+			},
+			"stackFrameAriaLabel",
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			{
+				"key": "sessionLabel",
+				"comment": [
+					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
+				]
+			},
+			"showMoreStackFrames",
+			"collapse"
 		],
-		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
-			"scm"
-		],
-		"vs/workbench/contrib/workspace/common/workspace": [
-			"workspaceTrustEnabledCtx",
-			"workspaceTrustedCtx"
-		],
-		"vs/workbench/contrib/scm/browser/scmViewPane": [
-			"scm",
-			"input",
-			"sortAction",
-			"repositories",
-			"setListViewMode",
-			"setTreeViewMode",
-			"repositorySortByDiscoveryTime",
-			"repositorySortByName",
-			"repositorySortByPath",
-			"sortChangesByName",
-			"sortChangesByPath",
-			"sortChangesByStatus",
-			"collapse all",
-			"expand all",
-			"label.close",
-			"scm.providerBorder"
+		"vs/workbench/contrib/debug/browser/debugCommands": [
+			"debug",
+			"restartDebug",
+			"stepOverDebug",
+			"stepIntoDebug",
+			"stepIntoTargetDebug",
+			"stepOutDebug",
+			"pauseDebug",
+			"disconnect",
+			"disconnectSuspend",
+			"stop",
+			"continueDebug",
+			"focusSession",
+			"selectAndStartDebugging",
+			"openLaunchJson",
+			"startDebug",
+			"startWithoutDebugging",
+			"nextDebugConsole",
+			"prevDebugConsole",
+			"openLoadedScript",
+			"callStackTop",
+			"callStackBottom",
+			"callStackUp",
+			"callStackDown",
+			"selectDebugConsole",
+			"selectDebugSession",
+			"chooseLocation",
+			"noExecutableCode",
+			"jumpToCursor",
+			"editor.debug.action.stepIntoTargets.none",
+			"addConfiguration",
+			"addInlineBreakpoint"
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"unverifiedExceptionBreakpoint",
@@ -10493,82 +10537,6 @@
 			"editBreakpoint",
 			"editHitCount"
 		],
-		"vs/workbench/contrib/debug/browser/debugColors": [
-			"debugToolBarBackground",
-			"debugToolBarBorder",
-			"debugIcon.startForeground",
-			"debugIcon.pauseForeground",
-			"debugIcon.stopForeground",
-			"debugIcon.disconnectForeground",
-			"debugIcon.restartForeground",
-			"debugIcon.stepOverForeground",
-			"debugIcon.stepIntoForeground",
-			"debugIcon.stepOutForeground",
-			"debugIcon.continueForeground",
-			"debugIcon.stepBackForeground"
-		],
-		"vs/workbench/contrib/debug/browser/callStackView": [
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"showMoreStackFrames2",
-			{
-				"key": "session",
-				"comment": [
-					"Session is a noun"
-				]
-			},
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			"restartFrame",
-			"loadAllStackFrames",
-			"showMoreAndOrigin",
-			"showMoreStackFrames",
-			{
-				"key": "pausedOn",
-				"comment": [
-					"indicates reason for program being paused"
-				]
-			},
-			"paused",
-			{
-				"comment": [
-					"Debug is a noun in this context, not a verb."
-				],
-				"key": "callStackAriaLabel"
-			},
-			{
-				"key": "threadAriaLabel",
-				"comment": [
-					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
-				]
-			},
-			"stackFrameAriaLabel",
-			{
-				"key": "running",
-				"comment": [
-					"indicates state"
-				]
-			},
-			{
-				"key": "sessionLabel",
-				"comment": [
-					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
-				]
-			},
-			"showMoreStackFrames",
-			"collapse"
-		],
-		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
-			"workbench.action.debug.startDebug"
-		],
 		"vs/workbench/contrib/debug/browser/debugIcons": [
 			"debugConsoleViewIcon",
 			"runViewIcon",
@@ -10625,39 +10593,6 @@
 			"debugConsoleEvaluationInput",
 			"debugConsoleEvaluationPrompt",
 			"debugInspectMemory"
-		],
-		"vs/workbench/contrib/debug/browser/debugCommands": [
-			"debug",
-			"restartDebug",
-			"stepOverDebug",
-			"stepIntoDebug",
-			"stepIntoTargetDebug",
-			"stepOutDebug",
-			"pauseDebug",
-			"disconnect",
-			"disconnectSuspend",
-			"stop",
-			"continueDebug",
-			"focusSession",
-			"selectAndStartDebugging",
-			"openLaunchJson",
-			"startDebug",
-			"startWithoutDebugging",
-			"nextDebugConsole",
-			"prevDebugConsole",
-			"openLoadedScript",
-			"callStackTop",
-			"callStackBottom",
-			"callStackUp",
-			"callStackDown",
-			"selectDebugConsole",
-			"selectDebugSession",
-			"chooseLocation",
-			"noExecutableCode",
-			"jumpToCursor",
-			"editor.debug.action.stepIntoTargets.none",
-			"addConfiguration",
-			"addInlineBreakpoint"
 		],
 		"vs/workbench/contrib/debug/browser/debugEditorActions": [
 			"toggleBreakpointAction",
@@ -10717,26 +10652,6 @@
 			"goToPreviousBreakpoint",
 			"closeExceptionWidget"
 		],
-		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
-			"noDebugResults",
-			"customizeLaunchConfig",
-			{
-				"key": "contributed",
-				"comment": [
-					"contributed is lower case because it looks better like that in UI. Nothing preceeds it. It is a name of the grouping of debug configurations."
-				]
-			},
-			"removeLaunchConfig",
-			{
-				"key": "providerAriaLabel",
-				"comment": [
-					"Placeholder stands for the provider label. For example \"NodeJS\"."
-				]
-			},
-			"configure",
-			"addConfigTo",
-			"addConfiguration"
-		],
 		"vs/workbench/contrib/debug/browser/debugService": [
 			"1activeSession",
 			"nActiveSessions",
@@ -10776,15 +10691,44 @@
 			"breakpointAdded",
 			"breakpointRemoved"
 		],
-		"vs/workbench/contrib/debug/browser/debugStatus": [
-			"status.debug",
-			"debugTarget",
-			"selectAndStartDebug"
+		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
+			"noDebugResults",
+			"customizeLaunchConfig",
+			{
+				"key": "contributed",
+				"comment": [
+					"contributed is lower case because it looks better like that in UI. Nothing preceeds it. It is a name of the grouping of debug configurations."
+				]
+			},
+			"removeLaunchConfig",
+			{
+				"key": "providerAriaLabel",
+				"comment": [
+					"Placeholder stands for the provider label. For example \"NodeJS\"."
+				]
+			},
+			"configure",
+			"addConfigTo",
+			"addConfiguration"
 		],
 		"vs/workbench/contrib/debug/browser/debugToolBar": [
 			"notebook.moreRunActionsLabel",
 			"stepBackDebug",
 			"reverseContinue"
+		],
+		"vs/workbench/contrib/debug/browser/debugStatus": [
+			"status.debug",
+			"debugTarget",
+			"selectAndStartDebug"
+		],
+		"vs/workbench/contrib/debug/browser/disassemblyView": [
+			"instructionNotAvailable",
+			"disassemblyTableColumnLabel",
+			"editorOpenedFromDisassemblyDescription",
+			"disassemblyView",
+			"instructionAddress",
+			"instructionBytes",
+			"instructionText"
 		],
 		"vs/workbench/contrib/debug/browser/loadedScriptsView": [
 			"loadedScriptsSession",
@@ -10802,16 +10746,24 @@
 		"vs/workbench/contrib/debug/browser/statusbarColorProvider": [
 			"statusBarDebuggingBackground",
 			"statusBarDebuggingForeground",
-			"statusBarDebuggingBorder"
+			"statusBarDebuggingBorder",
+			"commandCenter-activeBackground"
 		],
-		"vs/workbench/contrib/debug/browser/disassemblyView": [
-			"instructionNotAvailable",
-			"disassemblyTableColumnLabel",
-			"editorOpenedFromDisassemblyDescription",
-			"disassemblyView",
-			"instructionAddress",
-			"instructionBytes",
-			"instructionText"
+		"vs/workbench/contrib/debug/browser/variablesView": [
+			"variableValueAriaLabel",
+			"variablesAriaTreeLabel",
+			"variableScopeAriaLabel",
+			{
+				"key": "variableAriaLabel",
+				"comment": [
+					"Placeholders are variable name and variable value respectivly. They should not be translated."
+				]
+			},
+			"viewMemory.prompt",
+			"cancel",
+			"install",
+			"viewMemory.install.progress",
+			"collapse"
 		],
 		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
 			"typeNewValue",
@@ -10856,26 +10808,13 @@
 			},
 			"allDebuggersDisabled"
 		],
-		"vs/workbench/contrib/debug/browser/variablesView": [
-			"variableValueAriaLabel",
-			"variablesAriaTreeLabel",
-			"variableScopeAriaLabel",
-			{
-				"key": "variableAriaLabel",
-				"comment": [
-					"Placeholders are variable name and variable value respectivly. They should not be translated."
-				]
-			},
-			"viewMemory.prompt",
-			"cancel",
-			"install",
-			"viewMemory.install.progress",
-			"collapse"
-		],
 		"vs/workbench/contrib/debug/common/debugContentProvider": [
 			"unable",
 			"canNotResolveSourceWithError",
 			"canNotResolveSource"
+		],
+		"vs/workbench/contrib/debug/common/disassemblyViewInput": [
+			"disassemblyInputName"
 		],
 		"vs/workbench/contrib/debug/common/debugLifecycle": [
 			"debug.debugSessionCloseConfirmationSingular",
@@ -10887,9 +10826,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/debug/common/disassemblyViewInput": [
-			"disassemblyInputName"
-		],
 		"vs/workbench/contrib/debug/browser/breakpointWidget": [
 			"breakpointWidgetLogMessagePlaceholder",
 			"breakpointWidgetHitCountPlaceholder",
@@ -10898,6 +10834,85 @@
 			"hitCount",
 			"logMessage",
 			"breakpointType"
+		],
+		"vs/workbench/contrib/scm/browser/activity": [
+			"status.scm",
+			"scmPendingChangesBadge"
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
+			"source control"
+		],
+		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
+			"changes",
+			"change",
+			"multiChanges",
+			"multiChange",
+			"label.close",
+			"show previous change",
+			"show next change",
+			{
+				"key": "miGotoNextChange",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoPreviousChange",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"move to previous change",
+			"move to next change",
+			"editorGutterModifiedBackground",
+			"editorGutterAddedBackground",
+			"editorGutterDeletedBackground",
+			"minimapGutterModifiedBackground",
+			"minimapGutterAddedBackground",
+			"minimapGutterDeletedBackground",
+			"overviewRulerModifiedForeground",
+			"overviewRulerAddedForeground",
+			"overviewRulerDeletedForeground"
+		],
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"scm"
+		],
+		"vs/workbench/contrib/workspace/common/workspace": [
+			"workspaceTrustEnabledCtx",
+			"workspaceTrustedCtx"
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPane": [
+			"scm",
+			"input",
+			"sortAction",
+			"repositories",
+			"setListViewMode",
+			"setTreeViewMode",
+			"repositorySortByDiscoveryTime",
+			"repositorySortByName",
+			"repositorySortByPath",
+			"sortChangesByName",
+			"sortChangesByPath",
+			"sortChangesByStatus",
+			"collapse all",
+			"expand all",
+			"label.close",
+			"scm.providerBorder"
+		],
+		"vs/workbench/contrib/scm/browser/scmSyncViewPane": [
+			"scmSync",
+			"incoming",
+			"outgoing",
+			"refresh",
+			"setListViewMode",
+			"setTreeViewMode"
+		],
+		"vs/workbench/contrib/debug/browser/exceptionWidget": [
+			"debugExceptionWidgetBorder",
+			"debugExceptionWidgetBackground",
+			"exceptionThrownWithId",
+			"exceptionThrown",
+			"close"
 		],
 		"vs/workbench/contrib/debug/browser/debugHover": [
 			{
@@ -10913,13 +10928,6 @@
 					"Do not translate placeholders. Placeholders are name and value of a variable."
 				]
 			}
-		],
-		"vs/workbench/contrib/debug/browser/exceptionWidget": [
-			"debugExceptionWidgetBorder",
-			"debugExceptionWidgetBackground",
-			"exceptionThrownWithId",
-			"exceptionThrown",
-			"close"
 		],
 		"vs/workbench/contrib/debug/common/debugModel": [
 			"invalidVariableAttributes",
@@ -10940,6 +10948,9 @@
 			},
 			"breakpointDirtydHover"
 		],
+		"vs/platform/history/browser/contextScopedHistoryWidget": [
+			"suggestWidgetVisible"
+		],
 		"vs/workbench/contrib/debug/browser/debugActionViewItems": [
 			"debugLaunchConfigurations",
 			"noConfigurations",
@@ -10947,8 +10958,10 @@
 			"addConfiguration",
 			"debugSession"
 		],
-		"vs/platform/history/browser/contextScopedHistoryWidget": [
-			"suggestWidgetVisible"
+		"vs/platform/actions/browser/menuEntryActionViewItem": [
+			"titleAndKb",
+			"titleAndKb",
+			"titleAndKbAndAlt"
 		],
 		"vs/workbench/contrib/debug/browser/linkDetector": [
 			"followForwardedLink",
@@ -10957,6 +10970,9 @@
 			"fileLinkWithPath",
 			"fileLinkMac",
 			"fileLink"
+		],
+		"vs/workbench/contrib/debug/common/replModel": [
+			"consoleCleared"
 		],
 		"vs/workbench/contrib/debug/browser/replViewer": [
 			"debugConsole",
@@ -10970,8 +10986,11 @@
 			"replRawObjectAriaLabel",
 			"replGroup"
 		],
-		"vs/workbench/contrib/debug/common/replModel": [
-			"consoleCleared"
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"showing filtered problems",
+			"No problems filtered",
+			"problems filtered",
+			"clearFilter"
 		],
 		"vs/workbench/contrib/markers/browser/messages": [
 			"problems.view.toggle.label",
@@ -11022,18 +11041,6 @@
 			"problems.tree.aria.label.relatedinfo.message",
 			"errors.warnings.show.label"
 		],
-		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
-			"label",
-			"tooltip.1",
-			"tooltip.N",
-			"markers.showOnFile"
-		],
-		"vs/workbench/contrib/markers/browser/markersView": [
-			"showing filtered problems",
-			"No problems filtered",
-			"problems filtered",
-			"clearFilter"
-		],
 		"vs/workbench/browser/parts/views/viewFilter": [
 			"more filters"
 		],
@@ -11071,6 +11078,12 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
+			"label",
+			"tooltip.1",
+			"tooltip.N",
+			"markers.showOnFile"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
 			"name"
 		],
@@ -11093,17 +11106,16 @@
 		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
 			"mergeEditor"
 		],
-		"vs/workbench/contrib/comments/browser/commentService": [
-			"hasCommentingProvider"
-		],
-		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
-			"nextCommentThreadAction",
-			"previousCommentThreadAction",
-			"comments.toggleCommenting",
-			"comments.addCommand",
-			"comments.collapseAll",
-			"comments.expandAll",
-			"comments.expandUnresolved"
+		"vs/workbench/contrib/comments/common/commentContextKeys": [
+			"hasCommentingRange",
+			"editorHasCommentingRange",
+			"hasCommentingProvider",
+			"commentThreadIsEmpty",
+			"commentIsEmpty",
+			"comment",
+			"commentThread",
+			"commentController",
+			"commentFocused"
 		],
 		"vs/workbench/contrib/url/browser/trustedDomains": [
 			"trustedDomain.manageTrustedDomain",
@@ -11112,6 +11124,16 @@
 			"trustedDomain.trustSubDomain",
 			"trustedDomain.trustAllDomains",
 			"trustedDomain.manageTrustedDomains"
+		],
+		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
+			"comments.nextCommentingRange",
+			"comments.previousCommentingRange",
+			"comments.toggleCommenting",
+			"comments.addCommand.error",
+			"comments.addCommand",
+			"comments.collapseAll",
+			"comments.expandAll",
+			"comments.expandUnresolved"
 		],
 		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
 			"openExternalLinkAt",
@@ -11141,11 +11163,8 @@
 			"editor.action.webvieweditor.findPrevious",
 			"refreshWebviewLabel"
 		],
-		"vs/workbench/contrib/externalUriOpener/common/configuration": [
-			"externalUriOpeners",
-			"externalUriOpeners.uri",
-			"externalUriOpeners.uri",
-			"externalUriOpeners.defaultId"
+		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
+			"context.activeWebviewId"
 		],
 		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
 			"selectOpenerDefaultLabel.web",
@@ -11153,24 +11172,154 @@
 			"selectOpenerConfigureTitle",
 			"selectOpenerPlaceHolder"
 		],
+		"vs/workbench/contrib/externalUriOpener/common/configuration": [
+			"externalUriOpeners",
+			"externalUriOpeners.uri",
+			"externalUriOpeners.uri",
+			"externalUriOpeners.defaultId"
+		],
 		"vs/workbench/contrib/customEditor/common/customEditor": [
 			"context.customEditor"
 		],
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"extensionsInputName"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"disableOtherKeymapsConfirmation",
+			"yes",
+			"no"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionEditor": [
+			"extension version",
+			"preRelease",
+			"name",
+			"preview",
+			"preview",
+			"builtin",
+			"publisher",
+			"install count",
+			"rating",
+			"details",
+			"detailstooltip",
+			"contributions",
+			"contributionstooltip",
+			"changelog",
+			"changelogtooltip",
+			"dependencies",
+			"dependenciestooltip",
+			"extensionpack",
+			"extensionpacktooltip",
+			"runtimeStatus",
+			"runtimeStatus description",
+			"noReadme",
+			"Readme title",
+			"extension pack",
+			"noReadme",
+			"Readme title",
+			"categories",
+			"Marketplace",
+			"repository",
+			"license",
+			"resources",
+			"Marketplace Info",
+			"published",
+			"last released",
+			"last updated",
+			"id",
+			"noChangelog",
+			"Changelog title",
+			"noContributions",
+			"noContributions",
+			"noDependencies",
+			"activation reason",
+			"startup",
+			"activation time",
+			"activatedBy",
+			"not yet activated",
+			"uncaught errors",
+			"messages",
+			"noStatus",
+			"settings",
+			"setting name",
+			"description",
+			"default",
+			"debuggers",
+			"debugger name",
+			"debugger type",
+			"viewContainers",
+			"view container id",
+			"view container title",
+			"view container location",
+			"views",
+			"view id",
+			"view name",
+			"view location",
+			"localizations",
+			"localizations language id",
+			"localizations language name",
+			"localizations localized language name",
+			"customEditors",
+			"customEditors view type",
+			"customEditors priority",
+			"customEditors filenamePattern",
+			"codeActions",
+			"codeActions.title",
+			"codeActions.kind",
+			"codeActions.description",
+			"codeActions.languages",
+			"authentication",
+			"authentication.label",
+			"authentication.id",
+			"colorThemes",
+			"iconThemes",
+			"productThemes",
+			"colors",
+			"colorId",
+			"description",
+			"defaultDark",
+			"defaultLight",
+			"defaultHC",
+			"JSON Validation",
+			"fileMatch",
+			"schema",
+			"commands",
+			"command name",
+			"command title",
+			"keyboard shortcuts",
+			"menuContexts",
+			"languages",
+			"language id",
+			"language name",
+			"file extensions",
+			"grammar",
+			"snippets",
+			"activation events",
+			"Notebooks",
+			"Notebook id",
+			"Notebook name",
+			"NotebookRenderers",
+			"Notebook renderer name",
+			"Notebook mimetypes",
+			"find",
+			"find next",
+			"find previous"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
+			"app.extensions.json.title",
+			"app.extensions.json.recommendations",
+			"app.extension.identifier.errorMessage",
+			"app.extensions.json.unwantedRecommendations",
+			"app.extension.identifier.errorMessage"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"activation"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
 			"extensions",
-			"offline error",
-			"error",
-			"no extensions found",
-			"suggestProxyError",
-			"open user settings",
-			"no local extensions",
-			"extension.arialabel.verifiedPublisher",
-			"extension.arialabel.publisher",
-			"extension.arialabel.deprecated",
-			"extension.arialabel.rating"
+			"auto install missing deps",
+			"finished installing missing deps",
+			"reload",
+			"no missing deps"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"VS Code for Web",
@@ -11324,9 +11473,9 @@
 			"enabled in web worker",
 			"learn more",
 			"extension disabled because of dependency",
+			"workspace enabled",
 			"extension enabled on remote",
 			"globally enabled",
-			"workspace enabled",
 			"globally disabled",
 			"workspace disabled",
 			"reinstall",
@@ -11352,202 +11501,11 @@
 			"extensionButtonProminentForeground",
 			"extensionButtonProminentHoverBackground"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
-			"extensionsViewIcon",
-			"manageExtensionIcon",
-			"clearSearchResultsIcon",
-			"refreshIcon",
-			"filterIcon",
-			"installLocalInRemoteIcon",
-			"installWorkspaceRecommendedIcon",
-			"configureRecommendedIcon",
-			"syncEnabledIcon",
-			"syncIgnoredIcon",
-			"remoteIcon",
-			"installCountIcon",
-			"ratingIcon",
-			"verifiedPublisher",
-			"preReleaseIcon",
-			"sponsorIcon",
-			"starFullIcon",
-			"starHalfIcon",
-			"starEmptyIcon",
-			"errorIcon",
-			"warningIcon",
-			"infoIcon",
-			"trustIcon",
-			"activationtimeIcon"
-		],
-		"vs/platform/dnd/browser/dnd": [
-			"fileTooLarge"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
-			"app.extensions.json.title",
-			"app.extensions.json.recommendations",
-			"app.extension.identifier.errorMessage",
-			"app.extensions.json.unwantedRecommendations",
-			"app.extension.identifier.errorMessage"
-		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"disableOtherKeymapsConfirmation",
-			"yes",
-			"no"
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
-			"context.activeWebviewId"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
-			"activation"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionEditor": [
-			"extension version",
-			"preRelease",
-			"name",
-			"preview",
-			"preview",
-			"builtin",
-			"publisher",
-			"install count",
-			"rating",
-			"details",
-			"detailstooltip",
-			"contributions",
-			"contributionstooltip",
-			"changelog",
-			"changelogtooltip",
-			"dependencies",
-			"dependenciestooltip",
-			"extensionpack",
-			"extensionpacktooltip",
-			"runtimeStatus",
-			"runtimeStatus description",
-			"noReadme",
-			"Readme title",
-			"extension pack",
-			"noReadme",
-			"Readme title",
-			"categories",
-			"Marketplace",
-			"repository",
-			"license",
-			"resources",
-			"Marketplace Info",
-			"published",
-			"last released",
-			"last updated",
-			"id",
-			"noChangelog",
-			"Changelog title",
-			"noContributions",
-			"noContributions",
-			"noDependencies",
-			"activation reason",
-			"startup",
-			"activation time",
-			"activatedBy",
-			"not yet activated",
-			"uncaught errors",
-			"messages",
-			"noStatus",
-			"settings",
-			"setting name",
-			"description",
-			"default",
-			"debuggers",
-			"debugger name",
-			"debugger type",
-			"viewContainers",
-			"view container id",
-			"view container title",
-			"view container location",
-			"views",
-			"view id",
-			"view name",
-			"view location",
-			"localizations",
-			"localizations language id",
-			"localizations language name",
-			"localizations localized language name",
-			"customEditors",
-			"customEditors view type",
-			"customEditors priority",
-			"customEditors filenamePattern",
-			"codeActions",
-			"codeActions.title",
-			"codeActions.kind",
-			"codeActions.description",
-			"codeActions.languages",
-			"authentication",
-			"authentication.label",
-			"authentication.id",
-			"colorThemes",
-			"iconThemes",
-			"productThemes",
-			"colors",
-			"colorId",
-			"description",
-			"defaultDark",
-			"defaultLight",
-			"defaultHC",
-			"JSON Validation",
-			"fileMatch",
-			"schema",
-			"commands",
-			"command name",
-			"command title",
-			"keyboard shortcuts",
-			"menuContexts",
-			"languages",
-			"language id",
-			"language name",
-			"file extensions",
-			"grammar",
-			"snippets",
-			"activation events",
-			"Notebooks",
-			"Notebook id",
-			"Notebook name",
-			"NotebookRenderers",
-			"Notebook renderer name",
-			"Notebook mimetypes",
-			"find",
-			"find next",
-			"find previous"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"extensions",
-			"auto install missing deps",
-			"finished installing missing deps",
-			"reload",
-			"no missing deps"
-		],
 		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
 			"type",
 			"searchFor",
 			"install",
 			"manage"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
-			"Manifest is not found",
-			"postUninstallTooltip",
-			"postUpdateTooltip",
-			"enable locally",
-			"enable remote",
-			"postEnableTooltip",
-			"postEnableTooltip",
-			"postDisableTooltip",
-			"postEnableTooltip",
-			"postEnableTooltip",
-			"malicious",
-			"incompatible",
-			"uninstallingExtension",
-			"not found",
-			"installing extension",
-			"installing named extension",
-			"disable all",
-			"singleDependentError",
-			"twoDependentsError",
-			"multipleDependentsError"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
 			"neverShowAgain",
@@ -11577,6 +11535,54 @@
 		],
 		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
 			"restartExtensionHost.reason"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
+			"Manifest is not found",
+			"postUninstallTooltip",
+			"postUpdateTooltip",
+			"enable locally",
+			"enable remote",
+			"postEnableTooltip",
+			"postEnableTooltip",
+			"postDisableTooltip",
+			"postEnableTooltip",
+			"postEnableTooltip",
+			"malicious",
+			"incompatible",
+			"uninstallingExtension",
+			"not found",
+			"installing extension",
+			"installing named extension",
+			"disable all",
+			"singleDependentError",
+			"twoDependentsError",
+			"multipleDependentsError"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"extensionsViewIcon",
+			"manageExtensionIcon",
+			"clearSearchResultsIcon",
+			"refreshIcon",
+			"filterIcon",
+			"installLocalInRemoteIcon",
+			"installWorkspaceRecommendedIcon",
+			"configureRecommendedIcon",
+			"syncEnabledIcon",
+			"syncIgnoredIcon",
+			"remoteIcon",
+			"installCountIcon",
+			"ratingIcon",
+			"verifiedPublisher",
+			"preReleaseIcon",
+			"sponsorIcon",
+			"starFullIcon",
+			"starHalfIcon",
+			"starEmptyIcon",
+			"errorIcon",
+			"warningIcon",
+			"infoIcon",
+			"trustIcon",
+			"activationtimeIcon"
 		],
 		"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor": [
 			{
@@ -11637,8 +11643,21 @@
 			"showDeprecated",
 			"neverShowAgain"
 		],
-		"vs/workbench/contrib/output/browser/logViewer": [
-			"logViewerAriaLabel"
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"extensions",
+			"offline error",
+			"error",
+			"no extensions found",
+			"suggestProxyError",
+			"open user settings",
+			"no local extensions",
+			"extension.arialabel.verifiedPublisher",
+			"extension.arialabel.publisher",
+			"extension.arialabel.deprecated",
+			"extension.arialabel.rating"
+		],
+		"vs/platform/dnd/browser/dnd": [
+			"fileTooLarge"
 		],
 		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
 			"tasksQuickAccessPlaceholder",
@@ -11652,18 +11671,6 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
-			"workbench.action.terminal.focusAccessibleBuffer",
-			"workbench.action.terminal.navigateAccessibleBuffer",
-			"workbench.action.terminal.accessibleBufferGoToNextCommand",
-			"workbench.action.terminal.accessibleBufferGoToPreviousCommand"
-		],
-		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
-			"workbench.action.terminal.showEnvironmentContributions",
-			"envChanges",
-			"extension",
-			"ScopedEnvironmentContributionInfo"
-		],
 		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
 			"workbench.action.terminal.showTextureAtlas",
 			"workbench.action.terminal.writeDataToTerminal",
@@ -11676,6 +11683,22 @@
 			"terminals",
 			"terminalConnectingLabel"
 		],
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
+			"workbench.action.terminal.focusAccessibleBuffer",
+			"workbench.action.terminal.accessibleBufferGoToNextCommand",
+			"workbench.action.terminal.accessibleBufferGoToPreviousCommand"
+		],
+		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
+			"workbench.action.terminal.showEnvironmentContributions",
+			"envChanges",
+			"extension",
+			"ScopedEnvironmentContributionInfo"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
+			"workbench.action.terminal.openDetectedLink",
+			"workbench.action.terminal.openLastUrlLink",
+			"workbench.action.terminal.openLastLocalFileLink"
+		],
 		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
 			"workbench.action.terminal.focusFind",
 			"workbench.action.terminal.hideFind",
@@ -11686,11 +11709,6 @@
 			"workbench.action.terminal.findPrevious",
 			"workbench.action.terminal.searchWorkspace"
 		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
-			"workbench.action.terminal.openDetectedLink",
-			"workbench.action.terminal.openLastUrlLink",
-			"workbench.action.terminal.openLastLocalFileLink"
-		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
 			"workbench.action.terminal.showQuickFixes"
 		],
@@ -11699,15 +11717,75 @@
 			"workbench.action.tasks.allowAutomaticTasks",
 			"workbench.action.tasks.disallowAutomaticTasks"
 		],
-		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
-			"JsonSchema.version.deprecated",
-			"JsonSchema.version",
-			"JsonSchema._runner",
-			"JsonSchema.runner",
-			"JsonSchema.windows",
-			"JsonSchema.mac",
-			"JsonSchema.linux",
-			"JsonSchema.shell"
+		"vs/workbench/contrib/tasks/common/problemMatcher": [
+			"ProblemPatternParser.problemPattern.missingRegExp",
+			"ProblemPatternParser.loopProperty.notLast",
+			"ProblemPatternParser.problemPattern.kindProperty.notFirst",
+			"ProblemPatternParser.problemPattern.missingProperty",
+			"ProblemPatternParser.problemPattern.missingLocation",
+			"ProblemPatternParser.invalidRegexp",
+			"ProblemPatternSchema.regexp",
+			"ProblemPatternSchema.kind",
+			"ProblemPatternSchema.file",
+			"ProblemPatternSchema.location",
+			"ProblemPatternSchema.line",
+			"ProblemPatternSchema.column",
+			"ProblemPatternSchema.endLine",
+			"ProblemPatternSchema.endColumn",
+			"ProblemPatternSchema.severity",
+			"ProblemPatternSchema.code",
+			"ProblemPatternSchema.message",
+			"ProblemPatternSchema.loop",
+			"NamedProblemPatternSchema.name",
+			"NamedMultiLineProblemPatternSchema.name",
+			"NamedMultiLineProblemPatternSchema.patterns",
+			"ProblemPatternExtPoint",
+			"ProblemPatternRegistry.error",
+			"ProblemPatternRegistry.error",
+			"ProblemMatcherParser.noProblemMatcher",
+			"ProblemMatcherParser.noProblemPattern",
+			"ProblemMatcherParser.noOwner",
+			"ProblemMatcherParser.noFileLocation",
+			"ProblemMatcherParser.unknownSeverity",
+			"ProblemMatcherParser.noDefinedPatter",
+			"ProblemMatcherParser.noIdentifier",
+			"ProblemMatcherParser.noValidIdentifier",
+			"ProblemMatcherParser.problemPattern.watchingMatcher",
+			"ProblemMatcherParser.invalidRegexp",
+			"WatchingPatternSchema.regexp",
+			"WatchingPatternSchema.file",
+			"PatternTypeSchema.name",
+			"PatternTypeSchema.description",
+			"ProblemMatcherSchema.base",
+			"ProblemMatcherSchema.owner",
+			"ProblemMatcherSchema.source",
+			"ProblemMatcherSchema.severity",
+			"ProblemMatcherSchema.applyTo",
+			"ProblemMatcherSchema.fileLocation",
+			"ProblemMatcherSchema.background",
+			"ProblemMatcherSchema.background.activeOnStart",
+			"ProblemMatcherSchema.background.beginsPattern",
+			"ProblemMatcherSchema.background.endsPattern",
+			"ProblemMatcherSchema.watching.deprecated",
+			"ProblemMatcherSchema.watching",
+			"ProblemMatcherSchema.watching.activeOnStart",
+			"ProblemMatcherSchema.watching.beginsPattern",
+			"ProblemMatcherSchema.watching.endsPattern",
+			"LegacyProblemMatcherSchema.watchedBegin.deprecated",
+			"LegacyProblemMatcherSchema.watchedBegin",
+			"LegacyProblemMatcherSchema.watchedEnd.deprecated",
+			"LegacyProblemMatcherSchema.watchedEnd",
+			"NamedProblemMatcherSchema.name",
+			"NamedProblemMatcherSchema.label",
+			"ProblemMatcherExtPoint",
+			"msCompile",
+			"lessCompile",
+			"gulp-tsc",
+			"jshint",
+			"jshint-stylish",
+			"eslint-compact",
+			"eslint-stylish",
+			"go"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v2": [
 			"JsonSchema.shell",
@@ -11793,76 +11871,6 @@
 			"JsonSchema.mac",
 			"JsonSchema.linux"
 		],
-		"vs/workbench/contrib/tasks/common/problemMatcher": [
-			"ProblemPatternParser.problemPattern.missingRegExp",
-			"ProblemPatternParser.loopProperty.notLast",
-			"ProblemPatternParser.problemPattern.kindProperty.notFirst",
-			"ProblemPatternParser.problemPattern.missingProperty",
-			"ProblemPatternParser.problemPattern.missingLocation",
-			"ProblemPatternParser.invalidRegexp",
-			"ProblemPatternSchema.regexp",
-			"ProblemPatternSchema.kind",
-			"ProblemPatternSchema.file",
-			"ProblemPatternSchema.location",
-			"ProblemPatternSchema.line",
-			"ProblemPatternSchema.column",
-			"ProblemPatternSchema.endLine",
-			"ProblemPatternSchema.endColumn",
-			"ProblemPatternSchema.severity",
-			"ProblemPatternSchema.code",
-			"ProblemPatternSchema.message",
-			"ProblemPatternSchema.loop",
-			"NamedProblemPatternSchema.name",
-			"NamedMultiLineProblemPatternSchema.name",
-			"NamedMultiLineProblemPatternSchema.patterns",
-			"ProblemPatternExtPoint",
-			"ProblemPatternRegistry.error",
-			"ProblemPatternRegistry.error",
-			"ProblemMatcherParser.noProblemMatcher",
-			"ProblemMatcherParser.noProblemPattern",
-			"ProblemMatcherParser.noOwner",
-			"ProblemMatcherParser.noFileLocation",
-			"ProblemMatcherParser.unknownSeverity",
-			"ProblemMatcherParser.noDefinedPatter",
-			"ProblemMatcherParser.noIdentifier",
-			"ProblemMatcherParser.noValidIdentifier",
-			"ProblemMatcherParser.problemPattern.watchingMatcher",
-			"ProblemMatcherParser.invalidRegexp",
-			"WatchingPatternSchema.regexp",
-			"WatchingPatternSchema.file",
-			"PatternTypeSchema.name",
-			"PatternTypeSchema.description",
-			"ProblemMatcherSchema.base",
-			"ProblemMatcherSchema.owner",
-			"ProblemMatcherSchema.source",
-			"ProblemMatcherSchema.severity",
-			"ProblemMatcherSchema.applyTo",
-			"ProblemMatcherSchema.fileLocation",
-			"ProblemMatcherSchema.background",
-			"ProblemMatcherSchema.background.activeOnStart",
-			"ProblemMatcherSchema.background.beginsPattern",
-			"ProblemMatcherSchema.background.endsPattern",
-			"ProblemMatcherSchema.watching.deprecated",
-			"ProblemMatcherSchema.watching",
-			"ProblemMatcherSchema.watching.activeOnStart",
-			"ProblemMatcherSchema.watching.beginsPattern",
-			"ProblemMatcherSchema.watching.endsPattern",
-			"LegacyProblemMatcherSchema.watchedBegin.deprecated",
-			"LegacyProblemMatcherSchema.watchedBegin",
-			"LegacyProblemMatcherSchema.watchedEnd.deprecated",
-			"LegacyProblemMatcherSchema.watchedEnd",
-			"NamedProblemMatcherSchema.name",
-			"NamedProblemMatcherSchema.label",
-			"ProblemMatcherExtPoint",
-			"msCompile",
-			"lessCompile",
-			"gulp-tsc",
-			"jshint",
-			"jshint-stylish",
-			"eslint-compact",
-			"eslint-stylish",
-			"go"
-		],
 		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
 			"noTaskResults",
 			"TaskService.pickRunTask"
@@ -11873,6 +11881,16 @@
 			"TaskDefinition.when",
 			"TaskTypeConfiguration.noType",
 			"TaskDefinitionExtPoint"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
+			"JsonSchema.version.deprecated",
+			"JsonSchema.version",
+			"JsonSchema._runner",
+			"JsonSchema.runner",
+			"JsonSchema.windows",
+			"JsonSchema.mac",
+			"JsonSchema.linux",
+			"JsonSchema.shell"
 		],
 		"vs/workbench/contrib/remote/browser/tunnelFactory": [
 			"tunnelPrivacy.private",
@@ -11905,6 +11923,15 @@
 			"reconnectionPermanentFailure",
 			{
 				"key": "reloadWindow.dialog",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"expandAbbreviationAction",
+			{
+				"key": "miEmmetExpandAbbreviation",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
@@ -11955,14 +11982,96 @@
 			"remoteActions",
 			"remote.startActions.installingExtension"
 		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"expandAbbreviationAction",
+		"vs/workbench/contrib/format/browser/formatActionsNone": [
+			"formatDocument.label.multiple",
+			"too.large",
+			"no.provider",
 			{
-				"key": "miEmmetExpandAbbreviation",
+				"key": "install.formatter",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
 			}
+		],
+		"vs/workbench/contrib/format/browser/formatModified": [
+			"formatChanges"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
+			"global.scope",
+			"global.1",
+			"detail.label",
+			"name",
+			"bad_name1",
+			"bad_name2",
+			"bad_name3",
+			"openSnippet.label",
+			"userSnippets",
+			{
+				"key": "miOpenSnippets",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"new.global_scope",
+			"new.global",
+			"new.workspace_scope",
+			"new.folder",
+			"group.global",
+			"new.global.sep",
+			"new.global.sep",
+			"openSnippet.pickLanguage"
+		],
+		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
+			"null",
+			"nullFormatterDescription",
+			"miss",
+			"config.needed",
+			"config.bad",
+			"miss.1",
+			{
+				"key": "do.config",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"do.config.notification",
+			"select",
+			"do.config.command",
+			"summary",
+			"formatter",
+			"formatter.default",
+			"def",
+			"config",
+			"format.placeHolder",
+			"select",
+			"formatDocument.label.multiple",
+			"formatSelection.label.multiple"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
+			"label",
+			"placeholder"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
+			"label"
+		],
+		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
+			"snippet.suggestions.label"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
+			"codeAction",
+			"overflow.start.title",
+			"title"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"invalid.path.0",
+			"invalid.language.0",
+			"invalid.language",
+			"invalid.path.1",
+			"vscode.extension.contributes.snippets",
+			"vscode.extension.contributes.snippets-language",
+			"vscode.extension.contributes.snippets-path",
+			"badVariableUse",
+			"badFile"
 		],
 		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
 			"toggleScreenReaderMode"
@@ -11998,15 +12107,6 @@
 			"gotoLineQuickAccessPlaceholder",
 			"gotoLineQuickAccess"
 		],
-		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
-			"toggleMinimap",
-			{
-				"key": "miMinimap",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
 		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
 			{
 				"key": "formatting2",
@@ -12032,6 +12132,24 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
+			"toggleMinimap",
+			{
+				"key": "miMinimap",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"toggleRenderWhitespace",
+			{
+				"key": "miToggleRenderWhitespace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
 			"toggleLocation",
 			"miMultiCursorAlt",
@@ -12042,15 +12160,6 @@
 			"toggleRenderControlCharacters",
 			{
 				"key": "miToggleRenderControlCharacters",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
-			"toggleRenderWhitespace",
-			{
-				"key": "miToggleRenderWhitespace",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
@@ -12068,9 +12177,9 @@
 				]
 			}
 		],
-		"vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint": [
-			"untitledText",
-			"untitledText2",
+		"vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint": [
+			"emptyHintText",
+			"emptyHintTextDismiss",
 			{
 				"key": "inlineChatHint",
 				"comment": [
@@ -12086,97 +12195,6 @@
 			},
 			"defaultHintAriaLabel",
 			"disableHint"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
-			"global.scope",
-			"global.1",
-			"detail.label",
-			"name",
-			"bad_name1",
-			"bad_name2",
-			"bad_name3",
-			"openSnippet.label",
-			"userSnippets",
-			{
-				"key": "miOpenSnippets",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"new.global_scope",
-			"new.global",
-			"new.workspace_scope",
-			"new.folder",
-			"group.global",
-			"new.global.sep",
-			"new.global.sep",
-			"openSnippet.pickLanguage"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
-			"snippet.suggestions.label"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
-			"label",
-			"placeholder"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
-			"label"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
-			"codeAction",
-			"overflow.start.title",
-			"title"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"invalid.path.0",
-			"invalid.language.0",
-			"invalid.language",
-			"invalid.path.1",
-			"vscode.extension.contributes.snippets",
-			"vscode.extension.contributes.snippets-language",
-			"vscode.extension.contributes.snippets-path",
-			"badVariableUse",
-			"badFile"
-		],
-		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
-			"null",
-			"nullFormatterDescription",
-			"miss",
-			"config.needed",
-			"config.bad",
-			"miss.1",
-			{
-				"key": "do.config",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"do.config.notification",
-			"select",
-			"do.config.command",
-			"summary",
-			"formatter",
-			"formatter.default",
-			"def",
-			"config",
-			"format.placeHolder",
-			"select",
-			"formatDocument.label.multiple",
-			"formatSelection.label.multiple"
-		],
-		"vs/workbench/contrib/format/browser/formatActionsNone": [
-			"formatDocument.label.multiple",
-			"too.large",
-			"no.provider",
-			{
-				"key": "install.formatter",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/workbench/contrib/format/browser/formatModified": [
-			"formatChanges"
 		],
 		"vs/workbench/contrib/update/browser/update": [
 			"update.noReleaseNotesOnline",
@@ -12239,11 +12257,6 @@
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
 			"getStarted"
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
-			"builtin",
-			"developer",
-			"resetWelcomePageWalkthroughProgress"
-		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
 			"welcome.displayName",
 			"startupPage.markdownPreviewError"
@@ -12252,8 +12265,14 @@
 			"gettingStartedUnchecked",
 			"gettingStartedChecked"
 		],
-		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
-			"ViewsWelcomeExtensionPoint.proposedAPI"
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
+			"builtin",
+			"developer",
+			"resetWelcomePageWalkthroughProgress"
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
+			"walkThrough.unboundCommand",
+			"walkThrough.gitNotFound"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted": [
 			"welcomeAriaLabel",
@@ -12303,6 +12322,13 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
+			"editorWalkThrough.title",
+			"editorWalkThrough"
+		],
+		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
+			"ViewsWelcomeExtensionPoint.proposedAPI"
+		],
 		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeExtensionPoint": [
 			"contributes.viewsWelcome",
 			"contributes.viewsWelcome.view",
@@ -12313,20 +12339,11 @@
 			"contributes.viewsWelcome.view.group",
 			"contributes.viewsWelcome.view.enablement"
 		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
-			"walkThrough.unboundCommand",
-			"walkThrough.gitNotFound"
-		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
-			"editorWalkThrough.title",
-			"editorWalkThrough"
-		],
-		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
-			"callFrom",
-			"callsTo",
-			"title.loading",
-			"empt.callsFrom",
-			"empt.callsTo"
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree": [
+			"title.template",
+			"1.problem",
+			"N.problem",
+			"deep.problem"
 		],
 		"vs/workbench/contrib/typeHierarchy/browser/typeHierarchyPeek": [
 			"supertypes",
@@ -12335,11 +12352,12 @@
 			"empt.supertypes",
 			"empt.subtypes"
 		],
-		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree": [
-			"title.template",
-			"1.problem",
-			"N.problem",
-			"deep.problem"
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
+			"callFrom",
+			"callsTo",
+			"title.loading",
+			"empt.callsFrom",
+			"empt.callsTo"
 		],
 		"vs/workbench/contrib/outline/browser/outlinePane": [
 			"no-editor",
@@ -12354,6 +12372,42 @@
 			"sortByPosition",
 			"sortByName",
 			"sortByKind"
+		],
+		"vs/workbench/contrib/userDataProfile/browser/userDataProfileActions": [
+			"create temporary profile",
+			"rename profile",
+			"select profile to rename",
+			"profileExists",
+			"current",
+			"rename specific profile",
+			"pick profile to rename",
+			"mange",
+			"cleanup profile",
+			"reset workspaces"
+		],
+		"vs/workbench/contrib/userDataProfile/browser/userDataProfile": [
+			"profiles",
+			"switchProfile",
+			"selectProfile",
+			"edit profile",
+			"show profile contents",
+			"export profile",
+			"export profile in share",
+			"import profile",
+			"import from url",
+			"import from file",
+			"templates",
+			"import profile quick pick title",
+			"import profile placeholder",
+			"profile import error",
+			"import profile dialog",
+			"import profile share",
+			"save profile as",
+			"create profile",
+			"delete profile",
+			"current",
+			"delete specific profile",
+			"pick profile to delete"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
 			"stop sync",
@@ -12413,7 +12467,6 @@
 			},
 			"sign in and turn on",
 			"configure and turn on sync detail",
-			"per platform",
 			"configure sync title",
 			"configure sync placeholder",
 			"turn off sync confirmation",
@@ -12442,68 +12495,16 @@
 			"show sync log title",
 			"show sync log toolrip",
 			"complete merges title",
+			"download sync activity complete",
 			"workbench.actions.syncData.reset"
-		],
-		"vs/workbench/contrib/userDataProfile/browser/userDataProfile": [
-			"profiles",
-			"switchProfile",
-			"selectProfile",
-			"edit profile",
-			"show profile contents",
-			"export profile",
-			"export profile in share",
-			"import profile",
-			"import from url",
-			"import from file",
-			"templates",
-			"import profile quick pick title",
-			"import profile placeholder",
-			"profile import error",
-			"import profile dialog",
-			"import profile share",
-			"save profile as",
-			"create profile",
-			"delete profile",
-			"current",
-			"delete specific profile",
-			"pick profile to delete"
-		],
-		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
-			"contributes.codeActions",
-			"contributes.codeActions.languages",
-			"contributes.codeActions.kind",
-			"contributes.codeActions.title",
-			"contributes.codeActions.description"
-		],
-		"vs/workbench/contrib/userDataProfile/browser/userDataProfileActions": [
-			"create temporary profile",
-			"rename profile",
-			"select profile to rename",
-			"profileExists",
-			"current",
-			"rename specific profile",
-			"pick profile to rename",
-			"mange",
-			"cleanup profile",
-			"reset workspaces"
-		],
-		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
-			"contributes.documentation",
-			"contributes.documentation.refactorings",
-			"contributes.documentation.refactoring",
-			"contributes.documentation.refactoring.title",
-			"contributes.documentation.refactoring.when",
-			"contributes.documentation.refactoring.command"
-		],
-		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
-			"codeActionsOnSave.fixAll",
-			"codeActionsOnSave",
-			"codeActionsOnSave.generic"
 		],
 		"vs/workbench/contrib/editSessions/common/editSessions": [
 			"cloud changes",
 			"cloud changes",
 			"editSessionViewIcon"
+		],
+		"vs/workbench/contrib/editSessions/common/editSessionsLogService": [
+			"cloudChangesLog"
 		],
 		"vs/workbench/contrib/editSessions/browser/editSessionsStorageService": [
 			"choose account read placeholder",
@@ -12516,9 +12517,6 @@
 			"reset auth.v3",
 			"sign out of cloud changes clear data prompt",
 			"delete all cloud changes"
-		],
-		"vs/workbench/contrib/editSessions/common/editSessionsLogService": [
-			"cloudChangesLog"
 		],
 		"vs/workbench/contrib/editSessions/browser/editSessionsViews": [
 			"noStoredChanges",
@@ -12536,12 +12534,41 @@
 			"cloud changes",
 			"open file"
 		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"contributes.codeActions",
+			"contributes.codeActions.languages",
+			"contributes.codeActions.kind",
+			"contributes.codeActions.title",
+			"contributes.codeActions.description"
+		],
+		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
+			"contributes.documentation",
+			"contributes.documentation.refactorings",
+			"contributes.documentation.refactoring",
+			"contributes.documentation.refactoring.title",
+			"contributes.documentation.refactoring.when",
+			"contributes.documentation.refactoring.command"
+		],
+		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
+			"alwaysSave",
+			"explicitSave",
+			"neverSave",
+			"explicitSaveBoolean",
+			"neverSaveBoolean",
+			"codeActionsOnSave.fixAll",
+			"editor.codeActionsOnSave",
+			"codeActionsOnSave.generic"
+		],
 		"vs/workbench/contrib/timeline/browser/timelinePane": [
 			"timeline.loadingMore",
 			"timeline.loadMore",
 			"timeline",
 			"timeline.editorCannotProvideTimeline",
+			"timeline.noTimelineSourcesEnabled",
+			"timeline.noLocalHistoryYet",
+			"timeline.noTimelineInfoFromEnabledSources",
 			"timeline.noTimelineInfo",
+			"timeline.noSCM",
 			"timeline.editorCannotProvideTimeline",
 			"timeline.aria.item",
 			"timeline",
@@ -12608,6 +12635,9 @@
 			"localHistoryEditorLabel",
 			"localHistoryCompareToFileEditorLabel",
 			"localHistoryCompareToPreviousEditorLabel"
+		],
+		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
+			"workspaceTrustEditorInputName"
 		],
 		"vs/workbench/contrib/audioCues/browser/commands": [
 			"audioCues.help",
@@ -12719,13 +12749,6 @@
 			"untrustedFolderReason",
 			"trustedForcedReason"
 		],
-		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
-			"workspaceTrustEditorInputName"
-		],
-		"vs/workbench/contrib/share/browser/shareService": [
-			"shareProviderCount",
-			"type to filter"
-		],
 		"vs/workbench/contrib/accessibility/browser/accessibilityConfiguration": [
 			"accessibilityConfigurationTitle",
 			"verbosity.terminal.description",
@@ -12737,9 +12760,124 @@
 			"verbosity.notebook",
 			"verbosity.hover",
 			"verbosity.notification",
-			"verbosity.untitledhint",
+			"verbosity.emptyEditorHint",
+			"verbosity.comments",
 			"dimUnfocusedEnabled",
 			"dimUnfocusedOpacity"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibilityStatus": [
+			"screenReaderDetectedExplanation.question",
+			"screenReaderDetectedExplanation.answerYes",
+			"screenReaderDetectedExplanation.answerNo",
+			"screenReaderDetected",
+			"status.editor.screenReaderMode"
+		],
+		"vs/workbench/contrib/share/browser/shareService": [
+			"shareProviderCount",
+			"type to filter"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"notificationsEmpty",
+			"notifications",
+			"notificationsToolbar",
+			"notificationsCenterWidgetAriaLabel"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsStatus": [
+			"status.notifications",
+			"status.notifications",
+			"status.doNotDisturb",
+			"status.doNotDisturbTooltip",
+			"hideNotifications",
+			"zeroNotifications",
+			"noNotifications",
+			"oneNotification",
+			{
+				"key": "notifications",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "noNotificationsWithProgress",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "oneNotificationWithProgress",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "notificationsWithProgress",
+				"comment": [
+					"{0} and {1} will be replaced by a number"
+				]
+			},
+			"status.message"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCommands": [
+			"notifications",
+			"showNotifications",
+			"hideNotifications",
+			"clearAllNotifications",
+			"acceptNotificationPrimaryAction",
+			"toggleDoNotDisturbMode",
+			"focusNotificationToasts"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsToasts": [
+			"notificationAriaLabel",
+			"notificationWithSourceAriaLabel"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"alertErrorMessage",
+			"alertWarningMessage",
+			"alertInfoMessage"
+		],
+		"vs/workbench/services/configuration/common/configurationEditing": [
+			"fsError",
+			"openTasksConfiguration",
+			"openLaunchConfiguration",
+			"open",
+			"openTasksConfiguration",
+			"openLaunchConfiguration",
+			"saveAndRetry",
+			"saveAndRetry",
+			"open",
+			"errorPolicyConfiguration",
+			"errorUnknownKey",
+			"errorInvalidWorkspaceConfigurationApplication",
+			"errorInvalidWorkspaceConfigurationMachine",
+			"errorInvalidFolderConfiguration",
+			"errorInvalidUserTarget",
+			"errorInvalidWorkspaceTarget",
+			"errorInvalidFolderTarget",
+			"errorInvalidResourceLanguageConfiguration",
+			"errorNoWorkspaceOpened",
+			"errorInvalidTaskConfiguration",
+			"errorInvalidLaunchConfiguration",
+			"errorInvalidConfiguration",
+			"errorInvalidRemoteConfiguration",
+			"errorInvalidConfigurationWorkspace",
+			"errorInvalidConfigurationFolder",
+			"errorTasksConfigurationFileDirty",
+			"errorLaunchConfigurationFileDirty",
+			"errorConfigurationFileDirty",
+			"errorRemoteConfigurationFileDirty",
+			"errorConfigurationFileDirtyWorkspace",
+			"errorConfigurationFileDirtyFolder",
+			"errorTasksConfigurationFileModifiedSince",
+			"errorLaunchConfigurationFileModifiedSince",
+			"errorConfigurationFileModifiedSince",
+			"errorRemoteConfigurationFileModifiedSince",
+			"errorConfigurationFileModifiedSinceWorkspace",
+			"errorConfigurationFileModifiedSinceFolder",
+			"errorUnknown",
+			"userTarget",
+			"remoteUserTarget",
+			"workspaceTarget",
+			"folderTarget"
 		],
 		"vs/workbench/common/editor/textEditorModel": [
 			"languageAutoDetected"
@@ -12751,6 +12889,11 @@
 					"{0} is the resource that failed to save and {1} the error message"
 				]
 			}
+		],
+		"vs/workbench/browser/parts/titlebar/titlebarPart": [
+			"focusTitleBar",
+			"toggle.commandCenter",
+			"toggle.layout"
 		],
 		"vs/workbench/services/configurationResolver/common/variableResolver": [
 			"canNotResolveFile",
@@ -12772,13 +12915,16 @@
 		"vs/workbench/services/workingCopy/common/workingCopyHistoryTracker": [
 			"undoRedo.source"
 		],
-		"vs/workbench/services/extensions/common/extensionHostManager": [
-			"measureExtHostLatency"
-		],
 		"vs/workbench/services/extensions/common/extensionsUtil": [
 			"overwritingExtension",
 			"overwritingExtension",
 			"extensionUnderDevelopment"
+		],
+		"vs/workbench/services/extensions/common/extensionHostManager": [
+			"measureExtHostLatency"
+		],
+		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
+			"reportExtensionIssue"
 		],
 		"vs/workbench/contrib/localization/common/localizationsActions": [
 			"configureLocale",
@@ -12787,9 +12933,6 @@
 			"available",
 			"moreInfo",
 			"clearDisplayLanguage"
-		],
-		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
-			"reportExtensionIssue"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensionsSlowActions": [
 			"cmd.reportOrShow",
@@ -12802,52 +12945,6 @@
 		],
 		"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote": [
 			"workbench.action.terminal.newLocal"
-		],
-		"vs/workbench/browser/parts/titlebar/titlebarPart": [
-			"focusTitleBar",
-			"toggle.commandCenter",
-			"toggle.layout"
-		],
-		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
-			"ptyHostStatus",
-			"ptyHostStatus.short",
-			"nonResponsivePtyHost",
-			"ptyHostStatus.ariaLabel"
-		],
-		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
-			"taskTerminalStatus.active",
-			"taskTerminalStatus.succeeded",
-			"taskTerminalStatus.succeededInactive",
-			"taskTerminalStatus.errors",
-			"taskTerminalStatus.errorsInactive",
-			"taskTerminalStatus.warnings",
-			"taskTerminalStatus.warningsInactive",
-			"taskTerminalStatus.infos",
-			"taskTerminalStatus.infosInactive",
-			"task.watchFirstError"
-		],
-		"vs/workbench/contrib/tasks/common/taskConfiguration": [
-			"ConfigurationParser.invalidCWD",
-			"ConfigurationParser.inValidArg",
-			"ConfigurationParser.noShell",
-			"ConfigurationParser.noName",
-			"ConfigurationParser.unknownMatcherKind",
-			"ConfigurationParser.invalidVariableReference",
-			"ConfigurationParser.noTaskType",
-			"ConfigurationParser.noTypeDefinition",
-			"ConfigurationParser.missingType",
-			"ConfigurationParser.incorrectType",
-			"ConfigurationParser.notCustom",
-			"ConfigurationParser.noTaskName",
-			"taskConfiguration.providerUnavailable",
-			"taskConfiguration.noCommandOrDependsOn",
-			"taskConfiguration.noCommand",
-			{
-				"key": "TaskParse.noOsSpecificGlobalTasks",
-				"comment": [
-					"\"Task version 2.0.0\" refers to the 2.0.0 version of the task system. The \"version 2.0.0\" is not localizable as it is a json key and value."
-				]
-			}
 		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"dotnetCore",
@@ -12873,6 +12970,47 @@
 			"TaskQuickPick.goBack",
 			"TaskQuickPick.noTasksForType",
 			"noProviderForTask"
+		],
+		"vs/workbench/contrib/tasks/common/taskConfiguration": [
+			"ConfigurationParser.invalidCWD",
+			"ConfigurationParser.inValidArg",
+			"ConfigurationParser.noShell",
+			"ConfigurationParser.noName",
+			"ConfigurationParser.unknownMatcherKind",
+			"ConfigurationParser.invalidVariableReference",
+			"ConfigurationParser.noTaskType",
+			"ConfigurationParser.noTypeDefinition",
+			"ConfigurationParser.missingType",
+			"ConfigurationParser.incorrectType",
+			"ConfigurationParser.notCustom",
+			"ConfigurationParser.noTaskName",
+			"taskConfiguration.providerUnavailable",
+			"taskConfiguration.noCommandOrDependsOn",
+			"taskConfiguration.noCommand",
+			{
+				"key": "TaskParse.noOsSpecificGlobalTasks",
+				"comment": [
+					"\"Task version 2.0.0\" refers to the 2.0.0 version of the task system. The \"version 2.0.0\" is not localizable as it is a json key and value."
+				]
+			}
+		],
+		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
+			"taskTerminalStatus.active",
+			"taskTerminalStatus.succeeded",
+			"taskTerminalStatus.succeededInactive",
+			"taskTerminalStatus.errors",
+			"taskTerminalStatus.errorsInactive",
+			"taskTerminalStatus.warnings",
+			"taskTerminalStatus.warningsInactive",
+			"taskTerminalStatus.infos",
+			"taskTerminalStatus.infosInactive",
+			"task.watchFirstError"
+		],
+		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
+			"ptyHostStatus",
+			"ptyHostStatus.short",
+			"nonResponsivePtyHost",
+			"ptyHostStatus.ariaLabel"
 		],
 		"vs/workbench/contrib/localHistory/browser/localHistory": [
 			"localHistoryIcon",
@@ -13075,9 +13213,6 @@
 			"terminal.integrated.defaultProfile.osx",
 			"terminal.integrated.defaultProfile.windows"
 		],
-		"vs/base/browser/ui/findinput/findInput": [
-			"defaultLabel"
-		],
 		"vs/base/browser/ui/inputbox/inputBox": [
 			"alertErrorMessage",
 			"alertWarningMessage",
@@ -13090,43 +13225,13 @@
 			},
 			"clearedInput"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsList": [
-			"notificationAccessibleViewHint",
-			"notificationAccessibleViewHintNoKb",
-			"notificationAriaLabelHint",
-			"notificationAriaLabel",
-			"notificationWithSourceAriaLabelHint",
-			"notificationWithSourceAriaLabel",
-			"notificationsList"
+		"vs/base/browser/ui/findinput/findInput": [
+			"defaultLabel"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsActions": [
-			"clearIcon",
-			"clearAllIcon",
-			"hideIcon",
-			"expandIcon",
-			"collapseIcon",
-			"configureIcon",
-			"doNotDisturbIcon",
-			"clearNotification",
-			"clearNotifications",
-			"toggleDoNotDisturbMode",
-			"hideNotificationsCenter",
-			"expandNotification",
-			"collapseNotification",
-			"configureNotification",
-			"copyNotification"
-		],
-		"vs/base/browser/ui/actionbar/actionViewItems": [
-			{
-				"key": "titleLabel",
-				"comment": [
-					"action title",
-					"action keybinding"
-				]
-			}
-		],
-		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
-			"moreActions"
+		"vs/editor/contrib/codeAction/browser/lightBulbWidget": [
+			"preferredcodeActionWithKb",
+			"codeActionWithKb",
+			"codeAction"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionCommands": [
 			"args.schema.kind",
@@ -13158,59 +13263,19 @@
 			"autoFix.label",
 			"editor.action.autoFix.noneMessage"
 		],
-		"vs/editor/contrib/codeAction/browser/lightBulbWidget": [
-			"preferredcodeActionWithKb",
-			"codeActionWithKb",
-			"codeAction"
-		],
 		"vs/editor/contrib/codeAction/browser/codeActionController": [
+			"editingNewSelection",
 			"hideMoreActions",
 			"showMoreActions"
 		],
-		"vs/editor/browser/widget/diffReview": [
-			"diffReviewInsertIcon",
-			"diffReviewRemoveIcon",
-			"diffReviewCloseIcon",
-			"label.close",
-			"no_lines_changed",
-			"one_line_changed",
-			"more_lines_changed",
+		"vs/base/browser/ui/actionbar/actionViewItems": [
 			{
-				"key": "header",
+				"key": "titleLabel",
 				"comment": [
-					"This is the ARIA label for a git diff header.",
-					"A git diff header looks like this: @@ -154,12 +159,39 @@.",
-					"That encodes that at original line 154 (which is now line 159), 12 lines were removed/changed with 39 lines.",
-					"Variables 0 and 1 refer to the diff index out of total number of diffs.",
-					"Variables 2 and 4 will be numbers (a line number).",
-					"Variables 3 and 5 will be \"no lines changed\", \"1 line changed\" or \"X lines changed\", localized separately."
+					"action title",
+					"action keybinding"
 				]
-			},
-			"blankLine",
-			{
-				"key": "unchangedLine",
-				"comment": [
-					"The placeholders are contents of the line and should not be translated."
-				]
-			},
-			"equalLine",
-			"insertLine",
-			"deleteLine"
-		],
-		"vs/editor/browser/widget/inlineDiffMargin": [
-			"diff.clipboard.copyDeletedLinesContent.label",
-			"diff.clipboard.copyDeletedLinesContent.single.label",
-			"diff.clipboard.copyChangedLinesContent.label",
-			"diff.clipboard.copyChangedLinesContent.single.label",
-			"diff.clipboard.copyDeletedLineContent.label",
-			"diff.clipboard.copyChangedLineContent.label",
-			"diff.inline.revertChange.label",
-			"diff.clipboard.copyDeletedLineContent.label",
-			"diff.clipboard.copyChangedLineContent.label"
-		],
-		"vs/editor/common/viewLayout/viewLineRenderer": [
-			"showMore",
-			"overflow.chars"
+			}
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
 			"pasteWidgetVisible",
@@ -13218,11 +13283,6 @@
 			"pasteIntoEditorProgress",
 			"pasteAsPickerPlaceholder",
 			"pasteAsProgress"
-		],
-		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController": [
-			"dropWidgetVisible",
-			"postDropWidgetTitle",
-			"dropIntoEditorProgress"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders": [
 			"builtIn",
@@ -13233,6 +13293,11 @@
 			"defaultDropProvider.uriList.path",
 			"defaultDropProvider.uriList.relativePaths",
 			"defaultDropProvider.uriList.relativePath"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController": [
+			"dropWidgetVisible",
+			"postDropWidgetTitle",
+			"dropIntoEditorProgress"
 		],
 		"vs/editor/contrib/find/browser/findWidget": [
 			"findSelectionIcon",
@@ -13277,6 +13342,9 @@
 			"hint1n",
 			"hintnn"
 		],
+		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
+			"inlineSuggestionFollows"
+		],
 		"vs/editor/contrib/inlineCompletions/browser/commands": [
 			"action.inlineSuggest.showNext",
 			"action.inlineSuggest.showPrevious",
@@ -13298,6 +13366,11 @@
 			"labelLoading",
 			"metaTitle.N"
 		],
+		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
+			"hasSymbols",
+			"location.kb",
+			"location"
+		],
 		"vs/editor/contrib/gotoSymbol/browser/referencesModel": [
 			"aria.oneReference",
 			{
@@ -13316,34 +13389,6 @@
 		"vs/editor/contrib/message/browser/messageController": [
 			"messageVisible"
 		],
-		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
-			"hasSymbols",
-			"location.kb",
-			"location"
-		],
-		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
-			"inlineSuggestionFollows"
-		],
-		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget": [
-			"parameterHintsNextIcon",
-			"parameterHintsPreviousIcon",
-			{
-				"key": "content",
-				"comment": [
-					"A label",
-					"A keybinding"
-				]
-			},
-			"previous",
-			"next"
-		],
-		"vs/editor/contrib/hover/browser/markerHoverParticipant": [
-			"view problem",
-			"noQuickFixes",
-			"checkingForQuickFixes",
-			"noQuickFixes",
-			"quick fixes"
-		],
 		"vs/editor/contrib/gotoError/browser/gotoErrorWidget": [
 			"Error",
 			"Warning",
@@ -13360,10 +13405,40 @@
 			"editorMarkerNavigationInfoHeaderBackground",
 			"editorMarkerNavigationBackground"
 		],
+		"vs/editor/contrib/inlayHints/browser/inlayHintsHover": [
+			"hint.dbl",
+			"links.navigate.kb.meta.mac",
+			"links.navigate.kb.meta",
+			"links.navigate.kb.alt.mac",
+			"links.navigate.kb.alt",
+			"hint.defAndCommand",
+			"hint.def",
+			"hint.cmd"
+		],
 		"vs/editor/contrib/hover/browser/markdownHoverParticipant": [
 			"modesContentHover.loading",
 			"stopped rendering",
 			"too many characters"
+		],
+		"vs/editor/contrib/hover/browser/markerHoverParticipant": [
+			"view problem",
+			"noQuickFixes",
+			"checkingForQuickFixes",
+			"noQuickFixes",
+			"quick fixes"
+		],
+		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget": [
+			"parameterHintsNextIcon",
+			"parameterHintsPreviousIcon",
+			{
+				"key": "content",
+				"comment": [
+					"A label",
+					"A keybinding"
+				]
+			},
+			"previous",
+			"next"
 		],
 		"vs/editor/contrib/wordHighlighter/browser/highlightDecorations": [
 			"wordHighlight",
@@ -13381,16 +13456,6 @@
 			"parameterHintsPreviousIcon",
 			"hint",
 			"editorHoverWidgetHighlightForeground"
-		],
-		"vs/editor/contrib/inlayHints/browser/inlayHintsHover": [
-			"hint.dbl",
-			"links.navigate.kb.meta.mac",
-			"links.navigate.kb.meta",
-			"links.navigate.kb.alt.mac",
-			"links.navigate.kb.alt",
-			"hint.defAndCommand",
-			"hint.def",
-			"hint.cmd"
 		],
 		"vs/editor/contrib/rename/browser/renameInputField": [
 			"renameInputVisible",
@@ -13447,9 +13512,6 @@
 			"label.desc",
 			"ariaCurrenttSuggestionReadDetails"
 		],
-		"vs/workbench/api/browser/mainThreadWebviews": [
-			"errorMessage"
-		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
 			"schema.token.settings",
 			"schema.token.foreground",
@@ -13493,6 +13555,9 @@
 			"modification",
 			"async",
 			"readonly"
+		],
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"errorMessage"
 		],
 		"vs/workbench/browser/parts/editor/textEditor": [
 			"editor"
@@ -13550,34 +13615,8 @@
 			"toggle",
 			"toggleBadge"
 		],
-		"vs/base/browser/ui/tree/treeDefaults": [
-			"collapse all"
-		],
-		"vs/workbench/browser/parts/views/checkbox": [
-			"checked",
-			"unchecked"
-		],
 		"vs/base/browser/ui/splitview/paneview": [
 			"viewSection"
-		],
-		"vs/workbench/contrib/remote/browser/remoteIcons": [
-			"getStartedIcon",
-			"documentationIcon",
-			"feedbackIcon",
-			"reviewIssuesIcon",
-			"reportIssuesIcon",
-			"remoteExplorerViewIcon",
-			"portsViewIcon",
-			"portIcon",
-			"privatePortIcon",
-			"forwardPortIcon",
-			"stopForwardIcon",
-			"openBrowserIcon",
-			"openPreviewIcon",
-			"copyAddressIcon",
-			"labelPortIcon",
-			"forwardedPortWithoutProcessIcon",
-			"forwardedPortWithProcessIcon"
 		],
 		"vs/workbench/contrib/remote/browser/tunnelView": [
 			"remote.tunnelsView.addPort",
@@ -13632,6 +13671,7 @@
 			"remote.tunnel.copyAddressCommandPalette",
 			"remote.tunnel.copyAddressPlaceholdter",
 			"remote.tunnel.changeLocalPort",
+			"remote.tunnelsView.portShouldBeNumber",
 			"remote.tunnel.changeLocalPortNumber",
 			"remote.tunnelsView.changePort",
 			"remote.tunnel.protocolHttp",
@@ -13640,32 +13680,31 @@
 			"tunnelContext.protocolMenu",
 			"portWithRunningProcess.foreground"
 		],
-		"vs/workbench/browser/parts/editor/tabsTitleControl": [
-			"ariaLabelTabActions"
+		"vs/workbench/contrib/remote/browser/remoteIcons": [
+			"getStartedIcon",
+			"documentationIcon",
+			"feedbackIcon",
+			"reviewIssuesIcon",
+			"reportIssuesIcon",
+			"remoteExplorerViewIcon",
+			"portsViewIcon",
+			"portIcon",
+			"privatePortIcon",
+			"forwardPortIcon",
+			"stopForwardIcon",
+			"openBrowserIcon",
+			"openPreviewIcon",
+			"copyAddressIcon",
+			"labelPortIcon",
+			"forwardedPortWithoutProcessIcon",
+			"forwardedPortWithProcessIcon"
 		],
-		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
-			"watermark.showCommands",
-			"watermark.quickAccess",
-			"watermark.openFile",
-			"watermark.openFolder",
-			"watermark.openFileFolder",
-			"watermark.openRecent",
-			"watermark.newUntitledFile",
-			"watermark.findInFiles",
-			{
-				"key": "watermark.toggleTerminal",
-				"comment": [
-					"toggle is a verb here"
-				]
-			},
-			"watermark.startDebugging",
-			{
-				"key": "watermark.toggleFullscreen",
-				"comment": [
-					"toggle is a verb here"
-				]
-			},
-			"watermark.showSettings"
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"collapse all"
+		],
+		"vs/workbench/browser/parts/views/checkbox": [
+			"checked",
+			"unchecked"
 		],
 		"vs/workbench/browser/parts/editor/textCodeEditor": [
 			"textEditor"
@@ -13674,21 +13713,6 @@
 			"binaryEditor",
 			"binaryError",
 			"openAnyway"
-		],
-		"vs/workbench/browser/parts/editor/editorPanes": [
-			"editorOpenErrorDialog",
-			{
-				"key": "ok",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			}
-		],
-		"vs/editor/browser/widget/diffEditor.contribution": [
-			"accessibleDiffViewer",
-			"editor.action.accessibleDiffViewer.next",
-			"Open Accessible Diff Viewer",
-			"editor.action.accessibleDiffViewer.prev"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
 			"loading",
@@ -13796,8 +13820,50 @@
 		"vs/base/browser/ui/toolbar/toolbar": [
 			"moreActions"
 		],
+		"vs/workbench/browser/parts/editor/editorPanes": [
+			"editorOpenErrorDialog",
+			{
+				"key": "ok",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
+			"watermark.showCommands",
+			"watermark.quickAccess",
+			"watermark.openFile",
+			"watermark.openFolder",
+			"watermark.openFileFolder",
+			"watermark.openRecent",
+			"watermark.newUntitledFile",
+			"watermark.findInFiles",
+			{
+				"key": "watermark.toggleTerminal",
+				"comment": [
+					"toggle is a verb here"
+				]
+			},
+			"watermark.startDebugging",
+			{
+				"key": "watermark.toggleFullscreen",
+				"comment": [
+					"toggle is a verb here"
+				]
+			},
+			"watermark.showSettings"
+		],
 		"vs/base/browser/ui/iconLabel/iconLabelHover": [
 			"iconLabel.loading"
+		],
+		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
+			"default",
+			"extension",
+			"user",
+			"cat.title",
+			"cat.title",
+			"option",
+			"meta"
 		],
 		"vs/workbench/services/preferences/common/preferencesValidation": [
 			"validations.booleanIncorrectType",
@@ -13828,15 +13894,6 @@
 			"validations.stringArrayItemEnum",
 			"validations.objectIncorrectType",
 			"validations.objectPattern"
-		],
-		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
-			"default",
-			"extension",
-			"user",
-			"cat.title",
-			"cat.title",
-			"option",
-			"meta"
 		],
 		"vs/editor/common/model/editStack": [
 			"edit"
@@ -13886,36 +13943,6 @@
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"unbound"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
-			"userSettings",
-			"userSettingsRemote",
-			"workspaceSettings",
-			"folderSettings",
-			"settingsSwitcherBarAriaLabel",
-			"userSettings",
-			"userSettingsRemote",
-			"workspaceSettings",
-			"userSettings",
-			"workspaceSettings"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
-			"editTtile",
-			"replaceDefaultValue",
-			"copyDefaultValue",
-			"unsupportedPolicySetting",
-			"unsupportLanguageOverrideSetting",
-			"defaultProfileSettingWhileNonDefaultActive",
-			"allProfileSettingWhileInNonDefaultProfileSetting",
-			"unsupportedRemoteMachineSetting",
-			"unsupportedWindowSetting",
-			"unsupportedApplicationSetting",
-			"unsupportedMachineSetting",
-			"untrustedSetting",
-			"unknown configuration setting",
-			"manage workspace trust",
-			"manage workspace trust",
-			"unsupportedProperty"
-		],
 		"vs/workbench/contrib/preferences/common/settingsEditorColorRegistry": [
 			"headerForeground",
 			"settingsHeaderHoverForeground",
@@ -13938,6 +13965,36 @@
 			"focusedRowBackground",
 			"settings.rowHoverBackground",
 			"settings.focusedRowBorder"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
+			"editTtile",
+			"replaceDefaultValue",
+			"copyDefaultValue",
+			"unsupportedPolicySetting",
+			"unsupportLanguageOverrideSetting",
+			"defaultProfileSettingWhileNonDefaultActive",
+			"allProfileSettingWhileInNonDefaultProfileSetting",
+			"unsupportedRemoteMachineSetting",
+			"unsupportedWindowSetting",
+			"unsupportedApplicationSetting",
+			"unsupportedMachineSetting",
+			"untrustedSetting",
+			"unknown configuration setting",
+			"manage workspace trust",
+			"manage workspace trust",
+			"unsupportedProperty"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"folderSettings",
+			"settingsSwitcherBarAriaLabel",
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"userSettings",
+			"workspaceSettings"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsLayout": [
 			"commonlyUsed",
@@ -13989,6 +14046,26 @@
 			"security",
 			"workspace"
 		],
+		"vs/workbench/contrib/preferences/browser/settingsTree": [
+			"extensions",
+			"modified",
+			"settingsContextMenuTitle",
+			"newExtensionsButtonLabel",
+			"editInSettingsJson",
+			"editLanguageSettingLabel",
+			"settings.Default",
+			"modified",
+			"showExtension",
+			"resetSettingLabel",
+			"validationError",
+			"validationError",
+			"settings.Modified",
+			"settings",
+			"copySettingIdLabel",
+			"copySettingAsJSONLabel",
+			"stopSyncingSetting",
+			"applyToAllProfiles"
+		],
 		"vs/workbench/contrib/preferences/browser/tocTree": [
 			{
 				"key": "settingsTOC",
@@ -14013,26 +14090,6 @@
 			"onlineSettingsSearchTooltip",
 			"policySettingsSearch",
 			"policySettingsSearchTooltip"
-		],
-		"vs/workbench/contrib/preferences/browser/settingsTree": [
-			"extensions",
-			"modified",
-			"settingsContextMenuTitle",
-			"newExtensionsButtonLabel",
-			"editInSettingsJson",
-			"editLanguageSettingLabel",
-			"settings.Default",
-			"modified",
-			"showExtension",
-			"resetSettingLabel",
-			"validationError",
-			"validationError",
-			"settings.Modified",
-			"settings",
-			"copySettingIdLabel",
-			"copySettingAsJSONLabel",
-			"stopSyncingSetting",
-			"applyToAllProfiles"
 		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView": [
 			"notebookActions.selectKernel",
@@ -14112,24 +14169,6 @@
 			},
 			"webview title"
 		],
-		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy": [
-			"current1",
-			"current2",
-			"prompt.placeholder.change",
-			"prompt.placeholder.select",
-			"installSuggestedKernel",
-			"searchForKernels",
-			"selectAnotherKernel.more",
-			"select",
-			"selectAnotherKernel",
-			"selectKernel.placeholder",
-			"learnMoreTooltip",
-			"selectKernelFromExtension",
-			"kernels.selectedKernelAndKernelDetectionRunning",
-			"kernels.detecting",
-			"kernels.detecting",
-			"select"
-		],
 		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
 			"fileWorkingCopyCreate.source",
 			"fileWorkingCopyReplace.source",
@@ -14150,6 +14189,24 @@
 			"hide",
 			"resetThisMenu"
 		],
+		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy": [
+			"current1",
+			"current2",
+			"prompt.placeholder.change",
+			"prompt.placeholder.select",
+			"installSuggestedKernel",
+			"searchForKernels",
+			"selectAnotherKernel.more",
+			"select",
+			"selectAnotherKernel",
+			"selectKernel.placeholder",
+			"learnMoreTooltip",
+			"selectKernelFromExtension",
+			"kernels.selectedKernelAndKernelDetectionRunning",
+			"kernels.detecting",
+			"kernels.detecting",
+			"select"
+		],
 		"vs/workbench/contrib/notebook/browser/controller/cellOperations": [
 			"notebookActions.joinSelectedCells",
 			"notebookActions.joinSelectedCells.label"
@@ -14161,16 +14218,6 @@
 		],
 		"vs/editor/contrib/codeAction/browser/codeAction": [
 			"applyCodeActionFailed"
-		],
-		"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider": [
-			"empty"
-		],
-		"vs/workbench/contrib/comments/common/commentContextKeys": [
-			"commentThreadIsEmpty",
-			"commentIsEmpty",
-			"comment",
-			"commentThread",
-			"commentController"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
 			"chat.overview",
@@ -14223,14 +14270,24 @@
 			"chat.codeBlockLabel",
 			"treeAriaLabel"
 		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
+			"lines.0",
+			"lines.1",
+			"lines.N"
+		],
 		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys": [
 			"inlineSuggestionVisible",
 			"inlineSuggestionHasIndentation",
 			"inlineSuggestionHasIndentationLessThanTabSize",
 			"suppressSuggestions"
 		],
-		"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget": [
-			"exited slash command mode"
+		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
+			"aria-label",
+			"original",
+			"modified",
+			"inlineChat.accessibilityHelp",
+			"inlineChat.accessibilityHelpNoKb",
+			"inlineChatClosed"
 		],
 		"vs/workbench/contrib/testing/browser/theme": [
 			"testing.iconFailed",
@@ -14246,11 +14303,6 @@
 			"testing.message.error.marginBackground",
 			"testing.message.info.decorationForeground",
 			"testing.message.info.marginBackground"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
-			"lines.0",
-			"lines.1",
-			"lines.N"
 		],
 		"vs/workbench/contrib/testing/common/constants": [
 			"testState.errored",
@@ -14282,13 +14334,12 @@
 			"testing.filters.showExcludedTests",
 			"testing.filters.removeTestExclusions"
 		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
-			"aria-label",
-			"original",
-			"modified",
-			"inlineChat.accessibilityHelp",
-			"inlineChat.accessibilityHelpNoKb",
-			"inlineChatClosed"
+		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
+			"terminal.integrated.copySelection.noSelection",
+			"yes",
+			"no",
+			"dontShowAgain",
+			"terminal.slowRendering"
 		],
 		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
 			"terminal.background",
@@ -14313,44 +14364,12 @@
 			"terminal.tab.activeBorder",
 			"terminal.ansiColor"
 		],
-		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
-			"terminal.integrated.copySelection.noSelection",
-			"yes",
-			"no",
-			"dontShowAgain",
-			"terminal.slowRendering"
-		],
-		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
-			"canNotResolve",
-			"symbolicLlink",
-			"unknown",
-			"label"
-		],
-		"vs/workbench/contrib/files/browser/views/explorerViewer": [
-			"treeAriaLabel",
-			"fileInputAriaLabel",
-			"confirmRootsMove",
-			"confirmMultiMove",
-			"confirmRootMove",
-			"confirmMove",
-			"doNotAskAgain",
-			{
-				"key": "moveButtonLabel",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"copy",
-			"copying",
-			"move",
-			"moving",
-			"numberOfFolders",
-			"numberOfFiles"
-		],
 		"vs/platform/quickinput/browser/commandsQuickAccess": [
 			"recentlyUsed",
+			"suggested",
 			"commonlyUsed",
 			"morecCommands",
+			"suggested",
 			"commandPickAriaLabelWithKeybinding",
 			"canNotRun"
 		],
@@ -14419,6 +14438,63 @@
 				]
 			}
 		],
+		"vs/workbench/contrib/files/browser/views/explorerViewer": [
+			"treeAriaLabel",
+			"fileInputAriaLabel",
+			"confirmRootsMove",
+			"confirmMultiMove",
+			"confirmRootMove",
+			"confirmMove",
+			"doNotAskAgain",
+			{
+				"key": "moveButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"copy",
+			"copying",
+			"move",
+			"moving",
+			"numberOfFolders",
+			"numberOfFiles"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
+			"canNotResolve",
+			"symbolicLlink",
+			"unknown",
+			"label"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization": [
+			"invalidQueryStringError",
+			"numFiles",
+			"oneFile",
+			"numResults",
+			"oneResult",
+			"noResults",
+			"searchMaxResultsWarning"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
+			"bulkEdit",
+			"aria.renameAndEdit",
+			"aria.createAndEdit",
+			"aria.deleteAndEdit",
+			"aria.editOnly",
+			"aria.rename",
+			"aria.create",
+			"aria.delete",
+			"aria.replace",
+			"aria.del",
+			"aria.insert",
+			"rename.label",
+			"detail.rename",
+			"detail.create",
+			"detail.del",
+			"title"
+		],
+		"vs/workbench/contrib/search/browser/searchFindInput": [
+			"searchFindInputNotebookFilter.label"
+		],
 		"vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess": [
 			"cannotRunGotoSymbolWithoutEditor",
 			"cannotRunGotoSymbolWithoutSymbolProvider",
@@ -14454,39 +14530,9 @@
 			"field",
 			"constant"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
-			"bulkEdit",
-			"aria.renameAndEdit",
-			"aria.createAndEdit",
-			"aria.deleteAndEdit",
-			"aria.editOnly",
-			"aria.rename",
-			"aria.create",
-			"aria.delete",
-			"aria.replace",
-			"aria.del",
-			"aria.insert",
-			"rename.label",
-			"detail.rename",
-			"detail.create",
-			"detail.del",
-			"title"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization": [
-			"invalidQueryStringError",
-			"numFiles",
-			"oneFile",
-			"numResults",
-			"oneResult",
-			"noResults",
-			"searchMaxResultsWarning"
-		],
-		"vs/workbench/contrib/scm/browser/dirtyDiffSwitcher": [
-			"remotes",
-			"quickDiff.base.switch"
-		],
-		"vs/workbench/contrib/scm/browser/menus": [
-			"miShare"
+		"vs/workbench/contrib/search/browser/replaceService": [
+			"searchReplace.source",
+			"fileReplaceChanges"
 		],
 		"vs/workbench/contrib/debug/browser/baseDebugView": [
 			"debug.lazyButton.tooltip"
@@ -14496,15 +14542,8 @@
 			"workbench.action.debug.startDebug",
 			"workbench.action.debug.spawnFrom"
 		],
-		"vs/workbench/contrib/search/browser/searchFindInput": [
-			"searchFindInputNotebookFilter.label"
-		],
 		"vs/workbench/contrib/debug/common/loadedScriptsPicker": [
 			"moveFocusedView.selectView"
-		],
-		"vs/workbench/contrib/search/browser/replaceService": [
-			"searchReplace.source",
-			"fileReplaceChanges"
 		],
 		"vs/workbench/contrib/debug/browser/debugAdapterManager": [
 			"debugNoType",
@@ -14608,16 +14647,19 @@
 		"vs/workbench/contrib/debug/common/debugSource": [
 			"unknownSource"
 		],
+		"vs/workbench/contrib/scm/browser/menus": [
+			"miShare"
+		],
+		"vs/workbench/contrib/scm/browser/dirtyDiffSwitcher": [
+			"remotes",
+			"quickDiff.base.switch"
+		],
 		"vs/base/browser/ui/findinput/replaceInput": [
 			"defaultLabel",
 			"label.preserveCaseToggle"
 		],
-		"vs/workbench/contrib/markers/browser/markersTreeViewer": [
-			"problemsView",
-			"expandedIcon",
-			"collapsedIcon",
-			"single line",
-			"multi line"
+		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
+			"moreActions"
 		],
 		"vs/workbench/contrib/markers/browser/markersTable": [
 			"codeColumnLabel",
@@ -14634,6 +14676,13 @@
 			"showNonConflictingChanges",
 			"baseUri",
 			"resultUri"
+		],
+		"vs/workbench/contrib/markers/browser/markersTreeViewer": [
+			"problemsView",
+			"expandedIcon",
+			"collapsedIcon",
+			"single line",
+			"multi line"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInputModel": [
 			"messageN",
@@ -14732,13 +14781,6 @@
 			"accept.first",
 			"accept.second"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
-			"result",
-			"mergeEditor.remainingConflicts",
-			"mergeEditor.remainingConflict",
-			"goToNextConflict",
-			"allConflictHandled"
-		],
 		"vs/workbench/contrib/mergeEditor/browser/view/colors": [
 			"mergeEditor.change.background",
 			"mergeEditor.change.word.background",
@@ -14754,21 +14796,23 @@
 			"mergeEditor.conflict.input1.background",
 			"mergeEditor.conflict.input2.background"
 		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
+			"result",
+			"mergeEditor.remainingConflicts",
+			"mergeEditor.remainingConflict",
+			"goToNextConflict",
+			"allConflictHandled"
+		],
 		"vs/workbench/contrib/comments/browser/commentsController": [
-			"hasCommentingRange",
+			"commentRange",
+			"commentRangeStart",
+			"hasCommentRangesKb",
+			"hasCommentRangesNoKb",
+			"hasCommentRanges",
 			"pickCommentService"
 		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
 			"builtinProviderDisplayName"
-		],
-		"vs/platform/files/browser/htmlFileSystemProvider": [
-			"fileSystemRenameError",
-			"fileSystemNotAllowedError"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
-			"error",
-			"Unknown Extension",
-			"extensions"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"ratedLabel",
@@ -14796,6 +14840,14 @@
 			"extensionPreReleaseForeground",
 			"extensionIcon.sponsorForeground"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
+			"error",
+			"Unknown Extension",
+			"extensions"
+		],
+		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
+			"workspaceRecommendation"
+		],
 		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
 			"fileBasedRecommendation",
 			"languageName"
@@ -14803,14 +14855,27 @@
 		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
 			"exeBasedRecommendation"
 		],
-		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
-			"workspaceRecommendation"
-		],
 		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
 			"exeBasedRecommendation"
 		],
 		"vs/workbench/contrib/extensions/browser/webRecommendations": [
 			"reason"
+		],
+		"vs/platform/files/browser/htmlFileSystemProvider": [
+			"fileSystemRenameError",
+			"fileSystemNotAllowedError"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"terminalService.terminalCloseConfirmationSingular",
+			"terminalService.terminalCloseConfirmationPlural",
+			{
+				"key": "terminate",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"localTerminalVirtualWorkspace",
+			"localTerminalRemote"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
 			"showTerminalTabs",
@@ -14898,32 +14963,6 @@
 			"workbench.action.terminal.newWithProfilePlus",
 			"renameTerminal"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalIcons": [
-			"terminalViewIcon",
-			"renameTerminalIcon",
-			"killTerminalIcon",
-			"newTerminalIcon",
-			"configureTerminalProfileIcon",
-			"terminalDecorationMark",
-			"terminalDecorationIncomplete",
-			"terminalDecorationError",
-			"terminalDecorationSuccess",
-			"terminalCommandHistoryRemove",
-			"terminalCommandHistoryOutput",
-			"terminalCommandHistoryFuzzySearch"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalService": [
-			"terminalService.terminalCloseConfirmationSingular",
-			"terminalService.terminalCloseConfirmationPlural",
-			{
-				"key": "terminate",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"localTerminalVirtualWorkspace",
-			"localTerminalRemote"
-		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
 			"cwd",
 			"cwdFolder",
@@ -14958,7 +14997,6 @@
 			"terminal.integrated.tabs.location.left",
 			"terminal.integrated.tabs.location.right",
 			"terminal.integrated.tabs.location",
-			"tabFocusMode",
 			"terminal.integrated.defaultLocation.editor",
 			"terminal.integrated.defaultLocation.view",
 			"terminal.integrated.defaultLocation",
@@ -15132,6 +15170,20 @@
 			"defaultTerminalProfile",
 			"splitTerminal"
 		],
+		"vs/workbench/contrib/terminal/browser/terminalIcons": [
+			"terminalViewIcon",
+			"renameTerminalIcon",
+			"killTerminalIcon",
+			"newTerminalIcon",
+			"configureTerminalProfileIcon",
+			"terminalDecorationMark",
+			"terminalDecorationIncomplete",
+			"terminalDecorationError",
+			"terminalDecorationSuccess",
+			"terminalCommandHistoryRemove",
+			"terminalCommandHistoryOutput",
+			"terminalCommandHistoryFuzzySearch"
+		],
 		"vs/workbench/contrib/terminal/common/terminalStrings": [
 			"terminal",
 			"terminal.new",
@@ -15160,34 +15212,6 @@
 		"vs/platform/terminal/common/terminalLogService": [
 			"terminalLoggerName"
 		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
-			"focusAccessibleBuffer",
-			"focusAccessibleBufferNoKb",
-			"commandPromptMigration",
-			"shellIntegration",
-			"goToNextCommand",
-			"goToNextCommandNoKb",
-			"goToPreviousCommand",
-			"goToPreviousCommandNoKb",
-			"navigateAccessibleBuffer",
-			"navigateAccessibleBufferNoKb",
-			"runRecentCommand",
-			"runRecentCommandNoKb",
-			"goToRecentDirectory",
-			"goToRecentDirectoryNoKb",
-			"goToRecentDirectoryNoShellIntegration",
-			"goToRecentDirectoryNoKbNoShellIntegration",
-			"openDetectedLink",
-			"openDetectedLinkNoKb",
-			"newWithProfile",
-			"newWithProfileNoKb",
-			"focusAfterRun",
-			"accessibilitySettings"
-		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer": [
-			"terminal.integrated.accessibleBuffer",
-			"terminal.integrated.symbolQuickPick.labelNoExitCode"
-		],
 		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
 			"moveTabsRight",
 			"moveTabsLeft",
@@ -15205,14 +15229,29 @@
 			},
 			"shellProcessTooltip.commandLine"
 		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
-			"terminalLinkHandler.followLinkAlt.mac",
-			"terminalLinkHandler.followLinkAlt",
-			"terminalLinkHandler.followLinkCmd",
-			"terminalLinkHandler.followLinkCtrl",
-			"followLink",
-			"followForwardedLink",
-			"followLinkUrl"
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
+			"focusAccessibleBuffer",
+			"focusAccessibleBufferNoKb",
+			"commandPromptMigration",
+			"shellIntegration",
+			"goToNextCommand",
+			"goToNextCommandNoKb",
+			"goToPreviousCommand",
+			"goToPreviousCommandNoKb",
+			"goToSymbol",
+			"goToSymbolNoKb",
+			"runRecentCommand",
+			"runRecentCommandNoKb",
+			"goToRecentDirectory",
+			"goToRecentDirectoryNoKb",
+			"goToRecentDirectoryNoShellIntegration",
+			"goToRecentDirectoryNoKbNoShellIntegration",
+			"openDetectedLink",
+			"openDetectedLinkNoKb",
+			"newWithProfile",
+			"newWithProfileNoKb",
+			"focusAfterRun",
+			"accessibilitySettings"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick": [
 			"terminal.integrated.urlLinks",
@@ -15225,10 +15264,23 @@
 			"terminal.integrated.localFolderLinks",
 			"terminal.integrated.searchLinks"
 		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
+			"terminalLinkHandler.followLinkAlt.mac",
+			"terminalLinkHandler.followLinkAlt",
+			"terminalLinkHandler.followLinkCmd",
+			"terminalLinkHandler.followLinkCtrl",
+			"followLink",
+			"followForwardedLink",
+			"followLinkUrl"
+		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
 			"quickFix.command",
 			"quickFix.opener",
 			"codeAction.widget.id.quickfix"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
+			"terminal.freePort",
+			"terminal.createPR"
 		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
 			"vscode.extension.contributes.terminalQuickFixes",
@@ -15302,10 +15354,6 @@
 			"JsonSchema.input.command.args",
 			"JsonSchema.input.command.args"
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
-			"terminal.freePort",
-			"terminal.createPR"
-		],
 		"vs/workbench/contrib/remote/browser/explorerViewItems": [
 			"remotes",
 			"remote.explorer.switch"
@@ -15331,11 +15379,6 @@
 			"detail.snippet",
 			"snippetSuggest.longLabel",
 			"snippetSuggest.longLabel"
-		],
-		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
-			"releaseNotesInputName",
-			"unassigned",
-			"showOnUpdate"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent": [
 			"getting-started-setup-icon",
@@ -15473,17 +15516,10 @@
 			"gettingStarted.notebookProfile.title",
 			"gettingStarted.notebookProfile.description"
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
-			"gettingStarted.featuredTitle"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
-			"welcomePage.background",
-			"welcomePage.tileBackground",
-			"welcomePage.tileHoverBackground",
-			"welcomePage.tileBorder",
-			"welcomePage.progress.background",
-			"welcomePage.progress.foreground",
-			"walkthrough.stepTitle.foreground"
+		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
+			"releaseNotesInputName",
+			"unassigned",
+			"showOnUpdate"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedExtensionPoint": [
 			"title",
@@ -15527,15 +15563,17 @@
 		"vs/workbench/contrib/welcomeWalkthrough/common/walkThroughUtils": [
 			"walkThrough.embeddedEditorBackground"
 		],
-		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
-			"tree.aria",
-			"from",
-			"to"
+		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
+			"gettingStarted.featuredTitle"
 		],
-		"vs/workbench/contrib/typeHierarchy/browser/typeHierarchyTree": [
-			"tree.aria",
-			"supertypes",
-			"subtypes"
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
+			"welcomePage.background",
+			"welcomePage.tileBackground",
+			"welcomePage.tileHoverBackground",
+			"welcomePage.tileBorder",
+			"welcomePage.progress.background",
+			"welcomePage.progress.foreground",
+			"walkthrough.stepTitle.foreground"
 		],
 		"vs/editor/contrib/symbolIcons/browser/symbolIcons": [
 			"symbolIcon.arrayForeground",
@@ -15572,6 +15610,16 @@
 			"symbolIcon.unitForeground",
 			"symbolIcon.variableForeground"
 		],
+		"vs/workbench/contrib/typeHierarchy/browser/typeHierarchyTree": [
+			"tree.aria",
+			"supertypes",
+			"subtypes"
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
+			"tree.aria",
+			"from",
+			"to"
+		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
 			"conflicts",
 			"synced machines",
@@ -15579,6 +15627,9 @@
 			"workbench.actions.sync.turnOffSyncOnMachine",
 			"remote sync activity title",
 			"local sync activity title",
+			"downloaded sync activity title",
+			"workbench.actions.sync.loadActivity",
+			"select sync activity file",
 			"workbench.actions.sync.resolveResourceRef",
 			"workbench.actions.sync.compareWithLocal",
 			"remoteToLocalDiff",
@@ -15604,6 +15655,12 @@
 			"troubleshoot",
 			"reset",
 			"sideBySideLabels",
+			{
+				"key": "current",
+				"comment": [
+					"Represents current machine"
+				]
+			},
 			{
 				"key": "current",
 				"comment": [
@@ -15638,6 +15695,32 @@
 				]
 			}
 		],
+		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"notificationAccessibleViewHint",
+			"notificationAccessibleViewHintNoKb",
+			"notificationAriaLabelHint",
+			"notificationAriaLabel",
+			"notificationWithSourceAriaLabelHint",
+			"notificationWithSourceAriaLabel",
+			"notificationsList"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsActions": [
+			"clearIcon",
+			"clearAllIcon",
+			"hideIcon",
+			"expandIcon",
+			"collapseIcon",
+			"configureIcon",
+			"doNotDisturbIcon",
+			"clearNotification",
+			"clearNotifications",
+			"toggleDoNotDisturbMode",
+			"hideNotificationsCenter",
+			"expandNotification",
+			"collapseNotification",
+			"configureNotification",
+			"copyNotification"
+		],
 		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
 			"saveParticipants"
 		],
@@ -15647,14 +15730,12 @@
 			"label2",
 			"title",
 			"title2",
-			"commandCenter-foreground",
-			"commandCenter-activeForeground",
-			"commandCenter-inactiveForeground",
-			"commandCenter-background",
-			"commandCenter-activeBackground",
-			"commandCenter-border",
-			"commandCenter-activeBorder",
-			"commandCenter-inactiveBorder"
+			"title3"
+		],
+		"vs/workbench/browser/parts/titlebar/windowTitle": [
+			"userIsAdmin",
+			"userIsSudo",
+			"devExtensionWindowTitlePrefix"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopy": [
 			"staleSaveError",
@@ -15679,11 +15760,6 @@
 					"{0} is the resource that failed to save and {1} the error message"
 				]
 			}
-		],
-		"vs/workbench/browser/parts/titlebar/windowTitle": [
-			"userIsAdmin",
-			"userIsSudo",
-			"devExtensionWindowTitlePrefix"
 		],
 		"vs/platform/terminal/common/terminalProfiles": [
 			"terminalAutomaticProfile"
@@ -15711,12 +15787,12 @@
 		"vs/workbench/api/common/extHostProgress": [
 			"extensionSource"
 		],
-		"vs/workbench/api/common/extHostTreeViews": [
-			"treeView.duplicateElement"
-		],
 		"vs/workbench/api/common/extHostStatusBar": [
 			"extensionLabel",
 			"status.extensionMessage"
+		],
+		"vs/workbench/api/common/extHostTreeViews": [
+			"treeView.duplicateElement"
 		],
 		"vs/workbench/api/common/extHostNotebook": [
 			"err.readonly",
@@ -15731,15 +15807,57 @@
 			"wordsDescription",
 			"regexDescription"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsViewer": [
-			"executeCommand",
-			"notificationActions",
-			"notificationSource"
+		"vs/editor/browser/widget/diffEditor/accessibleDiffViewer": [
+			"accessibleDiffViewerInsertIcon",
+			"accessibleDiffViewerRemoveIcon",
+			"accessibleDiffViewerCloseIcon",
+			"label.close",
+			"ariaLabel",
+			"no_lines_changed",
+			"one_line_changed",
+			"more_lines_changed",
+			{
+				"key": "header",
+				"comment": [
+					"This is the ARIA label for a git diff header.",
+					"A git diff header looks like this: @@ -154,12 +159,39 @@.",
+					"That encodes that at original line 154 (which is now line 159), 12 lines were removed/changed with 39 lines.",
+					"Variables 0 and 1 refer to the diff index out of total number of diffs.",
+					"Variables 2 and 4 will be numbers (a line number).",
+					"Variables 3 and 5 will be \"no lines changed\", \"1 line changed\" or \"X lines changed\", localized separately."
+				]
+			},
+			"blankLine",
+			{
+				"key": "unchangedLine",
+				"comment": [
+					"The placeholders are contents of the line and should not be translated."
+				]
+			},
+			"equalLine",
+			"insertLine",
+			"deleteLine"
 		],
-		"vs/platform/languagePacks/common/localizedStrings": [
-			"open",
-			"close",
-			"find"
+		"vs/editor/browser/widget/diffEditor/movedBlocksLines": [
+			"codeMovedToWithChanges",
+			"codeMovedFromWithChanges",
+			"codeMovedTo",
+			"codeMovedFrom"
+		],
+		"vs/editor/browser/widget/diffEditor/hideUnchangedRegionsFeature": [
+			"foldUnchanged",
+			"diff.hiddenLines.top",
+			"showAll",
+			"diff.bottom",
+			"hiddenLines",
+			"diff.hiddenLines.expandAll"
+		],
+		"vs/editor/browser/widget/diffEditor/diffEditorEditors": [
+			"diff-aria-navigation-tip"
+		],
+		"vs/editor/browser/widget/diffEditor/colors": [
+			"diffEditor.move.border",
+			"diffEditor.moveActive.border"
 		],
 		"vs/editor/browser/controller/textAreaHandler": [
 			"editor",
@@ -15747,6 +15865,15 @@
 			"accessibilityOffAriaLabel",
 			"accessibilityOffAriaLabelNoKb",
 			"accessibilityOffAriaLabelNoKbs"
+		],
+		"vs/platform/actionWidget/browser/actionWidget": [
+			"actionBar.toggledBackground",
+			"codeActionMenuVisible",
+			"hideCodeActionWidget.title",
+			"selectPrevCodeAction.title",
+			"selectNextCodeAction.title",
+			"acceptSelected.title",
+			"previewSelected.title"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionMenu": [
 			"codeAction.widget.id.more",
@@ -15758,26 +15885,17 @@
 			"codeAction.widget.id.surround",
 			"codeAction.widget.id.source"
 		],
-		"vs/platform/actionWidget/browser/actionWidget": [
-			"actionBar.toggledBackground",
-			"codeActionMenuVisible",
-			"hideCodeActionWidget.title",
-			"selectPrevCodeAction.title",
-			"selectNextCodeAction.title",
-			"acceptSelected.title",
-			"previewSelected.title"
+		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
+			"clickToToggleColorOptions",
+			"closeIcon"
+		],
+		"vs/editor/contrib/editorState/browser/keybindingCancellation": [
+			"cancellableOperation"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/peek/referencesWidget": [
 			"missingPreviewMessage",
 			"noResults",
 			"peekView.alternateTitle"
-		],
-		"vs/editor/contrib/editorState/browser/keybindingCancellation": [
-			"cancellableOperation"
-		],
-		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
-			"clickToToggleColorOptions",
-			"closeIcon"
 		],
 		"vs/editor/contrib/snippet/browser/snippetVariables": [
 			"Sunday",
@@ -15828,13 +15946,13 @@
 				]
 			}
 		],
-		"vs/editor/contrib/suggest/browser/suggestWidgetRenderer": [
-			"suggestMoreInfoIcon",
-			"readMore"
-		],
 		"vs/editor/contrib/suggest/browser/suggestWidgetDetails": [
 			"details.close",
 			"loading"
+		],
+		"vs/editor/contrib/suggest/browser/suggestWidgetRenderer": [
+			"suggestMoreInfoIcon",
+			"readMore"
 		],
 		"vs/workbench/contrib/comments/common/commentModel": [
 			"noComments"
@@ -15850,6 +15968,17 @@
 			"comments",
 			"resolved"
 		],
+		"vs/workbench/browser/parts/editor/editorPlaceholder": [
+			"trustRequiredEditor",
+			"requiresFolderTrustText",
+			"requiresWorkspaceTrustText",
+			"manageTrust",
+			"errorEditor",
+			"unavailableResourceErrorEditorText",
+			"unknownErrorEditorTextWithError",
+			"unknownErrorEditorTextWithoutError",
+			"retry"
+		],
 		"vs/workbench/contrib/comments/browser/commentColors": [
 			"resolvedCommentIcon",
 			"unresolvedCommentIcon",
@@ -15858,9 +15987,12 @@
 			"commentThreadRangeBackground",
 			"commentThreadActiveRangeBackground"
 		],
-		"vs/workbench/browser/parts/editor/titleControl": [
-			"ariaLabelEditorActions",
-			"draggedEditorGroup"
+		"vs/base/browser/ui/menu/menubar": [
+			"mAppMenu",
+			"mMore"
+		],
+		"vs/workbench/browser/parts/editor/multiEditorTabsControl": [
+			"ariaLabelTabActions"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
 			"separatorIcon",
@@ -15885,82 +16017,15 @@
 			"cmd.focusAndSelect",
 			"cmd.focus"
 		],
-		"vs/workbench/browser/parts/editor/editorPlaceholder": [
-			"trustRequiredEditor",
-			"requiresFolderTrustText",
-			"requiresWorkspaceTrustText",
-			"manageTrust",
-			"errorEditor",
-			"unavailableResourceErrorEditorText",
-			"unknownErrorEditorTextWithError",
-			"unknownErrorEditorTextWithoutError",
-			"retry"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer": [
-			"accessibleDiffViewerInsertIcon",
-			"accessibleDiffViewerRemoveIcon",
-			"accessibleDiffViewerCloseIcon",
-			"label.close",
-			"ariaLabel",
-			"no_lines_changed",
-			"one_line_changed",
-			"more_lines_changed",
-			{
-				"key": "header",
-				"comment": [
-					"This is the ARIA label for a git diff header.",
-					"A git diff header looks like this: @@ -154,12 +159,39 @@.",
-					"That encodes that at original line 154 (which is now line 159), 12 lines were removed/changed with 39 lines.",
-					"Variables 0 and 1 refer to the diff index out of total number of diffs.",
-					"Variables 2 and 4 will be numbers (a line number).",
-					"Variables 3 and 5 will be \"no lines changed\", \"1 line changed\" or \"X lines changed\", localized separately."
-				]
-			},
-			"blankLine",
-			{
-				"key": "unchangedLine",
-				"comment": [
-					"The placeholders are contents of the line and should not be translated."
-				]
-			},
-			"equalLine",
-			"insertLine",
-			"deleteLine"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/movedBlocksLines": [
-			"codeMovedToWithChanges",
-			"codeMovedFromWithChanges",
-			"codeMovedTo",
-			"codeMovedFrom"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
-			"foldUnchanged",
-			"diff.hiddenLines.top",
-			"showAll",
-			"diff.bottom",
-			"hiddenLines",
-			"diff.hiddenLines.expandAll"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
-			"diff-aria-navigation-tip"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/colors": [
-			"diffEditor.move.border",
-			"diffEditor.moveActive.border"
-		],
-		"vs/base/browser/ui/menu/menubar": [
-			"mAppMenu",
-			"mMore"
-		],
-		"vs/platform/quickinput/browser/quickInputList": [
-			"quickInput"
-		],
 		"vs/platform/quickinput/browser/quickInput": [
 			"quickInput.back",
 			"inputModeEntry",
 			"quickInput.steps",
 			"quickInputBox.ariaLabel",
 			"inputModeEntryDescription"
+		],
+		"vs/platform/quickinput/browser/quickInputList": [
+			"quickInput"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
 			"workspaceUntrustedLabel",
@@ -16085,8 +16150,14 @@
 			"notebook.find.filter.findInCodeInput",
 			"notebook.find.filter.findInCodeOutput"
 		],
+		"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory": [
+			"empty"
+		],
 		"vs/platform/actions/browser/buttonbar": [
 			"labelWithKeybinding"
+		],
+		"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget": [
+			"exited slash command mode"
 		],
 		"vs/workbench/contrib/terminal/browser/xterm/decorationAddon": [
 			"terminal.rerunCommand",
@@ -16094,6 +16165,7 @@
 			"yes",
 			"no",
 			"terminal.copyCommand",
+			"terminal.copyCommandAndOutput",
 			"terminal.copyOutput",
 			"terminal.copyOutputAsHtml",
 			"workbench.action.terminal.runRecentCommand",
@@ -16132,6 +16204,7 @@
 			"vscode.extension.contributes.debuggers.configurationSnippets",
 			"vscode.extension.contributes.debuggers.configurationAttributes",
 			"vscode.extension.contributes.debuggers.when",
+			"vscode.extension.contributes.debuggers.hiddenWhen",
 			"vscode.extension.contributes.debuggers.deprecated",
 			"vscode.extension.contributes.debuggers.windows",
 			"vscode.extension.contributes.debuggers.windows.runtime",
@@ -16160,6 +16233,10 @@
 			"app.launch.json.compound.stopAll",
 			"compoundPrelaunchTask"
 		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
+			"conflictingLine",
+			"conflictingLines"
+		],
 		"vs/workbench/contrib/debug/browser/rawDebugSession": [
 			"noDebugAdapterStart",
 			"canNotStart",
@@ -16172,9 +16249,9 @@
 			"noDebugAdapter",
 			"moreInfo"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
-			"conflictingLine",
-			"conflictingLines"
+		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
+			"setInputHandled",
+			"undoMarkAsHandled"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/conflictActions": [
 			"accept",
@@ -16199,16 +16276,16 @@
 			"resetToBase",
 			"resetToBaseTooltip"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
-			"setInputHandled",
-			"undoMarkAsHandled"
-		],
 		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
 			"editorGutterCommentRangeForeground",
 			"editorOverviewRuler.commentForeground",
 			"editorOverviewRuler.commentUnresolvedForeground",
 			"editorGutterCommentGlyphForeground",
 			"editorGutterCommentUnresolvedGlyphForeground"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
+			"useWslExtension.title",
+			"install"
 		],
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"contributes.customEditors",
@@ -16219,23 +16296,6 @@
 			"contributes.priority",
 			"contributes.priority.default",
 			"contributes.priority.option"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
-			"useWslExtension.title",
-			"install"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick": [
-			"terminal.integrated.selectProfileToCreate",
-			"terminal.integrated.chooseDefaultProfile",
-			"enterTerminalProfileName",
-			"terminalProfileAlreadyExists",
-			"terminalProfiles",
-			"ICreateContributedTerminalProfileOptions",
-			"terminalProfiles.detected",
-			"unsafePathWarning",
-			"yes",
-			"cancel",
-			"createQuickLaunchProfile"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalInstance": [
 			"terminalTypeTask",
@@ -16269,14 +16329,26 @@
 			"setTerminalDimensionsColumn",
 			"setTerminalDimensionsRow",
 			"terminalStaleTextBoxAriaLabel",
+			"changeIcon",
+			"changeColor",
 			"launchFailed.exitCodeAndCommandLine",
 			"launchFailed.exitCodeOnly",
 			"terminated.exitCodeAndCommandLine",
 			"terminated.exitCodeOnly",
 			"launchFailed.errorMessage"
 		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget": [
-			"terminalAccessibleBuffer"
+		"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick": [
+			"terminal.integrated.selectProfileToCreate",
+			"terminal.integrated.chooseDefaultProfile",
+			"enterTerminalProfileName",
+			"terminalProfileAlreadyExists",
+			"terminalProfiles",
+			"ICreateContributedTerminalProfileOptions",
+			"terminalProfiles.detected",
+			"unsafePathWarning",
+			"yes",
+			"cancel",
+			"createQuickLaunchProfile"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalTabsList": [
 			"terminalInputAriaLabel",
@@ -16299,6 +16371,13 @@
 			},
 			"label"
 		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
+			"searchWorkspace",
+			"openFile",
+			"focusFolder",
+			"openFolder",
+			"followLink"
+		],
 		"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget": [
 			"label.find",
 			"placeholder.find",
@@ -16310,13 +16389,6 @@
 			"ariaSearchNoResult",
 			"ariaSearchNoResultWithLineNumNoCurrentMatch",
 			"simpleFindWidget.sashBorder"
-		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
-			"searchWorkspace",
-			"openFile",
-			"focusFolder",
-			"openFolder",
-			"followLink"
 		],
 		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
 			"terminalPromptContextMenu",
@@ -16330,11 +16402,6 @@
 			"HighContrast",
 			"HighContrastLight",
 			"seeMore"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
-			"default",
-			"jupyter",
-			"colab"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncConflictsView": [
 			"explanation",
@@ -16355,6 +16422,39 @@
 			"localResourceName",
 			"Theirs",
 			"Yours"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
+			"default",
+			"jupyter",
+			"colab"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsViewer": [
+			"executeCommand",
+			"notificationActions",
+			"notificationSource"
+		],
+		"vs/platform/languagePacks/common/localizedStrings": [
+			"open",
+			"close",
+			"find"
+		],
+		"vs/editor/common/viewLayout/viewLineRenderer": [
+			"showMore",
+			"overflow.chars"
+		],
+		"vs/editor/browser/widget/diffEditor/inlineDiffDeletedCodeMargin": [
+			"diff.clipboard.copyDeletedLinesContent.label",
+			"diff.clipboard.copyDeletedLinesContent.single.label",
+			"diff.clipboard.copyChangedLinesContent.label",
+			"diff.clipboard.copyChangedLinesContent.single.label",
+			"diff.clipboard.copyDeletedLineContent.label",
+			"diff.clipboard.copyChangedLineContent.label",
+			"diff.inline.revertChange.label"
+		],
+		"vs/editor/browser/widget/diffEditor/decorations": [
+			"diffInsertIcon",
+			"diffRemoveIcon",
+			"revertChangeHoverMessage"
 		],
 		"vs/platform/actionWidget/browser/actionList": [
 			{
@@ -16386,6 +16486,10 @@
 			"referencesCount",
 			"referenceCount",
 			"treeAriaLabel"
+		],
+		"vs/workbench/browser/parts/editor/editorTabsControl": [
+			"ariaLabelEditorActions",
+			"draggedEditorGroup"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbs": [
 			"title",
@@ -16433,20 +16537,6 @@
 		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
 			"breadcrumbs"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/decorations": [
-			"diffInsertIcon",
-			"diffRemoveIcon",
-			"revertChangeHoverMessage"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin": [
-			"diff.clipboard.copyDeletedLinesContent.label",
-			"diff.clipboard.copyDeletedLinesContent.single.label",
-			"diff.clipboard.copyChangedLinesContent.label",
-			"diff.clipboard.copyChangedLinesContent.single.label",
-			"diff.clipboard.copyDeletedLineContent.label",
-			"diff.clipboard.copyChangedLineContent.label",
-			"diff.inline.revertChange.label"
-		],
 		"vs/platform/quickinput/browser/quickInputUtils": [
 			"executeCommand"
 		],
@@ -16472,11 +16562,6 @@
 		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellRunToolbar": [
 			"notebook.moreRunActionsLabel"
 		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/collapsedCellOutput": [
-			"cellOutputsCollapsedMsg",
-			"cellExpandOutputButtonLabelWithDoubleClick",
-			"cellExpandOutputButtonLabel"
-		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/foldedCellHint": [
 			"hiddenCellsLabel",
 			"hiddenCellsLabelPlural"
@@ -16485,6 +16570,11 @@
 			"cellExpandInputButtonLabelWithDoubleClick",
 			"cellExpandInputButtonLabel"
 		],
+		"vs/workbench/contrib/notebook/browser/view/cellParts/collapsedCellOutput": [
+			"cellOutputsCollapsedMsg",
+			"cellExpandOutputButtonLabelWithDoubleClick",
+			"cellExpandOutputButtonLabel"
+		],
 		"vs/workbench/services/suggest/browser/simpleSuggestWidget": [
 			"suggest",
 			"label.full",
@@ -16492,9 +16582,10 @@
 			"label.desc",
 			"ariaCurrenttSuggestionReadDetails"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
-			"killportfailure",
-			"ptyHostRelaunch"
+		"vs/workbench/contrib/comments/browser/commentThreadWidget": [
+			"commentLabel",
+			"commentLabelWithKeybinding",
+			"commentLabelWithKeybindingNoKeybinding"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick": [
 			"removeCommand",
@@ -16505,11 +16596,9 @@
 			"selectRecentDirectoryMac",
 			"selectRecentDirectory"
 		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
-			"notebook.cell.status.success",
-			"notebook.cell.status.failed",
-			"notebook.cell.status.pending",
-			"notebook.cell.status.executing"
+		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
+			"killportfailure",
+			"ptyHostRelaunch"
 		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput": [
 			"empty",
@@ -16520,6 +16609,12 @@
 			"promptChooseMimeTypeInSecure.placeHolder",
 			"promptChooseMimeType.placeHolder",
 			"unavailableRenderInfo"
+		],
+		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
+			"notebook.cell.status.success",
+			"notebook.cell.status.failed",
+			"notebook.cell.status.pending",
+			"notebook.cell.status.executing"
 		],
 		"vs/workbench/contrib/comments/browser/commentThreadBody": [
 			"commentThreadAria.withRange",
@@ -16610,9 +16705,6 @@
 		"vs/workbench/electron-sandbox/desktop.main": [
 			"Saving UI state"
 		],
-		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
-			"Saving text files"
-		],
 		"vs/workbench/electron-sandbox/desktop.contribution": [
 			"New Window Tab",
 			"Show Previous Window Tab",
@@ -16642,8 +16734,7 @@
 			"Controls the dimensions of opening a new window when at least one window is already opened. Note that this setting does not have an impact on the first window that is opened. The first window will always restore the size and location as you left it before closing.",
 			"Controls whether closing the last editor should also close the window. This setting only applies for windows that do not show folders.",
 			"If enabled, this setting will close the window when the application icon in the title bar is double-clicked. The window will not be able to be dragged by the icon. This setting is effective only if `#window.titleBarStyle#` is set to `custom`.",
-			"Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.",
-			"Let the OS handle positioning of the context menu in cases where it should appear under the mouse.",
+			"Adjust the appearance of the window title bar to be native by the OS or custom. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.",
 			"Adjust the appearance of dialog windows.",
 			"Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured.",
 			"Controls if native full-screen should be used on macOS. Disable this option to prevent macOS from creating a new space when going full-screen.",
@@ -16663,6 +16754,9 @@
 			"Log level to use. Default is 'info'. Allowed values are 'error', 'warn', 'info', 'debug', 'trace', 'off'.",
 			"Disables the Chromium sandbox. This is useful when running VS Code as elevated on Linux and running under Applocker on Windows.",
 			"Forces the renderer to be accessible. ONLY change this if you are using a screen reader on Linux. On other platforms the renderer will automatically be accessible. This flag is automatically set if you have editor.accessibilitySupport: on."
+		],
+		"vs/workbench/services/textfile/electron-sandbox/nativeTextFileService": [
+			"Saving text files"
 		],
 		"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService": [
 			"Do you want to save your workspace configuration as a file?",
@@ -16698,14 +16792,21 @@
 			"More Information",
 			"Don't Show Again"
 		],
-		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
-			"Backup working copies"
+		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
+			"Reveal in File Explorer",
+			"Reveal in Finder",
+			"Open Containing Folder",
+			"Share",
+			"File"
 		],
 		"vs/workbench/services/voiceRecognition/electron-sandbox/workbenchVoiceRecognitionService": [
 			"Voice Transcription",
 			"Getting microphone ready...",
 			"Recording from microphone...",
 			"Voice transcription failed: {0}"
+		],
+		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupService": [
+			"Backup working copies"
 		],
 		"vs/workbench/services/extensions/electron-sandbox/nativeExtensionService": [
 			"Extension host cannot start: version mismatch.",
@@ -16725,20 +16826,18 @@
 			"Restart Extension Host",
 			"Restarting extension host on explicit request."
 		],
+		"vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution": [
+			"Running Extensions"
+		],
 		"vs/workbench/contrib/localization/electron-sandbox/localization.contribution": [
 			"Would you like to change {0}'s display language to {1} and restart?",
 			"Change Language and Restart",
 			"Don't Show Again"
 		],
-		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
-			"Reveal in File Explorer",
-			"Reveal in Finder",
-			"Open Containing Folder",
-			"Share",
-			"File"
-		],
-		"vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution": [
-			"Running Extensions"
+		"vs/workbench/contrib/remote/electron-sandbox/remote.contribution": [
+			"Whether the platform has the WSL feature installed",
+			"Remote",
+			"When enabled extensions are downloaded locally and installed on remote."
 		],
 		"vs/workbench/contrib/issue/electron-sandbox/issue.contribution": [
 			"Report Performance Issue...",
@@ -16750,23 +16849,20 @@
 			"Creating trace file...",
 			"This can take up to one minute to complete."
 		],
-		"vs/workbench/contrib/remote/electron-sandbox/remote.contribution": [
-			"Whether the platform has the WSL feature installed",
-			"Remote",
-			"When enabled extensions are downloaded locally and installed on remote."
-		],
 		"vs/workbench/contrib/userDataSync/electron-sandbox/userDataSync.contribution": [
 			"Open Local Backups Folder",
-			"Local backups folder does not exist"
-		],
-		"vs/workbench/contrib/performance/electron-sandbox/performance.contribution": [
-			"When enabled slow renderers are automatically profiled"
+			"Local backups folder does not exist",
+			"Successfully downloaded Settings Sync activity.",
+			"Open Folder"
 		],
 		"vs/workbench/contrib/tasks/electron-sandbox/taskService": [
 			"There is a task running. Do you want to terminate it?",
 			"&&Terminate Task",
 			"The launched task doesn't exist anymore. If the task spawned background processes exiting VS Code might result in orphaned processes. To avoid this start the last background process with a wait flag.",
 			"&&Exit Anyways"
+		],
+		"vs/workbench/contrib/performance/electron-sandbox/performance.contribution": [
+			"When enabled slow renderers are automatically profiled"
 		],
 		"vs/workbench/contrib/externalTerminal/electron-sandbox/externalTerminal.contribution": [
 			"Open New External Terminal",
@@ -16829,57 +16925,6 @@
 		"vs/base/common/platform": [
 			"_"
 		],
-		"vs/platform/environment/node/argv": [
-			"Options",
-			"Extensions Management",
-			"Troubleshooting",
-			"Directory where CLI metadata should be stored.",
-			"Directory where CLI metadata should be stored.",
-			"Compare two files with each other.",
-			"Perform a three-way merge by providing paths for two modified versions of a file, the common origin of both modified versions and the output file to save merge results.",
-			"Add folder(s) to the last active window.",
-			"Open a file at the path on the specified line and character position.",
-			"Force to open a new window.",
-			"Force to open a file or folder in an already opened window.",
-			"Wait for the files to be closed before returning.",
-			"The locale to use (e.g. en-US or zh-TW).",
-			"Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.",
-			"Opens the provided folder or workspace with the given profile and associates the profile with the workspace. If the profile does not exist, a new empty one is created. A folder or workspace must be provided for the profile to take effect.",
-			"Print usage.",
-			"Set the root path for extensions.",
-			"List the installed extensions.",
-			"Show versions of installed extensions, when using --list-extensions.",
-			"Filters installed extensions by provided category, when using --list-extensions.",
-			"Installs or updates an extension. The argument is either an extension id or a path to a VSIX. The identifier of an extension is '${publisher}.${name}'. Use '--force' argument to update to latest version. To install a specific version provide '@${version}'. For example: 'vscode.csharp@1.2.3'.",
-			"Installs the pre-release version of the extension, when using --install-extension",
-			"Uninstalls an extension.",
-			"Enables proposed API features for extensions. Can receive one or more extension IDs to enable individually.",
-			"Print version.",
-			"Print verbose output (implies --wait).",
-			"Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'. You can also configure the log level of an extension by passing extension id and log level in the following format: '${publisher}.${name}:${logLevel}'. For example: 'vscode.csharp:trace'. Can receive one or more such entries.",
-			"Print process usage and diagnostics information.",
-			"Run CPU profiler during startup.",
-			"Disable all installed extensions. This option is not persisted and is effective only when the command opens a new window.",
-			"Disable the provided extension. This option is not persisted and is effective only when the command opens a new window.",
-			"Turn sync on or off.",
-			"Allow debugging and profiling of extensions. Check the developer tools for the connection URI.",
-			"Allow debugging and profiling of extensions with the extension host being paused after start. Check the developer tools for the connection URI.",
-			"Disable GPU hardware acceleration.",
-			"Use this option only when there is requirement to launch the application as sudo user on Linux or when running as an elevated user in an applocker environment on Windows.",
-			"Shows all telemetry events which VS code collects.",
-			"Use {0} instead.",
-			"paths",
-			"Usage",
-			"options",
-			"To read output from another program, append '-' (e.g. 'echo Hello World | {0} -')",
-			"To read from stdin, append '-' (e.g. 'ps aux | grep code | {0} -')",
-			"Subcommands",
-			"Unknown version",
-			"Unknown commit"
-		],
-		"vs/platform/terminal/node/ptyService": [
-			"History restored"
-		],
 		"vs/editor/common/config/editorOptions": [
 			"Use platform APIs to detect when a Screen Reader is attached",
 			"Optimize for usage with a Screen Reader",
@@ -16926,6 +16971,7 @@
 			"Controls whether the hover is shown.",
 			"Controls the delay in milliseconds after which the hover is shown.",
 			"Controls whether the hover should remain visible when mouse is moved over it.",
+			"Controls the delay in milliseconds after thich the hover is hidden. Requires `editor.hover.sticky` to be enabled.",
 			"Prefer showing hovers above the line, if there's space.",
 			"Assumes that all characters are of the same width. This is a fast algorithm that works correctly for monospace fonts and certain scripts (like Latin characters) where glyphs are of equal width.",
 			"Delegates wrapping points computation to the browser. This is a slow algorithm, that might cause freezes for large files, but it works correctly in all cases.",
@@ -17085,6 +17131,9 @@
 			"Use language configurations to determine when to autoclose brackets.",
 			"Autoclose brackets only when the cursor is to the left of whitespace.",
 			"Controls whether the editor should automatically close brackets after the user adds an opening bracket.",
+			"Use language configurations to determine when to autoclose comments.",
+			"Autoclose comments only when the cursor is to the left of whitespace.",
+			"Controls whether the editor should automatically close comments after the user adds an opening comment.",
 			"Remove adjacent closing quotes or brackets only if they were automatically inserted.",
 			"Controls whether the editor should remove adjacent closing quotes or brackets when deleting.",
 			"Type over closing quotes or brackets only if they were automatically inserted.",
@@ -17123,7 +17172,7 @@
 			"Controls the minimal number of visible leading lines (minimum 0) and trailing lines (minimum 1) surrounding the cursor. Known as 'scrollOff' or 'scrollOffset' in some other editors.",
 			"`cursorSurroundingLines` is enforced only when triggered via the keyboard or API.",
 			"`cursorSurroundingLines` is enforced always.",
-			"Controls when `cursorSurroundingLines` should be enforced.",
+			"Controls when `#cursorSurroundingLines#` should be enforced.",
 			"Controls the width of the cursor when `#editor.cursorStyle#` is set to `line`.",
 			"Controls whether the editor should allow moving selections via drag and drop.",
 			"Use a new rendering method with svgs.",
@@ -17224,6 +17273,57 @@
 			"Controls whether inline color decorations should be shown using the default document color provider",
 			"Controls whether the editor receives tabs or defers them to the workbench for navigation."
 		],
+		"vs/platform/environment/node/argv": [
+			"Options",
+			"Extensions Management",
+			"Troubleshooting",
+			"Directory where CLI metadata should be stored.",
+			"Directory where CLI metadata should be stored.",
+			"Compare two files with each other.",
+			"Perform a three-way merge by providing paths for two modified versions of a file, the common origin of both modified versions and the output file to save merge results.",
+			"Add folder(s) to the last active window.",
+			"Open a file at the path on the specified line and character position.",
+			"Force to open a new window.",
+			"Force to open a file or folder in an already opened window.",
+			"Wait for the files to be closed before returning.",
+			"The locale to use (e.g. en-US or zh-TW).",
+			"Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.",
+			"Opens the provided folder or workspace with the given profile and associates the profile with the workspace. If the profile does not exist, a new empty one is created. A folder or workspace must be provided for the profile to take effect.",
+			"Print usage.",
+			"Set the root path for extensions.",
+			"List the installed extensions.",
+			"Show versions of installed extensions, when using --list-extensions.",
+			"Filters installed extensions by provided category, when using --list-extensions.",
+			"Installs or updates an extension. The argument is either an extension id or a path to a VSIX. The identifier of an extension is '${publisher}.${name}'. Use '--force' argument to update to latest version. To install a specific version provide '@${version}'. For example: 'vscode.csharp@1.2.3'.",
+			"Installs the pre-release version of the extension, when using --install-extension",
+			"Uninstalls an extension.",
+			"Enables proposed API features for extensions. Can receive one or more extension IDs to enable individually.",
+			"Print version.",
+			"Print verbose output (implies --wait).",
+			"Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'. You can also configure the log level of an extension by passing extension id and log level in the following format: '${publisher}.${name}:${logLevel}'. For example: 'vscode.csharp:trace'. Can receive one or more such entries.",
+			"Print process usage and diagnostics information.",
+			"Run CPU profiler during startup.",
+			"Disable all installed extensions. This option is not persisted and is effective only when the command opens a new window.",
+			"Disable the provided extension. This option is not persisted and is effective only when the command opens a new window.",
+			"Turn sync on or off.",
+			"Allow debugging and profiling of extensions. Check the developer tools for the connection URI.",
+			"Allow debugging and profiling of extensions with the extension host being paused after start. Check the developer tools for the connection URI.",
+			"Disable GPU hardware acceleration.",
+			"Use this option only when there is requirement to launch the application as sudo user on Linux or when running as an elevated user in an applocker environment on Windows.",
+			"Shows all telemetry events which VS code collects.",
+			"Use {0} instead.",
+			"paths",
+			"Usage",
+			"options",
+			"To read output from another program, append '-' (e.g. 'echo Hello World | {0} -')",
+			"To read from stdin, append '-' (e.g. 'ps aux | grep code | {0} -')",
+			"Subcommands",
+			"Unknown version",
+			"Unknown commit"
+		],
+		"vs/platform/terminal/node/ptyService": [
+			"History restored"
+		],
 		"vs/base/common/errorMessage": [
 			"{0}: {1}",
 			"A system error occurred ({0})",
@@ -17238,6 +17338,14 @@
 			"An external application wants to open '{0}' in {1}. Do you want to open this file or folder?",
 			"If you did not initiate this request, it may represent an attempted attack on your system. Unless you took an explicit action to initiate this request, you should press 'No'"
 		],
+		"vs/platform/files/common/files": [
+			"Unknown Error",
+			"{0}B",
+			"{0}KB",
+			"{0}MB",
+			"{0}GB",
+			"{0}TB"
+		],
 		"vs/platform/environment/node/argvHelper": [
 			"Option '{0}' is defined more than once. Using value '{1}'.",
 			"Option '{0}' requires a non empty value. Ignoring the option.",
@@ -17246,13 +17354,14 @@
 			"Warning: '{0}' is not in the list of known options, but still passed to Electron/Chromium.",
 			"Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`."
 		],
-		"vs/platform/files/common/files": [
-			"Unknown Error",
-			"{0}B",
-			"{0}KB",
-			"{0}MB",
-			"{0}GB",
-			"{0}TB"
+		"vs/platform/files/node/diskFileSystemProvider": [
+			"File already exists",
+			"File does not exist",
+			"Unable to move '{0}' into '{1}' ({2}).",
+			"Unable to copy '{0}' into '{1}' ({2}).",
+			"File cannot be copied to same path with different path case",
+			"File to move/copy does not exist",
+			"File at target already exists and thus will not be moved/copied to unless overwrite is specified"
 		],
 		"vs/platform/files/common/fileService": [
 			"Unable to resolve filesystem provider with relative file path '{0}'",
@@ -17262,6 +17371,7 @@
 			"Unable to write file '{0}' ({1})",
 			"Unable to unlock file '{0}' because provider does not support it.",
 			"Unable to atomically write file '{0}' because provider does not support it.",
+			"Unable to atomically write file '{0}' because provider does not support unbuffered writes.",
 			"Unable to unlock file '{0}' because atomic write is enabled.",
 			"Unable to write file '{0}' that is actually a directory",
 			"File Modified Since",
@@ -17282,15 +17392,6 @@
 			"Unable to modify read-only file '{0}'",
 			"Unable to modify read-only file '{0}'"
 		],
-		"vs/platform/files/node/diskFileSystemProvider": [
-			"File already exists",
-			"File does not exist",
-			"Unable to move '{0}' into '{1}' ({2}).",
-			"Unable to copy '{0}' into '{1}' ({2}).",
-			"File cannot be copied to same path with different path case",
-			"File to move/copy does not exist",
-			"File at target already exists and thus will not be moved/copied to unless overwrite is specified"
-		],
 		"vs/platform/request/common/request": [
 			"Network Requests",
 			"HTTP",
@@ -17303,7 +17404,8 @@
 			"Enable proxy support for extensions, fall back to request options, when no proxy found.",
 			"Enable proxy support for extensions, override request options.",
 			"Use the proxy support for extensions.",
-			"Controls whether CA certificates should be loaded from the OS. (On Windows and macOS, a reload of the window is required after turning this off.)"
+			"Controls whether CA certificates should be loaded from the OS. (On Windows and macOS, a reload of the window is required after turning this off.)",
+			"Controls whether experimental loading of CA certificates from the OS should be enabled. This uses a more general approach than the default implemenation."
 		],
 		"vs/platform/dialogs/common/dialogs": [
 			"&&Yes",
@@ -17388,12 +17490,25 @@
 			"Description",
 			"Please describe the feature you would like to see. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
 			"We have written the needed data into your clipboard because it was too large to send. Please paste.",
+			"Select extension",
 			"Extensions are disabled",
 			"No current experiments."
 		],
 		"vs/platform/extensionManagement/common/extensionManagement": [
 			"Extensions",
 			"Preferences"
+		],
+		"vs/platform/extensionManagement/common/extensionsScannerService": [
+			"Cannot read file {0}: {1}.",
+			"Failed to parse {0}: [{1}, {2}] {3}.",
+			"Invalid manifest file {0}: Not an JSON object.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected."
+		],
+		"vs/platform/languagePacks/common/languagePacks": [
+			" (Current)"
 		],
 		"vs/platform/extensionManagement/common/extensionManagementCLI": [
 			"Extension '{0}' not found.",
@@ -17424,15 +17539,6 @@
 			"Extension '{0}' is not installed on {1}.",
 			"Extension '{0}' is not installed."
 		],
-		"vs/platform/extensionManagement/common/extensionsScannerService": [
-			"Cannot read file {0}: {1}.",
-			"Failed to parse {0}: [{1}, {2}] {3}.",
-			"Invalid manifest file {0}: Not an JSON object.",
-			"Failed to parse {0}: {1}.",
-			"Invalid format {0}: JSON object expected.",
-			"Failed to parse {0}: {1}.",
-			"Invalid format {0}: JSON object expected."
-		],
 		"vs/platform/extensionManagement/node/extensionManagementService": [
 			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.",
 			"Marketplace is not enabled",
@@ -17443,9 +17549,6 @@
 			"Cannot read the extension from {0}",
 			"Please restart VS Code before reinstalling {0}.",
 			"Please restart VS Code before reinstalling {0}."
-		],
-		"vs/platform/languagePacks/common/languagePacks": [
-			" (Current)"
 		],
 		"vs/platform/telemetry/common/telemetryService": [
 			"Controls {0} telemetry, first-party extension telemetry, and participating third-party extension telemetry. Some third party extensions might not respect this setting. Consult the specific extension's documentation to be sure. Telemetry helps us better understand how {0} is performing, where improvements need to be made, and how features are being used.",
@@ -17480,11 +17583,14 @@
 			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
 			"Configure settings to be ignored while synchronizing."
 		],
+		"vs/platform/userDataSync/common/userDataSyncMachines": [
+			"Cannot read machines data as the current version is incompatible. Please update {0} and try again."
+		],
 		"vs/platform/userDataSync/common/userDataSyncLog": [
 			"Settings Sync"
 		],
-		"vs/platform/userDataSync/common/userDataSyncMachines": [
-			"Cannot read machines data as the current version is incompatible. Please update {0} and try again."
+		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
+			"Cannot parse sync data as it is not compatible with the current version."
 		],
 		"vs/platform/remoteTunnel/common/remoteTunnel": [
 			"Remote Tunnel Service"
@@ -17495,111 +17601,6 @@
 			"Opening tunnel {0}",
 			"Opening tunnel",
 			"Failed to install tunnel as a service, starting in session..."
-		],
-		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
-			"Cannot parse sync data as it is not compatible with the current version."
-		],
-		"vs/editor/common/languages": [
-			"array",
-			"boolean",
-			"class",
-			"constant",
-			"constructor",
-			"enumeration",
-			"enumeration member",
-			"event",
-			"field",
-			"file",
-			"function",
-			"interface",
-			"key",
-			"method",
-			"module",
-			"namespace",
-			"null",
-			"number",
-			"object",
-			"operator",
-			"package",
-			"property",
-			"string",
-			"struct",
-			"type parameter",
-			"variable",
-			"{0} ({1})"
-		],
-		"vs/workbench/browser/workbench": [
-			"Failed to load a required file. Please restart the application to try again. Details: {0}"
-		],
-		"vs/workbench/electron-sandbox/window": [
-			"Restart",
-			"Configure",
-			"Learn More",
-			"Writing login information to the keychain failed with error '{0}'.",
-			"Troubleshooting Guide",
-			"You are running an emulated version of {0}. For better performance download the native arm64 version of {0} build for your machine.",
-			"Download",
-			"Proxy Authentication Required",
-			"&&Log In",
-			"Username",
-			"Password",
-			"The proxy {0} requires a username and password.",
-			"Remember my credentials",
-			"Are you sure you want to quit?",
-			"Are you sure you want to exit?",
-			"Are you sure you want to close the window?",
-			"&&Quit",
-			"&&Exit",
-			"&&Close Window",
-			"Do not ask me again",
-			"Error: {0}",
-			"The following operations are still running: \n{0}",
-			"An unexpected error prevented the window to close",
-			"An unexpected error prevented the application to quit",
-			"An unexpected error prevented the window to reload",
-			"An unexpected error prevented to change the workspace",
-			"Closing the window is taking a bit longer...",
-			"Quitting the application is taking a bit longer...",
-			"Reloading the window is taking a bit longer...",
-			"Changing the workspace is taking a bit longer...",
-			"Close Anyway",
-			"Quit Anyway",
-			"Reload Anyway",
-			"Change Anyway",
-			"There is a dependency cycle in the AMD modules that needs to be resolved!",
-			"It is not recommended to run {0} as root user.",
-			"Files you store within the installation folder ('{0}') may be OVERWRITTEN or DELETED IRREVERSIBLY without warning at update time.",
-			"{0} on Windows 32-bit will soon stop receiving updates. Consider upgrading to the 64-bit build.",
-			"Learn More",
-			"{0}. Use navigation keys to access banner actions.",
-			"Learn More",
-			"Resolving shell environment...",
-			"Learn More"
-		],
-		"vs/workbench/services/configuration/browser/configurationService": [
-			"Contribute defaults for configurations",
-			"Experiments",
-			"Configure settings to be applied for all profiles."
-		],
-		"vs/platform/workspace/common/workspace": [
-			"Code Workspace"
-		],
-		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
-			"Open Developer Tools",
-			"Open in browser",
-			"Failed to connect to the remote extension host server (Error: {0})"
-		],
-		"vs/workbench/services/log/electron-sandbox/logService": [
-			"Window"
-		],
-		"vs/platform/workspace/common/workspaceTrust": [
-			"Trusted",
-			"Restricted Mode"
-		],
-		"vs/workbench/services/userDataProfile/common/userDataProfile": [
-			"Icon for Default Profile.",
-			"Profiles",
-			"Profile"
 		],
 		"vs/platform/list/browser/listService": [
 			"Workbench",
@@ -17626,7 +17627,7 @@
 			"Use contiguous matching when searching.",
 			"Controls the type of matching used when searching lists and trees in the workbench.",
 			"Controls how tree folders are expanded when clicking the folder names. Note that some trees and lists might choose to ignore this setting if it is not applicable.",
-			"Controls the how type navigation works in lists and trees in the workbench. When set to 'trigger', type navigation begins once the 'list.triggerTypeNavigation' command is run."
+			"Controls how type navigation works in lists and trees in the workbench. When set to `trigger`, type navigation begins once the `list.triggerTypeNavigation` command is run."
 		],
 		"vs/platform/markers/common/markers": [
 			"Error",
@@ -17649,14 +17650,6 @@
 			"Unexpected token. Hint: {0}",
 			"Unexpected token."
 		],
-		"vs/workbench/browser/actions/textInputActions": [
-			"Undo",
-			"Redo",
-			"Cut",
-			"Copy",
-			"Paste",
-			"Select All"
-		],
 		"vs/workbench/browser/workbench.contribution": [
 			"The default size.",
 			"Increases the size, so it can be grabbed more easily with the mouse.",
@@ -17675,7 +17668,7 @@
 			"The name of the untitled file is derived from the contents of its first line unless it has an associated file path. It will fallback to the name in case the line is empty or contains no word characters.",
 			"The name of the untitled file is not derived from the contents of the file.",
 			"Controls the format of the label for an untitled editor.",
-			"Controls if the untitled text hint should be visible in the editor.",
+			"Controls if the empty editor text hint should be visible in the editor.",
 			"Controls whether the language in a text editor is automatically detected unless the language has been explicitly set by the language picker. This can also be scoped by language so you can specify which languages you do not want to be switched off of. This is useful for languages like Markdown that often contain other languages that might trick language detection into thinking it's the embedded language and not Markdown.",
 			"Enables use of editor history in language detection. This causes automatic language detection to favor languages that have been recently opened and allows for automatic language detection to operate with smaller inputs.",
 			"When enabled, a language detection model that takes into account editor history will be given higher precedence.",
@@ -17689,10 +17682,12 @@
 			"Controls the size of editor tabs. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
 			"Controls the minimum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.",
 			"Controls the maximum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.",
+			"Controls the height of editor tabs. Also applies to the title control bar when `#workbench.editor.showTabs#` is disabled.",
 			"A pinned tab inherits the look of non pinned tabs.",
 			"A pinned tab will show in a compact form with only icon or first letter of the editor name.",
 			"A pinned tab shrinks to a compact fixed size showing parts of the editor name.",
 			"Controls the size of pinned editor tabs. Pinned tabs are sorted to the beginning of all opened tabs and typically do not close until unpinned. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"When enabled, displays pinned tabs in a separate row above all other tabs. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
 			"Always prevent closing the pinned editor when using mouse middle click or keyboard.",
 			"Prevent closing the pinned editor when using the keyboard.",
 			"Prevent closing the pinned editor when using mouse middle click.",
@@ -17738,6 +17733,9 @@
 			"Controls the number of recently used commands to keep in history for the command palette. Set to 0 to disable command history.",
 			"Controls whether the last typed input to the command palette should be restored when opening it the next time.",
 			"Controls whether the command palette should have a list of commonly used commands.",
+			"Controls where the command palette should ask chat questions.",
+			"Ask chat questions in the Chat view.",
+			"Ask chat questions in Quick Chat.",
 			"Controls whether the command palette should include similar commands. You must have an extension installed that provides Natural Language support.",
 			"Controls whether Quick Open should close automatically once it loses focus.",
 			"Controls whether the last typed input to Quick Open should be restored when opening it the next time.",
@@ -17837,6 +17835,50 @@
 			"Controls whether a window should restore to Zen Mode if it was exited in Zen Mode.",
 			"Controls whether notifications do not disturb mode should be enabled while in Zen Mode. If true, only error notifications will pop out."
 		],
+		"vs/workbench/browser/actions/textInputActions": [
+			"Undo",
+			"Redo",
+			"Cut",
+			"Copy",
+			"Paste",
+			"Select All"
+		],
+		"vs/workbench/browser/actions/developerActions": [
+			"Inspect Context Keys",
+			"Toggle Screencast Mode",
+			"Log Storage Database Contents",
+			"The storage database contents have been logged to the developer tools.",
+			"Open developer tools from the menu and select the Console tab.",
+			"Log Working Copies",
+			"Remove Large Storage Database Entries...",
+			"Scope: {0}, Target: {1}",
+			"Global",
+			"Profile",
+			"Workspace",
+			"Machine",
+			"User",
+			"Remove",
+			"Select large entries to remove from storage",
+			"There are no large storage entries to remove.",
+			"Do you want to remove the selected storage entries from the database?",
+			"{0}\n\nThis action is irreversible and may result in data loss!",
+			"&&Remove",
+			"Start Tracking Disposables",
+			"Snapshot Tracked Disposables",
+			"Stop Tracking Disposables",
+			"Screencast Mode",
+			"Controls the vertical offset of the screencast mode overlay from the bottom as a percentage of the workbench height.",
+			"Controls the font size (in pixels) of the screencast mode keyboard.",
+			"Options for customizing the keyboard overlay in screencast mode.",
+			"Show raw keys.",
+			"Show keyboard shortcuts.",
+			"Show command names.",
+			"Show command group names, when commands are also shown.",
+			"Show single editor cursor move commands.",
+			"Controls how long (in milliseconds) the keyboard overlay is shown in screencast mode.",
+			"Controls the color in hex (#RGB, #RGBA, #RRGGBB or #RRGGBBAA) of the mouse indicator in screencast mode.",
+			"Controls the size (in pixels) of the mouse indicator in screencast mode."
+		],
 		"vs/workbench/browser/actions/helpActions": [
 			"Keyboard Shortcuts Reference",
 			"&&Keyboard Shortcuts Reference",
@@ -17855,26 +17897,6 @@
 			"View &&License",
 			"Privacy Statement",
 			"Privac&&y Statement"
-		],
-		"vs/workbench/browser/actions/developerActions": [
-			"Inspect Context Keys",
-			"Toggle Screencast Mode",
-			"Log Storage Database Contents",
-			"The storage database contents have been logged to the developer tools.",
-			"Open developer tools from the menu and select the Console tab.",
-			"Log Working Copies",
-			"Screencast Mode",
-			"Controls the vertical offset of the screencast mode overlay from the bottom as a percentage of the workbench height.",
-			"Controls the font size (in pixels) of the screencast mode keyboard.",
-			"Options for customizing the keyboard overlay in screencast mode.",
-			"Show raw keys.",
-			"Show keyboard shortcuts.",
-			"Show command names.",
-			"Show command group names, when commands are also shown.",
-			"Show single editor cursor move commands.",
-			"Controls how long (in milliseconds) the keyboard overlay is shown in screencast mode.",
-			"Controls the color in hex (#RGB, #RGBA, #RRGGBB or #RRGGBBAA) of the mouse indicator in screencast mode.",
-			"Controls the size (in pixels) of the mouse indicator in screencast mode."
 		],
 		"vs/workbench/browser/actions/layoutActions": [
 			"Represents the menu bar",
@@ -17926,7 +17948,8 @@
 			"Toggle Primary Side Bar",
 			"Toggle Status Bar Visibility",
 			"S&&tatus Bar",
-			"Toggle Tab Visibility",
+			"Toggle Editor Tab Visibility",
+			"Separate Pinned Editor Tabs",
 			"Toggle Zen Mode",
 			"Zen Mode",
 			"Toggle Menu Bar",
@@ -18023,12 +18046,6 @@
 			"Confirm Before Close",
 			"Open &&Recent"
 		],
-		"vs/workbench/browser/actions/workspaceCommands": [
-			"Add Folder to Workspace...",
-			"&&Add",
-			"Add Folder to Workspace",
-			"Select workspace folder"
-		],
 		"vs/workbench/browser/actions/workspaceActions": [
 			"Workspaces",
 			"Open File...",
@@ -18052,6 +18069,12 @@
 			"Close &&Folder",
 			"Close &&Workspace"
 		],
+		"vs/workbench/browser/actions/workspaceCommands": [
+			"Add Folder to Workspace...",
+			"&&Add",
+			"Add Folder to Workspace",
+			"Select workspace folder"
+		],
 		"vs/workbench/browser/actions/quickAccessActions": [
 			"Go to File...",
 			"Quick Open",
@@ -18059,50 +18082,6 @@
 			"Navigate Previous in Quick Open",
 			"Select Next in Quick Open",
 			"Select Previous in Quick Open"
-		],
-		"vs/workbench/api/common/configurationExtensionPoint": [
-			"A title for the current category of settings. This label will be rendered in the Settings editor as a subheading. If the title is the same as the extension display name, then the category will be grouped under the main extension heading.",
-			"When specified, gives the order of this category of settings relative to other categories.",
-			"Description of the configuration properties.",
-			"Property should not be empty.",
-			"Schema of the configuration property.",
-			"Configuration that can be configured only in the user settings.",
-			"Configuration that can be configured only in the user settings or only in the remote settings.",
-			"Configuration that can be configured in the user, remote or workspace settings.",
-			"Configuration that can be configured in the user, remote, workspace or folder settings.",
-			"Resource configuration that can be configured in language specific settings.",
-			"Machine configuration that can be configured also in workspace or folder settings.",
-			"Scope in which the configuration is applicable. Available scopes are `application`, `machine`, `window`, `resource`, and `machine-overridable`.",
-			"Descriptions for enum values",
-			"Descriptions for enum values in the markdown format.",
-			"Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.",
-			"The description in the markdown format.",
-			"If set, the property is marked as deprecated and the given message is shown as an explanation.",
-			"If set, the property is marked as deprecated and the given message is shown as an explanation in the markdown format.",
-			"The value will be shown in an inputbox.",
-			"The value will be shown in a textarea.",
-			"When specified, controls the presentation format of the string setting.",
-			"When specified, gives the order of this setting relative to other settings within the same category. Settings with an order property will be placed before settings without this property set.",
-			"When enabled, Settings Sync will not sync the user value of this configuration by default.",
-			"Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.",
-			"Contributes configuration settings.",
-			"'configuration.title' must be a string",
-			"'configuration.properties' must be an object",
-			"Cannot register '{0}'. This property is already registered.",
-			"configuration.properties property '{0}' must be an object",
-			"'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point.",
-			"List of folders to be loaded in the workspace.",
-			"A file path. e.g. `/root/folderA` or `./folderA` for a relative path that will be resolved against the location of the workspace file.",
-			"An optional name for the folder. ",
-			"URI of the folder",
-			"An optional name for the folder. ",
-			"Workspace settings",
-			"Workspace launch configurations",
-			"Workspace task configurations",
-			"Workspace extensions",
-			"The remote server where the workspace is located.",
-			"A transient workspace will disappear when restarting or reloading.",
-			"Unknown workspace configuration property"
 		],
 		"vs/workbench/services/actions/common/menusExtensionPoint": [
 			"The Command Palette",
@@ -18218,6 +18197,50 @@
 			"Menu item references a submenu `{0}` which is not defined in the 'submenus' section.",
 			"The `{0}` submenu was already contributed to the `{1}` menu."
 		],
+		"vs/workbench/api/common/configurationExtensionPoint": [
+			"A title for the current category of settings. This label will be rendered in the Settings editor as a subheading. If the title is the same as the extension display name, then the category will be grouped under the main extension heading.",
+			"When specified, gives the order of this category of settings relative to other categories.",
+			"Description of the configuration properties.",
+			"Property should not be empty.",
+			"Schema of the configuration property.",
+			"Configuration that can be configured only in the user settings.",
+			"Configuration that can be configured only in the user settings or only in the remote settings.",
+			"Configuration that can be configured in the user, remote or workspace settings.",
+			"Configuration that can be configured in the user, remote, workspace or folder settings.",
+			"Resource configuration that can be configured in language specific settings.",
+			"Machine configuration that can be configured also in workspace or folder settings.",
+			"Scope in which the configuration is applicable. Available scopes are `application`, `machine`, `window`, `resource`, and `machine-overridable`.",
+			"Descriptions for enum values",
+			"Descriptions for enum values in the markdown format.",
+			"Labels for enum values to be displayed in the Settings editor. When specified, the {0} values still show after the labels, but less prominently.",
+			"The description in the markdown format.",
+			"If set, the property is marked as deprecated and the given message is shown as an explanation.",
+			"If set, the property is marked as deprecated and the given message is shown as an explanation in the markdown format.",
+			"The value will be shown in an inputbox.",
+			"The value will be shown in a textarea.",
+			"When specified, controls the presentation format of the string setting.",
+			"When specified, gives the order of this setting relative to other settings within the same category. Settings with an order property will be placed before settings without this property set.",
+			"When enabled, Settings Sync will not sync the user value of this configuration by default.",
+			"Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.",
+			"Contributes configuration settings.",
+			"'configuration.title' must be a string",
+			"'configuration.properties' must be an object",
+			"Cannot register '{0}'. This property is already registered.",
+			"configuration.properties property '{0}' must be an object",
+			"'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point.",
+			"List of folders to be loaded in the workspace.",
+			"A file path. e.g. `/root/folderA` or `./folderA` for a relative path that will be resolved against the location of the workspace file.",
+			"An optional name for the folder. ",
+			"URI of the folder",
+			"An optional name for the folder. ",
+			"Workspace settings",
+			"Workspace launch configurations",
+			"Workspace task configurations",
+			"Workspace extensions",
+			"The remote server where the workspace is located.",
+			"A transient workspace will disappear when restarting or reloading.",
+			"Unknown workspace configuration property"
+		],
 		"vs/workbench/api/browser/viewsExtensionPoint": [
 			"Unique id used to identify the container in which views can be contributed using 'views' contribution point",
 			"Human readable string used to render the container",
@@ -18292,7 +18315,8 @@
 			"Split Down",
 			"Split Left",
 			"Split Right",
-			"Enable Tabs",
+			"Editor Tabs",
+			"Separate Pinned Editor Tabs",
 			"Close",
 			"Close Others",
 			"Close to the Right",
@@ -18312,7 +18336,6 @@
 			"Show Opened Editors",
 			"Close All",
 			"Close Saved",
-			"Enable Tabs",
 			"Enable Preview Editors",
 			"Lock Group",
 			"Split Editor Right",
@@ -18403,11 +18426,11 @@
 			"Group &&Below",
 			"Switch &&Group"
 		],
-		"vs/workbench/browser/parts/banner/bannerPart": [
-			"Focus Banner"
-		],
 		"vs/workbench/browser/parts/statusbar/statusbarPart": [
 			"Hide Status Bar"
+		],
+		"vs/workbench/browser/parts/banner/bannerPart": [
+			"Focus Banner"
 		],
 		"vs/workbench/browser/parts/views/viewsService": [
 			"Show {0}",
@@ -18440,10 +18463,11 @@
 			"Could not redo '{0}' because there is already an undo or redo operation running."
 		],
 		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
-			"Allow an extension to open this URI?",
+			"Allow '{0}' extension to open this URI?",
 			"Don't ask again for this extension.",
 			"&&Open",
-			"Extension '{0}' is not installed. Would you like to install the extension and open this URL?",
+			"Would you like to install '{0}' extension from '{1}' to open this URI?",
+			"'{0}' extension wants to open a URI:",
 			"&&Install and Open",
 			"Installing Extension '{0}'...",
 			"Extension '{0}' is disabled. Would you like to enable the extension and open the URL?",
@@ -18594,6 +18618,10 @@
 			"Workspace Folder",
 			"Workspace"
 		],
+		"vs/workbench/services/notification/common/notificationService": [
+			"Don't Show Again",
+			"Don't Show Again"
+		],
 		"vs/workbench/services/userDataProfile/browser/userDataProfileManagement": [
 			"The current profile has been updated. Please reload to switch back to the updated profile",
 			"The current profile has been removed. Please reload to switch back to default profile",
@@ -18603,10 +18631,6 @@
 			"Switching to a profile.",
 			"Switching a profile requires reloading VS Code.",
 			"&&Reload"
-		],
-		"vs/workbench/services/notification/common/notificationService": [
-			"Don't Show Again",
-			"Don't Show Again"
 		],
 		"vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService": [
 			"Error while importing profile: {0}",
@@ -18629,10 +18653,14 @@
 			"The profile should contain at least one configuration.",
 			"Using Default Profile",
 			"Profile name is required and must be a non-empty value.",
+			"Icon:",
+			"Icon: {0}",
+			"Icon: {0}",
 			"Copy from:",
 			"None",
 			"Profile Templates",
 			"Existing Profiles",
+			"Copy profile from",
 			"Create Profile",
 			"Export",
 			"Close",
@@ -18715,14 +18743,13 @@
 			"This will clear your data in the cloud and stop sync on all your devices.",
 			"Clear",
 			"&&Reset",
+			"Select folder to download Settings Sync activity",
+			"Save",
 			"Select an account to sign in",
 			"Signed in",
 			"Last Used with Sync",
 			"Others",
 			"Sign in with {0}"
-		],
-		"vs/workbench/services/assignment/common/assignmentService": [
-			"Fetches experiments to run from a Microsoft online service."
 		],
 		"vs/workbench/services/authentication/browser/authenticationService": [
 			"The id of the authentication provider.",
@@ -18743,35 +18770,8 @@
 			"Grant access to {0} for {1}... (1)",
 			"Sign in with {0} to use {1} (1)"
 		],
-		"vs/workbench/services/issue/browser/issueTroubleshoot": [
-			"Troubleshoot Issue",
-			"Issue troubleshooting is a process to help you identify the cause for an issue. The cause for an issue can be a misconfiguration, due to an extension, or be {0} itself.\n\nDuring the process the window reloads repeatedly. Each time you must confirm if you are still seeing the issue.",
-			"&&Troubleshoot Issue",
-			"Issue troubleshooting is active and has temporarily disabled all installed extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
-			"Issue troubleshooting is active and has temporarily reset your configurations to defaults. Check if you can still reproduce the problem and proceed by selecting from these options.",
-			"Issue troubleshooting has identified that the issue is caused by your configurations. Please report the issue by exporting your configurations using \"Export Profile\" command and share the file in the issue report.",
-			"Issue troubleshooting has identified that the issue is with {0}.",
-			"I Can't Reproduce",
-			"I Can Reproduce",
-			"Stop",
-			"Troubleshoot Issue",
-			"This likely means that the issue has been addressed already and will be available in an upcoming release. You can safely use {0} insiders until the new stable version is available.",
-			"Troubleshoot Issue",
-			"Download {0} Insiders",
-			"Report Issue Anyway",
-			"Please try to download and reproduce the issue in {0} insiders.",
-			"Troubleshoot Issue",
-			"I can't reproduce",
-			"I can reproduce",
-			"Stop",
-			"Please try to reproduce the issue in {0} insiders and confirm if the issue exists there.",
-			"Troubleshoot Issue...",
-			"Stop Troubleshoot Issue"
-		],
-		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
-			"You won't be able to produce this key combination under your current keyboard layout.",
-			"**{0}** for your current keyboard layout (**{1}** for US standard).",
-			"**{0}** for your current keyboard layout."
+		"vs/workbench/services/assignment/common/assignmentService": [
+			"Fetches experiments to run from a Microsoft online service."
 		],
 		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
 			"Settings Editor 2",
@@ -18820,6 +18820,36 @@
 			"Open Settings (JSON)",
 			"&&Preferences"
 		],
+		"vs/workbench/services/issue/browser/issueTroubleshoot": [
+			"Troubleshoot Issue",
+			"Issue troubleshooting is a process to help you identify the cause for an issue. The cause for an issue can be a misconfiguration, due to an extension, or be {0} itself.\n\nDuring the process the window reloads repeatedly. Each time you must confirm if you are still seeing the issue.",
+			"&&Troubleshoot Issue",
+			"Issue troubleshooting is active and has temporarily disabled all installed extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
+			"Issue troubleshooting is active and has temporarily reset your configurations to defaults. Check if you can still reproduce the problem and proceed by selecting from these options.",
+			"Issue troubleshooting has identified that the issue is caused by your configurations. Please report the issue by exporting your configurations using \"Export Profile\" command and share the file in the issue report.",
+			"Issue troubleshooting has identified that the issue is with {0}.",
+			"I Can't Reproduce",
+			"I Can Reproduce",
+			"Stop",
+			"Troubleshoot Issue",
+			"This likely means that the issue has been addressed already and will be available in an upcoming release. You can safely use {0} insiders until the new stable version is available.",
+			"Troubleshoot Issue",
+			"Download {0} Insiders",
+			"Report Issue Anyway",
+			"Please try to download and reproduce the issue in {0} insiders.",
+			"Troubleshoot Issue",
+			"I can't reproduce",
+			"I can reproduce",
+			"Stop",
+			"Please try to reproduce the issue in {0} insiders and confirm if the issue exists there.",
+			"Troubleshoot Issue...",
+			"Stop Troubleshoot Issue"
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"You won't be able to produce this key combination under your current keyboard layout.",
+			"**{0}** for your current keyboard layout (**{1}** for US standard).",
+			"**{0}** for your current keyboard layout."
+		],
 		"vs/workbench/contrib/performance/browser/performance.contribution": [
 			"Startup Performance",
 			"Print Service Cycles",
@@ -18866,11 +18896,23 @@
 			"Initially render notebook outputs in a scrollable region when longer than the limit",
 			"Controls whether the lines in output should wrap.",
 			"Format a notebook on save. A formatter must be available, the file must not be saved after delay, and the editor must not be shutting down.",
-			"Experimental. Run a series of CodeActions for a notebook on save. CodeActions must be specified, the file must not be saved after delay, and the editor must not be shutting down. Example: `source.fixAll: true`",
+			"Run a series of CodeActions for a notebook on save. CodeActions must be specified, the file must not be saved after delay, and the editor must not be shutting down. Example: `\"notebook.source.organizeImports\": \"explicit\"`",
+			"Triggers Code Actions only when explicitly saved.",
+			"Never triggers Code Actions on save.",
+			"Triggers Code Actions only when explicitly saved. This value will be deprecated in favor of \"explicit\".",
+			"Triggers Code Actions only when explicitly saved. This value will be deprecated in favor of \"never\".",
 			"Format a notebook cell upon execution. A formatter must be available.",
 			"Control whether a confirmation prompt is required to delete a running cell.",
 			"Customize the Find Widget behavior for searching within notebook cells. When both markup source and markup preview are enabled, the Find Widget will search either the source code or preview based on the current state of the cell.",
-			"Enables the incremental saving of notebooks in Remote environment. When enabled, only the changes to the notebook are sent to the extension host, improving performance for large notebooks and slow network connections."
+			"Enables the incremental saving of notebooks in Remote environment. When enabled, only the changes to the notebook are sent to the extension host, improving performance for large notebooks and slow network connections.",
+			"How far to scroll when revealing the next cell upon running {0}.",
+			"Scroll to fully reveal the next cell.",
+			"Scroll to reveal the first line of the next cell.",
+			"Do not scroll.",
+			"Experimental. Keep the focused cell steady while surrounding cells change size.",
+			"Anchor the viewport to the focused cell depending on context unless {0} is set to {1}.",
+			"Always anchor the viewport to the focused cell.",
+			"The focused cell may shift around as cells resize."
 		],
 		"vs/workbench/contrib/chat/browser/chat.contribution": [
 			"Chat",
@@ -18882,6 +18924,20 @@
 			"Chat",
 			"Chat",
 			"Clear the session"
+		],
+		"vs/workbench/contrib/testing/browser/testing.contribution": [
+			"Testing",
+			"T&&esting",
+			"Test Results",
+			"Test Results",
+			"No tests have been found in this workspace yet.",
+			"Install Additional Test Extensions...",
+			"Test Explorer"
+		],
+		"vs/workbench/contrib/logs/common/logs.contribution": [
+			"Set Default Log Level",
+			"{0} (Remote)",
+			"Show Window Log"
 		],
 		"vs/workbench/contrib/interactive/browser/interactive.contribution": [
 			"Interactive Window",
@@ -18898,37 +18954,6 @@
 			"The border color for the current interactive code cell when the editor has focus.",
 			"The border color for the current interactive code cell when the editor does not have focus.",
 			"Automatically scroll the interactive window to show the output of the last statement executed. If this value is false, the window will only scroll if the last cell was already the one scrolled to."
-		],
-		"vs/workbench/contrib/logs/common/logs.contribution": [
-			"Set Default Log Level",
-			"{0} (Remote)",
-			"{0} (Remote)",
-			"Show Window Log"
-		],
-		"vs/workbench/contrib/testing/browser/testing.contribution": [
-			"Testing",
-			"T&&esting",
-			"Test Results",
-			"Test Results",
-			"No tests have been found in this workspace yet.",
-			"Install Additional Test Extensions...",
-			"Test Explorer"
-		],
-		"vs/workbench/contrib/files/browser/explorerViewlet": [
-			"View icon of the explorer view.",
-			"View icon of the open editors view.",
-			"Folders",
-			"Explorer",
-			"Explorer",
-			"&&Explorer",
-			"Open Folder",
-			"add a folder",
-			"Open Recent",
-			"You have not yet added a folder to the workspace.\n{0}",
-			"You have not yet opened a folder.\n{0}\n{1}",
-			"Connected to remote.\n{0}",
-			"You have not yet opened a folder.\n{0}\nOpening a folder will close all currently open editors. To keep them open, {1} instead.",
-			"You have not yet opened a folder.\n{0}"
 		],
 		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
 			"Type '{0}' to get help on the actions you can take from here.",
@@ -18984,16 +19009,32 @@
 			"&&Close Editor",
 			"Go to &&File..."
 		],
+		"vs/workbench/contrib/files/browser/explorerViewlet": [
+			"View icon of the explorer view.",
+			"View icon of the open editors view.",
+			"Folders",
+			"Explorer",
+			"Explorer",
+			"&&Explorer",
+			"Open Folder",
+			"add a folder",
+			"Open Recent",
+			"You have not yet added a folder to the workspace.\n{0}",
+			"You have not yet opened a folder.\n{0}\n{1}",
+			"Connected to remote.\n{0}",
+			"You have not yet opened a folder.\n{0}\nOpening a folder will close all currently open editors. To keep them open, {1} instead.",
+			"You have not yet opened a folder.\n{0}"
+		],
 		"vs/workbench/contrib/files/browser/files.contribution": [
 			"Text File Editor",
 			"Binary File Editor",
 			"Disable hot exit. A prompt will show when attempting to close a window with editors that have unsaved changes.",
 			"Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu). All windows without folders opened will be restored upon next launch. A list of previously opened windows with unsaved files can be accessed via `File > Open Recent > More...`",
 			"Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu), and also for any window with a folder opened regardless of whether it's the last window. All windows without folders opened will be restored upon next launch. A list of previously opened windows with unsaved files can be accessed via `File > Open Recent > More...`",
-			"Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.",
+			"[Hot Exit](https://aka.ms/vscode-hot-exit) controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.",
 			"Disable hot exit. A prompt will show when attempting to close a window with editors that have unsaved changes.",
 			"Hot exit will be triggered when the browser quits or the window or tab is closed.",
-			"Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.",
+			"[Hot Exit](https://aka.ms/vscode-hot-exit) controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.",
 			"Files",
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) for excluding files and folders. For example, the File Explorer decides which files and folders to show or hide based on this setting. Refer to the `#search.exclude#` setting to define search-specific excludes. Refer to the `#explorer.excludeGitIgnore#` setting for ignoring files based on your `.gitignore`.",
 			"Enable the pattern.",
@@ -19108,6 +19149,48 @@
 			"File operation",
 			"Controls if files that were part of a refactoring are saved automatically"
 		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
+			"Another refactoring is being previewed.",
+			"Press 'Continue' to discard the previous refactoring and continue with the current refactoring.",
+			"&&Continue",
+			"Apply Refactoring",
+			"Refactor Preview",
+			"Discard Refactoring",
+			"Refactor Preview",
+			"Toggle Change",
+			"Refactor Preview",
+			"Group Changes By File",
+			"Refactor Preview",
+			"Group Changes By Type",
+			"Refactor Preview",
+			"Group Changes By Type",
+			"Refactor Preview",
+			"View icon of the refactor preview view.",
+			"Refactor Preview",
+			"Refactor Preview"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
+			"Search Editor",
+			"Search Editor",
+			"Search Editor",
+			"Delete File Results",
+			"New Search Editor",
+			"Open Search Editor",
+			"Open New Search Editor to the Side",
+			"Open Results in Editor",
+			"Search Again",
+			"Focus Search Editor Input",
+			"Focus Search Editor Files to Include",
+			"Focus Search Editor Files to Exclude",
+			"Toggle Match Case",
+			"Toggle Match Whole Word",
+			"Toggle Use Regular Expression",
+			"Toggle Context Lines",
+			"Increase Context Lines",
+			"Decrease Context Lines",
+			"Select All Matches",
+			"Open New Search Editor"
+		],
 		"vs/workbench/contrib/search/browser/search.contribution": [
 			"Search",
 			"Search",
@@ -19178,26 +19261,6 @@
 			"Show notebook editor rich content results for closed notebooks. Please refresh your search results after changing this setting.",
 			"Controls whether the last typed input to Quick Search should be restored when opening it the next time."
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
-			"Another refactoring is being previewed.",
-			"Press 'Continue' to discard the previous refactoring and continue with the current refactoring.",
-			"&&Continue",
-			"Apply Refactoring",
-			"Refactor Preview",
-			"Discard Refactoring",
-			"Refactor Preview",
-			"Toggle Change",
-			"Refactor Preview",
-			"Group Changes By File",
-			"Refactor Preview",
-			"Group Changes By Type",
-			"Refactor Preview",
-			"Group Changes By Type",
-			"Refactor Preview",
-			"View icon of the refactor preview view.",
-			"Refactor Preview",
-			"Refactor Preview"
-		],
 		"vs/workbench/contrib/search/browser/searchView": [
 			"Search was canceled before any results could be found - ",
 			"Toggle Search Details",
@@ -19256,93 +19319,9 @@
 			"You have not opened or specified a folder. Only open files are currently searched - ",
 			"Open Folder"
 		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
-			"Search Editor",
-			"Search Editor",
-			"Search Editor",
-			"Delete File Results",
-			"New Search Editor",
-			"Open Search Editor",
-			"Open New Search Editor to the Side",
-			"Open Results in Editor",
-			"Search Again",
-			"Focus Search Editor Input",
-			"Focus Search Editor Files to Include",
-			"Focus Search Editor Files to Exclude",
-			"Toggle Match Case",
-			"Toggle Match Whole Word",
-			"Toggle Use Regular Expression",
-			"Toggle Context Lines",
-			"Increase Context Lines",
-			"Decrease Context Lines",
-			"Select All Matches",
-			"Open New Search Editor"
-		],
 		"vs/workbench/contrib/sash/browser/sash.contribution": [
 			"Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it's hard to resize views using the mouse.",
 			"Controls the hover feedback delay in milliseconds of the dragging area in between views/editors."
-		],
-		"vs/workbench/contrib/scm/browser/scm.contribution": [
-			"View icon of the Source Control view.",
-			"Source Control",
-			"No source control providers registered.",
-			"None of the registered source control providers work in Restricted Mode.",
-			"Manage Workspace Trust",
-			"Source Control",
-			"Source &&Control",
-			"Source Control Repositories",
-			"Source Control",
-			"Show the diff decorations in all available locations.",
-			"Show the diff decorations only in the editor gutter.",
-			"Show the diff decorations only in the overview ruler.",
-			"Show the diff decorations only in the minimap.",
-			"Do not show the diff decorations.",
-			"Controls diff decorations in the editor.",
-			"Controls the width(px) of diff decorations in gutter (added & modified).",
-			"Show the diff decorator in the gutter at all times.",
-			"Show the diff decorator in the gutter only on hover.",
-			"Controls the visibility of the Source Control diff decorator in the gutter.",
-			"Show the inline diff Peek view on click.",
-			"Do nothing.",
-			"Controls the behavior of Source Control diff gutter decorations.",
-			"Controls whether a pattern is used for the diff decorations in gutter.",
-			"Use pattern for the diff decorations in gutter for added lines.",
-			"Use pattern for the diff decorations in gutter for modified lines.",
-			"Ignore leading and trailing whitespace.",
-			"Do not ignore leading and trailing whitespace.",
-			"Inherit from `diffEditor.ignoreTrimWhitespace`.",
-			"Controls whether leading and trailing whitespace is ignored in Source Control diff gutter decorations.",
-			"Controls whether inline actions are always visible in the Source Control view.",
-			"Show the sum of all Source Control Provider count badges.",
-			"Show the count badge of the focused Source Control Provider.",
-			"Disable the Source Control count badge.",
-			"Controls the count badge on the Source Control icon on the Activity Bar.",
-			"Hide Source Control Provider count badges.",
-			"Only show count badge for Source Control Provider when non-zero.",
-			"Show Source Control Provider count badges.",
-			"Controls the count badges on Source Control Provider headers. These headers only appear when there is more than one provider.",
-			"Show the repository changes as a tree.",
-			"Show the repository changes as a list.",
-			"Controls the default Source Control repository view mode.",
-			"Sort the repository changes by file name.",
-			"Sort the repository changes by path.",
-			"Sort the repository changes by Source Control status.",
-			"Controls the default Source Control repository changes sort order when viewed as a list.",
-			"Controls whether the Source Control view should automatically reveal and select files when opening them.",
-			"Controls the font for the input message. Use `default` for the workbench user interface font family, `editor` for the `#editor.fontFamily#`'s value, or a custom font family.",
-			"Controls the font size for the input message in pixels.",
-			"Controls whether repositories should always be visible in the Source Control view.",
-			"Repositories in the Source Control Repositories view are sorted by discovery time. Repositories in the Source Control view are sorted in the order that they were selected.",
-			"Repositories in the Source Control Repositories and Source Control views are sorted by repository name.",
-			"Repositories in the Source Control Repositories and Source Control views are sorted by repository path.",
-			"Controls the sort order of the repositories in the source control repositories view.",
-			"Controls how many repositories are visible in the Source Control Repositories section. Set to 0, to be able to manually resize the view.",
-			"Controls whether an action button can be shown in the Source Control view.",
-			"Source Control: Accept Input",
-			"Source Control: View Next Commit",
-			"Source Control: View Previous Commit",
-			"Open in External Terminal",
-			"Open in Integrated Terminal"
 		],
 		"vs/workbench/contrib/debug/browser/debug.contribution": [
 			"Debug",
@@ -19403,7 +19382,11 @@
 			"Always show variable values inline in editor while debugging.",
 			"Never show variable values inline in editor while debugging.",
 			"Show variable values inline in editor while debugging when the language supports inline value locations.",
-			"Controls the location of the debug toolbar. Either `floating` in all views, `docked` in the debug view, or `hidden`.",
+			"Controls the location of the debug toolbar. Either `floating` in all views, `docked` in the debug view, `commandCenter` (requires `{0}`), or `hidden`.",
+			"Show debug toolbar in all views.",
+			"Show debug toolbar only in debug views.",
+			"`(Experimental)` Show debug toolbar in the command center.",
+			"Do not show debug toolbar.",
 			"Never show debug in Status bar",
 			"Always show debug in Status bar",
 			"Show debug in Status bar only after debug was started for the first time",
@@ -19480,19 +19463,73 @@
 			"Icon color for the current breakpoint stack frame.",
 			"Icon color for all breakpoint stack frames."
 		],
-		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
-			"Background color for the highlight of line at the top stack frame position.",
-			"Background color for the highlight of line at focused stack frame position."
+		"vs/workbench/contrib/scm/browser/scm.contribution": [
+			"View icon of the Source Control view.",
+			"Source Control",
+			"No source control providers registered.",
+			"None of the registered source control providers work in Restricted Mode.",
+			"Manage Workspace Trust",
+			"Source Control",
+			"Source &&Control",
+			"Source Control Repositories",
+			"Source Control Sync",
+			"Source Control",
+			"Show the diff decorations in all available locations.",
+			"Show the diff decorations only in the editor gutter.",
+			"Show the diff decorations only in the overview ruler.",
+			"Show the diff decorations only in the minimap.",
+			"Do not show the diff decorations.",
+			"Controls diff decorations in the editor.",
+			"Controls the width(px) of diff decorations in gutter (added & modified).",
+			"Show the diff decorator in the gutter at all times.",
+			"Show the diff decorator in the gutter only on hover.",
+			"Controls the visibility of the Source Control diff decorator in the gutter.",
+			"Show the inline diff Peek view on click.",
+			"Do nothing.",
+			"Controls the behavior of Source Control diff gutter decorations.",
+			"Controls whether a pattern is used for the diff decorations in gutter.",
+			"Use pattern for the diff decorations in gutter for added lines.",
+			"Use pattern for the diff decorations in gutter for modified lines.",
+			"Ignore leading and trailing whitespace.",
+			"Do not ignore leading and trailing whitespace.",
+			"Inherit from `diffEditor.ignoreTrimWhitespace`.",
+			"Controls whether leading and trailing whitespace is ignored in Source Control diff gutter decorations.",
+			"Controls whether inline actions are always visible in the Source Control view.",
+			"Show the sum of all Source Control Provider count badges.",
+			"Show the count badge of the focused Source Control Provider.",
+			"Disable the Source Control count badge.",
+			"Controls the count badge on the Source Control icon on the Activity Bar.",
+			"Hide Source Control Provider count badges.",
+			"Only show count badge for Source Control Provider when non-zero.",
+			"Show Source Control Provider count badges.",
+			"Controls the count badges on Source Control Provider headers. These headers only appear when there is more than one provider.",
+			"Show the repository changes as a tree.",
+			"Show the repository changes as a list.",
+			"Controls the default Source Control repository view mode.",
+			"Sort the repository changes by file name.",
+			"Sort the repository changes by path.",
+			"Sort the repository changes by Source Control status.",
+			"Controls the default Source Control repository changes sort order when viewed as a list.",
+			"Controls whether the Source Control view should automatically reveal and select files when opening them.",
+			"Controls the font for the input message. Use `default` for the workbench user interface font family, `editor` for the `#editor.fontFamily#`'s value, or a custom font family.",
+			"Controls the font size for the input message in pixels.",
+			"Controls whether repositories should always be visible in the Source Control view.",
+			"Repositories in the Source Control Repositories view are sorted by discovery time. Repositories in the Source Control view are sorted in the order that they were selected.",
+			"Repositories in the Source Control Repositories and Source Control views are sorted by repository name.",
+			"Repositories in the Source Control Repositories and Source Control views are sorted by repository path.",
+			"Controls the sort order of the repositories in the source control repositories view.",
+			"Controls how many repositories are visible in the Source Control Repositories section. Set to 0, to be able to manually resize the view.",
+			"Controls whether an action button can be shown in the Source Control view.",
+			"Controls whether the Source Control Sync view is shown.",
+			"Source Control: Accept Input",
+			"Source Control: View Next Commit",
+			"Source Control: View Previous Commit",
+			"Open in External Terminal",
+			"Open in Integrated Terminal"
 		],
 		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
 			"Color for the debug inline value text.",
 			"Color for the debug inline value background."
-		],
-		"vs/workbench/contrib/debug/browser/debugViewlet": [
-			"Open &&Configurations",
-			"Select a workspace folder to create a launch.json file in or add it to the workspace config file",
-			"Debug Console",
-			"Start Additional Session"
 		],
 		"vs/workbench/contrib/debug/browser/repl": [
 			"Filter (e.g. text, !exclude)",
@@ -19509,6 +19546,10 @@
 			"Paste",
 			"Copy All",
 			"Copy"
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"Background color for the highlight of line at the top stack frame position.",
+			"Background color for the highlight of line at focused stack frame position."
 		],
 		"vs/workbench/contrib/markers/browser/markers.contribution": [
 			"View icon of the markers view.",
@@ -19550,6 +19591,12 @@
 			"10K+",
 			"Total {0} Problems"
 		],
+		"vs/workbench/contrib/debug/browser/debugViewlet": [
+			"Open &&Configurations",
+			"Select a workspace folder to create a launch.json file in or add it to the workspace config file",
+			"Debug Console",
+			"Start Additional Session"
+		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
 			"Merge Editor",
 			"Uses the legacy diffing algorithm.",
@@ -19569,64 +19616,42 @@
 			"The comments view will never be opened.",
 			"The comments view will open when a file with comments is active.",
 			"If the comments view has not been opened yet during this session it will open the first time during a session that a file with comments is active.",
+			"If the comments view has not been opened yet during this session and the comment is not resolved, it will open the first time during a session that a file with comments is active.",
 			"Controls when the comments view should open.",
 			"Determines if relative time will be used in comment timestamps (ex. '1 day ago').",
 			"Controls the visibility of the comments bar and comment threads in editors that have commenting ranges and comments. Comments are still accessible via the Comments view and will cause commenting to be toggled on in the same way running the command \"Comments: Toggle Editor Commenting\" toggles comments.",
-			"Controls whether the comments widget scrolls or expands."
+			"Controls whether the comments widget scrolls or expands.",
+			"Controls whether the comment thread should collapse when the thread is resolved.",
+			"The editor contains commentable range(s). Some useful commands include:",
+			"This widget contains a text area, for composition of new comments, and actions, that can be tabbed to once tab moves focus mode has been enabled ({0}).",
+			"This widget contains a text area, for composition of new comments, and actions, that can be tabbed to once tab moves focus mode has been enabled with the command Toggle Tab Key Moves Focus, which is currently not triggerable via keybinding.",
+			"Some useful comment commands include:",
+			"- Dismiss Comment (Escape)",
+			"- Go to Next Commenting Range ({0})",
+			"- Go to Next Commenting Range, which is currently not triggerable via keybinding.",
+			"- Go to Previous Commenting Range ({0})",
+			"- Go to Previous Commenting Range, which is currently not triggerable via keybinding.",
+			"- Go to Next Comment Thread ({0})",
+			"- Go to Next Comment Thread, which is currently not triggerable via keybinding.",
+			"- Go to Previous Comment Thread ({0})",
+			"- Go to Previous Comment Thread, which is currently not triggerable via keybinding.",
+			"- Add Comment ({0})",
+			"- Add Comment on Current Selection, which is currently not triggerable via keybinding.",
+			"- Submit Comment ({0})",
+			"- Submit Comment, accessible via tabbing, as it's currently not triggerable with a keybinding."
 		],
 		"vs/workbench/contrib/url/browser/url.contribution": [
 			"Open URL",
 			"URL to open",
 			"When enabled, trusted domain prompts will appear when opening links in trusted workspaces."
 		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
-			"webview editor"
-		],
 		"vs/workbench/contrib/webview/browser/webview.contribution": [
 			"Cut",
 			"Copy",
 			"Paste"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
-			"Remote",
-			"Installed",
-			"Install Local Extensions in '{0}'...",
-			"Install Remote Extensions Locally...",
-			"Popular",
-			"Recommended",
-			"Enabled",
-			"Disabled",
-			"Marketplace",
-			"Installed",
-			"Recently Updated",
-			"Enabled",
-			"Disabled",
-			"Available Updates",
-			"Builtin",
-			"Workspace Unsupported",
-			"Workspace Recommendations",
-			"Other Recommendations",
-			"Features",
-			"Themes",
-			"Programming Languages",
-			"Disabled in Restricted Mode",
-			"Limited in Restricted Mode",
-			"Disabled in Virtual Workspaces",
-			"Limited in Virtual Workspaces",
-			"Deprecated",
-			"Search Extensions in Marketplace",
-			"1 extension found in the {0} section.",
-			"1 extension found.",
-			"{0} extensions found in the {1} section.",
-			"{0} extensions found.",
-			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
-			"Open User Settings",
-			"{0} requires update",
-			"{0} require update",
-			"{0} requires reload",
-			"{0} require reload",
-			"We have uninstalled '{0}' which was reported to be problematic.",
-			"Reload Now"
+		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
+			"webview editor"
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
 			"Press Enter to manage extensions.",
@@ -19679,6 +19704,7 @@
 			"Install or Search Extensions",
 			"&&Extensions",
 			"Extensions",
+			"Focus on Extensions View",
 			"Install Extensions",
 			"Keymaps",
 			"Migrate Keyboard Shortcuts from...",
@@ -19765,12 +19791,52 @@
 			"Extensions",
 			"Extensions"
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			"Remote",
+			"Installed",
+			"Install Local Extensions in '{0}'...",
+			"Install Remote Extensions Locally...",
+			"Popular",
+			"Recommended",
+			"Enabled",
+			"Disabled",
+			"Marketplace",
+			"Installed",
+			"Recently Updated",
+			"Enabled",
+			"Disabled",
+			"Available Updates",
+			"Builtin",
+			"Workspace Unsupported",
+			"Workspace Recommendations",
+			"Other Recommendations",
+			"Features",
+			"Themes",
+			"Programming Languages",
+			"Disabled in Restricted Mode",
+			"Limited in Restricted Mode",
+			"Disabled in Virtual Workspaces",
+			"Limited in Virtual Workspaces",
+			"Deprecated",
+			"Search Extensions in Marketplace",
+			"1 extension found in the {0} section.",
+			"1 extension found.",
+			"{0} extensions found in the {1} section.",
+			"{0} extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"{0} requires update",
+			"{0} require update",
+			"{0} requires reload",
+			"{0} require reload",
+			"We have uninstalled '{0}' which was reported to be problematic.",
+			"Reload Now"
+		],
 		"vs/workbench/contrib/output/browser/output.contribution": [
 			"View icon of the output view.",
 			"Output",
 			"Output",
 			"&&Output",
-			"Log Viewer",
 			"Switch Output",
 			"Switch Output",
 			"Show Output Channels...",
@@ -19797,6 +19863,11 @@
 			"Output",
 			"Output panel"
 		],
+		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
+			"Open in Integrated Terminal",
+			"Open in External Terminal",
+			"Open in Windows Terminal"
+		],
 		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
 			"A setting has changed that requires a restart to take effect.",
 			"A setting has changed that requires a reload to take effect.",
@@ -19805,11 +19876,6 @@
 			"&&Restart",
 			"&&Reload",
 			"Restarting extension host due to a workspace folder change."
-		],
-		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
-			"Open in Integrated Terminal",
-			"Open in External Terminal",
-			"Open in Windows Terminal"
 		],
 		"vs/workbench/contrib/tasks/browser/task.contribution": [
 			"Building...",
@@ -19906,9 +19972,6 @@
 			"Set default properties that are applied to all ports that don't get properties from the setting {0}. For example:\n\n```\n{\n  \"onAutoForward\": \"ignore\"\n}\n```",
 			"Specifies the local host name that will be used for port forwarding."
 		],
-		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
-			"Toggle Keyboard Shortcuts Troubleshooting"
-		],
 		"vs/workbench/contrib/snippets/browser/snippets.contribution": [
 			"Controls if surround-with-snippets or file template snippets show as Code Actions.",
 			"The prefix to use when selecting the snippet in intellisense",
@@ -19926,6 +19989,9 @@
 			"All active folding range providers",
 			"Defines a default folding range provider that takes precedence over all other folding range providers. Must be the identifier of an extension contributing a folding range provider."
 		],
+		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
+			"Toggle Keyboard Shortcuts Troubleshooting"
+		],
 		"vs/workbench/contrib/limitIndicator/browser/limitIndicator.contribution": [
 			"Configure",
 			"Color Decorator Status",
@@ -19941,6 +20007,19 @@
 			"Code with Inlay Hint Information",
 			"Read Line With Inline Hints",
 			"Stop Inlay Hints Reading"
+		],
+		"vs/workbench/contrib/update/browser/update.contribution": [
+			"Show Release Notes",
+			"Show &&Release Notes",
+			"This version of {0} does not have release notes online",
+			"Check for Updates...",
+			"Download Update",
+			"Install Update",
+			"Restart to Update",
+			"Download {0}",
+			"Apply Update...",
+			"Apply Update",
+			"&&Update"
 		],
 		"vs/workbench/contrib/themes/browser/themes.contribution": [
 			"Icon for the 'Manage' action in the theme selection quick pick.",
@@ -19971,6 +20050,7 @@
 			"Manage Extension",
 			"Generate Color Theme From Current Settings",
 			"Toggle between Light/Dark Themes",
+			"Browse Color Themes in Marketplace",
 			"Themes",
 			"&&Theme",
 			"Color Theme",
@@ -19984,24 +20064,6 @@
 			"Cancel",
 			"Visual Studio Code now ships with a new default theme '{0}'. Do you want to give it a try?"
 		],
-		"vs/workbench/contrib/update/browser/update.contribution": [
-			"Show Release Notes",
-			"Show &&Release Notes",
-			"This version of {0} does not have release notes online",
-			"Check for Updates...",
-			"Download Update",
-			"Install Update",
-			"Restart to Update",
-			"Download {0}",
-			"Apply Update...",
-			"Apply Update",
-			"&&Update"
-		],
-		"vs/workbench/contrib/surveys/browser/ces.contribution": [
-			"Got a moment to help the VS Code team? Please tell us about your experience with VS Code so far.",
-			"Give Feedback",
-			"Remind Me Later"
-		],
 		"vs/workbench/contrib/surveys/browser/nps.contribution": [
 			"Do you mind taking a quick feedback survey?",
 			"Take Survey",
@@ -20013,6 +20075,11 @@
 			"Take Short Survey",
 			"Remind Me Later",
 			"Don't Show Again"
+		],
+		"vs/workbench/contrib/surveys/browser/ces.contribution": [
+			"Got a moment to help the VS Code team? Please tell us about your experience with VS Code so far.",
+			"Give Feedback",
+			"Remind Me Later"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution": [
 			"Welcome",
@@ -20050,19 +20117,8 @@
 			"Create New File ({0})",
 			"Text File"
 		],
-		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
-			"Whether a call hierarchy provider is available",
-			"Whether call hierarchy peek is currently showing",
-			"Whether call hierarchy shows incoming or outgoing calls",
-			"No results",
-			"Failed to show call hierarchy",
-			"Peek Call Hierarchy",
-			"Show Incoming Calls",
-			"Icon for incoming calls in the call hierarchy view.",
-			"Show Outgoing Calls",
-			"Icon for outgoing calls in the call hierarchy view.",
-			"Refocus Call Hierarchy",
-			"Close"
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
+			"Document Symbols"
 		],
 		"vs/workbench/contrib/typeHierarchy/browser/typeHierarchy.contribution": [
 			"Whether a type hierarchy provider is available",
@@ -20076,8 +20132,19 @@
 			"Refocus Type Hierarchy",
 			"Close"
 		],
-		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
-			"Document Symbols"
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
+			"Whether a call hierarchy provider is available",
+			"Whether call hierarchy peek is currently showing",
+			"Whether call hierarchy shows incoming or outgoing calls",
+			"No results",
+			"Failed to show call hierarchy",
+			"Peek Call Hierarchy",
+			"Show Incoming Calls",
+			"Icon for incoming calls in the call hierarchy view.",
+			"Show Outgoing Calls",
+			"Icon for outgoing calls in the call hierarchy view.",
+			"Refocus Call Hierarchy",
+			"Close"
 		],
 		"vs/workbench/contrib/languageDetection/browser/languageDetection.contribution": [
 			"Accept Detected Language: {0}",
@@ -20123,16 +20190,6 @@
 			"When enabled, Outline shows `event`-symbols.",
 			"When enabled, Outline shows `operator`-symbols.",
 			"When enabled, Outline shows `typeParameter`-symbols."
-		],
-		"vs/workbench/contrib/languageStatus/browser/languageStatus.contribution": [
-			"Editor Language Status",
-			"Editor Language Status: {0}",
-			"Add to Status Bar",
-			"Remove from Status Bar",
-			"{0}, {1}",
-			"{0}",
-			"{0} (Language Status)",
-			"Reset Language Status Interaction Counter"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution": [
 			"Settings sync is suspended temporarily because the current device is making too many requests. Please reload {0} to resume.",
@@ -20210,37 +20267,30 @@
 			"Icon for the filter timeline action.",
 			"Filter Timeline"
 		],
+		"vs/workbench/contrib/languageStatus/browser/languageStatus.contribution": [
+			"Editor Language Status",
+			"Editor Language Status: {0}",
+			"Add to Status Bar",
+			"Remove from Status Bar",
+			"{0}, {1}",
+			"{0}",
+			"{0} (Language Status)",
+			"Reset Language Status Interaction Counter"
+		],
+		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
+			"This folder contains a workspace file '{0}'. Do you want to open it? [Learn more]({1}) about workspace files.",
+			"Open Workspace",
+			"This folder contains multiple workspace files. Do you want to open one? [Learn more]({0}) about workspace files.",
+			"Select Workspace",
+			"Select a workspace to open",
+			"Open Workspace",
+			"This workspace is already open."
+		],
 		"vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExtensionMigrator.contribution": [
 			"The extension 'Bracket pair Colorizer' got disabled because it was deprecated.",
 			"Uninstall Extension",
 			"Enable Native Bracket Pair Colorization",
 			"More Info"
-		],
-		"vs/workbench/contrib/audioCues/browser/audioCues.contribution": [
-			"Enable audio cue when a screen reader is attached.",
-			"Enable audio cue.",
-			"Disable audio cue.",
-			"The volume of the audio cues in percent (0-100).",
-			"Whether or not position changes should be debounced",
-			"Plays a sound when the active line has a breakpoint.",
-			"Plays a sound when the active line has an inline suggestion.",
-			"Plays a sound when the active line has an error.",
-			"Plays a sound when the active line has a folded area that can be unfolded.",
-			"Plays a sound when the active line has a warning.",
-			"Plays a sound when the debugger stopped on a breakpoint.",
-			"Plays a sound when trying to read a line with inlay hints that has no inlay hints.",
-			"Plays a sound when a task is completed.",
-			"Plays a sound when a task fails (non-zero exit code).",
-			"Plays a sound when a terminal command fails (non-zero exit code).",
-			"Plays a sound when terminal Quick Fixes are available.",
-			"Plays a sound when the focus moves to an inserted line in accessible diff viewer mode or to the next/previous change",
-			"Plays a sound when the focus moves to a deleted line in accessible diff viewer mode or to the next/previous change",
-			"Plays a sound when the focus moves to a modified line in accessible diff viewer mode or to the next/previous change",
-			"Plays a sound when a notebook cell execution is successfully completed.",
-			"Plays a sound when a notebook cell execution fails.",
-			"Plays a sound when a chat request is made.",
-			"Plays a sound on loop while the response is pending.",
-			"Plays a sound on loop while the response has been received."
 		],
 		"vs/workbench/contrib/workspace/browser/workspace.contribution": [
 			"You are trying to open untrusted files in a workspace which is trusted.",
@@ -20311,6 +20361,32 @@
 			"Always open untrusted files in a separate window in restricted mode without prompting.",
 			"Controls whether or not the empty window is trusted by default within VS Code. When used with `#{0}#`, you can enable the full functionality of VS Code without prompting in an empty window."
 		],
+		"vs/workbench/contrib/audioCues/browser/audioCues.contribution": [
+			"Enable audio cue when a screen reader is attached.",
+			"Enable audio cue.",
+			"Disable audio cue.",
+			"The volume of the audio cues in percent (0-100).",
+			"Whether or not position changes should be debounced",
+			"Plays a sound when the active line has a breakpoint.",
+			"Plays a sound when the active line has an inline suggestion.",
+			"Plays a sound when the active line has an error.",
+			"Plays a sound when the active line has a folded area that can be unfolded.",
+			"Plays a sound when the active line has a warning.",
+			"Plays a sound when the debugger stopped on a breakpoint.",
+			"Plays a sound when trying to read a line with inlay hints that has no inlay hints.",
+			"Plays a sound when a task is completed.",
+			"Plays a sound when a task fails (non-zero exit code).",
+			"Plays a sound when a terminal command fails (non-zero exit code).",
+			"Plays a sound when terminal Quick Fixes are available.",
+			"Plays a sound when the focus moves to an inserted line in accessible diff viewer mode or to the next/previous change",
+			"Plays a sound when the focus moves to a deleted line in accessible diff viewer mode or to the next/previous change",
+			"Plays a sound when the focus moves to a modified line in accessible diff viewer mode or to the next/previous change",
+			"Plays a sound when a notebook cell execution is successfully completed.",
+			"Plays a sound when a notebook cell execution fails.",
+			"Plays a sound when a chat request is made.",
+			"Plays a sound on loop while the response is pending.",
+			"Plays a sound on loop while the response has been received."
+		],
 		"vs/workbench/contrib/share/browser/share.contribution": [
 			"Share...",
 			"Generating link...",
@@ -20320,36 +20396,82 @@
 			"Open Link",
 			"Controls whether to render the Share action next to the command center when {0} is {1}."
 		],
-		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
-			"This folder contains a workspace file '{0}'. Do you want to open it? [Learn more]({1}) about workspace files.",
-			"Open Workspace",
-			"This folder contains multiple workspace files. Do you want to open one? [Learn more]({0}) about workspace files.",
-			"Select Workspace",
-			"Select a workspace to open",
-			"Open Workspace",
-			"This workspace is already open."
+		"vs/workbench/browser/workbench": [
+			"Failed to load a required file. Please restart the application to try again. Details: {0}"
 		],
-		"vs/workbench/browser/parts/dialogs/dialogHandler": [
-			"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
-			"&&Copy",
-			"OK"
+		"vs/workbench/services/configuration/browser/configurationService": [
+			"Contribute defaults for configurations",
+			"Experiments",
+			"Configure settings to be applied for all profiles."
 		],
-		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
-			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
-			"&&Copy",
-			"OK"
+		"vs/platform/workspace/common/workspace": [
+			"Code Workspace"
 		],
-		"vs/workbench/services/textfile/browser/textFileService": [
-			"File Created",
-			"File Replaced",
-			"Text File Model Decorations",
-			"Deleted, Read-only",
-			"Read-only",
-			"Deleted",
-			"File seems to be binary and cannot be opened as text",
-			"'{0}' already exists. Do you want to replace it?",
-			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
-			"&&Replace"
+		"vs/workbench/electron-sandbox/window": [
+			"Restart",
+			"Configure",
+			"Learn More",
+			"Writing login information to the keychain failed with error '{0}'.",
+			"Troubleshooting Guide",
+			"You are running an emulated version of {0}. For better performance download the native arm64 version of {0} build for your machine.",
+			"Download",
+			"Proxy Authentication Required",
+			"&&Log In",
+			"Username",
+			"Password",
+			"The proxy {0} requires a username and password.",
+			"Remember my credentials",
+			"Are you sure you want to quit?",
+			"Are you sure you want to exit?",
+			"Are you sure you want to close the window?",
+			"&&Quit",
+			"&&Exit",
+			"&&Close Window",
+			"Do not ask me again",
+			"Error: {0}",
+			"The following operations are still running: \n{0}",
+			"An unexpected error prevented the window to close",
+			"An unexpected error prevented the application to quit",
+			"An unexpected error prevented the window to reload",
+			"An unexpected error prevented to change the workspace",
+			"Closing the window is taking a bit longer...",
+			"Quitting the application is taking a bit longer...",
+			"Reloading the window is taking a bit longer...",
+			"Changing the workspace is taking a bit longer...",
+			"Close Anyway",
+			"Quit Anyway",
+			"Reload Anyway",
+			"Change Anyway",
+			"There is a dependency cycle in the AMD modules that needs to be resolved!",
+			"It is not recommended to run {0} as root user.",
+			"Files you store within the installation folder ('{0}') may be OVERWRITTEN or DELETED IRREVERSIBLY without warning at update time.",
+			"You are running {0} 32-bit, which will soon stop receiving updates on Windows. Consider upgrading to the 64-bit build.",
+			"Learn More",
+			"{0}. Use navigation keys to access banner actions.",
+			"Learn More",
+			"{0} on {1} will soon stop receiving updates. Consider upgrading your macOS version.",
+			"Learn More",
+			"{0}. Use navigation keys to access banner actions.",
+			"Learn More",
+			"Resolving shell environment...",
+			"Learn More"
+		],
+		"vs/workbench/services/remote/electron-sandbox/remoteAgentService": [
+			"Open Developer Tools",
+			"Open in browser",
+			"Failed to connect to the remote extension host server (Error: {0})"
+		],
+		"vs/platform/workspace/common/workspaceTrust": [
+			"Trusted",
+			"Restricted Mode"
+		],
+		"vs/workbench/services/userDataProfile/common/userDataProfile": [
+			"Icon for Default Profile.",
+			"Profiles",
+			"Profile"
+		],
+		"vs/workbench/services/log/electron-sandbox/logService": [
+			"Window"
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
 			"Default Language Configuration Overrides",
@@ -20386,13 +20508,6 @@
 			"Switch Window...",
 			"Quick Switch Window..."
 		],
-		"vs/workbench/electron-sandbox/actions/installActions": [
-			"Shell Command",
-			"Install '{0}' command in PATH",
-			"Shell command '{0}' successfully installed in PATH.",
-			"Uninstall '{0}' command from PATH",
-			"Shell command '{0}' successfully uninstalled from PATH."
-		],
 		"vs/platform/contextkey/common/contextkeys": [
 			"Whether the operating system is macOS",
 			"Whether the operating system is Linux",
@@ -20403,6 +20518,14 @@
 			"Whether the platform is a mobile web browser",
 			"Quality type of VS Code",
 			"Whether keyboard focus is inside an input box"
+		],
+		"vs/workbench/common/configuration": [
+			"Application",
+			"Workbench",
+			"Security",
+			"UNC host names must not contain backslashes.",
+			"A set of UNC host names (without leading or trailing backslash, for example `192.168.0.1` or `my-server`) to allow without user confirmation. If a UNC host is being accessed that is not allowed via this setting or has not been acknowledged via user confirmation, an error will occur and the operation stopped. A restart is required when changing this setting. Find out more about this setting at https://aka.ms/vscode-windows-unc.",
+			"If enabled, only allows access to UNC host names that are allowed by the `#security.allowedUNCHosts#` setting or after user confirmation. Find out more about this setting at https://aka.ms/vscode-windows-unc."
 		],
 		"vs/workbench/common/contextkeys": [
 			"The kind of workspace opened in the window, either 'empty' (no workspace), 'folder' (single folder) or 'workspace' (multi-root workspace)",
@@ -20466,14 +20589,6 @@
 			"Whether a resource is present or not",
 			"Whether the resource is backed by a file system provider"
 		],
-		"vs/workbench/common/configuration": [
-			"Application",
-			"Workbench",
-			"Security",
-			"UNC host names must not contain backslashes.",
-			"A set of UNC host names (without leading or trailing backslash, for example `192.168.0.1` or `my-server`) to allow without user confirmation. If a UNC host is being accessed that is not allowed via this setting or has not been acknowledged via user confirmation, an error will occur and the operation stopped. A restart is required when changing this setting. Find out more about this setting at https://aka.ms/vscode-windows-unc.",
-			"If enabled, only allows access to UNC host names that are allowed by the `#security.allowedUNCHosts#` setting or after user confirmation. Find out more about this setting at https://aka.ms/vscode-windows-unc."
-		],
 		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
 			"Your changes will be lost if you don't save them.",
 			"Do you want to save the changes you made to {0}?",
@@ -20490,6 +20605,173 @@
 			"Save As",
 			"All Files",
 			"No Extension"
+		],
+		"vs/workbench/electron-sandbox/actions/installActions": [
+			"Shell Command",
+			"Install '{0}' command in PATH",
+			"Shell command '{0}' successfully installed in PATH.",
+			"Uninstall '{0}' command from PATH",
+			"Shell command '{0}' successfully uninstalled from PATH."
+		],
+		"vs/workbench/services/textfile/browser/textFileService": [
+			"File Created",
+			"File Replaced",
+			"Text File Model Decorations",
+			"Deleted, Read-only",
+			"Read-only",
+			"Deleted",
+			"File seems to be binary and cannot be opened as text",
+			"'{0}' already exists. Do you want to replace it?",
+			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
+			"&&Replace"
+		],
+		"vs/workbench/browser/parts/dialogs/dialogHandler": [
+			"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
+			"&&Copy",
+			"OK"
+		],
+		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
+			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
+			"&&Copy",
+			"OK"
+		],
+		"vs/workbench/common/theme": [
+			"Active tab background color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Active tab background color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Inactive tab background color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Inactive tab background color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Active tab foreground color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Inactive tab foreground color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Active tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Inactive tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Tab background color when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Tab background color in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Tab foreground color when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Tab foreground color in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to separate tabs from each other. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to separate pinned tabs from other tabs. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the bottom of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the bottom of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to the top of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to highlight tabs when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to highlight tabs in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the top of modified active tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the top of modified inactive tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the top of modified active tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the top of modified inactive tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Background color of the editor pane visible on the left and right side of the centered editor layout.",
+			"Background color of an empty editor group. Editor groups are the containers of editors.",
+			"Border color of an empty editor group that is focused. Editor groups are the containers of editors.",
+			"Background color of the editor group title header when tabs are enabled. Editor groups are the containers of editors.",
+			"Border color of the editor group title header when tabs are enabled. Editor groups are the containers of editors.",
+			"Background color of the editor group title header when tabs are disabled (`\"workbench.editor.showTabs\": false`). Editor groups are the containers of editors.",
+			"Border color of the editor group title header. Editor groups are the containers of editors.",
+			"Color to separate multiple editor groups from each other. Editor groups are the containers of editors.",
+			"Background color when dragging editors around. The color should have transparency so that the editor contents can still shine through.",
+			"Foreground color of text shown over editors when dragging files. This text informs the user that they can hold shift to drop into the editor.",
+			"Background color of text shown over editors when dragging files. This text informs the user that they can hold shift to drop into the editor.",
+			"Border color of text shown over editors when dragging files. This text informs the user that they can hold shift to drop into the editor.",
+			"Color to separate two editors from each other when shown side by side in an editor group from top to bottom.",
+			"Color to separate two editors from each other when shown side by side in an editor group from left to right.",
+			"Panel background color. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Panel border color to separate the panel from the editor. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Title color for the active panel. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Title color for the inactive panel. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Border color for the active panel title. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Input box border for inputs in the panel.",
+			"Drag and drop feedback color for the panel titles. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Drag and drop feedback color for the panel sections. The color should have transparency so that the panel sections can still shine through. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Panel section header background color. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Panel section header foreground color. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Panel section header border color used when multiple views are stacked vertically in the panel. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Panel section border color used when multiple views are stacked horizontally in the panel. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Banner background color. The banner is shown under the title bar of the window.",
+			"Banner foreground color. The banner is shown under the title bar of the window.",
+			"Banner icon color. The banner is shown under the title bar of the window.",
+			"Status bar foreground color when a workspace or folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar foreground color when no folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar background color when a workspace or folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar background color when no folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar border color separating to the sidebar and editor. The status bar is shown in the bottom of the window.",
+			"Status bar border color when focused on keyboard navigation. The status bar is shown in the bottom of the window.",
+			"Status bar border color separating to the sidebar and editor when no folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar item background color when clicking. The status bar is shown in the bottom of the window.",
+			"Status bar item border color when focused on keyboard navigation. The status bar is shown in the bottom of the window.",
+			"Status bar item background color when hovering. The status bar is shown in the bottom of the window.",
+			"Status bar item foreground color when hovering. The status bar is shown in the bottom of the window.",
+			"Status bar item background color when hovering an item that contains two hovers. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items foreground color. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items background color. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items foreground color when hovering. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items background color when hovering. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
+			"Status bar error items background color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
+			"Status bar error items foreground color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
+			"Status bar error items foreground color when hovering. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
+			"Status bar error items background color when hovering. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
+			"Status bar warning items background color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
+			"Status bar warning items foreground color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
+			"Status bar warning items foreground color when hovering. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
+			"Status bar warning items background color when hovering. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
+			"Activity bar background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar border color separating to the side bar. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar focus border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar background color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Drag and drop feedback color for the activity bar items. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity notification badge background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity notification badge foreground color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Profile badge background color. The profile badge shows on top of the settings gear icon in the activity bar.",
+			"Profile badge foreground color. The profile badge shows on top of the settings gear icon in the activity bar.",
+			"Background color for the remote indicator on the status bar.",
+			"Foreground color for the remote indicator on the status bar.",
+			"Foreground color for the remote indicator on the status bar when hovering.",
+			"Background color for the remote indicator on the status bar when hovering.",
+			"Status bar item background color when the workbench is offline.",
+			"Status bar item foreground color when the workbench is offline.",
+			"Status bar item foreground hover color when the workbench is offline.",
+			"Status bar item background hover color when the workbench is offline.",
+			"Background color for the remote badge in the extensions view.",
+			"Foreground color for the remote badge in the extensions view.",
+			"Side bar background color. The side bar is the container for views like explorer and search.",
+			"Side bar foreground color. The side bar is the container for views like explorer and search.",
+			"Side bar border color on the side separating to the editor. The side bar is the container for views like explorer and search.",
+			"Side bar title foreground color. The side bar is the container for views like explorer and search.",
+			"Drag and drop feedback color for the side bar sections. The color should have transparency so that the side bar sections can still shine through. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
+			"Side bar section header background color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
+			"Side bar section header foreground color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
+			"Side bar section header border color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
+			"Title bar foreground when the window is active.",
+			"Title bar foreground when the window is inactive.",
+			"Title bar background when the window is active.",
+			"Title bar background when the window is inactive.",
+			"Title bar border color.",
+			"Foreground color of the selected menu item in the menubar.",
+			"Background color of the selected menu item in the menubar.",
+			"Border color of the selected menu item in the menubar.",
+			"Foreground color of the command center",
+			"Active foreground color of the command center",
+			"Foreground color of the command center when the window is inactive",
+			"Background color of the command center",
+			"Active background color of the command center",
+			"Border color of the command center",
+			"Active border color of the command center",
+			"Border color of the command center when the window is inactive",
+			"Notifications center border color. Notifications slide in from the bottom right of the window.",
+			"Notification toast border color. Notifications slide in from the bottom right of the window.",
+			"Notifications foreground color. Notifications slide in from the bottom right of the window.",
+			"Notifications background color. Notifications slide in from the bottom right of the window.",
+			"Notification links foreground color. Notifications slide in from the bottom right of the window.",
+			"Notifications center header foreground color. Notifications slide in from the bottom right of the window.",
+			"Notifications center header background color. Notifications slide in from the bottom right of the window.",
+			"Notifications border color separating from other notifications in the notifications center. Notifications slide in from the bottom right of the window.",
+			"The color used for the icon of error notifications. Notifications slide in from the bottom right of the window.",
+			"The color used for the icon of warning notifications. Notifications slide in from the bottom right of the window.",
+			"The color used for the icon of info notifications. Notifications slide in from the bottom right of the window.",
+			"The color used for the border of the window when it is active. Only supported in the macOS and Linux desktop client when using the custom title bar.",
+			"The color used for the border of the window when it is inactive. Only supported in the macOS and Linux desktop client when using the custom title bar."
 		],
 		"vs/platform/theme/common/colorRegistry": [
 			"Overall foreground color. This color is only used if not overridden by a component.",
@@ -20692,8 +20974,9 @@
 			"Minimap marker color for find matches.",
 			"Minimap marker color for repeating editor selections.",
 			"Minimap marker color for the editor selection.",
-			"Minimap marker color for errors.",
+			"Minimap marker color for infos.",
 			"Minimap marker color for warnings.",
+			"Minimap marker color for errors.",
 			"Minimap background color.",
 			"Opacity of foreground elements rendered in the minimap. For example, \"#000000c0\" will render the elements with 75% opacity.",
 			"Minimap slider background color.",
@@ -20711,136 +20994,6 @@
 			"The green color used in chart visualizations.",
 			"The purple color used in chart visualizations."
 		],
-		"vs/workbench/common/theme": [
-			"Active tab background color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Active tab background color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Inactive tab background color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Inactive tab background color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Active tab foreground color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Inactive tab foreground color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Active tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Inactive tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Tab background color when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Tab background color in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Tab foreground color when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Tab foreground color in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border to separate tabs from each other. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border to separate pinned tabs from other tabs. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border on the bottom of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border on the bottom of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border to the top of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border to highlight tabs when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border to highlight tabs in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border on the top of modified active tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border on the top of modified inactive tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border on the top of modified active tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Border on the top of modified inactive tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
-			"Background color of the editor pane visible on the left and right side of the centered editor layout.",
-			"Background color of an empty editor group. Editor groups are the containers of editors.",
-			"Border color of an empty editor group that is focused. Editor groups are the containers of editors.",
-			"Background color of the editor group title header when tabs are enabled. Editor groups are the containers of editors.",
-			"Border color of the editor group title header when tabs are enabled. Editor groups are the containers of editors.",
-			"Background color of the editor group title header when tabs are disabled (`\"workbench.editor.showTabs\": false`). Editor groups are the containers of editors.",
-			"Border color of the editor group title header. Editor groups are the containers of editors.",
-			"Color to separate multiple editor groups from each other. Editor groups are the containers of editors.",
-			"Background color when dragging editors around. The color should have transparency so that the editor contents can still shine through.",
-			"Foreground color of text shown over editors when dragging files. This text informs the user that they can hold shift to drop into the editor.",
-			"Background color of text shown over editors when dragging files. This text informs the user that they can hold shift to drop into the editor.",
-			"Border color of text shown over editors when dragging files. This text informs the user that they can hold shift to drop into the editor.",
-			"Color to separate two editors from each other when shown side by side in an editor group from top to bottom.",
-			"Color to separate two editors from each other when shown side by side in an editor group from left to right.",
-			"Panel background color. Panels are shown below the editor area and contain views like output and integrated terminal.",
-			"Panel border color to separate the panel from the editor. Panels are shown below the editor area and contain views like output and integrated terminal.",
-			"Title color for the active panel. Panels are shown below the editor area and contain views like output and integrated terminal.",
-			"Title color for the inactive panel. Panels are shown below the editor area and contain views like output and integrated terminal.",
-			"Border color for the active panel title. Panels are shown below the editor area and contain views like output and integrated terminal.",
-			"Input box border for inputs in the panel.",
-			"Drag and drop feedback color for the panel titles. Panels are shown below the editor area and contain views like output and integrated terminal.",
-			"Drag and drop feedback color for the panel sections. The color should have transparency so that the panel sections can still shine through. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
-			"Panel section header background color. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
-			"Panel section header foreground color. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
-			"Panel section header border color used when multiple views are stacked vertically in the panel. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
-			"Panel section border color used when multiple views are stacked horizontally in the panel. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
-			"Banner background color. The banner is shown under the title bar of the window.",
-			"Banner foreground color. The banner is shown under the title bar of the window.",
-			"Banner icon color. The banner is shown under the title bar of the window.",
-			"Status bar foreground color when a workspace or folder is opened. The status bar is shown in the bottom of the window.",
-			"Status bar foreground color when no folder is opened. The status bar is shown in the bottom of the window.",
-			"Status bar background color when a workspace or folder is opened. The status bar is shown in the bottom of the window.",
-			"Status bar background color when no folder is opened. The status bar is shown in the bottom of the window.",
-			"Status bar border color separating to the sidebar and editor. The status bar is shown in the bottom of the window.",
-			"Status bar border color when focused on keyboard navigation. The status bar is shown in the bottom of the window.",
-			"Status bar border color separating to the sidebar and editor when no folder is opened. The status bar is shown in the bottom of the window.",
-			"Status bar item background color when clicking. The status bar is shown in the bottom of the window.",
-			"Status bar item border color when focused on keyboard navigation. The status bar is shown in the bottom of the window.",
-			"Status bar item background color when hovering. The status bar is shown in the bottom of the window.",
-			"Status bar item foreground color when hovering. The status bar is shown in the bottom of the window.",
-			"Status bar item background color when hovering an item that contains two hovers. The status bar is shown in the bottom of the window.",
-			"Status bar prominent items foreground color. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
-			"Status bar prominent items background color. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
-			"Status bar prominent items foreground color when hovering. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
-			"Status bar prominent items background color when hovering. Prominent items stand out from other status bar entries to indicate importance. The status bar is shown in the bottom of the window.",
-			"Status bar error items background color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
-			"Status bar error items foreground color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
-			"Status bar error items foreground color when hovering. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
-			"Status bar error items background color when hovering. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
-			"Status bar warning items background color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
-			"Status bar warning items foreground color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
-			"Status bar warning items foreground color when hovering. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
-			"Status bar warning items background color when hovering. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
-			"Activity bar background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Activity bar border color separating to the side bar. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Activity bar border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Activity bar focus border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Activity bar background color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Drag and drop feedback color for the activity bar items. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Activity notification badge background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Activity notification badge foreground color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
-			"Profile badge background color. The profile badge shows on top of the settings gear icon in the activity bar.",
-			"Profile badge foreground color. The profile badge shows on top of the settings gear icon in the activity bar.",
-			"Background color for the remote indicator on the status bar.",
-			"Foreground color for the remote indicator on the status bar.",
-			"Foreground color for the remote indicator on the status bar when hovering.",
-			"Background color for the remote indicator on the status bar when hovering.",
-			"Status bar item background color when the workbench is offline.",
-			"Status bar item foreground color when the workbench is offline.",
-			"Status bar item foreground hover color when the workbench is offline.",
-			"Status bar item background hover color when the workbench is offline.",
-			"Background color for the remote badge in the extensions view.",
-			"Foreground color for the remote badge in the extensions view.",
-			"Side bar background color. The side bar is the container for views like explorer and search.",
-			"Side bar foreground color. The side bar is the container for views like explorer and search.",
-			"Side bar border color on the side separating to the editor. The side bar is the container for views like explorer and search.",
-			"Side bar title foreground color. The side bar is the container for views like explorer and search.",
-			"Drag and drop feedback color for the side bar sections. The color should have transparency so that the side bar sections can still shine through. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
-			"Side bar section header background color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
-			"Side bar section header foreground color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
-			"Side bar section header border color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
-			"Title bar foreground when the window is active.",
-			"Title bar foreground when the window is inactive.",
-			"Title bar background when the window is active.",
-			"Title bar background when the window is inactive.",
-			"Title bar border color.",
-			"Foreground color of the selected menu item in the menubar.",
-			"Background color of the selected menu item in the menubar.",
-			"Border color of the selected menu item in the menubar.",
-			"Notifications center border color. Notifications slide in from the bottom right of the window.",
-			"Notification toast border color. Notifications slide in from the bottom right of the window.",
-			"Notifications foreground color. Notifications slide in from the bottom right of the window.",
-			"Notifications background color. Notifications slide in from the bottom right of the window.",
-			"Notification links foreground color. Notifications slide in from the bottom right of the window.",
-			"Notifications center header foreground color. Notifications slide in from the bottom right of the window.",
-			"Notifications center header background color. Notifications slide in from the bottom right of the window.",
-			"Notifications border color separating from other notifications in the notifications center. Notifications slide in from the bottom right of the window.",
-			"The color used for the icon of error notifications. Notifications slide in from the bottom right of the window.",
-			"The color used for the icon of warning notifications. Notifications slide in from the bottom right of the window.",
-			"The color used for the icon of info notifications. Notifications slide in from the bottom right of the window.",
-			"The color used for the border of the window when it is active. Only supported in the macOS and Linux desktop client when using the custom title bar.",
-			"The color used for the border of the window when it is inactive. Only supported in the macOS and Linux desktop client when using the custom title bar."
-		],
 		"vs/base/common/actions": [
 			"(empty)"
 		],
@@ -20850,6 +21003,11 @@
 			"Unable to write into workspace configuration file. Please open the file to correct errors/warnings in it and try again.",
 			"Open Workspace Configuration"
 		],
+		"vs/platform/keyboardLayout/common/keyboardConfig": [
+			"Keyboard",
+			"Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`.",
+			"Controls if the AltGraph+ modifier should be treated as Ctrl+Alt+."
+		],
 		"vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService": [
 			"Cannot substitute command variable '{0}' because command did not return a result of type string.",
 			"Variable '{0}' must be defined in an '{1}' section of the debug or task configuration.",
@@ -20858,11 +21016,6 @@
 			"Cannot substitute input variable '{0}' because command '{1}' did not return a result of type string.",
 			"Input variable '{0}' can only be of type 'promptString', 'pickString', or 'command'.",
 			"Undefined input variable '{0}' encountered. Remove or define '{0}' to continue."
-		],
-		"vs/platform/keyboardLayout/common/keyboardConfig": [
-			"Keyboard",
-			"Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`.",
-			"Controls if the AltGraph+ modifier should be treated as Ctrl+Alt+."
 		],
 		"vs/workbench/services/extensionManagement/common/extensionManagementService": [
 			"Cannot uninstall extension '{0}'. Extension '{1}' depends on this.",
@@ -20887,71 +21040,15 @@
 			"Contains extensions which are not supported.",
 			"'{0}' contains extensions which are not supported in {1}."
 		],
-		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
-			"Can't install release version of '{0}' extension because it has no release version.",
-			"Can't install '{0}' extension because it is not compatible with the current version of {1} (version {2})."
-		],
-		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupTracker": [
-			"The following editors with unsaved changes could not be saved to the back up location.",
-			"The following editors with unsaved changes could not be saved or reverted.",
-			"Try saving or reverting the editors with unsaved changes first and then try again.",
-			"Backing up editors with unsaved changes is taking a bit longer...",
-			"Click 'Cancel' to stop waiting and to save or revert editors with unsaved changes.",
-			"Saving editors with unsaved changes is taking a bit longer...",
-			"Reverting editors with unsaved changes is taking a bit longer...",
-			"Discarding backups is taking a bit longer..."
-		],
 		"vs/workbench/services/workingCopy/common/workingCopyHistoryService": [
 			"File Saved",
 			"File Moved",
 			"File Renamed",
 			"Saving local history"
 		],
-		"vs/platform/action/common/actionCommonCategories": [
-			"View",
-			"Help",
-			"Test",
-			"File",
-			"Preferences",
-			"Developer"
-		],
-		"vs/workbench/services/extensions/common/abstractExtensionService": [
-			"The following extensions contain dependency loops and have been disabled: {0}",
-			"The following extensions contain dependency loops and have been disabled: {0}",
-			"No extension host found that can launch the test runner at {0}.",
-			"{0} (Error: {1})",
-			"The following operation was blocked: {0}",
-			"The reason for blocking the operation: {0}",
-			"The reasons for blocking the operation:\n- {0}",
-			"The remote extension host terminated unexpectedly. Restarting...",
-			"Remote Extension host terminated unexpectedly 3 times within the last 5 minutes.",
-			"Restart Remote Extension Host"
-		],
-		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
-			"Open Logs Folder",
-			"Open Extension Logs Folder"
-		],
-		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
-			"Search language packs in the Marketplace to change the display language to {0}.",
-			"Search Marketplace",
-			"Install language pack to change the display language to {0}.",
-			"Install and Restart"
-		],
-		"vs/workbench/contrib/localization/common/localization.contribution": [
-			"Contributes localizations to the editor",
-			"Id of the language into which the display strings are translated.",
-			"Name of the language in English.",
-			"Name of the language in contributed language.",
-			"List of translations associated to the language.",
-			"Id of VS Code or Extension for which this translation is contributed to. Id of VS Code is always `vscode` and of extension should be in format `publisherId.extensionName`.",
-			"Id should be `vscode` or in format `publisherId.extensionName` for translating VS code or an extension respectively.",
-			"A relative path to a file containing translations for the language."
-		],
-		"vs/workbench/common/editor": [
-			"Text Editor",
-			"Built-in",
-			"Open Anyway",
-			"Configure Limit"
+		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
+			"Can't install release version of '{0}' extension because it has no release version.",
+			"Can't install '{0}' extension because it is not compatible with the current version of {1} (version {2})."
 		],
 		"vs/editor/common/editorContextKeys": [
 			"Whether the editor text has focus (cursor is blinking)",
@@ -20994,8 +21091,55 @@
 			"Whether the editor has multiple document formatting providers",
 			"Whether the editor has multiple document selection formatting providers"
 		],
-		"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate": [
-			"Start Text Mate Syntax Grammar Logging"
+		"vs/workbench/services/workingCopy/electron-sandbox/workingCopyBackupTracker": [
+			"The following editors with unsaved changes could not be saved to the back up location.",
+			"The following editors with unsaved changes could not be saved or reverted.",
+			"Try saving or reverting the editors with unsaved changes first and then try again.",
+			"Backing up editors with unsaved changes is taking a bit longer...",
+			"Click 'Cancel' to stop waiting and to save or revert editors with unsaved changes.",
+			"Saving editors with unsaved changes is taking a bit longer...",
+			"Reverting editors with unsaved changes is taking a bit longer...",
+			"Discarding backups is taking a bit longer..."
+		],
+		"vs/workbench/common/editor": [
+			"Text Editor",
+			"Built-in",
+			"Open Anyway",
+			"Configure Limit"
+		],
+		"vs/platform/action/common/actionCommonCategories": [
+			"View",
+			"Help",
+			"Test",
+			"File",
+			"Preferences",
+			"Developer"
+		],
+		"vs/workbench/services/extensions/common/abstractExtensionService": [
+			"The following extensions contain dependency loops and have been disabled: {0}",
+			"The following extensions contain dependency loops and have been disabled: {0}",
+			"No extension host found that can launch the test runner at {0}.",
+			"{0} (Error: {1})",
+			"The following operation was blocked: {0}",
+			"The reason for blocking the operation: {0}",
+			"The reasons for blocking the operation:\n- {0}",
+			"The remote extension host terminated unexpectedly. Restarting...",
+			"Remote Extension host terminated unexpectedly 3 times within the last 5 minutes.",
+			"Restart Remote Extension Host"
+		],
+		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
+			"Open Logs Folder",
+			"Open Extension Logs Folder"
+		],
+		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
+			"Extensions have been modified on disk. Please reload the window.",
+			"Reload Window"
+		],
+		"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost": [
+			"Extension host did not start in 10 seconds, it might be stopped on the first line and needs a debugger to continue.",
+			"Extension host did not start in 10 seconds, that might be a problem.",
+			"Reload Window",
+			"Terminating extension debug session"
 		],
 		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
 			"Paste Selection Clipboard"
@@ -21004,6 +21148,12 @@
 			"{0}, preview",
 			"{0}, pinned"
 		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate": [
+			"Start Text Mate Syntax Grammar Logging"
+		],
+		"vs/workbench/contrib/extensions/common/runtimeExtensionsInput": [
+			"Running Extensions"
+		],
 		"vs/workbench/contrib/extensions/electron-sandbox/runtimeExtensionsEditor": [
 			"Start Extension Host Profile",
 			"Stop Extension Host Profile",
@@ -21011,25 +21161,12 @@
 			"Save Extension Host Profile",
 			"Save"
 		],
-		"vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost": [
-			"Extension host did not start in 10 seconds, it might be stopped on the first line and needs a debugger to continue.",
-			"Extension host did not start in 10 seconds, that might be a problem.",
-			"Reload Window",
-			"Terminating extension debug session"
-		],
-		"vs/workbench/services/extensions/electron-sandbox/cachedExtensionScanner": [
-			"Extensions have been modified on disk. Please reload the window.",
-			"Reload Window"
-		],
 		"vs/workbench/contrib/extensions/electron-sandbox/debugExtensionHostAction": [
 			"Start Debugging Extension Host",
 			"Profile Extensions",
 			"In order to profile extensions a restart is required. Do you want to restart '{0}' now?",
 			"&&Restart",
 			"Attach Extension Host"
-		],
-		"vs/workbench/contrib/extensions/common/runtimeExtensionsInput": [
-			"Running Extensions"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensionsActions": [
 			"Open Extensions Folder",
@@ -21049,9 +21186,21 @@
 			"The extension '{0}' took a very long time to complete its last operation and it has prevented other extensions from running.",
 			"Show Extensions"
 		],
-		"vs/workbench/contrib/issue/common/issue.contribution": [
-			"Report Issue...",
-			"Report &&Issue"
+		"vs/workbench/contrib/localization/electron-sandbox/minimalTranslations": [
+			"Search language packs in the Marketplace to change the display language to {0}.",
+			"Search Marketplace",
+			"Install language pack to change the display language to {0}.",
+			"Install and Restart"
+		],
+		"vs/workbench/contrib/localization/common/localization.contribution": [
+			"Contributes localizations to the editor",
+			"Id of the language into which the display strings are translated.",
+			"Name of the language in English.",
+			"Name of the language in contributed language.",
+			"List of translations associated to the language.",
+			"Id of VS Code or Extension for which this translation is contributed to. Id of VS Code is always `vscode` and of extension should be in format `publisherId.extensionName`.",
+			"Id should be `vscode` or in format `publisherId.extensionName` for translating VS code or an extension respectively.",
+			"A relative path to a file containing translations for the language."
 		],
 		"vs/workbench/services/dialogs/browser/simpleFileDialog": [
 			"Open Local File...",
@@ -21068,10 +21217,15 @@
 			"Please enter a valid file name.",
 			"The folder {0} does not exist. Would you like to create it?",
 			"Please enter a path that exists.",
+			"This folder cannot be used as a save destination. Please choose another folder",
 			"Please enter a path that exists.",
 			"Please start the path with a drive letter.",
 			"Please select a file.",
 			"Please select a folder."
+		],
+		"vs/workbench/contrib/issue/common/issue.contribution": [
+			"Report Issue...",
+			"Report &&Issue"
 		],
 		"vs/workbench/contrib/terminal/common/terminal": [
 			"Contributes terminal functionality.",
@@ -21081,6 +21235,35 @@
 			"A codicon, URI, or light and dark URIs to associate with this terminal type.",
 			"Icon path when a light theme is used",
 			"Icon path when a dark theme is used"
+		],
+		"vs/editor/common/languages": [
+			"array",
+			"boolean",
+			"class",
+			"constant",
+			"constructor",
+			"enumeration",
+			"enumeration member",
+			"event",
+			"field",
+			"file",
+			"function",
+			"interface",
+			"key",
+			"method",
+			"module",
+			"namespace",
+			"null",
+			"number",
+			"object",
+			"operator",
+			"package",
+			"property",
+			"string",
+			"struct",
+			"type parameter",
+			"variable",
+			"{0} ({1})"
 		],
 		"vs/workbench/services/userDataSync/common/userDataSync": [
 			"Settings",
@@ -21092,7 +21275,13 @@
 			"Profiles",
 			"Workspace State",
 			"Settings Sync",
-			"View icon of the Settings Sync view."
+			"View icon of the Settings Sync view.",
+			"Download Settings Sync Activity"
+		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"Whether a task is currently running.",
+			"Tasks",
+			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
 		],
 		"vs/workbench/contrib/performance/electron-sandbox/startupProfiler": [
 			"Successfully created profiles.",
@@ -21102,11 +21291,6 @@
 			"Thanks for helping us.",
 			"A final restart is required to continue to use '{0}'. Again, thank you for your contribution.",
 			"&&Restart"
-		],
-		"vs/workbench/contrib/tasks/common/tasks": [
-			"Whether a task is currently running.",
-			"Tasks",
-			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
 		],
 		"vs/workbench/contrib/tasks/common/taskService": [
 			"Whether CustomExecution tasks are supported. Consider using in the when clause of a 'taskDefinition' contribution.",
@@ -21119,22 +21303,6 @@
 			"Default view icon.",
 			"A view with id '{0}' is already registered",
 			"No tree view with id '{0}' registered."
-		],
-		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
-			"A unknown error has occurred while executing a task. See task output log for details.",
-			"There are issues with task \"{0}\". See the output for more details.",
-			"There is a dependency cycle. See task \"{0}\".",
-			"Couldn't resolve dependent task '{0}' in workspace folder '{1}'",
-			"Task {0} is a background task but uses a problem matcher without a background pattern",
-			"Executing task in folder {0}: {1}",
-			"Executing task: {0}",
-			"Executing task in folder {0}: {1}",
-			"Executing task: {0}",
-			"Executing task: {0}",
-			"Can't execute a shell command on an UNC drive using cmd.exe.",
-			"Problem matcher {0} can't be resolved. The matcher will be ignored",
-			"Press any key to close the terminal.",
-			"Terminal will be reused by tasks, press any key to close it."
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"Configure Task",
@@ -21226,6 +21394,22 @@
 			"Open diff",
 			"Open diffs"
 		],
+		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+			"A unknown error has occurred while executing a task. See task output log for details.",
+			"There are issues with task \"{0}\". See the output for more details.",
+			"There is a dependency cycle. See task \"{0}\".",
+			"Couldn't resolve dependent task '{0}' in workspace folder '{1}'",
+			"Task {0} is a background task but uses a problem matcher without a background pattern",
+			"Executing task in folder {0}: {1}",
+			"Executing task: {0}",
+			"Executing task in folder {0}: {1}",
+			"Executing task: {0}",
+			"Executing task: {0}",
+			"Can't execute a shell command on an UNC drive using cmd.exe.",
+			"Problem matcher {0} can't be resolved. The matcher will be ignored",
+			"Press any key to close the terminal.",
+			"Terminal will be reused by tasks, press any key to close it."
+		],
 		"vs/platform/audioCues/browser/audioCueService": [
 			"Error on Line",
 			"Warning on Line",
@@ -21248,11 +21432,13 @@
 			"Chat Response Received",
 			"Chat Response Pending"
 		],
+		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
+			"Open Webview Developer Tools",
+			"Using standard dev tools to debug iframe based webview"
+		],
 		"vs/workbench/contrib/terminal/common/terminalContextKey": [
 			"Whether the terminal is focused.",
 			"Whether any terminal is focused, including detached terminals used in other UI.",
-			"Whether the terminal accessible buffer is focused.",
-			"Whether the accessible buffer focus is on the last line.",
 			"Whether a terminal in the editor area is focused.",
 			"The current number of terminals.",
 			"Whether the terminal tabs widget is focused.",
@@ -21267,10 +21453,6 @@
 			"Whether the focused tab's terminal is a split terminal.",
 			"Whether the terminal run command picker is currently open.",
 			"Whether shell integration is enabled in the active terminal"
-		],
-		"vs/workbench/contrib/webview/electron-sandbox/webviewCommands": [
-			"Open Webview Developer Tools",
-			"Using standard dev tools to debug iframe based webview"
 		],
 		"vs/workbench/contrib/localHistory/electron-sandbox/localHistoryCommands": [
 			"Reveal in File Explorer",
@@ -21323,14 +21505,19 @@
 			"Extension Host (Worker)",
 			"Extension Host"
 		],
+		"vs/workbench/api/node/extHostDebugService": [
+			"Debug Process"
+		],
 		"vs/platform/terminal/node/terminalProcess": [
 			"Starting directory (cwd) \"{0}\" is not a directory",
 			"Starting directory (cwd) \"{0}\" does not exist",
 			"Path to shell executable \"{0}\" does not exist",
 			"Path to shell executable \"{0}\" is not a file or a symlink"
 		],
-		"vs/workbench/api/node/extHostDebugService": [
-			"Debug Process"
+		"vs/platform/shell/node/shellEnv": [
+			"Unable to resolve your shell environment in a reasonable time. Please review your shell configuration and restart.",
+			"Unable to resolve your shell environment: {0}",
+			"Unexpected exit code from spawned shell (code {0}, signal {1})"
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"Open",
@@ -21338,11 +21525,6 @@
 			"Open File",
 			"Open Workspace from File",
 			"&&Open"
-		],
-		"vs/platform/shell/node/shellEnv": [
-			"Unable to resolve your shell environment in a reasonable time. Please review your shell configuration and restart.",
-			"Unable to resolve your shell environment: {0}",
-			"Unexpected exit code from spawned shell (code {0}, signal {1})"
 		],
 		"vs/platform/externalTerminal/node/externalTerminalService": [
 			"VS Code Console",
@@ -21381,19 +21563,6 @@
 			"Unable to uninstall the shell command '{0}'.",
 			"Unable to find shell script in '{0}'"
 		],
-		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
-			"New Window",
-			"Opens a new window",
-			"Recent Folders & Workspaces",
-			"Recent Folders",
-			"Untitled (Workspace)",
-			"{0} (Workspace)"
-		],
-		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
-			"&&OK",
-			"Unable to save workspace '{0}'",
-			"The workspace is already opened in another window. Please close that window first and then try again."
-		],
 		"vs/platform/windows/electron-main/windowsMainService": [
 			"&&OK",
 			"Path does not exist",
@@ -21406,6 +21575,19 @@
 			"The host '{0}' was not found in the list of allowed hosts. Do you want to allow it anyway?",
 			"The path '{0}' uses a host that is not allowed. Unless you trust the host, you should press 'Cancel'",
 			"Permanently allow host '{0}'"
+		],
+		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
+			"&&OK",
+			"Unable to save workspace '{0}'",
+			"The workspace is already opened in another window. Please close that window first and then try again."
+		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"New Window",
+			"Opens a new window",
+			"Recent Folders & Workspaces",
+			"Recent Folders",
+			"Untitled (Workspace)",
+			"{0} (Workspace)"
 		],
 		"vs/platform/files/common/io": [
 			"File is too large to open"
@@ -21466,9 +21648,6 @@
 			"Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}' and '{3}' extensions depend on this.",
 			"Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}', '{3}' and other extensions depend on this."
 		],
-		"vs/platform/extensionManagement/node/extensionManagementUtil": [
-			"VSIX invalid: package.json is not a JSON file."
-		],
 		"vs/base/common/date": [
 			"in {0}",
 			"now",
@@ -21525,12 +21704,19 @@
 			"{0} years",
 			"{0} yrs"
 		],
-		"vs/platform/userDataSync/common/settingsSync": [
-			"Unable to sync settings as there are errors/warning in settings file."
+		"vs/platform/extensionManagement/node/extensionManagementUtil": [
+			"VSIX invalid: package.json is not a JSON file."
 		],
 		"vs/platform/userDataSync/common/keybindingsSync": [
 			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it.",
 			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it."
+		],
+		"vs/platform/userDataSync/common/settingsSync": [
+			"Unable to sync settings as there are errors/warning in settings file."
+		],
+		"vs/platform/userDataSync/common/abstractSynchronizer": [
+			"Cannot sync {0} as its local version {1} is not compatible with its remote version {2}",
+			"Cannot parse sync data as it is not compatible with the current version."
 		],
 		"vs/platform/userDataSync/common/userDataAutoSyncService": [
 			"Cannot sync because default service has changed",
@@ -21540,10 +21726,6 @@
 			"Cannot sync because sync service has changed",
 			"Cannot sync because current session is expired",
 			"Cannot sync because syncing is turned off on this machine from another machine."
-		],
-		"vs/platform/userDataSync/common/abstractSynchronizer": [
-			"Cannot sync {0} as its local version {1} is not compatible with its remote version {2}",
-			"Cannot parse sync data as it is not compatible with the current version."
 		],
 		"vs/base/browser/ui/tree/abstractTree": [
 			"Filter",
@@ -21560,94 +21742,6 @@
 			"Icon for the close action in widgets.",
 			"Icon for goto previous editor location.",
 			"Icon for goto next editor location."
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCenter": [
-			"No new notifications",
-			"Notifications",
-			"Notification Center Actions",
-			"Notifications Center"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsStatus": [
-			"Notifications",
-			"Notifications",
-			"Do Not Disturb",
-			"Do Not Disturb Mode is Enabled",
-			"Hide Notifications",
-			"No Notifications",
-			"No New Notifications",
-			"1 New Notification",
-			"{0} New Notifications",
-			"No New Notifications ({0} in progress)",
-			"1 New Notification ({0} in progress)",
-			"{0} New Notifications ({1} in progress)",
-			"Status Message"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsToasts": [
-			"{0}, notification",
-			"{0}, source: {1}, notification"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
-			"Error: {0}",
-			"Warning: {0}",
-			"Info: {0}"
-		],
-		"vs/workbench/browser/parts/notifications/notificationsCommands": [
-			"Notifications",
-			"Show Notifications",
-			"Hide Notifications",
-			"Clear All Notifications",
-			"Accept Notification Primary Action",
-			"Toggle Do Not Disturb Mode",
-			"Focus Notification Toast"
-		],
-		"vs/platform/actions/browser/menuEntryActionViewItem": [
-			"{0} ({1})",
-			"{0} ({1})",
-			"{0}\n[{1}] {2}"
-		],
-		"vs/workbench/services/configuration/common/configurationEditing": [
-			"Error while writing to {0}. {1}",
-			"Open Tasks Configuration",
-			"Open Launch Configuration",
-			"Open Settings",
-			"Open Tasks Configuration",
-			"Open Launch Configuration",
-			"Save and Retry",
-			"Save and Retry",
-			"Open Settings",
-			"Unable to write {0} because it is configured in system policy.",
-			"Unable to write to {0} because {1} is not a registered configuration.",
-			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
-			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
-			"Unable to write to Folder Settings because {0} does not support the folder resource scope.",
-			"Unable to write to User Settings because {0} does not support for global scope.",
-			"Unable to write to Workspace Settings because {0} does not support for workspace scope in a multi folder workspace.",
-			"Unable to write to Folder Settings because no resource is provided.",
-			"Unable to write to Language Settings because {0} is not a resource language setting.",
-			"Unable to write to {0} because no workspace is opened. Please open a workspace first and try again.",
-			"Unable to write into the tasks configuration file. Please open it to correct errors/warnings in it and try again.",
-			"Unable to write into the launch configuration file. Please open it to correct errors/warnings in it and try again.",
-			"Unable to write into user settings. Please open the user settings to correct errors/warnings in it and try again.",
-			"Unable to write into remote user settings. Please open the remote user settings to correct errors/warnings in it and try again.",
-			"Unable to write into workspace settings. Please open the workspace settings to correct errors/warnings in the file and try again.",
-			"Unable to write into folder settings. Please open the '{0}' folder settings to correct errors/warnings in it and try again.",
-			"Unable to write into tasks configuration file because the file has unsaved changes. Please save it first and then try again.",
-			"Unable to write into launch configuration file because the file has unsaved changes. Please save it first and then try again.",
-			"Unable to write into user settings because the file has unsaved changes. Please save the user settings file first and then try again.",
-			"Unable to write into remote user settings because the file has unsaved changes. Please save the remote user settings file first and then try again.",
-			"Unable to write into workspace settings because the file has unsaved changes. Please save the workspace settings file first and then try again.",
-			"Unable to write into folder settings because the file has unsaved changes. Please save the '{0}' folder settings file first and then try again.",
-			"Unable to write into tasks configuration file because the content of the file is newer.",
-			"Unable to write into launch configuration file because the content of the file is newer.",
-			"Unable to write into user settings because the content of the file is newer.",
-			"Unable to write into remote user settings because the content of the file is newer.",
-			"Unable to write into workspace settings because the content of the file is newer.",
-			"Unable to write into folder settings because the content of the file is newer.",
-			"Unable to write to {0} because of an internal error.",
-			"User Settings",
-			"Remote User Settings",
-			"Workspace Settings",
-			"Folder Settings"
 		],
 		"vs/editor/common/core/editorColorRegistry": [
 			"Background color for the highlight of line at the cursor position.",
@@ -21718,6 +21812,22 @@
 			"Border color used to highlight unicode characters.",
 			"Background color used to highlight unicode characters."
 		],
+		"vs/editor/browser/widget/diffEditor/diffEditor.contribution": [
+			"Toggle Collapse Unchanged Regions",
+			"Toggle Show Moved Code Blocks",
+			"Toggle Use Inline View When Space Is Limited",
+			"Use Inline View When Space Is Limited",
+			"Show Moved Code Blocks",
+			"Diff Editor",
+			"Switch Side",
+			"Exit Compare Move",
+			"Collapse All Unchanged Regions",
+			"Show All Unchanged Regions",
+			"Accessible Diff Viewer",
+			"Go to Next Difference",
+			"Open Accessible Diff Viewer",
+			"Go to Previous Difference"
+		],
 		"vs/platform/contextkey/common/scanner": [
 			"Did you mean {0}?",
 			"Did you mean {0} or {1}?",
@@ -21730,10 +21840,6 @@
 			"Stick to the end even when going to longer lines",
 			"Removed secondary cursors"
 		],
-		"vs/editor/contrib/caretOperations/browser/caretOperations": [
-			"Move Selected Text Left",
-			"Move Selected Text Right"
-		],
 		"vs/editor/contrib/anchorSelect/browser/anchorSelect": [
 			"Selection Anchor",
 			"Anchor set at {0}:{1}",
@@ -21742,12 +21848,9 @@
 			"Select from Anchor to Cursor",
 			"Cancel Selection Anchor"
 		],
-		"vs/editor/browser/widget/codeEditorWidget": [
-			"The number of cursors has been limited to {0}. Consider using [find and replace](https://code.visualstudio.com/docs/editor/codebasics#_find-and-replace) for larger changes or increase the editor multi cursor limit setting.",
-			"Increase Multi Cursor Limit"
-		],
-		"vs/editor/contrib/caretOperations/browser/transpose": [
-			"Transpose Letters"
+		"vs/editor/contrib/caretOperations/browser/caretOperations": [
+			"Move Selected Text Left",
+			"Move Selected Text Right"
 		],
 		"vs/editor/contrib/bracketMatching/browser/bracketMatching": [
 			"Overview ruler marker color for matching brackets.",
@@ -21755,6 +21858,13 @@
 			"Select to Bracket",
 			"Remove Brackets",
 			"Go to &&Bracket"
+		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"The number of cursors has been limited to {0}. Consider using [find and replace](https://code.visualstudio.com/docs/editor/codebasics#_find-and-replace) for larger changes or increase the editor multi cursor limit setting.",
+			"Increase Multi Cursor Limit"
+		],
+		"vs/editor/contrib/caretOperations/browser/transpose": [
+			"Transpose Letters"
 		],
 		"vs/editor/contrib/clipboard/browser/clipboard": [
 			"Cu&&t",
@@ -21777,17 +21887,12 @@
 			"Copy With Syntax Highlighting"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionContributions": [
-			"Enable/disable showing group headers in the Code Action menu."
-		],
-		"vs/editor/browser/widget/diffEditorWidget": [
-			"Line decoration for inserts in the diff editor.",
-			"Line decoration for removals in the diff editor.",
-			" use Shift + F7 to navigate changes",
-			"Cannot compare files because one file is too large.",
-			"Click to revert change"
+			"Enable/disable showing group headers in the Code Action menu.",
+			"Enable/disable showing nearest quickfix within a line when not currently on a diagnostic."
 		],
 		"vs/editor/contrib/codelens/browser/codelensController": [
-			"Show CodeLens Commands For Current Line"
+			"Show CodeLens Commands For Current Line",
+			"Select a command"
 		],
 		"vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions": [
 			"Show or Focus Standalone Color Picker",
@@ -21819,7 +21924,15 @@
 			"Cursor Undo",
 			"Cursor Redo"
 		],
+		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution": [
+			"Paste As...",
+			"The id of the paste edit to try applying. If not provided, the editor will show a picker."
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution": [
+			"Configures the default drop provider to use for content of a given mime type."
+		],
 		"vs/editor/contrib/find/browser/findController": [
+			"The file is too large to perform a replace all operation.",
 			"Find",
 			"&&Find",
 			"Overrides \"Use Regular Expression\" flag.\nThe flag will not be saved for the future.\n0: Do Nothing\n1: True\n2: False",
@@ -21845,9 +21958,6 @@
 			"Editor Font Zoom Out",
 			"Editor Font Zoom Reset"
 		],
-		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution": [
-			"Configures the default drop provider to use for content of a given mime type."
-		],
 		"vs/editor/contrib/folding/browser/folding": [
 			"Unfold",
 			"Unfold Recursively",
@@ -21867,10 +21977,6 @@
 			"Create Folding Range from Selection",
 			"Remove Manual Folding Ranges",
 			"Fold Level {0}"
-		],
-		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution": [
-			"Paste As...",
-			"The id of the paste edit to try applying. If not provided, the editor will show a picker."
 		],
 		"vs/editor/contrib/format/browser/formatActions": [
 			"Format Document",
@@ -21920,18 +22026,6 @@
 		"vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition": [
 			"Click to show {0} definitions."
 		],
-		"vs/editor/contrib/hover/browser/hover": [
-			"Show or Focus Hover",
-			"Show Definition Preview Hover",
-			"Scroll Up Hover",
-			"Scroll Down Hover",
-			"Scroll Left Hover",
-			"Scroll Right Hover",
-			"Page Up Hover",
-			"Page Down Hover",
-			"Go To Top Hover",
-			"Go To Bottom Hover"
-		],
 		"vs/editor/contrib/gotoError/browser/gotoError": [
 			"Go to Next Problem (Error, Warning, Info)",
 			"Icon for goto next marker.",
@@ -21956,12 +22050,40 @@
 			"Reindent Lines",
 			"Reindent Selected Lines"
 		],
+		"vs/editor/contrib/hover/browser/hover": [
+			"Show or Focus Hover",
+			"Show Definition Preview Hover",
+			"Scroll Up Hover",
+			"Scroll Down Hover",
+			"Scroll Left Hover",
+			"Scroll Right Hover",
+			"Page Up Hover",
+			"Page Down Hover",
+			"Go To Top Hover",
+			"Go To Bottom Hover"
+		],
 		"vs/editor/contrib/lineSelection/browser/lineSelection": [
 			"Expand Line Selection"
+		],
+		"vs/editor/contrib/linkedEditing/browser/linkedEditing": [
+			"Start Linked Editing",
+			"Background color when the editor auto renames on type."
 		],
 		"vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace": [
 			"Replace with Previous Value",
 			"Replace with Next Value"
+		],
+		"vs/editor/contrib/links/browser/links": [
+			"Failed to open this link because it is not well-formed: {0}",
+			"Failed to open this link because its target is missing.",
+			"Execute command",
+			"Follow link",
+			"cmd + click",
+			"ctrl + click",
+			"option + click",
+			"alt + click",
+			"Execute command {0}",
+			"Open Link"
 		],
 		"vs/editor/contrib/linesOperations/browser/linesOperations": [
 			"Copy Line Up",
@@ -21993,22 +22115,6 @@
 			"Transform to Snake Case",
 			"Transform to Camel Case",
 			"Transform to Kebab Case"
-		],
-		"vs/editor/contrib/links/browser/links": [
-			"Failed to open this link because it is not well-formed: {0}",
-			"Failed to open this link because its target is missing.",
-			"Execute command",
-			"Follow link",
-			"cmd + click",
-			"ctrl + click",
-			"option + click",
-			"alt + click",
-			"Execute command {0}",
-			"Open Link"
-		],
-		"vs/editor/contrib/linkedEditing/browser/linkedEditing": [
-			"Start Linked Editing",
-			"Background color when the editor auto renames on type."
 		],
 		"vs/editor/contrib/multicursor/browser/multicursor": [
 			"Cursor added: {0}",
@@ -22081,6 +22187,13 @@
 			"Pressing Tab will now move focus to the next focusable element",
 			"Pressing Tab will now insert the tab character"
 		],
+		"vs/editor/contrib/unusualLineTerminators/browser/unusualLineTerminators": [
+			"Unusual Line Terminators",
+			"Detected unusual line terminators",
+			"The file '{0}' contains one or more unusual line terminator characters, like Line Separator (LS) or Paragraph Separator (PS).\n\nIt is recommended to remove them from the file. This can be configured via `editor.unusualLineTerminators`.",
+			"&&Remove Unusual Line Terminators",
+			"Ignore"
+		],
 		"vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter": [
 			"Icon shown with a warning message in the extensions editor.",
 			"This document contains many non-basic ASCII unicode characters",
@@ -22107,20 +22220,13 @@
 			"Allow unicode characters that are more common in the language \"{0}\".",
 			"Configure Unicode Highlight Options"
 		],
-		"vs/editor/contrib/unusualLineTerminators/browser/unusualLineTerminators": [
-			"Unusual Line Terminators",
-			"Detected unusual line terminators",
-			"The file '{0}' contains one or more unusual line terminator characters, like Line Separator (LS) or Paragraph Separator (PS).\n\nIt is recommended to remove them from the file. This can be configured via `editor.unusualLineTerminators`.",
-			"&&Remove Unusual Line Terminators",
-			"Ignore"
-		],
-		"vs/editor/contrib/wordOperations/browser/wordOperations": [
-			"Delete Word"
-		],
 		"vs/editor/contrib/wordHighlighter/browser/wordHighlighter": [
 			"Go to Next Symbol Highlight",
 			"Go to Previous Symbol Highlight",
 			"Trigger Symbol Highlight"
+		],
+		"vs/editor/contrib/wordOperations/browser/wordOperations": [
+			"Delete Word"
 		],
 		"vs/editor/contrib/readOnlyMessage/browser/contribution": [
 			"Cannot edit in read-only input",
@@ -22128,22 +22234,22 @@
 		],
 		"vs/editor/common/standaloneStrings": [
 			"Accessibility Help",
-			"Now opening the Accessibility documentation page.",
+			"Opening the Accessibility documentation page.",
 			"You are in a read-only pane of a diff editor.",
 			"You are in a pane of a diff editor.",
 			"You are in a read-only code editor.",
 			"You are in a code editor.",
-			"To configure the application to be optimized for usage with a Screen Reader press Command+E now.",
-			"To configure the application to be optimized for usage with a Screen Reader press Control+E now.",
+			"Configure the application to be optimized for usage with a Screen Reader (Command+E).",
+			"Configure the application to be optimized for usage with a Screen Reader (Control+E).",
 			"The application is configured to be optimized for usage with a Screen Reader.",
 			"The application is configured to never be optimized for usage with a Screen Reader.",
 			"Screen Reader Optimized Mode enabled.",
 			"Screen Reader Optimized Mode disabled.",
-			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
+			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior {0}.",
 			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
-			"Run the command: Focus Sticky Scroll ({0}) to focus the currently nested scopes.",
-			"Run the command: Focus Sticky Scroll to focus the currently nested scopes. It is currently not triggerable by a keybinding.",
-			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
+			"Focus Sticky Scroll ({0}) to focus the currently nested scopes.",
+			"Focus Sticky Scroll to focus the currently nested scopes. It is currently not triggerable by a keybinding.",
+			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior {0}.",
 			"Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.",
 			"Show Accessibility Help",
 			"Developer: Inspect Tokens",
@@ -22201,20 +22307,6 @@
 			"Expected `contributes.icons.default.fontPath` to have file extension 'woff', woff2' or 'ttf', is '{0}'.",
 			"Expected `contributes.icons.default.fontPath` ({0}) to be included inside extension's folder ({0}).",
 			"'configuration.icons.default' must be either a reference to the id of an other theme icon (string) or a icon definition (object) with properties `fontPath` and `fontCharacter`."
-		],
-		"vs/workbench/api/browser/statusBarExtensionPoint": [
-			"The identifier of the status bar entry. Must be unique within the extension. The same value must be used when calling the `vscode.window.createStatusBarItem(id, ...)`-API",
-			"The name of the entry, like 'Python Language Indicator', 'Git Status' etc. Try to keep the length of the name short, yet descriptive enough that users can understand what the status bar item is about.",
-			"The text to show for the entry. You can embed icons in the text by leveraging the `$(<name>)`-syntax, like 'Hello $(globe)!'",
-			"The tooltip text for the entry.",
-			"The command to execute when the status bar entry is clicked.",
-			"The alignment of the status bar entry.",
-			"The priority of the status bar entry. Higher value means the item should be shown more to the left.",
-			"Defines the role and aria label to be used when the status bar entry is focused.",
-			"The role of the status bar entry which defines how a screen reader interacts with it. More about aria roles can be found here https://w3c.github.io/aria/#widget_roles",
-			"The aria label of the status bar entry. Defaults to the entry's text.",
-			"Contributes items to the status bar.",
-			"Invalid status bar item contribution."
 		],
 		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
 			"Contributes semantic token types.",
@@ -22307,6 +22399,20 @@
 			"Describes text to be appended after the new line and after the indentation.",
 			"Describes the number of characters to remove from the new line's indentation."
 		],
+		"vs/workbench/api/browser/statusBarExtensionPoint": [
+			"The identifier of the status bar entry. Must be unique within the extension. The same value must be used when calling the `vscode.window.createStatusBarItem(id, ...)`-API",
+			"The name of the entry, like 'Python Language Indicator', 'Git Status' etc. Try to keep the length of the name short, yet descriptive enough that users can understand what the status bar item is about.",
+			"The text to show for the entry. You can embed icons in the text by leveraging the `$(<name>)`-syntax, like 'Hello $(globe)!'",
+			"The tooltip text for the entry.",
+			"The command to execute when the status bar entry is clicked.",
+			"The alignment of the status bar entry.",
+			"The priority of the status bar entry. Higher value means the item should be shown more to the left.",
+			"Defines the role and aria label to be used when the status bar entry is focused.",
+			"The role of the status bar entry which defines how a screen reader interacts with it. More about aria roles can be found here https://w3c.github.io/aria/#widget_roles",
+			"The aria label of the status bar entry. Defaults to the entry's text.",
+			"Contributes items to the status bar.",
+			"Invalid status bar item contribution."
+		],
 		"vs/workbench/api/browser/mainThreadCLICommands": [
 			"Cannot install the '{0}' extension because it is declared to not run in this setup."
 		],
@@ -22319,7 +22425,7 @@
 			"Cannot activate the '{0}' extension because it depends on the '{1}' extension which is disabled. Would you like to enable the extension and reload the window?",
 			"Enable and Reload",
 			"Cannot activate the '{0}' extension because it depends on the '{1}' extension which is disabled.",
-			"Cannot activate the '{0}' extension because it depends on the '{1}' extension, which is not installed. Would you like to install the extension and reload the window?",
+			"Cannot activate the '{0}' extension because it depends on the '{1}' extension from '{2}', which is not installed. Would you like to install the extension and reload the window?",
 			"Install and Reload",
 			"Cannot activate the '{0}' extension because it depends on an unknown '{1}' extension."
 		],
@@ -22345,15 +22451,15 @@
 			"Running 'File Write' participants...",
 			"Reset choice for 'File operation needs preview'"
 		],
-		"vs/workbench/api/browser/mainThreadProgress": [
-			"Manage Extension"
-		],
 		"vs/workbench/api/browser/mainThreadMessageService": [
 			"{0} (Extension)",
 			"Extension",
 			"Manage Extension",
 			"Cancel",
 			"&&OK"
+		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"Manage Extension"
 		],
 		"vs/workbench/api/browser/mainThreadSaveParticipant": [
 			"Aborted onWillSaveTextDocument-event after 1750ms"
@@ -22539,15 +22645,6 @@
 			"The pricing information for the extension. Can be Free (default) or Trial. For more details visit: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#extension-pricing-label",
 			"API proposals that the respective extensions can freely use."
 		],
-		"vs/workbench/browser/parts/views/treeView": [
-			"There is no data provider registered that can provide view data.",
-			"Whether the the tree view with id {0} enables collapse all.",
-			"Whether the tree view with id {0} enables refresh.",
-			"Refresh",
-			"Collapse All",
-			"Whether collapse all is toggled for the tree view with id {0}.",
-			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
-		],
 		"vs/workbench/contrib/debug/common/debug": [
 			"Debug type of the active debug session. For example 'python'.",
 			"Debug type of the selected launch configuration. For example 'python'.",
@@ -22642,28 +22739,31 @@
 			"Make Public",
 			"Use Port {0} as Sudo..."
 		],
-		"vs/workbench/browser/parts/editor/editorDropTarget": [
-			"Hold __{0}__ to drop into editor"
+		"vs/workbench/browser/parts/views/treeView": [
+			"There is no data provider registered that can provide view data.",
+			"Whether the the tree view with id {0} enables collapse all.",
+			"Whether the tree view with id {0} enables refresh.",
+			"Refresh",
+			"Collapse All",
+			"Whether collapse all is toggled for the tree view with id {0}.",
+			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
 		],
-		"vs/workbench/browser/parts/editor/editorGroupView": [
-			"Empty editor group actions",
-			"{0} (empty)",
-			"Group {0}",
-			"Editor Group {0}"
-		],
-		"vs/workbench/browser/parts/editor/sideBySideEditor": [
-			"Side by Side Editor"
+		"vs/workbench/common/editor/sideBySideEditorInput": [
+			"{0} - {1}"
 		],
 		"vs/workbench/common/editor/diffEditorInput": [
 			"{0} ↔ {1}"
 		],
-		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
-			"{0} ↔ {1}"
+		"vs/workbench/browser/parts/editor/sideBySideEditor": [
+			"Side by Side Editor"
 		],
 		"vs/workbench/browser/parts/editor/textDiffEditor": [
 			"Text Diff Editor",
 			"At least one file is not displayed in the text compare editor because it is very large ({0}).",
 			"At least one file is not displayed in the text compare editor because it is very large."
+		],
+		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
+			"{0} ↔ {1}"
 		],
 		"vs/workbench/browser/parts/editor/editorStatus": [
 			"Ln {0}, Col {1} ({2} selected)",
@@ -22875,12 +22975,12 @@
 			"Lock Editor Group",
 			"Unlock Editor Group"
 		],
-		"vs/workbench/browser/parts/editor/accessibilityStatus": [
-			"Are you using a screen reader to operate VS Code?",
-			"Yes",
-			"No",
-			"Screen Reader Optimized",
-			"Screen Reader Mode"
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"No matching editors",
+			"{0}, unsaved changes, {1}",
+			"{0}, {1}",
+			"{0}, unsaved changes",
+			"Close Editor"
 		],
 		"vs/workbench/browser/parts/editor/editorConfiguration": [
 			"Interactive Window",
@@ -22890,28 +22990,12 @@
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
 			"Controls the minimum size of a file in MB before asking for confirmation when opening in the editor. Note that this setting may not apply to all editor types and environments."
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution": [
-			"Toggle Collapse Unchanged Regions",
-			"Toggle Show Moved Code Blocks",
-			"Toggle Use Inline View When Space Is Limited",
-			"Use Inline View When Space Is Limited",
-			"Show Moved Code Blocks",
-			"Diff Editor",
-			"Switch Side",
-			"Exit Compare Move",
-			"Collapse All Unchanged Regions",
-			"Show All Unchanged Regions"
-		],
-		"vs/workbench/common/editor/sideBySideEditorInput": [
-			"{0} - {1}"
-		],
 		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart": [
 			"Move Secondary Side Bar Left",
 			"Move Secondary Side Bar Right",
 			"Hide Secondary Side Bar"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
-			"Settings icon in the view bar.",
 			"Accounts icon in the view bar.",
 			"Menu",
 			"Hide Menu",
@@ -22920,8 +23004,8 @@
 			"Reset Location",
 			"Reset Location",
 			"Manage",
-			"Manage",
 			"Accounts",
+			"Manage",
 			"Accounts"
 		],
 		"vs/workbench/browser/parts/panel/panelPart": [
@@ -22933,18 +23017,28 @@
 			"Align Panel",
 			"Hide Panel"
 		],
-		"vs/workbench/browser/parts/editor/editorQuickAccess": [
-			"No matching editors",
-			"{0}, unsaved changes, {1}",
-			"{0}, {1}",
-			"{0}, unsaved changes",
-			"Close Editor"
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"Empty editor group actions",
+			"{0} (empty)",
+			"Group {0}",
+			"Editor Group {0}"
+		],
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"Hold __{0}__ to drop into editor"
+		],
+		"vs/workbench/browser/parts/statusbar/statusbarActions": [
+			"Hide '{0}'",
+			"Focus Status Bar"
 		],
 		"vs/platform/actions/common/menuResetAction": [
 			"Reset All Menus"
 		],
 		"vs/platform/actions/common/menuService": [
 			"Hide '{0}'"
+		],
+		"vs/base/browser/ui/icons/iconSelectBox": [
+			"Search icons",
+			"No results"
 		],
 		"vs/base/browser/ui/dialog/dialog": [
 			"OK",
@@ -22964,15 +23058,11 @@
 			"Commonly Used",
 			"Override key bindings by placing them into your key bindings file."
 		],
-		"vs/workbench/browser/parts/statusbar/statusbarActions": [
-			"Hide '{0}'",
-			"Focus Status Bar"
+		"vs/workbench/services/editor/common/editorResolverService": [
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior."
 		],
 		"vs/workbench/services/textfile/common/textFileEditorModel": [
 			"File Encoding Changed"
-		],
-		"vs/workbench/services/editor/common/editorResolverService": [
-			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior."
 		],
 		"vs/base/common/keybindingLabels": [
 			"Ctrl",
@@ -22995,26 +23085,6 @@
 			"Shift",
 			"Alt",
 			"Super"
-		],
-		"vs/platform/keybinding/common/abstractKeybindingService": [
-			"({0}) was pressed. Waiting for second key of chord...",
-			"({0}) was pressed. Waiting for next key of chord...",
-			"The key combination ({0}, {1}) is not a command.",
-			"The key combination ({0}, {1}) is not a command."
-		],
-		"vs/workbench/services/themes/common/colorThemeData": [
-			"Problems parsing JSON theme file: {0}",
-			"Invalid format for JSON theme file: Object expected.",
-			"Problem parsing color theme file: {0}. Property 'colors' is not of type 'object'.",
-			"Problem parsing color theme file: {0}. Property 'tokenColors' should be either an array specifying colors or a path to a TextMate theme file",
-			"Problem parsing color theme file: {0}. Property 'semanticTokenColors' contains a invalid selector",
-			"Problem parsing tmTheme file: {0}. 'settings' is not array.",
-			"Problems parsing tmTheme file: {0}",
-			"Problems loading tmTheme file {0}: {1}"
-		],
-		"vs/workbench/services/themes/browser/fileIconThemeData": [
-			"Problems parsing file icons file: {0}",
-			"Invalid format for file icons theme file: Object expected."
 		],
 		"vs/workbench/services/themes/common/fileIconThemeSchema": [
 			"The folder icon for expanded folders. The expanded folder icon is optional. If not set, the icon defined for folder will be shown.",
@@ -23051,6 +23121,41 @@
 			"Configures whether the file explorer's arrows should be hidden when this theme is active.",
 			"Configures whether the default language icons should be used if the theme does not define an icon for a language."
 		],
+		"vs/workbench/services/themes/browser/fileIconThemeData": [
+			"Problems parsing file icons file: {0}",
+			"Invalid format for file icons theme file: Object expected."
+		],
+		"vs/workbench/services/themes/common/colorThemeData": [
+			"Problems parsing JSON theme file: {0}",
+			"Invalid format for JSON theme file: Object expected.",
+			"Problem parsing color theme file: {0}. Property 'colors' is not of type 'object'.",
+			"Problem parsing color theme file: {0}. Property 'tokenColors' should be either an array specifying colors or a path to a TextMate theme file",
+			"Problem parsing color theme file: {0}. Property 'semanticTokenColors' contains a invalid selector",
+			"Problem parsing tmTheme file: {0}. 'settings' is not array.",
+			"Problems parsing tmTheme file: {0}",
+			"Problems loading tmTheme file {0}: {1}"
+		],
+		"vs/platform/keybinding/common/abstractKeybindingService": [
+			"({0}) was pressed. Waiting for second key of chord...",
+			"({0}) was pressed. Waiting for next key of chord...",
+			"The key combination ({0}, {1}) is not a command.",
+			"The key combination ({0}, {1}) is not a command."
+		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"Colors and styles for the token.",
+			"Foreground color for the token.",
+			"Token background colors are currently not supported.",
+			"Font style of the rule: 'italic', 'bold', 'underline', 'strikethrough' or a combination. The empty string unsets inherited settings.",
+			"Font style must be 'italic', 'bold', 'underline', 'strikethrough' or a combination or the empty string.",
+			"None (clear inherited style)",
+			"Description of the rule.",
+			"Scope selector against which this rule matches.",
+			"Colors in the workbench",
+			"Path to a tmTheme file (relative to the current file).",
+			"Colors for syntax highlighting",
+			"Whether semantic highlighting should be enabled for this theme.",
+			"Colors for semantic tokens"
+		],
 		"vs/workbench/services/themes/common/themeExtensionPoints": [
 			"Contributes textmate color themes.",
 			"Id of the color theme as used in the user settings.",
@@ -23070,21 +23175,6 @@
 			"Expected string in `contributes.{0}.id`. Provided value: {1}",
 			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
 		],
-		"vs/workbench/services/themes/common/colorThemeSchema": [
-			"Colors and styles for the token.",
-			"Foreground color for the token.",
-			"Token background colors are currently not supported.",
-			"Font style of the rule: 'italic', 'bold', 'underline', 'strikethrough' or a combination. The empty string unsets inherited settings.",
-			"Font style must be 'italic', 'bold', 'underline', 'strikethrough' or a combination or the empty string.",
-			"None (clear inherited style)",
-			"Description of the rule.",
-			"Scope selector against which this rule matches.",
-			"Colors in the workbench",
-			"Path to a tmTheme file (relative to the current file).",
-			"Colors for syntax highlighting",
-			"Whether semantic highlighting should be enabled for this theme.",
-			"Colors for semantic tokens"
-		],
 		"vs/workbench/services/themes/browser/productIconThemeData": [
 			"Problems processing product icons definitions in {0}:\n{1}",
 			"Default",
@@ -23098,6 +23188,16 @@
 			"Missing or invalid font id '{0}'. Skipping font definition.",
 			"Skipping icon definition '{0}'. Unknown font.",
 			"Skipping icon definition '{0}'. Unknown fontCharacter."
+		],
+		"vs/workbench/services/themes/common/productIconThemeSchema": [
+			"The ID of the font.",
+			"The ID must only contain letters, numbers, underscore and minus.",
+			"The location of the font.",
+			"The font path, relative to the current product icon theme file.",
+			"The format of the font.",
+			"The weight of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for valid values.",
+			"The style of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-style for valid values.",
+			"Association of icon name to a font character."
 		],
 		"vs/workbench/services/themes/common/themeConfiguration": [
 			"Specifies the color theme used in the workbench.",
@@ -23137,16 +23237,6 @@
 			"Semantic token styling rules for this theme.",
 			"Overrides editor semantic token color and styles from the currently selected color theme."
 		],
-		"vs/workbench/services/themes/common/productIconThemeSchema": [
-			"The ID of the font.",
-			"The ID must only contain letters, numbers, underscore and minus.",
-			"The location of the font.",
-			"The font path, relative to the current product icon theme file.",
-			"The format of the font.",
-			"The weight of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for valid values.",
-			"The style of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-style for valid values.",
-			"Association of icon name to a font character."
-		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
 			"I can't reproduce",
 			"I can reproduce",
@@ -23182,6 +23272,9 @@
 			"Snippets",
 			"Select Snippet {0}"
 		],
+		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
+			"UI State"
+		],
 		"vs/workbench/services/userDataProfile/browser/extensionsResource": [
 			"Extensions",
 			"Disabled",
@@ -23191,8 +23284,8 @@
 		"vs/workbench/services/userDataProfile/browser/tasksResource": [
 			"User Tasks"
 		],
-		"vs/workbench/services/userDataProfile/browser/globalStateResource": [
-			"UI State"
+		"vs/workbench/services/userDataProfile/common/userDataProfileIcons": [
+			"Settings icon in the view bar."
 		],
 		"vs/workbench/services/remote/common/tunnelModel": [
 			"Whether the Ports view is enabled.",
@@ -23223,12 +23316,6 @@
 			"Invalid value in `contributes.{0}.tokenTypes`. Must be an object map from scope name to token type. Provided value: {1}",
 			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
 		],
-		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
-			"Press desired key combination and then press ENTER.",
-			"1 existing command has this keybinding",
-			"{0} existing commands have this keybinding",
-			"chord to"
-		],
 		"vs/editor/contrib/suggest/browser/suggest": [
 			"Whether any suggestion is focused",
 			"Whether suggestion details are visible",
@@ -23238,25 +23325,6 @@
 			"Whether the current suggestion has insert and replace behaviour",
 			"Whether the default behaviour is to insert or replace",
 			"Whether the current suggestion supports to resolve further details"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesActions": [
-			"Configure Language Specific Settings...",
-			"({0})",
-			"Select Language"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
-			"Icon for the folder dropdown button in the split JSON Settings editor.",
-			"Icon for the 'more actions' action in the Settings UI.",
-			"Icon for the 'record keys' action in the keybinding UI.",
-			"Icon for the 'sort by precedence' toggle in the keybinding UI.",
-			"Icon for the edit action in the keybinding UI.",
-			"Icon for the add action in the keybinding UI.",
-			"Icon for the edit action in the Settings UI.",
-			"Icon for the remove action in the Settings UI.",
-			"Icon for the discard action in the Settings UI.",
-			"Icon for clear input in the Settings and keybinding UI.",
-			"Icon for the button that suggests filters for the Settings UI.",
-			"Icon for open settings commands."
 		],
 		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
 			"Record Keys",
@@ -23293,6 +23361,25 @@
 			"No when context",
 			"use space or enter to change the keybinding."
 		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"Configure Language Specific Settings...",
+			"({0})",
+			"Select Language"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
+			"Icon for the folder dropdown button in the split JSON Settings editor.",
+			"Icon for the 'more actions' action in the Settings UI.",
+			"Icon for the 'record keys' action in the keybinding UI.",
+			"Icon for the 'sort by precedence' toggle in the keybinding UI.",
+			"Icon for the edit action in the keybinding UI.",
+			"Icon for the add action in the keybinding UI.",
+			"Icon for the edit action in the Settings UI.",
+			"Icon for the remove action in the Settings UI.",
+			"Icon for the discard action in the Settings UI.",
+			"Icon for clear input in the Settings and keybinding UI.",
+			"Icon for the button that suggests filters for the Settings UI.",
+			"Icon for open settings commands."
+		],
 		"vs/workbench/contrib/preferences/browser/settingsEditor2": [
 			"Search settings",
 			"Clear Settings Search Input",
@@ -23304,15 +23391,21 @@
 			"No Settings Found",
 			"1 Setting Found",
 			"{0} Settings Found",
-			"Turn on Settings Sync",
+			"Backup and Sync Settings",
 			"Last synced: {0}"
 		],
 		"vs/workbench/contrib/preferences/common/preferencesContribution": [
 			"Split Settings Editor",
 			"Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service.",
-			"Hide the Table of Contents while searching.",
-			"Filter the Table of Contents to just categories that have matching settings. Clicking a category will filter the results to that category.",
+			"Hide the Table of Contents while searching. The search results will not be grouped by category, and instead will be sorted by similarity to the query, with exact keyword matches coming first.",
+			"Filter the Table of Contents to just categories that have matching settings. Clicking a category will filter the results to that category. The search results will be grouped by category.",
 			"Controls the behavior of the settings editor Table of Contents while searching."
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"Press desired key combination and then press ENTER.",
+			"1 existing command has this keybinding",
+			"{0} existing commands have this keybinding",
+			"chord to"
 		],
 		"vs/workbench/contrib/performance/browser/perfviewEditor": [
 			"Startup Performance"
@@ -23334,13 +23427,13 @@
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor": [
 			"Notebook Text Diff"
 		],
-		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
-			"Executing a notebook cell will run code from this workspace."
-		],
 		"vs/workbench/contrib/notebook/browser/services/notebookKeymapServiceImpl": [
 			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
 			"Yes",
 			"No"
+		],
+		"vs/workbench/contrib/notebook/browser/services/notebookExecutionServiceImpl": [
+			"Executing a notebook cell will run code from this workspace."
 		],
 		"vs/editor/common/languages/modesRegistry": [
 			"Plain Text"
@@ -23371,32 +23464,6 @@
 			"The Insert Cell Above/Below commands will create new empty code cells",
 			"The Change Cell to Code/Markdown commands are used to switch between cell types."
 		],
-		"vs/workbench/contrib/accessibility/browser/accessibleView": [
-			"({0}) {1}",
-			"({0}) {1}",
-			"{0} accessibility verbosity is now disabled",
-			"\n\nPress H now to open a browser window with more information related to accessibility.\n\n",
-			"\nExit this dialog via the Escape key.",
-			"Use Shift+Tab to explore actions such as disabling this hint.",
-			"Accessibility Help",
-			"Accessible View",
-			"Accessible View, {0}",
-			"Accessibility Help, {0}",
-			"Accessibility Help",
-			"Accessible View",
-			"Navigate to the toolbar (Shift+Tab))",
-			"In the accessible view, you can:\n",
-			"Show the next ({0}) or previous ({1}) item",
-			"Show the next or previous item by configuring keybindings for the Show Next & Previous in Accessible View commands",
-			"Disable accessibility verbosity for this feature ({0}). This will disable the hint to open the accessible view for example.\n",
-			"Add a keybinding for the command Disable Accessible View Hint, which disables accessibility verbosity for this feature.\n",
-			"Go to a symbol ({0})",
-			"To go to a symbol, configure a keybinding for the command Go To Symbol in Accessible View",
-			"Inspect this in the accessible view with {0}",
-			"Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding.",
-			"Type to search symbols",
-			"Go to Symbol Accessible View"
-		],
 		"vs/workbench/contrib/accessibility/browser/accessibleViewActions": [
 			"Show Next in Accessible View",
 			"Show Previous in Accessible View",
@@ -23405,6 +23472,33 @@
 			"Open Accessible View",
 			"Disable Accessible View Hint",
 			"Accept Inline Completion"
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibleView": [
+			"({0}) {1}",
+			"({0}) {1}",
+			"{0} accessibility verbosity is now disabled",
+			"\n\nOpen a browser window with more information related to accessibility (H).",
+			"\n\nExit this dialog (Escape).",
+			"Explore actions such as disabling this hint (Shift+Tab), use Escape to exit this dialog.",
+			"Explore actions such as disabling this hint (Shift+Tab).",
+			"Accessibility Help",
+			"Accessible View",
+			"Accessible View, {0}",
+			"Accessibility Help, {0}",
+			"Accessibility Help",
+			"Accessible View",
+			"Navigate to the toolbar (Shift+Tab)).",
+			"In the accessible view, you can:\n",
+			"Show the next ({0}) or previous ({1}) item.",
+			"Show the next or previous item by configuring keybindings for the Show Next & Previous in Accessible View commands.",
+			"\n\nDisable accessibility verbosity for this feature ({0}).",
+			"\n\nAdd a keybinding for the command Disable Accessible View Hint, which disables accessibility verbosity for this feature.s",
+			"Go to a symbol ({0})",
+			"To go to a symbol, configure a keybinding for the command Go To Symbol in Accessible View",
+			"Inspect this in the accessible view with {0}",
+			"Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding.",
+			"Type to search symbols",
+			"Go to Symbol Accessible View"
 		],
 		"vs/workbench/contrib/notebook/browser/controller/coreActions": [
 			"Notebook",
@@ -23461,6 +23555,9 @@
 			"Go to Most Recently Failed Cell",
 			"Go To"
 		],
+		"vs/workbench/contrib/notebook/browser/controller/cellOutputActions": [
+			"Copy Output"
+		],
 		"vs/workbench/contrib/notebook/browser/controller/layoutActions": [
 			"Select between Notebook Layouts",
 			"Customize Notebook Layout",
@@ -23495,13 +23592,22 @@
 			"Accept Detected Language for Cell",
 			"Unable to detect cell language"
 		],
-		"vs/workbench/contrib/notebook/browser/controller/cellOutputActions": [
-			"Copy Output"
-		],
 		"vs/workbench/contrib/notebook/browser/controller/foldingController": [
 			"Fold Cell",
 			"Unfold Cell",
 			"Fold Cell"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
+			"Format Notebook",
+			"Format Notebook",
+			"Format Cell",
+			"Format Cells"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
+			"Reset notebook getting started"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
+			"Toggle Cell Toolbar Position"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard": [
 			"Copy Cell",
@@ -23513,30 +23619,6 @@
 		"vs/workbench/contrib/notebook/browser/contrib/find/notebookFind": [
 			"Hide Find in Notebook",
 			"Find in Notebook"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
-			"Format Notebook",
-			"Format Notebook",
-			"Format Cell",
-			"Format Cells"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/layout/layoutActions": [
-			"Toggle Cell Toolbar Position"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
-			"Formatting",
-			"Format Notebook",
-			"Running 'Notebook' code actions",
-			"Running code actions",
-			"Getting code actions from '{0}' ([configure]({1})).",
-			"Applying code action '{0}'."
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/gettingStarted/notebookGettingStarted": [
-			"Reset notebook getting started"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
-			"When enabled notebook outline shows code cells.",
-			"When enabled notebook breadcrumbs contain code cells."
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/navigation/arrow": [
 			"Focus Next Cell Editor",
@@ -23552,13 +23634,29 @@
 			"Cell Cursor Page Down Select",
 			"When enabled cursor can navigate to the next/previous cell when the current cursor in the cell editor is at the first/last line."
 		],
+		"vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants": [
+			"Formatting",
+			"Format Notebook",
+			"Notebook Trim Trailing Whitespace",
+			"Trim Final New Lines",
+			"Insert Final New Line",
+			"Running 'Notebook' code actions",
+			"Running 'Cell' code actions",
+			"Getting code actions from '{0}' ([configure]({1})).",
+			"Applying code action '{0}'."
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
+			"When enabled notebook outline shows code cells.",
+			"When enabled notebook breadcrumbs contain code cells.",
+			"When enabled goto symbol quickpick will display full code symbols from the notebook, as well as markdown headers."
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
+			"Set Profile"
+		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders": [
 			"Unknown cell language. Click to search for '{0}' extensions",
 			"Select Cell Language Mode",
 			"Accept Detected Language: {0}"
-		],
-		"vs/workbench/contrib/notebook/browser/contrib/profile/notebookProfile": [
-			"Set Profile"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController": [
 			"Success",
@@ -23577,6 +23675,11 @@
 			"Notebook Editor Selections",
 			"Cell {0} ({1} selected)",
 			"Cell {0} of {1}"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
+			"Toggle Layout Troubleshoot",
+			"Inspect Notebook Layout",
+			"Clear Notebook Editor Type Cache"
 		],
 		"vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands": [
 			"Move Cell Up",
@@ -23601,11 +23704,6 @@
 			"Expand All Cell Outputs",
 			"Toggle Scroll Cell Output"
 		],
-		"vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout": [
-			"Toggle Layout Troubleshoot",
-			"Inspect Notebook Layout",
-			"Clear Notebook Editor Type Cache"
-		],
 		"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions": [
 			"Open Text Diff Editor",
 			"Revert Metadata",
@@ -23621,6 +23719,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatActions": [
 			"Chat",
+			"Quick Chat",
 			"Accept Chat Input",
 			"Clear Input History",
 			"Focus Chat List",
@@ -23630,14 +23729,6 @@
 			"Delete",
 			"Select a chat session to restore"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
-			"Copy",
-			"Insert at Cursor",
-			"Insert Into New File",
-			"Run in Terminal",
-			"Next Code Block",
-			"Previous Code Block"
-		],
 		"vs/workbench/contrib/chat/browser/actions/chatCopyActions": [
 			"Copy All",
 			"Copy"
@@ -23646,17 +23737,25 @@
 			"Submit",
 			"Cancel"
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
+			"Helpful",
+			"Unhelpful",
+			"Insert into Notebook",
+			"Remove Request and Response"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatQuickInputActions": [
 			"Open in Chat View",
 			"Close Quick Chat",
 			"Quick Chat",
 			"Open Quick Chat ({0})"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
-			"Helpful",
-			"Unhelpful",
-			"Insert into Notebook",
-			"Remove Request and Response"
+		"vs/workbench/contrib/chat/browser/actions/chatCodeblockActions": [
+			"Copy",
+			"Insert at Cursor",
+			"Insert Into New File",
+			"Run in Terminal",
+			"Next Code Block",
+			"Previous Code Block"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatImportExport": [
 			"Chat Session",
@@ -23682,11 +23781,6 @@
 			"Open Session In Editor",
 			"Open Session In Sidebar"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatClearActions": [
-			"Clear",
-			"Clear",
-			"Clear"
-		],
 		"vs/workbench/contrib/chat/common/chatContextKeys": [
 			"True when the provider has assigned an id to this response.",
 			"When the response has been voted up, is set to 'up'. When voted down, is set to 'down'. Otherwise an empty string.",
@@ -23699,6 +23793,11 @@
 			"True when focus is in the chat widget, false otherwise.",
 			"True when some chat provider has been registered."
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatClearActions": [
+			"Clear",
+			"Clear",
+			"Clear"
+		],
 		"vs/workbench/contrib/chat/common/chatViewModel": [
 			"Thinking"
 		],
@@ -23708,106 +23807,45 @@
 			"Contributes slash commands to chat",
 			"Invalid {0}: {1}"
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions": [
+			"Next File Tree",
+			"Previous File Tree"
+		],
 		"vs/workbench/contrib/accessibility/browser/accessibilityContributions": [
 			"{0} Source: {1}",
 			"{0}",
 			"Clear Notification",
 			"Clear Notification"
 		],
-		"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions": [
-			"Next File Tree",
-			"Previous File Tree"
-		],
-		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
-			"Ask a question or type '/' for topics",
-			"Ask a question"
+		"vs/workbench/contrib/chat/common/chatAgents": [
+			"The name of the agent which will be used as prefix.",
+			"The details of the agent.",
+			"Contributes agents to chat",
+			"Invalid {0}: {1}"
 		],
 		"vs/workbench/contrib/chat/common/chatColors": [
 			"The border color of a chat request.",
 			"The background color of a chat slash command.",
 			"The foreground color of a chat slash command."
 		],
-		"vs/editor/contrib/peekView/browser/peekView": [
-			"Whether the current code editor is embedded inside peek",
-			"Close",
-			"Background color of the peek view title area.",
-			"Color of the peek view title.",
-			"Color of the peek view title info.",
-			"Color of the peek view borders and arrow.",
-			"Background color of the peek view result list.",
-			"Foreground color for line nodes in the peek view result list.",
-			"Foreground color for file nodes in the peek view result list.",
-			"Background color of the selected entry in the peek view result list.",
-			"Foreground color of the selected entry in the peek view result list.",
-			"Background color of the peek view editor.",
-			"Background color of the gutter in the peek view editor.",
-			"Background color of sticky scroll in the peek view editor.",
-			"Match highlight color in the peek view result list.",
-			"Match highlight color in the peek view editor.",
-			"Match highlight border in the peek view editor."
+		"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib": [
+			"Ask a question or type '@' or '/'",
+			"Ask a question"
 		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
-			"Start Code Chat",
-			"Resume Last Dismissed Code Chat",
-			"Inline Chat",
-			"Make Request",
-			"Regenerate Response",
-			"Regenerate",
-			"Stop Request",
-			"Cursor Up",
-			"Cursor Down",
-			"Focus Input",
-			"Previous From History",
-			"Next From History",
-			"Discard...",
-			"Discard",
-			"Discard to Clipboard",
-			"Discard to New File",
-			"Helpful",
-			"Unhelpful",
-			"Show Diff",
-			"&&Show Diff",
-			"Show Diff",
-			"&&Show Diff",
-			"Accept Changes",
-			"Accept",
-			"Cancel",
-			"(Developer) Write Exchange to Clipboard",
-			"'{0}' and {1} follow ups ({2})",
-			"View in Chat",
-			"Show More",
-			"Show Less"
-		],
-		"vs/workbench/contrib/notebook/browser/notebookIcons": [
-			"Configure icon to select a kernel in notebook editors.",
-			"Icon to execute in notebook editors.",
-			"Icon to execute above cells in notebook editors.",
-			"Icon to execute below cells in notebook editors.",
-			"Icon to stop an execution in notebook editors.",
-			"Icon to delete a cell in notebook editors.",
-			"Icon to execute all cells in notebook editors.",
-			"Icon to edit a cell in notebook editors.",
-			"Icon to stop editing a cell in notebook editors.",
-			"Icon to move up a cell in notebook editors.",
-			"Icon to move down a cell in notebook editors.",
-			"Icon to clear cell outputs in notebook editors.",
-			"Icon to split a cell in notebook editors.",
-			"Icon to indicate a success state in notebook editors.",
-			"Icon to indicate an error state in notebook editors.",
-			"Icon to indicate a pending state in notebook editors.",
-			"Icon to indicate an executing state in notebook editors.",
-			"Icon to annotate a collapsed section in notebook editors.",
-			"Icon to annotate an expanded section in notebook editors.",
-			"Icon to open the notebook in a text editor.",
-			"Icon to revert in notebook editors.",
-			"Icon to render output in diff editor.",
-			"Icon for a mime type in notebook editors.",
-			"Icon to copy content to clipboard",
-			"Icon for the previous change action in the diff editor.",
-			"Icon for the next change action in the diff editor."
-		],
-		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
-			"Type '{0}' code here and press {1} to run"
+		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
+			"AI-generated code may be incorrect",
+			"Getting ready...",
+			"Failed to start editor chat",
+			"Please consult the error log and try again later.",
+			"AI-generated code may be incorrect",
+			"Ask a question",
+			"{0} ({1}, {2} for history)",
+			"Thinking…",
+			"No results, please refine your input and try again",
+			"{0}",
+			"Use tab to navigate to the diff editor and review proposed changes.",
+			"Failed to apply changes.",
+			"Failed to discard changes."
 		],
 		"vs/workbench/contrib/inlineChat/common/inlineChat": [
 			"Whether a provider for interactive editors exists",
@@ -23845,6 +23883,38 @@
 			"Changes are applied directly to the document but can be highlighted via inline diffs. Ending a session will keep the changes.",
 			"Enable/disable showing the diff when edits are generated. Works only with inlineChat.mode equal to live or livePreview."
 		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
+			"Start Code Chat",
+			"Resume Last Dismissed Code Chat",
+			"Inline Chat",
+			"Make Request",
+			"Regenerate Response",
+			"Regenerate",
+			"Stop Request",
+			"Cursor Up",
+			"Cursor Down",
+			"Focus Input",
+			"Previous From History",
+			"Next From History",
+			"Discard...",
+			"Discard",
+			"Discard to Clipboard",
+			"Discard to New File",
+			"Helpful",
+			"Unhelpful",
+			"Show Diff",
+			"&&Show Diff",
+			"Show Diff",
+			"&&Show Diff",
+			"Accept Changes",
+			"Accept",
+			"Cancel",
+			"(Developer) Write Exchange to Clipboard",
+			"'{0}' and {1} follow ups ({2})",
+			"View in Chat",
+			"Show More",
+			"Show Less"
+		],
 		"vs/workbench/contrib/files/browser/fileConstants": [
 			"Save As...",
 			"Save",
@@ -23852,27 +23922,6 @@
 			"Save All",
 			"Remove Folder from Workspace",
 			"New Untitled Text File"
-		],
-		"vs/workbench/contrib/logs/common/logsActions": [
-			"Set Log Level...",
-			"All",
-			"Extension Logs",
-			"Logs",
-			"Set Log Level",
-			" {0}: Select log level",
-			"Select log level",
-			"Set as Default Log Level",
-			"Trace",
-			"Debug",
-			"Info",
-			"Warning",
-			"Error",
-			"Off",
-			"Default",
-			"Open Window Log File (Session)...",
-			"Current",
-			"Select Session",
-			"Select Log file"
 		],
 		"vs/workbench/contrib/testing/browser/icons": [
 			"View icon of the test view.",
@@ -23899,24 +23948,6 @@
 			"Icon shown for tests that are queued.",
 			"Icon shown for tests that are skipped.",
 			"Icon shown for tests that are in an unset state."
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
-			"AI-generated code may be incorrect",
-			"Getting ready...",
-			"Failed to start editor chat",
-			"Please consult the error log and try again later.",
-			"AI-generated code may be incorrect",
-			"Ask a question",
-			"{0} ({1}, {2} for history)",
-			"Thinking…",
-			"No results, please refine your input and try again",
-			"{0}",
-			"Use tab to navigate to the diff editor and review proposed changes.",
-			"Failed to apply changes.",
-			"Failed to discard changes."
-		],
-		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
-			"Testing"
 		],
 		"vs/workbench/contrib/testing/browser/testingDecorations": [
 			"Peek Test Output",
@@ -23955,32 +23986,8 @@
 			"{0}, outdated result",
 			"Test Explorer"
 		],
-		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
-			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled.",
-			"Test Output",
-			"Expected result",
-			"Actual result",
-			"Test output is only available for new test runs.",
-			"The test run did not record any output.",
-			"Close",
-			"Unnamed Task",
-			"+ {0} more lines",
-			"+ 1 more line",
-			"Test Result Messages",
-			"Show Result Output",
-			"Show Result Output",
-			"Rerun Test Run",
-			"Debug Test Run",
-			"Go to Source",
-			"Show Result Output",
-			"Reveal in Test Explorer",
-			"Run Test",
-			"Debug Test",
-			"Go to Source",
-			"Go to Next Test Failure",
-			"Go to Previous Test Failure",
-			"Open in Editor",
-			"Toggle Test History in Peek"
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"Testing"
 		],
 		"vs/workbench/contrib/testing/common/configuration": [
 			"Testing",
@@ -24003,20 +24010,48 @@
 			"Open the context menu for more options.",
 			"Controls whether test decorations are shown in the editor gutter.",
 			"Control whether save all dirty editors before running a test.",
-			"Never automatically open the testing view",
-			"Open the testing view when tests start",
-			"Open the testing view on any test failure",
+			"Never automatically open the testing views",
+			"Open the test results view when tests start",
+			"Open the test result view on any test failure",
+			"Open the test explorer when tests start",
 			"Controls when the testing view should open.",
 			"Always reveal the executed test when `#testing.followRunningTest#` is on. If this setting is turned off, only failed tests will be revealed."
+		],
+		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
+			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled.",
+			"Test Output",
+			"Expected result",
+			"Actual result",
+			"Test output is only available for new test runs.",
+			"The test run did not record any output.",
+			"Close",
+			"Unnamed Task",
+			"+ {0} more lines",
+			"+ 1 more line",
+			"Test Result Messages",
+			"Show Result Output",
+			"Show Result Output",
+			"Rerun Test Run",
+			"Debug Test Run",
+			"Show Result Output",
+			"Reveal in Test Explorer",
+			"Run Test",
+			"Debug Test",
+			"Go to Source",
+			"Go to Source",
+			"Go to Next Test Failure",
+			"Go to Previous Test Failure",
+			"Open in Editor",
+			"Toggle Test History in Peek"
+		],
+		"vs/workbench/contrib/testing/common/testingContentProvider": [
+			"The test run did not record any output."
 		],
 		"vs/workbench/contrib/testing/common/testServiceImpl": [
 			"Running tests may execute code in your workspace.",
 			"An error occurred attempting to run tests: {0}",
 			"Running tests may execute code in your workspace.",
 			"An error occurred attempting to run tests: {0}"
-		],
-		"vs/workbench/contrib/testing/common/testingContentProvider": [
-			"The test run did not record any output."
 		],
 		"vs/workbench/contrib/testing/common/testingContextKeys": [
 			"Indicates whether any test controller has an attached refresh handler.",
@@ -24037,6 +24072,31 @@
 			"Boolean indicating whether the test item is hidden",
 			"Value set in `testMessage.contextValue`, available in editor/content and testing/message/context",
 			"Value available in editor/content and testing/message/context when the result is outdated"
+		],
+		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
+			"Pick a test profile to use",
+			"Update Test Configuration"
+		],
+		"vs/workbench/contrib/logs/common/logsActions": [
+			"Set Log Level...",
+			"All",
+			"Extension Logs",
+			"Logs",
+			"Set Log Level",
+			" {0}: Select log level",
+			"Select log level",
+			"Set as Default Log Level",
+			"Trace",
+			"Debug",
+			"Info",
+			"Warning",
+			"Error",
+			"Off",
+			"Default",
+			"Open Window Log File (Session)...",
+			"Current",
+			"Select Session",
+			"Select Log file"
 		],
 		"vs/workbench/contrib/testing/browser/testExplorerActions": [
 			"Hide Test",
@@ -24090,28 +24150,69 @@
 			"Refresh Tests",
 			"Cancel Test Refresh"
 		],
-		"vs/workbench/contrib/testing/browser/testingConfigurationUi": [
-			"Pick a test profile to use",
-			"Update Test Configuration"
+		"vs/editor/contrib/peekView/browser/peekView": [
+			"Whether the current code editor is embedded inside peek",
+			"Close",
+			"Background color of the peek view title area.",
+			"Color of the peek view title.",
+			"Color of the peek view title info.",
+			"Color of the peek view borders and arrow.",
+			"Background color of the peek view result list.",
+			"Foreground color for line nodes in the peek view result list.",
+			"Foreground color for file nodes in the peek view result list.",
+			"Background color of the selected entry in the peek view result list.",
+			"Foreground color of the selected entry in the peek view result list.",
+			"Background color of the peek view editor.",
+			"Background color of the gutter in the peek view editor.",
+			"Background color of sticky scroll in the peek view editor.",
+			"Match highlight color in the peek view result list.",
+			"Match highlight color in the peek view editor.",
+			"Match highlight border in the peek view editor."
 		],
-		"vs/workbench/contrib/files/browser/views/explorerView": [
-			"Explorer Section: {0}",
-			"New File...",
-			"New Folder...",
-			"Refresh Explorer",
-			"Collapse Folders in Explorer"
+		"vs/workbench/contrib/notebook/browser/notebookIcons": [
+			"Configure icon to select a kernel in notebook editors.",
+			"Icon to execute in notebook editors.",
+			"Icon to execute above cells in notebook editors.",
+			"Icon to execute below cells in notebook editors.",
+			"Icon to stop an execution in notebook editors.",
+			"Icon to delete a cell in notebook editors.",
+			"Icon to execute all cells in notebook editors.",
+			"Icon to edit a cell in notebook editors.",
+			"Icon to stop editing a cell in notebook editors.",
+			"Icon to move up a cell in notebook editors.",
+			"Icon to move down a cell in notebook editors.",
+			"Icon to clear cell outputs in notebook editors.",
+			"Icon to split a cell in notebook editors.",
+			"Icon to indicate a success state in notebook editors.",
+			"Icon to indicate an error state in notebook editors.",
+			"Icon to indicate a pending state in notebook editors.",
+			"Icon to indicate an executing state in notebook editors.",
+			"Icon to annotate a collapsed section in notebook editors.",
+			"Icon to annotate an expanded section in notebook editors.",
+			"Icon to open the notebook in a text editor.",
+			"Icon to revert in notebook editors.",
+			"Icon to render output in diff editor.",
+			"Icon for a mime type in notebook editors.",
+			"Icon to copy content to clipboard",
+			"Icon for the previous change action in the diff editor.",
+			"Icon for the next change action in the diff editor."
 		],
-		"vs/workbench/contrib/files/browser/views/emptyView": [
-			"No Folder Opened"
+		"vs/workbench/contrib/interactive/browser/interactiveEditor": [
+			"Type '{0}' code here and press {1} to run"
 		],
-		"vs/workbench/contrib/files/browser/views/openEditorsView": [
-			"Open Editors",
-			"{0} unsaved",
-			"Open Editors",
-			"Toggle Vertical/Horizontal Editor Layout",
-			"Flip Layout",
-			"Flip &&Layout",
-			"New Untitled Text File"
+		"vs/platform/quickinput/browser/helpQuickAccess": [
+			"{0}, {1}"
+		],
+		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
+			"No matching commands",
+			"Configure Keybinding",
+			"Ask {0}: {1}",
+			"{0}: {1}",
+			"Show All Commands",
+			"Clear Command History",
+			"Do you want to clear the history of recently used commands?",
+			"This action is irreversible!",
+			"&&Clear"
 		],
 		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
 			"No matching views",
@@ -24125,20 +24226,13 @@
 			"Open View",
 			"Quick Open View"
 		],
-		"vs/platform/quickinput/browser/helpQuickAccess": [
-			"{0}, {1}"
-		],
-		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
-			"No matching commands",
-			"Configure Keybinding",
-			"similar commands",
-			"Ask {0}: {1}",
-			"{0}: {1}",
-			"Show All Commands",
-			"Clear Command History",
-			"Do you want to clear the history of recently used commands?",
-			"This action is irreversible!",
-			"&&Clear"
+		"vs/workbench/contrib/files/browser/fileCommands": [
+			"{0} (in file) ↔ {1}",
+			"Failed to save '{0}': {1}",
+			"Retry",
+			"Discard",
+			"Failed to revert '{0}': {1}",
+			"Create File"
 		],
 		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
 			"Use the actions in the editor tool bar to either undo your changes or overwrite the content of the file with your changes.",
@@ -24244,26 +24338,27 @@
 			"Toggle Active Editor Read-only in Session",
 			"Reset Active Editor Read-only in Session"
 		],
-		"vs/workbench/contrib/files/browser/fileCommands": [
-			"{0} (in file) ↔ {1}",
-			"Failed to save '{0}': {1}",
-			"Retry",
-			"Discard",
-			"Failed to revert '{0}': {1}",
-			"Create File"
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"No Folder Opened"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerView": [
+			"Explorer Section: {0}",
+			"New File...",
+			"New Folder...",
+			"Refresh Explorer",
+			"Collapse Folders in Explorer"
+		],
+		"vs/workbench/contrib/files/browser/views/openEditorsView": [
+			"Open Editors",
+			"{0} unsaved",
+			"Open Editors",
+			"Toggle Vertical/Horizontal Editor Layout",
+			"Flip Layout",
+			"Flip &&Layout",
+			"New Untitled Text File"
 		],
 		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
 			"Binary File Viewer"
-		],
-		"vs/workbench/contrib/files/browser/workspaceWatcher": [
-			"Unable to watch for file changes in this large workspace folder. Please follow the instructions link to resolve this issue.",
-			"Instructions",
-			"File changes watcher stopped unexpectedly. A reload of the window may enable the watcher again unless the workspace cannot be watched for file changes.",
-			"Reload"
-		],
-		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
-			"1 unsaved file",
-			"{0} unsaved files"
 		],
 		"vs/editor/common/config/editorConfigurationSchema": [
 			"Editor",
@@ -24307,13 +24402,22 @@
 			"Lines will wrap according to the {0} setting.",
 			"Uses the legacy diffing algorithm.",
 			"Uses the advanced diffing algorithm.",
-			"Controls whether the diff editor shows unchanged regions. Only works when {0} is set.",
-			"Controls how many lines are used for unchanged regions. Only works when {0} is set.",
-			"Controls how many lines are used as a minimum for unchanged regions. Only works when {0} is set.",
-			"Controls how many lines are used as context when comparing unchanged regions. Only works when {0} is set.",
-			"Controls whether the diff editor should show detected code moves. Only works when {0} is set.",
-			"Controls whether the diff editor uses the new or the old implementation.",
+			"Controls whether the diff editor shows unchanged regions.",
+			"Controls how many lines are used for unchanged regions.",
+			"Controls how many lines are used as a minimum for unchanged regions.",
+			"Controls how many lines are used as context when comparing unchanged regions.",
+			"Controls whether the diff editor should show detected code moves.",
 			"Controls whether the diff editor shows empty decorations to see where characters got inserted or deleted."
+		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"1 unsaved file",
+			"{0} unsaved files"
+		],
+		"vs/workbench/contrib/files/browser/workspaceWatcher": [
+			"Unable to watch for file changes in this large workspace folder. Please follow the instructions link to resolve this issue.",
+			"Instructions",
+			"File changes watcher stopped unexpectedly. A reload of the window may enable the watcher again unless the workspace cannot be watched for file changes.",
+			"Reload"
 		],
 		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
 			"Text File Editor",
@@ -24325,32 +24429,23 @@
 			"The editor could not be opened because the file was not found.",
 			"Create File"
 		],
-		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
-			"Open a text editor first to go to a line.",
-			"Go to line {0} and character {1}.",
-			"Go to line {0}.",
-			"Current Line: {0}, Character: {1}. Type a line number between 1 and {2} to navigate to.",
-			"Current Line: {0}, Character: {1}. Type a line number to navigate to."
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
+			"Apply",
+			"Discard",
+			"Invoke a code action, like rename, to see a preview of its changes here.",
+			"Cannot apply refactoring because '{0}' has changed in the meantime.",
+			"Cannot apply refactoring because {0} other files have changed in the meantime.",
+			"{0} (delete, refactor preview)",
+			"rename",
+			"create",
+			"{0} ({1}, refactor preview)",
+			"{0} (refactor preview)"
 		],
-		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
-			"No matching results",
-			"recently opened",
-			"file and symbol results",
-			"file results",
-			"{0}, {1}",
-			"Open Quick Chat",
-			"Open to the Side",
-			"Open to the Bottom",
-			"Remove from Recently Opened",
-			"{0} unsaved changes"
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
+			"Other"
 		],
-		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
-			"No matching entries",
-			"Go to Symbol in Editor...",
-			"Go to &&Symbol in Editor...",
-			"Type the name of a symbol to go to.",
-			"Go to Symbol in Editor",
-			"Go to Symbol in Editor by Category"
+		"vs/workbench/contrib/search/browser/searchActionsBase": [
+			"Search"
 		],
 		"vs/workbench/contrib/search/browser/searchIcons": [
 			"Icon to make search details visible.",
@@ -24371,10 +24466,58 @@
 			"Icon for the action to open a new search editor.",
 			"Icon for the action to go to the file of the current search result."
 		],
-		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
-			"No matching workspace symbols",
-			"Open to the Side",
-			"Open to the Bottom"
+		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
+			"Toggle Search Details",
+			"files to include",
+			"Search Include Patterns",
+			"files to exclude",
+			"Search Exclude Patterns",
+			"Run Search",
+			"Matched {0} at {1} in file {2}",
+			"Search",
+			"Search editor text input box border."
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
+			"Search: {0}",
+			"Search: {0}",
+			"Search"
+		],
+		"vs/workbench/contrib/search/browser/patternInputWidget": [
+			"input",
+			"Search only in Open Editors",
+			"Use Exclude Settings and Ignore Files"
+		],
+		"vs/workbench/contrib/search/browser/searchMessage": [
+			"Unable to open command link from untrusted source: {0}",
+			"Unable to open unknown link: {0}"
+		],
+		"vs/workbench/browser/parts/views/viewPane": [
+			"Icon for an expanded view pane container.",
+			"Icon for a collapsed view pane container.",
+			"{0} actions"
+		],
+		"vs/workbench/contrib/search/browser/searchResultsView": [
+			"Other files",
+			"Other files",
+			"{0} files found",
+			"{0} file found",
+			"{0} matches found",
+			"{0} match found",
+			"From line {0}",
+			"{0} more lines",
+			"Search",
+			"{0} matches in folder root {1}, Search result",
+			"{0} matches outside of the workspace, Search result",
+			"{0} matches in file {1} of folder {2}, Search result",
+			"'{0}' at column {1} replace {2} with {3}",
+			"'{0}' at column {1} found {2}"
+		],
+		"vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess": [
+			"Open a text editor first to go to a line.",
+			"Go to line {0} and character {1}.",
+			"Go to line {0}.",
+			"Current Line: {0}, Character: {1}. Type a line number between 1 and {2} to navigate to.",
+			"Current Line: {0}, Character: {1}. Type a line number to navigate to."
 		],
 		"vs/workbench/contrib/search/browser/searchWidget": [
 			"Replace All (Submit Search to Enable)",
@@ -24385,6 +24528,34 @@
 			"Toggle Context Lines",
 			"Replace: Type replace term and press Enter to preview",
 			"Replace"
+		],
+		"vs/workbench/services/search/common/queryBuilder": [
+			"Workspace folder does not exist: {0}"
+		],
+		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
+			"No matching entries",
+			"Go to Symbol in Editor...",
+			"Go to &&Symbol in Editor...",
+			"Type the name of a symbol to go to.",
+			"Go to Symbol in Editor",
+			"Go to Symbol in Editor by Category"
+		],
+		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
+			"No matching workspace symbols",
+			"Open to the Side",
+			"Open to the Bottom"
+		],
+		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
+			"No matching results",
+			"recently opened",
+			"file and symbol results",
+			"file results",
+			"{0}, {1}",
+			"Open Quick Chat",
+			"Open to the Side",
+			"Open to the Bottom",
+			"Remove from Recently Opened",
+			"{0} unsaved changes"
 		],
 		"vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess": [
 			"See More Files",
@@ -24407,12 +24578,6 @@
 			"Find in Folder...",
 			"Find in Workspace..."
 		],
-		"vs/workbench/contrib/search/browser/searchActionsRemoveReplace": [
-			"Dismiss",
-			"Replace",
-			"Replace All",
-			"Replace All"
-		],
 		"vs/workbench/contrib/search/browser/searchActionsNav": [
 			"Toggle Query Details",
 			"Close Replace Widget",
@@ -24432,6 +24597,17 @@
 			"Focus Previous Search Result",
 			"Replace in Files"
 		],
+		"vs/workbench/contrib/search/browser/searchActionsRemoveReplace": [
+			"Dismiss",
+			"Replace",
+			"Replace All",
+			"Replace All"
+		],
+		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
+			"Go to Symbol in Workspace...",
+			"Go to Symbol in Workspace...",
+			"Go to Symbol in &&Workspace..."
+		],
 		"vs/workbench/contrib/search/browser/searchActionsTopBar": [
 			"Clear Search History",
 			"Cancel Search",
@@ -24442,134 +24618,77 @@
 			"View as Tree",
 			"View as List"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsSymbol": [
-			"Go to Symbol in Workspace...",
-			"Go to Symbol in Workspace...",
-			"Go to Symbol in &&Workspace..."
-		],
 		"vs/workbench/contrib/search/browser/searchActionsTextQuickAccess": [
 			"Quick Text Search (Experimental)"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
-			"Apply",
-			"Discard",
-			"Invoke a code action, like rename, to see a preview of its changes here.",
-			"Cannot apply refactoring because '{0}' has changed in the meantime.",
-			"Cannot apply refactoring because {0} other files have changed in the meantime.",
-			"{0} (delete, refactor preview)",
-			"rename",
-			"create",
-			"{0} ({1}, refactor preview)",
-			"{0} (refactor preview)"
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"Debug toolbar background color.",
+			"Debug toolbar border color.",
+			"Debug toolbar icon for start debugging.",
+			"Debug toolbar icon for pause.",
+			"Debug toolbar icon for stop.",
+			"Debug toolbar icon for disconnect.",
+			"Debug toolbar icon for restart.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for step into.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for continue.",
+			"Debug toolbar icon for step back."
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
-			"Other"
+		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
+			"Start a New Debug Session"
 		],
-		"vs/workbench/contrib/search/browser/searchActionsBase": [
-			"Search"
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			"Running",
+			"Show More Stack Frames",
+			"Session",
+			"Running",
+			"Restart Frame",
+			"Load More Stack Frames",
+			"Show {0} More: {1}",
+			"Show {0} More Stack Frames",
+			"Paused on {0}",
+			"Paused",
+			"Debug Call Stack",
+			"Thread {0} {1}",
+			"Stack Frame {0}, line {1}, {2}",
+			"Running",
+			"Session {0} {1}",
+			"Show {0} More Stack Frames",
+			"Collapse All"
 		],
-		"vs/workbench/browser/parts/views/viewPane": [
-			"Icon for an expanded view pane container.",
-			"Icon for a collapsed view pane container.",
-			"{0} actions"
-		],
-		"vs/workbench/contrib/search/browser/searchMessage": [
-			"Unable to open command link from untrusted source: {0}",
-			"Unable to open unknown link: {0}"
-		],
-		"vs/workbench/contrib/search/browser/patternInputWidget": [
-			"input",
-			"Search only in Open Editors",
-			"Use Exclude Settings and Ignore Files"
-		],
-		"vs/workbench/services/search/common/queryBuilder": [
-			"Workspace folder does not exist: {0}"
-		],
-		"vs/workbench/contrib/search/browser/searchResultsView": [
-			"Other files",
-			"Other files",
-			"{0} files found",
-			"{0} file found",
-			"{0} matches found",
-			"{0} match found",
-			"From line {0}",
-			"{0} more lines",
-			"Search",
-			"{0} matches in folder root {1}, Search result",
-			"{0} matches outside of the workspace, Search result",
-			"{0} matches in file {1} of folder {2}, Search result",
-			"'{0}' at column {1} replace {2} with {3}",
-			"'{0}' at column {1} found {2}"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
-			"Toggle Search Details",
-			"files to include",
-			"Search Include Patterns",
-			"files to exclude",
-			"Search Exclude Patterns",
-			"Run Search",
-			"Matched {0} at {1} in file {2}",
-			"Search",
-			"Search editor text input box border."
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
-			"Search: {0}",
-			"Search: {0}",
-			"Search"
-		],
-		"vs/workbench/contrib/scm/browser/activity": [
-			"Source Control",
-			"{0} pending changes"
-		],
-		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
-			"Source Control"
-		],
-		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
-			"{0} - {1} of {2} changes",
-			"{0} - {1} of {2} change",
-			"{0} of {1} changes",
-			"{0} of {1} change",
-			"Close",
-			"Show Previous Change",
-			"Show Next Change",
-			"Next &&Change",
-			"Previous &&Change",
-			"Go to Previous Change",
-			"Go to Next Change",
-			"Editor gutter background color for lines that are modified.",
-			"Editor gutter background color for lines that are added.",
-			"Editor gutter background color for lines that are deleted.",
-			"Minimap gutter background color for lines that are modified.",
-			"Minimap gutter background color for lines that are added.",
-			"Minimap gutter background color for lines that are deleted.",
-			"Overview ruler marker color for modified content.",
-			"Overview ruler marker color for added content.",
-			"Overview ruler marker color for deleted content."
-		],
-		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
-			"Source Control Repositories"
-		],
-		"vs/workbench/contrib/workspace/common/workspace": [
-			"Whether the workspace trust feature is enabled.",
-			"Whether the current workspace has been trusted by the user."
-		],
-		"vs/workbench/contrib/scm/browser/scmViewPane": [
-			"Source Control Management",
-			"Source Control Input",
-			"View & Sort",
-			"Repositories",
-			"View as List",
-			"View as Tree",
-			"Sort by Discovery Time",
-			"Sort by Name",
-			"Sort by Path",
-			"Sort Changes by Name",
-			"Sort Changes by Path",
-			"Sort Changes by Status",
-			"Collapse All Repositories",
-			"Expand All Repositories",
-			"Close",
-			"SCM Provider separator border."
+		"vs/workbench/contrib/debug/browser/debugCommands": [
+			"Debug",
+			"Restart",
+			"Step Over",
+			"Step Into",
+			"Step Into Target",
+			"Step Out",
+			"Pause",
+			"Disconnect",
+			"Disconnect and Suspend",
+			"Stop",
+			"Continue",
+			"Focus Session",
+			"Select and Start Debugging",
+			"Open '{0}'",
+			"Start Debugging",
+			"Start Without Debugging",
+			"Focus Next Debug Console",
+			"Focus Previous Debug Console",
+			"Open Loaded Script...",
+			"Navigate to Top of Call Stack",
+			"Navigate to Bottom of Call Stack",
+			"Navigate Up Call Stack",
+			"Navigate Down Call Stack",
+			"Select Debug Console",
+			"Select Debug Session",
+			"Choose the specific location",
+			"No executable code is associated at the current cursor position.",
+			"Jump to Cursor",
+			"No step targets available",
+			"Add Configuration...",
+			"Add Inline Breakpoint"
 		],
 		"vs/workbench/contrib/debug/browser/breakpointsView": [
 			"Unverified Exception Breakpoint",
@@ -24624,42 +24743,6 @@
 			"Edit Hit Count...",
 			"Edit Function Breakpoint...",
 			"Edit Hit Count..."
-		],
-		"vs/workbench/contrib/debug/browser/debugColors": [
-			"Debug toolbar background color.",
-			"Debug toolbar border color.",
-			"Debug toolbar icon for start debugging.",
-			"Debug toolbar icon for pause.",
-			"Debug toolbar icon for stop.",
-			"Debug toolbar icon for disconnect.",
-			"Debug toolbar icon for restart.",
-			"Debug toolbar icon for step over.",
-			"Debug toolbar icon for step into.",
-			"Debug toolbar icon for step over.",
-			"Debug toolbar icon for continue.",
-			"Debug toolbar icon for step back."
-		],
-		"vs/workbench/contrib/debug/browser/callStackView": [
-			"Running",
-			"Show More Stack Frames",
-			"Session",
-			"Running",
-			"Restart Frame",
-			"Load More Stack Frames",
-			"Show {0} More: {1}",
-			"Show {0} More Stack Frames",
-			"Paused on {0}",
-			"Paused",
-			"Debug Call Stack",
-			"Thread {0} {1}",
-			"Stack Frame {0}, line {1}, {2}",
-			"Running",
-			"Session {0} {1}",
-			"Show {0} More Stack Frames",
-			"Collapse All"
-		],
-		"vs/workbench/contrib/debug/browser/debugConsoleQuickAccess": [
-			"Start a New Debug Session"
 		],
 		"vs/workbench/contrib/debug/browser/debugIcons": [
 			"View icon of the debug console view.",
@@ -24718,39 +24801,6 @@
 			"Icon for the debug evaluation prompt.",
 			"Icon for the inspect memory action."
 		],
-		"vs/workbench/contrib/debug/browser/debugCommands": [
-			"Debug",
-			"Restart",
-			"Step Over",
-			"Step Into",
-			"Step Into Target",
-			"Step Out",
-			"Pause",
-			"Disconnect",
-			"Disconnect and Suspend",
-			"Stop",
-			"Continue",
-			"Focus Session",
-			"Select and Start Debugging",
-			"Open '{0}'",
-			"Start Debugging",
-			"Start Without Debugging",
-			"Focus Next Debug Console",
-			"Focus Previous Debug Console",
-			"Open Loaded Script...",
-			"Navigate to Top of Call Stack",
-			"Navigate to Bottom of Call Stack",
-			"Navigate Up Call Stack",
-			"Navigate Down Call Stack",
-			"Select Debug Console",
-			"Select Debug Session",
-			"Choose the specific location",
-			"No executable code is associated at the current cursor position.",
-			"Jump to Cursor",
-			"No step targets available",
-			"Add Configuration...",
-			"Add Inline Breakpoint"
-		],
 		"vs/workbench/contrib/debug/browser/debugEditorActions": [
 			"Debug: Toggle Breakpoint",
 			"Toggle &&Breakpoint",
@@ -24773,16 +24823,6 @@
 			"Debug: Go to Next Breakpoint",
 			"Debug: Go to Previous Breakpoint",
 			"Close Exception Widget"
-		],
-		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
-			"No matching launch configurations",
-			"Configure Launch Configuration",
-			"contributed",
-			"Remove Launch Configuration",
-			"{0} contributed configurations",
-			"configure",
-			"Add Config ({0})...",
-			"Add Configuration..."
 		],
 		"vs/workbench/contrib/debug/browser/debugService": [
 			"1 active session",
@@ -24807,15 +24847,34 @@
 			"Added breakpoint, line {0}, file {1}",
 			"Removed breakpoint, line {0}, file {1}"
 		],
-		"vs/workbench/contrib/debug/browser/debugStatus": [
-			"Debug",
-			"Debug: {0}",
-			"Select and start debug configuration"
+		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
+			"No matching launch configurations",
+			"Configure Launch Configuration",
+			"contributed",
+			"Remove Launch Configuration",
+			"{0} contributed configurations",
+			"configure",
+			"Add Config ({0})...",
+			"Add Configuration..."
 		],
 		"vs/workbench/contrib/debug/browser/debugToolBar": [
 			"More...",
 			"Step Back",
 			"Reverse"
+		],
+		"vs/workbench/contrib/debug/browser/debugStatus": [
+			"Debug",
+			"Debug: {0}",
+			"Select and start debug configuration"
+		],
+		"vs/workbench/contrib/debug/browser/disassemblyView": [
+			"Disassembly not available.",
+			"instructions",
+			"from disassembly",
+			"Disassembly View",
+			"Address",
+			"Bytes",
+			"Instruction"
 		],
 		"vs/workbench/contrib/debug/browser/loadedScriptsView": [
 			"Debug Session",
@@ -24828,16 +24887,19 @@
 		"vs/workbench/contrib/debug/browser/statusbarColorProvider": [
 			"Status bar background color when a program is being debugged. The status bar is shown in the bottom of the window",
 			"Status bar foreground color when a program is being debugged. The status bar is shown in the bottom of the window",
-			"Status bar border color separating to the sidebar and editor when a program is being debugged. The status bar is shown in the bottom of the window"
+			"Status bar border color separating to the sidebar and editor when a program is being debugged. The status bar is shown in the bottom of the window",
+			"Command center background color when a program is being debugged"
 		],
-		"vs/workbench/contrib/debug/browser/disassemblyView": [
-			"Disassembly not available.",
-			"instructions",
-			"from disassembly",
-			"Disassembly View",
-			"Address",
-			"Bytes",
-			"Instruction"
+		"vs/workbench/contrib/debug/browser/variablesView": [
+			"Type new variable value",
+			"Debug Variables",
+			"Scope {0}",
+			"{0}, value {1}",
+			"Inspecting binary data requires the Hex Editor extension. Would you like to install it now?",
+			"Cancel",
+			"Install",
+			"Installing the Hex Editor...",
+			"Collapse All"
 		],
 		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
 			"Type new value",
@@ -24859,29 +24921,18 @@
 			"To customize Run and Debug, [open a folder](command:{0}) and create a launch.json file.",
 			"All debug extensions are disabled. Enable a debug extension or install a new one from the Marketplace."
 		],
-		"vs/workbench/contrib/debug/browser/variablesView": [
-			"Type new variable value",
-			"Debug Variables",
-			"Scope {0}",
-			"{0}, value {1}",
-			"Inspecting binary data requires the Hex Editor extension. Would you like to install it now?",
-			"Cancel",
-			"Install",
-			"Installing the Hex Editor...",
-			"Collapse All"
-		],
 		"vs/workbench/contrib/debug/common/debugContentProvider": [
 			"Unable to resolve the resource without a debug session",
 			"Could not load source '{0}': {1}.",
 			"Could not load source '{0}'."
 		],
+		"vs/workbench/contrib/debug/common/disassemblyViewInput": [
+			"Disassembly"
+		],
 		"vs/workbench/contrib/debug/common/debugLifecycle": [
 			"There is an active debug session, are you sure you want to stop it?",
 			"There are active debug sessions, are you sure you want to stop them?",
 			"&&Stop Debugging"
-		],
-		"vs/workbench/contrib/debug/common/disassemblyViewInput": [
-			"Disassembly"
 		],
 		"vs/workbench/contrib/debug/browser/breakpointWidget": [
 			"Message to log when breakpoint is hit. Expressions within {} are interpolated. '{0}' to accept, '{1}' to cancel.",
@@ -24892,10 +24943,67 @@
 			"Log Message",
 			"Breakpoint Type"
 		],
-		"vs/workbench/contrib/debug/browser/debugHover": [
-			"Hold {0} key to switch to editor language hover",
-			"Debug Hover",
-			"{0}, value {1}, variables, debug"
+		"vs/workbench/contrib/scm/browser/activity": [
+			"Source Control",
+			"{0} pending changes"
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
+			"Source Control"
+		],
+		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
+			"{0} - {1} of {2} changes",
+			"{0} - {1} of {2} change",
+			"{0} of {1} changes",
+			"{0} of {1} change",
+			"Close",
+			"Show Previous Change",
+			"Show Next Change",
+			"Next &&Change",
+			"Previous &&Change",
+			"Go to Previous Change",
+			"Go to Next Change",
+			"Editor gutter background color for lines that are modified.",
+			"Editor gutter background color for lines that are added.",
+			"Editor gutter background color for lines that are deleted.",
+			"Minimap gutter background color for lines that are modified.",
+			"Minimap gutter background color for lines that are added.",
+			"Minimap gutter background color for lines that are deleted.",
+			"Overview ruler marker color for modified content.",
+			"Overview ruler marker color for added content.",
+			"Overview ruler marker color for deleted content."
+		],
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"Source Control Repositories"
+		],
+		"vs/workbench/contrib/workspace/common/workspace": [
+			"Whether the workspace trust feature is enabled.",
+			"Whether the current workspace has been trusted by the user."
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPane": [
+			"Source Control Management",
+			"Source Control Input",
+			"View & Sort",
+			"Repositories",
+			"View as List",
+			"View as Tree",
+			"Sort by Discovery Time",
+			"Sort by Name",
+			"Sort by Path",
+			"Sort Changes by Name",
+			"Sort Changes by Path",
+			"Sort Changes by Status",
+			"Collapse All Repositories",
+			"Expand All Repositories",
+			"Close",
+			"SCM Provider separator border."
+		],
+		"vs/workbench/contrib/scm/browser/scmSyncViewPane": [
+			"Source Control Sync",
+			"Incoming Changes",
+			"Outgoing Changes",
+			"Refresh",
+			"View as List",
+			"View as Tree"
 		],
 		"vs/workbench/contrib/debug/browser/exceptionWidget": [
 			"Exception widget border color.",
@@ -24903,6 +25011,11 @@
 			"Exception has occurred: {0}",
 			"Exception has occurred.",
 			"Close"
+		],
+		"vs/workbench/contrib/debug/browser/debugHover": [
+			"Hold {0} key to switch to editor language hover",
+			"Debug Hover",
+			"{0}, value {1}, variables, debug"
 		],
 		"vs/workbench/contrib/debug/common/debugModel": [
 			"Invalid variable attributes",
@@ -24913,6 +25026,9 @@
 			"Running",
 			"Unverified breakpoint. File is modified, please restart debug session."
 		],
+		"vs/platform/history/browser/contextScopedHistoryWidget": [
+			"Whether suggestion are visible"
+		],
 		"vs/workbench/contrib/debug/browser/debugActionViewItems": [
 			"Debug Launch Configurations",
 			"No Configurations",
@@ -24920,8 +25036,10 @@
 			"Add Configuration...",
 			"Debug Session"
 		],
-		"vs/platform/history/browser/contextScopedHistoryWidget": [
-			"Whether suggestion are visible"
+		"vs/platform/actions/browser/menuEntryActionViewItem": [
+			"{0} ({1})",
+			"{0} ({1})",
+			"{0}\n[{1}] {2}"
 		],
 		"vs/workbench/contrib/debug/browser/linkDetector": [
 			"follow link using forwarded port",
@@ -24931,6 +25049,9 @@
 			"Cmd + click to {0}",
 			"Ctrl + click to {0}"
 		],
+		"vs/workbench/contrib/debug/common/replModel": [
+			"Console was cleared"
+		],
 		"vs/workbench/contrib/debug/browser/replViewer": [
 			"Debug Console",
 			"Variable {0}, value {1}",
@@ -24938,8 +25059,11 @@
 			"Debug console variable {0}, value {1}",
 			"Debug console group {0}"
 		],
-		"vs/workbench/contrib/debug/common/replModel": [
-			"Console was cleared"
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"Showing {0} of {1}",
+			"Showing {0} problems",
+			"Showing {0} of {1} problems",
+			"Clear Filters"
 		],
 		"vs/workbench/contrib/markers/browser/messages": [
 			"Toggle Problems (Errors, Warnings, Infos)",
@@ -24990,18 +25114,6 @@
 			"{0} at line {1} and character {2} in {3}",
 			"Show Errors and Warnings"
 		],
-		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
-			"Problems",
-			"1 problem in this file",
-			"{0} problems in this file",
-			"Show Errors & Warnings on files and folder."
-		],
-		"vs/workbench/contrib/markers/browser/markersView": [
-			"Showing {0} of {1}",
-			"Showing {0} problems",
-			"Showing {0} of {1} problems",
-			"Clear Filters"
-		],
 		"vs/workbench/browser/parts/views/viewFilter": [
 			"More Filters..."
 		],
@@ -25034,6 +25146,12 @@
 			"The file contains unhandled conflicts.",
 			"&&Complete with Conflicts"
 		],
+		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
+			"Problems",
+			"1 problem in this file",
+			"{0} problems in this file",
+			"Show Errors & Warnings on files and folder."
+		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInput": [
 			"Merging: {0}"
 		],
@@ -25056,17 +25174,16 @@
 		"vs/workbench/contrib/mergeEditor/browser/view/mergeEditor": [
 			"Text Merge Editor"
 		],
-		"vs/workbench/contrib/comments/browser/commentService": [
-			"Whether the open workspace has either comments or commenting ranges."
-		],
-		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
-			"Go to Next Comment Thread",
-			"Go to Previous Comment Thread",
-			"Toggle Editor Commenting",
-			"Add Comment on Current Selection",
-			"Collapse All Comments",
-			"Expand All Comments",
-			"Expand Unresolved Comments"
+		"vs/workbench/contrib/comments/common/commentContextKeys": [
+			"Whether the position at the active cursor has a commenting range",
+			"Whether the active editor has a commenting range",
+			"Whether the open workspace has either comments or commenting ranges.",
+			"Set when the comment thread has no comments",
+			"Set when the comment has no input",
+			"The context value of the comment",
+			"The context value of the comment thread",
+			"The comment controller id associated with a comment thread",
+			"Set when the comment is focused"
 		],
 		"vs/workbench/contrib/url/browser/trustedDomains": [
 			"Manage Trusted Domains",
@@ -25075,6 +25192,16 @@
 			"Trust {0} and all its subdomains",
 			"Trust all domains (disables link protection)",
 			"Manage Trusted Domains"
+		],
+		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
+			"Go to Next Commenting Range",
+			"Go to Previous Commenting Range",
+			"Toggle Editor Commenting",
+			"The cursor must be within a commenting range to add a comment",
+			"Add Comment on Current Selection",
+			"Collapse All Comments",
+			"Expand All Comments",
+			"Expand Unresolved Comments"
 		],
 		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
 			"Do you want {0} to open the external website?",
@@ -25089,11 +25216,8 @@
 			"Find previous",
 			"Reload Webviews"
 		],
-		"vs/workbench/contrib/externalUriOpener/common/configuration": [
-			"Configure the opener to use for external URIs (http, https).",
-			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
-			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
-			"Open using VS Code's standard opener."
+		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
+			"The viewType of the currently active webview panel."
 		],
 		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
 			"Open in new browser window",
@@ -25101,24 +25225,154 @@
 			"Configure default opener...",
 			"How would you like to open: {0}"
 		],
+		"vs/workbench/contrib/externalUriOpener/common/configuration": [
+			"Configure the opener to use for external URIs (http, https).",
+			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
+			"Map URI pattern to an opener id.\nExample patterns: \n{0}",
+			"Open using VS Code's standard opener."
+		],
 		"vs/workbench/contrib/customEditor/common/customEditor": [
 			"The viewType of the currently active custom editor."
 		],
 		"vs/workbench/contrib/extensions/common/extensionsInput": [
 			"Extension: {0}"
 		],
-		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
+			"Yes",
+			"No"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionEditor": [
+			"Extension Version",
+			"Pre-Release",
+			"Extension name",
+			"Preview",
+			"Preview",
+			"Built-in",
+			"Publisher",
+			"Install count",
+			"Rating",
+			"Details",
+			"Extension details, rendered from the extension's 'README.md' file",
+			"Feature Contributions",
+			"Lists contributions to VS Code by this extension",
+			"Changelog",
+			"Extension update history, rendered from the extension's 'CHANGELOG.md' file",
+			"Dependencies",
+			"Lists extensions this extension depends on",
+			"Extension Pack",
+			"Lists extensions those will be installed together with this extension",
+			"Runtime Status",
+			"Extension runtime status",
+			"No README available.",
+			"Readme",
+			"Extension Pack ({0})",
+			"No README available.",
+			"Readme",
+			"Categories",
+			"Marketplace",
+			"Repository",
+			"License",
+			"Extension Resources",
+			"More Info",
+			"Published",
+			"Last released",
+			"Last updated",
+			"Identifier",
+			"No Changelog available.",
+			"Changelog",
+			"No Contributions",
+			"No Contributions",
+			"No Dependencies",
+			"Activation Event:",
+			"Startup",
+			"Activation Time:",
+			"Activated By:",
+			"Not yet activated.",
+			"Uncaught Errors ({0})",
+			"Messages ({0})",
+			"No status available.",
+			"Settings ({0})",
+			"ID",
+			"Description",
+			"Default",
+			"Debuggers ({0})",
+			"Name",
+			"Type",
+			"View Containers ({0})",
+			"ID",
+			"Title",
+			"Where",
+			"Views ({0})",
+			"ID",
+			"Name",
+			"Where",
+			"Localizations ({0})",
+			"Language ID",
+			"Language Name",
+			"Language Name (Localized)",
+			"Custom Editors ({0})",
+			"View Type",
+			"Priority",
+			"Filename Pattern",
+			"Code Actions ({0})",
+			"Title",
+			"Kind",
+			"Description",
+			"Languages",
+			"Authentication ({0})",
+			"Label",
+			"ID",
+			"Color Themes ({0})",
+			"File Icon Themes ({0})",
+			"Product Icon Themes ({0})",
+			"Colors ({0})",
+			"ID",
+			"Description",
+			"Dark Default",
+			"Light Default",
+			"High Contrast Default",
+			"JSON Validation ({0})",
+			"File Match",
+			"Schema",
+			"Commands ({0})",
+			"ID",
+			"Title",
+			"Keyboard Shortcuts",
+			"Menu Contexts",
+			"Languages ({0})",
+			"ID",
+			"Name",
+			"File Extensions",
+			"Grammar",
+			"Snippets",
+			"Activation Events ({0})",
+			"Notebooks ({0})",
+			"ID",
+			"Name",
+			"Notebook Renderers ({0})",
+			"Name",
+			"Mimetypes",
+			"Find",
+			"Find Next",
+			"Find Previous"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
 			"Extensions",
-			"Unable to search the Marketplace when offline, please check your network connection.",
-			"Error while fetching extensions. {0}",
-			"No extensions found.",
-			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
-			"Open User Settings",
-			"There are no extensions to install.",
-			"Verified Publisher {0}",
-			"Publisher {0}",
-			"Deprecated",
-			"Rated {0} out of 5 stars by {1} users"
+			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
+			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"Activating Extensions..."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"Extensions",
+			"Install Missing Dependencies",
+			"Finished installing missing dependencies. Please reload the window now.",
+			"Reload Window",
+			"There are no missing dependencies to install."
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"{0} for the Web",
@@ -25252,9 +25506,9 @@
 			"This extension is enabled in the Web Worker Extension Host because it prefers to run there.",
 			"Learn More",
 			"This extension has been disabled because it depends on an extension that is disabled.",
+			"This extension is enabled for this workspace by the user.",
 			"Extension is enabled on '{0}'",
 			"This extension is enabled globally.",
-			"This extension is enabled for this workspace by the user.",
 			"This extension is disabled globally by the user.",
 			"This extension is disabled for this workspace by the user.",
 			"Reinstall Extension...",
@@ -25279,6 +25533,53 @@
 			"Button background color for extension actions that stand out (e.g. install button).",
 			"Button foreground color for extension actions that stand out (e.g. install button).",
 			"Button background hover color for extension actions that stand out (e.g. install button)."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"Type an extension name to install or search.",
+			"Press Enter to search for extension '{0}'.",
+			"Press Enter to install extension '{0}'.",
+			"Press Enter to manage your extensions."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
+			"Don't Show Again",
+			"Do you want to ignore all extension recommendations?",
+			"Yes, Ignore All",
+			"No",
+			"this repository",
+			"'{0}' extension from {1}",
+			"extensions from {0}, {1} and others",
+			"extensions from {0} and {1}",
+			"extensions from {0}",
+			"Do you want to install the recommended {0} for {1}?",
+			"You have {0} installed on your system. Do you want to install the recommended {1} for it?",
+			"Install",
+			"Install (Do not sync)",
+			"Show Recommendations"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
+			"Restarting extension host due to workspace trust change."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
+			"Manifest is not found",
+			"Please reload Visual Studio Code to complete the uninstallation of this extension.",
+			"Please reload Visual Studio Code to enable the updated extension.",
+			"Please reload Visual Studio Code to enable this extension locally.",
+			"Please reload Visual Studio Code to enable this extension in {0}.",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Please reload Visual Studio Code to disable this extension.",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Please reload Visual Studio Code to enable this extension.",
+			"This extension is reported to be problematic.",
+			"Can't install '{0}' extension because it is not compatible.",
+			"Uninstalling extension....",
+			"Unable to install extension '{0}' because the requested version '{1}' is not found.",
+			"Installing extension....",
+			"Installing '{0}' extension....",
+			"Disable All",
+			"Cannot disable '{0}' extension alone. '{1}' extension depends on this. Do you want to disable all these extensions?",
+			"Cannot disable '{0}' extension alone. '{1}' and '{2}' extensions depend on this. Do you want to disable all these extensions?",
+			"Cannot disable '{0}' extension alone. '{1}', '{2}' and other extensions depend on this. Do you want to disable all these extensions?"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
 			"View icon of the extensions view.",
@@ -25306,196 +25607,6 @@
 			"Icon shown with a workspace trust message in the extension editor.",
 			"Icon shown with a activation time message in the extension editor."
 		],
-		"vs/platform/dnd/browser/dnd": [
-			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
-		],
-		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
-			"Extensions",
-			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
-			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
-			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
-			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
-		],
-		"vs/workbench/contrib/extensions/common/extensionsUtils": [
-			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
-			"Yes",
-			"No"
-		],
-		"vs/workbench/contrib/webviewPanel/browser/webviewEditor": [
-			"The viewType of the currently active webview panel."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
-			"Activating Extensions..."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionEditor": [
-			"Extension Version",
-			"Pre-Release",
-			"Extension name",
-			"Preview",
-			"Preview",
-			"Built-in",
-			"Publisher",
-			"Install count",
-			"Rating",
-			"Details",
-			"Extension details, rendered from the extension's 'README.md' file",
-			"Feature Contributions",
-			"Lists contributions to VS Code by this extension",
-			"Changelog",
-			"Extension update history, rendered from the extension's 'CHANGELOG.md' file",
-			"Dependencies",
-			"Lists extensions this extension depends on",
-			"Extension Pack",
-			"Lists extensions those will be installed together with this extension",
-			"Runtime Status",
-			"Extension runtime status",
-			"No README available.",
-			"Readme",
-			"Extension Pack ({0})",
-			"No README available.",
-			"Readme",
-			"Categories",
-			"Marketplace",
-			"Repository",
-			"License",
-			"Extension Resources",
-			"More Info",
-			"Published",
-			"Last released",
-			"Last updated",
-			"Identifier",
-			"No Changelog available.",
-			"Changelog",
-			"No Contributions",
-			"No Contributions",
-			"No Dependencies",
-			"Activation Event:",
-			"Startup",
-			"Activation Time:",
-			"Activated By:",
-			"Not yet activated.",
-			"Uncaught Errors ({0})",
-			"Messages ({0})",
-			"No status available.",
-			"Settings ({0})",
-			"ID",
-			"Description",
-			"Default",
-			"Debuggers ({0})",
-			"Name",
-			"Type",
-			"View Containers ({0})",
-			"ID",
-			"Title",
-			"Where",
-			"Views ({0})",
-			"ID",
-			"Name",
-			"Where",
-			"Localizations ({0})",
-			"Language ID",
-			"Language Name",
-			"Language Name (Localized)",
-			"Custom Editors ({0})",
-			"View Type",
-			"Priority",
-			"Filename Pattern",
-			"Code Actions ({0})",
-			"Title",
-			"Kind",
-			"Description",
-			"Languages",
-			"Authentication ({0})",
-			"Label",
-			"ID",
-			"Color Themes ({0})",
-			"File Icon Themes ({0})",
-			"Product Icon Themes ({0})",
-			"Colors ({0})",
-			"ID",
-			"Description",
-			"Dark Default",
-			"Light Default",
-			"High Contrast Default",
-			"JSON Validation ({0})",
-			"File Match",
-			"Schema",
-			"Commands ({0})",
-			"ID",
-			"Title",
-			"Keyboard Shortcuts",
-			"Menu Contexts",
-			"Languages ({0})",
-			"ID",
-			"Name",
-			"File Extensions",
-			"Grammar",
-			"Snippets",
-			"Activation Events ({0})",
-			"Notebooks ({0})",
-			"ID",
-			"Name",
-			"Notebook Renderers ({0})",
-			"Name",
-			"Mimetypes",
-			"Find",
-			"Find Next",
-			"Find Previous"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
-			"Extensions",
-			"Install Missing Dependencies",
-			"Finished installing missing dependencies. Please reload the window now.",
-			"Reload Window",
-			"There are no missing dependencies to install."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
-			"Type an extension name to install or search.",
-			"Press Enter to search for extension '{0}'.",
-			"Press Enter to install extension '{0}'.",
-			"Press Enter to manage your extensions."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
-			"Manifest is not found",
-			"Please reload Visual Studio Code to complete the uninstallation of this extension.",
-			"Please reload Visual Studio Code to enable the updated extension.",
-			"Please reload Visual Studio Code to enable this extension locally.",
-			"Please reload Visual Studio Code to enable this extension in {0}.",
-			"Please reload Visual Studio Code to enable this extension.",
-			"Please reload Visual Studio Code to enable this extension.",
-			"Please reload Visual Studio Code to disable this extension.",
-			"Please reload Visual Studio Code to enable this extension.",
-			"Please reload Visual Studio Code to enable this extension.",
-			"This extension is reported to be problematic.",
-			"Can't install '{0}' extension because it is not compatible.",
-			"Uninstalling extension....",
-			"Unable to install extension '{0}' because the requested version '{1}' is not found.",
-			"Installing extension....",
-			"Installing '{0}' extension....",
-			"Disable All",
-			"Cannot disable '{0}' extension alone. '{1}' extension depends on this. Do you want to disable all these extensions?",
-			"Cannot disable '{0}' extension alone. '{1}' and '{2}' extensions depend on this. Do you want to disable all these extensions?",
-			"Cannot disable '{0}' extension alone. '{1}', '{2}' and other extensions depend on this. Do you want to disable all these extensions?"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
-			"Don't Show Again",
-			"Do you want to ignore all extension recommendations?",
-			"Yes, Ignore All",
-			"No",
-			"this repository",
-			"'{0}' extension from {1}",
-			"extensions from {0}, {1} and others",
-			"extensions from {0} and {1}",
-			"extensions from {0}",
-			"Do you want to install the recommended {0} for {1}?",
-			"You have {0} installed on your system. Do you want to install the recommended {1} for it?",
-			"Install",
-			"Install (Do not sync)",
-			"Show Recommendations"
-		],
-		"vs/workbench/contrib/extensions/browser/extensionEnablementWorkspaceTrustTransitionParticipant": [
-			"Restarting extension host due to workspace trust change."
-		],
 		"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor": [
 			"Activated by {0} on start-up",
 			"Activated by {1} because a file matching {0} exists in your workspace",
@@ -25521,8 +25632,21 @@
 			"Show Deprecated Extensions",
 			"Don't Show Again"
 		],
-		"vs/workbench/contrib/output/browser/logViewer": [
-			"Log viewer"
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"Extensions",
+			"Unable to search the Marketplace when offline, please check your network connection.",
+			"Error while fetching extensions. {0}",
+			"No extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"There are no extensions to install.",
+			"Verified Publisher {0}",
+			"Publisher {0}",
+			"Deprecated",
+			"Rated {0} out of 5 stars by {1} users"
+		],
+		"vs/platform/dnd/browser/dnd": [
+			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
 		],
 		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
 			"Type the name of a terminal to open.",
@@ -25530,18 +25654,6 @@
 			"Terminal",
 			"Terminal",
 			"&&Terminal"
-		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
-			"Focus Accessible Buffer",
-			"Navigate Accessible Buffer",
-			"Accessible Buffer Go to Next Command",
-			"Accessible Buffer Go to Previous Command"
-		],
-		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
-			"Show Environment Contributions",
-			"Terminal Environment Changes",
-			"Extension: {0}",
-			"workspace"
 		],
 		"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution": [
 			"Show Terminal Texture Atlas",
@@ -25555,6 +25667,22 @@
 			"Open Terminals.",
 			"Starting..."
 		],
+		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution": [
+			"Focus Accessible Buffer",
+			"Accessible Buffer Go to Next Command",
+			"Accessible Buffer Go to Previous Command"
+		],
+		"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution": [
+			"Show Environment Contributions",
+			"Terminal Environment Changes",
+			"Extension: {0}",
+			"workspace"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
+			"Open Detected Link...",
+			"Open Last URL Link",
+			"Open Last Local File Link"
+		],
 		"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution": [
 			"Focus Find",
 			"Hide Find",
@@ -25565,11 +25693,6 @@
 			"Find Previous",
 			"Search Workspace"
 		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
-			"Open Detected Link...",
-			"Open Last URL Link",
-			"Open Last Local File Link"
-		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminal.quickFix.contribution": [
 			"Show Terminal Quick Fixes"
 		],
@@ -25578,15 +25701,75 @@
 			"Allow Automatic Tasks",
 			"Disallow Automatic Tasks"
 		],
-		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
-			"Task version 0.1.0 is deprecated. Please use 2.0.0",
-			"The config's version number",
-			"The runner has graduated. Use the official runner property",
-			"Defines whether the task is executed as a process and the output is shown in the output window or inside the terminal.",
-			"Windows specific command configuration",
-			"Mac specific command configuration",
-			"Linux specific command configuration",
-			"Specifies whether the command is a shell command or an external program. Defaults to false if omitted."
+		"vs/workbench/contrib/tasks/common/problemMatcher": [
+			"The problem pattern is missing a regular expression.",
+			"The loop property is only supported on the last line matcher.",
+			"The problem pattern is invalid. The kind property must be provided only in the first element",
+			"The problem pattern is invalid. It must have at least have a file and a message.",
+			"The problem pattern is invalid. It must either have kind: \"file\" or have a line or location match group.",
+			"Error: The string {0} is not a valid regular expression.\n",
+			"The regular expression to find an error, warning or info in the output.",
+			"whether the pattern matches a location (file and line) or only a file.",
+			"The match group index of the filename. If omitted 1 is used.",
+			"The match group index of the problem's location. Valid location patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn). If omitted (line,column) is assumed.",
+			"The match group index of the problem's line. Defaults to 2",
+			"The match group index of the problem's line character. Defaults to 3",
+			"The match group index of the problem's end line. Defaults to undefined",
+			"The match group index of the problem's end line character. Defaults to undefined",
+			"The match group index of the problem's severity. Defaults to undefined",
+			"The match group index of the problem's code. Defaults to undefined",
+			"The match group index of the message. If omitted it defaults to 4 if location is specified. Otherwise it defaults to 5.",
+			"In a multi line matcher loop indicated whether this pattern is executed in a loop as long as it matches. Can only specified on a last pattern in a multi line pattern.",
+			"The name of the problem pattern.",
+			"The name of the problem multi line problem pattern.",
+			"The actual patterns.",
+			"Contributes problem patterns",
+			"Invalid problem pattern. The pattern will be ignored.",
+			"Invalid problem pattern. The pattern will be ignored.",
+			"Error: the description can't be converted into a problem matcher:\n{0}\n",
+			"Error: the description doesn't define a valid problem pattern:\n{0}\n",
+			"Error: the description doesn't define an owner:\n{0}\n",
+			"Error: the description doesn't define a file location:\n{0}\n",
+			"Info: unknown severity {0}. Valid values are error, warning and info.\n",
+			"Error: the pattern with the identifier {0} doesn't exist.",
+			"Error: the pattern property refers to an empty identifier.",
+			"Error: the pattern property {0} is not a valid pattern variable name.",
+			"A problem matcher must define both a begin pattern and an end pattern for watching.",
+			"Error: The string {0} is not a valid regular expression.\n",
+			"The regular expression to detect the begin or end of a background task.",
+			"The match group index of the filename. Can be omitted.",
+			"The name of a contributed or predefined pattern",
+			"A problem pattern or the name of a contributed or predefined problem pattern. Can be omitted if base is specified.",
+			"The name of a base problem matcher to use.",
+			"The owner of the problem inside Code. Can be omitted if base is specified. Defaults to 'external' if omitted and base is not specified.",
+			"A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.",
+			"The default severity for captures problems. Is used if the pattern doesn't define a match group for severity.",
+			"Controls if a problem reported on a text document is applied only to open, closed or all documents.",
+			"Defines how file names reported in a problem pattern should be interpreted. A relative fileLocation may be an array, where the second element of the array is the path of the relative file location. The search fileLocation mode, performs a deep (and, possibly, heavy) file system search within the directories specified by the include/exclude properties of the second element (or the current workspace directory if not specified).",
+			"Patterns to track the begin and end of a matcher active on a background task.",
+			"If set to true the background monitor is in active mode when the task starts. This is equals of issuing a line that matches the beginsPattern",
+			"If matched in the output the start of a background task is signaled.",
+			"If matched in the output the end of a background task is signaled.",
+			"The watching property is deprecated. Use background instead.",
+			"Patterns to track the begin and end of a watching matcher.",
+			"If set to true the watcher is in active mode when the task starts. This is equals of issuing a line that matches the beginPattern",
+			"If matched in the output the start of a watching task is signaled.",
+			"If matched in the output the end of a watching task is signaled.",
+			"This property is deprecated. Use the watching property instead.",
+			"A regular expression signaling that a watched tasks begins executing triggered through file watching.",
+			"This property is deprecated. Use the watching property instead.",
+			"A regular expression signaling that a watched tasks ends executing.",
+			"The name of the problem matcher used to refer to it.",
+			"A human readable label of the problem matcher.",
+			"Contributes problem matchers",
+			"Microsoft compiler problems",
+			"Less problems",
+			"Gulp TSC Problems",
+			"JSHint problems",
+			"JSHint stylish problems",
+			"ESLint compact problems",
+			"ESLint stylish problems",
+			"Go problems"
 		],
 		"vs/workbench/contrib/tasks/common/jsonSchema_v2": [
 			"Specifies whether the command is a shell command or an external program. Defaults to false if omitted.",
@@ -25672,76 +25855,6 @@
 			"Mac specific command configuration",
 			"Linux specific command configuration"
 		],
-		"vs/workbench/contrib/tasks/common/problemMatcher": [
-			"The problem pattern is missing a regular expression.",
-			"The loop property is only supported on the last line matcher.",
-			"The problem pattern is invalid. The kind property must be provided only in the first element",
-			"The problem pattern is invalid. It must have at least have a file and a message.",
-			"The problem pattern is invalid. It must either have kind: \"file\" or have a line or location match group.",
-			"Error: The string {0} is not a valid regular expression.\n",
-			"The regular expression to find an error, warning or info in the output.",
-			"whether the pattern matches a location (file and line) or only a file.",
-			"The match group index of the filename. If omitted 1 is used.",
-			"The match group index of the problem's location. Valid location patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn). If omitted (line,column) is assumed.",
-			"The match group index of the problem's line. Defaults to 2",
-			"The match group index of the problem's line character. Defaults to 3",
-			"The match group index of the problem's end line. Defaults to undefined",
-			"The match group index of the problem's end line character. Defaults to undefined",
-			"The match group index of the problem's severity. Defaults to undefined",
-			"The match group index of the problem's code. Defaults to undefined",
-			"The match group index of the message. If omitted it defaults to 4 if location is specified. Otherwise it defaults to 5.",
-			"In a multi line matcher loop indicated whether this pattern is executed in a loop as long as it matches. Can only specified on a last pattern in a multi line pattern.",
-			"The name of the problem pattern.",
-			"The name of the problem multi line problem pattern.",
-			"The actual patterns.",
-			"Contributes problem patterns",
-			"Invalid problem pattern. The pattern will be ignored.",
-			"Invalid problem pattern. The pattern will be ignored.",
-			"Error: the description can't be converted into a problem matcher:\n{0}\n",
-			"Error: the description doesn't define a valid problem pattern:\n{0}\n",
-			"Error: the description doesn't define an owner:\n{0}\n",
-			"Error: the description doesn't define a file location:\n{0}\n",
-			"Info: unknown severity {0}. Valid values are error, warning and info.\n",
-			"Error: the pattern with the identifier {0} doesn't exist.",
-			"Error: the pattern property refers to an empty identifier.",
-			"Error: the pattern property {0} is not a valid pattern variable name.",
-			"A problem matcher must define both a begin pattern and an end pattern for watching.",
-			"Error: The string {0} is not a valid regular expression.\n",
-			"The regular expression to detect the begin or end of a background task.",
-			"The match group index of the filename. Can be omitted.",
-			"The name of a contributed or predefined pattern",
-			"A problem pattern or the name of a contributed or predefined problem pattern. Can be omitted if base is specified.",
-			"The name of a base problem matcher to use.",
-			"The owner of the problem inside Code. Can be omitted if base is specified. Defaults to 'external' if omitted and base is not specified.",
-			"A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.",
-			"The default severity for captures problems. Is used if the pattern doesn't define a match group for severity.",
-			"Controls if a problem reported on a text document is applied only to open, closed or all documents.",
-			"Defines how file names reported in a problem pattern should be interpreted. A relative fileLocation may be an array, where the second element of the array is the path of the relative file location. The search fileLocation mode, performs a deep (and, possibly, heavy) file system search within the directories specified by the include/exclude properties of the second element (or the current workspace directory if not specified).",
-			"Patterns to track the begin and end of a matcher active on a background task.",
-			"If set to true the background monitor is in active mode when the task starts. This is equals of issuing a line that matches the beginsPattern",
-			"If matched in the output the start of a background task is signaled.",
-			"If matched in the output the end of a background task is signaled.",
-			"The watching property is deprecated. Use background instead.",
-			"Patterns to track the begin and end of a watching matcher.",
-			"If set to true the watcher is in active mode when the task starts. This is equals of issuing a line that matches the beginPattern",
-			"If matched in the output the start of a watching task is signaled.",
-			"If matched in the output the end of a watching task is signaled.",
-			"This property is deprecated. Use the watching property instead.",
-			"A regular expression signaling that a watched tasks begins executing triggered through file watching.",
-			"This property is deprecated. Use the watching property instead.",
-			"A regular expression signaling that a watched tasks ends executing.",
-			"The name of the problem matcher used to refer to it.",
-			"A human readable label of the problem matcher.",
-			"Contributes problem matchers",
-			"Microsoft compiler problems",
-			"Less problems",
-			"Gulp TSC Problems",
-			"JSHint problems",
-			"JSHint stylish problems",
-			"ESLint compact problems",
-			"ESLint stylish problems",
-			"Go problems"
-		],
 		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
 			"No matching tasks",
 			"Select the task to run"
@@ -25752,6 +25865,16 @@
 			"Condition which must be true to enable this type of task. Consider using `shellExecutionSupported`, `processExecutionSupported`, and `customExecutionSupported` as appropriate for this task definition. See the [API documentation](https://code.visualstudio.com/api/extension-guides/task-provider#when-clause) for more information.",
 			"The task type configuration is missing the required 'taskType' property",
 			"Contributes task kinds"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
+			"Task version 0.1.0 is deprecated. Please use 2.0.0",
+			"The config's version number",
+			"The runner has graduated. Use the official runner property",
+			"Defines whether the task is executed as a process and the output is shown in the output window or inside the terminal.",
+			"Windows specific command configuration",
+			"Mac specific command configuration",
+			"Linux specific command configuration",
+			"Specifies whether the command is a shell command or an external program. Defaults to false if omitted."
 		],
 		"vs/workbench/contrib/remote/browser/tunnelFactory": [
 			"Private",
@@ -25784,6 +25907,10 @@
 			"Cannot reconnect. Please reload the window.",
 			"&&Reload Window"
 		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"Emmet: Expand Abbreviation",
+			"Emmet: E&&xpand Abbreviation"
+		],
 		"vs/workbench/contrib/remote/browser/remoteIndicator": [
 			"Remote",
 			"Show Remote Menu",
@@ -25809,81 +25936,14 @@
 			"Select an option to open a Remote Window",
 			"Installing extension... "
 		],
-		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
-			"Emmet: Expand Abbreviation",
-			"Emmet: E&&xpand Abbreviation"
+		"vs/workbench/contrib/format/browser/formatActionsNone": [
+			"Format Document",
+			"This file cannot be formatted because it is too large",
+			"There is no formatter for '{0}' files installed.",
+			"&&Install Formatter..."
 		],
-		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
-			"Toggle Screen Reader Accessibility Mode"
-		],
-		"vs/workbench/contrib/codeEditor/browser/diffEditorHelper": [
-			"Show Whitespace Differences",
-			"The diff algorithm was stopped early (after {0} ms.)",
-			"Remove Limit",
-			"You are in a diff editor.",
-			"Press {0} or {1} to view the next or previous diff in the diff review mode that is optimized for screen readers.",
-			"To control which audio cues should be played, the following settings can be configured: {0}."
-		],
-		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
-			"Inspect Key Mappings",
-			"Inspect Key Mappings (JSON)"
-		],
-		"vs/workbench/contrib/codeEditor/browser/largeFileOptimizations": [
-			"{0}: tokenization, wrapping, folding and sticky scroll have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
-			"Forcefully Enable Features",
-			"Please reopen file in order for this setting to take effect."
-		],
-		"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens": [
-			"Developer: Inspect Editor Tokens and Scopes",
-			"Loading..."
-		],
-		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess": [
-			"Go to Line/Column...",
-			"Type the line number and optional column to go to (e.g. 42:5 for line 42 and column 5).",
-			"Go to Line/Column"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
-			"Toggle Minimap",
-			"&&Minimap"
-		],
-		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
-			"Running '{0}' Formatter ([configure]({1})).",
-			"Quick Fixes",
-			"Getting code actions from '{0}' ([configure]({1})).",
-			"Applying code action '{0}'."
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
-			"Toggle Column Selection Mode",
-			"Column &&Selection Mode"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
-			"Toggle Multi-Cursor Modifier",
-			"Switch to Alt+Click for Multi-Cursor",
-			"Switch to Cmd+Click for Multi-Cursor",
-			"Switch to Ctrl+Click for Multi-Cursor"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
-			"Toggle Control Characters",
-			"Render &&Control Characters"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
-			"Toggle Render Whitespace",
-			"&&Render Whitespace"
-		],
-		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
-			"Whether the editor is currently using word wrapping.",
-			"View: Toggle Word Wrap",
-			"Disable wrapping for this file",
-			"Enable wrapping for this file",
-			"&&Word Wrap"
-		],
-		"vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint": [
-			"Press {0} to ask {1} to do something. ",
-			"Start typing to dismiss.",
-			"[[Ask {0} to do something]] or start typing to dismiss.",
-			"[[Select a language]], or [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don't show]] this again.",
-			"Execute {0} to select a language, execute {1} to fill with template, or execute {2} to open a different editor and get started. Start typing to dismiss.",
-			" Toggle {0} in settings to disable this hint."
+		"vs/workbench/contrib/format/browser/formatModified": [
+			"Format Modified Lines"
 		],
 		"vs/workbench/contrib/snippets/browser/commands/configureSnippets": [
 			"(global)",
@@ -25904,32 +25964,6 @@
 			"New Snippets",
 			"New Snippets",
 			"Select Snippets File or Create Snippets"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
-			"Insert Snippet"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
-			"Fill File with Snippet",
-			"Select a snippet"
-		],
-		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
-			"Surround With Snippet..."
-		],
-		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
-			"Surround With: {0}",
-			"Start with Snippet",
-			"Start with: {0}"
-		],
-		"vs/workbench/contrib/snippets/browser/snippetsService": [
-			"Expected string in `contributes.{0}.path`. Provided value: {1}",
-			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
-			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
-			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
-			"Contributes snippets.",
-			"Language identifier for which this snippet is contributed to.",
-			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
-			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
-			"The snippet file \"{0}\" could not be read."
 		],
 		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
 			"None",
@@ -25952,14 +25986,103 @@
 			"Format Document With...",
 			"Format Selection With..."
 		],
-		"vs/workbench/contrib/format/browser/formatActionsNone": [
-			"Format Document",
-			"This file cannot be formatted because it is too large",
-			"There is no formatter for '{0}' files installed.",
-			"&&Install Formatter..."
+		"vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets": [
+			"Fill File with Snippet",
+			"Select a snippet"
 		],
-		"vs/workbench/contrib/format/browser/formatModified": [
-			"Format Modified Lines"
+		"vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet": [
+			"Surround With Snippet..."
+		],
+		"vs/workbench/contrib/snippets/browser/commands/insertSnippet": [
+			"Insert Snippet"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetCodeActionProvider": [
+			"Surround With: {0}",
+			"Start with Snippet",
+			"Start with: {0}"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"Expected string in `contributes.{0}.path`. Provided value: {1}",
+			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
+			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
+			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"Contributes snippets.",
+			"Language identifier for which this snippet is contributed to.",
+			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
+			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
+			"The snippet file \"{0}\" could not be read."
+		],
+		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
+			"Toggle Screen Reader Accessibility Mode"
+		],
+		"vs/workbench/contrib/codeEditor/browser/diffEditorHelper": [
+			"Show Whitespace Differences",
+			"The diff algorithm was stopped early (after {0} ms.)",
+			"Remove Limit",
+			"You are in a diff editor.",
+			"View the next ({0}) or previous ({1}) diff in diff review mode, which is optimized for screen readers.",
+			"To control which audio cues should be played, the following settings can be configured: {0}."
+		],
+		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
+			"Inspect Key Mappings",
+			"Inspect Key Mappings (JSON)"
+		],
+		"vs/workbench/contrib/codeEditor/browser/largeFileOptimizations": [
+			"{0}: tokenization, wrapping, folding, codelens, word highlighting and sticky scroll have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
+			"Forcefully Enable Features",
+			"Please reopen file in order for this setting to take effect."
+		],
+		"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens": [
+			"Developer: Inspect Editor Tokens and Scopes",
+			"Loading..."
+		],
+		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess": [
+			"Go to Line/Column...",
+			"Type the line number and optional column to go to (e.g. 42:5 for line 42 and column 5).",
+			"Go to Line/Column"
+		],
+		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
+			"Running '{0}' Formatter ([configure]({1})).",
+			"Quick Fixes",
+			"Getting code actions from '{0}' ([configure]({1})).",
+			"Applying code action '{0}'."
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
+			"Toggle Column Selection Mode",
+			"Column &&Selection Mode"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
+			"Toggle Minimap",
+			"&&Minimap"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"Toggle Render Whitespace",
+			"&&Render Whitespace"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
+			"Toggle Multi-Cursor Modifier",
+			"Switch to Alt+Click for Multi-Cursor",
+			"Switch to Cmd+Click for Multi-Cursor",
+			"Switch to Ctrl+Click for Multi-Cursor"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
+			"Toggle Control Characters",
+			"Render &&Control Characters"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
+			"Whether the editor is currently using word wrapping.",
+			"View: Toggle Word Wrap",
+			"Disable wrapping for this file",
+			"Enable wrapping for this file",
+			"&&Word Wrap"
+		],
+		"vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint": [
+			"Press {0} to ask {1} to do something. ",
+			"Start typing to dismiss.",
+			"[[Ask {0} to do something]] or start typing to dismiss.",
+			"[[Select a language]], or [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don't show]] this again.",
+			"Execute {0} to select a language, execute {1} to fill with template, or execute {2} to open a different editor and get started. Start typing to dismiss.",
+			" Toggle {0} in settings to disable this hint."
 		],
 		"vs/workbench/contrib/update/browser/update": [
 			"This version of {0} does not have release notes online",
@@ -26007,11 +26130,6 @@
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput": [
 			"Welcome"
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
-			"Built-In",
-			"Developer",
-			"Reset Welcome Page Walkthrough Progress"
-		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/startupPage": [
 			"Welcome Page",
 			"Could not open markdown preview: {0}.\n\nPlease make sure the markdown extension is enabled."
@@ -26020,8 +26138,14 @@
 			"Used to represent walkthrough steps which have not been completed",
 			"Used to represent walkthrough steps which have been completed"
 		],
-		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
-			"The viewsWelcome contribution in '{0}' requires 'enabledApiProposals: [\"contribViewsWelcome\"]' in order to use the 'group' proposed property."
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService": [
+			"Built-In",
+			"Developer",
+			"Reset Welcome Page Walkthrough Progress"
+		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
+			"unbound",
+			"It looks like Git is not installed on your system."
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted": [
 			"Overview of how to get up to speed with your editor.",
@@ -26056,6 +26180,13 @@
 			"opt out",
 			"{0} collects usage data. Read our {1} and learn how to {2}."
 		],
+		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
+			"Editor Playground",
+			"Interactive Editor Playground"
+		],
+		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeContribution": [
+			"The viewsWelcome contribution in '{0}' requires 'enabledApiProposals: [\"contribViewsWelcome\"]' in order to use the 'group' proposed property."
+		],
 		"vs/workbench/contrib/welcomeViews/common/viewsWelcomeExtensionPoint": [
 			"Contributed views welcome content. Welcome content will be rendered in tree based views whenever they have no meaningful content to display, ie. the File Explorer when no folder is open. Such content is useful as in-product documentation to drive users to use certain features before they are available. A good example would be a `Clone Repository` button in the File Explorer welcome view.",
 			"Contributed welcome content for a specific view.",
@@ -26066,20 +26197,11 @@
 			"Group to which this welcome content belongs. Proposed API.",
 			"Condition when the welcome content buttons and command links should be enabled."
 		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart": [
-			"unbound",
-			"It looks like Git is not installed on your system."
-		],
-		"vs/workbench/contrib/welcomeWalkthrough/browser/editor/editorWalkThrough": [
-			"Editor Playground",
-			"Interactive Editor Playground"
-		],
-		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
-			"Calls from '{0}'",
-			"Callers of '{0}'",
-			"Loading...",
-			"No calls from '{0}'",
-			"No callers of '{0}'"
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree": [
+			"{0} ({1})",
+			"1 problem in this element",
+			"{0} problems in this element",
+			"Contains elements with problems"
 		],
 		"vs/workbench/contrib/typeHierarchy/browser/typeHierarchyPeek": [
 			"Supertypes of '{0}'",
@@ -26088,11 +26210,12 @@
 			"No supertypes of '{0}'",
 			"No subtypes of '{0}'"
 		],
-		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree": [
-			"{0} ({1})",
-			"1 problem in this element",
-			"{0} problems in this element",
-			"Contains elements with problems"
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
+			"Calls from '{0}'",
+			"Callers of '{0}'",
+			"Loading...",
+			"No calls from '{0}'",
+			"No callers of '{0}'"
 		],
 		"vs/workbench/contrib/outline/browser/outlinePane": [
 			"The active editor cannot provide outline information.",
@@ -26107,6 +26230,42 @@
 			"Sort By: Position",
 			"Sort By: Name",
 			"Sort By: Category"
+		],
+		"vs/workbench/contrib/userDataProfile/browser/userDataProfileActions": [
+			"Create a Temporary Profile",
+			"Rename...",
+			"Rename {0}",
+			"Profile with name {0} already exists.",
+			"Current",
+			"Rename Profile...",
+			"Select Profile to Rename",
+			"Manage...",
+			"Cleanup Profiles",
+			"Reset Workspace Profiles Associations"
+		],
+		"vs/workbench/contrib/userDataProfile/browser/userDataProfile": [
+			"Profiles ({0})",
+			"Switch Profile...",
+			"Select Profile",
+			"Edit Profile...",
+			"Show Profile Contents",
+			"Export Profile...",
+			"Export Profile ({0})...",
+			"Import Profile...",
+			"Import from URL",
+			"Select File...",
+			"Profile Templates",
+			"Import from Profile Template...",
+			"Provide Profile Template URL",
+			"Error while creating profile: {0}",
+			"Select Profile Template File",
+			"Import Profile...",
+			"Save Current Profile As...",
+			"Create Profile...",
+			"Delete Profile...",
+			"Current",
+			"Delete Profile...",
+			"Select Profiles to Delete"
 		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
 			"Turn Off",
@@ -26159,9 +26318,8 @@
 			"Error while turning on Settings Sync: Authentication failed.",
 			"Error while turning on Settings Sync. Please check [logs]({0}) for more details.",
 			"Error while turning on Settings Sync. {0}",
-			"Sign in & Turn on",
-			"Please sign in to synchronize your data across devices.",
-			"for each platform",
+			"Sign in",
+			"Please sign in to backup and sync your data across devices.",
 			"{0}: Configure...",
 			"Choose what to sync",
 			"Do you want to turn off sync?",
@@ -26173,7 +26331,7 @@
 			"Default",
 			"Insiders",
 			"Stable",
-			"Turn on Settings Sync...",
+			"Backup and Sync Settings...",
 			"Turning on Settings Sync...",
 			"Cancel",
 			"Sign in to Sync Settings",
@@ -26185,68 +26343,16 @@
 			"{0}: Show Log",
 			"Show Log",
 			"Complete Merge",
+			"Successfully downloaded Settings Sync activity.",
 			"Clear Data in Cloud..."
-		],
-		"vs/workbench/contrib/userDataProfile/browser/userDataProfile": [
-			"Profiles ({0})",
-			"Switch Profile...",
-			"Select Profile",
-			"Edit Profile...",
-			"Show Profile Contents",
-			"Export Profile...",
-			"Export Profile ({0})...",
-			"Import Profile...",
-			"Import from URL",
-			"Select File...",
-			"Profile Templates",
-			"Import from Profile Template...",
-			"Provide Profile Template URL",
-			"Error while creating profile: {0}",
-			"Select Profile Template File",
-			"Import Profile...",
-			"Save Current Profile As...",
-			"Create Profile...",
-			"Delete Profile...",
-			"Current",
-			"Delete Profile...",
-			"Select Profiles to Delete"
-		],
-		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
-			"Configure which editor to use for a resource.",
-			"Language modes that the code actions are enabled for.",
-			"`CodeActionKind` of the contributed code action.",
-			"Label for the code action used in the UI.",
-			"Description of what the code action does."
-		],
-		"vs/workbench/contrib/userDataProfile/browser/userDataProfileActions": [
-			"Create a Temporary Profile",
-			"Rename...",
-			"Rename {0}",
-			"Profile with name {0} already exists.",
-			"Current",
-			"Rename Profile...",
-			"Select Profile to Rename",
-			"Manage...",
-			"Cleanup Profiles",
-			"Reset Workspace Profiles Associations"
-		],
-		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
-			"Contributed documentation.",
-			"Contributed documentation for refactorings.",
-			"Contributed documentation for refactoring.",
-			"Label for the documentation used in the UI.",
-			"When clause.",
-			"Command executed."
-		],
-		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
-			"Controls whether auto fix action should be run on file save.",
-			"Code Action kinds to be run on save.",
-			"Controls whether '{0}' actions should be run on file save."
 		],
 		"vs/workbench/contrib/editSessions/common/editSessions": [
 			"Cloud Changes",
 			"Cloud Changes",
 			"View icon of the cloud changes view."
+		],
+		"vs/workbench/contrib/editSessions/common/editSessionsLogService": [
+			"Cloud Changes"
 		],
 		"vs/workbench/contrib/editSessions/browser/editSessionsStorageService": [
 			"Select an account to restore your working changes from the cloud",
@@ -26259,9 +26365,6 @@
 			"Turn off Cloud Changes...",
 			"Do you want to disable storing working changes in the cloud?",
 			"Delete all stored data from the cloud."
-		],
-		"vs/workbench/contrib/editSessions/common/editSessionsLogService": [
-			"Cloud Changes"
 		],
 		"vs/workbench/contrib/editSessions/browser/editSessionsViews": [
 			"You have no stored changes in the cloud to display.\n{0}",
@@ -26279,12 +26382,41 @@
 			"Cloud Changes",
 			"Open File"
 		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"Configure which editor to use for a resource.",
+			"Language modes that the code actions are enabled for.",
+			"`CodeActionKind` of the contributed code action.",
+			"Label for the code action used in the UI.",
+			"Description of what the code action does."
+		],
+		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
+			"Contributed documentation.",
+			"Contributed documentation for refactorings.",
+			"Contributed documentation for refactoring.",
+			"Label for the documentation used in the UI.",
+			"When clause.",
+			"Command executed."
+		],
+		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
+			"Triggers Code Actions on explicit saves and auto saves triggered by window or focus changes.",
+			"Triggers Code Actions only when explicitly saved",
+			"Never triggers Code Actions on save",
+			"Triggers Code Actions only when explicitly saved. This value will be deprecated in favor of \"explicit\".",
+			"Never triggers Code Actions on save. This value will be deprecated in favor of \"never\".",
+			"Controls whether auto fix action should be run on file save.",
+			"Run CodeActions for the editor on save. CodeActions must be specified and the editor must not be shutting down. Example: `\"source.organizeImports\": \"explicit\" `",
+			"Controls whether '{0}' actions should be run on file save."
+		],
 		"vs/workbench/contrib/timeline/browser/timelinePane": [
 			"Loading...",
 			"Load more",
 			"Timeline",
 			"The active editor cannot provide timeline information.",
+			"All timeline sources have been filtered out.",
+			"Local History will track recent changes as you save them unless the file has been excluded or is too large.",
+			"No filtered timeline information was provided.",
 			"No timeline information was provided.",
+			"Source Control has not been configured.",
 			"The active editor cannot provide timeline information.",
 			"{0}: {1}",
 			"Timeline",
@@ -26336,6 +26468,9 @@
 			"{0} ({1} • {2})",
 			"{0} ({1} • {2}) ↔ {3}",
 			"{0} ({1} • {2}) ↔ {3} ({4} • {5})"
+		],
+		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
+			"Workspace Trust"
 		],
 		"vs/workbench/contrib/audioCues/browser/commands": [
 			"Help: List Audio Cues",
@@ -26416,13 +26551,6 @@
 			"This folder is trusted via the bolded entries in the the trusted folders below.",
 			"This window is trusted by nature of the workspace that is opened."
 		],
-		"vs/workbench/services/workspaces/browser/workspaceTrustEditorInput": [
-			"Workspace Trust"
-		],
-		"vs/workbench/contrib/share/browser/shareService": [
-			"The number of available share providers",
-			"Choose how to share {0}"
-		],
 		"vs/workbench/contrib/accessibility/browser/accessibilityConfiguration": [
 			"Accessibility",
 			"Provide information about how to access the terminal accessibility help menu when the terminal is focused",
@@ -26434,15 +26562,115 @@
 			"Provide information about how to focus the cell container or inner editor when a notebook cell is focused.",
 			"Provide information about how to open the hover in an accessible view.",
 			"Provide information about how to open the notification in an accessible view.",
-			"Provide information about relevant actions in an untitled text editor.",
+			"Provide information about relevant actions in an empty text editor.",
+			"Provide information about actions that can be taken in the comment widget or in a file which contains comments.",
 			"Whether to dim unfocused editors and terminals, which makes it more clear where typed input will go to. This works with the majority of editors with the notable exceptions of those that utilize iframes like notebooks and extension webview editors.",
 			"The opacity fraction (0.2 to 1.0) to use for unfocused editors and terminals. This will only take effect when {0} is enabled."
+		],
+		"vs/workbench/contrib/accessibility/browser/accessibilityStatus": [
+			"Are you using a screen reader to operate VS Code?",
+			"Yes",
+			"No",
+			"Screen Reader Optimized",
+			"Screen Reader Mode"
+		],
+		"vs/workbench/contrib/share/browser/shareService": [
+			"The number of available share providers",
+			"Choose how to share {0}"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"No new notifications",
+			"Notifications",
+			"Notification Center Actions",
+			"Notifications Center"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsStatus": [
+			"Notifications",
+			"Notifications",
+			"Do Not Disturb",
+			"Do Not Disturb Mode is Enabled",
+			"Hide Notifications",
+			"No Notifications",
+			"No New Notifications",
+			"1 New Notification",
+			"{0} New Notifications",
+			"No New Notifications ({0} in progress)",
+			"1 New Notification ({0} in progress)",
+			"{0} New Notifications ({1} in progress)",
+			"Status Message"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCommands": [
+			"Notifications",
+			"Show Notifications",
+			"Hide Notifications",
+			"Clear All Notifications",
+			"Accept Notification Primary Action",
+			"Toggle Do Not Disturb Mode",
+			"Focus Notification Toast"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsToasts": [
+			"{0}, notification",
+			"{0}, source: {1}, notification"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"Error: {0}",
+			"Warning: {0}",
+			"Info: {0}"
+		],
+		"vs/workbench/services/configuration/common/configurationEditing": [
+			"Error while writing to {0}. {1}",
+			"Open Tasks Configuration",
+			"Open Launch Configuration",
+			"Open Settings",
+			"Open Tasks Configuration",
+			"Open Launch Configuration",
+			"Save and Retry",
+			"Save and Retry",
+			"Open Settings",
+			"Unable to write {0} because it is configured in system policy.",
+			"Unable to write to {0} because {1} is not a registered configuration.",
+			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
+			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
+			"Unable to write to Folder Settings because {0} does not support the folder resource scope.",
+			"Unable to write to User Settings because {0} does not support for global scope.",
+			"Unable to write to Workspace Settings because {0} does not support for workspace scope in a multi folder workspace.",
+			"Unable to write to Folder Settings because no resource is provided.",
+			"Unable to write to Language Settings because {0} is not a resource language setting.",
+			"Unable to write to {0} because no workspace is opened. Please open a workspace first and try again.",
+			"Unable to write into the tasks configuration file. Please open it to correct errors/warnings in it and try again.",
+			"Unable to write into the launch configuration file. Please open it to correct errors/warnings in it and try again.",
+			"Unable to write into user settings. Please open the user settings to correct errors/warnings in it and try again.",
+			"Unable to write into remote user settings. Please open the remote user settings to correct errors/warnings in it and try again.",
+			"Unable to write into workspace settings. Please open the workspace settings to correct errors/warnings in the file and try again.",
+			"Unable to write into folder settings. Please open the '{0}' folder settings to correct errors/warnings in it and try again.",
+			"Unable to write into tasks configuration file because the file has unsaved changes. Please save it first and then try again.",
+			"Unable to write into launch configuration file because the file has unsaved changes. Please save it first and then try again.",
+			"Unable to write into user settings because the file has unsaved changes. Please save the user settings file first and then try again.",
+			"Unable to write into remote user settings because the file has unsaved changes. Please save the remote user settings file first and then try again.",
+			"Unable to write into workspace settings because the file has unsaved changes. Please save the workspace settings file first and then try again.",
+			"Unable to write into folder settings because the file has unsaved changes. Please save the '{0}' folder settings file first and then try again.",
+			"Unable to write into tasks configuration file because the content of the file is newer.",
+			"Unable to write into launch configuration file because the content of the file is newer.",
+			"Unable to write into user settings because the content of the file is newer.",
+			"Unable to write into remote user settings because the content of the file is newer.",
+			"Unable to write into workspace settings because the content of the file is newer.",
+			"Unable to write into folder settings because the content of the file is newer.",
+			"Unable to write to {0} because of an internal error.",
+			"User Settings",
+			"Remote User Settings",
+			"Workspace Settings",
+			"Folder Settings"
 		],
 		"vs/workbench/common/editor/textEditorModel": [
 			"Language {0} was automatically detected and set as the language mode."
 		],
 		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
 			"Failed to save '{0}': {1}"
+		],
+		"vs/workbench/browser/parts/titlebar/titlebarPart": [
+			"Focus Title Bar",
+			"Command Center",
+			"Layout Controls"
 		],
 		"vs/workbench/services/configurationResolver/common/variableResolver": [
 			"Variable {0} can not be resolved. Please open an editor.",
@@ -26464,13 +26692,16 @@
 		"vs/workbench/services/workingCopy/common/workingCopyHistoryTracker": [
 			"Undo / Redo"
 		],
-		"vs/workbench/services/extensions/common/extensionHostManager": [
-			"Measure Extension Host Latency"
-		],
 		"vs/workbench/services/extensions/common/extensionsUtil": [
 			"Overwriting extension {0} with {1}.",
 			"Overwriting extension {0} with {1}.",
 			"Loading development extension at {0}"
+		],
+		"vs/workbench/services/extensions/common/extensionHostManager": [
+			"Measure Extension Host Latency"
+		],
+		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
+			"Report Issue"
 		],
 		"vs/workbench/contrib/localization/common/localizationsActions": [
 			"Configure Display Language",
@@ -26479,9 +26710,6 @@
 			"Available",
 			"More Info",
 			"Clear Display Language Preference"
-		],
-		"vs/workbench/contrib/extensions/common/reportExtensionIssueAction": [
-			"Report Issue"
 		],
 		"vs/workbench/contrib/extensions/electron-sandbox/extensionsSlowActions": [
 			"Performance Issue",
@@ -26494,47 +26722,6 @@
 		],
 		"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote": [
 			"Create New Integrated Terminal (Local)"
-		],
-		"vs/workbench/browser/parts/titlebar/titlebarPart": [
-			"Focus Title Bar",
-			"Command Center",
-			"Layout Controls"
-		],
-		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
-			"Pty Host Status",
-			"Pty Host",
-			"The connection to the terminal's pty host process is unresponsive, terminals may stop working. Click to manually restart the pty host.",
-			"Pty Host is unresponsive"
-		],
-		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
-			"Task is running",
-			"Task succeeded",
-			"Task succeeded and waiting...",
-			"Task has errors",
-			"Task has errors and is waiting...",
-			"Task has warnings",
-			"Task has warnings and is waiting...",
-			"Task has infos",
-			"Task has infos and is waiting...",
-			"Beginning of detected errors for this run"
-		],
-		"vs/workbench/contrib/tasks/common/taskConfiguration": [
-			"Warning: options.cwd must be of type string. Ignoring value {0}\n",
-			"Error: command argument must either be a string or a quoted string. Provided value is:\n{0}",
-			"Warning: shell configuration is only supported when executing tasks in the terminal.",
-			"Error: Problem Matcher in declare scope must have a name:\n{0}\n",
-			"Warning: the defined problem matcher is unknown. Supported types are string | ProblemMatcher | Array<string | ProblemMatcher>.\n{0}\n",
-			"Error: Invalid problemMatcher reference: {0}\n",
-			"Error: tasks configuration must have a type property. The configuration will be ignored.\n{0}\n",
-			"Error: there is no registered task type '{0}'. Did you miss installing an extension that provides a corresponding task provider?",
-			"Error: the task configuration '{0}' is missing the required property 'type'. The task configuration will be ignored.",
-			"Error: the task configuration '{0}' is using an unknown type. The task configuration will be ignored.",
-			"Error: tasks is not declared as a custom task. The configuration will be ignored.\n{0}\n",
-			"Error: a task must provide a label property. The task will be ignored.\n{0}\n",
-			"Warning: {0} tasks are unavailable in the current environment.\n",
-			"Error: the task '{0}' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:\n{1}",
-			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
-			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
 		],
 		"vs/workbench/contrib/tasks/common/taskTemplates": [
 			"Executes .NET Core build command",
@@ -26560,6 +26747,42 @@
 			"Go back ↩",
 			"No {0} tasks found. Go back ↩",
 			"There is no task provider registered for tasks of type \"{0}\"."
+		],
+		"vs/workbench/contrib/tasks/common/taskConfiguration": [
+			"Warning: options.cwd must be of type string. Ignoring value {0}\n",
+			"Error: command argument must either be a string or a quoted string. Provided value is:\n{0}",
+			"Warning: shell configuration is only supported when executing tasks in the terminal.",
+			"Error: Problem Matcher in declare scope must have a name:\n{0}\n",
+			"Warning: the defined problem matcher is unknown. Supported types are string | ProblemMatcher | Array<string | ProblemMatcher>.\n{0}\n",
+			"Error: Invalid problemMatcher reference: {0}\n",
+			"Error: tasks configuration must have a type property. The configuration will be ignored.\n{0}\n",
+			"Error: there is no registered task type '{0}'. Did you miss installing an extension that provides a corresponding task provider?",
+			"Error: the task configuration '{0}' is missing the required property 'type'. The task configuration will be ignored.",
+			"Error: the task configuration '{0}' is using an unknown type. The task configuration will be ignored.",
+			"Error: tasks is not declared as a custom task. The configuration will be ignored.\n{0}\n",
+			"Error: a task must provide a label property. The task will be ignored.\n{0}\n",
+			"Warning: {0} tasks are unavailable in the current environment.\n",
+			"Error: the task '{0}' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:\n{1}",
+			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
+			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
+		],
+		"vs/workbench/contrib/tasks/browser/taskTerminalStatus": [
+			"Task is running",
+			"Task succeeded",
+			"Task succeeded and waiting...",
+			"Task has errors",
+			"Task has errors and is waiting...",
+			"Task has warnings",
+			"Task has warnings and is waiting...",
+			"Task has infos",
+			"Task has infos and is waiting...",
+			"Beginning of detected errors for this run"
+		],
+		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
+			"Pty Host Status",
+			"Pty Host",
+			"The connection to the terminal's pty host process is unresponsive, terminals may stop working. Click to manually restart the pty host.",
+			"Pty Host is unresponsive"
 		],
 		"vs/workbench/contrib/localHistory/browser/localHistory": [
 			"Icon for a local history entry in the timeline view.",
@@ -26662,9 +26885,6 @@
 			"The default terminal profile on macOS.",
 			"The default terminal profile on Windows."
 		],
-		"vs/base/browser/ui/findinput/findInput": [
-			"input"
-		],
 		"vs/base/browser/ui/inputbox/inputBox": [
 			"Error: {0}",
 			"Warning: {0}",
@@ -26672,37 +26892,13 @@
 			"for history",
 			"Cleared Input"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsList": [
-			"Inspect the response in the accessible view with {0}",
-			"Inspect the response in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding",
-			"{0}, notification, {1}",
-			"{0}, notification",
-			"{0}, source: {1}, notification, {2}",
-			"{0}, source: {1}, notification",
-			"Notifications List"
+		"vs/base/browser/ui/findinput/findInput": [
+			"input"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsActions": [
-			"Icon for the clear action in notifications.",
-			"Icon for the clear all action in notifications.",
-			"Icon for the hide action in notifications.",
-			"Icon for the expand action in notifications.",
-			"Icon for the collapse action in notifications.",
-			"Icon for the configure action in notifications.",
-			"Icon for the mute all action in notifications.",
-			"Clear Notification",
-			"Clear All Notifications",
-			"Toggle Do Not Disturb Mode",
-			"Hide Notifications",
-			"Expand Notification",
-			"Collapse Notification",
-			"More Actions...",
-			"Copy Text"
-		],
-		"vs/base/browser/ui/actionbar/actionViewItems": [
-			"{0} ({1})"
-		],
-		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
-			"More Actions..."
+		"vs/editor/contrib/codeAction/browser/lightBulbWidget": [
+			"Show Code Actions. Preferred Quick Fix Available ({0})",
+			"Show Code Actions ({0})",
+			"Show Code Actions"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionCommands": [
 			"Kind of the code action to run.",
@@ -26734,44 +26930,13 @@
 			"Auto Fix...",
 			"No auto fixes available"
 		],
-		"vs/editor/contrib/codeAction/browser/lightBulbWidget": [
-			"Show Code Actions. Preferred Quick Fix Available ({0})",
-			"Show Code Actions ({0})",
-			"Show Code Actions"
-		],
 		"vs/editor/contrib/codeAction/browser/codeActionController": [
+			"Context: {0} at line {1} and column {2}.",
 			"Hide Disabled",
 			"Show Disabled"
 		],
-		"vs/editor/browser/widget/diffReview": [
-			"Icon for 'Insert' in diff review.",
-			"Icon for 'Remove' in diff review.",
-			"Icon for 'Close' in diff review.",
-			"Close",
-			"no lines changed",
-			"1 line changed",
-			"{0} lines changed",
-			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
-			"blank",
-			"{0} unchanged line {1}",
-			"{0} original line {1} modified line {2}",
-			"+ {0} modified line {1}",
-			"- {0} original line {1}"
-		],
-		"vs/editor/browser/widget/inlineDiffMargin": [
-			"Copy deleted lines",
-			"Copy deleted line",
-			"Copy changed lines",
-			"Copy changed line",
-			"Copy deleted line ({0})",
-			"Copy changed line ({0})",
-			"Revert this change",
-			"Copy deleted line ({0})",
-			"Copy changed line ({0})"
-		],
-		"vs/editor/common/viewLayout/viewLineRenderer": [
-			"Show more ({0})",
-			"{0} chars"
+		"vs/base/browser/ui/actionbar/actionViewItems": [
+			"{0} ({1})"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/copyPasteController": [
 			"Whether the paste widget is showing",
@@ -26779,11 +26944,6 @@
 			"Running paste handlers. Click to cancel",
 			"Select Paste Action",
 			"Running paste handlers"
-		],
-		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController": [
-			"Whether the drop widget is showing",
-			"Show drop options...",
-			"Running drop handlers. Click to cancel"
 		],
 		"vs/editor/contrib/dropOrPasteInto/browser/defaultProviders": [
 			"Built-in",
@@ -26794,6 +26954,11 @@
 			"Insert Path",
 			"Insert Relative Paths",
 			"Insert Relative Path"
+		],
+		"vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController": [
+			"Whether the drop widget is showing",
+			"Show drop options...",
+			"Running drop handlers. Click to cancel"
 		],
 		"vs/editor/contrib/find/browser/findWidget": [
 			"Icon for 'Find in Selection' in the editor find widget.",
@@ -26838,6 +27003,9 @@
 			"Made 1 formatting edit between lines {0} and {1}",
 			"Made {0} formatting edits between lines {1} and {2}"
 		],
+		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
+			"Suggestion:"
+		],
 		"vs/editor/contrib/inlineCompletions/browser/commands": [
 			"Show Next Inline Suggestion",
 			"Show Previous Inline Suggestion",
@@ -26859,6 +27027,11 @@
 			"Loading...",
 			"{0} ({1})"
 		],
+		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
+			"Whether there are symbol locations that can be navigated via keyboard-only.",
+			"Symbol {0} of {1}, {2} for next",
+			"Symbol {0} of {1}"
+		],
 		"vs/editor/contrib/gotoSymbol/browser/referencesModel": [
 			"in {0} on line {1} at column {2}",
 			"{0} in {1} on line {2} at column {3}",
@@ -26871,28 +27044,6 @@
 		],
 		"vs/editor/contrib/message/browser/messageController": [
 			"Whether the editor is currently showing an inline message"
-		],
-		"vs/editor/contrib/gotoSymbol/browser/symbolNavigation": [
-			"Whether there are symbol locations that can be navigated via keyboard-only.",
-			"Symbol {0} of {1}, {2} for next",
-			"Symbol {0} of {1}"
-		],
-		"vs/editor/contrib/inlineCompletions/browser/hoverParticipant": [
-			"Suggestion:"
-		],
-		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget": [
-			"Icon for show next parameter hint.",
-			"Icon for show previous parameter hint.",
-			"{0} ({1})",
-			"Previous",
-			"Next"
-		],
-		"vs/editor/contrib/hover/browser/markerHoverParticipant": [
-			"View Problem",
-			"No quick fixes available",
-			"Checking for quick fixes...",
-			"No quick fixes available",
-			"Quick Fix..."
 		],
 		"vs/editor/contrib/gotoError/browser/gotoErrorWidget": [
 			"Error",
@@ -26910,10 +27061,34 @@
 			"Editor marker navigation widget info heading background.",
 			"Editor marker navigation widget background."
 		],
+		"vs/editor/contrib/inlayHints/browser/inlayHintsHover": [
+			"Double-click to insert",
+			"cmd + click",
+			"ctrl + click",
+			"option + click",
+			"alt + click",
+			"Go to Definition ({0}), right click for more",
+			"Go to Definition ({0})",
+			"Execute Command"
+		],
 		"vs/editor/contrib/hover/browser/markdownHoverParticipant": [
 			"Loading...",
 			"Rendering paused for long line for performance reasons. This can be configured via `editor.stopRenderingLineAfter`.",
 			"Tokenization is skipped for long lines for performance reasons. This can be configured via `editor.maxTokenizationLineLength`."
+		],
+		"vs/editor/contrib/hover/browser/markerHoverParticipant": [
+			"View Problem",
+			"No quick fixes available",
+			"Checking for quick fixes...",
+			"No quick fixes available",
+			"Quick Fix..."
+		],
+		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget": [
+			"Icon for show next parameter hint.",
+			"Icon for show previous parameter hint.",
+			"{0} ({1})",
+			"Previous",
+			"Next"
 		],
 		"vs/editor/contrib/wordHighlighter/browser/highlightDecorations": [
 			"Background color of a symbol during read-access, like reading a variable. The color must not be opaque so as not to hide underlying decorations.",
@@ -26931,16 +27106,6 @@
 			"Icon for show previous parameter hint.",
 			"{0}, hint",
 			"Foreground color of the active item in the parameter hint."
-		],
-		"vs/editor/contrib/inlayHints/browser/inlayHintsHover": [
-			"Double-click to insert",
-			"cmd + click",
-			"ctrl + click",
-			"option + click",
-			"alt + click",
-			"Go to Definition ({0}), right click for more",
-			"Go to Definition ({0})",
-			"Execute Command"
 		],
 		"vs/editor/contrib/rename/browser/renameInputField": [
 			"Whether the rename input widget is visible",
@@ -26976,9 +27141,6 @@
 			"{0} {1}",
 			"{0}, {1}",
 			"{0}, docs: {1}"
-		],
-		"vs/workbench/api/browser/mainThreadWebviews": [
-			"An error occurred while loading view: {0}"
 		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
 			"Colors and styles for the token.",
@@ -27023,6 +27185,9 @@
 			"Style to use for write accesses.",
 			"Style to use for symbols that are async.",
 			"Style to use for symbols that are read-only."
+		],
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"An error occurred while loading view: {0}"
 		],
 		"vs/workbench/browser/parts/editor/textEditor": [
 			"Editor"
@@ -27075,34 +27240,8 @@
 			"Toggle View Pinned",
 			"Toggle View Badge"
 		],
-		"vs/base/browser/ui/tree/treeDefaults": [
-			"Collapse All"
-		],
-		"vs/workbench/browser/parts/views/checkbox": [
-			"Checked",
-			"Unchecked"
-		],
 		"vs/base/browser/ui/splitview/paneview": [
 			"{0} Section"
-		],
-		"vs/workbench/contrib/remote/browser/remoteIcons": [
-			"Getting started icon in the remote explorer view.",
-			"Documentation icon in the remote explorer view.",
-			"Feedback icon in the remote explorer view.",
-			"Review issue icon in the remote explorer view.",
-			"Report issue icon in the remote explorer view.",
-			"View icon of the remote explorer view.",
-			"View icon of the remote ports view.",
-			"Icon representing a remote port.",
-			"Icon representing a private remote port.",
-			"Icon for the forward action.",
-			"Icon for the stop forwarding action.",
-			"Icon for the open browser action.",
-			"Icon for the open preview action.",
-			"Icon for the copy local address action.",
-			"Icon for the label port action.",
-			"Icon for forwarded ports that don't have a running process.",
-			"Icon for forwarded ports that do have a running process."
 		],
 		"vs/workbench/contrib/remote/browser/tunnelView": [
 			"Add Port",
@@ -27157,6 +27296,7 @@
 			"Copy Forwarded Port Address",
 			"Choose a forwarded port",
 			"Change Local Address Port",
+			"Local port should be a number.",
 			"The local port {0} is not available. Port number {1} has been used instead",
 			"New local port",
 			"HTTP",
@@ -27165,22 +27305,31 @@
 			"Change Port Protocol",
 			"The color of the icon for a port that has an associated running process."
 		],
-		"vs/workbench/browser/parts/editor/tabsTitleControl": [
-			"Tab actions"
+		"vs/workbench/contrib/remote/browser/remoteIcons": [
+			"Getting started icon in the remote explorer view.",
+			"Documentation icon in the remote explorer view.",
+			"Feedback icon in the remote explorer view.",
+			"Review issue icon in the remote explorer view.",
+			"Report issue icon in the remote explorer view.",
+			"View icon of the remote explorer view.",
+			"View icon of the remote ports view.",
+			"Icon representing a remote port.",
+			"Icon representing a private remote port.",
+			"Icon for the forward action.",
+			"Icon for the stop forwarding action.",
+			"Icon for the open browser action.",
+			"Icon for the open preview action.",
+			"Icon for the copy local address action.",
+			"Icon for the label port action.",
+			"Icon for forwarded ports that don't have a running process.",
+			"Icon for forwarded ports that do have a running process."
 		],
-		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
-			"Show All Commands",
-			"Go to File",
-			"Open File",
-			"Open Folder",
-			"Open File or Folder",
-			"Open Recent",
-			"New Untitled Text File",
-			"Find in Files",
-			"Toggle Terminal",
-			"Start Debugging",
-			"Toggle Full Screen",
-			"Show Settings"
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"Collapse All"
+		],
+		"vs/workbench/browser/parts/views/checkbox": [
+			"Checked",
+			"Unchecked"
 		],
 		"vs/workbench/browser/parts/editor/textCodeEditor": [
 			"Text Editor"
@@ -27189,16 +27338,6 @@
 			"Binary Viewer",
 			"The file is not displayed in the text editor because it is either binary or uses an unsupported text encoding.",
 			"Open Anyway"
-		],
-		"vs/workbench/browser/parts/editor/editorPanes": [
-			"Unable to open '{0}'",
-			"&&OK"
-		],
-		"vs/editor/browser/widget/diffEditor.contribution": [
-			"Accessible Diff Viewer",
-			"Go to Next Difference",
-			"Open Accessible Diff Viewer",
-			"Go to Previous Difference"
 		],
 		"vs/workbench/browser/parts/activitybar/activitybarActions": [
 			"Loading...",
@@ -27246,8 +27385,35 @@
 		"vs/base/browser/ui/toolbar/toolbar": [
 			"More Actions..."
 		],
+		"vs/workbench/browser/parts/editor/editorPanes": [
+			"Unable to open '{0}'",
+			"&&OK"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
+			"Show All Commands",
+			"Go to File",
+			"Open File",
+			"Open Folder",
+			"Open File or Folder",
+			"Open Recent",
+			"New Untitled Text File",
+			"Find in Files",
+			"Toggle Terminal",
+			"Start Debugging",
+			"Toggle Full Screen",
+			"Show Settings"
+		],
 		"vs/base/browser/ui/iconLabel/iconLabelHover": [
 			"Loading..."
+		],
+		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
+			"System",
+			"Extension",
+			"User",
+			"{0}: {1}",
+			"{0}: {1}",
+			"option",
+			"meta"
 		],
 		"vs/workbench/services/preferences/common/preferencesValidation": [
 			"Incorrect type. Expected \"boolean\".",
@@ -27278,15 +27444,6 @@
 			"Value {0} is not one of {1}",
 			"Incorrect type. Expected an object.",
 			"Property {0} is not allowed.\n"
-		],
-		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
-			"System",
-			"Extension",
-			"User",
-			"{0}: {1}",
-			"{0}: {1}",
-			"option",
-			"meta"
 		],
 		"vs/editor/common/model/editStack": [
 			"Typing"
@@ -27321,36 +27478,6 @@
 		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
 			"Unbound"
 		],
-		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
-			"User",
-			"Remote",
-			"Workspace",
-			"Folder",
-			"Settings Switcher",
-			"User",
-			"Remote",
-			"Workspace",
-			"User",
-			"Workspace"
-		],
-		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
-			"Edit",
-			"Replace in Settings",
-			"Copy to Settings",
-			"This setting cannot be applied because it is configured in the system policy.",
-			"This setting cannot be applied because it is not registered as language override setting.",
-			"This setting cannot be applied while a non-default profile is active. It will be applied when the default profile is active.",
-			"This setting cannot be applied because it is configured to be applied in all profiles using setting {0}. Value from the default profile will be used instead.",
-			"This setting cannot be applied in this window. It will be applied when you open a local window.",
-			"This setting cannot be applied in this workspace. It will be applied when you open the containing workspace folder directly.",
-			"This setting has an application scope and can be set only in the user settings file.",
-			"This setting can only be applied in user settings in local window or in remote settings in remote window.",
-			"This setting can only be applied in a trusted workspace.",
-			"Unknown Configuration Setting",
-			"Manage Workspace Trust",
-			"Manage Workspace Trust",
-			"Unsupported Property"
-		],
 		"vs/workbench/contrib/preferences/common/settingsEditorColorRegistry": [
 			"The foreground color for a section header or active title.",
 			"The foreground color for a section header or hovered title.",
@@ -27373,6 +27500,36 @@
 			"The background color of a settings row when focused.",
 			"The background color of a settings row when hovered.",
 			"The color of the row's top and bottom border when the row is focused."
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
+			"Edit",
+			"Replace in Settings",
+			"Copy to Settings",
+			"This setting cannot be applied because it is configured in the system policy.",
+			"This setting cannot be applied because it is not registered as language override setting.",
+			"This setting cannot be applied while a non-default profile is active. It will be applied when the default profile is active.",
+			"This setting cannot be applied because it is configured to be applied in all profiles using setting {0}. Value from the default profile will be used instead.",
+			"This setting cannot be applied in this window. It will be applied when you open a local window.",
+			"This setting cannot be applied in this workspace. It will be applied when you open the containing workspace folder directly.",
+			"This setting has an application scope and can be set only in the user settings file.",
+			"This setting can only be applied in user settings in local window or in remote settings in remote window.",
+			"This setting can only be applied in a trusted workspace.",
+			"Unknown Configuration Setting",
+			"Manage Workspace Trust",
+			"Manage Workspace Trust",
+			"Unsupported Property"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"User",
+			"Remote",
+			"Workspace",
+			"Folder",
+			"Settings Switcher",
+			"User",
+			"Remote",
+			"Workspace",
+			"User",
+			"Workspace"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsLayout": [
 			"Commonly Used",
@@ -27424,26 +27581,6 @@
 			"Security",
 			"Workspace"
 		],
-		"vs/workbench/contrib/preferences/browser/tocTree": [
-			"Settings Table of Contents",
-			"{0}, group"
-		],
-		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
-			"Modified",
-			"Add or remove modified settings filter",
-			"Extension ID...",
-			"Add extension ID filter",
-			"Feature...",
-			"Add feature filter",
-			"Tag...",
-			"Add tag filter",
-			"Language...",
-			"Add language ID filter",
-			"Online services",
-			"Show settings for online services",
-			"Policy services",
-			"Show settings for policy services"
-		],
 		"vs/workbench/contrib/preferences/browser/settingsTree": [
 			"Extensions",
 			"The setting has been configured in the current scope.",
@@ -27463,6 +27600,26 @@
 			"Copy Setting as JSON",
 			"Sync This Setting",
 			"Apply Setting to all Profiles"
+		],
+		"vs/workbench/contrib/preferences/browser/tocTree": [
+			"Settings Table of Contents",
+			"{0}, group"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsSearchMenu": [
+			"Modified",
+			"Add or remove modified settings filter",
+			"Extension ID...",
+			"Add extension ID filter",
+			"Feature...",
+			"Add feature filter",
+			"Tag...",
+			"Add tag filter",
+			"Language...",
+			"Add language ID filter",
+			"Online services",
+			"Show settings for online services",
+			"Policy services",
+			"Show settings for policy services"
 		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView": [
 			"Select Notebook Kernel",
@@ -27532,6 +27689,21 @@
 			"Could not render content for '$0'",
 			"Notebook webview content"
 		],
+		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
+			"File Created",
+			"File Replaced",
+			"File Working Copy Decorations",
+			"Deleted, Read-only",
+			"Read-only",
+			"Deleted",
+			"'{0}' already exists. Do you want to replace it?",
+			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
+			"&&Replace"
+		],
+		"vs/platform/actions/browser/toolbar": [
+			"Hide",
+			"Reset Menu"
+		],
 		"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy": [
 			"Currently Selected",
 			"{0} - Currently Selected",
@@ -27550,21 +27722,6 @@
 			"Detecting Kernels",
 			"Select Kernel"
 		],
-		"vs/workbench/services/workingCopy/common/fileWorkingCopyManager": [
-			"File Created",
-			"File Replaced",
-			"File Working Copy Decorations",
-			"Deleted, Read-only",
-			"Read-only",
-			"Deleted",
-			"'{0}' already exists. Do you want to replace it?",
-			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
-			"&&Replace"
-		],
-		"vs/platform/actions/browser/toolbar": [
-			"Hide",
-			"Reset Menu"
-		],
 		"vs/workbench/contrib/notebook/browser/controller/cellOperations": [
 			"Cannot join cells of different kinds",
 			"Join Notebook Cells"
@@ -27576,16 +27733,6 @@
 		],
 		"vs/editor/contrib/codeAction/browser/codeAction": [
 			"An unknown error occurred while applying the code action"
-		],
-		"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider": [
-			"empty cell"
-		],
-		"vs/workbench/contrib/comments/common/commentContextKeys": [
-			"Set when the comment thread has no comments",
-			"Set when the comment has no input",
-			"The context value of the comment",
-			"The context value of the comment thread",
-			"The comment controller id associated with a comment thread"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
 			"The chat view is comprised of an input box and a request/response list. The input box is used to make requests and the list is used to display responses.",
@@ -27638,14 +27785,24 @@
 			"Code block {0}",
 			"File Tree"
 		],
+		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
+			"Nothing changed",
+			"Changed 1 line",
+			"Changed {0} lines"
+		],
 		"vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys": [
 			"Whether an inline suggestion is visible",
 			"Whether the inline suggestion starts with whitespace",
 			"Whether the inline suggestion starts with whitespace that is less than what would be inserted by tab",
 			"Whether suggestions should be suppressed for the current suggestion"
 		],
-		"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget": [
-			"Exited {0} mode"
+		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
+			"Inline Chat Input",
+			"Original",
+			"Modified",
+			"Inline Chat Input, Use {0} for Inline Chat Accessibility Help.",
+			"Inline Chat Input, Run the Inline Chat Accessibility Help command for more information.",
+			"Closed inline chat widget"
 		],
 		"vs/workbench/contrib/testing/browser/theme": [
 			"Color for the 'failed' icon in the test explorer.",
@@ -27661,11 +27818,6 @@
 			"Margin color beside error messages shown inline in the editor.",
 			"Text color of test info messages shown inline in the editor.",
 			"Margin color beside info messages shown inline in the editor."
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatStrategies": [
-			"Nothing changed",
-			"Changed 1 line",
-			"Changed {0} lines"
 		],
 		"vs/workbench/contrib/testing/common/constants": [
 			"Errored",
@@ -27692,13 +27844,12 @@
 			"Show Hidden Tests",
 			"Unhide All Tests"
 		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatWidget": [
-			"Inline Chat Input",
-			"Original",
-			"Modified",
-			"Inline Chat Input, Use {0} for Inline Chat Accessibility Help.",
-			"Inline Chat Input, Run the Inline Chat Accessibility Help command for more information.",
-			"Closed inline chat widget"
+		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
+			"The terminal has no selection to copy",
+			"Yes",
+			"No",
+			"Don't Show Again",
+			"Terminal GPU acceleration appears to be slow on your computer. Would you like to switch to disable it which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered)."
 		],
 		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
 			"The background color of the terminal, this allows coloring the terminal differently to the panel.",
@@ -27723,39 +27874,12 @@
 			"Border on the side of the terminal tab in the panel. This defaults to tab.activeBorder.",
 			"'{0}' ANSI color in the terminal."
 		],
-		"vs/workbench/contrib/terminal/browser/xterm/xtermTerminal": [
-			"The terminal has no selection to copy",
-			"Yes",
-			"No",
-			"Don't Show Again",
-			"Terminal GPU acceleration appears to be slow on your computer. Would you like to switch to disable it which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered)."
-		],
-		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
-			"Unable to resolve workspace folder ({0})",
-			"Symbolic Link",
-			"Unknown File Type",
-			"Explorer"
-		],
-		"vs/workbench/contrib/files/browser/views/explorerViewer": [
-			"Files Explorer",
-			"Type file name. Press Enter to confirm or Escape to cancel.",
-			"Are you sure you want to change the order of multiple root folders in your workspace?",
-			"Are you sure you want to move the following {0} files into '{1}'?",
-			"Are you sure you want to change the order of root folder '{0}' in your workspace?",
-			"Are you sure you want to move '{0}' into '{1}'?",
-			"Do not ask me again",
-			"&&Move",
-			"Copy {0}",
-			"Copying {0}",
-			"Move {0}",
-			"Moving {0}",
-			"{0} folders",
-			"{0} files"
-		],
 		"vs/platform/quickinput/browser/commandsQuickAccess": [
 			"recently used",
+			"similar commands",
 			"commonly used",
 			"other commands",
+			"similar commands",
 			"{0}, {1}",
 			"Command '{0}' resulted in an error"
 		],
@@ -27794,6 +27918,58 @@
 			"This action is irreversible!",
 			"&&Replace"
 		],
+		"vs/workbench/contrib/files/browser/views/explorerViewer": [
+			"Files Explorer",
+			"Type file name. Press Enter to confirm or Escape to cancel.",
+			"Are you sure you want to change the order of multiple root folders in your workspace?",
+			"Are you sure you want to move the following {0} files into '{1}'?",
+			"Are you sure you want to change the order of root folder '{0}' in your workspace?",
+			"Are you sure you want to move '{0}' into '{1}'?",
+			"Do not ask me again",
+			"&&Move",
+			"Copy {0}",
+			"Copying {0}",
+			"Move {0}",
+			"Moving {0}",
+			"{0} folders",
+			"{0} files"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
+			"Unable to resolve workspace folder ({0})",
+			"Symbolic Link",
+			"Unknown File Type",
+			"Explorer"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization": [
+			"All backslashes in Query string must be escaped (\\\\)",
+			"{0} files",
+			"1 file",
+			"{0} results",
+			"1 result",
+			"No Results",
+			"The result set only contains a subset of all matches. Be more specific in your search to narrow down the results."
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
+			"Bulk Edit",
+			"Renaming {0} to {1}, also making text edits",
+			"Creating {0}, also making text edits",
+			"Deleting {0}, also making text edits",
+			"{0}, making text edits",
+			"Renaming {0} to {1}",
+			"Creating {0}",
+			"Deleting {0}",
+			"line {0}, replacing {1} with {2}",
+			"line {0}, removing {1}",
+			"line {0}, inserting {1}",
+			"{0} → {1}",
+			"(renaming)",
+			"(creating)",
+			"(deleting)",
+			"{0} - {1}"
+		],
+		"vs/workbench/contrib/search/browser/searchFindInput": [
+			"Notebook Find Filters"
+		],
 		"vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess": [
 			"To go to a symbol, first open a text editor with symbol information.",
 			"The active text editor does not provide symbol information.",
@@ -27829,39 +28005,9 @@
 			"fields ({0})",
 			"constants ({0})"
 		],
-		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
-			"Bulk Edit",
-			"Renaming {0} to {1}, also making text edits",
-			"Creating {0}, also making text edits",
-			"Deleting {0}, also making text edits",
-			"{0}, making text edits",
-			"Renaming {0} to {1}",
-			"Creating {0}",
-			"Deleting {0}",
-			"line {0}, replacing {1} with {2}",
-			"line {0}, removing {1}",
-			"line {0}, inserting {1}",
-			"{0} → {1}",
-			"(renaming)",
-			"(creating)",
-			"(deleting)",
-			"{0} - {1}"
-		],
-		"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization": [
-			"All backslashes in Query string must be escaped (\\\\)",
-			"{0} files",
-			"1 file",
-			"{0} results",
-			"1 result",
-			"No Results",
-			"The result set only contains a subset of all matches. Be more specific in your search to narrow down the results."
-		],
-		"vs/workbench/contrib/scm/browser/dirtyDiffSwitcher": [
-			"Switch quick diff base",
-			"Switch Quick Diff Base"
-		],
-		"vs/workbench/contrib/scm/browser/menus": [
-			"Share"
+		"vs/workbench/contrib/search/browser/replaceService": [
+			"Search and Replace",
+			"{0} ↔ {1} (Replace Preview)"
 		],
 		"vs/workbench/contrib/debug/browser/baseDebugView": [
 			"Click to expand"
@@ -27871,15 +28017,8 @@
 			"Start a New Debug Session",
 			"Session {0} spawned from {1}"
 		],
-		"vs/workbench/contrib/search/browser/searchFindInput": [
-			"Notebook Find Filters"
-		],
 		"vs/workbench/contrib/debug/common/loadedScriptsPicker": [
 			"Search loaded scripts by name"
-		],
-		"vs/workbench/contrib/search/browser/replaceService": [
-			"Search and Replace",
-			"{0} ↔ {1} (Replace Preview)"
 		],
 		"vs/workbench/contrib/debug/browser/debugAdapterManager": [
 			"Debugger 'type' can not be omitted and must be of type 'string'.",
@@ -27963,16 +28102,19 @@
 		"vs/workbench/contrib/debug/common/debugSource": [
 			"Unknown Source"
 		],
+		"vs/workbench/contrib/scm/browser/menus": [
+			"Share"
+		],
+		"vs/workbench/contrib/scm/browser/dirtyDiffSwitcher": [
+			"Switch quick diff base",
+			"Switch Quick Diff Base"
+		],
 		"vs/base/browser/ui/findinput/replaceInput": [
 			"input",
 			"Preserve Case"
 		],
-		"vs/workbench/contrib/markers/browser/markersTreeViewer": [
-			"Problems View",
-			"Icon indicating that multiple lines are shown in the markers view.",
-			"Icon indicating that multiple lines are collapsed in the markers view.",
-			"Show message in single line",
-			"Show message in multiple lines"
+		"vs/base/browser/ui/dropdown/dropdownActionViewItem": [
+			"More Actions..."
 		],
 		"vs/workbench/contrib/markers/browser/markersTable": [
 			"Code",
@@ -27989,6 +28131,13 @@
 			"If the merge editor shows non-conflicting changes",
 			"The uri of the baser of a merge editor",
 			"The uri of the result of a merge editor"
+		],
+		"vs/workbench/contrib/markers/browser/markersTreeViewer": [
+			"Problems View",
+			"Icon indicating that multiple lines are shown in the markers view.",
+			"Icon indicating that multiple lines are collapsed in the markers view.",
+			"Show message in single line",
+			"Show message in multiple lines"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditorInputModel": [
 			"Do you want keep the merge result of {0} files?",
@@ -28042,13 +28191,6 @@
 			"Undo accept",
 			"Undo accept (currently second)"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
-			"Result",
-			"{0} Conflict Remaining",
-			"{0} Conflicts Remaining ",
-			"Go to next conflict",
-			"All conflicts handled, the merge can be completed now."
-		],
 		"vs/workbench/contrib/mergeEditor/browser/view/colors": [
 			"The background color for changes.",
 			"The background color for word changes.",
@@ -28064,21 +28206,23 @@
 			"The background color of decorations in input 1.",
 			"The background color of decorations in input 2."
 		],
+		"vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView": [
+			"Result",
+			"{0} Conflict Remaining",
+			"{0} Conflicts Remaining ",
+			"Go to next conflict",
+			"All conflicts handled, the merge can be completed now."
+		],
 		"vs/workbench/contrib/comments/browser/commentsController": [
-			"Whether the position at the active cursor has a commenting range",
+			"Line {0}",
+			"Lines {0} to {1}",
+			"Editor has commenting ranges, run the command Open Accessibility Help ({0}), for more information.",
+			"Editor has commenting ranges, run the command Open Accessibility Help, which is currently not triggerable via keybinding, for more information.",
+			"Editor has commenting ranges.",
 			"Select Comment Provider"
 		],
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
 			"Built-in"
-		],
-		"vs/platform/files/browser/htmlFileSystemProvider": [
-			"Rename is only supported for files.",
-			"Insufficient permissions. Please retry and allow the operation."
-		],
-		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
-			"Error",
-			"Unknown Extension:",
-			"Extensions"
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
 			"Average rating: {0} out of 5",
@@ -28106,6 +28250,14 @@
 			"The icon color for pre-release extension.",
 			"The icon color for extension sponsor."
 		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
+			"Error",
+			"Unknown Extension:",
+			"Extensions"
+		],
+		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
+			"This extension is recommended by users of the current workspace."
+		],
 		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
 			"This extension is recommended based on the files you recently opened.",
 			"the {0} language"
@@ -28113,14 +28265,22 @@
 		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
 			"This extension is recommended because you have {0} installed."
 		],
-		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
-			"This extension is recommended by users of the current workspace."
-		],
 		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
 			"This extension is recommended because of the current workspace configuration"
 		],
 		"vs/workbench/contrib/extensions/browser/webRecommendations": [
 			"This extension is recommended for {0} for the Web"
+		],
+		"vs/platform/files/browser/htmlFileSystemProvider": [
+			"Rename is only supported for files.",
+			"Insufficient permissions. Please retry and allow the operation."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"Do you want to terminate the active terminal session?",
+			"Do you want to terminate the {0} active terminal sessions?",
+			"&&Terminate",
+			"This shell is open to a {0}local{1} folder, NOT to the virtual folder",
+			"This shell is running on your {0}local{1} machine, NOT on the connected remote machine"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalActions": [
 			"Show Tabs",
@@ -28208,27 +28368,6 @@
 			"Create New Terminal With Profile",
 			"Rename Terminal"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalIcons": [
-			"View icon of the terminal view.",
-			"Icon for rename in the terminal quick menu.",
-			"Icon for killing a terminal instance.",
-			"Icon for creating a new terminal instance.",
-			"Icon for creating a new terminal profile.",
-			"Icon for a terminal decoration mark.",
-			"Icon for a terminal decoration of a command that was incomplete.",
-			"Icon for a terminal decoration of a command that errored.",
-			"Icon for a terminal decoration of a command that was successful.",
-			"Icon for removing a terminal command from command history.",
-			"Icon for viewing output of a terminal command.",
-			"Icon for toggling fuzzy search of command history."
-		],
-		"vs/workbench/contrib/terminal/browser/terminalService": [
-			"Do you want to terminate the active terminal session?",
-			"Do you want to terminate the {0} active terminal sessions?",
-			"&&Terminate",
-			"This shell is open to a {0}local{1} folder, NOT to the virtual folder",
-			"This shell is running on your {0}local{1} machine, NOT on the connected remote machine"
-		],
 		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
 			"the terminal's current working directory",
 			"the terminal's current working directory, displayed for multi-root workspaces or in a single root workspace when the value differs from the initial working directory. On Windows, this will only be displayed when shell integration is enabled.",
@@ -28263,7 +28402,6 @@
 			"Show the terminal tabs view to the left of the terminal",
 			"Show the terminal tabs view to the right of the terminal",
 			"Controls the location of the terminal tabs, either to the left or right of the actual terminal(s).",
-			"Controls whether the terminal receives tabs or defers them to the workbench for navigation. When set, this overrides {0} when the terminal is focused.",
 			"Create terminals in the editor",
 			"Create terminals in the terminal view",
 			"Controls where newly created terminals will appear.",
@@ -28303,7 +28441,7 @@
 			"Disable GPU acceleration within the terminal. The terminal will render much slower when GPU acceleration is off but it should reliably work on all systems.",
 			"Use the terminal's fallback canvas renderer which uses a 2d context instead of webgl which may perform better on some systems. Note that some features are limited in the canvas renderer like opaque selection.",
 			"Controls whether the terminal will leverage the GPU to do its rendering.",
-			"Separator used by {0} and {0}.",
+			"Separator used by {0} and {1}.",
 			"Show the context menu.",
 			"Copy when there is a selection, otherwise paste.",
 			"Paste on right click.",
@@ -28333,7 +28471,7 @@
 			"Disable the indicator.",
 			"Enable the indicator.",
 			"Only show the warning indicator when a terminal's environment is 'stale', not the information indicator that shows a terminal has had its environment modified by an extension.",
-			"Whether to relaunch terminals automatically if extension want to contribute to their environment and have not been interacted with yet.",
+			"Whether to relaunch terminals automatically if extensions want to contribute to their environment and have not been interacted with yet.",
 			"Controls whether to show the alert \"The terminal process terminated with exit code\" when exit code is non-zero.",
 			"Controls the working directory a split terminal starts with.",
 			"A new split terminal will use the workspace root as the working directory. In a multi-root workspace a choice for which root folder to use is offered.",
@@ -28417,6 +28555,20 @@
 			"{0} (Default)",
 			"Split Terminal"
 		],
+		"vs/workbench/contrib/terminal/browser/terminalIcons": [
+			"View icon of the terminal view.",
+			"Icon for rename in the terminal quick menu.",
+			"Icon for killing a terminal instance.",
+			"Icon for creating a new terminal instance.",
+			"Icon for creating a new terminal profile.",
+			"Icon for a terminal decoration mark.",
+			"Icon for a terminal decoration of a command that was incomplete.",
+			"Icon for a terminal decoration of a command that errored.",
+			"Icon for a terminal decoration of a command that was successful.",
+			"Icon for removing a terminal command from command history.",
+			"Icon for viewing output of a terminal command.",
+			"Icon for toggling fuzzy search of command history."
+		],
 		"vs/workbench/contrib/terminal/common/terminalStrings": [
 			"Terminal",
 			"New Terminal",
@@ -28445,17 +28597,29 @@
 		"vs/platform/terminal/common/terminalLogService": [
 			"Terminal"
 		],
+		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
+			"Move Tabs Right",
+			"Move Tabs Left",
+			"Hide Tabs"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
+			"Shell integration activated",
+			"The terminal process failed to launch. Disabling shell integration with terminal.integrated.shellIntegration.enabled might help.",
+			"Shell integration failed to activate",
+			"Process ID ({0}): {1}",
+			"Command line: {0}"
+		],
 		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp": [
 			"The Focus Accessible Buffer ({0}) command enables screen readers to read terminal contents.",
 			"The Focus Accessible Buffer command enables screen readers to read terminal contents and is currently not triggerable by a keybinding.",
 			"Consider using powershell instead of command prompt for an improved experience",
 			"The terminal has a feature called shell integration that offers an enhanced experience and provides useful commands for screen readers such as:",
-			"Go to Next Command ({0})",
-			"Go to Next Command is currently not triggerable by a keybinding.",
-			"Go to Previous Command ({0})",
-			"Go to Previous Command is currently not triggerable by a keybinding.",
-			"Navigate Accessible Buffer ({0})",
-			"Navigate Accessible Buffer is currently not triggerable by a keybinding.",
+			"Go to Next Command ({0}) in the accessible view",
+			"Go to Next Command in the accessible view is currently not triggerable by a keybinding.",
+			"Go to Previous Command ({0}) in the accessible view",
+			"Go to Previous Command in the accessible view is currently not triggerable by a keybinding.",
+			"Go to Symbol ({0})",
+			"Go to symbol is currently not triggerable by a keybinding.",
 			"Run Recent Command ({0})",
 			"Run Recent Command is currently not triggerable by a keybinding.",
 			"Go to Recent Directory ({0})",
@@ -28469,31 +28633,6 @@
 			"Configure what gets focused after running selected text in the terminal with `{0}`.",
 			"Access accessibility settings such as `terminal.integrated.tabFocusMode` via the Preferences: Open Accessibility Settings command."
 		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer": [
-			"Terminal buffer",
-			"{0}"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalTabbedView": [
-			"Move Tabs Right",
-			"Move Tabs Left",
-			"Hide Tabs"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalTooltip": [
-			"Shell integration activated",
-			"The terminal process failed to launch. Disabling shell integration with terminal.integrated.shellIntegration.enabled might help.",
-			"Shell integration failed to activate",
-			"Process ID ({0}): {1}",
-			"Command line: {0}"
-		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
-			"option + click",
-			"alt + click",
-			"cmd + click",
-			"ctrl + click",
-			"Follow link",
-			"Follow link using forwarded port",
-			"Link"
-		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick": [
 			"Url",
 			"File",
@@ -28505,10 +28644,23 @@
 			"Folder",
 			"Workspace Search"
 		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager": [
+			"option + click",
+			"alt + click",
+			"cmd + click",
+			"ctrl + click",
+			"Follow link",
+			"Follow link using forwarded port",
+			"Link"
+		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon": [
 			"Run: {0}",
 			"Open: {0}",
 			"Quick Fix"
+		],
+		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
+			"Free port {0}",
+			"Create PR {0}"
 		],
 		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixService": [
 			"Contributes terminal quick fixes.",
@@ -28582,10 +28734,6 @@
 			"Optional arguments passed to the command.",
 			"Optional arguments passed to the command."
 		],
-		"vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions": [
-			"Free port {0}",
-			"Create PR {0}"
-		],
 		"vs/workbench/contrib/remote/browser/explorerViewItems": [
 			"Switch Remote",
 			"Switch Remote"
@@ -28611,11 +28759,6 @@
 			"{0} ({1})",
 			"{0}, {1}",
 			"{0}, {1}"
-		],
-		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
-			"Release Notes: {0}",
-			"unassigned",
-			"Show release notes after an update"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent": [
 			"Icon used for the setup category of welcome page",
@@ -28748,17 +28891,10 @@
 			"Select the layout for your notebooks",
 			"Get notebooks to feel just the way you prefer"
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
-			"Recommended"
-		],
-		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
-			"Background color for the Welcome page.",
-			"Background color for the tiles on the Welcome page.",
-			"Hover background color for the tiles on the Welcome.",
-			"Border color for the tiles on the Welcome page.",
-			"Foreground color for the Welcome page progress bars.",
-			"Background color for the Welcome page progress bars.",
-			"Foreground color of the heading of each walkthrough step"
+		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
+			"Release Notes: {0}",
+			"unassigned",
+			"Show release notes after an update"
 		],
 		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedExtensionPoint": [
 			"Title",
@@ -28802,15 +28938,17 @@
 		"vs/workbench/contrib/welcomeWalkthrough/common/walkThroughUtils": [
 			"Background color for the embedded editors on the Interactive Playground."
 		],
-		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
-			"Call Hierarchy",
-			"calls from {0}",
-			"callers of {0}"
+		"vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService": [
+			"Recommended"
 		],
-		"vs/workbench/contrib/typeHierarchy/browser/typeHierarchyTree": [
-			"Type Hierarchy",
-			"supertypes of {0}",
-			"subtypes of {0}"
+		"vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedColors": [
+			"Background color for the Welcome page.",
+			"Background color for the tiles on the Welcome page.",
+			"Hover background color for the tiles on the Welcome.",
+			"Border color for the tiles on the Welcome page.",
+			"Foreground color for the Welcome page progress bars.",
+			"Background color for the Welcome page progress bars.",
+			"Foreground color of the heading of each walkthrough step"
 		],
 		"vs/editor/contrib/symbolIcons/browser/symbolIcons": [
 			"The foreground color for array symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
@@ -28847,6 +28985,16 @@
 			"The foreground color for unit symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
 			"The foreground color for variable symbols. These symbols appear in the outline, breadcrumb, and suggest widget."
 		],
+		"vs/workbench/contrib/typeHierarchy/browser/typeHierarchyTree": [
+			"Type Hierarchy",
+			"supertypes of {0}",
+			"subtypes of {0}"
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
+			"Call Hierarchy",
+			"calls from {0}",
+			"callers of {0}"
+		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
 			"Conflicts",
 			"Synced Machines",
@@ -28854,6 +29002,9 @@
 			"Turn off Settings Sync",
 			"Sync Activity (Remote)",
 			"Sync Activity (Local)",
+			"Sync Activity (Developer)",
+			"Load Sync Activity",
+			"Select Sync Activity File or Folder",
 			"Show raw JSON sync data",
 			"Compare with Local",
 			"{0} ↔ {1}",
@@ -28864,6 +29015,7 @@
 			"Troubleshoot",
 			"Reset Synced Data",
 			"{0} ↔ {1}",
+			"Current",
 			"Current",
 			"No Machines",
 			"Current",
@@ -28878,6 +29030,32 @@
 			"Last Synced Remotes",
 			"Current"
 		],
+		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"Inspect the response in the accessible view with {0}",
+			"Inspect the response in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding",
+			"{0}, notification, {1}",
+			"{0}, notification",
+			"{0}, source: {1}, notification, {2}",
+			"{0}, source: {1}, notification",
+			"Notifications List"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsActions": [
+			"Icon for the clear action in notifications.",
+			"Icon for the clear all action in notifications.",
+			"Icon for the hide action in notifications.",
+			"Icon for the expand action in notifications.",
+			"Icon for the collapse action in notifications.",
+			"Icon for the configure action in notifications.",
+			"Icon for the mute all action in notifications.",
+			"Clear Notification",
+			"Clear All Notifications",
+			"Toggle Do Not Disturb Mode",
+			"Hide Notifications",
+			"Expand Notification",
+			"Collapse Notification",
+			"More Actions...",
+			"Copy Text"
+		],
 		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
 			"Saving '{0}'"
 		],
@@ -28887,14 +29065,12 @@
 			"{0} {1}",
 			"Search {0} ({1}) — {2}",
 			"Search {0} — {1}",
-			"Foreground color of the command center",
-			"Active foreground color of the command center",
-			"Foreground color of the command center when the window is inactive",
-			"Background color of the command center",
-			"Active background color of the command center",
-			"Border color of the command center",
-			"Active border color of the command center",
-			"Border color of the command center when the window is inactive"
+			"Command Center"
+		],
+		"vs/workbench/browser/parts/titlebar/windowTitle": [
+			"[Administrator]",
+			"[Superuser]",
+			"[Extension Development Host]"
 		],
 		"vs/workbench/services/workingCopy/common/storedFileWorkingCopy": [
 			"Failed to save '{0}': The content of the file is newer. Do you want to overwrite the file with your changes?",
@@ -28914,11 +29090,6 @@
 			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Admin' to retry as administrator.",
 			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Sudo' to retry as superuser.",
 			"Failed to save '{0}': {1}"
-		],
-		"vs/workbench/browser/parts/titlebar/windowTitle": [
-			"[Administrator]",
-			"[Superuser]",
-			"[Extension Development Host]"
 		],
 		"vs/platform/terminal/common/terminalProfiles": [
 			"Automatically detect the default"
@@ -28941,12 +29112,12 @@
 		"vs/workbench/api/common/extHostProgress": [
 			"{0} (Extension)"
 		],
-		"vs/workbench/api/common/extHostTreeViews": [
-			"Element with id {0} is already registered"
-		],
 		"vs/workbench/api/common/extHostStatusBar": [
 			"{0} (Extension)",
 			"Extension Status"
+		],
+		"vs/workbench/api/common/extHostTreeViews": [
+			"Element with id {0} is already registered"
 		],
 		"vs/workbench/api/common/extHostNotebook": [
 			"Unable to modify read-only file '{0}'",
@@ -28961,15 +29132,42 @@
 			"Match Whole Word",
 			"Use Regular Expression"
 		],
-		"vs/workbench/browser/parts/notifications/notificationsViewer": [
-			"Click to execute command '{0}'",
-			"Notification Actions",
-			"Source: {0}"
+		"vs/editor/browser/widget/diffEditor/accessibleDiffViewer": [
+			"Icon for 'Insert' in accessible diff viewer.",
+			"Icon for 'Remove' in accessible diff viewer.",
+			"Icon for 'Close' in accessible diff viewer.",
+			"Close",
+			"Accessible Diff Viewer. Use arrow up and down to navigate.",
+			"no lines changed",
+			"1 line changed",
+			"{0} lines changed",
+			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
+			"blank",
+			"{0} unchanged line {1}",
+			"{0} original line {1} modified line {2}",
+			"+ {0} modified line {1}",
+			"- {0} original line {1}"
 		],
-		"vs/platform/languagePacks/common/localizedStrings": [
-			"open",
-			"close",
-			"find"
+		"vs/editor/browser/widget/diffEditor/movedBlocksLines": [
+			"Code moved with changes to line {0}-{1}",
+			"Code moved with changes from line {0}-{1}",
+			"Code moved to line {0}-{1}",
+			"Code moved from line {0}-{1}"
+		],
+		"vs/editor/browser/widget/diffEditor/hideUnchangedRegionsFeature": [
+			"Fold Unchanged Region",
+			"Click or drag to show more above",
+			"Show all",
+			"Click or drag to show more below",
+			"{0} hidden lines",
+			"Double click to unfold"
+		],
+		"vs/editor/browser/widget/diffEditor/diffEditorEditors": [
+			" use {0} to open the accessibility help."
+		],
+		"vs/editor/browser/widget/diffEditor/colors": [
+			"The border color for text that got moved in the diff editor.",
+			"The active border color for text that got moved in the diff editor."
 		],
 		"vs/editor/browser/controller/textAreaHandler": [
 			"editor",
@@ -28977,6 +29175,15 @@
 			"{0} To enable screen reader optimized mode, use {1}",
 			"{0} To enable screen reader optimized mode, open the quick pick with {1} and run the command Toggle Screen Reader Accessibility Mode, which is currently not triggerable via keyboard.",
 			"{0} Please assign a keybinding for the command Toggle Screen Reader Accessibility Mode by accessing the keybindings editor with {1} and run it."
+		],
+		"vs/platform/actionWidget/browser/actionWidget": [
+			"Background color for toggled action items in action bar.",
+			"Whether the action widget list is visible",
+			"Hide action widget",
+			"Select previous action",
+			"Select next action",
+			"Accept selected action",
+			"Preview selected action"
 		],
 		"vs/editor/contrib/codeAction/browser/codeActionMenu": [
 			"More Actions...",
@@ -28988,26 +29195,17 @@
 			"Surround With",
 			"Source Action"
 		],
-		"vs/platform/actionWidget/browser/actionWidget": [
-			"Background color for toggled action items in action bar.",
-			"Whether the action widget list is visible",
-			"Hide action widget",
-			"Select previous action",
-			"Select next action",
-			"Accept selected action",
-			"Preview selected action"
+		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
+			"Click to toggle color options (rgb/hsl/hex)",
+			"Icon to close the color picker"
+		],
+		"vs/editor/contrib/editorState/browser/keybindingCancellation": [
+			"Whether the editor runs a cancellable operation, e.g. like 'Peek References'"
 		],
 		"vs/editor/contrib/gotoSymbol/browser/peek/referencesWidget": [
 			"no preview available",
 			"No results",
 			"References"
-		],
-		"vs/editor/contrib/editorState/browser/keybindingCancellation": [
-			"Whether the editor runs a cancellable operation, e.g. like 'Peek References'"
-		],
-		"vs/editor/contrib/colorPicker/browser/colorPickerWidget": [
-			"Click to toggle color options (rgb/hsl/hex)",
-			"Icon to close the color picker"
 		],
 		"vs/editor/contrib/snippet/browser/snippetVariables": [
 			"Sunday",
@@ -29052,13 +29250,13 @@
 		"vs/editor/contrib/suggest/browser/suggestWidgetStatus": [
 			"{0} ({1})"
 		],
-		"vs/editor/contrib/suggest/browser/suggestWidgetRenderer": [
-			"Icon for more information in the suggest widget.",
-			"Read More"
-		],
 		"vs/editor/contrib/suggest/browser/suggestWidgetDetails": [
 			"Close",
 			"Loading..."
+		],
+		"vs/editor/contrib/suggest/browser/suggestWidgetRenderer": [
+			"Icon for more information in the suggest widget.",
+			"Read More"
 		],
 		"vs/workbench/contrib/comments/common/commentModel": [
 			"There are no comments in this workspace yet."
@@ -29074,6 +29272,17 @@
 			"Comments",
 			"Show Resolved"
 		],
+		"vs/workbench/browser/parts/editor/editorPlaceholder": [
+			"Workspace Trust Required",
+			"The file is not displayed in the editor because trust has not been granted to the folder.",
+			"The file is not displayed in the editor because trust has not been granted to the workspace.",
+			"Manage Workspace Trust",
+			"Error Editor",
+			"The editor could not be opened because the file was not found.",
+			"The editor could not be opened due to an unexpected error: {0}",
+			"The editor could not be opened due to an unexpected error.",
+			"Try Again"
+		],
 		"vs/workbench/contrib/comments/browser/commentColors": [
 			"Icon color for resolved comments.",
 			"Icon color for unresolved comments.",
@@ -29082,9 +29291,12 @@
 			"Color of background for comment ranges.",
 			"Color of background for currently selected or hovered comment range."
 		],
-		"vs/workbench/browser/parts/editor/titleControl": [
-			"Editor actions",
-			"{0} (+{1})"
+		"vs/base/browser/ui/menu/menubar": [
+			"Application Menu",
+			"More"
+		],
+		"vs/workbench/browser/parts/editor/multiEditorTabsControl": [
+			"Tab actions"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
 			"Icon for the separator in the breadcrumbs.",
@@ -29099,67 +29311,15 @@
 			"Focus and Select Breadcrumbs",
 			"Focus Breadcrumbs"
 		],
-		"vs/workbench/browser/parts/editor/editorPlaceholder": [
-			"Workspace Trust Required",
-			"The file is not displayed in the editor because trust has not been granted to the folder.",
-			"The file is not displayed in the editor because trust has not been granted to the workspace.",
-			"Manage Workspace Trust",
-			"Error Editor",
-			"The editor could not be opened because the file was not found.",
-			"The editor could not be opened due to an unexpected error: {0}",
-			"The editor could not be opened due to an unexpected error.",
-			"Try Again"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer": [
-			"Icon for 'Insert' in accessible diff viewer.",
-			"Icon for 'Remove' in accessible diff viewer.",
-			"Icon for 'Close' in accessible diff viewer.",
-			"Close",
-			"Accessible Diff Viewer. Use arrow up and down to navigate.",
-			"no lines changed",
-			"1 line changed",
-			"{0} lines changed",
-			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
-			"blank",
-			"{0} unchanged line {1}",
-			"{0} original line {1} modified line {2}",
-			"+ {0} modified line {1}",
-			"- {0} original line {1}"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/movedBlocksLines": [
-			"Code moved with changes to line {0}-{1}",
-			"Code moved with changes from line {0}-{1}",
-			"Code moved to line {0}-{1}",
-			"Code moved from line {0}-{1}"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges": [
-			"Fold Unchanged Region",
-			"Click or drag to show more above",
-			"Show all",
-			"Click or drag to show more below",
-			"{0} hidden lines",
-			"Double click to unfold"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors": [
-			" use {0} to open the accessibility help."
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/colors": [
-			"The border color for text that got moved in the diff editor.",
-			"The active border color for text that got moved in the diff editor."
-		],
-		"vs/base/browser/ui/menu/menubar": [
-			"Application Menu",
-			"More"
-		],
-		"vs/platform/quickinput/browser/quickInputList": [
-			"Quick Input"
-		],
 		"vs/platform/quickinput/browser/quickInput": [
 			"Back",
 			"Press 'Enter' to confirm your input or 'Escape' to cancel",
 			"{0}/{1}",
 			"Type to narrow down results.",
 			"{0} (Press 'Enter' to confirm or 'Escape' to cancel)"
+		],
+		"vs/platform/quickinput/browser/quickInputList": [
+			"Quick Input"
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
 			"Setting value not applied",
@@ -29274,8 +29434,14 @@
 			"Code Cell Source",
 			"Code Cell Output"
 		],
+		"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory": [
+			"empty cell"
+		],
 		"vs/platform/actions/browser/buttonbar": [
 			"{0} ({1})"
+		],
+		"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget": [
+			"Exited {0} mode"
 		],
 		"vs/workbench/contrib/terminal/browser/xterm/decorationAddon": [
 			"Rerun Command",
@@ -29283,6 +29449,7 @@
 			"Yes",
 			"No",
 			"Copy Command",
+			"Copy Command and Output",
 			"Copy Output",
 			"Copy Output as HTML",
 			"Run Recent Command",
@@ -29321,6 +29488,7 @@
 			"Snippets for adding new configurations in 'launch.json'.",
 			"JSON schema configurations for validating 'launch.json'.",
 			"Condition which must be true to enable this type of debugger. Consider using 'shellExecutionSupported', 'virtualWorkspace', 'resourceScheme' or an extension-defined context key as appropriate for this.",
+			"When this condition is true, this debugger type is hidden from the debugger list, but is still enabled.",
 			"Optional message to mark this debug type as being deprecated.",
 			"Windows specific settings.",
 			"Runtime used for Windows.",
@@ -29349,6 +29517,10 @@
 			"Controls whether manually terminating one session will stop all of the compound sessions.",
 			"Task to run before any of the compound configurations start."
 		],
+		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
+			"1 Conflicting Line",
+			"{0} Conflicting Lines"
+		],
 		"vs/workbench/contrib/debug/browser/rawDebugSession": [
 			"No debug adapter, can not start debug session.",
 			"The debugger needs to open a new tab or window for the debuggee but the browser prevented this. You must give permission to continue.",
@@ -29356,9 +29528,9 @@
 			"No debugger available found. Can not send '{0}'.",
 			"More Info"
 		],
-		"vs/workbench/contrib/mergeEditor/browser/mergeMarkers/mergeMarkersController": [
-			"1 Conflicting Line",
-			"{0} Conflicting Lines"
+		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
+			"Set Input Handled",
+			"Undo Mark As Handled"
 		],
 		"vs/workbench/contrib/mergeEditor/browser/view/conflictActions": [
 			"Accept {0}",
@@ -29383,16 +29555,16 @@
 			"Reset to base",
 			"Reset this conflict to the common ancestor of both the right and left changes."
 		],
-		"vs/workbench/contrib/mergeEditor/browser/model/mergeEditorModel": [
-			"Set Input Handled",
-			"Undo Mark As Handled"
-		],
 		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
 			"Editor gutter decoration color for commenting ranges. This color should be opaque.",
 			"Editor overview ruler decoration color for resolved comments. This color should be opaque.",
 			"Editor overview ruler decoration color for unresolved comments. This color should be opaque.",
 			"Editor gutter decoration color for commenting glyphs.",
 			"Editor gutter decoration color for commenting glyphs for unresolved comment threads."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
+			"The '{0}' extension is recommended for opening a terminal in WSL.",
+			"Install"
 		],
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"Contributed custom editors.",
@@ -29403,23 +29575,6 @@
 			"Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.",
 			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
 			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command."
-		],
-		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
-			"The '{0}' extension is recommended for opening a terminal in WSL.",
-			"Install"
-		],
-		"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick": [
-			"Select the terminal profile to create",
-			"Select your default terminal profile",
-			"Enter terminal profile name",
-			"A terminal profile already exists with that name",
-			"profiles",
-			"contributed",
-			"detected",
-			"This terminal profile uses a potentially unsafe path that can be modified by another user: {0}. Are you sure you want to use it?",
-			"Yes",
-			"Cancel",
-			"Configure Terminal Profile"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalInstance": [
 			"Task",
@@ -29448,14 +29603,26 @@
 			"Set Fixed Dimensions: Column",
 			"Set Fixed Dimensions: Row",
 			"Terminal {0} environment is stale, run the 'Show Environment Information' command for more information",
+			"Select an icon for the terminal",
+			"Select a color for the terminal",
 			"The terminal process \"{0}\" failed to launch (exit code: {1}).",
 			"The terminal process failed to launch (exit code: {0}).",
 			"The terminal process \"{0}\" terminated with exit code: {1}.",
 			"The terminal process terminated with exit code: {0}.",
 			"The terminal process failed to launch: {0}."
 		],
-		"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget": [
-			"Terminal Buffer"
+		"vs/workbench/contrib/terminal/browser/terminalProfileQuickpick": [
+			"Select the terminal profile to create",
+			"Select your default terminal profile",
+			"Enter terminal profile name",
+			"A terminal profile already exists with that name",
+			"profiles",
+			"contributed",
+			"detected",
+			"This terminal profile uses a potentially unsafe path that can be modified by another user: {0}. Are you sure you want to use it?",
+			"Yes",
+			"Cancel",
+			"Configure Terminal Profile"
 		],
 		"vs/workbench/contrib/terminal/browser/terminalTabsList": [
 			"Type terminal name. Press Enter to confirm or Escape to cancel.",
@@ -29463,6 +29630,13 @@
 			"Terminal {0} {1}, split {2} of {3}",
 			"Terminal {0} {1}",
 			"Terminal"
+		],
+		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
+			"Search workspace",
+			"Open file in editor",
+			"Focus folder in explorer",
+			"Open folder in new window",
+			"Follow link"
 		],
 		"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget": [
 			"Find",
@@ -29475,13 +29649,6 @@
 			"{0} found for '{1}'",
 			"{0} found for '{1}'",
 			"Border color of the sash border."
-		],
-		"vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter": [
-			"Search workspace",
-			"Open file in editor",
-			"Focus folder in explorer",
-			"Open folder in new window",
-			"Follow link"
 		],
 		"vs/workbench/contrib/terminal/browser/xterm/decorationStyles": [
 			"Show Command Actions",
@@ -29496,11 +29663,6 @@
 			"Light High Contrast",
 			"See More Themes..."
 		],
-		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
-			"Default",
-			"Jupyter",
-			"Colab"
-		],
 		"vs/workbench/contrib/userDataSync/browser/userDataSyncConflictsView": [
 			"Please go through each entry and merge to resolve conflicts.",
 			"Show Conflicts",
@@ -29510,6 +29672,39 @@
 			"{0} (Local)",
 			"Theirs",
 			"Yours"
+		],
+		"vs/workbench/contrib/welcomeGettingStarted/common/media/notebookProfile": [
+			"Default",
+			"Jupyter",
+			"Colab"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsViewer": [
+			"Click to execute command '{0}'",
+			"Notification Actions",
+			"Source: {0}"
+		],
+		"vs/platform/languagePacks/common/localizedStrings": [
+			"open",
+			"close",
+			"find"
+		],
+		"vs/editor/common/viewLayout/viewLineRenderer": [
+			"Show more ({0})",
+			"{0} chars"
+		],
+		"vs/editor/browser/widget/diffEditor/inlineDiffDeletedCodeMargin": [
+			"Copy deleted lines",
+			"Copy deleted line",
+			"Copy changed lines",
+			"Copy changed line",
+			"Copy deleted line ({0})",
+			"Copy changed line ({0})",
+			"Revert this change"
+		],
+		"vs/editor/browser/widget/diffEditor/decorations": [
+			"Line decoration for inserts in the diff editor.",
+			"Line decoration for removals in the diff editor.",
+			"Click to revert change"
 		],
 		"vs/platform/actionWidget/browser/actionList": [
 			"{0} to apply, {1} to preview",
@@ -29521,6 +29716,10 @@
 			"{0} references",
 			"{0} reference",
 			"References"
+		],
+		"vs/workbench/browser/parts/editor/editorTabsControl": [
+			"Editor actions",
+			"{0} (+{1})"
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbs": [
 			"Breadcrumb Navigation",
@@ -29568,20 +29767,6 @@
 		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
 			"Breadcrumbs"
 		],
-		"vs/editor/browser/widget/diffEditorWidget2/decorations": [
-			"Line decoration for inserts in the diff editor.",
-			"Line decoration for removals in the diff editor.",
-			"Click to revert change"
-		],
-		"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin": [
-			"Copy deleted lines",
-			"Copy deleted line",
-			"Copy changed lines",
-			"Copy changed line",
-			"Copy deleted line ({0})",
-			"Copy changed line ({0})",
-			"Revert this change"
-		],
 		"vs/platform/quickinput/browser/quickInputUtils": [
 			"Click to execute command '{0}'"
 		],
@@ -29607,11 +29792,6 @@
 		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellRunToolbar": [
 			"More..."
 		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/collapsedCellOutput": [
-			"Outputs are collapsed",
-			"Double-click to expand cell output ({0})",
-			"Expand Cell Output (${0})"
-		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/foldedCellHint": [
 			"1 cell hidden",
 			"{0} cells hidden"
@@ -29620,6 +29800,11 @@
 			"Double-click to expand cell input ({0})",
 			"Expand Cell Input ({0})"
 		],
+		"vs/workbench/contrib/notebook/browser/view/cellParts/collapsedCellOutput": [
+			"Outputs are collapsed",
+			"Double-click to expand cell output ({0})",
+			"Expand Cell Output (${0})"
+		],
 		"vs/workbench/services/suggest/browser/simpleSuggestWidget": [
 			"Suggest",
 			"{0}{1}, {2}",
@@ -29627,9 +29812,10 @@
 			"{0}, {1}",
 			"{0}, docs: {1}"
 		],
-		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
-			"Could not kill process listening on port {0}, command exited with error {1}",
-			"Restarting the terminal because the connection to the shell process was lost..."
+		"vs/workbench/contrib/comments/browser/commentThreadWidget": [
+			"Comment",
+			"{0}, use ({1}) for accessibility help",
+			"{0}, run the command Open Accessibility Help which is currently not triggerable via keybinding."
 		],
 		"vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick": [
 			"Remove from Command History",
@@ -29640,11 +29826,9 @@
 			"Select a directory to go to (hold Option-key to edit the command)",
 			"Select a directory to go to (hold Alt-key to edit the command)"
 		],
-		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
-			"Success",
-			"Failed",
-			"Pending",
-			"Executing"
+		"vs/workbench/contrib/terminal/browser/terminalProcessManager": [
+			"Could not kill process listening on port {0}, command exited with error {1}",
+			"Restarting the terminal because the connection to the shell process was lost..."
 		],
 		"vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput": [
 			"Cell has no output",
@@ -29655,6 +29839,12 @@
 			"Select mimetype to render for current output",
 			"Select mimetype to render for current output",
 			"renderer not available"
+		],
+		"vs/workbench/contrib/notebook/browser/view/cellParts/codeCellExecutionIcon": [
+			"Success",
+			"Failed",
+			"Pending",
+			"Executing"
 		],
 		"vs/workbench/contrib/comments/browser/commentThreadBody": [
 			"Comment thread with {0} comments on lines {1} through {2}. {3}.",
@@ -29701,6 +29891,7 @@
 			"vs/base/browser/ui/findinput/replaceInput",
 			"vs/base/browser/ui/hover/hoverWidget",
 			"vs/base/browser/ui/iconLabel/iconLabelHover",
+			"vs/base/browser/ui/icons/iconSelectBox",
 			"vs/base/browser/ui/inputbox/inputBox",
 			"vs/base/browser/ui/keybindingLabel/keybindingLabel",
 			"vs/base/browser/ui/menu/menubar",
@@ -29719,18 +29910,14 @@
 			"vs/editor/browser/coreCommands",
 			"vs/editor/browser/editorExtensions",
 			"vs/editor/browser/widget/codeEditorWidget",
-			"vs/editor/browser/widget/diffEditor.contribution",
-			"vs/editor/browser/widget/diffEditorWidget",
-			"vs/editor/browser/widget/diffEditorWidget2/accessibleDiffViewer",
-			"vs/editor/browser/widget/diffEditorWidget2/colors",
-			"vs/editor/browser/widget/diffEditorWidget2/decorations",
-			"vs/editor/browser/widget/diffEditorWidget2/diffEditorEditors",
-			"vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.contribution",
-			"vs/editor/browser/widget/diffEditorWidget2/inlineDiffDeletedCodeMargin",
-			"vs/editor/browser/widget/diffEditorWidget2/movedBlocksLines",
-			"vs/editor/browser/widget/diffEditorWidget2/unchangedRanges",
-			"vs/editor/browser/widget/diffReview",
-			"vs/editor/browser/widget/inlineDiffMargin",
+			"vs/editor/browser/widget/diffEditor/accessibleDiffViewer",
+			"vs/editor/browser/widget/diffEditor/colors",
+			"vs/editor/browser/widget/diffEditor/decorations",
+			"vs/editor/browser/widget/diffEditor/diffEditor.contribution",
+			"vs/editor/browser/widget/diffEditor/diffEditorEditors",
+			"vs/editor/browser/widget/diffEditor/hideUnchangedRegionsFeature",
+			"vs/editor/browser/widget/diffEditor/inlineDiffDeletedCodeMargin",
+			"vs/editor/browser/widget/diffEditor/movedBlocksLines",
 			"vs/editor/common/config/editorConfigurationSchema",
 			"vs/editor/common/config/editorOptions",
 			"vs/editor/common/core/editorColorRegistry",
@@ -29919,7 +30106,6 @@
 			"vs/workbench/browser/parts/compositeBarActions",
 			"vs/workbench/browser/parts/compositePart",
 			"vs/workbench/browser/parts/dialogs/dialogHandler",
-			"vs/workbench/browser/parts/editor/accessibilityStatus",
 			"vs/workbench/browser/parts/editor/binaryDiffEditor",
 			"vs/workbench/browser/parts/editor/binaryEditor",
 			"vs/workbench/browser/parts/editor/breadcrumbs",
@@ -29936,12 +30122,12 @@
 			"vs/workbench/browser/parts/editor/editorPlaceholder",
 			"vs/workbench/browser/parts/editor/editorQuickAccess",
 			"vs/workbench/browser/parts/editor/editorStatus",
+			"vs/workbench/browser/parts/editor/editorTabsControl",
+			"vs/workbench/browser/parts/editor/multiEditorTabsControl",
 			"vs/workbench/browser/parts/editor/sideBySideEditor",
-			"vs/workbench/browser/parts/editor/tabsTitleControl",
 			"vs/workbench/browser/parts/editor/textCodeEditor",
 			"vs/workbench/browser/parts/editor/textDiffEditor",
 			"vs/workbench/browser/parts/editor/textEditor",
-			"vs/workbench/browser/parts/editor/titleControl",
 			"vs/workbench/browser/parts/notifications/notificationsActions",
 			"vs/workbench/browser/parts/notifications/notificationsAlerts",
 			"vs/workbench/browser/parts/notifications/notificationsCenter",
@@ -29978,6 +30164,7 @@
 			"vs/workbench/common/views",
 			"vs/workbench/contrib/accessibility/browser/accessibilityConfiguration",
 			"vs/workbench/contrib/accessibility/browser/accessibilityContributions",
+			"vs/workbench/contrib/accessibility/browser/accessibilityStatus",
 			"vs/workbench/contrib/accessibility/browser/accessibleView",
 			"vs/workbench/contrib/accessibility/browser/accessibleViewActions",
 			"vs/workbench/contrib/audioCues/browser/audioCues.contribution",
@@ -30008,6 +30195,7 @@
 			"vs/workbench/contrib/chat/browser/chatListRenderer",
 			"vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget",
 			"vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib",
+			"vs/workbench/contrib/chat/common/chatAgents",
 			"vs/workbench/contrib/chat/common/chatColors",
 			"vs/workbench/contrib/chat/common/chatContextKeys",
 			"vs/workbench/contrib/chat/common/chatServiceImpl",
@@ -30019,6 +30207,7 @@
 			"vs/workbench/contrib/codeActions/common/documentationExtensionPoint",
 			"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility",
 			"vs/workbench/contrib/codeEditor/browser/diffEditorHelper",
+			"vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint",
 			"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget",
 			"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens",
 			"vs/workbench/contrib/codeEditor/browser/inspectKeybindings",
@@ -30035,7 +30224,6 @@
 			"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter",
 			"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace",
 			"vs/workbench/contrib/codeEditor/browser/toggleWordWrap",
-			"vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint",
 			"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard",
 			"vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate",
 			"vs/workbench/contrib/commands/common/commands.contribution",
@@ -30043,9 +30231,9 @@
 			"vs/workbench/contrib/comments/browser/commentGlyphWidget",
 			"vs/workbench/contrib/comments/browser/commentNode",
 			"vs/workbench/contrib/comments/browser/commentReply",
-			"vs/workbench/contrib/comments/browser/commentService",
 			"vs/workbench/contrib/comments/browser/commentThreadBody",
 			"vs/workbench/contrib/comments/browser/commentThreadHeader",
+			"vs/workbench/contrib/comments/browser/commentThreadWidget",
 			"vs/workbench/contrib/comments/browser/comments.contribution",
 			"vs/workbench/contrib/comments/browser/commentsController",
 			"vs/workbench/contrib/comments/browser/commentsEditorContribution",
@@ -30268,7 +30456,7 @@
 			"vs/workbench/contrib/notebook/browser/view/cellParts/markupCell",
 			"vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView",
 			"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer",
-			"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider",
+			"vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory",
 			"vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll",
 			"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy",
 			"vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView",
@@ -30276,7 +30464,6 @@
 			"vs/workbench/contrib/outline/browser/outline.contribution",
 			"vs/workbench/contrib/outline/browser/outlineActions",
 			"vs/workbench/contrib/outline/browser/outlinePane",
-			"vs/workbench/contrib/output/browser/logViewer",
 			"vs/workbench/contrib/output/browser/output.contribution",
 			"vs/workbench/contrib/output/browser/outputView",
 			"vs/workbench/contrib/performance/browser/performance.contribution",
@@ -30321,6 +30508,7 @@
 			"vs/workbench/contrib/scm/browser/menus",
 			"vs/workbench/contrib/scm/browser/scm.contribution",
 			"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane",
+			"vs/workbench/contrib/scm/browser/scmSyncViewPane",
 			"vs/workbench/contrib/scm/browser/scmViewPane",
 			"vs/workbench/contrib/scm/browser/scmViewPaneContainer",
 			"vs/workbench/contrib/search/browser/anythingQuickAccess",
@@ -30409,8 +30597,6 @@
 			"vs/workbench/contrib/terminal/electron-sandbox/terminalRemote",
 			"vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution",
 			"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp",
-			"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer",
-			"vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget",
 			"vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution",
 			"vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution",
 			"vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution",
@@ -30575,6 +30761,7 @@
 			"vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService",
 			"vs/workbench/services/userDataProfile/browser/userDataProfileManagement",
 			"vs/workbench/services/userDataProfile/common/userDataProfile",
+			"vs/workbench/services/userDataProfile/common/userDataProfileIcons",
 			"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService",
 			"vs/workbench/services/userDataSync/common/userDataSync",
 			"vs/workbench/services/views/browser/viewDescriptorService",
@@ -30670,6 +30857,7 @@
 			"vs/platform/configuration/common/configurationRegistry",
 			"vs/platform/contextkey/common/contextkey",
 			"vs/platform/contextkey/common/scanner",
+			"vs/platform/dialogs/common/dialogs",
 			"vs/platform/extensionManagement/common/extensionManagement",
 			"vs/platform/extensions/common/extensionValidator",
 			"vs/platform/externalTerminal/node/externalTerminalService",
@@ -30678,6 +30866,7 @@
 			"vs/platform/files/node/diskFileSystemProvider",
 			"vs/platform/markers/common/markers",
 			"vs/platform/theme/common/iconRegistry",
+			"vs/platform/userDataProfile/common/userDataProfile",
 			"vs/platform/workspace/common/workspace",
 			"vs/workbench/api/common/extHostChat",
 			"vs/workbench/api/common/extHostDiagnostics",
@@ -30702,6 +30891,7 @@
 			"vs/workbench/contrib/tasks/common/tasks",
 			"vs/workbench/services/configurationResolver/common/variableResolver",
 			"vs/workbench/services/extensions/common/extensionsRegistry",
+			"vs/workbench/services/remote/common/tunnelModel",
 			"vs/workbench/services/search/common/queryBuilder"
 		],
 		"vs/code/electron-main/main": [

--- a/packages/core/src/electron-browser/window/electron-window-preferences.ts
+++ b/packages/core/src/electron-browser/window/electron-window-preferences.ts
@@ -46,7 +46,7 @@ export const electronWindowPreferencesSchema: PreferenceSchema = {
             default: isWindows ? 'custom' : 'native',
             scope: 'application',
             // eslint-disable-next-line max-len
-            description: nls.localizeByDefault('Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.'),
+            description: nls.localizeByDefault('Adjust the appearance of the window title bar to be native by the OS or custom. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.'),
             included: !isOSX
         },
     }

--- a/packages/editor/src/browser/editor-generated-preference-schema.ts
+++ b/packages/editor/src/browser/editor-generated-preference-schema.ts
@@ -598,7 +598,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             nls.localizeByDefault("`cursorSurroundingLines` is enforced only when triggered via the keyboard or API."),
             nls.localizeByDefault("`cursorSurroundingLines` is enforced always.")
         ],
-        "description": nls.localizeByDefault("Controls when `cursorSurroundingLines` should be enforced."),
+        "description": nls.localizeByDefault("Controls when `#cursorSurroundingLines#` should be enforced."),
         "type": "string",
         "enum": [
             "default",


### PR DESCRIPTION
#### What it does

Related to https://github.com/eclipse-theia/theia/pull/13118

Uplifts our nls.metadata.json file for the new vscode API version.

#### How to test

CI is green and localizations work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
