### PR TITLE
Improve title rendering on menu bar change

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -18,7 +18,7 @@ import { inject, injectable, postConstruct } from 'inversify';
 import { Command, CommandContribution, CommandRegistry, isOSX, isWindows, MenuModelRegistry, MenuContribution, Disposable, nls } from '../../common';
 import {
     codicon, ConfirmDialog, KeybindingContribution, KeybindingRegistry, PreferenceScope, Widget,
-    FrontendApplication, FrontendApplicationContribution, CommonMenus, CommonCommands, Dialog, Message, ApplicationShell,
+    FrontendApplication, FrontendApplicationContribution, CommonMenus, CommonCommands, Dialog, Message, ApplicationShell, PreferenceService, animationFrame,
 } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 import { FrontendApplicationStateService, FrontendApplicationState } from '../../browser/frontend-application-state';
@@ -441,6 +441,9 @@ export class CustomTitleWidget extends Widget {
     @inject(ApplicationShell)
     protected readonly applicationShell: ApplicationShell;
 
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
     constructor() {
         super();
         this.id = 'theia-custom-title';
@@ -451,6 +454,11 @@ export class CustomTitleWidget extends Widget {
         this.updateTitle(this.windowTitleService.title);
         this.windowTitleService.onDidChangeTitle(title => {
             this.updateTitle(title);
+        });
+        this.preferenceService.onPreferenceChanged(e => {
+            if (e.preferenceName === 'window.menuBarVisibility') {
+                animationFrame().then(() => this.adjustTitleToCenter());
+            }
         });
     }
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13311

Awaits the first rendering of the menu bar and then updates the title widget position.

#### How to test

1. Resize the electron window until the title widget disappears. 
2. Change the menu bar visibility preference.
3. Confirm that the title widget appears/disappears as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
