### PR TITLE
(fix) bundle-size: reuse ts helper functions from tslib instead of in…

### DIFF
--- a/configs/base.tsconfig.json
+++ b/configs/base.tsconfig.json
@@ -12,6 +12,7 @@
     "strictNullChecks": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "importHelpers": true,
     "downlevelIteration": true,
     "resolveJsonModule": true,
     "module": "CommonJS",

--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -59,6 +59,7 @@
     "source-map-support": "^0.5.19",
     "string-replace-loader": "^3.1.0",
     "style-loader": "^2.0.0",
+    "tslib": "^2.6.2",
     "umd-compat-loader": "^2.1.2",
     "webpack": "^5.76.0",
     "webpack-cli": "4.7.0",

--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -39,6 +39,7 @@
     "nano": "^10.1.3",
     "resolve-package-path": "^4.0.3",
     "semver": "^7.5.4",
+    "tslib": "^2.6.2",
     "write-json-file": "^2.2.0"
   },
   "devDependencies": {

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -52,6 +52,7 @@
     "puppeteer-core": "19.7.2",
     "puppeteer-to-istanbul": "1.4.0",
     "temp": "^0.9.1",
+    "tslib": "^2.6.2",
     "yargs": "^15.3.1"
   },
   "devDependencies": {

--- a/dev-packages/ffmpeg/package.json
+++ b/dev-packages/ffmpeg/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@electron/get": "^2.0.0",
+    "tslib": "^2.6.2",
     "unzipper": "^0.9.11"
   },
   "devDependencies": {

--- a/dev-packages/localization-manager/package.json
+++ b/dev-packages/localization-manager/package.json
@@ -36,6 +36,7 @@
     "deepmerge": "^4.2.2",
     "fs-extra": "^4.0.2",
     "glob": "^7.2.0",
+    "tslib": "^2.6.2",
     "typescript": "~4.5.5"
   },
   "devDependencies": {

--- a/dev-packages/native-webpack-plugin/package.json
+++ b/dev-packages/native-webpack-plugin/package.json
@@ -29,6 +29,7 @@
     "watch": "theiaext watch"
   },
   "dependencies": {
+    "tslib": "^2.6.2",
     "webpack": "^5.76.0"
   }
 }

--- a/dev-packages/ovsx-client/package.json
+++ b/dev-packages/ovsx-client/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@theia/request": "1.46.0",
-    "semver": "^7.5.4"
+    "semver": "^7.5.4",
+    "tslib": "^2.6.2"
   }
 }

--- a/dev-packages/private-re-exports/package.json
+++ b/dev-packages/private-re-exports/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "mustache": "^4.2.0",
     "semver": "^7.5.4",
+    "tslib": "^2.6.2",
     "yargs": "^15.3.1"
   },
   "devDependencies": {

--- a/dev-packages/request/package.json
+++ b/dev-packages/request/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "http-proxy-agent": "^5.0.0",
-    "https-proxy-agent": "^5.0.0"
+    "https-proxy-agent": "^5.0.0",
+    "tslib": "^2.6.2"
   }
 }

--- a/packages/bulk-edit/package.json
+++ b/packages/bulk-edit/package.json
@@ -8,7 +8,8 @@
     "@theia/filesystem": "1.46.0",
     "@theia/monaco": "1.46.0",
     "@theia/monaco-editor-core": "1.83.101",
-    "@theia/workspace": "1.46.0"
+    "@theia/workspace": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/callhierarchy/package.json
+++ b/packages/callhierarchy/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@theia/core": "1.46.0",
     "@theia/editor": "1.46.0",
-    "ts-md5": "^1.2.2"
+    "ts-md5": "^1.2.2",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -6,7 +6,8 @@
     "@theia/core": "1.46.0",
     "@theia/monaco": "1.46.0",
     "@theia/monaco-editor-core": "1.83.101",
-    "anser": "^2.0.1"
+    "anser": "^2.0.1",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,6 +69,7 @@
     "safer-buffer": "^2.1.2",
     "socket.io": "^4.5.3",
     "socket.io-client": "^4.5.3",
