### PR TITLE
Only initialize notebook cell editor when in viewport

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -240,6 +240,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this.onDidPostKernelMessageEmitter.dispose();
         this.onDidReceiveKernelMessageEmitter.dispose();
         this.onPostRendererMessageEmitter.dispose();
+        this.viewportService.dispose();
         super.dispose();
     }
 }

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -31,7 +31,6 @@ import { NotebookCellToolbarFactory } from './view/notebook-cell-toolbar-factory
 import { createNotebookModelContainer, NotebookModel, NotebookModelFactory, NotebookModelProps } from './view-model/notebook-model';
 import { createNotebookCellModelContainer, NotebookCellModel, NotebookCellModelFactory, NotebookCellModelProps } from './view-model/notebook-cell-model';
 import { createNotebookEditorWidgetContainer, NotebookEditorWidgetContainerFactory, NotebookEditorProps, NotebookEditorWidget } from './notebook-editor-widget';
-import { NotebookMarkdownCellRenderer } from './view/notebook-markdown-cell-view';
 import { NotebookActionsContribution } from './contributions/notebook-actions-contribution';
 import { NotebookExecutionService } from './service/notebook-execution-service';
 import { NotebookExecutionStateService } from './service/notebook-execution-state-service';

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -31,6 +31,7 @@ import { NotebookCellToolbarFactory } from './view/notebook-cell-toolbar-factory
 import { createNotebookModelContainer, NotebookModel, NotebookModelFactory, NotebookModelProps } from './view-model/notebook-model';
 import { createNotebookCellModelContainer, NotebookCellModel, NotebookCellModelFactory, NotebookCellModelProps } from './view-model/notebook-cell-model';
 import { createNotebookEditorWidgetContainer, NotebookEditorWidgetContainerFactory, NotebookEditorProps, NotebookEditorWidget } from './notebook-editor-widget';
+import { NotebookMarkdownCellRenderer } from './view/notebook-markdown-cell-view';
 import { NotebookActionsContribution } from './contributions/notebook-actions-contribution';
 import { NotebookExecutionService } from './service/notebook-execution-service';
 import { NotebookExecutionStateService } from './service/notebook-execution-state-service';

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -171,10 +171,16 @@
   overflow: hidden;
 }
 
