### PR TITLE
improved focusing of the notebook cell editors

### DIFF
--- a/packages/notebook/src/browser/view-model/notebook-cell-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-cell-model.ts
@@ -100,6 +100,9 @@ export class NotebookCellModel implements NotebookCell, Disposable {
     protected readonly onDidRequestCellEditChangeEmitter = new Emitter<boolean>();
     readonly onDidRequestCellEditChange = this.onDidRequestCellEditChangeEmitter.event;
 
+    protected readonly onWillFocusCellEditorEmitter = new Emitter<void>();
+    readonly onWillFocusCellEditor = this.onWillFocusCellEditorEmitter.event;
+
     @inject(NotebookCellModelProps)
     protected readonly props: NotebookCellModelProps;
     @inject(MonacoTextModelService)
@@ -211,6 +214,11 @@ export class NotebookCellModel implements NotebookCell, Disposable {
     requestStopEdit(): void {
         this._editing = false;
         this.onDidRequestCellEditChangeEmitter.fire(false);
+    }
+
+    requestFocusEditor(): void {
+        this.requestEdit();
+        this.onWillFocusCellEditorEmitter.fire();
     }
 
     spliceNotebookCellOutputs(splice: NotebookCellOutputsSplice): void {

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -344,6 +344,10 @@ export class NotebookModel implements Saveable, Disposable {
 
         this.onDidAddOrRemoveCellEmitter.fire({ rawEvent: { kind: NotebookCellsChangeType.ModelChange, changes }, newCellIds: cells.map(cell => cell.handle) });
         this.onDidChangeContentEmitter.fire([{ kind: NotebookCellsChangeType.ModelChange, changes }]);
+        if (cells.length > 0) {
+            this.setSelectedCell(cells[cells.length - 1]);
+            cells[cells.length - 1].requestEdit();
+        }
     }
 
     protected changeCellInternalMetadataPartial(cell: NotebookCellModel, internalMetadata: NullablePartialNotebookCellInternalMetadata): void {

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -56,6 +56,13 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
         this.toDispose.push(this.props.cell.onWillFocusCellEditor(() => {
             this.editor?.getControl().focus();
         }));
+        this.toDispose.push(this.props.notebookModel.onDidChangeSelectedCell(() => {
+            if (this.props.notebookModel.selectedCell !== this.props.cell && this.editor?.getControl().hasTextFocus()) {
+                if (document.activeElement && 'blur' in document.activeElement) {
+                    (document.activeElement as HTMLElement).blur();
+                }
+            }
+        }));
         if (!this.props.notebookViewportService || (this.container && this.props.notebookViewportService.isElementInViewport(this.container))) {
             this.initEditor();
         } else {

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -53,6 +53,9 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
 
     override componentDidMount(): void {
         this.disposeEditor();
+        this.toDispose.push(this.props.cell.onWillFocusCellEditor(() => {
+            this.editor?.getControl().focus();
+        }));
         if (!this.props.notebookViewportService || (this.container && this.props.notebookViewportService.isElementInViewport(this.container))) {
             this.initEditor();
         } else {
@@ -103,6 +106,9 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
             this.toDispose.push(this.editor.getControl().onDidBlurEditorText(() => {
                 this.props.notebookContextManager.onDidEditorTextFocus(false);
             }));
+            if (cell.editing && notebookModel.selectedCell === cell) {
+                this.editor.getControl().focus();
+            }
         }
     }
 

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -76,7 +76,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
                         notebookContextManager={this.notebookContextManager}
                         notebookViewportService={this.notebookViewportService}
                         fontInfo={this.getOrCreateMonacoFontInfo()} />
-                    <NotebookCodeCellStatus cell={cell} executionStateService={this.executionStateService}></NotebookCodeCellStatus>
+                    <NotebookCodeCellStatus cell={cell} executionStateService={this.executionStateService} onClick={() => cell.requestFocusEditor()}></NotebookCodeCellStatus>
                 </div >
             </div >
             <div className='theia-notebook-cell-with-sidebar'>
@@ -110,6 +110,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
 export interface NotebookCodeCellStatusProps {
     cell: NotebookCellModel;
     executionStateService: NotebookExecutionStateService;
+    onClick: () => void;
 }
 
 export interface NotebookCodeCellStatusState {
@@ -152,7 +153,7 @@ export class NotebookCodeCellStatus extends React.Component<NotebookCodeCellStat
     }
 
     override render(): React.ReactNode {
-        return <div className='notebook-cell-status'>
+        return <div className='notebook-cell-status' onClick={() => this.props.onClick()}>
             <div className='notebook-cell-status-left'>
                 {this.renderExecutionState()}
             </div>

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -54,7 +54,7 @@ interface MarkdownCellProps {
 }
 
 function MarkdownCell({ markdownRenderer, monacoServices, cell, notebookModel, notebookContextManager }: MarkdownCellProps): React.JSX.Element {
-    const [editMode, setEditMode] = React.useState(false);
+    const [editMode, setEditMode] = React.useState(cell.editing);
 
     React.useEffect(() => {
         const listener = cell.onDidRequestCellEditChange(cellEdit => setEditMode(cellEdit));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This improves focusing of cell editors in multiple ways:
- code cell editor will now recieve focus when clicking on the code cell status bar below the editor (the are showing python/markdown and the execution state)
- creating a new code cell now directly focuses the editor
- creating a new markdown cell now sets the cell into edit mode and focuses the editor
- when using shift+enter to execute and select next cell, the cursor does not stay in the previous cells editor anymore

#### How to test

open or create a new notebook. Test the cases listed above

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
