### PR TITLE
Install vsix files from the explorer view (#13269)

### DIFF
--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/core": "1.46.0",
     "@theia/filesystem": "1.46.0",
+    "@theia/navigator": "1.46.0",
     "@theia/ovsx-client": "1.46.0",
     "@theia/plugin-ext": "1.46.0",
     "@theia/plugin-ext-vscode": "1.46.0",

--- a/packages/vsx-registry/src/browser/vsx-extension-commands.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-commands.ts
@@ -36,6 +36,11 @@ export namespace VSXExtensionsCommands {
         label: nls.localizeByDefault('Install from VSIX') + '...',
         dialogLabel: nls.localizeByDefault('Install from VSIX')
     };
+    export const INSTALL_VSIX_FILE: Command = Command.toDefaultLocalizedCommand({
+        id: 'vsxExtensions.installVSIX',
+        label: 'Install Extension VSIX',
+        category: EXTENSIONS_CATEGORY,
+    });
     export const INSTALL_ANOTHER_VERSION: Command = {
         id: 'vsxExtensions.installAnotherVersion'
     };

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -14,29 +14,32 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { DateTime } from 'luxon';
-import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
-import debounce = require('@theia/core/shared/lodash.debounce');
-import { Command, CommandRegistry } from '@theia/core/lib/common/command';
-import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
-import { VSXExtensionsViewContainer } from './vsx-extensions-view-container';
-import { VSXExtensionsModel } from './vsx-extensions-model';
+import { CommonMenus, LabelProvider, PreferenceService, QuickInputService, QuickPickItem } from '@theia/core/lib/browser';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
-import { Color } from '@theia/core/lib/common/color';
 import { FrontendApplication } from '@theia/core/lib/browser/frontend-application';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application-contribution';
-import { MenuModelRegistry, MessageService, nls } from '@theia/core/lib/common';
+import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { MenuModelRegistry, MessageService, SelectionService, nls } from '@theia/core/lib/common';
+import { Color } from '@theia/core/lib/common/color';
+import { Command, CommandRegistry } from '@theia/core/lib/common/command';
+import URI from '@theia/core/lib/common/uri';
+import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
-import { LabelProvider, PreferenceService, QuickPickItem, QuickInputService, CommonMenus } from '@theia/core/lib/browser';
+import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
+import { OVSXApiFilter, VSXExtensionRaw } from '@theia/ovsx-client';
 import { VscodeCommands } from '@theia/plugin-ext-vscode/lib/browser/plugin-vscode-commands-contribution';
-import { VSXExtensionsContextMenu, VSXExtension } from './vsx-extension';
-import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
-import { BUILTIN_QUERY, INSTALLED_QUERY, RECOMMENDED_QUERY } from './vsx-extensions-search-model';
-import { IGNORE_RECOMMENDATIONS_ID } from './recommended-extensions/recommended-extensions-preference-contribution';
-import { VSXExtensionsCommands } from './vsx-extension-commands';
-import { VSXExtensionRaw, OVSXApiFilter } from '@theia/ovsx-client';
+import { DateTime } from 'luxon';
 import { OVSXClientProvider } from '../common/ovsx-client-provider';
+import { IGNORE_RECOMMENDATIONS_ID } from './recommended-extensions/recommended-extensions-preference-contribution';
+import { VSXExtension, VSXExtensionsContextMenu } from './vsx-extension';
+import { VSXExtensionsCommands } from './vsx-extension-commands';
+import { VSXExtensionsModel } from './vsx-extensions-model';
+import { BUILTIN_QUERY, INSTALLED_QUERY, RECOMMENDED_QUERY } from './vsx-extensions-search-model';
+import { VSXExtensionsViewContainer } from './vsx-extensions-view-container';
+import debounce = require('@theia/core/shared/lodash.debounce');
 
 export namespace VSXCommands {
     export const TOGGLE_EXTENSIONS: Command = {
@@ -57,6 +60,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
     @inject(OVSXClientProvider) protected clientProvider: OVSXClientProvider;
     @inject(OVSXApiFilter) protected vsxApiFilter: OVSXApiFilter;
     @inject(QuickInputService) protected quickInput: QuickInputService;
+    @inject(SelectionService) protected readonly selectionService: SelectionService;
 
     constructor() {
         super({
@@ -94,6 +98,13 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
         commands.registerCommand(VSXExtensionsCommands.INSTALL_FROM_VSIX, {
             execute: () => this.installFromVSIX()
         });
+
+        commands.registerCommand(VSXExtensionsCommands.INSTALL_VSIX_FILE,
+            UriAwareCommandHandler.MonoSelect(this.selectionService, {
+                execute: fileURI => this.installVsixFile(fileURI),
+                isEnabled: fileURI => fileURI.scheme === 'file' && fileURI.path.ext === '.vsix'
+            })
+        );
 
         commands.registerCommand(VSXExtensionsCommands.INSTALL_ANOTHER_VERSION, {
             // Check downloadUrl to ensure we have an idea of where to look for other versions.
@@ -142,6 +153,11 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
         menus.registerMenuAction(VSXExtensionsContextMenu.INSTALL, {
             commandId: VSXExtensionsCommands.INSTALL_ANOTHER_VERSION.id,
             label: nls.localizeByDefault('Install Another Version...'),
+        });
+        menus.registerMenuAction(NAVIGATOR_CONTEXT_MENU, {
+            commandId: VSXExtensionsCommands.INSTALL_VSIX_FILE.id,
+            label: VSXExtensionsCommands.INSTALL_VSIX_FILE.label,
+            when: 'resourceScheme == file && resourceExtname == .vsix'
         });
     }
 
@@ -199,22 +215,34 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
             title: VSXExtensionsCommands.INSTALL_FROM_VSIX.dialogLabel,
             openLabel: nls.localizeByDefault('Install from VSIX'),
             filters: { 'VSIX Extensions (*.vsix)': ['vsix'] },
-            canSelectMany: false
+            canSelectMany: false,
+            canSelectFiles: true
         };
         const extensionUri = await this.fileDialogService.showOpenDialog(props);
         if (extensionUri) {
             if (extensionUri.path.ext === '.vsix') {
-                const extensionName = this.labelProvider.getName(extensionUri);
-                try {
-                    await this.commandRegistry.executeCommand(VscodeCommands.INSTALL_FROM_VSIX.id, extensionUri);
-                    this.messageService.info(nls.localizeByDefault('Completed installing {0} extension from VSIX.', extensionName));
-                } catch (e) {
-                    this.messageService.error(nls.localize('theia/vsx-registry/failedInstallingVSIX', 'Failed to install {0} from VSIX.', extensionName));
-                    console.warn(e);
-                }
+                await this.installVsixFile(extensionUri);
             } else {
                 this.messageService.error(nls.localize('theia/vsx-registry/invalidVSIX', 'The selected file is not a valid "*.vsix" plugin.'));
             }
+        }
+    }
+
+    /**
+     * Installs a local vs-code extension file.
+     * The implementation doesn't check if the file is a valid VSIX file, or the URI has a *.vsix extension.
+     * The caller should ensure the file is a valid VSIX file.
+     *
+     * @param fileURI the URI of the file to install.
+     */
+    protected async installVsixFile(fileURI: URI): Promise<void> {
+        const extensionName = this.labelProvider.getName(fileURI);
+        try {
+            await this.commandRegistry.executeCommand(VscodeCommands.INSTALL_FROM_VSIX.id, fileURI);
+            this.messageService.info(nls.localizeByDefault('Completed installing {0} extension from VSIX.', extensionName));
+        } catch (e) {
+            this.messageService.error(nls.localize('theia/vsx-registry/failedInstallingVSIX', 'Failed to install {0} from VSIX.', extensionName));
+            console.warn(e);
         }
     }
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable, interfaces, postConstruct, inject } from '@theia/core/shared/inversify';
-import { TreeModel, TreeNode } from '@theia/core/lib/browser';
+import { Message, TreeModel, TreeNode } from '@theia/core/lib/browser';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
 import { nls } from '@theia/core/lib/common/nls';
@@ -152,5 +152,14 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
             }
         }
         return super.renderTree(model);
+    }
+
+    protected override onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        if (this.options.id === VSXExtensionsSourceOptions.INSTALLED) {
+            // This is needed when an Extension was installed outside of the extension view.
+            // E.g. using explorer context menu.
+            this.doUpdateRows();
+        }
     }
 }

