### PR TITLE
Add prefix to contributed view container ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [component] add here -->
 
 ## v1.46.0 - 01/25/2024
-
+- [plugin] Add prefix to contributed view container ids [#13362](https://github.com/eclipse-theia/theia/pull/13362) - contributed on behalf of STMicroelectronics
 - [application-manager] updated message for missing Electron main entries [#13242](https://github.com/eclipse-theia/theia/pull/13242)
 - [application-package] bumped the default supported API from `1.84.2` to `1.85.1` [#13276](https://github.com/eclipse-theia/theia/pull/13276) - contributed on behalf of STMicroelectronics
 - [browser-only] added support for 'browser-only' Theia [#12853](https://github.com/eclipse-theia/theia/pull/12853)


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Adds the prefix `workbench.view.extension.` to the id of view containers contributed by plugins. As the id of the view container now contains dots, it can no longer be used as a css selector, so we now generate a sequential id.

Fixes #13249

Contributed on behalf of STMicroelectronics

#### How to test
I use the tree-view-sample from https://github.com/microsoft/vscode-extension-samples/. The example contributes a view called "Node Dependencies" in a container called "Package Explorer" plus it adds a bunch of views to the standard "Explorer" view container. Make sure you can open/close/reopen the "Package Explorer" view and that all the contributed views are functional, including showing the proper icons.

#### Follow-ups
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
