### PR TITLE
Fix `vscode.env.appRoot` path

### DIFF
--- a/packages/core/src/browser-only/frontend-only-application-module.ts
+++ b/packages/core/src/browser-only/frontend-only-application-module.ts
@@ -55,6 +55,7 @@ export const frontendOnlyApplicationModule = new ContainerModule((bind, unbind, 
     const mockedApplicationServer: ApplicationServer = {
         getExtensionsInfos: async (): Promise<ExtensionInfo[]> => [],
         getApplicationInfo: async (): Promise<ApplicationInfo | undefined> => undefined,
+        getApplicationRoot: async (): Promise<string> => '',
         getBackendOS: async (): Promise<OS.Type> => OS.Type.Linux
     };
     if (isBound(ApplicationServer)) {

--- a/packages/core/src/common/application-protocol.ts
+++ b/packages/core/src/common/application-protocol.ts
@@ -23,6 +23,7 @@ export const ApplicationServer = Symbol('ApplicationServer');
 export interface ApplicationServer {
     getExtensionsInfos(): Promise<ExtensionInfo[]>;
     getApplicationInfo(): Promise<ApplicationInfo | undefined>;
+    getApplicationRoot(): Promise<string>;
     /**
      * @deprecated since 1.25.0. Use `OS.backend.type()` instead.
      */

--- a/packages/core/src/node/application-server.ts
+++ b/packages/core/src/node/application-server.ts
@@ -37,9 +37,16 @@ export class ApplicationServerImpl implements ApplicationServer {
             const name = pck.name;
             const version = pck.version;
 
-            return Promise.resolve({ name, version });
+            return Promise.resolve({
+                name,
+                version
+            });
         }
         return Promise.resolve(undefined);
+    }
+
+    getApplicationRoot(): Promise<string> {
+        return Promise.resolve(this.applicationPackage.projectPath);
     }
 
     async getBackendOS(): Promise<OS.Type> {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -163,9 +163,10 @@ export interface EnvInit {
     queryParams: QueryParameters;
     language: string;
     shell: string;
-    uiKind: UIKind,
+    uiKind: UIKind;
     appName: string;
     appHost: string;
+    appRoot: string;
 }
 
 export interface PluginAPI {

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-env-ext.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-env-ext.ts
@@ -31,7 +31,7 @@ export class WorkerEnvExtImpl extends EnvExtImpl {
     /**
      * Throw error for app-root as there is no filesystem in worker context
      */
-    get appRoot(): string {
+    override get appRoot(): string {
         throw new Error('There is no app root in worker context');
     }
 

--- a/packages/plugin-ext/src/plugin/env.ts
+++ b/packages/plugin-ext/src/plugin/env.ts
@@ -34,6 +34,7 @@ export abstract class EnvExtImpl {
     private envMachineId: string;
     private envSessionId: string;
     private host: string;
+    private applicationRoot: string;
     private _remoteName: string | undefined;
 
     constructor() {
@@ -84,6 +85,10 @@ export abstract class EnvExtImpl {
         this.host = appHost;
     }
 
+    setAppRoot(appRoot: string): void {
+        this.applicationRoot = appRoot;
+    }
+
     getClientOperatingSystem(): Promise<theia.OperatingSystem> {
         return this.proxy.$getClientOperatingSystem();
     }
@@ -92,7 +97,9 @@ export abstract class EnvExtImpl {
         return this.applicationName;
     }
 
-    abstract get appRoot(): string;
+    get appRoot(): string {
+        return this.applicationRoot;
+    }
 
     abstract get isNewAppInstall(): boolean;
 

--- a/packages/plugin-ext/src/plugin/node/env-node-ext.ts
+++ b/packages/plugin-ext/src/plugin/node/env-node-ext.ts
@@ -51,13 +51,6 @@ export class EnvNodeExtImpl extends EnvExtImpl {
         return this.macMachineId;
     }
 
-    /**
-     * Provides application root.
-     */
-    get appRoot(): string {
-        return __dirname;
-    }
-
     get isNewAppInstall(): boolean {
         return this._isNewAppInstall;
     }

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -467,6 +467,7 @@ export class PluginManagerExtImpl extends AbstractPluginManagerExtImpl<PluginMan
         this.terminalService.$setShell(params.env.shell);
         this.envExt.setApplicationName(params.env.appName);
         this.envExt.setAppHost(params.env.appHost);
+        this.envExt.setAppRoot(params.env.appRoot);
 
         this.preferencesManager.init(params.preferences);
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11477

Extends the `ApplicationServer` to also return the `appRoot`. We now use this new field to provide the plugin host with an accurate app root directory.

#### How to test

1. Install the plugin from https://github.com/eclipse-theia/theia/issues/11477
2. Confirm that the notification shows the expected application root. (i.e. `.../theia/examples/browser` or `.../theia/examples/electron`)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
