### PR TITLE
Improve terminalQuickFixProvider stubbed API with vscode 1.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## not yet released
+
+- [terminal] update terminalQuickFixProvider proposed API according to vscode 1.85 version [#13240](https://github.com/eclipse-theia/theia/pull/13240) - contributed on behalf of STMicroelectronics
+
 ## v1.45.0 - 12/21/2023
 
 - [application-manager] updated logic to allow rebinding messaging services in preload [#13199](https://github.com/eclipse-theia/theia/pull/13199)

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -200,7 +200,7 @@ import {
     ExternalUriOpenerPriority,
     EditSessionIdentityMatch,
     TerminalOutputAnchor,
-    TerminalQuickFixExecuteTerminalCommand,
+    TerminalQuickFixTerminalCommand,
     TerminalQuickFixOpener,
     TestResultState
 } from './types-impl';
@@ -1375,7 +1375,7 @@ export function createAPIFactory(
             TerminalExitReason,
             DocumentPasteEdit,
             ExternalUriOpenerPriority,
-            TerminalQuickFixExecuteTerminalCommand,
+            TerminalQuickFixTerminalCommand,
             TerminalQuickFixOpener,
             EditSessionIdentityMatch,
             TestResultState

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -3673,15 +3673,19 @@ export enum EditSessionIdentityMatch {
 // #endregion
 
 // #region terminalQuickFixProvider
-export class TerminalQuickFixExecuteTerminalCommand {
+export class TerminalQuickFixTerminalCommand {
     /**
      * The terminal command to run
      */
     terminalCommand: string;
     /**
+     * Whether the command should be executed or just inserted (default)
+     */
+    shouldExecute?: boolean;
+    /**
      * @stubbed
      */
-    constructor(terminalCommand: string) { }
+    constructor(terminalCommand: string, shouldExecute?: boolean) { }
 }
 export class TerminalQuickFixOpener {
     /**

--- a/packages/plugin/src/theia.proposed.terminalQuickFixProvider.d.ts
+++ b/packages/plugin/src/theia.proposed.terminalQuickFixProvider.d.ts
@@ -40,7 +40,7 @@ export module '@theia/plugin' {
          * @return Terminal quick fix(es) if any
          */
         provideTerminalQuickFixes(commandMatchResult: TerminalCommandMatchResult, token: CancellationToken):
-            ProviderResult<SingleOrMany<TerminalQuickFixExecuteTerminalCommand | TerminalQuickFixOpener | Command>>;
+            ProviderResult<SingleOrMany<TerminalQuickFixTerminalCommand | TerminalQuickFixOpener | Command>>;
     }
 
     export interface TerminalCommandMatchResult {
@@ -52,12 +52,16 @@ export module '@theia/plugin' {
         };
     }
 
-    export class TerminalQuickFixExecuteTerminalCommand {
+    export class TerminalQuickFixTerminalCommand {
         /**
-         * The terminal command to run
+         * The terminal command to insert or run
          */
         terminalCommand: string;
-        constructor(terminalCommand: string);
+        /**
+         * Whether the command should be executed or just inserted (default)
+         */
+        shouldExecute?: boolean;
+        constructor(terminalCommand: string, shouldExecute?: boolean);
     }
     export class TerminalQuickFixOpener {
         /**


### PR DESCRIPTION
#### What it does
This PR updates the proposed API for terminalQuickFixProvider, that was updated in vscode 1.85. This API is currently stubbed,  so this will not change any behavior 

Fixes #13234

Contributed on behalf of STMicroelectronics

#### How to test 

There should be no runtime changes compared to master, as the API is only stubbed. The _npm_ builtin extension depends on this interface, it should still install and run on 1.85 version.

#### Follow-ups

no follow up.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)