--- a/packages/vsx-registry/tsconfig.json
+++ b/packages/vsx-registry/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../filesystem"
     },
     {
+      "path": "../navigator"
+    },
+    {
       "path": "../plugin-ext"
     },
     {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Allows installing VSIX extensions from the file explorer using context menu.

- Contributes a new command that uses selection service to get the *.vsix file instead of opening a dialog
- Adds a `@theia/navigator`  dependency to get the navigator menu ID (existing dependencies like `@theia/plugin-ext` already depends on the navigator package) 
- Refresh 'Installed' tree entries when extension view becomes visible, otherwise one will see updated extension count (badge), but not the new installed entry.  
- Other fixes: Added explicit `canSelectFiles: true` to dialog options, otherwise one can't select files in the electron app. Could be a problem with default handling in `ElectronFileDialogService.toOpenDialogOptions()`

#### How to test

Add a `*.vsix` to your workspace. Use the context menu to execute `Install Extension VSIX` action. You should see the 'Successfully installed' message. Go to the "Extensions" view and check the "Installed" list contains the new installed extension.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
When testing extension installation I noticed that when installing an already installed extension a `Failed to install` error is reported. This is because local file deployer rejects installing existing extensions, but because the installing routine can only check the number of installed extension (in this case it's `0`) a misleading error is reported. 
I think we need to change the installation routine return value to something more meaningful than just a number. With more information we can then to produce a better user feedback.  See ` PluginDeployerImpl.deployPlugins()`.


#### Review checklist

- [ x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
