### PR TITLE
Save untitled files to the last active folder

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -445,6 +445,7 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
 
     bind(SaveResourceService).toSelf().inSingletonScope();
     bind(UserWorkingDirectoryProvider).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(UserWorkingDirectoryProvider);
 
     bind(HoverService).toSelf().inSingletonScope();
 

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-service.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-service.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
-import { MaybeArray, nls } from '@theia/core/lib/common';
+import { MaybeArray, UNTITLED_SCHEME, nls } from '@theia/core/lib/common';
 import { LabelProvider } from '@theia/core/lib/browser';
 import { FileStat } from '../../common/files';
 import { DirNode } from '../file-tree';
@@ -81,7 +81,9 @@ export class DefaultFileDialogService implements FileDialogService {
     }
 
     protected async getRootNode(folderToOpen?: FileStat): Promise<DirNode | undefined> {
-        const folderExists = folderToOpen && await this.fileService.exists(folderToOpen.resource);
+        const folderExists = folderToOpen
+            && folderToOpen.resource.scheme !== UNTITLED_SCHEME
+            && await this.fileService.exists(folderToOpen.resource);
         const folder = folderToOpen && folderExists ? folderToOpen : {
             resource: await this.rootProvider.getUserWorkingDir(),
             isDirectory: true

--- a/packages/workspace/src/browser/workspace-user-working-directory-provider.ts
+++ b/packages/workspace/src/browser/workspace-user-working-directory-provider.ts
@@ -28,6 +28,7 @@ export class WorkspaceUserWorkingDirectoryProvider extends UserWorkingDirectoryP
 
     override async getUserWorkingDir(): Promise<URI> {
         return await this.getFromSelection()
+            ?? await this.getFromLastOpenResource()
             ?? await this.getFromWorkspace()
             ?? this.getFromUserHome();
     }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13182

The changes to `UserWorkingDirectoryProvider` will now keep track of the latest opened navigatable resource. In case the current file doesn't use a valid URI scheme (i.e. `untitled`), it will now always default to the latest opened resource.

The changes in `DefaultFileDialogService ` ensure that in case no resource has been opened yet, it will default to the first open workspace folder or the user home directory.

#### How to test

1. Create an untitled file.
2. Try to save it. The save dialog should point to the current workspace folder/home directory (in case of no workspace)
3. Open a different file in the workspace.
4. Try to save the untitled file again. The save dialog should point to the parent folder of the last opened file.
5. Running `Save As...` on existing files should behave as expected (i.e. save to their parent folder).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
