### PR TITLE
Fix window revealing when navigating with multiple windows

### DIFF
--- a/packages/core/src/electron-browser/preload.ts
+++ b/packages/core/src/electron-browser/preload.ts
@@ -75,7 +75,7 @@ const api: TheiaCoreAPI = {
         ipcRenderer.send(CHANNEL_SET_MENU, mainMenuId, convertMenu(menu, handlers));
     },
     getSecurityToken: () => ipcRenderer.sendSync(CHANNEL_GET_SECURITY_TOKEN),
-    focusWindow: (name: string) => ipcRenderer.send(CHANNEL_FOCUS_WINDOW, name),
+    focusWindow: (name?: string) => ipcRenderer.send(CHANNEL_FOCUS_WINDOW, name),
     showItemInFolder: fsPath => {
         ipcRenderer.send(CHANNEL_SHOW_ITEM_IN_FOLDER, fsPath);
     },

--- a/packages/core/src/electron-browser/window/electron-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-window-service.ts
@@ -58,7 +58,7 @@ export class ElectronWindowService extends DefaultWindowService {
     }
 
     override focus(): void {
-        window.electronTheiaCore.focusWindow(window.name);
+        window.electronTheiaCore.focusWindow();
     }
     @postConstruct()
     protected init(): void {

--- a/packages/core/src/electron-common/electron-api.ts
+++ b/packages/core/src/electron-common/electron-api.ts
@@ -53,7 +53,7 @@ export interface TheiaCoreAPI {
     popup(menu: MenuDto[], x: number, y: number, onClosed: () => void, windowName?: string): Promise<number>;
     closePopup(handle: number): void;
 
-    focusWindow(name: string): void;
+    focusWindow(name?: string): void;
 
     showItemInFolder(fsPath: string): void;
 

--- a/packages/core/src/electron-main/electron-api-main.ts
+++ b/packages/core/src/electron-main/electron-api-main.ts
@@ -147,7 +147,9 @@ export class TheiaMainApi implements ElectronMainApplicationContribution {
 
         // focus windows for secondary window support
         ipcMain.on(CHANNEL_FOCUS_WINDOW, (event, windowName) => {
-            const electronWindow = BrowserWindow.getAllWindows().find(win => win.webContents.mainFrame.name === windowName);
+            const electronWindow = windowName
+                ? BrowserWindow.getAllWindows().find(win => win.webContents.mainFrame.name === windowName)
+                : BrowserWindow.fromWebContents(event.sender);
             if (electronWindow) {
                 if (electronWindow.isMinimized()) {
                     electronWindow.restore();


### PR DESCRIPTION
#### What it does

Makes sure the correct window is brought to the top when navigating between editors.

Fixes: #13559

Contributed on behalf of STMicroelectronics

#### How to test
1. Follow the scenario from the linked issue and make sure the correct windows is revealed when navigating in both windows
2. In each Theia window from scenario No. 1, open a file in a secondary window and make sure we can navigate from both the secondary window and the main window and vice-versa.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
