### PR TITLE
Fix default translation of `Close Editor` command

### DIFF
--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -83,7 +83,9 @@ class LocalizationKeyProvider {
 
     private preferredKeys = new Set([
         // We only want the `File` translation used in the menu
-        'vscode/fileActions.contribution/filesCategory'
+        'vscode/fileActions.contribution/filesCategory',
+        // Needed for `Close Editor` translation
+        'vscode/editor.contribution/closeEditor'
     ]);
     private data = this.buildData();
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13333

Adds a new entry to our preferred keys to correctly localize the value.

#### How to test

1. Configure Theia to use the simplified chinese local (`zh-cn`).
2. Assert that the command `Close Editor` (see picture in the linked issue) is localized.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
