### PR TITLE
Automated release publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,8 +4,16 @@ permissions:
   id-token: write
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release Type'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - 'minor'
+          - 'patch'
 
 jobs:
   publish:
@@ -39,7 +47,27 @@ jobs:
       - name: Publish NPM
         shell: bash
         run: |
-          yarn publish:latest
+          yarn publish:latest -- ${{ inputs.release_type }}
+          yarn publish:check
         env:
           NPM_CONFIG_PROVENANCE: "true" # enable provenance check
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: Get Actor User Data
+        uses: octokit/request-action@v2.x
+        id: actor_user_data
+        with:
+          route: GET /users/{user}
+          user: ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commiter: ${{ github.actor }} <${{ fromJson(steps.actor_user_data.outputs.data).email }}>
+          author: ${{ github.actor }} <${{ fromJson(steps.actor_user_data.outputs.data).email }}>
+          branch: bot/package-update
+          title: Package update for version ${{ env.NEXT_VERSION_NUMBER }}
+          commit-message: Package update for version ${{ env.NEXT_VERSION_NUMBER }}
+          body: Automated package update for Theia version ${{ env.NEXT_VERSION_NUMBER }}. Triggered by @${{ github.actor }}.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,9 +1,11 @@
-name: Publish Next
+name: Publish Release
 
 permissions:
   id-token: write
 
-on: workflow_dispatch
+on:
+  release:
+    types: [published]
 
 jobs:
   publish:
@@ -37,7 +39,7 @@ jobs:
       - name: Publish NPM
         shell: bash
         run: |
-          yarn publish:next
+          yarn publish:latest
         env:
-          NPM_CONFIG_PROVENANCE: "true"
+          NPM_CONFIG_PROVENANCE: "true" # enable provenance check
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint:oneshot": "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js --cache=true \"{dev-packages,packages,examples}/**/*.{ts,tsx}\"",
     "preinstall": "node-gyp install",
     "prepare": "yarn -s compile:references && lerna run prepare && yarn -s compile",
-    "publish:latest": "lerna publish --exact --yes --no-push && yarn -s publish:check",
+    "publish:latest": "lerna publish --exact --yes --no-push",
     "publish:next": "lerna publish preminor --exact --canary --preid next --dist-tag next --no-git-reset --no-git-tag-version --no-push --yes && yarn -s publish:check",
     "publish:check": "node scripts/check-publish.js",
     "rebuild:clean": "rimraf .browser_modules",


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13384

Adds a GitHub action that is triggered on every GitHub release. It automatically publishes the code that is associated with the release. We have a very similar mechanism in [Langium](https://github.com/eclipse-langium/langium/blob/main/.github/workflows/publish.yml). Uses the `NPM_CONFIG_PROVENANCE` env variable to provide provenance. That seems to work with Lerna, see https://github.com/lerna/lerna/issues/3657.

#### How to test

We will see during the next release whether this works as expected. But since the `Publish Next` GitHub Action already works as expected, I don't see too much room for error.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
