### PR TITLE
Make tree widget indentation configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [plugin] stub multiDocumentHighlightProvider proposed API [#13248](https://github.com/eclipse-theia/theia/pull/13248) - contributed on behalf of STMicroelectronics
 - [terminal] update terminalQuickFixProvider proposed API according to vscode 1.85 version [#13240](https://github.com/eclipse-theia/theia/pull/13240) - contributed on behalf of STMicroelectronics
+- [core] added preference 'workbench.tree.indent' to control the indentation in the tree widget [#13179](https://github.com/eclipse-theia/theia/pull/13179) - contributed on behalf of STMicroelectronics
 
 ## v1.45.0 - 12/21/2023
 

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -139,6 +139,7 @@ import { bindCommonStylingParticipants } from './common-styling-participants';
 import { HoverService } from './hover-service';
 import { AdditionalViewsMenuWidget, AdditionalViewsMenuWidgetFactory } from './shell/additional-views-menu-widget';
 import { LanguageIconLabelProvider } from './language-icon-provider';
+import { bindTreePreferences } from './tree';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -366,6 +367,7 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(ThemeService).toSelf().inSingletonScope();
 
     bindCorePreferences(bind);
+    bindTreePreferences(bind);
 
     bind(MimeService).toSelf().inSingletonScope();
 

--- a/packages/core/src/browser/tree/index.ts
+++ b/packages/core/src/browser/tree/index.ts
@@ -26,3 +26,4 @@ export * from './tree-container';
 export * from './tree-decorator';
 export * from './tree-search';
 export * from './tree-compression';
+export * from './tree-preference';

--- a/packages/core/src/browser/tree/tree-preference.ts
+++ b/packages/core/src/browser/tree/tree-preference.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { interfaces } from 'inversify';
+import { PreferenceProxy, PreferenceContribution, PreferenceSchema } from '../preferences';
+import { PreferenceProxyFactory } from '../preferences/injectable-preference-proxy';
+import { nls } from '../../common/nls';
+
+export const PREFERENCE_NAME_TREE_INDENT = 'workbench.tree.indent';
+
+export const treePreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        [PREFERENCE_NAME_TREE_INDENT]: {
+            description: nls.localizeByDefault('Controls tree indentation in pixels.'),
+            type: 'number',
+            default: 8,
+            minimum: 4,
+            maximum: 40
+        },
+    }
+};
+
+export class TreeConfiguration {
+    [PREFERENCE_NAME_TREE_INDENT]: number;
+}
+
+export const TreePreferences = Symbol('treePreferences');
+export type TreePreferences = PreferenceProxy<TreeConfiguration>;
+
+export function bindTreePreferences(bind: interfaces.Bind): void {
+    bind(TreePreferences).toDynamicValue(ctx => {
+        const factory = ctx.container.get<PreferenceProxyFactory>(PreferenceProxyFactory);
+        return factory(treePreferencesSchema);
+    }).inSingletonScope();
+    bind(PreferenceContribution).toConstantValue({ schema: treePreferencesSchema });
+}

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -43,6 +43,8 @@ import { LabelProvider } from '../label-provider';
 import { CorePreferences } from '../core-preferences';
 import { TreeFocusService } from './tree-focus-service';
 import { useEffect } from 'react';
+import { PreferenceService, PreferenceChange } from '../preferences';
+import { PREFERENCE_NAME_TREE_INDENT } from './tree-preference';
 
 const debounce = require('lodash.debounce');
 
@@ -73,8 +75,7 @@ export interface TreeProps {
     readonly contextMenuPath?: MenuPath;
 
     /**
-     * The size of the padding (in pixels) per hierarchy depth. The root element won't have left padding but
-     * the padding for the children will be calculated as `leftPadding * hierarchyDepth` and so on.
+     * The size of the padding (in pixels) for the root node of the tree.
      */
     readonly leftPadding: number;
 
@@ -174,6 +175,9 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
 
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
     @inject(LabelProvider)
     protected readonly labelProvider: LabelProvider;
 
@@ -181,6 +185,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected readonly corePreferences: CorePreferences;
 
     protected shouldScrollToRow = true;
+
+    protected treeIndent: number = 8;
 
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
@@ -198,6 +204,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
 
     @postConstruct()
     protected init(): void {
+        this.treeIndent = this.preferenceService.get(PREFERENCE_NAME_TREE_INDENT, this.treeIndent);
         if (this.props.search) {
             this.searchBox = this.searchBoxFactory({ ...SearchBoxProps.DEFAULT, showButtons: true, showFilter: true });
             this.searchBox.node.addEventListener('focus', () => {
@@ -263,6 +270,12 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                         this.update();
                         return;
                     }
+                }
+            }),
+            this.preferenceService.onPreferenceChanged((event: PreferenceChange) => {
+                if (event.preferenceName === PREFERENCE_NAME_TREE_INDENT) {
+                    this.treeIndent = event.newValue;
+                    this.update();
                 }
             })
         ]);
@@ -1500,7 +1513,10 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         return this.labelProvider.getLongName(node);
     }
     protected getDepthPadding(depth: number): number {
-        return depth * this.props.leftPadding;
+        if (depth === 1) {
+            return this.props.leftPadding;
+        }
+        return depth * this.treeIndent;
     }
 }
 export namespace TreeWidget {

--- a/packages/navigator/src/browser/abstract-navigator-tree-widget.ts
+++ b/packages/navigator/src/browser/abstract-navigator-tree-widget.ts
@@ -16,16 +16,12 @@
 
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { FileNavigatorPreferences } from './navigator-preferences';
-import { PreferenceService } from '@theia/core/lib/browser/preferences/preference-service';
 import { FileTreeWidget } from '@theia/filesystem/lib/browser';
 import { Attributes, HTMLAttributes } from '@theia/core/shared/react';
 import { TreeNode } from '@theia/core/lib/browser';
 
 @injectable()
 export class AbstractNavigatorTreeWidget extends FileTreeWidget {
-
-    @inject(PreferenceService)
-    protected readonly preferenceService: PreferenceService;
 
     @inject(FileNavigatorPreferences)
     protected readonly navigatorPreferences: FileNavigatorPreferences;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Make the indentation of the tree widget configurable via preference.

Contributed on behalf of STMicroelectronics
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Open the settings view from File → Preferences → Settings
2. Search for `workbench.tree.indent`
3.  Change the `Workbench › Tree: Indent` preference and notice how the indentation of the tree widget, e.g. in the workspace navigator view, changes accordingly

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
