### PR TITLE
Add GitHub action for next version publishing

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,39 @@
+name: Publish Next
+
+on: workflow_dispatch
+
+jobs:
+  publish:
+    name: Perform Publishing
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Use Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install
+        shell: bash
+        run: |
+          yarn global add node-gyp
+          yarn --skip-integrity-check --network-timeout 100000
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Publish NPM
+        shell: bash
+        run: |
+          yarn publish:next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
#### What it does

Related to https://github.com/eclipse-theia/theia/issues/13384

Adds a manual workflow trigger for next publishing. 

#### How to test

Nothing to test - after merging, I'll perform the workflow and let you know whether it works as expected.

Note that I'm not sure whether our stored `NPM_AUTH_TOKEN` is still valid. I might need a new one that we plug into the secrets storage.

#### Follow-ups

In order to fully close https://github.com/eclipse-theia/theia/issues/13384, we would also need an Action that publishes on a tag/release. I plan to add that after verifying that the next publishing works as expected (as a sort of integration test).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
