### PR TITLE
Implement previously stubbed window#registerURIhandler (#13169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
-
 ## Unreleased
+- [plugin] implement stubbed API window registerUriHandler() [#13306](https://github.com/eclipse-theia/theia/pull/13306) - contributed on behalf of STMicroelectronics
 - [core] Download json schema catalog at build-time - [#14065](https://github.com/eclipse-theia/theia/pull/14065/) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.53.0">[Breaking Changes:](#breaking_changes_1.53.0)</a>
 - [dependencies] Updated electron to version 30.1.2 - [#14041](https://github.com/eclipse-theia/theia/pull/14041) - Contributed on behalf of STMicroelectronics
 - [dependencies] increased minimum node version to 18. [#14027](https://github.com/eclipse-theia/theia/pull/14027) - Contributed on behalf of STMicroelectronics
+
 
 ## 1.52.0 - 07/25/2024
 

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -34,7 +34,8 @@ export namespace ElectronFrontendApplicationConfig {
     export const DEFAULT: ElectronFrontendApplicationConfig = {
         windowOptions: {},
         showWindowEarly: true,
-        splashScreenOptions: {}
+        splashScreenOptions: {},
+        uriScheme: 'theia'
     };
     export interface SplashScreenOptions {
         /**
@@ -85,6 +86,11 @@ export namespace ElectronFrontendApplicationConfig {
          * Defaults to `{}` which results in no splash screen being displayed.
          */
         readonly splashScreenOptions?: SplashScreenOptions;
+
+        /**
+         * The custom uri scheme the application registers to in the operating system.
+         */
+        readonly uriScheme: string;
     }
 }
 
@@ -122,7 +128,8 @@ export namespace FrontendApplicationConfig {
         electron: ElectronFrontendApplicationConfig.DEFAULT,
         defaultLocale: '',
         validatePreferencesSchema: true,
-        reloadOnReconnect: false
+        reloadOnReconnect: false,
+        uriScheme: 'theia'
     };
     export interface Partial extends ApplicationConfig {
 

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -465,7 +465,6 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(FrontendApplicationContribution).toService(StylingService);
 
     bind(SecondaryWindowHandler).toSelf().inSingletonScope();
-
     bind(ViewColumnService).toSelf().inSingletonScope();
 
     bind(UndoRedoHandlerService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/opener-service.ts
+++ b/packages/core/src/browser/opener-service.ts
@@ -79,6 +79,12 @@ export interface OpenerService {
      * Add open handler i.e. for custom editors
      */
     addHandler?(openHandler: OpenHandler): Disposable;
+
+    /**
+     * Remove open handler
+     */
+    removeHandler?(openHandler: OpenHandler): void;
+
     /**
      * Event that fires when a new opener is added or removed.
      */
@@ -108,9 +114,13 @@ export class DefaultOpenerService implements OpenerService {
         this.onDidChangeOpenersEmitter.fire();
 
         return Disposable.create(() => {
-            this.customEditorOpenHandlers.splice(this.customEditorOpenHandlers.indexOf(openHandler), 1);
-            this.onDidChangeOpenersEmitter.fire();
+            this.removeHandler(openHandler);
         });
+    }
+
+    removeHandler(openHandler: OpenHandler): void {
+        this.customEditorOpenHandlers.splice(this.customEditorOpenHandlers.indexOf(openHandler), 1);
+        this.onDidChangeOpenersEmitter.fire();
     }
 
     async getOpener(uri: URI, options?: OpenerOptions): Promise<OpenHandler> {

--- a/packages/core/src/electron-browser/electron-uri-handler.ts
+++ b/packages/core/src/electron-browser/electron-uri-handler.ts
@@ -1,0 +1,42 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution, OpenerService } from '../browser';
+
+import { injectable, inject } from 'inversify';
+import { URI } from '../common';
+
+@injectable()
+export class ElectronUriHandlerContribution implements FrontendApplicationContribution {
+    @inject(OpenerService)
+    protected readonly openenerService: OpenerService;
+
+    initialize(): void {
+        window.electronTheiaCore.setOpenUrlHandler(async url => {
+            const uri = new URI(url);
+            try {
+                const handler = await this.openenerService.getOpener(uri);
+                if (handler) {
+                    await handler.open(uri);
+                    return true;
+                }
+            } catch (e) {
+                // no handler
+            }
+            return false;
+        });
+    }
+}

--- a/packages/core/src/electron-browser/preload.ts
+++ b/packages/core/src/electron-browser/preload.ts
@@ -26,7 +26,8 @@ import {
     CHANNEL_IS_FULL_SCREEN, CHANNEL_SET_MENU_BAR_VISIBLE, CHANNEL_REQUEST_CLOSE, CHANNEL_SET_TITLE_STYLE, CHANNEL_RESTART,
     CHANNEL_REQUEST_RELOAD, CHANNEL_APP_STATE_CHANGED, CHANNEL_SHOW_ITEM_IN_FOLDER, CHANNEL_READ_CLIPBOARD, CHANNEL_WRITE_CLIPBOARD,
     CHANNEL_KEYBOARD_LAYOUT_CHANGED, CHANNEL_IPC_CONNECTION, InternalMenuDto, CHANNEL_REQUEST_SECONDARY_CLOSE, CHANNEL_SET_BACKGROUND_COLOR,
-    CHANNEL_WC_METADATA, CHANNEL_ABOUT_TO_CLOSE, CHANNEL_OPEN_WITH_SYSTEM_APP
+    CHANNEL_WC_METADATA, CHANNEL_ABOUT_TO_CLOSE, CHANNEL_OPEN_WITH_SYSTEM_APP,
+    CHANNEL_OPEN_URL
 } from '../electron-common/electron-api';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -37,6 +38,16 @@ const commandHandlers = new Map<number, Map<number, () => void>>();
 let nextHandlerId = 0;
 const mainMenuId = 0;
 let nextMenuId = mainMenuId + 1;
+
+let openUrlHandler: ((url: string) => Promise<boolean>) | undefined;
+
+ipcRenderer.on(CHANNEL_OPEN_URL, async (event: Electron.IpcRendererEvent, url: string, replyChannel: string) => {
+    if (openUrlHandler) {
+        event.sender.send(replyChannel, await openUrlHandler(url));
+    } else {
+        event.sender.send(replyChannel, false);
+    }
+});
 
 function convertMenu(menu: MenuDto[] | undefined, handlerMap: Map<number, () => void>): InternalMenuDto[] | undefined {
     if (!menu) {
@@ -133,6 +144,10 @@ const api: TheiaCoreAPI = {
 
         ipcRenderer.on(CHANNEL_ABOUT_TO_CLOSE, h);
         return Disposable.create(() => ipcRenderer.off(CHANNEL_ABOUT_TO_CLOSE, h));
+    },
+
+    setOpenUrlHandler(handler: (url: string) => Promise<boolean>): void {
+        openUrlHandler = handler;
     },
 
     onWindowEvent: function (event: WindowEvent, handler: () => void): Disposable {

--- a/packages/core/src/electron-browser/window/electron-window-module.ts
+++ b/packages/core/src/electron-browser/window/electron-window-module.ts
@@ -29,6 +29,7 @@ import { ElectronSecondaryWindowService } from './electron-secondary-window-serv
 import { bindWindowPreferences } from './electron-window-preferences';
 import { ElectronWindowService } from './electron-window-service';
 import { ExternalAppOpenHandler } from './external-app-open-handler';
+import { ElectronUriHandlerContribution } from '../electron-uri-handler';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(ElectronMainWindowService).toDynamicValue(context =>
@@ -37,6 +38,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindWindowPreferences(bind);
     bind(WindowService).to(ElectronWindowService).inSingletonScope();
     bind(FrontendApplicationContribution).toService(WindowService);
+    bind(ElectronUriHandlerContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(ElectronUriHandlerContribution);
     bind(ClipboardService).to(ElectronClipboardService).inSingletonScope();
     rebind(FrontendApplicationStateService).to(ElectronFrontendApplicationStateService).inSingletonScope();
     bind(SecondaryWindowService).to(ElectronSecondaryWindowService).inSingletonScope();

--- a/packages/core/src/electron-browser/window/external-app-open-handler.ts
+++ b/packages/core/src/electron-browser/window/external-app-open-handler.ts
@@ -36,7 +36,7 @@ export class ExternalAppOpenHandler implements OpenHandler {
     async open(uri: URI): Promise<undefined> {
         // For files 'file:' scheme, system accepts only the path.
         // For other protocols e.g. 'vscode:' we use the full URI to propagate target app information.
-        window.electronTheiaCore.openWithSystemApp(uri.scheme === 'file' ? uri.path.fsPath() : uri.toString(true));
+        window.electronTheiaCore.openWithSystemApp(uri.toString(true));
         return undefined;
     }
 }

--- a/packages/core/src/electron-common/electron-api.ts
+++ b/packages/core/src/electron-common/electron-api.ts
@@ -74,6 +74,8 @@ export interface TheiaCoreAPI {
     onAboutToClose(handler: () => void): Disposable;
     setCloseRequestHandler(handler: (reason: StopReason) => Promise<boolean>): void;
 
+    setOpenUrlHandler(handler: (url: string) => Promise<boolean>): void;
+
     setSecondaryWindowCloseRequestHandler(windowName: string, handler: () => Promise<boolean>): void;
 
     toggleDevTools(): void;
@@ -129,6 +131,7 @@ export const CHANNEL_MAXIMIZE = 'Maximize';
 export const CHANNEL_IS_MAXIMIZED = 'IsMaximized';
 
 export const CHANNEL_ABOUT_TO_CLOSE = 'AboutToClose';
+export const CHANNEL_OPEN_URL = 'OpenUrl';
 
 export const CHANNEL_UNMAXIMIZE = 'UnMaximize';
 export const CHANNEL_ON_WINDOW_EVENT = 'OnWindowEvent';

--- a/packages/core/src/electron-main/theia-electron-window.ts
+++ b/packages/core/src/electron-main/theia-electron-window.ts
@@ -58,6 +58,7 @@ enum ClosingState {
 
 @injectable()
 export class TheiaElectronWindow {
+
     @inject(TheiaBrowserWindowOptions) protected readonly options: TheiaBrowserWindowOptions;
     @inject(WindowApplicationConfig) protected readonly config: WindowApplicationConfig;
     @inject(ElectronMainApplicationGlobals) protected readonly globals: ElectronMainApplicationGlobals;
@@ -200,6 +201,10 @@ export class TheiaElectronWindow {
 
     protected attachReloadListener(): void {
         this.toDispose.push(TheiaRendererAPI.onRequestReload(this.window.webContents, (newUrl?: string) => this.reload(newUrl)));
+    }
+
+    openUrl(url: string): Promise<boolean> {
+        return TheiaRendererAPI.openUrl(this.window.webContents, url);
     }
 
     dispose(): void {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -181,6 +181,7 @@ export interface EnvInit {
     appName: string;
     appHost: string;
     appRoot: string;
+    appUriScheme: string;
 }
 
 export interface PluginAPI {
@@ -2241,6 +2242,17 @@ export interface TestingExt {
     $onResolveChildren(controllerId: string, path: string[]): void;
 }
 
+// based from https://github.com/microsoft/vscode/blob/1.85.1/src/vs/workbench/api/common/extHostUrls.ts
+export interface UriExt {
+    registerUriHandler(handler: theia.UriHandler, plugin: PluginInfo): theia.Disposable;
+    $handleExternalUri(uri: UriComponents): Promise<void>;
+}
+
+export interface UriMain {
+    $registerUriHandler(extensionId: string, extensionName: string): void;
+    $unregisterUriHandler(extensionId: string): void;
+}
+
 export interface TestControllerUpdate {
     label: string;
     canRefresh: boolean;
@@ -2318,7 +2330,8 @@ export const PLUGIN_RPC_CONTEXT = {
     TABS_MAIN: <ProxyIdentifier<TabsMain>>createProxyIdentifier<TabsMain>('TabsMain'),
     TELEMETRY_MAIN: <ProxyIdentifier<TelemetryMain>>createProxyIdentifier<TelemetryMain>('TelemetryMain'),
     LOCALIZATION_MAIN: <ProxyIdentifier<LocalizationMain>>createProxyIdentifier<LocalizationMain>('LocalizationMain'),
-    TESTING_MAIN: createProxyIdentifier<TestingMain>('TestingMain')
+    TESTING_MAIN: createProxyIdentifier<TestingMain>('TestingMain'),
+    URI_MAIN: createProxyIdentifier<UriMain>('UriMain')
 };
 
 export const MAIN_RPC_CONTEXT = {
@@ -2360,7 +2373,8 @@ export const MAIN_RPC_CONTEXT = {
     COMMENTS_EXT: createProxyIdentifier<CommentsExt>('CommentsExt'),
     TABS_EXT: createProxyIdentifier<TabsExt>('TabsExt'),
     TELEMETRY_EXT: createProxyIdentifier<TelemetryExt>('TelemetryExt)'),
-    TESTING_EXT: createProxyIdentifier<TestingExt>('TestingExt')
+    TESTING_EXT: createProxyIdentifier<TestingExt>('TestingExt'),
+    URI_EXT: createProxyIdentifier<UriExt>('UriExt')
 };
 
 export interface TasksExt {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -328,7 +328,8 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
                     uiKind: isElectron ? UIKind.Desktop : UIKind.Web,
                     appName: FrontendApplicationConfigProvider.get().applicationName,
                     appHost: isElectron ? 'desktop' : 'web', // TODO: 'web' could be the embedder's name, e.g. 'github.dev'
-                    appRoot
+                    appRoot,
+                    appUriScheme: FrontendApplicationConfigProvider.get().electron.uriScheme
                 },
                 extApi,
                 webview: {
@@ -414,6 +415,10 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
     async activateByLanguage(languageId: string): Promise<void> {
         await this.activateByEvent('onLanguage');
         await this.activateByEvent(`onLanguage:${languageId}`);
+    }
+
+    async activateByUri(scheme: string, authority: string): Promise<void> {
+        await this.activateByEvent(`onUri:${scheme}://${authority}`);
     }
 
     async activateByCommand(commandId: string): Promise<void> {

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -64,6 +64,7 @@ import { NotebookDocumentsMainImpl } from './notebooks/notebook-documents-main';
 import { NotebookKernelsMainImpl } from './notebooks/notebook-kernels-main';
 import { NotebooksAndEditorsMain } from './notebooks/notebook-documents-and-editors-main';
 import { TestingMainImpl } from './test-main';
+import { UriMainImpl } from './uri-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const authenticationMain = new AuthenticationMainImpl(rpc, container);
@@ -203,4 +204,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const localizationMain = new LocalizationMainImpl(container);
     rpc.set(PLUGIN_RPC_CONTEXT.LOCALIZATION_MAIN, localizationMain);
+
+    const uriMain = new UriMainImpl(rpc, container);
+    rpc.set(PLUGIN_RPC_CONTEXT.URI_MAIN, uriMain);
 }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -286,6 +286,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(CellOutputWebviewFactory).toFactory(ctx => async (cell: NotebookCellModel, notebook: NotebookModel) =>
         createCellOutputWebviewContainer(ctx.container, cell, notebook).getAsync(CellOutputWebviewImpl)
     );
-
     bindContributionProvider(bind, ArgumentProcessorContribution);
+
 });

--- a/packages/plugin-ext/src/main/browser/uri-main.ts
+++ b/packages/plugin-ext/src/main/browser/uri-main.ts
@@ -1,0 +1,72 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Disposable, URI } from '@theia/core';
+import { MAIN_RPC_CONTEXT, UriExt, UriMain } from '../../common';
+import { RPCProtocol } from '../../common/rpc-protocol';
+import { interfaces } from '@theia/core/shared/inversify';
+import { OpenHandler, OpenerOptions, OpenerService } from '@theia/core/lib/browser';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { HostedPluginSupport } from '../../hosted/browser/hosted-plugin';
+
+export class UriMainImpl implements UriMain, Disposable {
+    private readonly proxy: UriExt;
+    private handlers = new Set<string>();
+    private readonly openerService: OpenerService;
+    private readonly pluginSupport: HostedPluginSupport;
+    private readonly openHandler: OpenHandler;
+
+    constructor(rpc: RPCProtocol, container: interfaces.Container) {
+        this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.URI_EXT);
+        this.openerService = container.get(OpenerService);
+        this.pluginSupport = container.get(HostedPluginSupport);
+
+        this.openHandler = {
+            id: 'theia-plugin-open-handler',
+            canHandle: async (uri: URI, options?: OpenerOptions | undefined): Promise<number> => {
+                if (uri.scheme !== FrontendApplicationConfigProvider.get().electron.uriScheme) {
+                    return 0;
+                }
+                await this.pluginSupport.activateByUri(uri.scheme, uri.authority);
+                if (this.handlers.has(uri.authority)) {
+                    return 500;
+                }
+                return 0;
+            },
+            open: async (uri: URI, options?: OpenerOptions | undefined): Promise<undefined> => {
+                if (!this.handlers.has(uri.authority)) {
+                    throw new Error(`No plugin to handle this uri: : '${uri}'`);
+                }
+                this.proxy.$handleExternalUri(uri.toComponents());
+            }
+        };
+
+        this.openerService.addHandler?.(this.openHandler);
+    }
+
+    dispose(): void {
+        this.openerService.removeHandler?.(this.openHandler);
+        this.handlers.clear();
+    }
+
+    async $registerUriHandler(pluginId: string, extensionDisplayName: string): Promise<void> {
+        this.handlers.add(pluginId);
+    }
+
+    async $unregisterUriHandler(pluginId: string): Promise<void> {
+        this.handlers.delete(pluginId);
+    }
+}

--- a/packages/plugin-ext/src/plugin/env.ts
+++ b/packages/plugin-ext/src/plugin/env.ts
@@ -35,6 +35,7 @@ export abstract class EnvExtImpl {
     private envSessionId: string;
     private host: string;
     private applicationRoot: string;
+    private appUriScheme: string;
     private _remoteName: string | undefined;
 
     constructor() {
@@ -89,6 +90,10 @@ export abstract class EnvExtImpl {
         this.applicationRoot = appRoot;
     }
 
+    setAppUriScheme(uriScheme: string): void {
+        this.appUriScheme = uriScheme;
+    }
+
     getClientOperatingSystem(): Promise<theia.OperatingSystem> {
         return this.proxy.$getClientOperatingSystem();
     }
@@ -121,7 +126,7 @@ export abstract class EnvExtImpl {
         return this.envSessionId;
     }
     get uriScheme(): string {
-        return 'theia';
+        return this.appUriScheme;
     }
     get uiKind(): theia.UIKind {
         return this.ui;

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -276,6 +276,7 @@ import { NotebookKernelsExtImpl } from './notebook/notebook-kernels';
 import { NotebookDocumentsExtImpl } from './notebook/notebook-documents';
 import { NotebookEditorsExtImpl } from './notebook/notebook-editors';
 import { TestingExtImpl } from './tests';
+import { UriExtImpl } from './uri-ext';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -324,6 +325,7 @@ export function createAPIFactory(
     const webviewViewsExt = rpc.set(MAIN_RPC_CONTEXT.WEBVIEW_VIEWS_EXT, new WebviewViewsExtImpl(rpc, webviewExt));
     const telemetryExt = rpc.set(MAIN_RPC_CONTEXT.TELEMETRY_EXT, new TelemetryExtImpl());
     const testingExt = rpc.set(MAIN_RPC_CONTEXT.TESTING_EXT, new TestingExtImpl(rpc, commandRegistry));
+    const uriExt = rpc.set(MAIN_RPC_CONTEXT.URI_EXT, new UriExtImpl(rpc));
     rpc.set(MAIN_RPC_CONTEXT.DEBUG_EXT, debugExt);
 
     return function (plugin: InternalPlugin): typeof theia {
@@ -596,8 +598,7 @@ export function createAPIFactory(
                 return decorationsExt.registerFileDecorationProvider(provider, pluginToPluginInfo(plugin));
             },
             registerUriHandler(handler: theia.UriHandler): theia.Disposable {
-                // TODO ?
-                return new Disposable(() => { });
+                return uriExt.registerUriHandler(handler, pluginToPluginInfo(plugin));
             },
             createInputBox(): theia.InputBox {
                 return quickOpenExt.createInputBox(plugin);

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -252,7 +252,7 @@ export abstract class AbstractPluginManagerExtImpl<P extends Record<string, any>
             }
             for (let activationEvent of activationEvents) {
                 if (activationEvent === 'onUri') {
-                    activationEvent = `onUri:theia://${plugin.model.id}`;
+                    activationEvent = `onUri:${this.envExt.uriScheme}://${plugin.model.id}`;
                 }
                 this.setActivation(activationEvent, activation);
             }
@@ -481,6 +481,7 @@ export class PluginManagerExtImpl extends AbstractPluginManagerExtImpl<PluginMan
         this.envExt.setApplicationName(params.env.appName);
         this.envExt.setAppHost(params.env.appHost);
         this.envExt.setAppRoot(params.env.appRoot);
+        this.envExt.setAppUriScheme(params.env.appUriScheme);
 
         this.preferencesManager.init(params.preferences);
 

--- a/packages/plugin-ext/src/plugin/uri-ext.ts
+++ b/packages/plugin-ext/src/plugin/uri-ext.ts
@@ -1,0 +1,60 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as theia from '@theia/plugin';
+import {
+    UriExt,
+    PLUGIN_RPC_CONTEXT, PluginInfo, UriMain
+} from '../common/plugin-api-rpc';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { Disposable, URI } from './types-impl';
+import { UriComponents } from '../common/uri-components';
+
+export class UriExtImpl implements UriExt {
+
+    private handlers = new Map<string, theia.UriHandler>();
+
+    private readonly proxy: UriMain;
+
+    constructor(readonly rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.URI_MAIN);
+        console.log(this.proxy);
+    }
+
+    registerUriHandler(handler: theia.UriHandler, plugin: PluginInfo): theia.Disposable {
+        const pluginId = plugin.id;
+        if (this.handlers.has(pluginId)) {
+            throw new Error(`URI handler already registered for plugin ${pluginId}`);
+        }
+
+        this.handlers.set(pluginId, handler);
+        this.proxy.$registerUriHandler(pluginId, plugin.displayName || plugin.name);
+
+        return new Disposable(() => {
+            this.proxy.$unregisterUriHandler(pluginId);
+            this.handlers.delete(pluginId);
+        });
+    }
+
+    $handleExternalUri(uri: UriComponents): Promise<void> {
+        const handler = this.handlers.get(uri.authority);
+        if (!handler) {
+            return Promise.resolve();
+        }
+        handler.handleUri(URI.revive(uri));
+        return Promise.resolve();
+    }
+}


### PR DESCRIPTION
#### What it does
This PR implements the stubbed API window#registerUriHandler(). This was not marked properly as '@stubbed', but the implementation returned nothing.
A detailed explanation on how this is supposed to be used in extensions is located here:  https://github.com/microsoft/vscode/blob/1.85.1/src/vscode-dts/vscode.d.ts#L10146.

Fixes #13169

Contributed on behalf of STMicroelectronics

#### How to test 

1. install the following extension on theia browser example, main branch: 
- vsix archive: [open-external-0.1.0.zip](https://github.com/eclipse-theia/theia/files/14036122/open-external-0.1.0.zip)
- src: https://github.com/rschnekenbu/open-external
2. trigger the "Open External: Open external URI", then select "uri handler" menu. Nothing will happened
![13169-before-patch](https://github.com/eclipse-theia/theia/assets/3964263/bc74688f-3ee1-43fa-a8af-52717b035b40)

3. Update to this PR
4. The same sequence of actions will display a notification, as implemented by the uri handler provided by the test extension.
![13169-after-patch](https://github.com/eclipse-theia/theia/assets/3964263/c1a203ca-67c4-4c3f-a36a-f4e65c4d6793)

#### Follow-ups

- [x] https://github.com/eclipse-theia/theia/issues/13960
- [ ] https://github.com/eclipse-theia/theia-blueprint/issues/378

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)