### PR TITLE
fix context for multiple notebooks

### DIFF
--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -27,7 +27,6 @@ import { NotebookEditorWidgetFactory } from './notebook-editor-widget-factory';
 import { NotebookCellResourceResolver } from './notebook-cell-resource-resolver';
 import { NotebookModelResolverService } from './service/notebook-model-resolver-service';
 import { NotebookCellActionContribution } from './contributions/notebook-cell-actions-contribution';
-import { NotebookCellToolbarFactory } from './view/notebook-cell-toolbar-factory';
 import { createNotebookModelContainer, NotebookModel, NotebookModelFactory, NotebookModelProps } from './view-model/notebook-model';
 import { createNotebookCellModelContainer, NotebookCellModel, NotebookCellModelFactory, NotebookCellModelProps } from './view-model/notebook-cell-model';
 import { createNotebookEditorWidgetContainer, NotebookEditorWidgetContainerFactory, NotebookEditorProps, NotebookEditorWidget } from './notebook-editor-widget';
@@ -53,7 +52,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookRendererRegistry).toSelf().inSingletonScope();
 
     bind(WidgetFactory).to(NotebookEditorWidgetFactory).inSingletonScope();
-    bind(NotebookCellToolbarFactory).toSelf().inSingletonScope();
 
     bind(NotebookService).toSelf().inSingletonScope();
     bind(NotebookEditorWidgetService).toSelf().inSingletonScope();

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -235,8 +235,10 @@ export class NotebookModel implements Saveable, Disposable {
     }
 
     setSelectedCell(cell: NotebookCellModel): void {
-        this.selectedCell = cell;
-        this.onDidChangeSelectedCellEmitter.fire(cell);
+        if (this.selectedCell !== cell) {
+            this.selectedCell = cell;
+            this.onDidChangeSelectedCellEmitter.fire(cell);
+        }
     }
 
     private addCellOutputListeners(cells: NotebookCellModel[]): void {

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -45,7 +45,7 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
 
     constructor(props: CellListProps) {
         super(props);
-        this.state = { selectedCell: undefined, dragOverIndicator: undefined };
+        this.state = { selectedCell: props.notebookModel.selectedCell, dragOverIndicator: undefined };
         this.toDispose.push(props.notebookModel.onDidAddOrRemoveCell(e => {
             if (e.newCellIds && e.newCellIds.length > 0) {
                 this.setState({ ...this.state, selectedCell: this.props.notebookModel.cells.find(model => model.handle === e.newCellIds![e.newCellIds!.length - 1]) });

--- a/packages/notebook/src/browser/view/notebook-cell-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-toolbar.tsx
@@ -35,8 +35,9 @@ abstract class NotebookCellActionBar extends React.Component<NotebookCellToolbar
     constructor(props: NotebookCellToolbarProps) {
         super(props);
         this.toDispose.push(props.onContextKeysChanged(e => {
-            if (this.props.getMenuItems().some(item => item.contextKeys ? e.affects(item.contextKeys) : false)) {
-                this.setState({ inlineItems: this.props.getMenuItems() });
+            const menuItems = this.props.getMenuItems();
+            if (menuItems.some(item => item.contextKeys ? e.affects(item.contextKeys) : false)) {
+                this.setState({ inlineItems: menuItems });
             }
         }));
         this.state = { inlineItems: this.props.getMenuItems() };


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Focuses and puts the first cell in edit mode when creating a new empty notebook
- fixes context for multiple open notebooks (this seemed to be broken before)

#### How to test

Create a new notebook. See first cell is selected and the editor is focused.

Create a second new notebook. cell toolbar should show the correct entries

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
