### PR TITLE
Fix monaco localization

### DIFF
--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -14,22 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import * as MonacoNls from '@theia/monaco-editor-core/esm/vs/nls';
-import { nls } from '@theia/core/lib/common/nls';
-import { FormatType, Localization } from '@theia/core/lib/common/i18n/localization';
-
-Object.assign(MonacoNls, {
-    localize(_key: string, label: string, ...args: FormatType[]): string {
-        if (nls.locale) {
-            const defaultKey = nls.getDefaultKey(label);
-            if (defaultKey) {
-                return nls.localize(defaultKey, label, ...args);
-            }
-        }
-        return Localization.format(label, args);
-    }
-});
-
 import '../../src/browser/style/index.css';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { MenuContribution, CommandContribution, quickInputServicePath } from '@theia/core/lib/common';

--- a/packages/monaco/src/browser/monaco-init.ts
+++ b/packages/monaco/src/browser/monaco-init.ts
@@ -27,6 +27,23 @@
  * is allowed.
  */
 
+// Before importing anything from monaco we need to override its localization function
+import * as MonacoNls from '@theia/monaco-editor-core/esm/vs/nls';
+import { nls } from '@theia/core/lib/common/nls';
+import { FormatType, Localization } from '@theia/core/lib/common/i18n/localization';
+
+Object.assign(MonacoNls, {
+    localize(_key: string, label: string, ...args: FormatType[]): string {
+        if (nls.locale) {
+            const defaultKey = nls.getDefaultKey(label);
+            if (defaultKey) {
+                return nls.localize(defaultKey, label, ...args);
+            }
+        }
+        return Localization.format(label, args);
+    }
+});
+
 import { Container } from '@theia/core/shared/inversify';
 import { ICodeEditorService } from '@theia/monaco-editor-core/esm/vs/editor/browser/services/codeEditorService';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';

--- a/packages/vsx-registry/src/browser/vsx-language-quick-pick-service.ts
+++ b/packages/vsx-registry/src/browser/vsx-language-quick-pick-service.ts
@@ -72,7 +72,7 @@ export class VSXLanguageQuickPickService extends LanguageQuickPickService {
                                     localizationContribution.localizedLanguageName ?? localizationContribution.languageName ?? localizationContribution.languageId),
                             });
                             try {
-                                const extensionUri = VSCodeExtensionUri.fromId(extension.extension.name, extension.extension.namespace).toString();
+                                const extensionUri = VSCodeExtensionUri.fromId(`${extension.extension.namespace}.${extension.extension.name}`).toString();
                                 await this.pluginServer.deploy(extensionUri);
                             } finally {
                                 progress.cancel();


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13438
Closes https://github.com/eclipse-theia/theia/issues/13556

Moves the monaco localization code into the `monaco-init.ts` file so that the localization function is overriden before any other monaco code is loaded.

Fixes the automatic install of language packs as a drive-by.

#### How to test

1. Change the language of Theia to any other than English.
2. Open the context menu of a monaco editor. It should be correctly translated

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
