### PR TITLE
Handle activeCustomEditorId (#13219)

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview-context-keys.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-context-keys.ts
@@ -14,9 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { ApplicationShell, FocusTracker, Widget } from '@theia/core/lib/browser';
+import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { CustomEditorWidget } from '../custom-editors/custom-editor-widget';
 import { WebviewWidget } from './webview';
 
 @injectable()
@@ -27,6 +28,11 @@ export class WebviewContextKeys {
      */
     activeWebviewPanelId: ContextKey<string>;
 
+    /**
+     * Context key representing the `viewType` of the active `CustomEditorWidget`, if any.
+     */
+    activeCustomEditorId: ContextKey<string>;
+
     @inject(ApplicationShell)
     protected applicationShell: ApplicationShell;
 
@@ -36,12 +42,19 @@ export class WebviewContextKeys {
     @postConstruct()
     protected init(): void {
         this.activeWebviewPanelId = this.contextKeyService.createKey('activeWebviewPanelId', '');
+        this.activeCustomEditorId = this.contextKeyService.createKey('activeCustomEditorId', '');
         this.applicationShell.onDidChangeCurrentWidget(this.handleDidChangeCurrentWidget, this);
     }
 
     protected handleDidChangeCurrentWidget(change: FocusTracker.IChangedArgs<Widget>): void {
-        if (change.newValue instanceof WebviewWidget) {
-            this.activeWebviewPanelId.set(change.newValue.viewType);
+        const { newValue } = change;
+        if (newValue instanceof CustomEditorWidget) {
+            this.activeCustomEditorId.set(newValue.viewType);
+        } else {
+            this.activeCustomEditorId.set('');
+        }
+        if (newValue instanceof WebviewWidget) {
+            this.activeWebviewPanelId.set(newValue.viewType);
         } else {
             this.activeWebviewPanelId.set('');
         }


### PR DESCRIPTION
#### What it does

Tracks `activeCustomEditorId` context key next to existing `activeWebviewPanelId`

#### How to test
It is a bit tricky to test it manually and I found no test spec to re-use to test context keys.

- To test it manually checkout [custom editor sample](https://github.com/microsoft/vscode-extension-samples/tree/main/custom-editor-sample).
- Change the `catCustoms.pawDraw.new` command contribution by adding `"enablement": "activeCustomEditorId == 'catCustoms.catScratch'"`
- build the extension using `vsce package`. Note: You will need to change the publisher in the package json to something meaningful.  
- install cat-customs-0.0.1.vsix into Theia
- create a file named `test.cscratch` and open it  
- A command CMD+Shift+P `Create new Paw Draw Document` should only be visible when the cscratch custom editor is active

#### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
