### PR TITLE
Use more stable hostname for webviews #13092

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct, optional } from '@theia/core/shared/
 import {
     ApplicationShell, ViewContainer as ViewContainerWidget, WidgetManager, QuickViewService,
     ViewContainerIdentifier, ViewContainerTitleOptions, Widget, FrontendApplicationContribution,
-    StatefulWidget, CommonMenus, TreeViewWelcomeWidget, ViewContainerPart, BaseWidget
+    StatefulWidget, CommonMenus, TreeViewWelcomeWidget, ViewContainerPart, BaseWidget,
 } from '@theia/core/lib/browser';
 import { ViewContainer, View, ViewWelcome, PluginViewType } from '../../../common';
 import { PluginSharedStyle } from '../plugin-shared-style';
@@ -424,7 +424,10 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
 
     protected async createNewWebviewView(viewId: string): Promise<WebviewView> {
         const webview = await this.widgetManager.getOrCreateWidget<WebviewWidget>(
-            WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: v4() });
+            WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{
+                id: v4(),
+                viewId,
+            });
         webview.setContentOptions({ allowScripts: true });
 
         let _description: string | undefined;
@@ -893,7 +896,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             const webviewView = await this.createNewWebviewView(viewId);
             webviewId = webviewView.webview.identifier.id;
         }
-        const webviewWidget = this.widgetManager.getWidget(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: webviewId });
+        const webviewWidget = this.widgetManager.getWidget(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: webviewId, viewId });
         return webviewWidget;
     }
 

--- a/packages/plugin-ext/src/main/browser/webview/webview-widget-factory.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-widget-factory.ts
@@ -17,6 +17,8 @@
 import { interfaces } from '@theia/core/shared/inversify';
 import { WebviewWidget, WebviewWidgetIdentifier, WebviewWidgetExternalEndpoint } from './webview';
 import { WebviewEnvironment } from './webview-environment';
+import { StorageService } from '@theia/core/lib/browser';
+import { v4 } from 'uuid';
 
 export class WebviewWidgetFactory {
 
@@ -30,7 +32,7 @@ export class WebviewWidgetFactory {
 
     async createWidget(identifier: WebviewWidgetIdentifier): Promise<WebviewWidget> {
         const externalEndpoint = await this.container.get(WebviewEnvironment).externalEndpoint();
-        let endpoint = externalEndpoint.replace('{{uuid}}', identifier.id);
+        let endpoint = externalEndpoint.replace('{{uuid}}', identifier.viewId ? await this.getOrigin(this.container.get(StorageService), identifier.viewId) : identifier.id);
         if (endpoint[endpoint.length - 1] === '/') {
             endpoint = endpoint.slice(0, endpoint.length - 1);
         }
@@ -38,6 +40,18 @@ export class WebviewWidgetFactory {
         child.bind(WebviewWidgetIdentifier).toConstantValue(identifier);
         child.bind(WebviewWidgetExternalEndpoint).toConstantValue(endpoint);
         return child.get(WebviewWidget);
+    }
+
+    protected async getOrigin(storageService: StorageService, viewId: string): Promise<string> {
+        const key = 'plugin-view-registry.origin.' + viewId;
+        const origin = await storageService.getData<string>(key);
+        if (!origin) {
+            const newOrigin = v4();
+            storageService.setData(key, newOrigin);
+            return newOrigin;
+        } else {
+            return origin;
+        }
     }
 
 }

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -97,6 +97,7 @@ export interface WebviewConsoleLog {
 @injectable()
 export class WebviewWidgetIdentifier {
     id: string;
+    viewId?: string;
 }
 
 export const WebviewWidgetExternalEndpoint = Symbol('WebviewWidgetExternalEndpoint');

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -63,7 +63,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
         showOptions: WebviewPanelShowOptions,
         options: WebviewPanelOptions & WebviewOptions
     ): Promise<void> {
-        const view = await this.widgetManager.getOrCreateWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: panelId });
+        const view = await this.widgetManager.getOrCreateWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: panelId, viewId: viewType });
         this.hookWebview(view);
         view.viewType = viewType;
         view.title.label = title;
@@ -269,7 +269,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
     }
 
     private async tryGetWebview(id: string): Promise<WebviewWidget | undefined> {
-        const webview = await this.widgetManager.getWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id })
+        const webview = this.widgetManager.getWidgets(WebviewWidget.FACTORY_ID).find(widget => widget instanceof WebviewWidget && widget.identifier.id === id) as WebviewWidget
             || await this.widgetManager.getWidget<CustomEditorWidget>(CustomEditorWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id });
         return webview;
     }


### PR DESCRIPTION
#### What it does

* add optional `viewId` to `WebviewWidgetIdentifier`, which may be used to create stable hostnames for webviews
* use this `viewId` to store a uuid which will be used as part of the stable hostname

For VSCode the WebView iFrame src url looks like this:
```
vscode-webview://0a7iho5kovpr5p4ctn5fvcns9h4du51vr2fb4iachonmmqsceaes/fake.html?id=ad9dff6c-9d20-4aec-b8b1-edfeecc19d07 (initial open)
vscode-webview://0a7iho5kovpr5p4ctn5fvcns9h4du51vr2fb4iachonmmqsceaes/fake.html?id=faec60d8-1f93-4e66-94b7-931081a8a4ba (close and reopen; restart of application)
```

In Theia, the pattern was like this:
```
http://401ed951-431e-4866-9a42-b033d95521d4.webview.localhost:33391/webview/fake.html?id=401ed951-431e-4866-9a42-b033d95521d4 (initial open)
http://837d0c96-f06d-4bad-91ba-efec327876be.webview.localhost:33391/webview/fake.html?id=837d0c96-f06d-4bad-91ba-efec327876be (close and reopen)
http://6444a35c-161b-4205-96b4-a5aee01c0f9e.webview.localhost:37883/webview/fake.html?id=6444a35c-161b-4205-96b4-a5aee01c0f9e (restart of application)
```

The changing id was used as part of the hostname. Also the port changes between restarts of the electron app. 

With this change the src url will look more like this:
```
http://33544e87-f49c-45eb-b7f7-3387c39fc913.webview.localhost:33391/webview/fake.html?id=401ed951-431e-4866-9a42-b033d95521d4 (initial open)
http://33544e87-f49c-45eb-b7f7-3387c39fc913.webview.localhost:33391/webview/fake.html?id=837d0c96-f06d-4bad-91ba-efec327876be (close and reopen)
http://33544e87-f49c-45eb-b7f7-3387c39fc913.webview.localhost:37883/webview/fake.html?id=6444a35c-161b-4205-96b4-a5aee01c0f9e (restart of application)
```

In order to fix the port in electron, which is 0 by default so any non-used port, adopers may use the --port option when starting Theia. I think 0 should stay the default.

Fixes #13092

#### How to test

Webviews should still work as before. 
When it comes to testing the storage you may use the reproducer from https://github.com/eclipse-theia/theia/issues/13092 and start the electron example either with 
* `yarn electron start --port=3124`
* a custom electron main script, e.g. 
```
process.argv.push('--port=3124')
require('../lib/backend/electron-main.js');
```

#### Follow-ups

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
