### PR TITLE
Fix notebook cell EOL splitting

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-dto.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-dto.ts
@@ -94,7 +94,7 @@ export namespace NotebookDto {
         return {
             handle: cell.handle,
             uri: cell.uri.toComponents(),
-            source: cell.text.split(eol),
+            source: cell.text.split(/\r?\n/g),
             eol,
             language: cell.language,
             cellKind: cell.cellKind,

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -32,7 +32,7 @@ import { UriComponents } from '../../common/uri-components';
 import { CommandsConverter } from '../command-registry';
 import * as typeConverters from '../type-converters';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
-import { NotebookDocument } from './notebook-document';
+import { Cell, NotebookDocument } from './notebook-document';
 import { NotebookEditor } from './notebook-editor';
 import { EditorsAndDocumentsExtImpl } from '../editors-and-documents';
 import { DocumentsExtImpl } from '../documents';
@@ -243,14 +243,7 @@ export class NotebooksExtImpl implements NotebooksExt {
                 this.documents.set(uri.toString(), document);
 
                 this.textDocumentsAndEditors.$acceptEditorsAndDocumentsDelta({
-                    addedDocuments: modelData.cells.map(cell => ({
-                        uri: cell.uri,
-                        versionId: 1,
-                        lines: cell.source,
-                        EOL: cell.eol,
-                        modeId: '',
-                        isDirty: false
-                    }))
+                    addedDocuments: modelData.cells.map(cell => Cell.asModelAddData(cell))
                 });
 
                 this.onDidOpenNotebookDocumentEmitter.fire(document.apiNotebook);


### PR DESCRIPTION
#### What it does

When opening a notebook with `\n` line endings on Windows, cell editing wasn't applied to the plugin host, since the EOL splitting used the system EOL instead of being more lenient with the line endings.

This change uses a less strict regex to split the lines to ensure that `\n` is being correctly split on Windows.

#### How to test

1. Open a notebook document that has a code cell that uses Unix-style line endings.
2. Edit that cell and confirm that the cell content has actually changed on the plugin host (i.e. run the cell and confirm that the runtime behavior is consistent with the code)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
