### PR TITLE
doc/developing.md: fixed link to '../dev-packages/private-ext-scripts/README.md'

### DIFF
--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -165,7 +165,7 @@ Theia repository has multiple folders:
  - `packages` folder contains runtime packages, as the core package and extensions to it
  - `dev-packages` folder contains devtime packages
     - [@theia/cli](../dev-packages/cli/README.md) is a command line tool to manage Theia applications
-    - [@theia/ext-scripts](../dev-packages/ext-scripts/README.md) is a command line tool to share scripts between Theia runtime packages
+    - [@theia/ext-scripts](../dev-packages/private-ext-scripts/README.md) is a command line tool to share scripts between Theia runtime packages
  - `examples` folder contains example applications, both Electron-based and browser-based
  - `doc` folder provides documentation about how Theia works
  - `scripts` folder contains JavaScript scripts used by npm scripts when


### PR DESCRIPTION

#### What it does

Fixes a broken link in [doc/developing.md](doc/developing.md)

#### How to test

Open https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#the-repository-structure
and test the link to [@theia/ext-scripts](https://github.com/eclipse-theia/theia/blob/master/dev-packages/ext-scripts/README.md)

also
open https://github.com/sailingKieler/theia/blob/master/doc/Developing.md#the-repository-structure
and check the fixed link to [@theia/ext-scripts](https://github.com/sailingKieler/theia/blob/master/dev-packages/private-ext-scripts/README.md)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
