### PR TITLE
Bump API version to 1.85.1

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.84.2';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.85.1';


### PR DESCRIPTION
#### What it does

Increase compatibility version to 1.85.1 as implementation tasks from task #13230 are closed.
Fixes #13231

Contributed on behalf of STMicroelectronics

#### How to test
Make sure the system starts and built-ins work as expected as described in https://github.com/eclipse-theia/vscode-builtin-extensions/wiki/Produce-and-Publish-the-set-of-vscode-built-in-extensions#local-testing

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)