### PR TITLE
fixed renaming and moving of open notebooks

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -172,7 +172,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     }
 
     createMoveToUri(resourceUri: URI): URI | undefined {
-        return this.props.uri;
+        return this.model?.uri.withPath(resourceUri.path);
     }
 
     undo(): void {

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -199,12 +199,8 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         }
     }
 
-    protected override onAfterAttach(msg: Message): void {
-        super.onAfterAttach(msg);
-    }
-
-    protected override onAfterDetach(msg: Message): void {
-        super.onAfterDetach(msg);
+    protected override onCloseRequest(msg: Message): void {
+        super.onCloseRequest(msg);
         this.notebookEditorService.removeNotebookEditor(this);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This is a small fix for the notebook editor. Before this fix notebook editors would just close when renaming the file or when mopving the editor to another area. This should be fixed now

#### How to test
for renaming:
1. open a notebook file
2. rename the file
3. notebook editor should correctly "stay open" with the new file name

for moving:
1. open a notebook
2. move to bottom area
3. should work fine

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
