### PR TITLE
Support specifying the port of a remote SSH connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [terminal] rename terminal.sendText() parameter from addNewLine to shouldExecute [#13236](https://github.com/eclipse-theia/theia/pull/13236) - contributed on behalf of STMicroelectronics
 - [terminal] update terminalQuickFixProvider proposed API according to vscode 1.85 version [#13240](https://github.com/eclipse-theia/theia/pull/13240) - contributed on behalf of STMicroelectronics
 - [core] added preference 'workbench.tree.indent' to control the indentation in the tree widget [#13179](https://github.com/eclipse-theia/theia/pull/13179) - contributed on behalf of STMicroelectronics
+- [remote] upport specifying the port of a remote SSH connection [#13296](https://github.com/eclipse-theia/theia/pull/13296) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a>
 


### PR DESCRIPTION
#### What it does

Uses `new URL(<host>)` to parse the host specified by the user and pass on `url.hostname` and `url.port` when establishing the SSH connection. This way we enable users to specify the port of the remote SSH server.

Contributed on behalf of STMicroelectronics.
Fixes https://github.com/eclipse-theia/theia/issues/13295

#### How to test

1. Start a container with open SSH server running and map it e.g. to port `2222` with `docker run -d -p 2222:22 ssh-container`
2. Run *Connect to Host...*
3. Enter `user@localhost:2222`
4. Observe how the establishing the connection now works

Test whether specifying no port, e.g. `user@localhost` still works.

#### Follow-ups

N/A

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
