### PR TITLE
Rename Terminal.sendText addNewLine parameter to align with vscode api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## not yet released
 
 - [plugin] stub multiDocumentHighlightProvider proposed API [#13248](https://github.com/eclipse-theia/theia/pull/13248) - contributed on behalf of STMicroelectronics
+- [terminal] rename terminal.sendText() parameter from addNewLine to shouldExecute [#13236](https://github.com/eclipse-theia/theia/pull/13236) - contributed on behalf of STMicroelectronics
 - [terminal] update terminalQuickFixProvider proposed API according to vscode 1.85 version [#13240](https://github.com/eclipse-theia/theia/pull/13240) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a>

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -327,9 +327,9 @@ export interface TerminalServiceMain {
      * Send text to the terminal by id.
      * @param id - terminal widget id.
      * @param text - text content.
-     * @param addNewLine - in case true - add new line after the text, otherwise - don't apply new line.
+     * @param shouldExecute - in case true - Indicates that the text being sent should be executed rather than just inserted in the terminal.
      */
-    $sendText(id: string, text: string, addNewLine?: boolean): void;
+    $sendText(id: string, text: string, shouldExecute?: boolean): void;
 
     /**
      * Write data to the terminal by id.

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -181,11 +181,11 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, TerminalLin
         return undefined;
     }
 
-    $sendText(id: string, text: string, addNewLine?: boolean): void {
+    $sendText(id: string, text: string, shouldExecute?: boolean): void {
         const terminal = this.terminals.getById(id);
         if (terminal) {
             text = text.replace(/\r?\n/g, '\r');
-            if (addNewLine && text.charAt(text.length - 1) !== '\r') {
+            if (shouldExecute && text.charAt(text.length - 1) !== '\r') {
                 text += '\r';
             }
             terminal.sendText(text);

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -463,8 +463,8 @@ export class TerminalExtImpl implements Terminal {
         this.creationOptions = this.options;
     }
 
-    sendText(text: string, addNewLine: boolean = true): void {
-        this.id.promise.then(id => this.proxy.$sendText(id, text, addNewLine));
+    sendText(text: string, shouldExecute: boolean = true): void {
+        this.id.promise.then(id => this.proxy.$sendText(id, text, shouldExecute));
     }
 
     show(preserveFocus?: boolean): void {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3043,10 +3043,11 @@ export module '@theia/plugin' {
 
         /**
          * Send text to the terminal.
-         * @param text - text content.
-         * @param addNewLine - in case true - apply new line after the text, otherwise don't apply new line. This defaults to `true`.
+         * @param text - The text to send.
+         * @param shouldExecute - Indicates that the text being sent should be executed rather than just inserted in the terminal.
+         * The character added is \r, independent from the platform (compared to platform specific in vscode). This defaults to `true`.
          */
-        sendText(text: string, addNewLine?: boolean): void;
+        sendText(text: string, shouldExecute?: boolean): void;
 
         /**
          * Show created terminal on the UI.


### PR DESCRIPTION
#### What it does
This PR simply renames a parameter from theia.d.ts and the related implementation. This does not change any behavior, goal is only to remain align with vscode code here.  

Fixes #13235

Contributed on behalf of STMicroelectronics

#### How to test 
The test can be done installing the following extension (bundled from vscode extension sample repository) :
- zip: 
[terminal-sample-0.0.1.zip](https://github.com/eclipse-theia/theia/files/13821463/terminal-sample-0.0.1.zip)

- src: 
[terminal-sample-0.0.1-src.zip](https://github.com/eclipse-theia/theia/files/13821464/terminal-sample-0.0.1-src.zip)

The extension provides several command prefixed with 'Terminal API'. Among the actions, send text and send text with no new line can be invoked. 
Behavior should be equivalent between master and after this PR is applied.

#### Follow-ups

no follow up.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)