### PR TITLE
SelectComponent does not render droplist correctly in dialog (#12895)

### DIFF
--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -14,12 +14,16 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ConfirmDialog, QuickInputService } from '@theia/core/lib/browser';
+import { ConfirmDialog, Dialog, QuickInputService } from '@theia/core/lib/browser';
+import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
+import { SelectComponent } from '@theia/core/lib/browser/widgets/select-component';
 import {
     Command, CommandContribution, CommandRegistry, MAIN_MENU_BAR,
     MenuContribution, MenuModelRegistry, MenuNode, MessageService, SubMenuOptions
 } from '@theia/core/lib/common';
 import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import * as React from '@theia/core/shared/react';
+import { ReactNode } from '@theia/core/shared/react';
 
 const SampleCommand: Command = {
     id: 'sample-command',
@@ -49,6 +53,10 @@ const SampleQuickInputCommand: Command = {
     id: 'sample-quick-input-command',
     category: 'Quick Input',
     label: 'Test Positive Integer'
+};
+const SampleReactDialog: Command = {
+    id: 'sample-command-react-dialog',
+    label: 'Sample React Dialog'
 };
 
 @injectable()
@@ -112,6 +120,25 @@ export class SampleCommandContribution implements CommandContribution {
                     msg: mainDiv
                 }).open();
                 this.messageService.info(`Sample confirm dialog returned with: \`${JSON.stringify(choice)}\``);
+            }
+        });
+        commands.registerCommand(SampleReactDialog, {
+            execute: async () => {
+                await new class extends ReactDialog<boolean> {
+                    constructor() {
+                        super({ title: 'Sample React Dialog' });
+                        this.appendAcceptButton(Dialog.OK);
+                    }
+                    protected override render(): ReactNode {
+                        return React.createElement(SelectComponent, {
+                            options: Array.from(Array(10).keys()).map(i => ({ label: 'Option ' + ++i })),
+                            defaultValue: 0
+                        });
+                    }
+                    override get value(): boolean {
+                        return true;
+                    }
+                }().open();
             }
         });
         commands.registerCommand(SampleQuickInputCommand, {

--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -122,11 +122,11 @@ export class SampleCommandContribution implements CommandContribution {
                 this.messageService.info(`Sample confirm dialog returned with: \`${JSON.stringify(choice)}\``);
             }
         });
-        commands.registerCommand(SampleReactDialog, {
+        commands.registerCommand(SampleSelectDialog, {
             execute: async () => {
                 await new class extends ReactDialog<boolean> {
                     constructor() {
-                        super({ title: 'Sample React Dialog' });
+                        super({ title: 'Sample Select Component Dialog' });
                         this.appendAcceptButton(Dialog.OK);
                     }
                     protected override render(): ReactNode {

--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -54,9 +54,9 @@ const SampleQuickInputCommand: Command = {
     category: 'Quick Input',
     label: 'Test Positive Integer'
 };
-const SampleReactDialog: Command = {
-    id: 'sample-command-react-dialog',
-    label: 'Sample React Dialog'
+const SampleSelectDialog: Command = {
+    id: 'sample-command-select-dialog',
+    label: 'Sample Select Component Dialog'
 };
 
 @injectable()

--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -14,6 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
  ********************************************************************************/
 
+.theia-select-component-container {
+  /* required to set z-index */
+  position: fixed;
+  /* dialog overlay has a z-index of 5000 */
+  z-index: 6000;
+}
+
 .theia-select-component {
   background-color: var(--theia-dropdown-background);
   cursor: pointer;
@@ -64,33 +71,25 @@
   padding: 6px 5px;
 }
 
-.theia-select-component-dropdown
-  .theia-select-component-description:first-child {
+.theia-select-component-dropdown .theia-select-component-description:first-child {
   border-bottom: 1px solid var(--theia-editorWidget-border);
   margin-bottom: 2px;
 }
 
-.theia-select-component-dropdown
-  .theia-select-component-description:last-child {
+.theia-select-component-dropdown .theia-select-component-description:last-child {
   border-top: 1px solid var(--theia-editorWidget-border);
   margin-top: 2px;
 }
 
-.theia-select-component-dropdown
-  .theia-select-component-option
-  .theia-select-component-option-value {
+.theia-select-component-dropdown .theia-select-component-option .theia-select-component-option-value {
   width: 100%;
 }
 
-.theia-select-component-dropdown
-  .theia-select-component-option
-  .theia-select-component-option-detail {
+.theia-select-component-dropdown .theia-select-component-option .theia-select-component-option-detail {
   padding-left: 4px;
 }
 
-.theia-select-component-dropdown
-  .theia-select-component-option:not(.selected)
-  .theia-select-component-option-detail {
+.theia-select-component-dropdown .theia-select-component-option:not(.selected) .theia-select-component-option-detail {
   color: var(--theia-textLink-foreground);
 }
 

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -77,6 +77,7 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         if (!list) {
             list = document.createElement('div');
             list.id = SELECT_COMPONENT_CONTAINER;
+            list.className = 'theia-select-component-container';
             document.body.appendChild(list);
         }
         this.dropdownElement = list;


### PR DESCRIPTION
#### What it does
Fixes #12895

#### How to test
I've added a new "Sample React Dialog" as there were any samples that are using react. Open it using the "Sample React Dialog" command.

Before:
<img width="459" alt="Bildschirmfoto 2024-01-11 um 10 57 45" src="https://github.com/eclipse-theia/theia/assets/454322/4beca4ea-a9a1-4c11-94e5-958df70bcb02">

After:

<img width="475" alt="Bildschirmfoto 2024-01-11 um 10 56 27" src="https://github.com/eclipse-theia/theia/assets/454322/19c7996d-64dc-4dc9-8199-b3059cb7bbdc">


#### Follow-ups
I can remove the sample dialog again if you don't want to have it.
Also, I don't  know why, but the *.css file was auto formatted with a probably different rules as it was initially created. 

