### PR TITLE
Jiden/ipydatagrid+ipyleaflets support

### DIFF
--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -237,12 +237,12 @@ export interface FileSystemProviderCapabilitiesChangeEvent {
 }
 
 export interface FileSystemProviderReadOnlyMessageChangeEvent {
-     /** The affected file system provider for which this event was fired. */
-     provider: FileSystemProvider;
-     /** The uri for which the provider is registered */
-     scheme: string;
-     /** The new read only message */
-     message: MarkdownString | undefined;
+    /** The affected file system provider for which this event was fired. */
+    provider: FileSystemProvider;
+    /** The uri for which the provider is registered */
+    scheme: string;
+    /** The new read only message */
+    message: MarkdownString | undefined;
 }
 
 /**
@@ -378,7 +378,7 @@ export class FileService {
         providerDisposables.push(provider.onFileWatchError(() => this.handleFileWatchError()));
         providerDisposables.push(provider.onDidChangeCapabilities(() => this.onDidChangeFileSystemProviderCapabilitiesEmitter.fire({ provider, scheme })));
         if (ReadOnlyMessageFileSystemProvider.is(provider)) {
-            providerDisposables.push(provider.onDidChangeReadOnlyMessage(message => this.onDidChangeFileSystemProviderReadOnlyMessageEmitter.fire({ provider, scheme, message})));
+            providerDisposables.push(provider.onDidChangeReadOnlyMessage(message => this.onDidChangeFileSystemProviderReadOnlyMessageEmitter.fire({ provider, scheme, message })));
         }
 
         return Disposable.create(() => {

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -243,4 +243,14 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this.viewportService.dispose();
         super.dispose();
     }
+
+    protected override onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        this.notebookEditorService.notebookEditorFocusChanged(this, true);
+    }
+
+    protected override onAfterHide(msg: Message): void {
+        super.onAfterHide(msg);
+        this.notebookEditorService.notebookEditorFocusChanged(this, false);
+    }
 }

--- a/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
+++ b/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
@@ -50,17 +50,8 @@ export class NotebookEditorWidgetService {
     @postConstruct()
     protected init(): void {
         this.applicationShell.onDidChangeActiveWidget(event => {
-            if (event.newValue instanceof NotebookEditorWidget) {
-                if (event.newValue !== this.focusedEditor) {
-                    this.focusedEditor = event.newValue;
-                    this.contextKeyService.setContext(NOTEBOOK_EDITOR_FOCUSED, true);
-                    this.onDidChangeFocusedEditorEmitter.fire(this.focusedEditor);
-                }
-            } else if (event.newValue) {
-                // Only unfocus editor if a new widget has been focused
-                this.focusedEditor = undefined;
-                this.contextKeyService.setContext(NOTEBOOK_EDITOR_FOCUSED, true);
-                this.onDidChangeFocusedEditorEmitter.fire(undefined);
+            if (event.newValue) {
+                this.notebookEditorFocusChanged(event.newValue as NotebookEditorWidget, event.newValue instanceof NotebookEditorWidget);
             }
         });
     }
@@ -90,6 +81,20 @@ export class NotebookEditorWidgetService {
 
     getNotebookEditors(): readonly NotebookEditorWidget[] {
         return Array.from(this.notebookEditors.values());
+    }
+
+    notebookEditorFocusChanged(editor: NotebookEditorWidget, focus: boolean): void {
+        if (focus) {
+            if (editor !== this.focusedEditor) {
+                this.focusedEditor = editor;
+                this.contextKeyService.setContext(NOTEBOOK_EDITOR_FOCUSED, true);
+                this.onDidChangeFocusedEditorEmitter.fire(this.focusedEditor);
+            }
+        } else if (this.focusedEditor && editor === this.focusedEditor) {
+            this.focusedEditor = undefined;
+            this.contextKeyService.setContext(NOTEBOOK_EDITOR_FOCUSED, false);
+            this.onDidChangeFocusedEditorEmitter.fire(undefined);
+        }
     }
 
 }

--- a/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
+++ b/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
@@ -50,9 +50,7 @@ export class NotebookEditorWidgetService {
     @postConstruct()
     protected init(): void {
         this.applicationShell.onDidChangeActiveWidget(event => {
-            if (event.newValue) {
-                this.notebookEditorFocusChanged(event.newValue as NotebookEditorWidget, event.newValue instanceof NotebookEditorWidget);
-            }
+            this.notebookEditorFocusChanged(event.newValue as NotebookEditorWidget, event.newValue instanceof NotebookEditorWidget);
         });
     }
 
@@ -90,7 +88,7 @@ export class NotebookEditorWidgetService {
                 this.contextKeyService.setContext(NOTEBOOK_EDITOR_FOCUSED, true);
                 this.onDidChangeFocusedEditorEmitter.fire(this.focusedEditor);
             }
-        } else if (this.focusedEditor && editor === this.focusedEditor) {
+        } else if (this.focusedEditor) {
             this.focusedEditor = undefined;
             this.contextKeyService.setContext(NOTEBOOK_EDITOR_FOCUSED, false);
             this.onDidChangeFocusedEditorEmitter.fire(undefined);

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -99,6 +99,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
         if (this.editor) {
             this.toDispose.push(this.editor.onDidPostKernelMessage(message => {
+                // console.log('from extension customKernelMessage ', JSON.stringify(message));
                 this.webviewWidget.sendMessage({
                     type: 'customKernelMessage',
                     message
@@ -106,6 +107,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
             }));
 
             this.toDispose.push(this.editor.onPostRendererMessage(messageObj => {
+                // console.log('from extension customRendererMessage ', JSON.stringify(messageObj));
                 this.webviewWidget.sendMessage({
                     type: 'customRendererMessage',
                     ...messageObj
@@ -188,6 +190,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 this.updateOutput({ newOutputs: this.cell.outputs, start: 0, deleteCount: 0 });
                 break;
             case 'customRendererMessage':
+                // console.log('from webview customRendererMessage ', message.rendererId, '', JSON.stringify(message.message));
                 this.messagingService.getScoped(this.editor.id).postMessage(message.rendererId, message.message);
                 break;
             case 'didRenderOutput':
@@ -197,6 +200,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 this.editor.node.getElementsByClassName('theia-notebook-viewport')[0].children[0].scrollBy(message.deltaX, message.deltaY);
                 break;
             case 'customKernelMessage':
+                // console.log('from webview customKernelMessage ', JSON.stringify(message.message));
                 this.editor.recieveKernelMessage(message.message);
                 break;
         }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -573,5 +573,13 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
     });
     window.addEventListener('wheel', handleWheel);
 
+    (document.head as HTMLHeadElement & { originalAppendChild: typeof document.head.appendChild }).originalAppendChild = document.head.appendChild;
+    (document.head as HTMLHeadElement & { originalAppendChild: typeof document.head.appendChild }).appendChild = function appendChild<T extends Node>(node: T): T {
+        if (node instanceof HTMLScriptElement && node.src.includes('webviewuuid')) {
+            node.src = node.src.replace('webviewuuid', location.hostname.split('.')[0]);
+        }
+        return this.originalAppendChild(node);
+    };
+
     theia.postMessage(<webviewCommunication.WebviewInitialized>{ type: 'initialized' });
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -276,7 +276,7 @@ export function createAPIFactory(
     const notebooksExt = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOKS_EXT, new NotebooksExtImpl(rpc, commandRegistry, editorsAndDocumentsExt, documents));
     const notebookEditors = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_EDITORS_EXT, new NotebookEditorsExtImpl(notebooksExt));
     const notebookRenderers = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_RENDERERS_EXT, new NotebookRenderersExtImpl(rpc, notebooksExt));
-    const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry, webviewExt));
+    const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry, webviewExt, workspaceExt));
     const notebookDocuments = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_EXT, new NotebookDocumentsExtImpl(notebooksExt));
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -276,7 +276,7 @@ export function createAPIFactory(
     const notebooksExt = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOKS_EXT, new NotebooksExtImpl(rpc, commandRegistry, editorsAndDocumentsExt, documents));
     const notebookEditors = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_EDITORS_EXT, new NotebookEditorsExtImpl(notebooksExt));
     const notebookRenderers = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_RENDERERS_EXT, new NotebookRenderersExtImpl(rpc, notebooksExt));
-    const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry));
+    const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry, webviewExt));
     const notebookDocuments = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_EXT, new NotebookDocumentsExtImpl(notebooksExt));
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
@@ -744,7 +744,7 @@ export function createAPIFactory(
             registerTextDocumentContentProvider(scheme: string, provider: theia.TextDocumentContentProvider): theia.Disposable {
                 return workspaceExt.registerTextDocumentContentProvider(scheme, provider);
             },
-            registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider, options?: { isCaseSensitive?: boolean, isReadonly?: boolean | MarkdownString}):
+            registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider, options?: { isCaseSensitive?: boolean, isReadonly?: boolean | MarkdownString }):
                 theia.Disposable {
                 return fileSystemExt.registerFileSystemProvider(scheme, provider, options);
             },

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -24,6 +24,7 @@ import { fromViewColumn, toViewColumn, toWebviewPanelShowOptions } from './type-
 import { Disposable, WebviewPanelTargetArea, URI } from './types-impl';
 import { WorkspaceExtImpl } from './workspace';
 import { PluginIconPath } from './plugin-icon-path';
+import { PluginModel, PluginPackage } from '../common';
 
 @injectable()
 export class WebviewsExtImpl implements WebviewsExt {
@@ -194,6 +195,14 @@ export class WebviewsExtImpl implements WebviewsExt {
             return this.webviewPanels.get(viewId);
         }
         return undefined;
+    }
+
+    toGeneralWebviewResource(extension: PluginModel, resource: theia.Uri): theia.Uri {
+        const extensionUri = URI.parse(extension.packageUri);
+        const relativeResourcePath = resource.path.replace(extensionUri.path, '');
+        const basePath = PluginPackage.toPluginUrl(extension, '') + relativeResourcePath;
+
+        return URI.parse(this.initData!.webviewResourceRoot.replace('{{uuid}}', 'webviewUUID')).with({ path: basePath });
     }
 
     public deleteWebview(handle: string): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

this adds support for other ipywidget types like ipydatagrid and ipyleaflets.
Also fixes focusing of notebook editor widget after its shown and updating associated notebooks for extensions after the workspace was granted trust.

To explain overwriting the append child of head in `output-webview.internal.ts` a bit more: 
Vscode has a single endpoint all webviews can downlaod script files from, in theia though every webview can only download files from its own host address as the endpoint. 
There is a `asWebviewURL` function in the extension API which we don't know for which webview the webviewUri is for. In VScode thsts no problem because the endpoint is always the same but in theia its dependent on the webview.
So what im doing is adding a placeholder to the url which is replaced when a script is added to the head to generate the correct URL and make downloading the script work.

#### How to test

`pip install ipydatagrid` in your used python environment
Create or open a notebook and add the following cell.

```python
import numpy as np
import pandas as pd
from ipydatagrid import DataGrid

df = pd.DataFrame(
    data={
        "Col1HasAVeryLongName": [1, 2, 4],
        "Col2MediumName": [4, 5, 6],
        "Col3": [7, 8, 10],
    }
)
grid = DataGrid(df, index_name="index_column", layout={"height": "90px"})
grid
```

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
