### PR TITLE
fix: fix render toolbar error when group is undefined

### DIFF
--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -173,9 +173,9 @@ export class ToolbarImpl extends TabBarToolbar {
                 tabIndex={0}
                 ref={this.assignRef}
             >
-                {this.renderColumnWrapper(ToolbarAlignment.LEFT, leftGroups)}
-                {this.renderColumnWrapper(ToolbarAlignment.CENTER, centerGroups)}
-                {this.renderColumnWrapper(ToolbarAlignment.RIGHT, rightGroups)}
+                {leftGroups ? this.renderColumnWrapper(ToolbarAlignment.LEFT, leftGroups) : <></>}
+                {centerGroups ? this.renderColumnWrapper(ToolbarAlignment.CENTER, centerGroups) : <></>}
+                {rightGroups ? this.renderColumnWrapper(ToolbarAlignment.RIGHT, rightGroups) : <></>}
             </div>
         );
     }


### PR DESCRIPTION
#### What it does
fix render toolbar error when group is undefined
![image](https://github.com/eclipse-theia/theia/assets/17584383/aede90e0-492f-4289-b936-e09083da086a)

#### How to test

use @theia/toolbar

#### Follow-ups

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
