### PR TITLE
fix keybindings triggering when cell editor is focused

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -328,12 +328,12 @@ export class NotebookCellActionContribution implements MenuContribution, Command
             {
                 command: NotebookCellCommands.TO_CODE_CELL_COMMAND.id,
                 keybinding: 'Y',
-                when: `${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED} && ${NOTEBOOK_CELL_TYPE} == 'markdown'`,
+                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED} && ${NOTEBOOK_CELL_TYPE} == 'markdown'`,
             },
             {
                 command: NotebookCellCommands.TO_MARKDOWN_CELL_COMMAND.id,
                 keybinding: 'M',
-                when: `${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED} && ${NOTEBOOK_CELL_TYPE} == 'code'`,
+                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED} && ${NOTEBOOK_CELL_TYPE} == 'code'`,
             }
         );
     }

--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -113,6 +113,10 @@ export class NotebookContextManager {
 
     }
 
+    onDidEditorTextFocus(focus: boolean): void {
+        this.scopedStore.setContext('inputFocus', focus);
+    }
+
     createContextKeyChangedEvent(affectedKeys: string[]): ContextKeyChangeEvent {
         return { affects: keys => affectedKeys.some(key => keys.has(key)) };
     }

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -97,6 +97,12 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
             this.toDispose.push(this.editor.onDocumentContentChanged(e => {
                 notebookModel.cellDirtyChanged(cell, true);
             }));
+            this.toDispose.push(this.editor.getControl().onDidFocusEditorText(() => {
+                this.props.notebookContextManager.onDidEditorTextFocus(true);
+            }));
+            this.toDispose.push(this.editor.getControl().onDidBlurEditorText(() => {
+                this.props.notebookContextManager.onDidEditorTextFocus(false);
+            }));
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes some keybindings triggering when a cell text-editor is focused.


#### How to test

open a notebook wit a code editor. 
Check that the keybindings for `y` (change to code) `m` (change to markdown) `a`(insert cell above) and `b`(insert cell below) are not working anymore when the text editor is focused,

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
