### PR TITLE
Fix core localizations for electron builds

### DIFF
--- a/packages/core/src/electron-browser/messaging/electron-messaging-frontend-module.ts
+++ b/packages/core/src/electron-browser/messaging/electron-messaging-frontend-module.ts
@@ -23,7 +23,7 @@ import { ElectronFrontendIdProvider } from './electron-frontend-id-provider';
 import { FrontendIdProvider } from '../../browser/messaging/frontend-id-provider';
 import { ConnectionSource } from '../../browser/messaging/connection-source';
 import { LocalConnectionProvider, RemoteConnectionProvider, ServiceConnectionProvider } from '../../browser/messaging/service-connection-provider';
-import { WebSocketConnectionProvider } from '../../browser';
+import { WebSocketConnectionProvider } from '../../browser/messaging/ws-connection-provider';
 import { ConnectionCloseService, connectionCloseServicePath } from '../../common/messaging/connection-management';
 import { WebSocketConnectionSource } from '../../browser/messaging/ws-connection-source';
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13330

Modifies the general `../../browser` import to be more specific. The general import tries to import all sorts of code that requires the localizations.

#### How to test

1. Start the electron application and install a localization.
2. Confirm that the menus are all correctly localized.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
