### PR TITLE
Resolve links to workspace files in terminal

### DIFF
--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -9,6 +9,7 @@
     "@theia/process": "1.47.0",
     "@theia/variable-resolver": "1.47.0",
     "@theia/workspace": "1.47.0",
+    "@theia/file-search": "1.47.0",
     "tslib": "^2.6.2",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -41,7 +41,7 @@ import { TerminalThemeService } from './terminal-theme-service';
 import { QuickAccessContribution } from '@theia/core/lib/browser/quick-input/quick-access';
 import { createXtermLinkFactory, TerminalLinkProvider, TerminalLinkProviderContribution, XtermLinkFactory } from './terminal-link-provider';
 import { UrlLinkProvider } from './terminal-url-link-provider';
-import { FileDiffPostLinkProvider, FileDiffPreLinkProvider, FileLinkProvider } from './terminal-file-link-provider';
+import { FileDiffPostLinkProvider, FileDiffPreLinkProvider, FileLinkProvider, LocalFileLinkProvider } from './terminal-file-link-provider';
 import {
     ContributedTerminalProfileStore, DefaultProfileStore, DefaultTerminalProfileService,
     TerminalProfileService, TerminalProfileStore, UserTerminalProfileStore
@@ -123,6 +123,8 @@ export default new ContainerModule(bind => {
     bind(TerminalLinkProvider).toService(FileDiffPreLinkProvider);
     bind(FileDiffPostLinkProvider).toSelf().inSingletonScope();
     bind(TerminalLinkProvider).toService(FileDiffPostLinkProvider);
+    bind(LocalFileLinkProvider).toSelf().inSingletonScope();
+    bind(TerminalLinkProvider).toService(LocalFileLinkProvider);
 
     bind(ContributedTerminalProfileStore).to(DefaultProfileStore).inSingletonScope();
     bind(UserTerminalProfileStore).to(DefaultProfileStore).inSingletonScope();

--- a/packages/terminal/tsconfig.json
+++ b/packages/terminal/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../editor"
     },
     {
+      "path": "../file-search"
+    },
+    {
       "path": "../filesystem"
     },
     {


### PR DESCRIPTION




<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Try and provide links for paths pointing to workspace files in the terminal. The links are created by searching for matching files based on the provided path.

Fixes #13047

Contributed on behalf of STMicroelectronics
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Open the theia workspace and echo some partial paths in the terminal. All paths that can be resolved to a workspace file should have valid links that can be used to open the files from the terminal, e.g.:
* ../../packages/terminal/src/browser/terminal-file-link-provider.ts:17:20
* src/browser/terminal-file-link-provider.ts

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
