### PR TITLE
Fix race condition in notebook kernel association

### DIFF
--- a/packages/notebook/src/browser/service/notebook-kernel-service.ts
+++ b/packages/notebook/src/browser/service/notebook-kernel-service.ts
@@ -144,7 +144,7 @@ export class SourceCommand implements Disposable {
 
 const NOTEBOOK_KERNEL_BINDING_STORAGE_KEY = 'notebook.kernel.bindings';
 @injectable()
-export class NotebookKernelService implements Disposable {
+export class NotebookKernelService {
 
     @inject(NotebookService)
     protected notebookService: NotebookService;
@@ -152,33 +152,34 @@ export class NotebookKernelService implements Disposable {
     @inject(StorageService)
     protected storageService: StorageService;
 
-    private readonly kernels = new Map<string, KernelInfo>();
+    protected readonly kernels = new Map<string, KernelInfo>();
 
-    private notebookBindings: { [key: string]: string } = {};
+    protected notebookBindings: Record<string, string> = {};
 
-    private readonly kernelDetectionTasks = new Map<string, string[]>();
-    private readonly onDidChangeKernelDetectionTasksEmitter = new Emitter<string>();
+    protected readonly kernelDetectionTasks = new Map<string, string[]>();
+    protected readonly onDidChangeKernelDetectionTasksEmitter = new Emitter<string>();
     readonly onDidChangeKernelDetectionTasks = this.onDidChangeKernelDetectionTasksEmitter.event;
 
-    private readonly onDidChangeSourceActionsEmitter = new Emitter<NotebookSourceActionChangeEvent>();
-    private readonly kernelSourceActionProviders = new Map<string, KernelSourceActionProvider[]>();
+    protected readonly onDidChangeSourceActionsEmitter = new Emitter<NotebookSourceActionChangeEvent>();
+    protected readonly kernelSourceActionProviders = new Map<string, KernelSourceActionProvider[]>();
     readonly onDidChangeSourceActions: Event<NotebookSourceActionChangeEvent> = this.onDidChangeSourceActionsEmitter.event;
 
-    private readonly onDidAddKernelEmitter = new Emitter<NotebookKernel>();
+    protected readonly onDidAddKernelEmitter = new Emitter<NotebookKernel>();
     readonly onDidAddKernel: Event<NotebookKernel> = this.onDidAddKernelEmitter.event;
 
-    private readonly onDidRemoveKernelEmitter = new Emitter<NotebookKernel>();
+    protected readonly onDidRemoveKernelEmitter = new Emitter<NotebookKernel>();
     readonly onDidRemoveKernel: Event<NotebookKernel> = this.onDidRemoveKernelEmitter.event;
 
-    private readonly onDidChangeSelectedNotebookKernelBindingEmitter = new Emitter<SelectedNotebookKernelChangeEvent>();
+    protected readonly onDidChangeSelectedNotebookKernelBindingEmitter = new Emitter<SelectedNotebookKernelChangeEvent>();
     readonly onDidChangeSelectedKernel: Event<SelectedNotebookKernelChangeEvent> = this.onDidChangeSelectedNotebookKernelBindingEmitter.event;
 
-    private readonly onDidChangeNotebookAffinityEmitter = new Emitter<void>();
+    protected readonly onDidChangeNotebookAffinityEmitter = new Emitter<void>();
     readonly onDidChangeNotebookAffinity: Event<void> = this.onDidChangeNotebookAffinityEmitter.event;
 
     @postConstruct()
     init(): void {
-        this.storageService.getData(NOTEBOOK_KERNEL_BINDING_STORAGE_KEY).then((value: { [key: string]: string } | undefined) => {
+        this.notebookService.onDidAddNotebookDocument(model => this.tryAutoBindNotebook(model));
+        this.storageService.getData(NOTEBOOK_KERNEL_BINDING_STORAGE_KEY).then((value: Record<string, string> | undefined) => {
             if (value) {
                 this.notebookBindings = value;
             }
@@ -343,14 +344,5 @@ export class NotebookKernelService implements Disposable {
         const promises = providers.map(provider => provider.provideKernelSourceActions());
         const allActions = await Promise.all(promises);
         return allActions.flat();
-    }
-
-    dispose(): void {
-        this.onDidChangeKernelDetectionTasksEmitter.dispose();
-        this.onDidChangeSourceActionsEmitter.dispose();
-        this.onDidAddKernelEmitter.dispose();
-        this.onDidRemoveKernelEmitter.dispose();
-        this.onDidChangeSelectedNotebookKernelBindingEmitter.dispose();
-        this.onDidChangeNotebookAffinityEmitter.dispose();
     }
 }

--- a/packages/plugin-ext/src/plugin/notebook/notebook-kernels.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebook-kernels.ts
@@ -294,11 +294,11 @@ export class NotebookKernelsExtImpl implements NotebookKernelsExt {
         };
     }
 
-    $acceptNotebookAssociation(handle: number, uri: UriComponents, value: boolean): void {
+    async $acceptNotebookAssociation(handle: number, uri: UriComponents, value: boolean): Promise<void> {
         const obj = this.kernelData.get(handle);
         if (obj) {
             // update data structure
-            const notebook = this.notebooks.getNotebookDocument(URI.from(uri))!;
+            const notebook = await this.notebooks.waitForNotebookDocument(URI.from(uri));
             if (value) {
                 obj.associatedNotebooks.set(notebook.uri.toString(), true);
             } else {
@@ -320,7 +320,7 @@ export class NotebookKernelsExtImpl implements NotebookKernelsExt {
             // extension can dispose kernels in the meantime
             return Promise.resolve();
         }
-        const document = this.notebooks.getNotebookDocument(URI.from(uri));
+        const document = await this.notebooks.waitForNotebookDocument(URI.from(uri));
         const cells: theia.NotebookCell[] = [];
         for (const cellHandle of handles) {
             const cell = document.getCell(cellHandle);
@@ -347,7 +347,7 @@ export class NotebookKernelsExtImpl implements NotebookKernelsExt {
 
         // cancel or interrupt depends on the controller. When an interrupt handler is used we
         // don't trigger the cancelation token of executions.N
-        const document = this.notebooks.getNotebookDocument(URI.from(uri));
+        const document = await this.notebooks.waitForNotebookDocument(URI.from(uri));
         if (obj.controller.interruptHandler) {
             await obj.controller.interruptHandler.call(obj.controller, document.apiNotebook);
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -709,7 +709,8 @@ export function createAPIFactory(
                 } else {
                     throw new Error('Invalid arguments');
                 }
-                return notebooksExt.getNotebookDocument(uri).apiNotebook;
+                const result = await notebooksExt.waitForNotebookDocument(uri);
+                return result.apiNotebook;
 
             },
             createFileSystemWatcher: (pattern, ignoreCreate, ignoreChange, ignoreDelete): theia.FileSystemWatcher =>


### PR DESCRIPTION
#### What it does

There's a race condition in the notebook kernel association code. Whenever you open a notebook, Theia will automatically try to associate a kernel to it. However, if this notification arrives in the plugin host before the notebook open notification arrives, it will not be able to associate the kernel to the notebook - this effectively disables all cell execution for the specific notebook.

#### How to test

The issue can be fairly reliably reproduced by:

1. Open a notebook and select a kernel for it
2. Just reload the application, with the notebook being open

Previously, notebook cells weren't executing afterwards. This change should alleviate that issue.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
