### PR TITLE
fix: configure tasks from open task quick pick

### DIFF
--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -191,7 +191,7 @@ export interface QuickPick<T extends QuickPickItemOrSeparator> extends QuickInpu
     readonly onDidAccept: Event<{ inBackground: boolean } | undefined>;
     readonly onDidChangeValue: Event<string>;
     readonly onDidTriggerButton: Event<QuickInputButton>;
-    readonly onDidTriggerItemButton: Event<QuickPickItemButtonEvent<T>>;
+    readonly onDidTriggerItemButton: Event<QuickPickItemButtonEvent<QuickPickItem>>;
     readonly onDidChangeActive: Event<T[]>;
     readonly onDidChangeSelection: Event<T[]>;
 }

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -182,6 +182,7 @@ export class QuickOpenTask implements QuickAccessProvider {
         picker.matchOnDescription = true;
         picker.ignoreFocusOut = false;
         picker.items = this.items;
+        picker.onDidTriggerItemButton(({ item }) => this.onDidTriggerGearIcon(item));
 
         const firstLevelTask = await this.doPickerFirstLevel(picker);
 
@@ -225,7 +226,10 @@ export class QuickOpenTask implements QuickAccessProvider {
             execute: () => this.showMultiLevelQuickPick(true)
         }));
 
-        this.quickInputService?.showQuickPick(providedTasksItems, { placeholder: CHOOSE_TASK });
+        this.quickInputService?.showQuickPick(providedTasksItems, {
+            placeholder: CHOOSE_TASK,
+            onDidTriggerItemButton: ({ item }) => this.onDidTriggerGearIcon(item)
+        });
     }
 
     attach(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The gear icon in the task quick pick should open the task configuration.

Fixes #13086

Contributed on behalf of STMicroelectronics

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open the task quick pick from _>Task: Run Task..._
2. For any configured task, press the gear icon  → the `tasks.json` configuration file should open

Or:
1. Open the task quick pick from _>Task: Run Task..._
2. Select a task category from the dialog, e.g. `npm`
4. In the list of tasks, press the gear icon → the `tasks.json` configuration file should open


<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
