### PR TITLE
Always consider the "passthrough" commmand enabled for keybindings

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -497,7 +497,7 @@ export class KeybindingRegistry {
 
     isEnabledInScope(binding: common.Keybinding, target: HTMLElement | undefined): boolean {
         const context = binding.context && this.contexts[binding.context];
-        if (binding.command && !this.commandRegistry.isEnabled(binding.command, binding.args)) {
+        if (binding.command && (!this.isPseudoCommand(binding.command) && !this.commandRegistry.isEnabled(binding.command, binding.args))) {
             return false;
         }
         if (context && !context.isEnabled(binding)) {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Theia has a "passthrough" command that is supposed to mark occasions where keystrokes are supposed to be passed to the target widget instead of being handled by the keybinding infrastructure. We recently added a check whether a keybinding has an enabled command handler to be considered active. But since the "passthrough" command has no handler, it was always considered disabled. This PR considers the passthrough command as always enabled.

Fixes #13560

Contributed on behalf of STMicroelectronics
#### How to test
Make sure `ctrl-c` aborts running tasks in the terminal. Make sure ctrl-c still works to copy text/files, etc elsewhere.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
