### PR TITLE
Don't await plugin deployment in backend process

### DIFF
--- a/packages/core/src/browser/preload/i18n-preload-contribution.ts
+++ b/packages/core/src/browser/preload/i18n-preload-contribution.ts
@@ -33,7 +33,7 @@ export class I18nPreloadContribution implements PreloadContribution {
                 locale: defaultLocale
             });
         }
-        if (nls.locale) {
+        if (nls.locale && nls.locale !== nls.defaultLocale) {
             const localization = await this.localizationServer.loadLocalization(nls.locale);
             if (localization.languagePack) {
                 nls.localization = localization;

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -377,8 +377,12 @@ export class HostedPluginSupport {
                 waitPluginsMeasurement.error('Backend deployment failed.');
             }
         }
-
-        syncPluginsMeasurement?.log(`Sync of ${this.getPluginCount(initialized)}`);
+        if (initialized > 0) {
+            // Only log sync measurement if there are were plugins to sync.
+            syncPluginsMeasurement?.log(`Sync of ${this.getPluginCount(initialized)}`);
+        } else {
+            syncPluginsMeasurement.stop();
+        }
     }
 
     /**
@@ -416,8 +420,12 @@ export class HostedPluginSupport {
                 }));
             }
         }
-
-        loadPluginsMeasurement.log(`Load contributions of ${this.getPluginCount(loaded)}`);
+        if (loaded > 0) {
+            // Only log load measurement if there are were plugins to load.
+            loadPluginsMeasurement?.log(`Load contributions of ${this.getPluginCount(loaded)}`);
+        } else {
+            loadPluginsMeasurement.stop();
+        }
 
         return hostContributions;
     }
@@ -488,7 +496,11 @@ export class HostedPluginSupport {
             return;
         }
 
-        startPluginsMeasurement.log(`Start of ${this.getPluginCount(started)}`);
+        if (started > 0) {
+            startPluginsMeasurement.log(`Start of ${this.getPluginCount(started)}`);
+        } else {
+            startPluginsMeasurement.stop();
+        }
     }
 
     protected async obtainManager(host: string, hostContributions: PluginContributions[], toDisconnect: DisposableCollection): Promise<PluginManagerExt | undefined> {

--- a/packages/plugin-ext/src/main/node/plugin-deployer-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-contribution.ts
@@ -28,7 +28,7 @@ export class PluginDeployerContribution implements BackendApplicationContributio
     @inject(PluginDeployer)
     protected pluginDeployer: PluginDeployer;
 
-    initialize(): Promise<void> {
-        return this.pluginDeployer.start();
+    initialize(): void {
+        this.pluginDeployer.start().catch(error => this.logger.error('Initializing plugin deployer failed.', error));
     }
 }

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -130,8 +130,9 @@ export class PluginDeployerImpl implements PluginDeployer {
             id,
             type: PluginType.System
         }));
+        const resolvePlugins = this.measure('resolvePlugins');
         const plugins = await this.resolvePlugins([...unresolvedUserEntries, ...unresolvedSystemEntries]);
-        deployPlugins.log('Resolve plugins list');
+        resolvePlugins.log('Resolve plugins list');
         await this.deployPlugins(plugins);
         deployPlugins.log('Deploy plugins list');
     }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
- Don't await `initialize` method in `PluginDeployerContribution` sync to  continue with backend loading while plugins are deployed
- Fix wrong performance measurements of `resolvePlugins` & `deployPlugins` &  in `PluginDeployerImpl`
- Improve performance logging in `HostedPluginSupport` by only logging relevant measurements of `sync`/`load` and `start` plugins  (i.e. if the plugin count is 0 just stop the measurement but don`t log)
- Update `I18nPreloadContribution` to ensure that we only load the localizations from the back end if the current locale is not equal to the default locale. This fixes an issue where we unnecessarily queried the localization server in the preload step if the locale is explicitly set to "en". (This happens for instance if you change the display language and then switch back to english).

Contributed on behalf of ST Microelectronics
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Everything should work as before. In the example apps the deploy plugin step does not take very long because most of the
default plugins are rather minimal and can deployed very fast.
To see a the real benefit you could add a timeout to the `PluginDeployerImpl` to simulate a longer plugin deploy process:
```ts
    protected async doStart(): Promise<void> {
            await new Promise(resolve => setTimeout(resolve, 3500));
            ...
    }
  ```
  
  On the current master the backend process will block and not start the frontend loading until the `pluginDeployer` is finished.
  With this change the fronted is started and loaded right away. Once the plugins are deployed the frontend will be notified and
  starts the plugins.
  
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
