### PR TITLE
Fix non recursive folder delete using file system

### DIFF
--- a/packages/filesystem/src/node/disk-file-system-provider.ts
+++ b/packages/filesystem/src/node/disk-file-system-provider.ts
@@ -509,7 +509,12 @@ export class DiskFileSystemProvider implements Disposable,
             if (opts.recursive) {
                 await this.rimraf(filePath);
             } else {
-                await promisify(unlink)(filePath);
+                const stat = await promisify(lstat)(filePath);
+                if (stat.isDirectory() && !stat.isSymbolicLink()) {
+                    await promisify(rmdir)(filePath);
+                } else {
+                    await promisify(unlink)(filePath);
+                }
             }
         } else {
             await trash(filePath);


### PR DESCRIPTION
Fixes https://github.com/eclipse-theia/theia/issues/13349

Deleting a folder without recursive enabled failed as the used nodejs API unlink does not support folder deletion. Fixing it by first checking if it is a folder, and if so using rmdir instead.

Added a simple unit test, which also exposed that
the folder deletion also fails when using trash support, but that is a different issue.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Handle the deletion of a folder using the file system api.
Previously this did only work when asking to delete the folders content as well, now with recursive: false,
it does delete the folder if it is empty.

#### How to test

I did add a unit test, which fails without the fix.

#### Follow-ups

I did notice that when using the trash support, the deletion of a folder with content (recursive: true) did fail.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
