### PR TITLE
Improve notebook cell context key handling

### DIFF
--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -53,6 +53,8 @@ export class NotebookContextManager {
         return this._context;
     }
 
+    protected cellContexts: Map<number, Record<string, unknown>> = new Map();
+
     init(widget: NotebookEditorWidget): void {
         this._context = widget.node;
         this.scopedStore = this.contextKeyService.createScoped(widget.node);
@@ -80,6 +82,14 @@ export class NotebookContextManager {
             this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_CELL_FOCUSED]));
         });
 
+        this.toDispose.push(this.executionStateService.onDidChangeExecution(e => {
+            if (e.notebook.toString() === widget.model?.uri.toString()) {
+                this.setCellContext(e.cellHandle, NOTEBOOK_CELL_EXECUTING, !!e.changed);
+                this.setCellContext(e.cellHandle, NOTEBOOK_CELL_EXECUTION_STATE, e.changed?.state ?? 'idle');
+                this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_CELL_EXECUTING, NOTEBOOK_CELL_EXECUTION_STATE]));
+            }
+        }));
+
         widget.model?.onDidChangeSelectedCell(e => this.selectedCellChanged(e));
 
         this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_VIEW_TYPE, NOTEBOOK_KERNEL_SELECTED, NOTEBOOK_KERNEL]));
@@ -100,17 +110,24 @@ export class NotebookContextManager {
                 this.scopedStore.setContext(NOTEBOOK_CELL_EDITABLE, cell.cellKind === CellKind.Markup && !cellEdit);
                 this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_CELL_MARKDOWN_EDIT_MODE]));
             }));
-            this.cellDisposables.push(this.executionStateService.onDidChangeExecution(e => {
-                if (cell && e.affectsCell(cell.uri)) {
-                    this.scopedStore.setContext(NOTEBOOK_CELL_EXECUTING, !!e.changed);
-                    this.scopedStore.setContext(NOTEBOOK_CELL_EXECUTION_STATE, e.changed?.state ?? 'idle');
-                    this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_CELL_EXECUTING, NOTEBOOK_CELL_EXECUTION_STATE]));
-                }
-            }));
         }
 
         this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_CELL_TYPE]));
 
+    }
+
+    protected setCellContext(cellHandle: number, key: string, value: unknown): void {
+        let cellContext = this.cellContexts.get(cellHandle);
+        if (!cellContext) {
+            cellContext = {};
+            this.cellContexts.set(cellHandle, cellContext);
+        }
+
+        cellContext[key] = value;
+    }
+
+    withCellContext<T>(cellHandle: number, action: () => unknown): unknown {
+        return this.contextKeyService.with(this.cellContexts.get(cellHandle) ?? {}, action);
     }
 
     onDidEditorTextFocus(focus: boolean): void {

--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { ContextKeyChangeEvent, ContextKeyService, ScopedValueStore } from '@theia/core/lib/browser/context-key-service';
+import { ContextKeyChangeEvent, ContextKeyService, ContextMatcher, ScopedValueStore } from '@theia/core/lib/browser/context-key-service';
 import { DisposableCollection, Emitter } from '@theia/core';
 import { NotebookKernelService } from './notebook-kernel-service';
 import {
@@ -126,8 +126,8 @@ export class NotebookContextManager {
         cellContext[key] = value;
     }
 
-    withCellContext<T>(cellHandle: number, action: () => unknown): unknown {
-        return this.contextKeyService.with(this.cellContexts.get(cellHandle) ?? {}, action);
+    getCellContext(cellHandle: number): ContextMatcher {
+        return this.contextKeyService.createOverlay(Object.entries(this.cellContexts.get(cellHandle) ?? {}));
     }
 
     onDidEditorTextFocus(focus: boolean): void {

--- a/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
@@ -64,16 +64,17 @@ export class NotebookCellToolbarFactory {
 
     private getMenuItems(menuItemPath: string[], notebookModel: NotebookModel, cell: NotebookCellModel, output?: NotebookCellOutputModel): NotebookCellToolbarItem[] {
         const inlineItems: NotebookCellToolbarItem[] = [];
-
-        for (const menuNode of this.menuRegistry.getMenu(menuItemPath).children) {
-            if (!menuNode.when || this.contextKeyService.match(menuNode.when, this.notebookContextManager.context)) {
-                if (menuNode.role === CompoundMenuNodeRole.Flat) {
-                    inlineItems.push(...menuNode.children?.map(child => this.createToolbarItem(child, notebookModel, cell, output)) ?? []);
-                } else {
-                    inlineItems.push(this.createToolbarItem(menuNode, notebookModel, cell, output));
+        this.notebookContextManager.withCellContext(cell.handle, () => {
+            for (const menuNode of this.menuRegistry.getMenu(menuItemPath).children) {
+                if (!menuNode.when || this.contextKeyService.match(menuNode.when, this.notebookContextManager.context)) {
+                    if (menuNode.role === CompoundMenuNodeRole.Flat) {
+                        inlineItems.push(...menuNode.children?.map(child => this.createToolbarItem(child, notebookModel, cell, output)) ?? []);
+                    } else {
+                        inlineItems.push(this.createToolbarItem(menuNode, notebookModel, cell, output));
+                    }
                 }
             }
-        }
+        });
         return inlineItems;
     }
 

--- a/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
@@ -64,17 +64,15 @@ export class NotebookCellToolbarFactory {
 
     private getMenuItems(menuItemPath: string[], notebookModel: NotebookModel, cell: NotebookCellModel, output?: NotebookCellOutputModel): NotebookCellToolbarItem[] {
         const inlineItems: NotebookCellToolbarItem[] = [];
-        this.notebookContextManager.withCellContext(cell.handle, () => {
-            for (const menuNode of this.menuRegistry.getMenu(menuItemPath).children) {
-                if (!menuNode.when || this.contextKeyService.match(menuNode.when, this.notebookContextManager.context)) {
-                    if (menuNode.role === CompoundMenuNodeRole.Flat) {
-                        inlineItems.push(...menuNode.children?.map(child => this.createToolbarItem(child, notebookModel, cell, output)) ?? []);
-                    } else {
-                        inlineItems.push(this.createToolbarItem(menuNode, notebookModel, cell, output));
-                    }
+        for (const menuNode of this.menuRegistry.getMenu(menuItemPath).children) {
+            if (!menuNode.when || this.notebookContextManager.getCellContext(cell.handle).match(menuNode.when, this.notebookContextManager.context)) {
+                if (menuNode.role === CompoundMenuNodeRole.Flat) {
+                    inlineItems.push(...menuNode.children?.map(child => this.createToolbarItem(child, notebookModel, cell, output)) ?? []);
+                } else {
+                    inlineItems.push(this.createToolbarItem(menuNode, notebookModel, cell, output));
                 }
             }
-        });
+        }
         return inlineItems;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

just a small fix to not change the execute button for each cell when only executing one

#### How to test

Open a notebook and add multiple code cells. Execute one cell, the other cells execute icons should not be affected, only the the executed cell should show the cancel icon

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