+    "tslib": "^2.6.2",
     "uuid": "^9.0.1",
     "vscode-languageserver-protocol": "^3.17.2",
     "vscode-uri": "^2.1.1",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -19,7 +19,8 @@
     "@vscode/debugprotocol": "^1.51.0",
     "fast-deep-equal": "^3.1.3",
     "jsonc-parser": "^2.2.0",
-    "p-debounce": "^2.1.0"
+    "p-debounce": "^2.1.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor-preview/package.json
+++ b/packages/editor-preview/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@theia/core": "1.46.0",
     "@theia/editor": "1.46.0",
-    "@theia/navigator": "1.46.0"
+    "@theia/navigator": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -4,7 +4,8 @@
   "description": "Theia - Editor Extension",
   "dependencies": {
     "@theia/core": "1.46.0",
-    "@theia/variable-resolver": "1.46.0"
+    "@theia/variable-resolver": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/external-terminal/package.json
+++ b/packages/external-terminal/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@theia/core": "1.46.0",
     "@theia/editor": "1.46.0",
-    "@theia/workspace": "1.46.0"
+    "@theia/workspace": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -8,7 +8,8 @@
     "@theia/filesystem": "1.46.0",
     "@theia/process": "1.46.0",
     "@theia/workspace": "1.46.0",
-    "@vscode/ripgrep": "^1.14.2"
+    "@vscode/ripgrep": "^1.14.2",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -18,6 +18,7 @@
     "stat-mode": "^1.0.0",
     "tar-fs": "^1.16.2",
     "trash": "^7.2.0",
+    "tslib": "^2.6.2",
     "vscode-languageserver-textdocument": "^1.0.1"
   },
   "publishConfig": {

--- a/packages/getting-started/package.json
+++ b/packages/getting-started/package.json
@@ -8,7 +8,8 @@
     "@theia/filesystem": "1.46.0",
     "@theia/keymaps": "1.46.0",
     "@theia/preview": "1.46.0",
-    "@theia/workspace": "1.46.0"
+    "@theia/workspace": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -21,7 +21,8 @@
     "node-ssh": "^12.0.1",
     "octicons": "^7.1.0",
     "p-queue": "^2.4.2",
-    "ts-md5": "^1.2.2"
+    "ts-md5": "^1.2.2",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -8,7 +8,8 @@
     "@theia/monaco-editor-core": "1.83.101",
     "@theia/preferences": "1.46.0",
     "@theia/userstorage": "1.46.0",
-    "jsonc-parser": "^2.2.0"
+    "jsonc-parser": "^2.2.0",
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@theia/ext-scripts": "1.46.0"

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@theia/core": "1.46.0",
     "@theia/filesystem": "1.46.0",
-    "@theia/workspace": "1.46.0"
+    "@theia/workspace": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/memory-inspector/package.json
+++ b/packages/memory-inspector/package.json
@@ -30,7 +30,8 @@
     "@theia/core": "1.46.0",
     "@theia/debug": "1.46.0",
     "@vscode/debugprotocol": "^1.51.0",
-    "long": "^4.0.0"
+    "long": "^4.0.0",
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@types/long": "^4.0.0"

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@theia/core": "1.46.0",
     "react-perfect-scrollbar": "^1.5.3",
-    "ts-md5": "^1.2.2"
+    "ts-md5": "^1.2.2",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -4,7 +4,8 @@
   "description": "Theia - Metrics Extension",
   "dependencies": {
     "@theia/core": "1.46.0",
-    "prom-client": "^10.2.0"
+    "prom-client": "^10.2.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mini-browser/package.json
+++ b/packages/mini-browser/package.json
@@ -8,6 +8,7 @@
     "@types/mime-types": "^2.1.0",
     "mime-types": "^2.1.18",
     "pdfobject": "^2.0.201604172",
+    "tslib": "^2.6.2",
     "vhost": "^3.0.2"
   },
   "publishConfig": {

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -13,6 +13,7 @@
     "fast-plist": "^0.1.2",
     "idb": "^4.0.5",
     "jsonc-parser": "^2.2.0",
+    "tslib": "^2.6.2",
     "vscode-oniguruma": "1.6.1",
     "vscode-textmate": "^9.0.0"
   },

--- a/packages/navigator/package.json
+++ b/packages/navigator/package.json
@@ -6,7 +6,8 @@
     "@theia/core": "1.46.0",
     "@theia/filesystem": "1.46.0",
     "@theia/workspace": "1.46.0",
-    "minimatch": "^5.1.0"
+    "minimatch": "^5.1.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -7,7 +7,8 @@
     "@theia/editor": "1.46.0",
     "@theia/filesystem": "1.46.0",
     "@theia/monaco": "1.46.0",
-    "react-perfect-scrollbar": "^1.5.8"
+    "react-perfect-scrollbar": "^1.5.8",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/outline-view/package.json
+++ b/packages/outline-view/package.json
@@ -3,7 +3,8 @@
   "version": "1.46.0",
   "description": "Theia - Outline View Extension",
   "dependencies": {
-    "@theia/core": "1.46.0"
+    "@theia/core": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -8,7 +8,8 @@
     "@theia/monaco": "1.46.0",
     "@theia/monaco-editor-core": "1.83.101",
     "@types/p-queue": "^2.3.1",
-    "p-queue": "^2.4.2"
+    "p-queue": "^2.4.2",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-dev/package.json
+++ b/packages/plugin-dev/package.json
@@ -11,7 +11,8 @@
     "@theia/output": "1.46.0",
     "@theia/plugin-ext": "1.46.0",
     "@theia/workspace": "1.46.0",
-    "ps-tree": "^1.2.0"
+    "ps-tree": "^1.2.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ext-headless/package.json
+++ b/packages/plugin-ext-headless/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "@theia/core": "1.46.0",
     "@theia/plugin-ext": "1.46.0",
-    "@theia/terminal": "1.46.0"
+    "@theia/terminal": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -17,7 +17,8 @@
     "@theia/userstorage": "1.46.0",
     "@theia/workspace": "1.46.0",
     "decompress": "^4.2.1",
-    "filenamify": "^4.1.0"
+    "filenamify": "^4.1.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -46,6 +46,7 @@
     "mime": "^2.4.4",
     "ps-tree": "^1.2.0",
     "semver": "^7.5.4",
+    "tslib": "^2.6.2",
     "vhost": "^3.0.2",
     "vscode-textmate": "^9.0.0"
   },

--- a/packages/plugin-metrics/package.json
+++ b/packages/plugin-metrics/package.json
@@ -7,7 +7,8 @@
     "@theia/metrics": "1.46.0",
     "@theia/monaco-editor-core": "1.83.101",
     "@theia/plugin": "1.46.0",
-    "@theia/plugin-ext": "1.46.0"
+    "@theia/plugin-ext": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -13,7 +13,8 @@
     "async-mutex": "^0.3.1",
     "fast-deep-equal": "^3.1.3",
     "jsonc-parser": "^2.2.0",
-    "p-debounce": "^2.1.0"
+    "p-debounce": "^2.1.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -10,7 +10,8 @@
     "@types/highlight.js": "^10.1.0",
     "@types/markdown-it-anchor": "^4.0.1",
     "highlight.js": "10.4.1",
-    "markdown-it-anchor": "~5.0.0"
+    "markdown-it-anchor": "~5.0.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@theia/core": "1.46.0",
     "node-pty": "0.11.0-beta17",
-    "string-argv": "^0.1.1"
+    "string-argv": "^0.1.1",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/property-view/package.json
+++ b/packages/property-view/package.json
@@ -4,7 +4,8 @@
   "description": "Theia - Property View Extension",
   "dependencies": {
     "@theia/core": "1.46.0",
-    "@theia/filesystem": "1.46.0"
+    "@theia/filesystem": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -15,7 +15,8 @@
     "ssh2": "^1.12.0",
     "ssh2-sftp-client": "^9.1.0",
     "socket.io": "^4.5.3",
-    "socket.io-client": "^4.5.3"
+    "socket.io-client": "^4.5.3",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scm-extra/package.json
+++ b/packages/scm-extra/package.json
@@ -7,7 +7,8 @@
     "@theia/editor": "1.46.0",
     "@theia/filesystem": "1.46.0",
     "@theia/navigator": "1.46.0",
-    "@theia/scm": "1.46.0"
+    "@theia/scm": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -10,7 +10,8 @@
     "diff": "^3.4.0",
     "p-debounce": "^2.1.0",
     "react-autosize-textarea": "^7.0.0",
-    "ts-md5": "^1.2.2"
+    "ts-md5": "^1.2.2",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -11,7 +11,8 @@
     "@theia/workspace": "1.46.0",
     "@vscode/ripgrep": "^1.14.2",
     "minimatch": "^5.1.0",
-    "react-autosize-textarea": "^7.0.0"
+    "react-autosize-textarea": "^7.0.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/secondary-window/package.json
+++ b/packages/secondary-window/package.json
@@ -3,7 +3,8 @@
   "version": "1.46.0",
   "description": "Theia - Secondary Window Extension",
   "dependencies": {
-    "@theia/core": "1.46.0"
+    "@theia/core": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -16,7 +16,8 @@
     "@theia/workspace": "1.46.0",
     "async-mutex": "^0.3.1",
     "jsonc-parser": "^2.2.0",
-    "p-debounce": "^2.1.0"
+    "p-debounce": "^2.1.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -9,6 +9,7 @@
     "@theia/process": "1.46.0",
     "@theia/variable-resolver": "1.46.0",
     "@theia/workspace": "1.46.0",
+    "tslib": "^2.6.2",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
     "xterm-addon-search": "^0.13.0"

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -4,7 +4,8 @@
   "description": "Theia - Timeline Extension",
   "dependencies": {
     "@theia/core": "1.46.0",
-    "@theia/navigator": "1.46.0"
+    "@theia/navigator": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -38,7 +38,8 @@
     "@theia/workspace": "1.46.0",
     "ajv": "^6.5.3",
     "jsonc-parser": "^2.2.0",
-    "perfect-scrollbar": "^1.3.0"
+    "perfect-scrollbar": "^1.3.0",
+    "tslib": "^2.6.2"
   },
   "theiaExtensions": [
     {

--- a/packages/typehierarchy/package.json
+++ b/packages/typehierarchy/package.json
@@ -4,7 +4,8 @@
   "description": "Theia - Type Hierarchy Extension",
   "dependencies": {
     "@theia/core": "1.46.0",
-    "@theia/editor": "1.46.0"
+    "@theia/editor": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/userstorage/package.json
+++ b/packages/userstorage/package.json
@@ -4,7 +4,8 @@
   "description": "Theia - User Storage Extension",
   "dependencies": {
     "@theia/core": "1.46.0",
-    "@theia/filesystem": "1.46.0"
+    "@theia/filesystem": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/variable-resolver/package.json
+++ b/packages/variable-resolver/package.json
@@ -3,7 +3,8 @@
   "version": "1.46.0",
   "description": "Theia - Variable Resolver Extension",
   "dependencies": {
-    "@theia/core": "1.46.0"
+    "@theia/core": "1.46.0",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -13,7 +13,8 @@
     "@theia/workspace": "1.46.0",
     "luxon": "^2.4.0",
     "p-debounce": "^2.1.0",
-    "semver": "^7.5.4"
+    "semver": "^7.5.4",
+    "tslib": "^2.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -7,6 +7,7 @@
     "@theia/filesystem": "1.46.0",
     "@theia/variable-resolver": "1.46.0",
     "jsonc-parser": "^2.2.0",
+    "tslib": "^2.6.2",
     "valid-filename": "^2.0.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11356,7 +11356,7 @@ tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
+tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
#### What it does

Fixes #13345

Reuses ts helper functions from tslib instead of inlining

#### How to test

Build master, check its size, build this branch, size will be smaller

#### Follow-ups

none

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
