### PR TITLE
Improve readonly editor behavior

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,13 +12,10 @@ ports:
   - port: 9339 # Node.js debug port
     onOpen: ignore
 tasks:
-  - init: yarn --network-timeout 100000 && yarn build:examples && yarn download:plugins
+  - init: yarn --network-timeout 100000 && yarn browser build && yarn download:plugins
     command: >
       jwm &
-      yarn --cwd examples/browser start ../.. --hostname=0.0.0.0
-github:
-  prebuilds:
-    pullRequestsFromForks: true
+      yarn browser start ../.. --hostname=0.0.0.0
 vscode:
   extensions:
-    - dbaeumer.vscode-eslint@2.0.0:CwAMx4wYz1Kq39+1Aul4VQ==
+    - dbaeumer.vscode-eslint

--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -29,6 +29,7 @@ import { bindMonacoPreferenceExtractor } from './monaco-editor-preferences/monac
 import { rebindOVSXClientFactory } from '../common/vsx/sample-ovsx-client-factory';
 import { bindSampleAppInfo } from './vsx/sample-frontend-app-info';
 import { bindTestSample } from './test/sample-test-contribution';
+import { bindSampleFileSystemCapabilitiesCommands } from './file-system/sample-file-system-capabilities';
 
 export default new ContainerModule((
     bind: interfaces.Bind,
@@ -47,5 +48,6 @@ export default new ContainerModule((
     bindMonacoPreferenceExtractor(bind);
     bindSampleAppInfo(bind);
     bindTestSample(bind);
+    bindSampleFileSystemCapabilitiesCommands(bind);
     rebindOVSXClientFactory(rebind);
 });

--- a/examples/api-samples/src/browser/file-system/sample-file-system-capabilities.ts
+++ b/examples/api-samples/src/browser/file-system/sample-file-system-capabilities.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2024 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { CommandContribution, CommandRegistry } from '@theia/core';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { RemoteFileSystemProvider } from '@theia/filesystem/lib/common/remote-file-system-provider';
+import { FileSystemProviderCapabilities } from '@theia/filesystem/lib/common/files';
+
+@injectable()
+export class SampleFileSystemCapabilities implements CommandContribution {
+
+    @inject(RemoteFileSystemProvider)
+    protected readonly remoteFileSystemProvider: RemoteFileSystemProvider;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand({
+            id: 'toggleFileSystemReadonly',
+            label: 'Toggle File System Readonly'
+        }, {
+            execute: () => {
+                const readonly = (this.remoteFileSystemProvider.capabilities & FileSystemProviderCapabilities.Readonly) !== 0;
+                if (readonly) {
+                    this.remoteFileSystemProvider['setCapabilities'](this.remoteFileSystemProvider.capabilities & ~FileSystemProviderCapabilities.Readonly);
+                } else {
+                    this.remoteFileSystemProvider['setCapabilities'](this.remoteFileSystemProvider.capabilities | FileSystemProviderCapabilities.Readonly);
+                }
+            }
+        });
+    }
+
+}
+
+export function bindSampleFileSystemCapabilitiesCommands(bind: interfaces.Bind): void {
+    bind(CommandContribution).to(SampleFileSystemCapabilities).inSingletonScope();
+}

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -381,10 +381,18 @@ export function pin(title: Title<Widget>): void {
     }
 }
 
