### PR TITLE
Provide "New File" default implementation (#13303)

### DIFF
--- a/examples/playwright/src/tests/theia-getting-started.test.ts
+++ b/examples/playwright/src/tests/theia-getting-started.test.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2024 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect, test } from '@playwright/test';
+import { TheiaApp } from '../theia-app';
+import { TheiaAppLoader } from '../theia-app-loader';
+import { TheiaExplorerView } from '../theia-explorer-view';
+
+/**
+ * Test the Theia welcome page from the getting-started package.
+ */
+test.describe('Theia Welcome Page', () => {
+    let app: TheiaApp;
+
+    test.beforeAll(async ({ playwright, browser }) => {
+        app = await TheiaAppLoader.load({ playwright, browser });
+        await app.isMainContentPanelVisible();
+    });
+
+    test.afterAll(async () => {
+        await app.page.close();
+    });
+
+    test('New File... entry should create a new file.', async () => {
+        await app.page.getByRole('button', { name: 'New File...' }).click();
+        const quickPicker = app.page.getByPlaceholder('Select File Type or Enter');
+        await quickPicker.fill('testfile.txt');
+        await quickPicker.press('Enter');
+        await app.page.getByRole('button', { name: 'Create File' }).click();
+
+        // check file in workspace exists
+        const explorer = await app.openView(TheiaExplorerView);
+        await explorer.refresh();
+        await explorer.waitForVisibleFileNodes();
+        expect(await explorer.existsFileNode('testfile.txt')).toBe(true);
+    });
+});

--- a/examples/playwright/src/tests/theia-main-menu.test.ts
+++ b/examples/playwright/src/tests/theia-main-menu.test.ts
@@ -20,6 +20,7 @@ import { TheiaAppLoader } from '../theia-app-loader';
 import { TheiaAboutDialog } from '../theia-about-dialog';
 import { TheiaMenuBar } from '../theia-main-menu';
 import { OSUtil } from '../util';
+import { TheiaExplorerView } from '../theia-explorer-view';
 
 test.describe('Theia Main Menu', () => {
 
@@ -109,4 +110,24 @@ test.describe('Theia Main Menu', () => {
         expect(await fileDialog.isVisible()).toBe(false);
     });
 
+    test('Create file via New File menu and cancel', async () => {
+        const openFileEntry = 'New File...';
+        await (await menuBar.openMenu('File')).clickMenuItem(openFileEntry);
+        const quickPick = app.page.getByPlaceholder('Select File Type or Enter');
+        // type file name and press enter
+        await quickPick.fill('test.txt');
+        await quickPick.press('Enter');
+
+        // check file dialog is opened and accept with "Create File" button
+        const fileDialog = await app.page.waitForSelector('div[class="dialogBlock"]');
+        expect(await fileDialog.isVisible()).toBe(true);
+        await app.page.locator('#theia-dialog-shell').getByRole('button', { name: 'Create File' }).click();
+        expect(await fileDialog.isVisible()).toBe(false);
+
+        // check file in workspace exists
+        const explorer = await app.openView(TheiaExplorerView);
+        await explorer.refresh();
+        await explorer.waitForVisibleFileNodes();
+        expect(await explorer.existsFileNode('test.txt')).toBe(true);
+    });
 });

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -135,7 +135,7 @@ export class GettingStartedWidget extends ReactWidget {
                 <hr className='gs-hr' />
                 <div className='flex-grid'>
                     <div className='col'>
-                        {this.renderOpen()}
+                        {this.renderStart()}
                     </div>
                 </div>
                 <div className='flex-grid'>
@@ -176,11 +176,21 @@ export class GettingStartedWidget extends ReactWidget {
     }
 
     /**
-     * Render the `open` section.
-     * Displays a collection of `open` commands.
+     * Render the `Start` section.
+     * Displays a collection of "start-to-work" related commands like `open` commands and some other.
      */
-    protected renderOpen(): React.ReactNode {
+    protected renderStart(): React.ReactNode {
         const requireSingleOpen = isOSX || !environment.electron.is();
+
+        const createFile = <div className='gs-action-container'>
+            <a
+                role={'button'}
+                tabIndex={0}
+                onClick={this.doCreateFile}
+                onKeyDown={this.doCreateFileEnter}>
+                {CommonCommands.NEW_UNTITLED_FILE.label ?? nls.localizeByDefault('New File...')}
+            </a>
+        </div>;
 
         const open = requireSingleOpen && <div className='gs-action-container'>
             <a
@@ -223,7 +233,8 @@ export class GettingStartedWidget extends ReactWidget {
         );
 
         return <div className='gs-section'>
-            <h3 className='gs-section-header'><i className={codicon('folder-opened')}></i>{nls.localizeByDefault('Open')}</h3>
+            <h3 className='gs-section-header'><i className={codicon('folder-opened')}></i>{nls.localizeByDefault('Start')}</h3>
+            {createFile}
             {open}
             {openFile}
             {openFolder}
@@ -391,6 +402,16 @@ export class GettingStartedWidget extends ReactWidget {
         });
         return paths;
     }
+
+    /**
+     * Trigger the create file command.
+     */
+    protected doCreateFile = () => this.commandRegistry.executeCommand(CommonCommands.NEW_UNTITLED_FILE.id);
+    protected doCreateFileEnter = (e: React.KeyboardEvent) => {
+        if (this.isEnterKey(e)) {
+            this.doCreateFile();
+        }
+    };
 
     /**
      * Trigger the open command.


### PR DESCRIPTION
#### What it does

Fixes #13303 

Adds a new dynamic `Create New File` item to the  create file picker. The new item will appear as soon as the user types something in the input field. Accepting the item will execute a `file.newFile` command handler and bypass the file name to it.


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- In the browser app select `New File...`item from the `File` menu.
- Start typing. A new item `Create New File` should become visible
- Selecting this item will open a "save file" dialog with a file name pre-set. The parent directory should be the current user working directory or a workspace folder if selected.  

<img width="668" alt="Bildschirmfoto 2024-02-02 um 12 43 46" src="https://github.com/eclipse-theia/theia/assets/454322/9227a67a-7846-4af0-9c99-da696c04656a">

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
