### PR TITLE
Hide cmd terminal while debugging

### DIFF
--- a/packages/plugin-ext/src/plugin/node/debug/plugin-node-debug-adapter-creator.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/plugin-node-debug-adapter-creator.ts
@@ -113,6 +113,10 @@ export class NodeDebugAdapterCreator extends PluginDebugAdapterCreator {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const options: any = { stdio: ['pipe', 'pipe', 2] };
 
+        if (isWindows) {
+            options.windowsHide = true;
+        }
+
         if (executable.options) {
             options.cwd = executable.options.cwd;
 


### PR DESCRIPTION

#### What it does

Hide cmd terminal while debugging
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

* Use [cpptools](https://github.com/microsoft/vscode-cpptools) plug-in to debug c/c++ code
* `startDebugAdapter` will pull up an empty cmd terminal
![image](https://github.com/eclipse-theia/theia/assets/40431602/00a04245-9b22-4953-9c38-dbac8a63b584)


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