+export function isLocked(title: Title<Widget>): boolean {
+    return title.className.includes(LOCKED_CLASS);
+}
+
 export function lock(title: Title<Widget>): void {
     if (!title.className.includes(LOCKED_CLASS)) {
         title.className += ` ${LOCKED_CLASS}`;
     }
+}
+
+export function unlock(title: Title<Widget>): void {
+    title.className = title.className.replace(LOCKED_CLASS, '').trim();
 }
 
 export function togglePinned(title?: Title<Widget>): void {

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -25,6 +25,7 @@ import { CancellationToken } from './cancellation';
 import { ApplicationError } from './application-error';
 import { ReadableStream, Readable } from './stream';
 import { SyncReferenceCollection, Reference } from './reference';
+import { MarkdownString } from './markdown-rendering';
 
 export interface ResourceVersion {
 }
@@ -55,7 +56,10 @@ export interface Resource extends Disposable {
      * Undefined if a resource did not read content yet.
      */
     readonly encoding?: string | undefined;
-    readonly isReadonly?: boolean;
+
+    readonly onDidChangeReadOnly?: Event<boolean | MarkdownString>;
+
+    readonly readOnly?: boolean | MarkdownString;
     /**
      * Reads latest content of this resource.
      *

--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { Disposable, SelectionService, Event, UNTITLED_SCHEME, DisposableCollection } from '@theia/core/lib/common';
-import { Widget, BaseWidget, Message, Saveable, SaveableSource, Navigatable, StatefulWidget, lock, TabBar, DockPanel } from '@theia/core/lib/browser';
+import { Widget, BaseWidget, Message, Saveable, SaveableSource, Navigatable, StatefulWidget, lock, TabBar, DockPanel, unlock } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { find } from '@theia/core/shared/@phosphor/algorithm';
 import { TextEditor } from './editor';
@@ -38,6 +38,13 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
         this.toDispose.push(this.toDisposeOnTabbarChange);
         this.toDispose.push(this.editor.onSelectionChanged(() => this.setSelection()));
         this.toDispose.push(this.editor.onFocusChanged(() => this.setSelection()));
+        this.toDispose.push(this.editor.onDidChangeReadOnly(isReadonly => {
+            if (isReadonly) {
+                lock(this.title);
+            } else {
+                unlock(this.title);
+            }
+        }));
         this.toDispose.push(Disposable.create(() => {
             if (this.selectionService.selection === this.editor) {
                 this.selectionService.selection = undefined;

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -20,6 +20,7 @@ import URI from '@theia/core/lib/common/uri';
 import { Event, Disposable, TextDocumentContentChangeDelta, Reference, isObject } from '@theia/core/lib/common';
 import { Saveable, Navigatable, Widget } from '@theia/core/lib/browser';
 import { EditorDecoration } from './decorations/editor-decoration';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 
 export { Position, Range, Location };
 
@@ -207,7 +208,8 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
     readonly node: HTMLElement;
 
     readonly uri: URI;
-    readonly isReadonly: boolean;
+    readonly isReadonly: boolean | MarkdownString;
+    readonly onDidChangeReadOnly: Event<boolean | MarkdownString>;
     readonly document: TextEditorDocument;
     readonly onDocumentContentChanged: Event<TextDocumentChangeEvent>;
 

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -32,6 +32,7 @@ import { ILanguageService } from '@theia/monaco-editor-core/esm/vs/editor/common
 import { IModelService } from '@theia/monaco-editor-core/esm/vs/editor/common/services/model';
 import { createTextBufferFactoryFromStream } from '@theia/monaco-editor-core/esm/vs/editor/common/model/textModel';
 import { editorGeneratedPreferenceProperties } from '@theia/editor/lib/browser/editor-generated-preference-schema';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 
 export {
     TextDocumentSaveReason
@@ -80,6 +81,8 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
 
     protected readonly onDidChangeEncodingEmitter = new Emitter<string>();
     readonly onDidChangeEncoding = this.onDidChangeEncodingEmitter.event;
+
+    readonly onDidChangeReadOnly: Event<boolean | MarkdownString> = this.resource.onDidChangeReadOnly ?? Event.None;
 
     private preferredEncoding: string | undefined;
     private contentEncoding: string | undefined;
@@ -302,11 +305,11 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
         return this.m2p.asRange(this.model.validateRange(this.p2m.asRange(range)));
     }
 
-    get readOnly(): boolean {
-        return this.resource.saveContents === undefined;
+    get readOnly(): boolean | MarkdownString {
+        return this.resource.readOnly ?? false;
     }
 
-    isReadonly(): boolean {
+    isReadonly(): boolean | MarkdownString {
         return this.readOnly;
     }
 

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -26,7 +26,6 @@ import { MonacoDiffNavigatorFactory } from './monaco-diff-navigator-factory';
 import { EditorServiceOverrides, MonacoEditor, MonacoEditorServices } from './monaco-editor';
 import { MonacoEditorModel, WillSaveMonacoModelEvent } from './monaco-editor-model';
 import { MonacoWorkspace } from './monaco-workspace';
-import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
 import { ContributionProvider } from '@theia/core';
 import { KeybindingRegistry, OpenerService, open, WidgetOpenerOptions, FormatType } from '@theia/core/lib/browser';
 import { MonacoResolvedKeybinding } from './monaco-resolved-keybinding';
@@ -86,8 +85,6 @@ export class MonacoEditorProvider {
         @inject(MonacoWorkspace) protected readonly workspace: MonacoWorkspace,
         @inject(EditorPreferences) protected readonly editorPreferences: EditorPreferences,
         @inject(MonacoDiffNavigatorFactory) protected readonly diffNavigatorFactory: MonacoDiffNavigatorFactory,
-        /** @deprecated since 1.6.0 */
-        @inject(ApplicationServer) protected readonly applicationServer: ApplicationServer,
     ) {
     }
 

--- a/packages/monaco/src/browser/simple-monaco-editor.ts
+++ b/packages/monaco/src/browser/simple-monaco-editor.ts
@@ -43,6 +43,7 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
     readonly onEncodingChanged = this.document.onDidChangeEncoding;
     protected readonly onResizeEmitter = new Emitter<Dimension | null>();
     readonly onDidResize = this.onResizeEmitter.event;
+    readonly onDidChangeReadOnly = this.document.onDidChangeReadOnly;
 
     constructor(
         readonly uri: URI,
@@ -62,7 +63,10 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
             this.onLanguageChangedEmitter,
             this.onScrollChangedEmitter
         ]);
