### PR TITLE
Fix using copy/paste from a menu in electron. 

### DIFF
--- a/packages/core/src/browser/browser.ts
+++ b/packages/core/src/browser/browser.ts
@@ -18,6 +18,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { environment } from '../common';
+
 const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : '';
 
 export const isIE = (userAgent.indexOf('Trident') >= 0);
@@ -31,7 +33,10 @@ export const isChrome = (userAgent.indexOf('Chrome') >= 0);
 export const isSafari = (userAgent.indexOf('Chrome') === -1) && (userAgent.indexOf('Safari') >= 0);
 export const isIPad = (userAgent.indexOf('iPad') >= 0);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isNative = typeof (window as any).process !== 'undefined';
+/**
+ * @deprecated us Environment.electron.is
+ */
+export const isNative = environment.electron.is();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isBasicWasmSupported = typeof (window as any).WebAssembly !== 'undefined';
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -351,12 +351,12 @@ export namespace CommonCommands {
     });
 }
 
-export const supportCut = browser.isNative || document.queryCommandSupported('cut');
-export const supportCopy = browser.isNative || document.queryCommandSupported('copy');
+export const supportCut = environment.electron.is() || document.queryCommandSupported('cut');
+export const supportCopy = environment.electron.is() || document.queryCommandSupported('copy');
 // Chrome incorrectly returns true for document.queryCommandSupported('paste')
 // when the paste feature is available but the calling script has insufficient
 // privileges to actually perform the action
-export const supportPaste = browser.isNative || (!browser.isChrome && document.queryCommandSupported('paste'));
+export const supportPaste = environment.electron.is() || (!browser.isChrome && document.queryCommandSupported('paste'));
 
 export const RECENT_COMMANDS_STORAGE_KEY = 'commands';
 


### PR DESCRIPTION
#### What it does
The fix is to replace a old test for whether we run on electron with on that works on current electron.

Fixes #12487

Contributed on behalf of STMicroelectronics

#### How to test
Start Theia Electron and make sure that copy/pasting from a menu actually works (for example in the terminal or in the editor)

#### Follow-ups

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
