### PR TITLE
notebook kernel messaging and renderer messaging fixes

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -90,6 +90,9 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected readonly onPostKernelMessageEmitter = new Emitter<unknown>();
     readonly onPostKernelMessage = this.onPostKernelMessageEmitter.event;
 
+    protected readonly onPostRendererMessageEmitter = new Emitter<{ rendererId: string; message: unknown }>();
+    readonly onPostRendererMessage = this.onPostRendererMessageEmitter.event;
+
     protected readonly onDidRecieveKernelMessageEmitter = new Emitter<unknown>();
     readonly onDidRecieveKernelMessage = this.onDidRecieveKernelMessageEmitter.event;
 
@@ -199,6 +202,10 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
 
     postKernelMessage(message: unknown): void {
         this.onPostKernelMessageEmitter.fire(message);
+    }
+
+    postRendererMessage(rendererId: string, message: unknown): void {
+        this.onPostRendererMessageEmitter.fire({ rendererId, message });
     }
 
     recieveKernelMessage(message: unknown): void {

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -87,6 +87,12 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected readonly onDidChangeReadOnlyEmitter = new Emitter<boolean | MarkdownString>();
     readonly onDidChangeReadOnly = this.onDidChangeReadOnlyEmitter.event;
 
+    protected readonly onPostKernelMessageEmitter = new Emitter<unknown>();
+    readonly onPostKernelMessage = this.onPostKernelMessageEmitter.event;
+
+    protected readonly onDidRecieveKernelMessageEmitter = new Emitter<unknown>();
+    readonly onDidRecieveKernelMessage = this.onDidRecieveKernelMessageEmitter.event;
+
     protected readonly renderers = new Map<CellKind, CellRenderer>();
     protected _model?: NotebookModel;
     protected _ready: Deferred<NotebookModel> = new Deferred();
@@ -189,5 +195,20 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected override onAfterDetach(msg: Message): void {
         super.onAfterDetach(msg);
         this.notebookEditorService.removeNotebookEditor(this);
+    }
+
+    postKernelMessage(message: unknown): void {
+        this.onPostKernelMessageEmitter.fire(message);
+    }
+
+    recieveKernelMessage(message: unknown): void {
+        this.onDidRecieveKernelMessageEmitter.fire(message);
+    }
+
+    override dispose(): void {
+        this.onDidChangeModelEmitter.dispose();
+        this.onPostKernelMessageEmitter.dispose();
+        this.onDidRecieveKernelMessageEmitter.dispose();
+        super.dispose();
     }
 }

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -46,6 +46,11 @@ export function createNotebookEditorWidgetContainer(parent: interfaces.Container
 
 const NotebookEditorProps = Symbol('NotebookEditorProps');
 
+interface RenderMessage {
+    rendererId: string;
+    message: unknown;
+}
+
 export interface NotebookEditorProps {
     uri: URI,
     readonly notebookType: string,
@@ -90,11 +95,14 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected readonly onPostKernelMessageEmitter = new Emitter<unknown>();
     readonly onPostKernelMessage = this.onPostKernelMessageEmitter.event;
 
-    protected readonly onPostRendererMessageEmitter = new Emitter<{ rendererId: string; message: unknown }>();
+    protected readonly onDidPostKernelMessageEmitter = new Emitter<unknown>();
+    readonly onDidPostKernelMessage = this.onDidPostKernelMessageEmitter.event;
+
+    protected readonly onPostRendererMessageEmitter = new Emitter<RenderMessage>();
     readonly onPostRendererMessage = this.onPostRendererMessageEmitter.event;
 
-    protected readonly onDidRecieveKernelMessageEmitter = new Emitter<unknown>();
-    readonly onDidRecieveKernelMessage = this.onDidRecieveKernelMessageEmitter.event;
+    protected readonly onDidReceiveKernelMessageEmitter = new Emitter<unknown>();
+    readonly onDidRecieveKernelMessage = this.onDidReceiveKernelMessageEmitter.event;
 
     protected readonly renderers = new Map<CellKind, CellRenderer>();
     protected _model?: NotebookModel;
@@ -201,7 +209,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     }
 
     postKernelMessage(message: unknown): void {
-        this.onPostKernelMessageEmitter.fire(message);
+        this.onDidPostKernelMessageEmitter.fire(message);
     }
 
     postRendererMessage(rendererId: string, message: unknown): void {
@@ -209,13 +217,14 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     }
 
     recieveKernelMessage(message: unknown): void {
-        this.onDidRecieveKernelMessageEmitter.fire(message);
+        this.onDidReceiveKernelMessageEmitter.fire(message);
     }
 
     override dispose(): void {
         this.onDidChangeModelEmitter.dispose();
-        this.onPostKernelMessageEmitter.dispose();
-        this.onDidRecieveKernelMessageEmitter.dispose();
+        this.onDidPostKernelMessageEmitter.dispose();
+        this.onDidReceiveKernelMessageEmitter.dispose();
+        this.onPostRendererMessageEmitter.dispose();
         super.dispose();
     }
 }

