### PR TITLE
Fix notebook kernel selection

### DIFF
--- a/packages/notebook/src/common/notebook-common.ts
+++ b/packages/notebook/src/common/notebook-common.ts
@@ -14,10 +14,18 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Command, URI } from '@theia/core';
+import { Command, URI, isObject } from '@theia/core';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering/markdown-string';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { UriComponents } from '@theia/core/lib/common/uri';
+
+export interface NotebookCommand {
+    id: string;
+    title?: string;
+    tooltip?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    arguments?: any[];
+}
 
 export enum CellKind {
     Markup = 1,
@@ -157,6 +165,19 @@ export interface NotebookCellsChangeInternalMetadataEvent {
 export interface NotebookCellContentChangeEvent {
     readonly kind: NotebookCellsChangeType.ChangeCellContent;
     readonly index: number;
+}
+
+export interface NotebookModelResource {
+    notebookModelUri: URI;
+}
+
+export namespace NotebookModelResource {
+    export function is(item: unknown): item is NotebookModelResource {
+        return isObject<NotebookModelResource>(item) && item.notebookModelUri instanceof URI;
+    }
+    export function create(uri: URI): NotebookModelResource {
+        return { notebookModelUri: uri };
+    }
 }
 
 export enum NotebookCellExecutionState {

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -204,11 +204,16 @@ export class CommandsConverter {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private executeSafeCommand<R>(...args: any[]): PromiseLike<R | undefined> {
-        const command = this.commandsMap.get(args[0]);
-        if (!command || !command.command) {
-            return Promise.reject(`command ${args[0]} not found`);
+        const handle = args[0];
+        if (typeof handle !== 'number') {
+            return Promise.reject(`Invalid handle ${handle}`);
         }
-        return this.commands.executeCommand(command.command, ...(command.arguments || []));
+        const command = this.commandsMap.get(handle);
+        if (!command || !command.command) {
+            return Promise.reject(`Safe command with handle ${handle} not found`);
+        }
+        const allArgs = (command.arguments ?? []).concat(args.slice(1));
+        return this.commands.executeCommand(command.command, ...allArgs);
     }
 
 }

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -36,6 +36,7 @@ import { NotebookDocument } from './notebook-document';
 import { NotebookEditor } from './notebook-editor';
 import { EditorsAndDocumentsExtImpl } from '../editors-and-documents';
 import { DocumentsExtImpl } from '../documents';
+import { NotebookModelResource } from '@theia/notebook/lib/common';
 
 export class NotebooksExtImpl implements NotebooksExt {
 
@@ -82,11 +83,12 @@ export class NotebooksExtImpl implements NotebooksExt {
         this.notebookEditors = rpc.getProxy(PLUGIN_RPC_CONTEXT.NOTEBOOK_EDITORS_MAIN);
 
         commands.registerArgumentProcessor({
-            processArgument: (arg: { uri: URI }) => {
-                if (arg && arg.uri && this.documents.has(arg.uri.toString())) {
-                    return this.documents.get(arg.uri.toString())?.apiNotebook;
+            processArgument: arg => {
+                if (NotebookModelResource.is(arg)) {
+                    return this.documents.get(arg.notebookModelUri.toString())?.apiNotebook;
+                } else {
+                    return arg;
                 }
-                return arg;
             }
         });
     }


### PR DESCRIPTION
#### What it does

Closes #13167

Fixes quite a few issues which prevented the notebook kernel selection from working correctly. The most major issue was related to the fact that the safe command wasn't transmitted correctly (it was missing its arguments). See changes in the `command.ts` and `command-registry.ts` file.

There where also a few issues related to the way we communicated open/focused editors to the plugin host. This was fixed in `notebook-editor-widget-service.ts` and `notebook-documents-and-editors-main.ts`.

#### How to test

1. Install the Jupyter notebook related extensions.
2. Select a different notebook kernel. All options should work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
