### PR TITLE
Better Support for ReadOnly message on editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v1.47.0 not yet released
 
+- [filesystem] Implement readonly markdown message for file system providers [#13414]((<https://github.com/eclipse-theia/theia/pull/13414>) - contributed on behalf of STMicroelectronics
 - [plugin] Add command to install plugins from the command line [#13406](https://github.com/eclipse-theia/theia/issues/13406) - contributed on behalf of STMicroelectronics
 - [testing] support TestRunProfile onDidChangeDefault introduced in VS Code 1.86.0 [#13388](https://github.com/eclipse-theia/theia/pull/13388) - contributed on behalf of STMicroelectronics
 

--- a/examples/api-samples/src/browser/file-system/sample-file-system-capabilities.ts
+++ b/examples/api-samples/src/browser/file-system/sample-file-system-capabilities.ts
@@ -18,6 +18,7 @@ import { CommandContribution, CommandRegistry } from '@theia/core';
 import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { RemoteFileSystemProvider } from '@theia/filesystem/lib/common/remote-file-system-provider';
 import { FileSystemProviderCapabilities } from '@theia/filesystem/lib/common/files';
+import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 
 @injectable()
 export class SampleFileSystemCapabilities implements CommandContribution {
@@ -37,6 +38,25 @@ export class SampleFileSystemCapabilities implements CommandContribution {
                 } else {
                     this.remoteFileSystemProvider['setCapabilities'](this.remoteFileSystemProvider.capabilities | FileSystemProviderCapabilities.Readonly);
                 }
+            }
+        });
+
+        commands.registerCommand({
+            id: 'addFileSystemReadonlyMessage',
+            label: 'Add a File System ReadonlyMessage for readonly'
+        }, {
+            execute: () => {
+                const readonlyMessage = new MarkdownStringImpl(`Added new **Markdown** string '+${Date.now()}`);
+                this.remoteFileSystemProvider['setReadOnlyMessage'](readonlyMessage);
+            }
+        });
+
+        commands.registerCommand({
+            id: 'removeFileSystemReadonlyMessage',
+            label: 'Remove File System ReadonlyMessage for readonly'
+        }, {
+            execute: () => {
+                this.remoteFileSystemProvider['setReadOnlyMessage'](undefined);
             }
         });
     }