--- a/packages/notebook/src/browser/notebook-renderer-registry.ts
+++ b/packages/notebook/src/browser/notebook-renderer-registry.ts
@@ -30,6 +30,11 @@ export interface NotebookRendererInfo {
     readonly requiresMessaging: boolean;
 }
 
+export interface NotebookPreloadInfo {
+    readonly type: string;
+    readonly entrypoint: string;
+}
+
 @injectable()
 export class NotebookRendererRegistry {
 
@@ -37,6 +42,12 @@ export class NotebookRendererRegistry {
 
     get notebookRenderers(): readonly NotebookRendererInfo[] {
         return this._notebookRenderers;
+    }
+
+    private readonly _staticNotebookPreloads: NotebookPreloadInfo[] = [];
+
+    get staticNotebookPreloads(): readonly NotebookPreloadInfo[] {
+        return this._staticNotebookPreloads;
     }
 
     registerNotebookRenderer(type: NotebookRendererDescriptor, basePath: string): Disposable {
@@ -60,6 +71,14 @@ export class NotebookRendererRegistry {
         });
         return Disposable.create(() => {
             this._notebookRenderers.splice(this._notebookRenderers.findIndex(renderer => renderer.id === type.id), 1);
+        });
+    }
+
+    registerStaticNotebookPreload(type: string, entrypoint: string, basePath: string): Disposable {
+        const staticPreload = { type, entrypoint: new Path(basePath).join(entrypoint).toString() };
+        this._staticNotebookPreloads.push(staticPreload);
+        return Disposable.create(() => {
+            this._staticNotebookPreloads.splice(this._staticNotebookPreloads.indexOf(staticPreload), 1);
         });
     }
 }

--- a/packages/notebook/src/browser/renderers/cell-output-webview.ts
+++ b/packages/notebook/src/browser/renderers/cell-output-webview.ts
@@ -16,10 +16,11 @@
 
 import { Disposable } from '@theia/core';
 import { NotebookCellModel } from '../view-model/notebook-cell-model';
+import { NotebookModel } from '../view-model/notebook-model';
 
 export const CellOutputWebviewFactory = Symbol('outputWebviewFactory');
 
