### PR TITLE
fix: revise vscode extension directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - [terminal] Use application shell methods for expanding/collapsing bottom panel for "Terminal: Toggle Terminal" command [#13131](https://github.com/eclipse-theia/theia/pull/13131)
 - [workspace] Create an empty workspace if no workspace is active on updateWorkspaceFolders [#13181](https://github.com/eclipse-theia/theia/pull/13181) - contributed on behalf of STMicroelectronics
 
+<a name="breaking_changes_1.43.0">[Breaking Changes:](#breaking_changes_1.45.0)</a>
+
+- [plugin] handling of vscode extension locations has changed: deployment dir switched to `$CONFDIR/deployedPlugin`, `.vsix` files from `$CONFDIR/extensions` are deployed automatically [#13178](https://github.com/eclipse-theia/theia/pull/13178) - Contributed on behalf of STMicroelectronics
+
 ## v1.44.0 - 11/30/2023
 
 - [application-manager] added option to copy `trash` dependency to the bundle [#13112](https://github.com/eclipse-theia/theia/pull/13112)

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -16,6 +16,7 @@
     "@theia/typehierarchy": "1.44.0",
     "@theia/userstorage": "1.44.0",
     "@theia/workspace": "1.44.0",
+    "decompress": "^4.2.1",
     "filenamify": "^4.1.0"
   },
   "publishConfig": {

--- a/packages/plugin-ext-vscode/src/common/plugin-vscode-environment.ts
+++ b/packages/plugin-ext-vscode/src/common/plugin-vscode-environment.ts
@@ -24,13 +24,36 @@ export class PluginVSCodeEnvironment {
     @inject(EnvVariablesServer)
     protected readonly environments: EnvVariablesServer;
 
-    protected _extensionsDirUri: URI | undefined;
-    async getExtensionsDirUri(): Promise<URI> {
-        if (!this._extensionsDirUri) {
+    protected _userExtensionsDirUri: URI | undefined;
+    protected _deployedPluginsUri: URI | undefined;
+    protected _tmpDirUri: URI | undefined;
+
+    async getUserExtensionsDirUri(): Promise<URI> {
+        if (!this._userExtensionsDirUri) {
             const configDir = new URI(await this.environments.getConfigDirUri());
-            this._extensionsDirUri = configDir.resolve('extensions');
+            this._userExtensionsDirUri = configDir.resolve('extensions');
         }
-        return this._extensionsDirUri;
+        return this._userExtensionsDirUri;
     }
 
+    async getDeploymentDirUri(): Promise<URI> {
+        if (!this._deployedPluginsUri) {
+            const configDir = new URI(await this.environments.getConfigDirUri());
+            this._deployedPluginsUri = configDir.resolve('deployedPlugins');
+        }
+        return this._deployedPluginsUri;
+    }
+
+    async getTempDirUri(prefix?: string): Promise<URI> {
+        if (!this._tmpDirUri) {
+            const configDir: URI = new URI(await this.environments.getConfigDirUri());
+            this._tmpDirUri = configDir.resolve('tmp');
+        }
+
+        if (prefix) {
+            return this._tmpDirUri.resolve(prefix);
+        }
+
+        return this._tmpDirUri;
+    }
 }

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-deployer-participant.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-deployer-participant.ts
@@ -15,8 +15,11 @@
 // *****************************************************************************
 
 import { injectable, inject } from '@theia/core/shared/inversify';
+import * as fs from '@theia/core/shared/fs-extra';
+import { FileUri } from '@theia/core/lib/node';
 import { PluginVSCodeEnvironment } from '../common/plugin-vscode-environment';
 import { PluginDeployerParticipant, PluginDeployerStartContext } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { LocalVSIXFilePluginDeployerResolver } from './local-vsix-file-plugin-deployer-resolver';
 
 @injectable()
 export class PluginVSCodeDeployerParticipant implements PluginDeployerParticipant {
@@ -25,8 +28,21 @@ export class PluginVSCodeDeployerParticipant implements PluginDeployerParticipan
     protected readonly environments: PluginVSCodeEnvironment;
 
     async onWillStart(context: PluginDeployerStartContext): Promise<void> {
-        const extensionsDirUri = await this.environments.getExtensionsDirUri();
-        context.userEntries.push(extensionsDirUri.withScheme('local-dir').toString());
-    }
+        const extensionDeploymentDirUri = await this.environments.getDeploymentDirUri();
+        context.userEntries.push(extensionDeploymentDirUri.withScheme('local-dir').toString());
 
+        const userExtensionDirUri = await this.environments.getUserExtensionsDirUri();
+        const userExtensionDirPath = FileUri.fsPath(userExtensionDirUri);
+
+        if (await fs.pathExists(userExtensionDirPath)) {
+            const files = await fs.readdir(userExtensionDirPath);
+            for (const file of files) {
+                if (file.endsWith(LocalVSIXFilePluginDeployerResolver.FILE_EXTENSION)) {
+                    const extensionUri = userExtensionDirUri.resolve(file).withScheme('local-file').toString();
+                    console.log(`found drop-in extension "${extensionUri}"`);
+                    context.userEntries.push(extensionUri);
+                }
+            }
+        }
+    }
 }

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
@@ -14,32 +14,20 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { PluginDeployerFileHandler, PluginDeployerEntry, PluginDeployerFileHandlerContext, PluginType } from '@theia/plugin-ext';
-import * as fs from '@theia/core/shared/fs-extra';
-import * as path from 'path';
+import { PluginDeployerFileHandler, PluginDeployerEntry, PluginDeployerFileHandlerContext } from '@theia/plugin-ext';
 import * as filenamify from 'filenamify';
-import type { URI } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { Deferred } from '@theia/core/lib/common/promise-util';
-import { getTempDirPathAsync } from '@theia/plugin-ext/lib/main/node/temp-dir-util';
+import * as fs from '@theia/core/shared/fs-extra';
+import { FileUri } from '@theia/core/lib/node';
 import { PluginVSCodeEnvironment } from '../common/plugin-vscode-environment';
-import { FileUri } from '@theia/core/lib/node/file-uri';
+import { unpackToDeploymentDir } from './plugin-vscode-utils';
 
 export const isVSCodePluginFile = (pluginPath?: string) => Boolean(pluginPath && (pluginPath.endsWith('.vsix') || pluginPath.endsWith('.tgz')));
 
 @injectable()
 export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
-
     @inject(PluginVSCodeEnvironment)
     protected readonly environment: PluginVSCodeEnvironment;
-
-    private readonly systemExtensionsDirUri: Deferred<URI>;
-
-    constructor() {
-        this.systemExtensionsDirUri = new Deferred();
-        getTempDirPathAsync('vscode-unpacked')
-            .then(systemExtensionsDirPath => this.systemExtensionsDirUri.resolve(FileUri.create(systemExtensionsDirPath)));
-    }
 
     async accept(resolvedPlugin: PluginDeployerEntry): Promise<boolean> {
         return resolvedPlugin.isFile().then(file => {
@@ -51,33 +39,24 @@ export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
     }
 
     async handle(context: PluginDeployerFileHandlerContext): Promise<void> {
-        const id = context.pluginEntry().id();
-        const extensionDir = await this.getExtensionDir(context);
-        console.log(`[${id}]: trying to decompress into "${extensionDir}"...`);
-        if (context.pluginEntry().type === PluginType.User && await fs.pathExists(extensionDir)) {
-            console.log(`[${id}]: already found`);
-            context.pluginEntry().updatePath(extensionDir);
-            return;
-        }
-        await this.decompress(extensionDir, context);
-        console.log(`[${id}]: decompressed`);
-        context.pluginEntry().updatePath(extensionDir);
-    }
-
-    protected async getExtensionDir(context: PluginDeployerFileHandlerContext): Promise<string> {
-        const systemExtensionsDirUri = await this.systemExtensionsDirUri.promise;
-        return FileUri.fsPath(systemExtensionsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
-    }
-
-    protected async decompress(extensionDir: string, context: PluginDeployerFileHandlerContext): Promise<void> {
-        await context.unzip(context.pluginEntry().path(), extensionDir);
-        if (context.pluginEntry().path().endsWith('.tgz')) {
-            const extensionPath = path.join(extensionDir, 'package');
-            const vscodeNodeModulesPath = path.join(extensionPath, 'vscode_node_modules.zip');
-            if (await fs.pathExists(vscodeNodeModulesPath)) {
-                await context.unzip(vscodeNodeModulesPath, path.join(extensionPath, 'node_modules'));
+        const id = this.getNormalizedExtensionId(context.pluginEntry().id());
+        const extensionDeploymentDir = await unpackToDeploymentDir(this.environment, context.pluginEntry().path(), id);
+        context.pluginEntry().updatePath(extensionDeploymentDir);
+        console.log(`root path: ${context.pluginEntry().rootPath}`);
+        const originalPath = context.pluginEntry().originalPath();
+        if (originalPath && originalPath !== extensionDeploymentDir) {
+            const tempDirUri = await this.environment.getTempDirUri();
+            if (originalPath.startsWith(FileUri.fsPath(tempDirUri))) {
+                try {
+                    await fs.remove(FileUri.fsPath(originalPath));
+                } catch (e) {
+                    console.error(`[${id}]: failed to remove temporary files: "${originalPath}"`, e);
+                }
             }
         }
     }
 
+    protected getNormalizedExtensionId(pluginId: string): string {
+        return filenamify(pluginId, { replacement: '_' }).replace(/\.vsix$/, '');
+    }
 }

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-utils.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-utils.ts
@@ -1,0 +1,101 @@
+// *****************************************************************************
+// Copyright (C) 2023 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as decompress from 'decompress';
+import * as path from 'path';
+import * as filenamify from 'filenamify';
+import { FileUri } from '@theia/core/lib/node';
+import * as fs from '@theia/core/shared/fs-extra';
+import { PluginVSCodeEnvironment } from '../common/plugin-vscode-environment';
+
+export async function decompressExtension(sourcePath: string, destPath: string): Promise<boolean> {
+    try {
+        await decompress(sourcePath, destPath);
+        if (sourcePath.endsWith('.tgz')) {
+            // unzip node_modules from built-in extensions, see https://github.com/eclipse-theia/theia/issues/5756
+            const extensionPath = path.join(destPath, 'package');
+            const vscodeNodeModulesPath = path.join(extensionPath, 'vscode_node_modules.zip');
+            if (await fs.pathExists(vscodeNodeModulesPath)) {
+                await decompress(vscodeNodeModulesPath, path.join(extensionPath, 'node_modules'));
+            }
+        }
+        return true;
+    } catch (error) {
+        console.error(`Failed to decompress ${sourcePath} to ${destPath}: ${error}`);
+        throw error;
+    }
+}
+
+export async function existsInDeploymentDir(env: PluginVSCodeEnvironment, extensionId: string): Promise<boolean> {
+    return fs.pathExists(await getExtensionDeploymentDir(env, extensionId));
+}
+
+export const TMP_DIR_PREFIX = 'tmp-vscode-unpacked-';
+export async function unpackToDeploymentDir(env: PluginVSCodeEnvironment, sourcePath: string, extensionId: string): Promise<string> {
+    const extensionDeploymentDir = await getExtensionDeploymentDir(env, extensionId);
+    if (await fs.pathExists(extensionDeploymentDir)) {
+        console.log(`[${extensionId}]: deployment dir "${extensionDeploymentDir}" already exists`);
+        return extensionDeploymentDir;
+    }
+
+    const tempDir = await getTempDir(env, TMP_DIR_PREFIX);
+    try {
+        console.log(`[${extensionId}]: trying to decompress "${sourcePath}" into "${tempDir}"...`);
+        if (!await decompressExtension(sourcePath, tempDir)) {
+            await fs.remove(tempDir);
+            const msg = `[${extensionId}]: decompressing "${sourcePath}" to "${tempDir}" failed`;
+            console.error(msg);
+            throw new Error(msg);
+        }
+    } catch (e) {
+        await fs.remove(tempDir);
+        const msg = `[${extensionId}]: error while decompressing "${sourcePath}" to "${tempDir}"`;
+        console.error(msg, e);
+        throw e;
+    }
+    console.log(`[${extensionId}]: decompressed to temp dir "${tempDir}"`);
+
+    try {
+        console.log(`[${extensionId}]: renaming to extension dir "${extensionDeploymentDir}"...`);
+        await fs.rename(tempDir, extensionDeploymentDir);
+        return extensionDeploymentDir;
+    } catch (e) {
+        await fs.remove(tempDir);
+        console.error(`[${extensionId}]: error while renaming "${tempDir}" to "${extensionDeploymentDir}"`, e);
+        throw e;
+    }
+}
+
+export async function getExtensionDeploymentDir(env: PluginVSCodeEnvironment, extensionId: string): Promise<string> {
+    const deployedPluginsDirUri = await env.getDeploymentDirUri();
+    const normalizedExtensionId = filenamify(extensionId, { replacement: '_' });
+    const extensionDeploymentDirPath = FileUri.fsPath(deployedPluginsDirUri.resolve(normalizedExtensionId));
+    return extensionDeploymentDirPath;
+}
+
+export async function getTempDir(env: PluginVSCodeEnvironment, prefix: string): Promise<string> {
+    const deploymentDirPath = FileUri.fsPath(await env.getDeploymentDirUri());
+    try {
+        if (!await fs.pathExists(deploymentDirPath)) {
+            console.log(`Creating deployment dir ${deploymentDirPath}`);
+            await fs.mkdirs(deploymentDirPath);
+        }
+        return await fs.mkdtemp(path.join(deploymentDirPath, prefix));
+    } catch (error) {
+        console.error(`Failed to create deployment dir ${deploymentDirPath}: ${error}`);
+        throw error;
+    }
+}

--- a/packages/plugin-ext/src/main/node/plugin-deployer-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-contribution.ts
@@ -28,7 +28,8 @@ export class PluginDeployerContribution implements BackendApplicationContributio
     @inject(PluginDeployer)
     protected pluginDeployer: PluginDeployer;
 
-    initialize(): void {
+    initialize(): Promise<void> {
         this.pluginDeployer.start().catch(error => this.logger.error('Initializing plugin deployer failed.', error));
+        return Promise.resolve();
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
This patch eliminates the use of the temporary directories `vscode-unpacked` and `vscode-copied` for installing and deploying vscode extensions. The file-handler and directory handler for vscode extensions have been adjusted accordingly:

1. A temporary directory is now only used for downloading extensions from the registry. This temporary directory is now user-specific and resides within the configdir (i.e., per default in the user's home: <userhome>/.theia/tmp/) to avoid clashes and permission issues on multi-user operating systems that share temporary directories, such as Linux or BSDs. Having this temporary directory in a location that is configurable by the user also seems the more sensible approach when extensions are considered confidential data.
2. `$configDir/deployedPlugins` replaces our volatile `/tmp/vscode-copied` deployment directory. Having a more permanent way of handling installed extensions should improve startup time and reduce issues with multiple instances running in parallel.
3. The local file resolver unpacks the vsix file from the temp dir into `$configDir/deployedPlugins/<extension-id>`.
4. The simplified directory handler loads unpacked extensions directly from `$configDir/deployedPlugins/<extension-id>`.
5. We use `$configDir/extensions` as a location for the user to drop vsix files that will be installed to the deployment location automatically on startup. We do not manage or remove files within `$configDir/extensions`.

Overall, this should improve the stability on systems with shared temp dir locations and reduce the startup of the first application start after a reboot.

Fixes #12757

Contributed on behalf of STMicroelectronics

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Installing from registry

1. Start Theia
2. Use the vsix registry to install an extension
3. Verify that the extension is loaded and its functionality is enabled.
4. Verify that the extension is permanently stored unpacked in $configDir/deployedPlugins/<extension-id>.
5. Try starting Theia again to verify the extension gets correctly loaded
6. Remove the extension (this should indicate that a reload of the window is required), and verify that the extension is no longer active
7. Verify that $configDir/extensions/<extension-id> has been removed

Installing a local vsix extensions

1. Start Theia
2. Select `Install from VSIX` in the triple-dot menu of the extensions view
3. Browse to a local .vsix file and install ut
4. Verify that the extension is permanently stored unpacked in $configDir/deployedPlugins/<extension-id>.
5. Remove the extension (this should indicate that a reload of the window is required), and verify that the extension is no longer active
6. Verify that $configDir/extensions/<extension-id> has been removed

Store a vsix file in the drop-in location

1. Put a .vsix file into $configDir/extensions
2. Start Theia
3. Verify that the extension is permanently stored unpacked in $configDir/deployedPlugins/<extension-id>.
4. Removing the extension will cause it to be reinstalled until you remove it from the drop-in location

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
