### PR TITLE
[vscode] Add support for TestRunProfile onDidChangeProfile event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v1.47.0 not yet released
 
 - [plugin] Add command to install plugins from the command line [#13406](https://github.com/eclipse-theia/theia/issues/13406) - contributed on behalf of STMicroelectronics
+- [testing] support TestRunProfile onDidChangeDefault introduced in VS Code 1.86.0 [#13388](https://github.com/eclipse-theia/theia/pull/13388) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a>
 - [monaco] Upgrade Monaco dependency to 1.83.1 [#13217](https://github.com/eclipse-theia/theia/pull/13217)- contributed on behalf of STMicroelectronics\

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2186,6 +2186,9 @@ export interface TestingExt {
     /** Configures a test run config. */
     $onConfigureRunProfile(controllerId: string, profileId: string): void;
 
+    /** Sets the default on a given run profile */
+    $onDidChangeDefault(controllerId: string, profileId: string, isDefault: boolean): void;
+
     $onRunControllerTests(reqs: TestRunRequestDTO[]): void;
 
     /** Asks the controller to refresh its tests */

--- a/packages/plugin-ext/src/main/browser/test-main.ts
+++ b/packages/plugin-ext/src/main/browser/test-main.ts
@@ -195,7 +195,16 @@ function itemToPath(item: TestItem): string[] {
 class TestRunProfileImpl implements TestRunProfile {
 
     label: string;
-    isDefault: boolean;
+
+    private _isDefault: boolean;
+    set isDefault(isDefault: boolean) {
+        this._isDefault = isDefault;
+        this.proxy.$onDidChangeDefault(this.controllerId, this.id, isDefault);
+    }
+    get isDefault(): boolean {
+        return this._isDefault;
+    }
+
     tag: string;
     canConfigure: boolean;
 
@@ -205,7 +214,7 @@ class TestRunProfileImpl implements TestRunProfile {
         }
 
         if ('isDefault' in update) {
-            this.isDefault = update.isDefault!;
+            this._isDefault = update.isDefault!;
         }
 
         if ('tag' in update) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -15979,8 +15979,17 @@ export module '@theia/plugin' {
          * the generic "run all" button, then the default profile for
          * {@link TestRunProfileKind.Run} will be executed, although the
          * user can configure this.
+         *
+         * Changes the user makes in their default profiles will be reflected
+         * in this property after a {@link onDidChangeDefault} event.
          */
         isDefault: boolean;
+
+        /**
+         * Fired when a user has changed whether this is a default profile. The
+         * event contains the new value of {@link isDefault}
+         */
+        onDidChangeDefault: Event<boolean>;
 
         /**
          * Whether this profile supports continuous running of requests. If so,

--- a/packages/test/src/browser/view/test-view-contribution.ts
+++ b/packages/test/src/browser/view/test-view-contribution.ts
@@ -109,6 +109,12 @@ export namespace TestViewCommands {
         category: 'Test'
     });
 
+    export const SELECT_DEFAULT_PROFILES: Command = Command.toDefaultLocalizedCommand({
+        id: TestCommandId.SelectDefaultTestProfiles,
+        label: 'Select Default Test Profiles...',
+        category: 'Test'
+    });
+
     export const CLEAR_ALL_RESULTS: Command = Command.toDefaultLocalizedCommand({
         id: TestCommandId.ClearTestResultsAction,
         label: 'Clear All Results',
@@ -186,6 +192,14 @@ export class TestViewContribution extends AbstractViewContribution<TestTreeWidge
             }
         });
 
+        commands.registerCommand(TestViewCommands.SELECT_DEFAULT_PROFILES, {
+            isEnabled: t => TestItem.is(t),
+            isVisible: t => TestItem.is(t),
+            execute: () => {
+                this.testService.selectDefaultProfile();
+            }
+        });
+
         commands.registerCommand(TestViewCommands.DEBUG_TEST, {
             isEnabled: t => TestItem.is(t),
             isVisible: t => TestItem.is(t),
@@ -253,6 +267,11 @@ export class TestViewContribution extends AbstractViewContribution<TestTreeWidge
         menus.registerMenuAction(TEST_VIEW_CONTEXT_MENU, {
             commandId: TestViewCommands.RUN_TEST_WITH_PROFILE.id,
             order: 'aaaa'
+        });
+
+        menus.registerMenuAction(TEST_VIEW_CONTEXT_MENU, {
+            commandId: TestViewCommands.SELECT_DEFAULT_PROFILES.id,
+            order: 'aaaaa'
         });
     }
 


### PR DESCRIPTION
#### What it does

This pull request add the support of API introduced with VS Code 1.86 on TestRunProfile, the onDidChangeDefault event.
It also adds the capability of changing default profile for a given test controller and a given kind of test run. The _isDefault_ value is now updated as soon as the command "Select Default Test Profiles..." is used in the tool.

Fixes #13354

Contributed on behalf of STMicroelectronics

#### How to test

Install the following extension, mainly inspired from https://github.com/KevinClapperton/Test-API-functional-test
- src: 
[Test-API-functional-test-0.0.6-src.zip](https://github.com/eclipse-theia/theia/files/14281002/Test-API-functional-test-0.0.6-src.zip)

- zip vsix:
[test-api-functional-test-0.0.6.zip](https://github.com/eclipse-theia/theia/files/14281003/test-api-functional-test-0.0.6.zip)

This extension will add a test controller and a command to create a test run profile, install a bunch of test and create a test run. 
1. When extension is installed, the "Test API: Run all tests" command can be invoked
2. It will create 2 run profiles, and some tests. A couple of message windows will pop up.
3. Then it is possible to switch between default profiles using the "Select Default Test Profiles..." in the command palette. 
4. The app should notify that _isDefault_ has changed for the profiles impacted by the choice, i.e. the profiles from same controller that have the right kind as selected in the first pick dialog. Only one profile per controller and kind can be activated at once, on the contrary of VS code implementation. This latter implementation is a bug IMO, as only one profile will be chosen to run the tests, so having several default profiles is not relevant. 

![testing-default-profile](https://github.com/eclipse-theia/theia/assets/3964263/ef7c65c6-44ba-4c9b-b966-4de54a47c322)

Note: the set `isDefault` value is not kept in settings, so user may need to configure it each time the app is started. This behavior is similar to the one on VS Code. 

#### Follow-ups

There are no follow ups known currently.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)