-        this.toDispose.push(this.create(options, override));
+        this.toDispose.push(this.create({
+            ...MonacoEditor.createReadOnlyOptions(document.readOnly),
+            ...options
+        }, override));
         this.addHandlers(this.editor);
         this.editor.setModel(document.textEditorModel);
     }
@@ -124,6 +128,9 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
         }));
         this.toDispose.push(codeEditor.onDidScrollChange(e => {
             this.onScrollChangedEmitter.fire(undefined);
+        }));
+        this.toDispose.push(this.onDidChangeReadOnly(readOnly => {
+            codeEditor.updateOptions(MonacoEditor.createReadOnlyOptions(readOnly));
         }));
     }
 

--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -138,8 +138,8 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
 
     protected editableCommandHandler(execute: (notebookModel: NotebookModel) => void): CommandHandler {
         return {
-            isEnabled: (notebookModel: NotebookModel) => !Boolean(notebookModel.readOnly),
-            isVisible: (notebookModel: NotebookModel) => !Boolean(notebookModel.readOnly),
+            isEnabled: (notebookModel: NotebookModel) => !Boolean(notebookModel?.readOnly),
+            isVisible: (notebookModel: NotebookModel) => !Boolean(notebookModel?.readOnly),
             execute: (notebookModel: NotebookModel) => {
                 execute(notebookModel);
             }

--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Command, CommandContribution, CommandRegistry, CompoundMenuNodeRole, MenuContribution, MenuModelRegistry, nls } from '@theia/core';
+import { Command, CommandContribution, CommandHandler, CommandRegistry, CompoundMenuNodeRole, MenuContribution, MenuModelRegistry, nls } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ApplicationShell, codicon, CommonCommands } from '@theia/core/lib/browser';
 import { NotebookModel } from '../view-model/notebook-model';
@@ -100,35 +100,50 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
             }
         });
 
-        commands.registerCommand(NotebookCommands.ADD_NEW_MARKDOWN_CELL_COMMAND, {
-            execute: (notebookModel: NotebookModel) => commands.executeCommand(NotebookCommands.ADD_NEW_CELL_COMMAND.id, notebookModel, CellKind.Markup)
-        });
+        commands.registerCommand(NotebookCommands.ADD_NEW_MARKDOWN_CELL_COMMAND, this.editableCommandHandler(
+            notebookModel => commands.executeCommand(NotebookCommands.ADD_NEW_CELL_COMMAND.id, notebookModel, CellKind.Markup)
+        ));
 
-        commands.registerCommand(NotebookCommands.ADD_NEW_CODE_CELL_COMMAND, {
-            execute: (notebookModel: NotebookModel) => commands.executeCommand(NotebookCommands.ADD_NEW_CELL_COMMAND.id, notebookModel, CellKind.Code)
-        });
+        commands.registerCommand(NotebookCommands.ADD_NEW_CODE_CELL_COMMAND, this.editableCommandHandler(
+            notebookModel => commands.executeCommand(NotebookCommands.ADD_NEW_CELL_COMMAND.id, notebookModel, CellKind.Code)
+        ));
 
-        commands.registerCommand(NotebookCommands.SELECT_KERNEL_COMMAND, {
-            execute: (notebookModel: NotebookModel) => this.notebookKernelQuickPickService.showQuickPick(notebookModel)
-        });
+        commands.registerCommand(NotebookCommands.SELECT_KERNEL_COMMAND, this.editableCommandHandler(
+            notebookModel => this.notebookKernelQuickPickService.showQuickPick(notebookModel)
+        ));
 
