### PR TITLE
fix: Cannot quit app when there is a dirty editor (#13164)

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -458,40 +458,6 @@ export class ConfirmSaveDialog extends AbstractDialog<boolean | undefined> {
 
 }
 
-// Asks the user to confirm whether they want to exit with or without saving the changes
-export async function confirmExitWithOrWithoutSaving(captionsToSave: string[], performSave: () => Promise<void>): Promise<boolean> {
-    const div: HTMLElement = document.createElement('div');
-    div.innerText = nls.localizeByDefault("Your changes will be lost if you don't save them.");
-
-    if (captionsToSave.length > 0) {
-        const span = document.createElement('span');
-        span.appendChild(document.createElement('br'));
-        captionsToSave.forEach(cap => {
-            const b = document.createElement('b');
-            b.innerText = cap;
-            span.appendChild(b);
-            span.appendChild(document.createElement('br'));
-        });
-        span.appendChild(document.createElement('br'));
-        div.appendChild(span);
-        const result = await new ConfirmSaveDialog({
-            title: nls.localizeByDefault('Do you want to save the changes to the following {0} files?', captionsToSave.length),
-            msg: div,
-            dontSave: nls.localizeByDefault("Don't Save"),
-            save: nls.localizeByDefault('Save All'),
-            cancel: Dialog.CANCEL
-        }).open();
-
-        if (result) {
-            await performSave();
-        }
-        return result !== undefined;
-    } else {
-        // fallback if not passed with an empty caption-list.
-        return confirmExit();
-    }
-
-}
 @injectable()
 export class SingleTextInputDialogProps extends DialogProps {
     readonly confirmButtonLabel?: string;


### PR DESCRIPTION
#### What it does

fixes issue https://github.com/eclipse-theia/theia/issues/13164, TheiaBlueprint 1.44.0 cannot quit app when there is a dirty editor

#### How to test

1. Open Theia Blueprint,
2. Disable auto-save,
3. Create a new file,
4. Make the editor dirty,
5. Quit Theia,
6. Click don't save when prompted

=> the app quits.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Contributed by STMicroelectronics