### PR TITLE
Add a cli parameter '--userDataArea` to set the Electron 'userData' path

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -57,7 +57,7 @@ export interface ElectronMainCommandOptions {
     readonly cwd: string;
 
     /**
-     * If the app is launched for the first time, `secondInstance` is false. 
+     * If the app is launched for the first time, `secondInstance` is false.
      * If the app is already running but user relaunches it, `secondInstance` is true.
      */
     readonly secondInstance: boolean;

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -55,6 +55,11 @@ export interface ElectronMainCommandOptions {
     readonly file?: string;
 
     readonly cwd: string;
+
+    /**
+     * If the app is launched for the first time, `secondInstance` is false. 
+     * If the app is already running but user relaunches it, `secondInstance` is true.
+     */
     readonly secondInstance: boolean;
 }
 
@@ -205,16 +210,16 @@ export class ElectronMainApplication {
         createYargs(argv, process.cwd())
             .command('$0 [file]', false,
                 cmd => cmd
-                    .option('userDataArea', {
+                    .option('electronUserData', {
                         type: 'string',
                         describe: 'The area where the electron main process puts its data'
                     })
                     .positional('file', { type: 'string' }),
                 async args => {
-                    if (args.userDataArea) {
-                        console.info(`using electron user data area : '${args.userDataArea}'`);
-                        await fs.mkdir(args.userDataArea, { recursive: true });
-                        app.setPath('userData', args.userDataArea);
+                    if (args.electronUserData) {
+                        console.info(`using electron user data area : '${args.electronUserData}'`);
+                        await fs.mkdir(args.electronUserData, { recursive: true });
+                        app.setPath('userData', args.electronUserData);
                     }
                     this.useNativeWindowFrame = this.getTitleBarStyle(config) === 'native';
                     this._config = config;

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -54,19 +54,8 @@ export interface ElectronMainCommandOptions {
      */
     readonly file?: string;
 
-}
-
-/**
- * Fields related to a launch event.
- *
- * This kind of event is triggered in two different contexts:
- *  1. The app is launched for the first time, `secondInstance` is false.
- *  2. The app is already running but user relaunches it, `secondInstance` is true.
- */
-export interface ElectronMainExecutionParams {
-    readonly secondInstance: boolean;
-    readonly argv: string[];
     readonly cwd: string;
+    readonly secondInstance: boolean;
 }
 
 /**
@@ -212,21 +201,38 @@ export class ElectronMainApplication {
     }
 
     async start(config: FrontendApplicationConfig): Promise<void> {
-        const args = this.processArgv.getProcessArgvWithoutBin(process.argv);
-        this.useNativeWindowFrame = this.getTitleBarStyle(config) === 'native';
-        this._config = config;
-        this.hookApplicationEvents();
-        this.showInitialWindow();
-        const port = await this.startBackend();
-        this._backendPort.resolve(port);
-        await app.whenReady();
-        await this.attachElectronSecurityToken(port);
-        await this.startContributions();
-        await this.launch({
-            secondInstance: false,
-            argv: args,
-            cwd: process.cwd()
-        });
+        const argv = this.processArgv.getProcessArgvWithoutBin(process.argv);
+        createYargs(argv, process.cwd())
+            .command('$0 [file]', false,
+                cmd => cmd
+                    .option('userDataArea', {
+                        type: 'string',
+                        describe: 'The area where the electron main process puts its data'
+                    })
+                    .positional('file', { type: 'string' }),
+                async args => {
+                    if (args.userDataArea) {
+                        console.info(`using electron user data area : '${args.userDataArea}'`);
+                        await fs.mkdir(args.userDataArea, { recursive: true });
+                        app.setPath('userData', args.userDataArea);
+                    }
+                    this.useNativeWindowFrame = this.getTitleBarStyle(config) === 'native';
+                    this._config = config;
+                    this.hookApplicationEvents();
+                    this.showInitialWindow();
+                    const port = await this.startBackend();
+                    this._backendPort.resolve(port);
+                    await app.whenReady();
+                    await this.attachElectronSecurityToken(port);
+                    await this.startContributions();
+
+                    this.handleMainCommand({
+                        file: args.file,
+                        cwd: process.cwd(),
+                        secondInstance: false
+                    });
+                },
+            ).parse();
     }
 
     protected getTitleBarStyle(config: FrontendApplicationConfig): 'native' | 'custom' {
@@ -286,15 +292,6 @@ export class ElectronMainApplication {
                 this.initialWindow.show();
             });
         }
-    }
-
-    protected async launch(params: ElectronMainExecutionParams): Promise<void> {
-        createYargs(params.argv, params.cwd)
-            .command('$0 [file]', false,
-                cmd => cmd
-                    .positional('file', { type: 'string' }),
-                args => this.handleMainCommand(params, { file: args.file }),
-            ).parse();
     }
 
     /**
@@ -422,15 +419,15 @@ export class ElectronMainApplication {
         app.quit();
     }
 
-    protected async handleMainCommand(params: ElectronMainExecutionParams, options: ElectronMainCommandOptions): Promise<void> {
-        if (params.secondInstance === false) {
+    protected async handleMainCommand(options: ElectronMainCommandOptions): Promise<void> {
+        if (options.secondInstance === false) {
             await this.openWindowWithWorkspace(''); // restore previous workspace.
         } else if (options.file === undefined) {
             await this.openDefaultWindow();
         } else {
             let workspacePath: string | undefined;
             try {
-                workspacePath = await fs.realpath(path.resolve(params.cwd, options.file));
+                workspacePath = await fs.realpath(path.resolve(options.cwd, options.file));
             } catch {
                 console.error(`Could not resolve the workspace path. "${options.file}" is not a valid 'file' option. Falling back to the default workspace location.`);
             }
@@ -645,9 +642,8 @@ export class ElectronMainApplication {
         if (wrapper) {
             const listener = wrapper.onDidClose(async () => {
                 listener.dispose();
-                await this.launch({
+                await this.handleMainCommand({
                     secondInstance: false,
-                    argv: this.processArgv.getProcessArgvWithoutBin(process.argv),
                     cwd: process.cwd()
                 });
                 this.restarting = false;


### PR DESCRIPTION
This PR allows to set a non-default Electron `userData` path in order to allow two copies of Theia without concurrency issues related to shared `localStorage` etc. 

Part of #13107

Contributed on behalf of STMicroelectronics

#### What it does
Adds the relevant cli parameter.

#### How to test
Run two instances of Theia with different user data areas and make sure webviews work in both instances and the there are no concurrency-related issues show up in the log.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
