### PR TITLE
Prevent stack overflow with cyclic menu contributions

### DIFF
--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -99,9 +99,12 @@ export class MenusContributionPointHandler {
                         const targets = this.getMatchingMenu(contributionPoint as ContributionPoint) ?? [contributionPoint];
                         const { group, order } = this.parseGroup(item.group);
                         const { submenu, command } = item;
-                        if (submenu) {
-                            targets.forEach(target => toDispose.push(this.menuRegistry.linkSubmenu(target, submenu!, { order, when: item.when }, group)));
-                        } else if (command) {
+                        if (submenu && command) {
+                            console.warn(
+                                `Menu item ${command} from plugin ${plugin.metadata.model.id} contributed both submenu and command. Only command will be registered.`
+                            );
+                        }
+                        if (command) {
                             toDispose.push(this.commandAdapter.addCommand(command));
                             targets.forEach(target => {
                                 const node = new ActionMenuNode({
@@ -112,6 +115,8 @@ export class MenusContributionPointHandler {
                                 const parent = this.menuRegistry.getMenuNode(target, group);
                                 toDispose.push(parent.addNode(node));
                             });
+                        } else if (submenu) {
+                            targets.forEach(target => toDispose.push(this.menuRegistry.linkSubmenu(target, submenu!, { order, when: item.when }, group)));
                         }
                     }
                 } catch (error) {


### PR DESCRIPTION
#### What it does

- Notifies about a menu item contribution where both a `command` and `submenu` is used. In such a case the command will be used and submenu entry ignored (vs-code behavior). 
- Checks for menu recursion in `MenuModelRegistry.linkSubmenu()`. If detected a warning is logged and the contribution is ignored.

#### How to test

Follow the steps from #13036. After installing the extension several warnings should be logged:
```
2024-01-12T08:44:30.199Z root WARN Menu item robot.runSuite from plugin robocorp.robotframework-lsp contributed both submenu and command. Only command will be registered.
...
2024-01-12T08:44:30.199Z root WARN Recursive menu contribution detected: robotsubmenu is already in hierarchy of 1_run.
``` 
A "Maximum call stack size exceeded" should not be thrown and you should be able to see a new "Robot Framework" submenu in the explorer view. 


#### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
