### PR TITLE
Remove deprecated actions and Playwright API usage

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -20,10 +20,10 @@ jobs:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Use Python 3.x
+      - name: Use Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: '3.11'
 
       - name: Build
         shell: bash
@@ -36,14 +36,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
 
       - name: Performance (browser)
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: yarn performance:startup:browser
+        shell: bash
+        run: yarn performance:startup:browser
 
       - name: Performance (Electron)
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: yarn performance:startup:electron
+        shell: bash
+        run: xvfb-run yarn performance:startup:electron
 
       - name: Analyze performance results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -36,12 +36,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
 
       - name: Performance (browser)
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: yarn performance:startup:browser
 
       - name: Performance (Electron)
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: yarn performance:startup:electron
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,6 +49,5 @@ jobs:
           yarn --cwd examples/playwright build
 
       - name: Test (playwright)
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: yarn --cwd examples/playwright ui-tests-ci
+        shell: bash
+        run: yarn --cwd examples/playwright ui-tests-ci

--- a/.github/workflows/production-smoke-test.yml
+++ b/.github/workflows/production-smoke-test.yml
@@ -47,6 +47,5 @@ jobs:
           yarn --cwd examples/playwright build
 
       - name: Run Smoke Test (examples/playwright/src/tests/theia-app)
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: yarn test:playwright theia-app
+        shell: bash
+        run: yarn test:playwright theia-app

--- a/examples/playwright/src/theia-quick-command-palette.ts
+++ b/examples/playwright/src/theia-quick-command-palette.ts
@@ -64,12 +64,10 @@ export class TheiaQuickCommandPalette extends TheiaPageObject {
             this.open();
         }
         const input = this.page.locator(`${this.selector} .monaco-inputbox .input`);
-        if (input != null) {
-            await input.focus();
-            await input.pressSequentially(value, { delay: USER_KEY_TYPING_DELAY });
-            if (confirm) {
-                await this.page.keyboard.press('Enter');
-            }
+        await input.focus();
+        await input.pressSequentially(value, { delay: USER_KEY_TYPING_DELAY });
+        if (confirm) {
+            await this.page.keyboard.press('Enter');
         }
     }
 

--- a/examples/playwright/src/theia-quick-command-palette.ts
+++ b/examples/playwright/src/theia-quick-command-palette.ts
@@ -63,10 +63,10 @@ export class TheiaQuickCommandPalette extends TheiaPageObject {
         if (!await this.isOpen()) {
             this.open();
         }
-        const input = await this.page.waitForSelector(`${this.selector} .monaco-inputbox .input`);
+        const input = this.page.locator(`${this.selector} .monaco-inputbox .input`);
         if (input != null) {
             await input.focus();
-            await input.type(value, { delay: USER_KEY_TYPING_DELAY });
+            await input.pressSequentially(value, { delay: USER_KEY_TYPING_DELAY });
             if (confirm) {
                 await this.page.keyboard.press('Enter');
             }

--- a/examples/playwright/src/theia-rename-dialog.ts
+++ b/examples/playwright/src/theia-rename-dialog.ts
@@ -15,15 +15,14 @@
 // *****************************************************************************
 
 import { TheiaDialog } from './theia-dialog';
-import { OSUtil, USER_KEY_TYPING_DELAY } from './util';
+import { OSUtil } from './util';
 
 export class TheiaRenameDialog extends TheiaDialog {
 
     async enterNewName(newName: string): Promise<void> {
         const inputField = await this.page.waitForSelector(`${this.blockSelector} .theia-input`);
         await inputField.press(OSUtil.isMacOS ? 'Meta+a' : 'Control+a');
-        await inputField.type(newName, { delay: USER_KEY_TYPING_DELAY });
-        await this.page.waitForTimeout(USER_KEY_TYPING_DELAY);
+        await inputField.fill(newName);
     }
 
     async confirm(): Promise<void> {

--- a/examples/playwright/src/theia-rename-dialog.ts
+++ b/examples/playwright/src/theia-rename-dialog.ts
@@ -15,14 +15,14 @@
 // *****************************************************************************
 
 import { TheiaDialog } from './theia-dialog';
-import { OSUtil } from './util';
+import { USER_KEY_TYPING_DELAY } from './util';
 
 export class TheiaRenameDialog extends TheiaDialog {
 
     async enterNewName(newName: string): Promise<void> {
-        const inputField = await this.page.waitForSelector(`${this.blockSelector} .theia-input`);
-        await inputField.press(OSUtil.isMacOS ? 'Meta+a' : 'Control+a');
-        await inputField.fill(newName);
+        const inputField = this.page.locator(`${this.blockSelector} .theia-input`);
+        await inputField.selectText();
+        await inputField.pressSequentially(newName, { delay: USER_KEY_TYPING_DELAY });
     }
 
     async confirm(): Promise<void> {

--- a/examples/playwright/src/theia-terminal.ts
+++ b/examples/playwright/src/theia-terminal.ts
@@ -38,7 +38,7 @@ export class TheiaTerminal extends TheiaView {
     async write(text: string): Promise<void> {
         await this.activate();
         const input = await this.waitForInputArea();
-        await input.type(text);
+        await input.fill(text);
     }
 
     async contents(): Promise<string> {


### PR DESCRIPTION
#### What it does

* Replace usage of deprecated `GabrielBB/xvfb-action@v1`
* Replace usage of deprecated `<obj>.type(...)`

Contributed on behalf of STMicroelectronics.

#### How to test

Ensure workflows and Playwright tests still work as before.

#### Follow-ups

We should update https://github.com/eclipse-theia/theia-playwright-template and https://github.com/eclipse-theia/theia-e2e-test-suite accordingly to avoid using the deprecated GH action.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
