### PR TITLE
fix: use correct path for hosted plugin deployer handler

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -260,8 +260,8 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         const knownLocations = this.sourceLocations.get(id) ?? new Set();
         const maybeStoredLocations = entry.getValue('sourceLocations');
         const storedLocations = Array.isArray(maybeStoredLocations) && maybeStoredLocations.every(location => typeof location === 'string')
-            ? maybeStoredLocations.concat(entry.originalPath())
-            : [entry.originalPath()];
+            ? maybeStoredLocations.concat(entry.rootPath)
+            : [entry.rootPath];
         storedLocations.forEach(location => knownLocations.add(location));
         this.sourceLocations.set(id, knownLocations);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This patch stores `plugin.rootPath` instead of `plugin.originalPath()` as the source location when a plugin is deployed.
This ensures that the plugin is deleted from the deployment directory when uninstalled.

Contributed on behalf of STMicroelectronics

Fixes #13379 
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Install a vscode extension either from the vsix registry or from a local vsix file
2. Verify that the vscode extension is installed (and deployed to e.g., `~/.theia/deployedPlugins/`
3. Uninstall the extension again
4. Verify that it has been removed from the `~/.theia/deployedPlugins/`
5. Restart theia
6. Verify that the plugin is not installed anymore

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