+.theia-notebook-viewport {
+  display: flex;
+  overflow: hidden;
+  height: 100%;
+}
+
 .theia-notebook-scroll-container {
-    flex: 1;
-    overflow: hidden;
-    position: relative;
+  flex: 1;
+  overflow: hidden;
+  position: relative;
 }
 
 .theia-notebook-main-toolbar {

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -53,12 +53,10 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
 
     override componentDidMount(): void {
         this.disposeEditor();
-        console.log('init editor');
         if (!this.props.notebookViewportService || (this.container && this.props.notebookViewportService.isElementInViewport(this.container))) {
             this.initEditor();
         } else {
             const disposable = this.props.notebookViewportService?.onDidChangeViewport(() => {
-                console.log('init editor on viewport change');
                 if (!this.editor && this.container && this.props.notebookViewportService!.isElementInViewport(this.container)) {
                     this.initEditor();
                     disposable.dispose();

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -53,10 +53,12 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
 
     override componentDidMount(): void {
         this.disposeEditor();
+        console.log('init editor');
         if (!this.props.notebookViewportService || (this.container && this.props.notebookViewportService.isElementInViewport(this.container))) {
             this.initEditor();
         } else {
             const disposable = this.props.notebookViewportService?.onDidChangeViewport(() => {
+                console.log('init editor on viewport change');
                 if (!this.editor && this.container && this.props.notebookViewportService!.isElementInViewport(this.container)) {
                     this.initEditor();
                     disposable.dispose();
@@ -79,6 +81,7 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
         const { cell, notebookModel, monacoServices } = this.props;
         if (this.container) {
             const editorNode = this.container;
+            editorNode.style.height = '';
             const editorModel = await cell.resolveTextModel();
             const uri = cell.uri;
             this.editor = new SimpleMonacoEditor(uri,
@@ -109,7 +112,7 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
 
     protected estimateHeight(): string {
         const lineHeight = this.props.fontInfo?.lineHeight ?? 20;
-        return this.props.cell.text.split(OS.backend.EOL).length * lineHeight + 7 + 'px';
+        return this.props.cell.text.split(OS.backend.EOL).length * lineHeight + 10 + 7 + 'px';
     }
 
     override render(): React.ReactNode {

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -20,17 +20,19 @@ import { NotebookCellModel } from '../view-model/notebook-cell-model';
 import { SimpleMonacoEditor } from '@theia/monaco/lib/browser/simple-monaco-editor';
 import { MonacoEditor, MonacoEditorServices } from '@theia/monaco/lib/browser/monaco-editor';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
-import { DisposableCollection } from '@theia/core';
 import { IContextKeyService } from '@theia/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
 import { NotebookContextManager } from '../service/notebook-context-manager';
+import { DisposableCollection, OS } from '@theia/core';
 import { NotebookViewportService } from './notebook-viewport-service';
+import { BareFontInfo } from '@theia/monaco-editor-core/esm/vs/editor/common/config/fontInfo';
 
 interface CellEditorProps {
     notebookModel: NotebookModel,
     cell: NotebookCellModel,
     monacoServices: MonacoEditorServices,
     notebookContextManager: NotebookContextManager;
-    notebookViewportService?: NotebookViewportService
+    notebookViewportService?: NotebookViewportService,
+    fontInfo?: BareFontInfo;
 }
 
 const DEFAULT_EDITOR_OPTIONS: MonacoEditor.IOptions = {
@@ -106,7 +108,8 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
     };
 
     protected estimateHeight(): string {
-        return this.props.cell.text.split('\n').length * 20 + 7 + 'px';
+        const lineHeight = this.props.fontInfo?.lineHeight ?? 20;
+        return this.props.cell.text.split(OS.backend.EOL).length * lineHeight + 7 + 'px';
     }
 
     override render(): React.ReactNode {

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -31,6 +31,9 @@ import { NotebookCellExecutionState } from '../../common';
 import { DisposableCollection } from '@theia/core';
 import { NotebookContextManager } from '../service/notebook-context-manager';
 import { NotebookViewportService } from './notebook-viewport-service';
+import { EditorPreferences } from '@theia/editor/lib/browser';
+import { BareFontInfo } from '@theia/monaco-editor-core/esm/vs/editor/common/config/fontInfo';
+import { PixelRatio } from '@theia/monaco-editor-core/esm/vs/base/browser/browser';
 
 @injectable()
 export class NotebookCodeCellRenderer implements CellRenderer {
@@ -55,6 +58,11 @@ export class NotebookCodeCellRenderer implements CellRenderer {
     @inject(NotebookViewportService)
     protected readonly notebookViewportService: NotebookViewportService;
 
+    @inject(EditorPreferences)
+    protected readonly editorPreferences: EditorPreferences;
+
+    protected fontInfo: BareFontInfo | undefined;
+
     render(notebookModel: NotebookModel, cell: NotebookCellModel, handle: number): React.ReactNode {
         return <div>
             <div className='theia-notebook-cell-with-sidebar'>
@@ -64,8 +72,11 @@ export class NotebookCodeCellRenderer implements CellRenderer {
                     <p className='theia-notebook-code-cell-execution-order'>{`[${cell.exec ?? ' '}]`}</p> */}
                 </div>
                 <div className='theia-notebook-cell-editor-container'>
-                    <CellEditor notebookModel={notebookModel} cell={cell} monacoServices={this.monacoServices}
-                        notebookContextManager={this.notebookContextManager} notebookViewportService={this.notebookViewportService} />
+                    <CellEditor notebookModel={notebookModel} cell={cell}
+                        monacoServices={this.monacoServices}
+                        notebookContextManager={this.notebookContextManager}
+                        notebookViewportService={this.notebookViewportService}
+                        fontInfo={this.getOrCreateMonacoFontInfo()} />
                     <NotebookCodeCellStatus cell={cell} executionStateService={this.executionStateService}></NotebookCodeCellStatus>
                 </div >
             </div >
@@ -75,6 +86,25 @@ export class NotebookCodeCellRenderer implements CellRenderer {
                         this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.OUTPUT_SIDEBAR_MENU, notebookModel, cell, cell.outputs[0])} />
             </div>
         </div >;
+    }
+
+    protected getOrCreateMonacoFontInfo(): BareFontInfo {
+        if (!this.fontInfo) {
+            this.fontInfo = this.createFontInfo();
+            this.editorPreferences.onPreferenceChanged(e => this.fontInfo = this.createFontInfo());
+        }
+        return this.fontInfo;
+    }
+
+    protected createFontInfo(): BareFontInfo {
+        return BareFontInfo.createFromRawSettings({
+            fontFamily: this.editorPreferences['editor.fontFamily'],
+            fontWeight: String(this.editorPreferences['editor.fontWeight']),
+            fontSize: this.editorPreferences['editor.fontSize'],
+            fontLigatures: this.editorPreferences['editor.fontLigatures'],
+            lineHeight: this.editorPreferences['editor.lineHeight'],
+            letterSpacing: this.editorPreferences['editor.letterSpacing'],
+        }, PixelRatio.value);
     }
 }
 

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -30,6 +30,7 @@ import { codicon } from '@theia/core/lib/browser';
 import { NotebookCellExecutionState } from '../../common';
 import { DisposableCollection } from '@theia/core';
 import { NotebookContextManager } from '../service/notebook-context-manager';
+import { NotebookViewportService } from './notebook-viewport-service';
 
 @injectable()
 export class NotebookCodeCellRenderer implements CellRenderer {
@@ -51,6 +52,9 @@ export class NotebookCodeCellRenderer implements CellRenderer {
     @inject(NotebookContextManager)
     protected readonly notebookContextManager: NotebookContextManager;
 
+    @inject(NotebookViewportService)
+    protected readonly notebookViewportService: NotebookViewportService;
+
     render(notebookModel: NotebookModel, cell: NotebookCellModel, handle: number): React.ReactNode {
         return <div>
             <div className='theia-notebook-cell-with-sidebar'>
@@ -60,10 +64,11 @@ export class NotebookCodeCellRenderer implements CellRenderer {
                     <p className='theia-notebook-code-cell-execution-order'>{`[${cell.exec ?? ' '}]`}</p> */}
                 </div>
                 <div className='theia-notebook-cell-editor-container'>
-                    <CellEditor notebookModel={notebookModel} cell={cell} monacoServices={this.monacoServices} notebookContextManager={this.notebookContextManager} />
+                    <CellEditor notebookModel={notebookModel} cell={cell} monacoServices={this.monacoServices}
+                        notebookContextManager={this.notebookContextManager} notebookViewportService={this.notebookViewportService} />
                     <NotebookCodeCellStatus cell={cell} executionStateService={this.executionStateService}></NotebookCodeCellStatus>
-                </div>
-            </div>
+                </div >
+            </div >
             <div className='theia-notebook-cell-with-sidebar'>
                 <NotebookCodeCellOutputs cell={cell} notebook={notebookModel} outputWebviewFactory={this.cellOutputWebviewFactory}
                     renderSidebar={() =>

--- a/packages/notebook/src/browser/view/notebook-viewport-service.ts
+++ b/packages/notebook/src/browser/view/notebook-viewport-service.ts
@@ -1,0 +1,51 @@
+// *****************************************************************************
+// Copyright (C) 2024 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { Emitter } from '@theia/core/shared/vscode-languageserver-protocol';
+
+/**
+ * this service is for managing the viewport and scroll state of a notebook editor.
+ * its used both for restoring scroll state after reopening an editor and for cell to check if they are in the viewport.
+ */
+@injectable()
+export class NotebookViewportService {
+
+    protected onDidChangeViewportEmitter = new Emitter<void>();
+    readonly onDidChangeViewport = this.onDidChangeViewportEmitter.event;
+
+    protected _viewportElement: HTMLDivElement | undefined;
+
+    set viewportElement(element: HTMLDivElement | undefined) {
+        this._viewportElement = element;
+        if (element) {
+            this.onDidChangeViewportEmitter.fire();
+        }
+    }
+
+    isElementInViewport(element: HTMLElement): boolean {
+        if (this._viewportElement) {
+            const rect = element.getBoundingClientRect();
+            const viewRect = this._viewportElement.getBoundingClientRect();
+            return rect.top < viewRect.top ? rect.bottom > viewRect.top : rect.top < viewRect.bottom;
+        }
+        return false;
+    }
+
+    onScroll(e: HTMLDivElement): void {
+        this.onDidChangeViewportEmitter.fire();
+    }
+}

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -194,7 +194,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 this.webviewWidget.setIframeHeight(message.contentHeight + 5);
                 break;
             case 'did-scroll-wheel':
-                this.editor.node.children[0].children[1].scrollBy(message.deltaX, message.deltaY);
+                this.editor.node.getElementsByClassName('theia-notebook-viewport')[0].children[0].scrollBy(message.deltaX, message.deltaY);
                 break;
             case 'customKernelMessage':
                 this.editor.recieveKernelMessage(message.message);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This implements parts of #13015 
This optimizes the notebook editor widget so that monaco editors for code cells are only created once they come into the viewport. This should make opening large notbooks quite a bit more performant.

#### How to test

Open a notebook. Everything should still look the same. You should be able to see in the dom tree that all except the editors in the view are only mock editors with the estimated height of the content

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
