### PR TITLE
Fix inputbox onTriggerButton() event

### DIFF
--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -131,7 +131,7 @@ export namespace QuickInputButton {
 }
 
 export interface QuickInputButtonHandle extends QuickInputButton {
-    index: number; // index of where they are in buttons array if QuickInputButton or -1 if QuickInputButtons.Back
+    handle: number; // index of where the button is in buttons array if QuickInputButton or -1 if QuickInputButtons.Back
 }
 
 export enum QuickInputHideReason {

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -246,11 +246,11 @@ export class QuickOpenExtImpl implements QuickOpenExt {
     async $acceptOnDidTriggerButton(sessionId: number, btn: QuickInputButtonHandle): Promise<void> {
         const session = this._sessions.get(sessionId);
         if (session) {
-            if (btn.index === -1) {
+            if (btn.handle === -1) {
                 session._fireButtonTrigger(QuickInputButtons.Back);
             } else if (session && (session instanceof InputBoxExt || session instanceof QuickPickExt)) {
-                const btnFromIndex = session.buttons[btn.index];
-                session._fireButtonTrigger(btnFromIndex as theia.QuickInputButton);
+                const btnFromHandle = session.buttons[btn.handle];
+                session._fireButtonTrigger(btnFromHandle as theia.QuickInputButton);
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Ensure that the clicked button is correctly forwarded to event handlers when using `InputBox.onDidTriggerButton` (Plugin API).

The  interface definition of `QuickInputButtonHandle` expects an `index` property but monaco actually calls the property `handle`

Fixes #13077

Contributed on behalf of ST Microelectronics

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

Create a simple plugin that opens a QuickInputBox with two buttons and log the `onDidTriggerButton` event.
On master the event is always undefined. With this change the clicked button is correctly forwarded to the event handlers.
e.g:

```ts
export async function activate(context: vscode.ExtensionContext) {

		const inputBox = vscode.window.createInputBox();
		const addButton={
			iconPath: new vscode.ThemeIcon('add'),
			tooltip: 'Add Item'
		};
		inputBox.buttons = [vscode.QuickInputButtons.Back, addButton ];
		await new Promise<void>(resolve => {
			inputBox.onDidTriggerButton(event => {
				console.log(event);
			});

			inputBox.onDidAccept(() => {
				resolve();
			});

			inputBox.show();

		});
}
```

You can also use this  example plugin:
[quickpick-0.0.1.zip](https://github.com/eclipse-theia/theia/files/13751525/quickpick-0.0.1.zip)




<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
