### PR TITLE
fix: update message for missing Electron main entries

### DIFF
--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -139,7 +139,7 @@ export class ApplicationPackageManager {
             console.warn(
                 `WARNING: ${this.pck.packagePath} does not have a "main" entry.\n` +
                 'Please add the following line:\n' +
-                '    "main": "src-gen/frontend/electron-main.js"'
+                '    "main": "lib/backend/electron-main.js"'
             );
         }
 


### PR DESCRIPTION
The warning message for missing Electron main entries still refered to `src-gen/frontend`. However since Theia 1.39.0 it should be either `src-gen/backend` or as now indicated `lib/backend`.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Update the warning message emitted by the Theia CLI when starting Theia Electron whose `package.json` does not contain a `main` entry.

#### How to test

Remove the `main` entry of the example Electron application and start it.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
