### PR TITLE
Make `acquireVsCodeApi` available on global objects

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -146,7 +146,7 @@
      */
     function getDefaultScript(state) {
         return `
-const acquireVsCodeApi = (function() {
+globalThis.acquireVsCodeApi = (function() {
     const originalPostMessage = window.parent.postMessage.bind(window.parent);
     const originalConsole = {...console};
     const targetOrigin = '*';
@@ -198,7 +198,7 @@ const acquireVsCodeApi = (function() {
         });
     };
 })();
-const acquireTheiaApi = acquireVsCodeApi;
+globalThis.acquireTheiaApi = acquireVsCodeApi;
 delete window.parent;
 delete window.top;
 delete window.frameElement;        


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13374

Aligns our implementation of the `acquireVsCodeApi` method to vscode, which is also available on the `globalThis` and `window` objects.

#### How to test

1. Open a webview and hit a breakpoint within
2. Run these scripts in the browsers debugger:
```js
globalThis.acquireVsCodeApi()
window.acquireVsCodeApi()
acquireVsCodeApi()
```
3. All of them should return the vscode API object.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
