### PR TITLE
Address gap in coding guideliness.

### DIFF
--- a/doc/coding-guidelines.md
+++ b/doc/coding-guidelines.md
@@ -301,11 +301,12 @@ export namespace DirtyDiffModel {
 }
 ```
 <a name="no-multi-inject"></a>
-* [5.](#no-multi-inject) Don't use multi-inject, use `ContributionProvider` to inject multiple instances.
+* [5.](#no-multi-inject) Don't use InversifyJS's `@multiInject`, use Theia's utility `ContributionProvider` to inject multiple instances.
 > Why?
 > - `ContributionProvider` is a documented way to introduce contribution points. See `Contribution-Points`: https://www.theia-ide.org/docs/services_and_contributions
 > - If nothing is bound to an identifier, multi-inject resolves to `undefined`, not an empty array. `ContributionProvider` provides an empty array.
 > - Multi-inject does not guarantee the same instances are injected if an extender does not use `inSingletonScope`. `ContributionProvider` caches instances to ensure uniqueness.
+> - `ContributionProvider` supports filtering. See `ContributionFilterRegistry`.
 
 
 ## CSS


### PR DESCRIPTION
The guidelines discourage the use of @multiInject and lists the benefits of ContributionProvider, but neglects to mention the filtering feature of that utility.

Addresses #13277 

#### What it does
Makes a simple enhancement to the coding guidelines.

#### How to test
Read the enhancement.

#### Follow-ups
None

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
