### PR TITLE
Disable clear all outputs in notebook main toolbar

### DIFF
--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -467,3 +467,21 @@ export class AsyncEmitter<T extends WaitUntilEvent> extends Emitter<T> {
     }
 
 }
+
+export class QueueableEmitter<T> extends Emitter<T[]> {
+
+    currentQueue?: T[];
+
+    queue(...arg: T[]): void {
+        if (!this.currentQueue) {
+            this.currentQueue = [];
+        }
+        this.currentQueue.push(...arg);
+    }
+
+    override fire(): void {
+        super.fire(this.currentQueue || []);
+        this.currentQueue = undefined;
+    }
+
+}

--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -24,7 +24,7 @@ import { NotebookKernelQuickPickService } from '../service/notebook-kernel-quick
 import { NotebookExecutionService } from '../service/notebook-execution-service';
 import { NotebookEditorWidget } from '../notebook-editor-widget';
 import { NotebookEditorWidgetService } from '../service/notebook-editor-widget-service';
-import { NOTEBOOK_CELL_FOCUSED, NOTEBOOK_EDITOR_FOCUSED } from './notebook-context-keys';
+import { NOTEBOOK_CELL_FOCUSED, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_HAS_OUTPUTS } from './notebook-context-keys';
 
 export namespace NotebookCommands {
     export const ADD_NEW_CELL_COMMAND = Command.toDefaultLocalizedCommand({
@@ -141,7 +141,10 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
         ));
 
         commands.registerCommand(NotebookCommands.CLEAR_ALL_OUTPUTS_COMMAND, this.editableCommandHandler(
-            notebookModel => notebookModel.cells.forEach(cell => cell.spliceNotebookCellOutputs({ start: 0, deleteCount: cell.outputs.length, newOutputs: [] }))
+            notebookModel => notebookModel.applyEdits(notebookModel.cells.map(cell => ({
+                editType: CellEditType.Output,
+                handle: cell.handle, deleteCount: cell.outputs.length, outputs: []
+            })), false)
         ));
 
         commands.registerCommand(NotebookCommands.CHANGE_SELECTED_CELL,
@@ -217,7 +220,8 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
             commandId: NotebookCommands.CLEAR_ALL_OUTPUTS_COMMAND.id,
             label: nls.localizeByDefault('Clear All Outputs'),
             icon: codicon('clear-all'),
-            order: '30'
+            order: '30',
+            when: NOTEBOOK_HAS_OUTPUTS
         });
         // other items
     }

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -301,7 +301,10 @@ export class NotebookCellActionContribution implements MenuContribution, Command
             }
         });
         commands.registerCommand(NotebookCellCommands.CLEAR_OUTPUTS_COMMAND, this.editableCellCommandHandler(
-            (_, cell) => cell.spliceNotebookCellOutputs({ start: 0, deleteCount: (cell ?? this.getSelectedCell()).outputs.length, newOutputs: [] })
+            (notebook, cell) => notebook.applyEdits([{
+                editType: CellEditType.Output,
+                handle: cell.handle, outputs: [], deleteCount: cell.outputs.length, append: false
+            }], true)
         ));
         commands.registerCommand(NotebookCellCommands.CHANGE_OUTPUT_PRESENTATION_COMMAND, this.editableCellCommandHandler(
             (_, __, output) => output?.requestOutputPresentationUpdate()

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -303,7 +303,10 @@ export class NotebookCellActionContribution implements MenuContribution, Command
         commands.registerCommand(NotebookCellCommands.CLEAR_OUTPUTS_COMMAND, this.editableCellCommandHandler(
             (notebook, cell) => notebook.applyEdits([{
                 editType: CellEditType.Output,
-                handle: cell.handle, outputs: [], deleteCount: cell.outputs.length, append: false
+                handle: cell.handle,
+                outputs: [],
+                deleteCount: cell.outputs.length,
+                append: false
             }], true)
         ));
         commands.registerCommand(NotebookCellCommands.CHANGE_OUTPUT_PRESENTATION_COMMAND, this.editableCellCommandHandler(

--- a/packages/notebook/src/browser/notebook-types.ts
+++ b/packages/notebook/src/browser/notebook-types.ts
@@ -111,6 +111,7 @@ export interface CellOutputEdit {
     editType: CellEditType.Output;
     index: number;
     outputs: CellOutput[];
+    deleteCount?: number;
     append?: boolean;
 }
 
@@ -118,6 +119,7 @@ export interface CellOutputEditByHandle {
     editType: CellEditType.Output;
     handle: number;
     outputs: CellOutput[];
+    deleteCount?: number;
     append?: boolean;
 }
 

--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -29,7 +29,6 @@ import { NotebookEditorWidget } from '../notebook-editor-widget';
 import { NotebookCellModel } from '../view-model/notebook-cell-model';
 import { CellKind, NotebookCellsChangeType } from '../../common';
 import { NotebookExecutionStateService } from './notebook-execution-state-service';
-import debounce = require('@theia/core/shared/lodash.debounce');
 
 @injectable()
 export class NotebookContextManager {

--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -22,13 +22,14 @@ import {
     NOTEBOOK_CELL_EDITABLE,
     NOTEBOOK_CELL_EXECUTING, NOTEBOOK_CELL_EXECUTION_STATE,
     NOTEBOOK_CELL_FOCUSED, NOTEBOOK_CELL_MARKDOWN_EDIT_MODE,
-    NOTEBOOK_CELL_TYPE, NOTEBOOK_KERNEL, NOTEBOOK_KERNEL_SELECTED,
+    NOTEBOOK_CELL_TYPE, NOTEBOOK_HAS_OUTPUTS, NOTEBOOK_KERNEL, NOTEBOOK_KERNEL_SELECTED,
     NOTEBOOK_VIEW_TYPE
 } from '../contributions/notebook-context-keys';
 import { NotebookEditorWidget } from '../notebook-editor-widget';
 import { NotebookCellModel } from '../view-model/notebook-cell-model';
-import { CellKind } from '../../common';
+import { CellKind, NotebookCellsChangeType } from '../../common';
 import { NotebookExecutionStateService } from './notebook-execution-state-service';
+import debounce = require('@theia/core/shared/lodash.debounce');
 
 @injectable()
 export class NotebookContextManager {
@@ -72,6 +73,15 @@ export class NotebookContextManager {
                 this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_KERNEL_SELECTED, NOTEBOOK_KERNEL]));
             }
         }));