-        commands.registerCommand(NotebookCommands.EXECUTE_NOTEBOOK_COMMAND, {
-            execute: (notebookModel: NotebookModel) => this.notebookExecutionService.executeNotebookCells(notebookModel, notebookModel.cells)
-        });
+        commands.registerCommand(NotebookCommands.EXECUTE_NOTEBOOK_COMMAND, this.editableCommandHandler(
+            notebookModel => this.notebookExecutionService.executeNotebookCells(notebookModel, notebookModel.cells)
+        ));
 
-        commands.registerCommand(NotebookCommands.CLEAR_ALL_OUTPUTS_COMMAND, {
-            execute: (notebookModel: NotebookModel) =>
-                notebookModel.cells.forEach(cell => cell.spliceNotebookCellOutputs({ start: 0, deleteCount: cell.outputs.length, newOutputs: [] }))
-        });
+        commands.registerCommand(NotebookCommands.CLEAR_ALL_OUTPUTS_COMMAND, this.editableCommandHandler(
+            notebookModel => notebookModel.cells.forEach(cell => cell.spliceNotebookCellOutputs({ start: 0, deleteCount: cell.outputs.length, newOutputs: [] }))
+        ));
 
         commands.registerHandler(CommonCommands.UNDO.id, {
-            isEnabled: () => this.shell.activeWidget instanceof NotebookEditorWidget,
+            isEnabled: () => {
+                const widget = this.shell.activeWidget;
+                return widget instanceof NotebookEditorWidget && !Boolean(widget.model?.readOnly);
+            },
             execute: () => (this.shell.activeWidget as NotebookEditorWidget).undo()
         });
         commands.registerHandler(CommonCommands.REDO.id, {
-            isEnabled: () => this.shell.activeWidget instanceof NotebookEditorWidget,
+            isEnabled: () => {
+                const widget = this.shell.activeWidget;
+                return widget instanceof NotebookEditorWidget && !Boolean(widget.model?.readOnly);
+            },
             execute: () => (this.shell.activeWidget as NotebookEditorWidget).redo()
         });
+    }
+
+    protected editableCommandHandler(execute: (notebookModel: NotebookModel) => void): CommandHandler {
+        return {
+            isEnabled: (notebookModel: NotebookModel) => !Boolean(notebookModel.readOnly),
+            isVisible: (notebookModel: NotebookModel) => !Boolean(notebookModel.readOnly),
+            execute: (notebookModel: NotebookModel) => {
+                execute(notebookModel);
+            }
+        };
     }
 
     registerMenus(menus: MenuModelRegistry): void {

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -199,8 +199,8 @@ export class NotebookCellActionContribution implements MenuContribution, Command
 
     protected editableCellCommandHandler(execute: (notebookModel: NotebookModel, cell: NotebookCellModel, output?: NotebookCellOutputModel) => void): CommandHandler {
         return {
-            isEnabled: (notebookModel: NotebookModel) => !Boolean(notebookModel.readOnly),
-            isVisible: (notebookModel: NotebookModel) => !Boolean(notebookModel.readOnly),
+            isEnabled: (notebookModel: NotebookModel) => !Boolean(notebookModel?.readOnly),
+            isVisible: (notebookModel: NotebookModel) => !Boolean(notebookModel?.readOnly),
             execute: (notebookModel: NotebookModel, cell: NotebookCellModel, output?: NotebookCellOutputModel) => {
                 execute(notebookModel, cell, output);
             }

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -16,7 +16,7 @@
 
 import * as React from '@theia/core/shared/react';
 import { CommandRegistry, MenuModelRegistry, URI } from '@theia/core';
-import { ReactWidget, Navigatable, SaveableSource, Message, DelegatingSaveable } from '@theia/core/lib/browser';
+import { ReactWidget, Navigatable, SaveableSource, Message, DelegatingSaveable, lock, unlock } from '@theia/core/lib/browser';
 import { ReactNode } from '@theia/core/shared/react';
 import { CellKind } from '../common';
 import { CellRenderer as CellRenderer, NotebookCellListView } from './view/notebook-cell-list-view';
@@ -29,6 +29,7 @@ import { Emitter } from '@theia/core/shared/vscode-languageserver-protocol';
 import { NotebookEditorWidgetService } from './service/notebook-editor-widget-service';
 import { NotebookMainToolbarRenderer } from './view/notebook-main-toolbar';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 
 export const NotebookEditorWidgetContainerFactory = Symbol('NotebookEditorWidgetContainerFactory');
 
@@ -81,6 +82,9 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected readonly onDidChangeModelEmitter = new Emitter<void>();
     readonly onDidChangeModel = this.onDidChangeModelEmitter.event;
 
+    protected readonly onDidChangeReadOnlyEmitter = new Emitter<boolean | MarkdownString>();
+    readonly onDidChangeReadOnly = this.onDidChangeReadOnlyEmitter.event;
+
     protected readonly renderers = new Map<CellKind, CellRenderer>();
     protected _model?: NotebookModel;
     protected _ready: Deferred<NotebookModel> = new Deferred();
@@ -106,6 +110,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this.update();
 
         this.toDispose.push(this.onDidChangeModelEmitter);
+        this.toDispose.push(this.onDidChangeReadOnlyEmitter);
 
         this.renderers.set(CellKind.Markup, this.markdownCellRenderer);
         this.renderers.set(CellKind.Code, this.codeCellRenderer);
@@ -116,6 +121,18 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this._model = await this.props.notebookData;
         this.saveable.delegate = this._model;
         this.toDispose.push(this._model);
+        this.toDispose.push(this._model.onDidChangeReadOnly(readOnly => {
+            if (readOnly) {
+                lock(this.title);
+            } else {
+                unlock(this.title);
+            }
+            this.onDidChangeReadOnlyEmitter.fire(readOnly);
+            this.update();
+        }));
+        if (this._model.readOnly) {
+            lock(this.title);
+        }
         // Ensure that the model is loaded before adding the editor
         this.notebookEditorService.addNotebookEditor(this);
         this.update();

--- a/packages/notebook/src/browser/service/notebook-service.ts
+++ b/packages/notebook/src/browser/service/notebook-service.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Disposable, DisposableCollection, Emitter, URI } from '@theia/core';
+import { Disposable, DisposableCollection, Emitter, Resource, URI } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { NotebookData, TransientOptions } from '../../common';
@@ -101,14 +101,14 @@ export class NotebookService implements Disposable {
         });
     }
 
