### PR TITLE
Add terminal observer API

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -301,6 +301,7 @@ export interface TerminalServiceExt {
     $handleTerminalLink(link: ProvidedTerminalLink): Promise<void>;
     getEnvironmentVariableCollection(extensionIdentifier: string): theia.GlobalEnvironmentVariableCollection;
     $setShell(shell: string): void;
+    $reportOutputMatch(observerId: string, groups: string[]): void;
 }
 export interface OutputChannelRegistryExt {
     createOutputChannel(name: string, pluginInfo: PluginInfo): theia.OutputChannel,
@@ -438,6 +439,20 @@ export interface TerminalServiceMain {
      * @param providerId id of the terminal link provider to be unregistered.
      */
     $unregisterTerminalLinkProvider(providerId: string): Promise<void>;
+
+    /**
+     * Register a new terminal observer.
+     * @param providerId id of the terminal link provider to be registered.
+     * @param nrOfLinesToMatch the number of lines to match the outputMatcherRegex against
+     * @param outputMatcherRegex the regex to match the output to
+     */
+    $registerTerminalObserver(id: string, nrOfLinesToMatch: number, outputMatcherRegex: string): unknown;
+
+    /**
+     * Unregister the terminal observer with the specified id.
+     * @param providerId id of the terminal observer to be unregistered.
+     */
+    $unregisterTerminalObserver(id: string): unknown;
 }
 
 export interface AutoFocus {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -603,6 +603,12 @@ export function createAPIFactory(
             registerTerminalQuickFixProvider(id: string, provider: theia.TerminalQuickFixProvider): theia.Disposable {
                 return terminalExt.registerTerminalQuickFixProvider(id, provider);
             },
+
+            /** Theia-specific TerminalObserver */
+            registerTerminalObserver(observer: theia.TerminalObserver): theia.Disposable {
+                return terminalExt.registerTerminalObserver(observer);
+            },
+
             /** @stubbed ShareProvider */
             registerShareProvider: () => Disposable.NULL,
         };

--- a/packages/plugin/src/theia-extra.d.ts
+++ b/packages/plugin/src/theia-extra.d.ts
@@ -363,6 +363,26 @@ export module '@theia/plugin' {
         color?: ThemeColor;
     }
 
+    export interface TerminalObserver {
+
+        /**
+         * A regex to match against the latest terminal output.
+         */
+        readonly outputMatcherRegex: string;
+        /**
+         * The maximum number of lines to match the regex against. Maximum is 40 lines.
+         */
+        readonly nrOfLinesToMatch: number;
+        /**
+         * Invoked when the regex matched against the terminal contents.
+         * @param groups The matched groups
+         */
+        matchOccurred(groups: string[]): void;
+    }
+
+    export namespace window {
+        export function registerTerminalObserver(observer: TerminalObserver): Disposable;
+    }
 }
 
 /**

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -48,6 +48,15 @@ export interface TerminalSplitLocation {
     readonly parentTerminal: string;
 }
 
+export interface TerminalBuffer {
+    readonly length: number;
+    /**
+     * @param start zero based index of the first line to return
+     * @param length the max number or lines to return
+     */
+    getLines(start: number, length: number): string[];
+}
+
 /**
  * Terminal UI widget.
  */
@@ -117,6 +126,10 @@ export abstract class TerminalWidget extends BaseWidget {
 
     /** Event that fires when the terminal input data */
     abstract onData: Event<string>;
+
+    abstract onOutput: Event<string>;
+
+    abstract buffer: TerminalBuffer;
 
     abstract scrollLineUp(): void;
 


### PR DESCRIPTION
#### What it does
This is a draft PR for feedback on https://github.com/eclipse-theia/theia/issues/13085

#### How to test
The attached theia plugin adds two commands: "Register Observer" and "Remove Observer". The first one allows to register a terminal observer with a given name, regular expression to match and a number of lines to match. The second command unregisters obeservers registered before by name.

The registered observers write the matched strings to the Theia back end log.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