+
+        widget.model?.onDidChangeContent(events => {
+            if (events.some(e => e.kind === NotebookCellsChangeType.ModelChange || e.kind === NotebookCellsChangeType.Output)) {
+                this.scopedStore.setContext(NOTEBOOK_HAS_OUTPUTS, widget.model?.cells.some(cell => cell.outputs.length > 0));
+                this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_HAS_OUTPUTS]));
+            }
+        });
+
+        this.scopedStore.setContext(NOTEBOOK_HAS_OUTPUTS, !!widget.model?.cells.find(cell => cell.outputs.length > 0));
 
         // Cell Selection realted keys
         this.scopedStore.setContext(NOTEBOOK_CELL_FOCUSED, !!widget.model?.selectedCell);

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -213,8 +213,9 @@
   cursor: pointer;
 }
 
-.theia-notebook-main-toolbar-item:hover {
-  background-color: var(--theia-toolbar-hoverBackground);
+.theia-notebook-main-toolbar-item.theia-mod-disabled:hover {
+  background-color: transparent;
+  cursor: default;
 }
 
 .theia-notebook-main-toolbar-item-text {

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Disposable, Emitter, Event, Resource, URI } from '@theia/core';
+import { Disposable, Emitter, Event, QueueableEmitter, Resource, URI } from '@theia/core';
 import { Saveable, SaveOptions } from '@theia/core/lib/browser';
 import {
     CellData, CellEditType, CellUri, NotebookCellInternalMetadata,
@@ -65,7 +65,7 @@ export class NotebookModel implements Saveable, Disposable {
     protected readonly onDidAddOrRemoveCellEmitter = new Emitter<NotebookModelWillAddRemoveEvent>();
     readonly onDidAddOrRemoveCell = this.onDidAddOrRemoveCellEmitter.event;
 
-    protected readonly onDidChangeContentEmitter = new Emitter<NotebookContentChangedEvent[]>();
+    protected readonly onDidChangeContentEmitter = new QueueableEmitter<NotebookContentChangedEvent>();
     readonly onDidChangeContent = this.onDidChangeContentEmitter.event;
 
     protected readonly onDidChangeSelectedCellEmitter = new Emitter<NotebookCellModel | undefined>();
@@ -281,13 +281,18 @@ export class NotebookModel implements Saveable, Disposable {
                     } else {
                         // could definitely be more efficient. See vscode __spliceNotebookCellOutputs2
                         // For now, just replace the whole existing output with the new output
-                        cell.spliceNotebookCellOutputs({ start: 0, deleteCount: cell.outputs.length, newOutputs: edit.outputs });
+                        cell.spliceNotebookCellOutputs({ start: 0, deleteCount: edit.deleteCount ?? cell.outputs.length, newOutputs: edit.outputs });
                     }
-
+                    this.onDidChangeContentEmitter.queue({ kind: NotebookCellsChangeType.Output, index: cellIndex, outputs: cell.outputs, append: edit.append ?? false });
                     break;
                 }
                 case CellEditType.OutputItems:
                     cell.changeOutputItems(edit.outputId, !!edit.append, edit.items);
+                    this.onDidChangeContentEmitter.queue({
+                        kind: NotebookCellsChangeType.OutputItem, index: cellIndex, outputItems: edit.items,
+                        outputId: edit.outputId, append: edit.append ?? false
+                    });
+
                     break;
                 case CellEditType.Metadata:
                     this.changeCellMetadata(this.cells[cellIndex], edit.metadata, computeUndoRedo);
@@ -308,11 +313,14 @@ export class NotebookModel implements Saveable, Disposable {
                     this.moveCellToIndex(cellIndex, edit.length, edit.newIdx, computeUndoRedo);
                     break;
             }
+
             // if selected cell is affected update it because it can potentially have been replaced
             if (cell === this.selectedCell) {
                 this.setSelectedCell(this.cells[cellIndex]);
             }
         }
+
+        this.onDidChangeContentEmitter.fire();
 
     }
 
