### PR TITLE
fix for the file explorer progress bar issue (related to network disconnection)

### DIFF
--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -397,9 +397,10 @@ export class TreeImpl implements Tree {
 
     protected async doMarkAsBusy(node: Mutable<TreeNode>, ms: number, token: CancellationToken): Promise<void> {
         try {
-            await timeout(ms, token);
-            this.doSetBusy(node);
             token.onCancellationRequested(() => this.doResetBusy(node));
+            await timeout(ms, token);
+            if (token.isCancellationRequested) { return; }
+            this.doSetBusy(node);
         } catch {
             /* no-op */
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes:
https://github.com/eclipse-theia/theia/issues/13216


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. set the frontendConnectionTimeout to some high value (e.g 15000ms)
2. set the reloadOnReconnect to false
3. do a network disconnection (or just a web-socket disconnection)
4. expand any folder in the file explorer
5. reconnect back
6. try to expand the folder again: the spinner and progress bar should disappear

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