-export type CellOutputWebviewFactory = (cell: NotebookCellModel) => Promise<CellOutputWebview>;
+export type CellOutputWebviewFactory = (cell: NotebookCellModel, notebook: NotebookModel) => Promise<CellOutputWebview>;
 
 export interface CellOutputWebview extends Disposable {
 

--- a/packages/notebook/src/browser/service/notebook-kernel-service.ts
+++ b/packages/notebook/src/browser/service/notebook-kernel-service.ts
@@ -54,6 +54,11 @@ export interface NotebookKernel {
     // ID of the extension providing this kernel
     readonly extensionId: string;
 
+    readonly localResourceRoot: URI;
+    readonly preloadUris: URI[];
+    readonly preloadProvides: string[];
+
+    readonly handle: number;
     label: string;
     description?: string;
     detail?: string;

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -61,7 +61,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
                 </div>
             </div>
             <div className='theia-notebook-cell-with-sidebar'>
-                <NotebookCodeCellOutputs cell={cell} outputWebviewFactory={this.cellOutputWebviewFactory}
+                <NotebookCodeCellOutputs cell={cell} notebook={notebookModel} outputWebviewFactory={this.cellOutputWebviewFactory}
                     renderSidebar={() =>
                         this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.OUTPUT_SIDEBAR_MENU, notebookModel, cell, cell.outputs[0])} />
             </div>
@@ -166,6 +166,7 @@ export class NotebookCodeCellStatus extends React.Component<NotebookCodeCellStat
 
 interface NotebookCellOutputProps {
     cell: NotebookCellModel;
+    notebook: NotebookModel;
     outputWebviewFactory: CellOutputWebviewFactory;
     renderSidebar: () => React.ReactNode;
 }
@@ -182,14 +183,14 @@ export class NotebookCodeCellOutputs extends React.Component<NotebookCellOutputP
     }
 
     override async componentDidMount(): Promise<void> {
-        const { cell, outputWebviewFactory } = this.props;
+        const { cell, notebook, outputWebviewFactory } = this.props;
         this.toDispose.push(cell.onDidChangeOutputs(async () => {
             if (!this.outputsWebviewPromise && cell.outputs.length > 0) {
-                this.outputsWebviewPromise = outputWebviewFactory(cell).then(webview => {
+                this.outputsWebviewPromise = outputWebviewFactory(cell, notebook).then(webview => {
                     this.outputsWebview = webview;
                     this.forceUpdate();
                     return webview;
-                    });
+                });
                 this.forceUpdate();
             } else if (this.outputsWebviewPromise && cell.outputs.length === 0 && cell.internalMetadata.runEndTime) {
                 (await this.outputsWebviewPromise).dispose();
@@ -199,7 +200,7 @@ export class NotebookCodeCellOutputs extends React.Component<NotebookCellOutputP
             }
         }));
         if (cell.outputs.length > 0) {
-            this.outputsWebviewPromise = outputWebviewFactory(cell).then(webview => {
+            this.outputsWebviewPromise = outputWebviewFactory(cell, notebook).then(webview => {
                 this.outputsWebview = webview;
                 this.forceUpdate();
                 return webview;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2288,7 +2288,7 @@ export const MAIN_RPC_CONTEXT = {
     NOTEBOOKS_EXT: createProxyIdentifier<NotebooksExt>('NotebooksExt'),
     NOTEBOOK_DOCUMENTS_EXT: createProxyIdentifier<NotebookDocumentsExt>('NotebookDocumentsExt'),
     NOTEBOOK_EDITORS_EXT: createProxyIdentifier<NotebookEditorsExt>('NotebookEditorsExt'),
-    NOTEBOOK_RENDERERS_EXT: createProxyIdentifier<NotebookRenderersExt>('NotebooksExt'),
+    NOTEBOOK_RENDERERS_EXT: createProxyIdentifier<NotebookRenderersExt>('NotebooksRenderersExt'),
     NOTEBOOK_KERNELS_EXT: createProxyIdentifier<NotebookKernelsExt>('NotebookKernelsExt'),
     TERMINAL_EXT: createProxyIdentifier<TerminalServiceExt>('TerminalServiceExt'),
     OUTPUT_CHANNEL_REGISTRY_EXT: createProxyIdentifier<OutputChannelRegistryExt>('OutputChannelRegistryExt'),
@@ -2488,7 +2488,7 @@ export interface NotebookKernelDto {
     id: string;
     notebookType: string;
     extensionId: string;
-    // extensionLocation: UriComponents;
+    extensionLocation: UriComponents;
     label: string;
     detail?: string;
     description?: string;

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -103,6 +103,7 @@ export interface PluginPackageContribution {
     terminal?: PluginPackageTerminal;
     notebooks?: PluginPackageNotebook[];
     notebookRenderer?: PluginNotebookRendererContribution[];
+    notebookPreload?: PluginPackageNotebookPreload[];
 }
 
 export interface PluginPackageNotebook {
@@ -118,6 +119,11 @@ export interface PluginNotebookRendererContribution {
     readonly mimeTypes: string[];
     readonly entrypoint: string | { readonly extends: string; readonly path: string };
     readonly requiresMessaging?: 'always' | 'optional' | 'never'
+}
+
+export interface PluginPackageNotebookPreload {
+    type: string;
+    entrypoint: string;
 }
 
 export interface PluginPackageAuthenticationProvider {
@@ -610,8 +616,8 @@ export interface PluginContribution {
     terminalProfiles?: TerminalProfile[];
     notebooks?: NotebookContribution[];
     notebookRenderer?: NotebookRendererContribution[];
+    notebookPreload?: notebookPreloadContribution[];
 }
-
 export interface NotebookContribution {
     type: string;
     displayName: string;
@@ -625,6 +631,11 @@ export interface NotebookRendererContribution {
     readonly mimeTypes: string[];
     readonly entrypoint: string | { readonly extends: string; readonly path: string };
     readonly requiresMessaging?: 'always' | 'optional' | 'never'
+}
+
+export interface notebookPreloadContribution {
+    type: string;
+    entrypoint: string;
 }
 
 export interface AuthenticationProviderInformation {

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -341,13 +341,19 @@ export class TheiaPluginScanner extends AbstractPluginScanner {
         try {
             contributions.notebooks = rawPlugin.contributes.notebooks;
         } catch (err) {
-            console.error(`Could not read '${rawPlugin.name}' contribution 'notebooks'.`, rawPlugin.contributes.authentication, err);
+            console.error(`Could not read '${rawPlugin.name}' contribution 'notebooks'.`, rawPlugin.contributes.notebooks, err);
         }
 
         try {
             contributions.notebookRenderer = rawPlugin.contributes.notebookRenderer;
         } catch (err) {
-            console.error(`Could not read '${rawPlugin.name}' contribution 'notebooks'.`, rawPlugin.contributes.authentication, err);
+            console.error(`Could not read '${rawPlugin.name}' contribution 'notebook-renderer'.`, rawPlugin.contributes.notebookRenderer, err);
+        }
+
+        try {
+            contributions.notebookPreload = rawPlugin.contributes.notebookPreload;
+        } catch (err) {
+            console.error(`Could not read '${rawPlugin.name}' contribution 'notebooks-preload'.`, rawPlugin.contributes.notebookPreload, err);
         }
 
         try {

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -98,7 +98,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
         }));
 
         if (this.editor) {
-            this.toDispose.push(this.editor.onPostKernelMessage(message => {
+            this.toDispose.push(this.editor.onDidPostKernelMessage(message => {
                 this.webviewWidget.sendMessage({
                     type: 'customKernelMessage',
                     message

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -186,7 +186,6 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
         switch (message.type) {
             case 'initialized':
                 this.updateOutput({ newOutputs: this.cell.outputs, start: 0, deleteCount: 0 });
-                this.getPreloads();
                 break;
             case 'customRendererMessage':
                 this.messagingService.getScoped(this.editor.id).postMessage(message.rendererId, message.message);

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -104,6 +104,14 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                     message
                 });
             }));
+
+            this.toDispose.push(this.editor.onPostRendererMessage(messageObj => {
+                this.webviewWidget.sendMessage({
+                    type: 'customRendererMessage',
+                    ...messageObj
+                });
+            }));
+
         }
 
         this.webviewWidget = await this.widgetManager.getOrCreateWidget(WebviewWidget.FACTORY_ID, { id: this.id });
@@ -191,7 +199,6 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 break;
             case 'customKernelMessage':
                 this.editor.recieveKernelMessage(message.message);
-                console.log('Kernel message from webview', message.message);
                 break;
         }
     }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -121,7 +121,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
 
     async function runKernelPreload(url: string): Promise<void> {
         try {
-            return await activateModuleKernelPreload(url);
+            return activateModuleKernelPreload(url);
         } catch (e) {
             console.error(e);
             throw e;
@@ -200,6 +200,10 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             if (this.rendererApi) {
                 return this.rendererApi;
             }
+
+            // Preloads need to be loaded before loading renderers.
+            await kernelPreloads.waitForAllCurrent();
+
             const baseUri = window.location.href.replace(/\/webview\/index\.html.*/, '');
             const rendererModule = await __import(`${baseUri}/${this.data.entrypoint.uri}`) as { activate: rendererApi.ActivationFunction };
             this.rendererApi = await rendererModule.activate(this.createRendererContext());

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -114,7 +114,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         return Object.freeze({
             onDidReceiveKernelMessage: onDidReceiveKernelMessage.event,
             postKernelMessage: (data: unknown) => {
-                console.log('postKernelMessage ', data);
                 theia.postMessage({ type: 'customKernelMessage', message: data });
             }
         });
@@ -238,7 +237,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             if (this.data.requiresMessaging) {
                 context.onDidReceiveMessage = this.onMessageEvent.event;
                 context.postMessage = message => {
-                    console.log('post Renderer Message ', message);
                     theia.postMessage({ type: 'customRendererMessage', rendererId: this.data.id, message });
                 };
             }
@@ -463,7 +461,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         }
     };
 
-    console.log('loading preload ', ctx.staticPreloadsData);
     await Promise.all(ctx.staticPreloadsData.map(preload => kernelPreloads.load(preload)));
 
     function clearOutput(output: Output): void {
@@ -541,7 +538,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
 
     window.addEventListener('message', async rawEvent => {
         const event = rawEvent as ({ data: webviewCommunication.ToWebviewMessage });
-        console.log('message ', event.data);
         switch (event.data.type) {
             case 'updateRenderers':
                 renderers.updateRendererData(event.data.rendererData);
@@ -550,7 +546,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                 outputsChanged(event.data);
                 break;
             case 'customRendererMessage':
-                console.log('customRendererMessage ', event.data.message);
                 renderers.getRenderer(event.data.rendererId)?.receiveMessage(event.data.message);
                 break;
             case 'changePreferredMimetype':
@@ -561,7 +556,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                 renderers.render(outputs[index], event.data.mimeType, undefined, new AbortController().signal);
                 break;
             case 'customKernelMessage':
-                console.log('customKernelMessage ', event.data.message);
                 onDidReceiveKernelMessage.fire(event.data.message);
                 break;
             case 'preload': {

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -237,7 +237,10 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
 
             if (this.data.requiresMessaging) {
                 context.onDidReceiveMessage = this.onMessageEvent.event;
-                context.postMessage = message => theia.postMessage({ type: 'customRendererMessage', rendererId: this.data.id, message });
+                context.postMessage = message => {
+                    console.log('post Renderer Message ', message);
+                    theia.postMessage({ type: 'customRendererMessage', rendererId: this.data.id, message });
+                };
             }
 
             return Object.freeze(context);
@@ -536,7 +539,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         }
     };
 
-    console.log('adding message listener');
     window.addEventListener('message', async rawEvent => {
         const event = rawEvent as ({ data: webviewCommunication.ToWebviewMessage });
         console.log('message ', event.data);
@@ -548,6 +550,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                 outputsChanged(event.data);
                 break;
             case 'customRendererMessage':
+                console.log('customRendererMessage ', event.data.message);
                 renderers.getRenderer(event.data.rendererId)?.receiveMessage(event.data.message);
                 break;
             case 'changePreferredMimetype':

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -49,7 +49,17 @@ export interface ChangePreferredMimetypeMessage {
     readonly mimeType: string;
 }
 
-export type ToWebviewMessage = UpdateRenderersMessage | OutputChangedMessage | ChangePreferredMimetypeMessage | CustomRendererMessage;
+export interface KernelMessage {
+    readonly type: 'customKernelMessage';
+    readonly message: unknown;
+}
+
+export interface PreloadMessage {
+    readonly type: 'preload';
+    readonly resources: string[];
+}
+
+export type ToWebviewMessage = UpdateRenderersMessage | OutputChangedMessage | ChangePreferredMimetypeMessage | CustomRendererMessage | KernelMessage | PreloadMessage;
 
 export interface WebviewInitialized {
     readonly type: 'initialized';
@@ -66,7 +76,7 @@ export interface WheelMessage {
     readonly deltaX: number;
 }
 
-export type FromWebviewMessage = WebviewInitialized | OnDidRenderOutput | WheelMessage | CustomRendererMessage;
+export type FromWebviewMessage = WebviewInitialized | OnDidRenderOutput | WheelMessage | CustomRendererMessage | KernelMessage;
 
 export interface Output {
     id: string

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -447,6 +447,14 @@ export class PluginContributionHandler {
             }
         }
 
+        if (contributions.notebookPreload) {
+            for (const preload of contributions.notebookPreload) {
+                pushContribution(`notebookPreloads.${preload.type}:${preload.entrypoint}`,
+                    () => this.notebookRendererRegistry.registerStaticNotebookPreload(preload.type, preload.entrypoint, PluginPackage.toPluginUrl(plugin.metadata.model, ''))
+                );
+            }
+        }
+
         return toDispose;
     }
 

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -88,6 +88,7 @@ import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar
 import { CellOutputWebviewFactory } from '@theia/notebook/lib/browser';
 import { CellOutputWebviewImpl, createCellOutputWebviewContainer } from './notebooks/renderers/cell-output-webview';
 import { NotebookCellModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-model';
+import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
@@ -262,7 +263,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         return provider.createProxy<LanguagePackService>(languagePackServicePath);
     }).inSingletonScope();
 
-    bind(CellOutputWebviewFactory).toFactory(ctx => async (cell: NotebookCellModel) =>
-        createCellOutputWebviewContainer(ctx.container, cell).getAsync(CellOutputWebviewImpl)
+    bind(CellOutputWebviewFactory).toFactory(ctx => async (cell: NotebookCellModel, notebook: NotebookModel) =>
+        createCellOutputWebviewContainer(ctx.container, cell, notebook).getAsync(CellOutputWebviewImpl)
     );
 });

--- a/packages/plugin-ext/src/plugin/notebook/notebook-kernels.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebook-kernels.ts
@@ -98,7 +98,7 @@ export class NotebookKernelsExtImpl implements NotebookKernelsExt {
             extensionId: extension.id,
             extensionLocation: toUriComponents(extension.packageUri),
             label: label || extension.id,
-            preloads: rendererScripts ? rendererScripts.map(preload => ({ uri: toUriComponents(preload.uri.toString()), provides: preload.provides })) : []
+            preloads: rendererScripts?.map(preload => ({ uri: toUriComponents(preload.uri.toString()), provides: preload.provides })) ?? []
         };
 
         //

--- a/packages/plugin-ext/src/plugin/notebook/notebook-renderers.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebook-renderers.ts
@@ -43,7 +43,6 @@ export class NotebookRenderersExtImpl implements NotebookRenderersExt {
         const messaging: theia.NotebookRendererMessaging = {
             onDidReceiveMessage: (listener, thisArg, disposables) => this.getOrCreateEmitterFor(rendererId).event(listener, thisArg, disposables),
             postMessage: (message, editorOrAlias) => {
-
                 const extHostEditor = editorOrAlias && NotebookEditor.apiEditorsToExtHost.get(editorOrAlias);
                 return this.proxy.$postMessage(extHostEditor?.id, rendererId, message);
             },

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -276,7 +276,7 @@ export function createAPIFactory(
     const notebooksExt = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOKS_EXT, new NotebooksExtImpl(rpc, commandRegistry, editorsAndDocumentsExt, documents));
     const notebookEditors = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_EDITORS_EXT, new NotebookEditorsExtImpl(notebooksExt));
     const notebookRenderers = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_RENDERERS_EXT, new NotebookRenderersExtImpl(rpc, notebooksExt));
-    const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry, webviewExt));
+    const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry));
     const notebookDocuments = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_EXT, new NotebookDocumentsExtImpl(notebooksExt));
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
@@ -1183,7 +1183,7 @@ export function createAPIFactory(
                     controller: theia.NotebookController) => void | Thenable<void>,
                 rendererScripts?: NotebookRendererScript[]
             ) {
-                return notebookKernels.createNotebookController(plugin.model.id, plugin.pluginUri, id, notebookType, label, handler, rendererScripts);
+                return notebookKernels.createNotebookController(plugin.model, id, notebookType, label, handler, rendererScripts);
             },
             createRendererMessaging(rendererId) {
                 return notebookRenderers.createRendererMessaging(rendererId);

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -276,7 +276,7 @@ export function createAPIFactory(
     const notebooksExt = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOKS_EXT, new NotebooksExtImpl(rpc, commandRegistry, editorsAndDocumentsExt, documents));
     const notebookEditors = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_EDITORS_EXT, new NotebookEditorsExtImpl(notebooksExt));
     const notebookRenderers = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_RENDERERS_EXT, new NotebookRenderersExtImpl(rpc, notebooksExt));
-    const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry));
+    const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry, webviewExt));
     const notebookDocuments = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_EXT, new NotebookDocumentsExtImpl(notebooksExt));
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
@@ -1183,7 +1183,7 @@ export function createAPIFactory(
                     controller: theia.NotebookController) => void | Thenable<void>,
                 rendererScripts?: NotebookRendererScript[]
             ) {
-                return notebookKernels.createNotebookController(plugin.model.id, id, notebookType, label, handler, rendererScripts);
+                return notebookKernels.createNotebookController(plugin.model.id, plugin.pluginUri, id, notebookType, label, handler, rendererScripts);
             },
             createRendererMessaging(rendererId) {
                 return notebookRenderers.createRendererMessaging(rendererId);

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -203,6 +203,10 @@ export class WebviewsExtImpl implements WebviewsExt {
     public getWebview(handle: string): WebviewImpl | undefined {
         return this.webviews.get(handle);
     }
+
+    public getResourceRoot(): string | undefined {
+        return this.initData?.webviewResourceRoot;
+    }
 }
 
 export class WebviewImpl implements theia.Webview {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This implements the proposed Kernel messaging API (`vscode.proposed.notebookMessaging.d.ts`) and the `notebookPreload` contribution point. Also fixes notebook renderer messaging. This is to support interactive output widgets like for the `ipywidgets` library.

Tested with ipywidgets 7.8.1 and 8.1.2

#### How to test

1. `pip install ipywidgets` in your used kernel
2. Open a notebook
3. add following cell
```
import ipywidgets as widgets
widgets.IntSlider(min=1, max=12)
```
4. Execute the cell and see the interactive slider is rendered

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
