### PR TITLE
added the context to be passed as arg to the command as done by vscode

### DIFF
--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -108,7 +108,7 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
             ['timeline/item/context', (...args) => this.toTimelineArgs(...args)],
             ['view/item/context', (...args) => this.toTreeArgs(...args)],
             ['view/title', noArgs],
-            ['webview/context', noArgs]
+            ['webview/context', firstArgOnly]
         ]).forEach(([contributionPoint, adapter]) => {
             if (adapter) {
                 const paths = codeToTheiaMappings.get(contributionPoint);

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -404,6 +404,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
             () => {
                 this.contextMenuRenderer.render({
                     menuPath: WEBVIEW_CONTEXT_MENU,
+                    args: [context],
                     anchor: {
                         x: domRect.x + event.clientX, y: domRect.y + event.clientY
                     }

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -404,7 +404,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
             () => {
                 this.contextMenuRenderer.render({
                     menuPath: WEBVIEW_CONTEXT_MENU,
-                    args: [context],
+                    args: [event.context],
                     anchor: {
                         x: domRect.x + event.clientX, y: domRect.y + event.clientY
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

When execute a command via the context menu of a webview, vscode passes the context of the clicked html node to the cammand as an argument.
This PR aligns Theias implementation of the webview context menu with this behaviour 

#### How to test

A small test extension can be found [here](https://github.com/jonah-iden/webview-context-test)
this repo also contains a vsix file to download directly.

Go to explorer tab, expand the Webview Test View webview. This contains two elements opening the context menu on each should return a different command because of their given context through the data-vscode-context property. Executing the command should now also include the stringified data from the `vscode-data-context` html-attribute

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
