### PR TITLE
Make sure we can reopen secondary windows

### DIFF
--- a/packages/core/src/electron-browser/window/electron-secondary-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-secondary-window-service.ts
@@ -24,16 +24,12 @@ export class ElectronSecondaryWindowService extends DefaultSecondaryWindowServic
         window.electronTheiaCore.focusWindow(win.name);
     }
 
-    protected override doCreateSecondaryWindow(widget: ExtractableWidget, shell: ApplicationShell): Window | undefined {
-        const w = super.doCreateSecondaryWindow(widget, shell);
-        if (w) {
-            window.electronTheiaCore.setMenuBarVisible(false, w.name);
-            window.electronTheiaCore.setSecondaryWindowCloseRequestHandler(w.name, () => this.canClose(widget, shell));
-        }
-        return w;
+    protected override windowCreated(newWindow: Window, widget: ExtractableWidget, shell: ApplicationShell): void {
+        window.electronTheiaCore.setMenuBarVisible(false, newWindow.name);
+        window.electronTheiaCore.setSecondaryWindowCloseRequestHandler(newWindow.name, () => this.canClose(widget, shell));
     }
     private async canClose(widget: ExtractableWidget, shell: ApplicationShell): Promise<boolean> {
-        await shell.closeWidget(widget.id, undefined);
+        await shell.closeWidget(widget.id);
         return widget.isDisposed;
     }
 }


### PR DESCRIPTION


#### What it does
There were two problems: 

1. A listener for the 'close' even on secondary windows went missing in the browser case when introducing secondary window support for Electron
2. The code uses a listener for the 'close' event on the secondary window. However, this event does not exist. So basically, this never worked 🤦 

Fixes #13214

Contributred on behalf of STMicroelectronics.


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Open and close secondary windows in both the browser and electron case. Make sure there are no exceptions and documents can be reopened. I used the `hediet.vscode-drawio` extension from open-vsx to test.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
