### PR TITLE
Added support for webview/context menu contributions

### DIFF
--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -103,6 +103,7 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
             ['timeline/item/context', (...args) => this.toTimelineArgs(...args)],
             ['view/item/context', (...args) => this.toTreeArgs(...args)],
             ['view/title', noArgs],
+            ['webview/context', noArgs]
         ]).forEach(([contributionPoint, adapter]) => {
             if (adapter) {
                 const paths = codeToTheiaMappings.get(contributionPoint);

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -29,7 +29,7 @@ import { ScmTreeWidget } from '@theia/scm/lib/browser/scm-tree-widget';
 import { TIMELINE_ITEM_CONTEXT_MENU } from '@theia/timeline/lib/browser/timeline-tree-widget';
 import { COMMENT_CONTEXT, COMMENT_THREAD_CONTEXT, COMMENT_TITLE } from '../comments/comment-thread-widget';
 import { VIEW_ITEM_CONTEXT_MENU } from '../view/tree-view-widget';
-import { WebviewWidget } from '../webview/webview';
+import { WEBVIEW_CONTEXT_MENU, WebviewWidget } from '../webview/webview';
 import { EDITOR_LINENUMBER_CONTEXT_MENU } from '@theia/editor/lib/browser/editor-linenumber-contribution';
 import { TEST_VIEW_CONTEXT_MENU } from '@theia/test/lib/browser/view/test-view-contribution';
 
@@ -58,7 +58,8 @@ export const implementedVSCodeContributionPoints = [
     'timeline/item/context',
     'testing/item/context',
     'view/item/context',
-    'view/title'
+    'view/title',
+    'webview/context'
 ] as const;
 
 export type ContributionPoint = (typeof implementedVSCodeContributionPoints)[number];
@@ -85,6 +86,7 @@ export const codeToTheiaMappings = new Map<ContributionPoint, MenuPath[]>([
     ['timeline/item/context', [TIMELINE_ITEM_CONTEXT_MENU]],
     ['view/item/context', [VIEW_ITEM_CONTEXT_MENU]],
     ['view/title', [PLUGIN_VIEW_TITLE_MENU]],
+    ['webview/context', [WEBVIEW_CONTEXT_MENU]]
 ]);
 
 type CodeEditorWidget = EditorWidget | WebviewWidget;

--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -345,7 +345,6 @@ delete window.frameElement;
         };
 
         const handleContextMenu = (e) => {
-            console.log('onContextMenu', e);
             if (e.defaultPrevented) {
                 return;
             }

--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -339,9 +339,35 @@ delete window.frameElement;
                 clientY: e.clientY,
                 ctrlKey: e.ctrlKey,
                 metaKey: e.metaKey,
-                shiftKey: e.shiftKey
+                shiftKey: e.shiftKey,
+                // @ts-ignore the dataset should exist if the target is an element
             });
         };
+
+        const handleContextMenu = (e) => {
+            console.log('onContextMenu', e);
+            if (e.defaultPrevented) {
+                return;
+            }
+
+            e.preventDefault();
+
+            host.postMessage('did-context-menu', {
+                clientX: e.clientX,
+                clientY: e.clientY,
+                context: findVscodeContext(e.target)
+            });
+        };
+
+        function findVscodeContext(node) {
+            if (node) {
+                if (node.dataset?.vscodeContext) {
+                    return JSON.parse(node.dataset.vscodeContext);
+                }
+                return findVscodeContext(node.parentElement);
+            }
+            return {};
+        }
 
         function preventDefaultBrowserHotkeys(e) {
             var isOSX = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
@@ -602,7 +628,7 @@ delete window.frameElement;
                     newFrame.contentWindow.addEventListener('keydown', handleInnerKeydown);
                     newFrame.contentWindow.addEventListener('mousedown', handleInnerMousedown);
                     newFrame.contentWindow.addEventListener('mouseup', handleInnerMouseup);
-                    newFrame.contentWindow.addEventListener('contextmenu', e => e.preventDefault());
+                    newFrame.contentWindow.addEventListener('contextmenu', handleContextMenu);
 
                     if (host.onIframeLoaded) {
                         host.onIframeLoaded(newFrame);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

closes #12756
implements the webview/context menu contributions from the missing declarative api as seen in #13051

#### How to test

A small test extension can be found [here](https://github.com/jonah-iden/webview-context-test)
this repo also contains a vsix file to download directly.

Go to explorer tab, expand the `Webview Test View` webview. This contains two elements opening the context menu on each should return a different command because of their given context through the `data-vscode-context` property

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
