### PR TITLE
Fix publishing of `next` version

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # To fetch all history for all branches and tags.
+          # Required for lerna to determine the version of the next package.
+          fetch-depth: 0
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3


### PR DESCRIPTION
#### What it does

While the publishing of the `next` version worked the [first time](https://github.com/eclipse-theia/theia/actions/runs/7908281490/job/21587112681), it didn't the [second time](https://github.com/eclipse-theia/theia/actions/runs/7992568466/job/21826357009#step:6:162) (at least not correctly). Lerna attempted to set the version to `1.47.0-next.0`, since there was no tag information available in the repo. Since the version was already published, the publishing process did nothing.

#### How to test

Nothing to test, I'll report back on whether this change worked.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
