### PR TITLE
Fixed context keys for notebook editor context

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -138,7 +138,6 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this.renderers.set(CellKind.Markup, this.markdownCellRenderer);
         this.renderers.set(CellKind.Code, this.codeCellRenderer);
         this._ready.resolve(this.waitForData());
-
     }
 
     protected async waitForData(): Promise<NotebookModel> {

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -39,6 +39,7 @@ export function createNotebookEditorWidgetContainer(parent: interfaces.Container
     const child = parent.createChild();
 
     child.bind(NotebookEditorProps).toConstantValue(props);
+    child.bind(NotebookMainToolbarRenderer).toSelf().inSingletonScope();
     child.bind(NotebookEditorWidget).toSelf();
 
     return child;
@@ -138,6 +139,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this.renderers.set(CellKind.Markup, this.markdownCellRenderer);
         this.renderers.set(CellKind.Code, this.codeCellRenderer);
         this._ready.resolve(this.waitForData());
+
     }
 
     protected async waitForData(): Promise<NotebookModel> {
@@ -186,7 +188,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected render(): ReactNode {
         if (this._model) {
             return <div className='theia-notebook-main-container'>
-                {this.notebookMainToolbarRenderer.render(this._model)}
+                {this.notebookMainToolbarRenderer.render(this._model, this.node)}
                 <PerfectScrollbar className='theia-notebook-scroll-container'>
                     <NotebookCellListView renderers={this.renderers}
                         notebookModel={this._model}

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -39,7 +39,6 @@ export function createNotebookEditorWidgetContainer(parent: interfaces.Container
     const child = parent.createChild();
 
     child.bind(NotebookEditorProps).toConstantValue(props);
-    child.bind(NotebookMainToolbarRenderer).toSelf().inSingletonScope();
     child.bind(NotebookEditorWidget).toSelf();
 
     return child;

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -44,6 +44,7 @@ import { NotebookRendererMessagingService } from './service/notebook-renderer-me
 import { NotebookColorContribution } from './contributions/notebook-color-contribution';
 import { NotebookCellContextManager } from './service/notebook-cell-context-manager';
 import { NotebookContextManager } from './service/notebook-context-manager';
+import { NotebookMainToolbarRenderer } from './view/notebook-main-toolbar';
 
 export default new ContainerModule(bind => {
     bind(NotebookColorContribution).toSelf().inSingletonScope();
@@ -81,6 +82,7 @@ export default new ContainerModule(bind => {
 
     bind(NotebookCodeCellRenderer).toSelf().inSingletonScope();
     bind(NotebookMarkdownCellRenderer).toSelf().inSingletonScope();
+    bind(NotebookMainToolbarRenderer).toSelf().inSingletonScope();
 
     bind(NotebookContextManager).toSelf();
 

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -43,8 +43,6 @@ import { NotebookEditorWidgetService } from './service/notebook-editor-widget-se
 import { NotebookRendererMessagingService } from './service/notebook-renderer-messaging-service';
 import { NotebookColorContribution } from './contributions/notebook-color-contribution';
 import { NotebookCellContextManager } from './service/notebook-cell-context-manager';
-import { NotebookContextManager } from './service/notebook-context-manager';
-import { NotebookMainToolbarRenderer } from './view/notebook-main-toolbar';
 
 export default new ContainerModule(bind => {
     bind(NotebookColorContribution).toSelf().inSingletonScope();
@@ -82,9 +80,6 @@ export default new ContainerModule(bind => {
 
     bind(NotebookCodeCellRenderer).toSelf().inSingletonScope();
     bind(NotebookMarkdownCellRenderer).toSelf().inSingletonScope();
-    bind(NotebookMainToolbarRenderer).toSelf().inSingletonScope();
-
-    bind(NotebookContextManager).toSelf();
 
     bind(NotebookEditorWidgetContainerFactory).toFactory(ctx => (props: NotebookEditorProps) =>
         createNotebookEditorWidgetContainer(ctx.container, props).get(NotebookEditorWidget)

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -43,7 +43,7 @@ import { NotebookEditorWidgetService } from './service/notebook-editor-widget-se
 import { NotebookRendererMessagingService } from './service/notebook-renderer-messaging-service';
 import { NotebookColorContribution } from './contributions/notebook-color-contribution';
 import { NotebookCellContextManager } from './service/notebook-cell-context-manager';
-import { NotebookMainToolbarRenderer } from './view/notebook-main-toolbar';
+import { NotebookContextManager } from './service/notebook-context-manager';
 
 export default new ContainerModule(bind => {
     bind(NotebookColorContribution).toSelf().inSingletonScope();
@@ -81,7 +81,8 @@ export default new ContainerModule(bind => {
 
     bind(NotebookCodeCellRenderer).toSelf().inSingletonScope();
     bind(NotebookMarkdownCellRenderer).toSelf().inSingletonScope();
-    bind(NotebookMainToolbarRenderer).toSelf().inSingletonScope();
+
+    bind(NotebookContextManager).toSelf();
 
     bind(NotebookEditorWidgetContainerFactory).toFactory(ctx => (props: NotebookEditorProps) =>
         createNotebookEditorWidgetContainer(ctx.container, props).get(NotebookEditorWidget)

--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -34,8 +34,6 @@ export class NotebookContextManager {
     readonly onDidChangeContext = this.onDidChangeContextEmitter.event;
 
     init(widget: NotebookEditorWidget): void {
-        this.toDispose.push(this.contextKeyService.onDidChange(e => this.onDidChangeContextEmitter.fire(e)));
-
         const scopedStore = this.contextKeyService.createScoped(widget.node);
 
         this.toDispose.dispose();

--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -1,21 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2023 TypeFox and others.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License v. 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0.
-//
-// This Source Code may also be made available under the following Secondary
-// Licenses when the conditions for such availability set forth in the Eclipse
-// Public License v. 2.0 are satisfied: GNU General Public License, version 2
-// with the GNU Classpath Exception which is available at
-// https://www.gnu.org/software/classpath/license.html.
-//
-// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
-// *****************************************************************************
-
-// *****************************************************************************
-// Copyright (C) 2023 TypeFox and others.
+// Copyright (C) 2024 TypeFox and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -1,0 +1,78 @@
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// *****************************************************************************
+// Copyright (C) 2023 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { DisposableCollection } from '@theia/core';
+import { NotebookKernelService } from './notebook-kernel-service';
+import { NOTEBOOK_KERNEL, NOTEBOOK_KERNEL_SELECTED, NOTEBOOK_VIEW_TYPE } from '../contributions/notebook-context-keys';
+import { NotebookEditorWidget } from '../notebook-editor-widget';
+import { NotebookEditorWidgetService } from './notebook-editor-widget-service';
+
+@injectable()
+export class NotebookContextManager {
+    @inject(ContextKeyService) protected contextKeyService: ContextKeyService;
+
+    @inject(NotebookKernelService)
+    protected readonly notebookKernelService: NotebookKernelService;
+
+    @inject(NotebookEditorWidgetService)
+    protected readonly notebookEditorWidgetService: NotebookEditorWidgetService;
+
+    protected readonly toDispose = new DisposableCollection();
+
+    @postConstruct()
+    init(): void {
+        this.notebookEditorWidgetService.onDidChangeFocusedEditor(e => {
+            this.update(e);
+        });
+        if (this.notebookEditorWidgetService.focusedEditor) {
+            this.update(this.notebookEditorWidgetService.focusedEditor);
+        }
+    }
+
+    update(widget: NotebookEditorWidget | undefined): void {
+        this.toDispose.dispose();
+
+        this.contextKeyService.setContext(NOTEBOOK_VIEW_TYPE, widget?.notebookType);
+
+        const kernel = widget?.model ? this.notebookKernelService.getSelectedNotebookKernel(widget.model) : undefined;
+        this.contextKeyService.setContext(NOTEBOOK_KERNEL_SELECTED, !!kernel);
+        this.contextKeyService.setContext(NOTEBOOK_KERNEL, kernel?.id);
+        this.toDispose.push(this.notebookKernelService.onDidChangeSelectedKernel(e => {
+            if (e.notebook.toString() === widget?.getResourceUri()?.toString()) {
+                this.contextKeyService.setContext(NOTEBOOK_KERNEL_SELECTED, !!e.newKernel);
+                this.contextKeyService.setContext(NOTEBOOK_KERNEL, e.newKernel);
+            }
+        }));
+    }
+}

--- a/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
+++ b/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
@@ -59,7 +59,6 @@ export class NotebookEditorWidgetService {
                 this.onDidChangeFocusedEditorEmitter.fire(undefined);
             }
         });
-        this.openerService.
     }
 
     // --- editor management

--- a/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
+++ b/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
@@ -21,7 +21,7 @@
 
 import { Emitter } from '@theia/core';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { ApplicationShell, OpenerService, WidgetFactory } from '@theia/core/lib/browser';
+import { ApplicationShell } from '@theia/core/lib/browser';
 import { NotebookEditorWidget } from '../notebook-editor-widget';
 
 @injectable()
@@ -29,9 +29,6 @@ export class NotebookEditorWidgetService {
 
     @inject(ApplicationShell)
     protected applicationShell: ApplicationShell;
-
-    @inject(WidgetFactory)
-    protected openerService: OpenerService;
 
     private readonly notebookEditors = new Map<string, NotebookEditorWidget>();
 

--- a/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
+++ b/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
@@ -21,7 +21,7 @@
 
 import { Emitter } from '@theia/core';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { ApplicationShell } from '@theia/core/lib/browser';
+import { ApplicationShell, OpenerService, WidgetFactory } from '@theia/core/lib/browser';
 import { NotebookEditorWidget } from '../notebook-editor-widget';
 
 @injectable()
@@ -29,6 +29,9 @@ export class NotebookEditorWidgetService {
 
     @inject(ApplicationShell)
     protected applicationShell: ApplicationShell;
+
+    @inject(WidgetFactory)
+    protected openerService: OpenerService;
 
     private readonly notebookEditors = new Map<string, NotebookEditorWidget>();
 
@@ -56,6 +59,7 @@ export class NotebookEditorWidgetService {
                 this.onDidChangeFocusedEditorEmitter.fire(undefined);
             }
         });
+        this.openerService.
     }
 
     // --- editor management

--- a/packages/notebook/src/browser/service/notebook-kernel-service.ts
+++ b/packages/notebook/src/browser/service/notebook-kernel-service.ts
@@ -253,7 +253,6 @@ export class NotebookKernelService {
     getSelectedNotebookKernel(notebook: NotebookTextModelLike): NotebookKernel | undefined {
         const selectedId = this.notebookBindings[`${notebook.viewType}/${notebook.uri}`];
         return selectedId ? this.kernels.get(selectedId)?.kernel : undefined;
-
     }
 
     selectKernelForNotebook(kernel: NotebookKernel | undefined, notebook: NotebookTextModelLike): void {
@@ -267,7 +266,6 @@ export class NotebookKernelService {
             }
             this.storageService.setData(NOTEBOOK_KERNEL_BINDING_STORAGE_KEY, this.notebookBindings);
             this.onDidChangeSelectedNotebookKernelBindingEmitter.fire({ notebook: notebook.uri, oldKernel, newKernel: kernel?.id });
-
         }
     }
 

--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -81,6 +81,11 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
                 this.forceUpdate();
             }
         });
+        props.contextKeyService.onDidChange(e => {
+            if (e.affects(contextKeys)) {
+                this.forceUpdate();
+            }
+        });
 
     }
 

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -59,10 +59,8 @@ import { UntitledResourceResolver } from '@theia/core/lib/common/resource';
 import { ThemeService } from '@theia/core/lib/browser/theming';
 import { TabsMainImpl } from './tabs/tabs-main';
 import { NotebooksMainImpl } from './notebooks/notebooks-main';
-import { NotebookService } from '@theia/notebook/lib/browser';
 import { LocalizationMainImpl } from './localization-main';
 import { NotebookRenderersMainImpl } from './notebooks/notebook-renderers-main';
-import { HostedPluginSupport } from '../../hosted/browser/hosted-plugin';
 import { NotebookEditorsMainImpl } from './notebooks/notebook-editors-main';
 import { NotebookDocumentsMainImpl } from './notebooks/notebook-documents-main';
 import { NotebookKernelsMainImpl } from './notebooks/notebook-kernels-main';
@@ -102,9 +100,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const documentsMain = new DocumentsMainImpl(editorsAndDocuments, modelService, rpc, editorManager, openerService, shell, untitledResourceResolver, languageService);
     rpc.set(PLUGIN_RPC_CONTEXT.DOCUMENTS_MAIN, documentsMain);
 
-    const notebookService = container.get(NotebookService);
-    const pluginSupport = container.get(HostedPluginSupport);
-    rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOKS_MAIN, new NotebooksMainImpl(rpc, notebookService, pluginSupport));
+    rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOKS_MAIN, new NotebooksMainImpl(rpc, container, commandRegistryMain));
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_RENDERERS_MAIN, new NotebookRenderersMainImpl(rpc, container));
     const notebookEditorsMain = new NotebookEditorsMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_EDITORS_MAIN, notebookEditorsMain);

--- a/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
@@ -18,12 +18,15 @@ import { CancellationToken, DisposableCollection, Emitter, Event } from '@theia/
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { NotebookCellStatusBarItem, NotebookData, TransientOptions } from '@theia/notebook/lib/common';
 import { NotebookService } from '@theia/notebook/lib/browser';
+import { NotebookContextManager } from '@theia/notebook/lib/browser/service/notebook-context-manager';
 import { Disposable } from '@theia/plugin';
-import { MAIN_RPC_CONTEXT, NotebooksExt, NotebooksMain } from '../../../common';
+import { CommandRegistryMain, MAIN_RPC_CONTEXT, NotebooksExt, NotebooksMain } from '../../../common';
 import { RPCProtocol } from '../../../common/rpc-protocol';
 import { NotebookDto } from './notebook-dto';
 import { UriComponents } from '@theia/core/lib/common/uri';
 import { HostedPluginSupport } from '../../../hosted/browser/hosted-plugin';
+import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
+import { interfaces } from '@theia/core/shared/inversify';
 
 export interface NotebookCellStatusBarItemList {
     items: NotebookCellStatusBarItem[];
@@ -38,20 +41,33 @@ export interface NotebookCellStatusBarItemProvider {
 
 export class NotebooksMainImpl implements NotebooksMain {
 
-    private readonly disposables = new DisposableCollection();
+    protected readonly disposables = new DisposableCollection();
 
-    private readonly proxy: NotebooksExt;
-    private readonly notebookSerializer = new Map<number, Disposable>();
-    private readonly notebookCellStatusBarRegistrations = new Map<number, Disposable>();
+    protected notebookService: NotebookService;
+
+    protected readonly proxy: NotebooksExt;
+    protected readonly notebookSerializer = new Map<number, Disposable>();
+    protected readonly notebookCellStatusBarRegistrations = new Map<number, Disposable>();
 
     constructor(
         rpc: RPCProtocol,
-        private notebookService: NotebookService,
-        plugins: HostedPluginSupport
+        container: interfaces.Container,
+        commands: CommandRegistryMain
     ) {
+        this.notebookService = container.get(NotebookService);
+        const plugins = container.get(HostedPluginSupport);
+        container.get(NotebookContextManager);
+
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.NOTEBOOKS_EXT);
-        notebookService.onWillUseNotebookSerializer(async event => plugins.activateByNotebookSerializer(event));
-        notebookService.markReady();
+        this.notebookService.onWillUseNotebookSerializer(async event => plugins.activateByNotebookSerializer(event));
+        this.notebookService.markReady();
+        commands.registerArgumentProcessor({
+            processArgument: arg => {
+                if (arg instanceof NotebookModel) {
+                    return arg.uri;
+                }
+            }
+        });
     }
 
     dispose(): void {

--- a/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
@@ -66,6 +66,7 @@ export class NotebooksMainImpl implements NotebooksMain {
                 if (arg instanceof NotebookModel) {
                     return arg.uri;
                 }
+                return arg;
             }
         });
     }

--- a/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
@@ -18,7 +18,6 @@ import { CancellationToken, DisposableCollection, Emitter, Event } from '@theia/
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { NotebookCellStatusBarItem, NotebookData, TransientOptions } from '@theia/notebook/lib/common';
 import { NotebookService } from '@theia/notebook/lib/browser';
-import { NotebookContextManager } from '@theia/notebook/lib/browser/service/notebook-context-manager';
 import { Disposable } from '@theia/plugin';
 import { CommandRegistryMain, MAIN_RPC_CONTEXT, NotebooksExt, NotebooksMain } from '../../../common';
 import { RPCProtocol } from '../../../common/rpc-protocol';
@@ -56,7 +55,6 @@ export class NotebooksMainImpl implements NotebooksMain {
     ) {
         this.notebookService = container.get(NotebookService);
         const plugins = container.get(HostedPluginSupport);
-        container.get(NotebookContextManager);
 
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.NOTEBOOKS_EXT);
         this.notebookService.onWillUseNotebookSerializer(async event => plugins.activateByNotebookSerializer(event));

--- a/packages/workspace/src/browser/workspace-trust-service.ts
+++ b/packages/workspace/src/browser/workspace-trust-service.ts
@@ -26,6 +26,7 @@ import {
 } from './workspace-trust-preferences';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { WorkspaceService } from './workspace-service';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 
 const STORAGE_TRUSTED = 'trusted';
 
@@ -49,6 +50,9 @@ export class WorkspaceTrustService {
     @inject(WindowService)
     protected readonly windowService: WindowService;
 
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
     protected workspaceTrust = new Deferred<boolean>();
 
     @postConstruct()
@@ -71,6 +75,7 @@ export class WorkspaceTrustService {
             const trust = givenTrust ?? await this.calculateWorkspaceTrust();
             if (trust !== undefined) {
                 await this.storeWorkspaceTrust(trust);
+                this.contextKeyService.setContext('isWorkspaceTrusted', trust);
                 this.workspaceTrust.resolve(trust);
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes the setting of context keys for editor level context keys. Only implements some of the keys currently (see `notebook-context-manager.ts`). 
This makes jupyter commands like `Export As` or `Restart Kernel` available in the notebook editor toolbar

#### How to test

1. Have the python and jupyter extension installed.
2. After opening and clicking on a notebook the export command should pop up in the toolbar.
3. Then after selecting a kernel the restart kernel command should appear as well
4. both should be executable

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

Implement the outline view for notebooks including the `outline.focus` command so that the `Show Table of Contents` command works as well

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
