### PR TITLE
fix: regressions from headless plugins refactoring

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -240,6 +240,7 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
     }
 
     protected override afterStart(): void {
+        this.watcher.onDidDeploy(() => this.load());
         this.server.onDidOpenConnection(() => this.load());
     }
 

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -20,7 +20,7 @@ import * as theia from '@theia/plugin';
 import { emptyPlugin, MAIN_RPC_CONTEXT, Plugin } from '../../../common/plugin-api-rpc';
 import { ExtPluginApi } from '../../../common/plugin-ext-api-contribution';
 import { getPluginId, PluginMetadata } from '../../../common/plugin-protocol';
-import { RPCProtocol, RPCProtocolImpl } from '../../../common/rpc-protocol';
+import { RPCProtocol } from '../../../common/rpc-protocol';
 import { ClipboardExt } from '../../../plugin/clipboard-ext';
 import { EditorsAndDocumentsExtImpl } from '../../../plugin/editors-and-documents';
 import { MessageRegistryExt } from '../../../plugin/message-registry';
@@ -56,7 +56,7 @@ function initialize(contextPath: string, pluginMetadata: PluginMetadata): void {
 const container = new Container();
 container.load(pluginHostModule);
 
-const rpc: RPCProtocol = container.get(RPCProtocolImpl);
+const rpc: RPCProtocol = container.get(RPCProtocol);
 const pluginManager = container.get(PluginManagerExtImpl);
 pluginManager.setPluginHost({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
@@ -23,10 +23,10 @@ import { RPCProtocol, RPCProtocolImpl } from '../../../common/rpc-protocol';
 import { ClipboardExt } from '../../../plugin/clipboard-ext';
 import { EditorsAndDocumentsExtImpl } from '../../../plugin/editors-and-documents';
 import { MessageRegistryExt } from '../../../plugin/message-registry';
-import { PluginManagerExtImpl } from '../../../plugin/plugin-manager';
-import { KeyValueStorageProxy } from '../../../plugin/plugin-storage';
+import { MinimalTerminalServiceExt, PluginManagerExtImpl } from '../../../plugin/plugin-manager';
+import { InternalStorageExt, KeyValueStorageProxy } from '../../../plugin/plugin-storage';
 import { PreferenceRegistryExtImpl } from '../../../plugin/preference-registry';
-import { SecretsExtImpl } from '../../../plugin/secrets-ext';
+import { InternalSecretsExt, SecretsExtImpl } from '../../../plugin/secrets-ext';
 import { TerminalServiceExtImpl } from '../../../plugin/terminal-ext';
 import { WebviewsExtImpl } from '../../../plugin/webviews';
 import { WorkspaceExtImpl } from '../../../plugin/workspace';
@@ -58,16 +58,23 @@ export default new ContainerModule(bind => {
 
     bind(PluginManagerExtImpl).toSelf().inSingletonScope();
     bind(EnvExtImpl).to(WorkerEnvExtImpl).inSingletonScope();
-    bind(LocalizationExt).to(LocalizationExtImpl).inSingletonScope();
+    bind(LocalizationExtImpl).toSelf().inSingletonScope();
+    bind(LocalizationExt).toService(LocalizationExtImpl);
     bind(KeyValueStorageProxy).toSelf().inSingletonScope();
+    bind(InternalStorageExt).toService(KeyValueStorageProxy);
     bind(SecretsExtImpl).toSelf().inSingletonScope();
+    bind(InternalSecretsExt).toService(SecretsExtImpl);
     bind(PreferenceRegistryExtImpl).toSelf().inSingletonScope();
-    bind(DebugExtImpl).toDynamicValue(({ container }) => createDebugExtStub(container))
-        .inSingletonScope();
+    bind(DebugExtImpl).toDynamicValue(({ container }) => {
+        const child = container.createChild();
+        child.bind(DebugExtImpl).toSelf();
+        return createDebugExtStub(child);
+    }).inSingletonScope();
     bind(EditorsAndDocumentsExtImpl).toSelf().inSingletonScope();
     bind(WorkspaceExtImpl).toSelf().inSingletonScope();
     bind(MessageRegistryExt).toSelf().inSingletonScope();
     bind(ClipboardExt).toSelf().inSingletonScope();
     bind(WebviewsExtImpl).toSelf().inSingletonScope();
     bind(TerminalServiceExtImpl).toSelf().inSingletonScope();
+    bind(MinimalTerminalServiceExt).toService(TerminalServiceExtImpl);
 });

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -81,7 +81,7 @@ class ActivatedPlugin {
 
 export const MinimalTerminalServiceExt = Symbol('MinimalTerminalServiceExt');
 export type MinimalTerminalServiceExt = Pick<TerminalServiceExt,
-    'getEnvironmentVariableCollection'|'$initEnvironmentVariableCollections'|'$setShell'>;
+    'getEnvironmentVariableCollection' | '$initEnvironmentVariableCollections' | '$setShell'>;
 
 @injectable()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #13320

Contributed on behalf of STMicroelectronics

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Fixes regressions from headless plugins refactoring (#13320 )

- fix gaps in Inversify DI configuration in the web worker for frontend plugins
- restore the onDidDeploy() dorwarding lost in the refactoring for headless plugins

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start browser example
2. Check that there are no DI related error messages in the debug console
3. Install or remove a vscode extension
4. Verify that the UI updates the button correctly after the action
5. Repeat with electron example

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
