### PR TITLE
fix: debug configuration provider replaces different provider

### DIFF
--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
@@ -97,6 +97,13 @@ export class PluginDebugService implements DebugService {
     }, 100);
 
     registerDebugConfigurationProvider(provider: PluginDebugConfigurationProvider): Disposable {
+        if (this.configurationProviders.has(provider.handle)) {
+            const configuration = this.configurationProviders.get(provider.handle);
+            if (configuration && configuration.type !== provider.type) {
+                console.warn(`Different debug configuration provider with type '${configuration.type}' already registered.`);
+                provider.handle = this.configurationProviders.size;
+            }
+        }
         const handle = provider.handle;
         this.configurationProviders.set(handle, provider);
         this.fireOnDidConfigurationProvidersChanged();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

This PR solves the problem when multiple plugins try to register debug configuration provider under the same handle number. Currently the old provider gets replaced. After this change the new number will be assigned.

Similar guard exists already in `registerDebugAdapterContribution`

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
