### PR TITLE
Show decorations in the editor tabs (#13301)

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -200,6 +200,11 @@ export const corePreferenceSchema: PreferenceSchema = {
             'description': nls.localizeByDefault('Controls whether an editor is revealed in any of the visible groups if opened. If disabled, an editor will prefer to open in the currently active editor group. If enabled, an already opened editor will be revealed instead of opened again in the currently active editor group. Note that there are some cases where this setting is ignored, such as when forcing an editor to open in a specific group or to the side of the currently active group.'),
             'default': false
         },
+        'workbench.editor.decorations.badges': {
+            'type': 'boolean',
+            'description': nls.localizeByDefault('Controls whether editor file decorations should use badges.'),
+            'default': true
+        },
         'workbench.commandPalette.history': {
             type: 'number',
             default: 50,
@@ -295,6 +300,7 @@ export interface CoreConfiguration {
     'workbench.editor.mouseBackForwardToNavigate': boolean;
     'workbench.editor.closeOnFileDelete': boolean;
     'workbench.editor.revealIfOpen': boolean;
+    'workbench.editor.decorations.badges': boolean;
     'workbench.colorTheme': string;
     'workbench.iconTheme': string;
     'workbench.silentNotifications': boolean;

--- a/packages/core/src/browser/shell/tab-bar-decorator.ts
+++ b/packages/core/src/browser/shell/tab-bar-decorator.ts
@@ -81,9 +81,10 @@ export class TabBarDecoratorService implements FrontendApplicationContribution {
             all = all.concat(decorations);
         }
         if (Navigatable.is(title.owner)) {
-            if (title.owner.getResourceUri() !== undefined) {
-                const serviceDecorations = this.decorationsService.getDecoration(title.owner.getResourceUri()!, false);
-                all = all.concat(serviceDecorations.map(d => this.toDecorator(d)));
+            const resourceUri = title.owner.getResourceUri();
+            if (resourceUri) {
+                const serviceDecorations = this.decorationsService.getDecoration(resourceUri, false);
+                all.push(...serviceDecorations.map(d => this.toDecorator(d)));
             }
         }
         return all;

--- a/packages/core/src/browser/shell/tab-bar-decorator.ts
+++ b/packages/core/src/browser/shell/tab-bar-decorator.ts
@@ -75,22 +75,21 @@ export class TabBarDecoratorService implements FrontendApplicationContribution {
      */
     getDecorations(title: Title<Widget>): WidgetDecoration.Data[] {
         const decorators = this.contributions.getContributions();
-        let all: WidgetDecoration.Data[] = [];
+        const decorations: WidgetDecoration.Data[] = [];
         for (const decorator of decorators) {
-            const decorations = decorator.decorate(title);
-            all = all.concat(decorations);
+            decorations.push(...decorator.decorate(title));
         }
         if (Navigatable.is(title.owner)) {
             const resourceUri = title.owner.getResourceUri();
             if (resourceUri) {
                 const serviceDecorations = this.decorationsService.getDecoration(resourceUri, false);
-                all.push(...serviceDecorations.map(d => this.toDecorator(d)));
+                decorations.push(...serviceDecorations.map(d => this.fromDecoration(d)));
             }
         }
-        return all;
+        return decorations;
     }
 
-    protected toDecorator(decoration: Decoration): WidgetDecoration.Data {
+    protected fromDecoration(decoration: Decoration): WidgetDecoration.Data {
         const colorVariable = decoration.colorId && this.colors.toCssVariableName(decoration.colorId);
         return {
             tailDecorations: [

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -17,7 +17,7 @@
 import PerfectScrollbar from 'perfect-scrollbar';
 import { TabBar, Title, Widget } from '@phosphor/widgets';
 import { VirtualElement, h, VirtualDOM, ElementInlineStyle } from '@phosphor/virtualdom';
-import { Disposable, DisposableCollection, MenuPath, notEmpty, SelectionService, CommandService, nls } from '../../common';
+import { Disposable, DisposableCollection, MenuPath, notEmpty, SelectionService, CommandService, nls, ArrayUtils } from '../../common';
 import { ContextMenuRenderer } from '../context-menu-renderer';
 import { Signal, Slot } from '@phosphor/signaling';
 import { Message, MessageLoop } from '@phosphor/messaging';
@@ -294,8 +294,7 @@ export class TabBarRenderer extends TabBar.Renderer {
         if (!this.corePreferences?.get('workbench.editor.decorations.badges')) {
             return [];
         }
-        const tailDecorations = this.getDecorationData(renderData.title, 'tailDecorations')
-            .filter(acc => acc !== undefined).reduce((acc, current) => acc!.concat(current!), []);
+        const tailDecorations = ArrayUtils.coalesce(this.getDecorationData(renderData.title, 'tailDecorations')).flat();
         if (tailDecorations === undefined || tailDecorations.length === 0) {
             return [];
         }

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -170,8 +170,8 @@ export class TabBarRenderer extends TabBar.Renderer {
         const hover = this.tabBar && (this.tabBar.orientation === 'horizontal' && this.corePreferences?.['window.tabbar.enhancedPreview'] === 'classic')
             ? { title: title.caption }
             : {
-            onmouseenter: this.handleMouseEnterEvent
-        };
+                onmouseenter: this.handleMouseEnterEvent
+            };
 
         return h.li(
             {
@@ -188,6 +188,7 @@ export class TabBarRenderer extends TabBar.Renderer {
                 { className: 'theia-tab-icon-label' },
                 this.renderIcon(data, isInSidePanel),
                 this.renderLabel(data, isInSidePanel),
+                this.renderTailDecorations(data, isInSidePanel),
                 this.renderBadge(data, isInSidePanel),
                 this.renderLock(data, isInSidePanel)
             ),
@@ -287,6 +288,38 @@ export class TabBarRenderer extends TabBar.Renderer {
                 h.div({ className: 'p-TabBar-tabLabelDetails', style }, labelDetails));
         }
         return h.div({ className: 'p-TabBar-tabLabel', style }, data.title.label);
+    }
+
+    protected renderTailDecorations(renderData: SideBarRenderData, isInSidePanel?: boolean): VirtualElement[] {
+        if (!this.corePreferences?.get('workbench.editor.decorations.badges')) {
+            return [];
+        }
+        const tailDecorations = this.getDecorationData(renderData.title, 'tailDecorations')
+            .filter(acc => acc !== undefined).reduce((acc, current) => acc!.concat(current!), []);
+        if (tailDecorations === undefined || tailDecorations.length === 0) {
+            return [];
+        }
+        let dotDecoration: WidgetDecoration.TailDecoration.AnyPartial | undefined;
+        const otherDecorations: WidgetDecoration.TailDecoration.AnyPartial[] = [];
+        tailDecorations.reverse().forEach(decoration => {
+            const partial = decoration as WidgetDecoration.TailDecoration.AnyPartial;
+            if (WidgetDecoration.TailDecoration.isDotDecoration(partial)) {
+                dotDecoration ||= partial;
+            } else if (partial.data || partial.icon || partial.iconClass) {
+                otherDecorations.push(partial);
+            }
+        });
+        const decorationsToRender = dotDecoration ? [dotDecoration, ...otherDecorations] : otherDecorations;
+        return decorationsToRender.map((decoration, index) => {
+            const { tooltip, data, fontData, color, icon, iconClass } = decoration;
+            const iconToRender = icon ?? iconClass;
+            const className = ['p-TabBar-tail', 'flex'].join(' ');
+            const style = fontData ? fontData : color ? { color } : undefined;
+            const content = (data ? data : iconToRender
+                ? h.span({ className: this.getIconClass(iconToRender, iconToRender === 'circle' ? [WidgetDecoration.Styles.DECORATOR_SIZE_CLASS] : []) })
+                : '') + (index !== decorationsToRender.length - 1 ? ',' : '');
+            return h.span({ key: ('tailDecoration_' + index), className, style, title: tooltip ?? content }, content);
+        });
     }
 
     renderBadge(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -123,6 +123,12 @@
   white-space: nowrap;
 }
 
+.p-TabBar-tail {
+  padding-left: 5px;
+  text-align: center;
+  justify-content: center;
+}
+
 .p-TabBar.theia-app-centers .p-TabBar-tabLabelWrapper {
   display: flex;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

As described in  #13301 there were no git status indication in the editor tabs.  Now all decorations contributed to the `DecorationsService` are rendered in tabs that owned by a `Navigatable` Widget.  This currently includes SCM (git) and Problem decorations.

Rendering is controlled with `workbench.editor.decorations.badges`  preference.

#### How to test

Open en example workspace, produce some SCM changes and errors. You should see tail decoration appearing in the editor tabs similar to the navigator.


<img width="845" alt="Bildschirmfoto 2024-02-09 um 14 04 13" src="https://github.com/eclipse-theia/theia/assets/454322/961ceda9-ac05-40b9-b21a-f800721e43ae">


#### Follow-ups



#### Review checklist

- [ x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
