### PR TITLE
[vscode] Extend TextEditorLineNumbersStyle with Interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## not yet released
 
 - [core]  Fix quickpick problems found in IDE testing [#13451](https://github.com/eclipse-theia/theia/pull/13451) - contributed on behalf of STMicroelectronics
+- [plugin] Extend TextEditorLineNumbersStyle with Interval [#13458](https://github.com/eclipse-theia/theia/pull/13458) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a>
 

--- a/packages/plugin-ext/src/main/browser/text-editor-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-main.ts
@@ -151,13 +151,16 @@ export class TextEditorMain implements Disposable {
         }
 
         if (typeof newConfiguration.lineNumbers !== 'undefined') {
-            let lineNumbers: 'on' | 'off' | 'relative';
+            let lineNumbers: 'on' | 'off' | 'relative' | 'interval';
             switch (newConfiguration.lineNumbers) {
                 case TextEditorLineNumbersStyle.On:
                     lineNumbers = 'on';
                     break;
                 case TextEditorLineNumbersStyle.Relative:
                     lineNumbers = 'relative';
+                    break;
+                case TextEditorLineNumbersStyle.Interval:
+                    lineNumbers = 'interval';
                     break;
                 default:
                     lineNumbers = 'off';
@@ -399,6 +402,9 @@ export class TextEditorPropertiesMain {
                     break;
                 case monaco.editor.RenderLineNumbersType.Relative:
                     lineNumbers = TextEditorLineNumbersStyle.Relative;
+                    break;
+                case monaco.editor.RenderLineNumbersType.Interval:
+                    lineNumbers = TextEditorLineNumbersStyle.Interval;
                     break;
                 default:
                     lineNumbers = TextEditorLineNumbersStyle.On;

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -153,7 +153,8 @@ export enum StatusBarAlignment {
 export enum TextEditorLineNumbersStyle {
     Off = 0,
     On = 1,
-    Relative = 2
+    Relative = 2,
+    Interval = 3
 }
 
 /**

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1897,7 +1897,11 @@ export module '@theia/plugin' {
         /**
          * Render the line numbers with values relative to the primary cursor location.
          */
-        Relative = 2
+        Relative = 2,
+        /**
+         * Render the line numbers on every 10th line number.
+         */
+        Interval = 3
     }
 
     /**


### PR DESCRIPTION
#### What it does
fixes #13447

The value Interval=3 was missing for the enum TextEditorLineNumberStyle. This PR adds this style, an extension can now set this style. 

contributed on behalf of STMicroelectronics

#### How to test
* Install provided extension, that adds a command 'Set Line Style Number'. It displays a quickpick menu to choose the line number style for the active text editor.
- src: [lineoptions-extension-0.0.1-src.zip](https://github.com/eclipse-theia/theia/files/14508892/lineoptions-extension-0.0.1-src.zip)
- zipped vsix: [lineoptions-extension-0.0.1.zip](https://github.com/eclipse-theia/theia/files/14508894/lineoptions-extension-0.0.1.zip)
*  On theia master, try to switch the line style options on a text editor, especially choosing Interval. Nothing shows up.
* After applying this PR, try again. Now setting the style to 'Interval' will display the line numbers every 10 lines + the current line number.

![LineNumberStyle](https://github.com/eclipse-theia/theia/assets/3964263/287e42ee-8002-4e66-baec-84a5e5d36670)

#### Follow-ups
none

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
