### PR TITLE
Allow to rebind messaging services in preload

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -92,9 +92,7 @@ function load(container, jsModule) {
         .then(containerModule => container.load(containerModule.default));
 }
 
-async function preload(parent) {
-    const container = new Container();
-    container.parent = parent;
+async function preload(container) {
     try {
 ${Array.from(frontendPreloadModules.values(), jsModulePath => `\
         await load(container, ${this.importOrRequire()}('${jsModulePath}'));`).join(EOL)}


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13094

When trying to rebind the messaging services in the preload step, you were only able to bind them for a child container of the original container. That eventually led to multiple messaging services being created, which leads to unexpected issues, such as multiple websocket connections (where only one is actually needed).

This change binds the preload services directly on the global frontend container. This way, adopters can rebind messaging services already in the preload stage, preventing multiple instances of those services from appearing.

#### How to test

You will need to rebind the messaging services. Create a new module and perform the binding like this:

```ts
import { ContainerModule } from 'inversify';
import { LocalConnectionProvider, RemoteConnectionProvider, ServiceConnectionProvider } from '../messaging/service-connection-provider';
import { ConnectionSource } from '../messaging/connection-source';
import { WebSocketConnectionSource } from '../messaging/ws-connection-source';

const backendServiceProvider = Symbol('backendServiceProvider');

export default new ContainerModule((bind, _, __, rebind) => {
    bind(backendServiceProvider).toDynamicValue(ctx => {
        bind(CustomServiceConnectionProvider).toSelf().inSingletonScope();
        const container = ctx.container.createChild();
        container.bind(ConnectionSource).toService(WebSocketConnectionSource);
        return container.get(CustomServiceConnectionProvider);
    }).inSingletonScope();
    rebind(LocalConnectionProvider).toService(backendServiceProvider);
    rebind(RemoteConnectionProvider).toService(backendServiceProvider);
});

class CustomServiceConnectionProvider extends ServiceConnectionProvider {

    override init(): void {
        console.log('Constructing custom service connection');
        super.init();
    }
}

```

Afterwards put this in an additional `frontendPreload` entry in the package.json, build and start the browser app. At frontend startup, the logging above should be printed only **once** and the frontend preload should perform without errors.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
