### PR TITLE
Fixed scroll behaviour of Notebooks

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -194,7 +194,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 this.webviewWidget.setIframeHeight(message.contentHeight + 5);
                 break;
             case 'did-scroll-wheel':
-                this.editor.node.scrollBy(message.deltaX, message.deltaY);
+                this.editor.node.children[0].children[1].scrollBy(message.deltaX, message.deltaY);
                 break;
             case 'customKernelMessage':
                 this.editor.recieveKernelMessage(message.message);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #13409

iFrames are not stealing scroll events anymore in Notebook editor. 
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Follow the "How to test" instructions https://github.com/eclipse-theia/theia/pull/12442 and scroll like you've never scrolled before.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
