### PR TITLE
Avoid disposal of QuickInputExt on hide

### DIFF
--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -455,7 +455,6 @@ export class QuickInputExt implements theia.QuickInput {
 
     hide(): void {
         this.quickOpenMain.$hide();
-        this.dispose();
     }
 
     protected convertURL(iconPath: URI | { light: string | URI; dark: string | URI } | ThemeIcon):


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Remove implicit `dispose()` in `QuickInputExt.hide()`. This prevented quick input/quick pick instances from being shown again after they were hidden. This aligns the behavior with VS Code.
Note that there is still another issue related to this:
The following code sequence will open an empty quickpick overlay:

```ts
const quickPick = vscode.window.createQuickPick();
quickPick.items = [{ label: 'A' }, { label: 'B' }];
quickPick.show();
quickPick.hide();
quickPick.show();
```
This issue is also present in VS Code and is caused by the underlying monaco implementation.
If we also want to fix this we would probably have to directly change this in monaco.
There exists a workaround: Setting the items again before showing results in a correct quick pick overlay.

```ts
const quickPick = vscode.window.createQuickPick();
quickPick.items = [{ label: 'A' }, { label: 'B' }];
quickPick.show();
quickPick.hide();
quickPick.items = [{ label: 'A' }, { label: 'B' }];
quickPick.show();
```

Fixes https://github.com/eclipse-theia/theia/issues/13072

Contributed on behalf of STMicroelectronics

#### How to test
You can use the following plugin (vsix+sourcecode) to test this:
[theia13072.zip](https://github.com/eclipse-theia/theia/files/14586321/theia13072.zip)

This plugin contributed 3 commands
- `Test quickpick (hide,show)`: Creates a quick pick, hides it, then shows it again
- `Test quickpick (show,hide,show)`: Creates a quick pick,shows it, hides it, then shows it again. This is the error case described above that results in an empty quickpick overlay
- `Test quickpick (show,hide,show)`: Same as the show-hide-show command but it also incorporate the workaround (setting items again before showing). This should result in a correct quickpick overlay.

Here is also a quick demo how the commands behave on master and the PR branch:
Master:

https://github.com/eclipse-theia/theia/assets/2311075/a5f6f3c1-b177-4682-9334-1db6e2650fde

PR:

https://github.com/eclipse-theia/theia/assets/2311075/6c5077fc-33c7-4422-8308-bb78d1b735b8



<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
