### PR TITLE
Fix overflow behavior of sidebars

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -35,7 +35,8 @@ import {
     MenuCommandAdapterRegistry,
     MenuCommandExecutor,
     MenuCommandAdapterRegistryImpl,
-    MenuCommandExecutorImpl
+    MenuCommandExecutorImpl,
+    MenuPath
 } from '../common';
 import { KeybindingRegistry, KeybindingContext, KeybindingContribution } from './keybinding';
 import { FrontendApplication } from './frontend-application';
@@ -137,7 +138,7 @@ import { MarkdownRenderer, MarkdownRendererFactory, MarkdownRendererImpl } from 
 import { StylingParticipant, StylingService } from './styling-service';
 import { bindCommonStylingParticipants } from './common-styling-participants';
 import { HoverService } from './hover-service';
-import { AdditionalViewsMenuWidget, AdditionalViewsMenuWidgetFactory } from './shell/additional-views-menu-widget';
+import { AdditionalViewsMenuPath, AdditionalViewsMenuWidget, AdditionalViewsMenuWidgetFactory } from './shell/additional-views-menu-widget';
 import { LanguageIconLabelProvider } from './language-icon-provider';
 import { bindTreePreferences } from './tree';
 import { OpenWithService } from './open-with-service';
@@ -177,9 +178,9 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(SidebarBottomMenuWidgetFactory).toAutoFactory(SidebarBottomMenuWidget);
     bind(AdditionalViewsMenuWidget).toSelf();
     bind(AdditionalViewsMenuWidgetFactory).toFactory(ctx => (side: 'left' | 'right') => {
-        const widget = ctx.container.resolve(AdditionalViewsMenuWidget);
-        widget.setSide(side);
-        return widget;
+        const childContainer = ctx.container.createChild();
+        childContainer.bind<MenuPath>(AdditionalViewsMenuPath).toConstantValue(['additional_views_menu', side]);
+        return childContainer.resolve(AdditionalViewsMenuWidget);
     });
     bind(SplitPositionHandler).toSelf().inSingletonScope();
 

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -178,7 +178,7 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(AdditionalViewsMenuWidget).toSelf();
     bind(AdditionalViewsMenuWidgetFactory).toFactory(ctx => (side: 'left' | 'right') => {
         const widget = ctx.container.resolve(AdditionalViewsMenuWidget);
-        widget.side = side;
+        widget.setSide(side);
         return widget;
     });
     bind(SplitPositionHandler).toSelf().inSingletonScope();

--- a/packages/core/src/browser/shell/additional-views-menu-widget.tsx
+++ b/packages/core/src/browser/shell/additional-views-menu-widget.tsx
@@ -23,14 +23,12 @@ import { SideTabBar } from './tab-bars';
 export const AdditionalViewsMenuWidgetFactory = Symbol('AdditionalViewsMenuWidgetFactory');
 export type AdditionalViewsMenuWidgetFactory = (side: 'left' | 'right') => AdditionalViewsMenuWidget;
 