@@ -352,7 +360,7 @@ export class NotebookModel implements Saveable, Disposable {
         await Promise.all(cells.map(cell => cell.resolveTextModel()));
 
         this.onDidAddOrRemoveCellEmitter.fire({ rawEvent: { kind: NotebookCellsChangeType.ModelChange, changes }, newCellIds: cells.map(cell => cell.handle) });
-        this.onDidChangeContentEmitter.fire([{ kind: NotebookCellsChangeType.ModelChange, changes }]);
+        this.onDidChangeContentEmitter.queue({ kind: NotebookCellsChangeType.ModelChange, changes });
         if (cells.length > 0) {
             this.setSelectedCell(cells[cells.length - 1]);
             cells[cells.length - 1].requestEdit();
@@ -370,9 +378,7 @@ export class NotebookModel implements Saveable, Disposable {
         }
 
         cell.internalMetadata = newInternalMetadata;
-        this.onDidChangeContentEmitter.fire([
-            { kind: NotebookCellsChangeType.ChangeCellInternalMetadata, index: this.cells.indexOf(cell), internalMetadata: newInternalMetadata }
-        ]);
+        this.onDidChangeContentEmitter.queue({ kind: NotebookCellsChangeType.ChangeCellInternalMetadata, index: this.cells.indexOf(cell), internalMetadata: newInternalMetadata });
     }
 
     protected updateNotebookMetadata(metadata: NotebookDocumentMetadata, computeUndoRedo: boolean): void {
@@ -385,7 +391,7 @@ export class NotebookModel implements Saveable, Disposable {
         }
 
         this.metadata = metadata;
-        this.onDidChangeContentEmitter.fire([{ kind: NotebookCellsChangeType.ChangeDocumentMetadata, metadata: this.metadata }]);
+        this.onDidChangeContentEmitter.queue({ kind: NotebookCellsChangeType.ChangeDocumentMetadata, metadata: this.metadata });
     }
 
     protected changeCellMetadataPartial(cell: NotebookCellModel, metadata: NullablePartialNotebookCellMetadata, computeUndoRedo: boolean): void {
@@ -417,7 +423,7 @@ export class NotebookModel implements Saveable, Disposable {
         }
 
         cell.metadata = metadata;
-        this.onDidChangeContentEmitter.fire([{ kind: NotebookCellsChangeType.ChangeCellMetadata, index: this.cells.indexOf(cell), metadata: cell.metadata }]);
+        this.onDidChangeContentEmitter.queue({ kind: NotebookCellsChangeType.ChangeCellMetadata, index: this.cells.indexOf(cell), metadata: cell.metadata });
     }
 
     protected changeCellLanguage(cell: NotebookCellModel, languageId: string, computeUndoRedo: boolean): void {
@@ -427,7 +433,7 @@ export class NotebookModel implements Saveable, Disposable {
 
         cell.language = languageId;
 
-        this.onDidChangeContentEmitter.fire([{ kind: NotebookCellsChangeType.ChangeCellLanguage, index: this.cells.indexOf(cell), language: languageId }]);
+        this.onDidChangeContentEmitter.queue({ kind: NotebookCellsChangeType.ChangeCellLanguage, index: this.cells.indexOf(cell), language: languageId });
     }
 
     protected moveCellToIndex(fromIndex: number, length: number, toIndex: number, computeUndoRedo: boolean): boolean {
@@ -440,7 +446,7 @@ export class NotebookModel implements Saveable, Disposable {
 
         const cells = this.cells.splice(fromIndex, length);
         this.cells.splice(toIndex, 0, ...cells);
-        this.onDidChangeContentEmitter.fire([{ kind: NotebookCellsChangeType.Move, index: fromIndex, length, newIdx: toIndex, cells }]);
+        this.onDidChangeContentEmitter.queue({ kind: NotebookCellsChangeType.Move, index: fromIndex, length, newIdx: toIndex, cells });
 
         return true;
     }

--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -57,6 +57,10 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
 
     protected toDispose = new DisposableCollection();
 
+    protected nativeSubmenus = [
+        NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_CELL_ADD_GROUP[NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_CELL_ADD_GROUP.length - 1],
+        NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_EXECUTION_GROUP[NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_EXECUTION_GROUP.length - 1]];
+
     constructor(props: NotebookMainToolbarProps) {
         super(props);
 
@@ -107,22 +111,22 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
         </div>;
     }
 
-    protected renderMenuItem(item: MenuNode): React.ReactNode {
+    protected renderMenuItem(item: MenuNode, submenu?: string): React.ReactNode {
         if (item.role === CompoundMenuNodeRole.Group) {
-            const itemNodes = ArrayUtils.coalesce(item.children?.map(child => this.renderMenuItem(child)) ?? []);
+            const itemNodes = ArrayUtils.coalesce(item.children?.map(child => this.renderMenuItem(child, item.id)) ?? []);
             return <React.Fragment key={item.id}>
                 {itemNodes}
                 {itemNodes && itemNodes.length > 0 && <span key={`${item.id}-separator`} className='theia-notebook-toolbar-separator'></span>}
             </React.Fragment>;
-        } else if (!item.when || this.props.contextKeyService.match(item.when, this.props.editorNode)) {
+        } else if ((this.nativeSubmenus.includes(submenu ?? '')) || !item.when || this.props.contextKeyService.match(item.when, this.props.editorNode)) {
             const visibleCommand = Boolean(this.props.commandRegistry.getVisibleHandler(item.command ?? '', this.props.notebookModel));
             if (!visibleCommand) {
                 return undefined;
             }
             const title = (this.props.commandRegistry.getCommand(item.command ?? '') as NotebookCommand)?.tooltip ?? item.label;
-            return <div key={item.id} title={title} className='theia-notebook-main-toolbar-item action-label'
+            return <div key={item.id} title={title} className={`theia-notebook-main-toolbar-item action-label${this.getAdditionalClasses(item)}`}
                 onClick={() => {
-                    if (item.command) {
+                    if (item.command && (!item.when || this.props.contextKeyService.match(item.when, this.props.editorNode))) {
                         this.props.commandRegistry.executeCommand(item.command, this.props.notebookModel);
                     }
                 }}>
@@ -133,15 +137,18 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
         return undefined;
     }
 
-    private getMenuItems(): readonly MenuNode[] {
+    protected getMenuItems(): readonly MenuNode[] {
         const menuPath = NotebookMenus.NOTEBOOK_MAIN_TOOLBAR;
         const pluginCommands = this.props.menuRegistry.getMenuNode(menuPath).children;
         const theiaCommands = this.props.menuRegistry.getMenu([menuPath]).children;
-        // TODO add specifc arguments to commands
         return theiaCommands.concat(pluginCommands);
     }
 
-    private getAllContextKeys(menus: readonly MenuNode[], keySet: Set<string>): void {
+    protected getAdditionalClasses(item: MenuNode): string {
+        return !item.when || this.props.contextKeyService.match(item.when, this.props.editorNode) ? '' : ' theia-mod-disabled';
+    }
+
+    protected getAllContextKeys(menus: readonly MenuNode[], keySet: Set<string>): void {
         menus.filter(item => item.when)
             .forEach(item => this.props.contextKeyService.parseKeys(item.when!)?.forEach(key => keySet.add(key)));
 

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -749,9 +749,9 @@ export function isUriComponents(arg: unknown): arg is UriComponents {
     return isObject<UriComponents>(arg) &&
         typeof arg.scheme === 'string' &&
         (arg['$mid'] === 1 || (
-        typeof arg.path === 'string' &&
-        typeof arg.query === 'string' &&
-        typeof arg.fragment === 'string'));
+            typeof arg.path === 'string' &&
+            typeof arg.query === 'string' &&
+            typeof arg.fragment === 'string'));
 }
 
 export function isModelCallHierarchyItem(arg: unknown): arg is model.CallHierarchyItem {
@@ -1522,8 +1522,8 @@ export namespace NotebookCellData {
             cellKind: NotebookCellKind.from(data.kind),
             language: data.languageId,
             source: data.value,
-            // metadata: data.metadata,
-            // internalMetadata: NotebookCellExecutionSummary.from(data.executionSummary ?? {}),
+            metadata: data.metadata,
+            internalMetadata: NotebookCellExecutionSummary.from(data.executionSummary ?? {}),
             outputs: data.outputs ? data.outputs.map(NotebookCellOutputConverter.from) : []
         };
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This disables the clear all outputs command in the notebook main toolbar when no outputs are available in the notebook.

#### How to test

Open or create a new notebook. Execute cells and clear the outputs. Depending on if there are outputs in the notebook the clear all output option should be enabled or disabled

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
