### PR TITLE
Improve notebook error logging

### DIFF
--- a/packages/notebook/src/browser/service/notebook-kernel-history-service.ts
+++ b/packages/notebook/src/browser/service/notebook-kernel-history-service.ts
@@ -48,10 +48,8 @@ export class NotebookKernelHistoryService implements Disposable {
     @inject(CommandService)
     protected commandService: CommandService;
 
-    declare serviceBrand: undefined;
-
-    private static STORAGE_KEY = 'notebook.kernelHistory';
-    private mostRecentKernelsMap: KernelsList = {};
+    protected static STORAGE_KEY = 'notebook.kernelHistory';
+    protected mostRecentKernelsMap: KernelsList = {};
 
     @postConstruct()
     protected init(): void {
@@ -97,16 +95,16 @@ export class NotebookKernelHistoryService implements Disposable {
         this.saveState();
     }
 
-    private saveState(): void {
+    protected saveState(): void {
         let notEmpty = false;
-        for (const [_, kernels] of Object.entries(this.mostRecentKernelsMap)) {
+        for (const kernels of Object.values(this.mostRecentKernelsMap)) {
             notEmpty = notEmpty || Object.entries(kernels).length > 0;
         }
 
         this.storageService.setData(NotebookKernelHistoryService.STORAGE_KEY, notEmpty ? this.mostRecentKernelsMap : undefined);
     }
 
-    private async loadState(): Promise<void> {
+    protected async loadState(): Promise<void> {
         const kernelMap = await this.storageService.getData(NotebookKernelHistoryService.STORAGE_KEY);
         if (kernelMap) {
             this.mostRecentKernelsMap = kernelMap as KernelsList;

--- a/packages/notebook/src/browser/service/notebook-kernel-quick-pick-service.ts
+++ b/packages/notebook/src/browser/service/notebook-kernel-quick-pick-service.ts
@@ -356,6 +356,7 @@ export class NotebookKernelQuickPickService {
                         return this.displaySelectAnotherQuickPick(editor, false);
                     }
                 } catch (ex) {
+                    console.error('Failed to select notebook kernel', ex);
                     return false;
                 }
             } else if (isKernelPick(selectedKernelPickItem)) {
@@ -370,6 +371,7 @@ export class NotebookKernelQuickPickService {
                     await selectedKernelPickItem.action.run(this.commandService);
                     return true;
                 } catch (ex) {
+                    console.error('Failed to select notebook kernel', ex);
                     return false;
                 }
             }

--- a/packages/plugin-ext/src/plugin/notebook/notebook-kernels.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebook-kernels.ts
@@ -334,7 +334,6 @@ export class NotebookKernelsExtImpl implements NotebookKernelsExt {
             await obj.controller.executeHandler.call(obj.controller, cells, document.apiNotebook, obj.controller);
         } catch (err) {
             console.error(`NotebookController[${handle}] execute cells FAILED`, err);
-            console.error(err);
         }
 
     }


### PR DESCRIPTION
#### What it does

I recently had to debug an issue in a production environment, in which the notebook kernel selection didn't "stick". You could select a kernel, but it wouldn't actually apply. The kernel selection silently threw an error in that case. This change adds a console error in case this happens.

#### How to test

The changes should be pretty self-evident. However, you can test whether 

1. Open a new (untrusted) workspace.
2. Set the `security.workspace.trust.startupPrompt` preference to `never`.
3. Open a jupyter notebook and select a kernel. An error should be logged into the console.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
