### PR TITLE
Add keybindings to toggle the tree checkbox

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1227,12 +1227,15 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
 
     /**
      * Handle the `space key` keyboard event.
-     * - By default should be similar to a single-click action.
+     * - If the element has a checkbox, it will be toggled.
+     * - Otherwise, it should be similar to a single-click action.
      * @param event the `space key` keyboard event.
      */
     protected handleSpace(event: KeyboardEvent): void {
         const { focusedNode } = this.focusService;
-        if (!this.props.multiSelect || (!event.ctrlKey && !event.metaKey && !event.shiftKey)) {
+        if (focusedNode && focusedNode.checkboxInfo) {
+            this.model.markAsChecked(focusedNode, !focusedNode.checkboxInfo.checked);
+        } else if (!this.props.multiSelect || (!event.ctrlKey && !event.metaKey && !event.shiftKey)) {
             this.tapNode(focusedNode);
         }
     }


### PR DESCRIPTION
#### What it does

Allows the user to toggle the checkbox on a tree node using the keyboard.

Fixes #13263

#### How to test

1. Download the VSIX 
[checkbox-keyboard-toggle-0.0.1.zip](https://github.com/eclipse-theia/theia/files/13936129/checkbox-keyboard-toggle-0.0.1.zip)
https://github.com/haydar-metin/theia-playground/tree/issues/13263 
2. In the explorer view you should have a new tree view 
![image](https://github.com/eclipse-theia/theia/assets/13104167/4deae234-b130-4360-ba17-c41663efe409)
3. With `space` you can toggle the checkbox

The current behavior of collapsed entires is defined here:
https://github.com/eclipse-theia/theia/blob/master/packages/plugin/src/theia.d.ts#L6055

`If the tree item is collapsed by default (meaning that the children haven't yet been fetched) then child checkboxes will not be updated.`

#### Follow-ups



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