-export function getAdditionalViewsMenuPath(side: 'left' | 'right'): MenuPath {
-    return ['additional_views_menu', side];
-}
+export const AdditionalViewsMenuPath = Symbol('AdditionalViewsMenuPath');
 @injectable()
 export class AdditionalViewsMenuWidget extends SidebarMenuWidget {
     static readonly ID = 'sidebar.additional.views';
 
-    protected side: 'left' | 'right';
+    @inject(AdditionalViewsMenuPath)
     protected menuPath: MenuPath;
 
     @inject(CommandRegistry)
@@ -40,11 +38,6 @@ export class AdditionalViewsMenuWidget extends SidebarMenuWidget {
     protected readonly menuModelRegistry: MenuModelRegistry;
 
     protected menuDisposables: Disposable[] = [];
-
-    setSide(side: 'left' | 'right'): void {
-        this.side = side;
-        this.menuPath = getAdditionalViewsMenuPath(side);
-    }
 
     updateAdditionalViews(sender: SideTabBar, event: { titles: Title<Widget>[], startIndex: number }): void {
         if (event.startIndex === -1) {

--- a/packages/core/src/browser/shell/additional-views-menu-widget.tsx
+++ b/packages/core/src/browser/shell/additional-views-menu-widget.tsx
@@ -23,13 +23,15 @@ import { SideTabBar } from './tab-bars';
 export const AdditionalViewsMenuWidgetFactory = Symbol('AdditionalViewsMenuWidgetFactory');
 export type AdditionalViewsMenuWidgetFactory = (side: 'left' | 'right') => AdditionalViewsMenuWidget;
 
-export const ADDITIONAL_VIEWS_MENU_PATH: MenuPath = ['additional_views_menu'];
-
+export function getAdditionalViewsMenuPath(side: 'left' | 'right'): MenuPath {
+    return ['additional_views_menu', side];
+}
 @injectable()
 export class AdditionalViewsMenuWidget extends SidebarMenuWidget {
     static readonly ID = 'sidebar.additional.views';
 
-    side: 'left' | 'right';
+    protected side: 'left' | 'right';
+    protected menuPath: MenuPath;
 
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
@@ -39,6 +41,11 @@ export class AdditionalViewsMenuWidget extends SidebarMenuWidget {
 
     protected menuDisposables: Disposable[] = [];
 
+    setSide(side: 'left' | 'right'): void {
+        this.side = side;
+        this.menuPath = getAdditionalViewsMenuPath(side);
+    }
+
     updateAdditionalViews(sender: SideTabBar, event: { titles: Title<Widget>[], startIndex: number }): void {
         if (event.startIndex === -1) {
             this.removeMenu(AdditionalViewsMenuWidget.ID);
@@ -47,7 +54,7 @@ export class AdditionalViewsMenuWidget extends SidebarMenuWidget {
                 title: nls.localizeByDefault('Additional Views'),
                 iconClass: codicon('ellipsis'),
                 id: AdditionalViewsMenuWidget.ID,
-                menuPath: ADDITIONAL_VIEWS_MENU_PATH,
+                menuPath: this.menuPath,
                 order: 0
             });
         }
@@ -66,6 +73,6 @@ export class AdditionalViewsMenuWidget extends SidebarMenuWidget {
                 });
             }
         }));
-        this.menuDisposables.push(this.menuModelRegistry.registerMenuAction(ADDITIONAL_VIEWS_MENU_PATH, { commandId: command.id, order: index.toString() }));
+        this.menuDisposables.push(this.menuModelRegistry.registerMenuAction(this.menuPath, { commandId: command.id, order: index.toString() }));
     }
 }

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -653,7 +653,7 @@ export class SidePanelHandler {
     }
 
     protected onTabsOverflowChanged(sender: SideTabBar, event: { titles: Title<Widget>[], startIndex: number }): void {
-        if (event.startIndex >= 0 && event.startIndex <= sender.currentIndex) {
+        if (event.startIndex > 0 && event.startIndex <= sender.currentIndex) {
             sender.revealTab(sender.currentIndex);
         } else {
             this.additionalViewsMenu.updateAdditionalViews(sender, event);

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -211,6 +211,7 @@ export class SidePanelHandler {
     protected createAdditionalViewsWidget(): AdditionalViewsMenuWidget {
         const widget = this.additionalViewsMenuFactory(this.side);
         widget.addClass('theia-sidebar-menu');
+        widget.addClass('theia-additional-views-menu');
         return widget;
     }
 

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -1212,10 +1212,12 @@ export class SideTabBar extends ScrollableTabBar {
                 let overflowStartIndex = -1;
                 for (let i = 0; i < n; i++) {
                     const hiddenTab = hiddenContent.children[i];
-                    // Extract tab padding from the computed style
+                    // Extract tab padding and margin from the computed style
                     const tabStyle = window.getComputedStyle(hiddenTab);
-                    const paddingTop = parseFloat(tabStyle.paddingTop!);
-                    const paddingBottom = parseFloat(tabStyle.paddingBottom!);
+                    const paddingTop = tabStyle.paddingTop ? parseFloat(tabStyle.paddingTop) : 0;
+                    const paddingBottom = tabStyle.paddingBottom ? parseFloat(tabStyle.paddingBottom) : 0;
+                    const marginTop = tabStyle.marginTop ? parseFloat(tabStyle.marginTop) : 0;
+                    const marginBottom = tabStyle.marginBottom ? parseFloat(tabStyle.marginBottom) : 0;
                     const rd: Partial<SideBarRenderData> = {
                         paddingTop,
                         paddingBottom
@@ -1231,28 +1233,20 @@ export class SideTabBar extends ScrollableTabBar {
                     if (iconElements.length === 1) {
                         const icon = iconElements[0];
                         rd.iconSize = { width: icon.clientWidth, height: icon.clientHeight };
-                        actualWidth += icon.clientHeight + paddingTop + paddingBottom + this.tabRowGap;
+                        actualWidth += icon.clientHeight + paddingTop + paddingBottom + marginTop;
 
-                        if (actualWidth > availableWidth && i !== 0) {
+                        if (actualWidth > availableWidth) {
                             rd.visible = false;
                             if (overflowStartIndex === -1) {
                                 overflowStartIndex = i;
                             }
                         }
+                        // Add the tab row gap to the actual width after the visibility check
+                        actualWidth += marginBottom + this.tabRowGap;
                         renderData[i] = rd;
                     }
                 }
 
-                // Special handling if only one element is overflowing.
-                if (overflowStartIndex === n - 1 && renderData[overflowStartIndex]) {
-                    if (!this.tabsOverflowData) {
-                        overflowStartIndex--;
-                        renderData[overflowStartIndex].visible = false;
-                    } else {
-                        renderData[overflowStartIndex].visible = true;
-                        overflowStartIndex = -1;
-                    }
-                }
                 // Render into the visible node
                 this.renderTabs(this.contentNode, renderData);
                 this.computeOverflowingTabsData(overflowStartIndex);

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -1084,8 +1084,6 @@ export class SideTabBar extends ScrollableTabBar {
         startIndex: number
     };
 
-    protected _rowGap: number;
-
     constructor(options?: TabBar.IOptions<Widget> & PerfectScrollbar.Options) {
         super(options);
 
@@ -1142,31 +1140,6 @@ export class SideTabBar extends ScrollableTabBar {
         }
     }
 
-    // Queries the tabRowGap value of the content node. Needed to properly compute overflowing
-    // tabs that should be hidden
-    protected get tabRowGap(): number {
-        // We assume that the tab row gap is static i.e. we compute it once an then cache it
-        if (!this._rowGap) {
-            this._rowGap = this.computeTabRowGap();
-        }
-        return this._rowGap;
-
-    }
-
-    protected computeTabRowGap(): number {
-        const style = window.getComputedStyle(this.contentNode);
-        const rowGapStyle = style.getPropertyValue('row-gap');
-        const numericValue = parseFloat(rowGapStyle);
-        const unit = rowGapStyle.match(/[a-zA-Z]+/)?.[0];
-
-        const tempDiv = document.createElement('div');
-        tempDiv.style.height = '1' + unit;
-        document.body.appendChild(tempDiv);
-        const rowGapValue = numericValue * tempDiv.offsetHeight;
-        document.body.removeChild(tempDiv);
-        return rowGapValue;
-    }
-
     /**
      * Reveal the tab with the given index by moving it into the non-overflowing tabBar section
      * if necessary.
@@ -1207,20 +1180,13 @@ export class SideTabBar extends ScrollableTabBar {
                 const hiddenContent = this.hiddenContentNode;
                 const n = hiddenContent.children.length;
                 const renderData = new Array<Partial<SideBarRenderData>>(n);
-                const availableWidth = this.node.clientHeight - this.tabRowGap;
-                let actualWidth = 0;
-                let overflowStartIndex = -1;
                 for (let i = 0; i < n; i++) {
                     const hiddenTab = hiddenContent.children[i];
-                    // Extract tab padding and margin from the computed style
+                    // Extract tab padding, and margin from the computed style
                     const tabStyle = window.getComputedStyle(hiddenTab);
-                    const paddingTop = tabStyle.paddingTop ? parseFloat(tabStyle.paddingTop) : 0;
-                    const paddingBottom = tabStyle.paddingBottom ? parseFloat(tabStyle.paddingBottom) : 0;
-                    const marginTop = tabStyle.marginTop ? parseFloat(tabStyle.marginTop) : 0;
-                    const marginBottom = tabStyle.marginBottom ? parseFloat(tabStyle.marginBottom) : 0;
                     const rd: Partial<SideBarRenderData> = {
-                        paddingTop,
-                        paddingBottom
+                        paddingTop: parseFloat(tabStyle.paddingTop!),
+                        paddingBottom: parseFloat(tabStyle.paddingBottom!)
                     };
                     // Extract label size from the DOM
                     const labelElements = hiddenTab.getElementsByClassName('p-TabBar-tabLabel');
@@ -1233,30 +1199,21 @@ export class SideTabBar extends ScrollableTabBar {
                     if (iconElements.length === 1) {
                         const icon = iconElements[0];
                         rd.iconSize = { width: icon.clientWidth, height: icon.clientHeight };
-                        actualWidth += icon.clientHeight + paddingTop + paddingBottom + marginTop;
-
-                        if (actualWidth > availableWidth) {
-                            rd.visible = false;
-                            if (overflowStartIndex === -1) {
-                                overflowStartIndex = i;
-                            }
-                        }
-                        // Add the tab row gap to the actual width after the visibility check
-                        actualWidth += marginBottom + this.tabRowGap;
-                        renderData[i] = rd;
                     }
-                }
 
+                    renderData[i] = rd;
+                }
                 // Render into the visible node
                 this.renderTabs(this.contentNode, renderData);
-                this.computeOverflowingTabsData(overflowStartIndex);
+                this.computeOverflowingTabsData();
             });
         }
     }
 
-    protected computeOverflowingTabsData(startIndex: number): void {
+    protected computeOverflowingTabsData(): void {
         // ensure that render tabs has completed
         window.requestAnimationFrame(() => {
+            const startIndex = this.hideOverflowingTabs();
             if (startIndex === -1) {
                 if (this.tabsOverflowData) {
                     this.tabsOverflowData = undefined;
@@ -1278,6 +1235,38 @@ export class SideTabBar extends ScrollableTabBar {
                 this.tabsOverflowChanged.emit(this.tabsOverflowData);
             }
         });
+    }
+
+    /**
+     * Hide overflowing tabs and return the index of the first hidden tab.
+     */
+    protected hideOverflowingTabs(): number {
+        const availableHeight = this.node.clientHeight;
+        const invisibleClass = 'p-mod-invisible';
+        let startIndex = -1;
+        const n = this.contentNode.children.length;
+        for (let i = 0; i < n; i++) {
+            const tab = this.contentNode.children[i] as HTMLLIElement;
+            if (tab.offsetTop + tab.offsetHeight >= availableHeight) {
+                tab.classList.add(invisibleClass);
+                if (startIndex === -1) {
+                    startIndex = i;
+                    /* If only one element is overflowing and the additional menu widget is visible (i.e. this.tabsOverflowData is set)
+                     * there might already be enough space to show the last tab. In this case, we need to include the size of the
+                     * additional menu widget and recheck if the last tab is visible */
+                    if (startIndex === n - 1 && this.tabsOverflowData) {
+                        const additionalViewsMenu = this.node.parentElement?.querySelector('.theia-additional-views-menu') as HTMLDivElement;
+                        if (tab.offsetTop + tab.offsetHeight < availableHeight + additionalViewsMenu.offsetHeight) {
+                            tab.classList.remove(invisibleClass);
+                            startIndex = -1;
+                        }
+                    }
+                }
+            } else {
+                tab.classList.remove(invisibleClass);
+            }
+        }
+        return startIndex;
     }
 
     /**


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
- Ensure that last visible element also gets added to `...` overflow menu if there is not enough space
  (Normally this only happens if there is also a top menu configured for the side bar. Otherwise application specific
  min height restrictions typically prevent resizing that far)
- Remove special behavior for only one overflowing element
  -  This behavior would always add a second element to the `overflow` menu if only one element is currently overflowing. This did not work for the case where only two tabs where open in the first place. In addition, it unnecessarily hide a tab in some cases even if there was enough space to render it. This is inline with the behavior of VS Code.
- Also consider potential tab margins in overflow computation

Fixes #13482

Contributed on behalf of STMicroelectronics
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

__Precondition__:
To fully test this you should have ta at least one top menu in the sidebar. Otherwise application specific minimum size settings might prevent you from reszing the window to a point where all tabs are hidden.

I did this by adding the following code to the `configure` method of the `CommonFrontendContribution`

```ts
app.shell.leftPanelHandler.addTopMenu({
            id: 'settings-menu1',
            iconClass: 'codicon codicon-settings-gear',
            title: nls.localizeByDefault(CommonCommands.MANAGE_CATEGORY),
            menuPath: MANAGE_MENU,
            order: 1,
        });
app.shell.leftPanelHandler.addTopMenu({
            id: 'settings-menu2',
            iconClass: 'codicon codicon-settings-gear',
            title: nls.localizeByDefault(CommonCommands.MANAGE_CATEGORY),
            menuPath: MANAGE_MENU,
            order: 1,
        });
```
The test the overflow behavior by resizing the window.
In particular you should ensure that the previously bugged corner cases are now working as expected
1. Overflow with only two open tabs.
On master the overflow behavior does not work as expected. Instead of showing  the 
`...` menu the view icons just flicker.

2. Ensure that the last not-hidden tab (i.e. the first tab overall) also gets hidden if there is not enough space
3. Ensure that overflow is working correctly if margins are added via custom styling
  You can do this in the dev tools by adding he following rule to the `inspector stylesheet`
  ```css
    .p-TabBar-tab{
      margin-top:15px;
      margin-bottom:15px;
  }
  ```
  If the `inspector-stylesheet` does not show up via ctrl+p you might have to force the creation by navigating to the
  `elements` tabs and applying a new style via the `toolbox` in the styles section:
  
![image](https://github.com/eclipse-theia/theia/assets/2311075/e6ede28a-eceb-4e87-932f-f5363f7bdd02)

After that the stylesheet should be present.

See also this short demo video for reference:

https://github.com/eclipse-theia/theia/assets/2311075/84a68c6b-cc76-4200-a7db-fce40afdf013



#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