-    async createNotebookModel(data: NotebookData, viewType: string, uri: URI): Promise<NotebookModel> {
+    async createNotebookModel(data: NotebookData, viewType: string, resource: Resource): Promise<NotebookModel> {
         const serializer = this.notebookProviders.get(viewType)?.serializer;
         if (!serializer) {
             throw new Error('no notebook serializer for ' + viewType);
         }
 
-        const model = this.notebookModelFactory({ data, uri, viewType, serializer });
-        this.notebookModels.set(uri.toString(), model);
+        const model = this.notebookModelFactory({ data, resource, viewType, serializer });
+        this.notebookModels.set(resource.uri.toString(), model);
         // Resolve cell text models right after creating the notebook model
         // This ensures that all text models are available in the plugin host
         await Promise.all(model.cells.map(e => e.resolveTextModel()));

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -26,9 +26,12 @@
 }
 
 .theia-notebook-cell {
-  cursor: grab;
   display: flex;
   margin: 10px 0px;
+}
+
+.theia-notebook-cell.draggable {
+  cursor: grab;
 }
 
 .theia-notebook-cell:hover .theia-notebook-cell-marker {

--- a/packages/notebook/src/browser/view-model/notebook-cell-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-cell-model.ts
@@ -225,7 +225,9 @@ export class NotebookCellModel implements NotebookCell, Disposable {
     }
 
     requestEdit(): void {
-        this.onDidRequestCellEditChangeEmitter.fire(true);
+        if (!this.textModel.readOnly) {
+            this.onDidRequestCellEditChangeEmitter.fire(true);
+        }
     }
 
     requestStopEdit(): void {

--- a/packages/notebook/src/browser/view-model/notebook-cell-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-cell-model.ts
@@ -150,7 +150,7 @@ export class NotebookCellModel implements NotebookCell, Disposable {
 
     }
 
-    textModel: MonacoEditorModel;
+    protected textModel?: MonacoEditorModel;
 
     protected htmlContext: HTMLLIElement;
 
@@ -220,12 +220,12 @@ export class NotebookCellModel implements NotebookCell, Disposable {
         this.onDidChangeInternalMetadataEmitter.dispose();
         this.onDidChangeLanguageEmitter.dispose();
         this.notebookCellContextManager.dispose();
-        this.textModel.dispose();
+        this.textModel?.dispose();
         this.toDispose.dispose();
     }
 
     requestEdit(): void {
-        if (!this.textModel.readOnly) {
+        if (!this.textModel || !this.textModel.readOnly) {
             this.onDidRequestCellEditChangeEmitter.fire(true);
         }
     }

--- a/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
@@ -29,6 +29,7 @@ export interface NotebookCellToolbarItem {
     icon?: string;
     label?: string;
     onClick: (e: React.MouseEvent) => void;
+    isVisible: () => boolean;
     contextKeys?: Set<string>
 }
 
@@ -87,6 +88,7 @@ export class NotebookCellToolbarFactory {
                         args: [notebookModel, cell, output]
                     }) :
                 () => this.commandRegistry.executeCommand(menuNode.command!, notebookModel, cell, output),
+            isVisible: () => menuPath ? true : Boolean(this.commandRegistry.getVisibleHandler(menuNode.command!, notebookModel, cell, output)),
             contextKeys: menuNode.when ? this.contextKeyService.parseKeys(menuNode.when) : undefined
         };
     }

--- a/packages/notebook/src/browser/view/notebook-cell-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-toolbar.tsx
@@ -56,7 +56,7 @@ export class NotebookCellToolbar extends NotebookCellActionBar {
 
     override render(): React.ReactNode {
         return <div className='theia-notebook-cell-toolbar'>
-            {this.state.inlineItems.map(item => this.renderItem(item))}
+            {this.state.inlineItems.filter(e => e.isVisible()).map(item => this.renderItem(item))}
         </div>;
     }
 
@@ -66,7 +66,7 @@ export class NotebookCellSidebar extends NotebookCellActionBar {
 
     override render(): React.ReactNode {
         return <div className='theia-notebook-cell-sidebar'>
-            {this.state.inlineItems.map(item => this.renderItem(item))}
+            {this.state.inlineItems.filter(e => e.isVisible()).map(item => this.renderItem(item))}
         </div>;
     }
 }

--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { CommandRegistry, CompoundMenuNodeRole, DisposableCollection, MenuModelRegistry, MenuNode, nls } from '@theia/core';
+import { ArrayUtils, CommandRegistry, CompoundMenuNodeRole, DisposableCollection, MenuModelRegistry, MenuNode, nls } from '@theia/core';
 import * as React from '@theia/core/shared/react';
 import { codicon } from '@theia/core/lib/browser';
 import { NotebookCommands, NotebookMenus } from '../contributions/notebook-actions-contribution';
@@ -98,12 +98,16 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
 
     protected renderMenuItem(item: MenuNode): React.ReactNode {
         if (item.role === CompoundMenuNodeRole.Group) {
-            const itemNodes = item.children?.map(child => this.renderMenuItem(child)).filter(child => !!child);
+            const itemNodes = ArrayUtils.coalesce(item.children?.map(child => this.renderMenuItem(child)) ?? []);
             return <React.Fragment key={item.id}>
                 {itemNodes}
                 {itemNodes && itemNodes.length > 0 && <span key={`${item.id}-separator`} className='theia-notebook-toolbar-separator'></span>}
             </React.Fragment>;
         } else if (!item.when || this.props.contextKeyService.match(item.when)) {
+            const visibleCommand = Boolean(this.props.commandRegistry.getVisibleHandler(item.command ?? '', this.props.notebookModel));
+            if (!visibleCommand) {
+                return undefined;
+            }
             const title = (this.props.commandRegistry.getCommand(item.command ?? '') as NotebookCommand)?.tooltip ?? item.label;
             return <div key={item.id} title={title} className='theia-notebook-main-toolbar-item action-label'
                 onClick={() => {

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
@@ -569,7 +569,7 @@ export class CustomTextEditorModel implements CustomEditorModel {
     };
 
     get readonly(): boolean {
-        return this.editorTextModel.readOnly;
+        return Boolean(this.editorTextModel.readOnly);
     }
 
     get editorTextModel(): MonacoEditorModel {


### PR DESCRIPTION
#### What it does

Improves our readonly handling for monaco editors (editors can now dynamically change being readonly and writable).

Additionally adds a readonly mode to notebook editors. This new readonly mode disables a lot of notebook features:
* Editing (code & markdown)
* Execution
* Drag & drop
* Creating new cells

This change lays the groundwork for a few features in the collaboration feature (where readonly can be toggled) and the changes required for https://github.com/eclipse-theia/theia/issues/13353.

#### How to test

1. Open a monaco editor (or notebook editor).
2. Run the command `Toggle File System Readonly`. It toggles whether the `file` URI scheme is treated as readonly.
3. Play around with the editors. You should not be able to manipulate the editors.
4. Open a new editor. It should open in readonly mode.
5. Run the command again. Everything should work as normal.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