--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -27,6 +27,7 @@ import type { TextDocumentContentChangeEvent } from '@theia/core/shared/vscode-l
 import { ReadableStreamEvents } from '@theia/core/lib/common/stream';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { isObject } from '@theia/core/lib/common';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 
 export const enum FileOperation {
     CREATE,
@@ -763,6 +764,18 @@ export interface FileSystemProviderWithUpdateCapability extends FileSystemProvid
 
 export function hasUpdateCapability(provider: FileSystemProvider): provider is FileSystemProviderWithUpdateCapability {
     return !!(provider.capabilities & FileSystemProviderCapabilities.Update);
+}
+
+export interface ReadOnlyMessageFileSystemProvider {
+    readOnlyMessage: MarkdownString | undefined;
+    readonly onDidChangeReadOnlyMessage: Event<MarkdownString | undefined>;
+}
+
+export namespace ReadOnlyMessageFileSystemProvider {
+    export function is(arg: unknown): arg is ReadOnlyMessageFileSystemProvider {
+        return isObject<ReadOnlyMessageFileSystemProvider>(arg)
+        && 'readOnlyMessage' in arg;
+    }
 }
 
 /**

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -653,7 +653,7 @@ export namespace MonacoEditor {
 
     export function createReadOnlyOptions(readOnly?: boolean | MarkdownString): monaco.editor.IEditorOptions {
         if (typeof readOnly === 'boolean') {
-            return { readOnly };
+            return { readOnly, readOnlyMessage: undefined };
         }
         if (readOnly) {
             return { readOnly: true, readOnlyMessage: readOnly };

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1984,7 +1984,7 @@ export interface IFileChangeDto {
 }
 
 export interface FileSystemMain {
-    $registerFileSystemProvider(handle: number, scheme: string, capabilities: files.FileSystemProviderCapabilities): void;
+    $registerFileSystemProvider(handle: number, scheme: string, capabilities: files.FileSystemProviderCapabilities, readonlyMessage?: MarkdownString): void;
     $unregisterProvider(handle: number): void;
     $onFileSystemChange(handle: number, resource: IFileChangeDto[]): void;
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -738,7 +738,8 @@ export function createAPIFactory(
             registerTextDocumentContentProvider(scheme: string, provider: theia.TextDocumentContentProvider): theia.Disposable {
                 return workspaceExt.registerTextDocumentContentProvider(scheme, provider);
             },
-            registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider, options?: { isCaseSensitive?: boolean, isReadonly?: boolean }): theia.Disposable {
+            registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider, options?: { isCaseSensitive?: boolean, isReadonly?: boolean | MarkdownString}):
+                theia.Disposable {
                 return fileSystemExt.registerFileSystemProvider(scheme, provider, options);
             },
             getWorkspaceFolder(uri: theia.Uri): theia.WorkspaceFolder | undefined {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7593,7 +7593,7 @@ export module '@theia/plugin' {
          * @param options Immutable metadata about the provider.
          * @return A {@link Disposable disposable} that unregisters this provider when being disposed.
          */
-        export function registerFileSystemProvider(scheme: string, provider: FileSystemProvider, options?: { readonly isCaseSensitive?: boolean, readonly isReadonly?: boolean }): Disposable;
+        export function registerFileSystemProvider(scheme: string, provider: FileSystemProvider, options?: { readonly isCaseSensitive?: boolean, readonly isReadonly?: boolean | MarkdownString }): Disposable;
 
         /**
          * Returns the {@link WorkspaceFolder workspace folder} that contains a given uri.


### PR DESCRIPTION
#### What it does

This Pull Request continues the work initiated with #13403 and it adds the support of the introduced API in VS Code as described in #13353.  This API addition is the workspace.registerFileSystemProvider() with readonly option being also potentially a Markdown String and not only a boolean. 

Also, it completes the file system API sample with an action to add and remove a read-only message. 
Finally, it improves toggling the readOnly value for a given editor by retrieving the real status of the file, and not only the status of the file system provider. The file can be readonly because of specific permissions for example.

Note: it is currently hard to test the VS Code API as indicated there: https://github.com/eclipse-theia/theia/issues/13353#issuecomment-1946067274. I used the FS provider vscode  sample, but I had same issue. I do not understand why URI has to be transformed to relative and absolute. Removing the lines as indicated in the comment https://github.com/eclipse-theia/theia/issues/8167#issuecomment-842317679 and avoiding some absolute translation works for me, but there are probably reasons why this was done initially.  

#### How to test

1. In a standard workspace, create 2 text files, and make one only writable, the second with only read permissions.
2. Use the various commands from API sample for File system: 
- Add a File System ReadonlyMessage for readonly
- Remove File System ReadonlyMessage for readonly
- Toggle File System Readonly 

3. Check if the lock symbol appears in the title, and also what is displayed in the editor when trying to edit when readonly, for both files. For example, when toggling readonly to false and no readonly message, the file with only read permissions shall still not be editable.

![ReadOnlyMessage](https://github.com/eclipse-theia/theia/assets/3964263/ca1cc577-cc08-4c86-9c41-25692d4d3751)

The behavior is similar to the one on VS Code: the readOnlyMessage has priority over the capability. 

#### Follow-ups

Check the API thanks to this extension when the workspace update is working with other file systems:
- zip vsix: 
[vscode-memfs-0.0.8.zip](https://github.com/eclipse-theia/theia/files/14377115/vscode-memfs-0.0.8.zip)

- src: 
[vscode-memfs-0.0.8-src.zip](https://github.com/eclipse-theia/theia/files/14377113/vscode-memfs-0.0.8-src.zip)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
