### PR TITLE
reenable initial reading of execution summary

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -749,9 +749,9 @@ export function isUriComponents(arg: unknown): arg is UriComponents {
     return isObject<UriComponents>(arg) &&
         typeof arg.scheme === 'string' &&
         (arg['$mid'] === 1 || (
-        typeof arg.path === 'string' &&
-        typeof arg.query === 'string' &&
-        typeof arg.fragment === 'string'));
+            typeof arg.path === 'string' &&
+            typeof arg.query === 'string' &&
+            typeof arg.fragment === 'string'));
 }
 
 export function isModelCallHierarchyItem(arg: unknown): arg is model.CallHierarchyItem {
@@ -1522,8 +1522,8 @@ export namespace NotebookCellData {
             cellKind: NotebookCellKind.from(data.kind),
             language: data.languageId,
             source: data.value,
-            // metadata: data.metadata,
-            // internalMetadata: NotebookCellExecutionSummary.from(data.executionSummary ?? {}),
+            metadata: data.metadata,
+            internalMetadata: NotebookCellExecutionSummary.from(data.executionSummary ?? {}),
             outputs: data.outputs ? data.outputs.map(NotebookCellOutputConverter.from) : []
         };
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

It reenables the reading of the execution summary from the deserialized notebook data. 
This shows the exectution order (cell numbers) correctly after first opening the notebook

#### How to test

open or create a new notebook. Execute a cell and check the cell number has been set correctly. Close and reopen the notebook and see the cell number should be set correctly again

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
