### PR TITLE
Open editor on file upload

### DIFF
--- a/packages/filesystem/src/browser/file-upload-service.ts
+++ b/packages/filesystem/src/browser/file-upload-service.ts
@@ -30,6 +30,7 @@ import { FileSystemPreferences } from './filesystem-preferences';
 import { FileService } from './file-service';
 import { ConfirmDialog, Dialog } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
+import { Emitter, Event } from '@theia/core/lib/common/event';
 
 export const HTTP_UPLOAD_URL: string = new Endpoint({ path: HTTP_FILE_UPLOAD_PATH }).getRestUrl().toString(true);
 
@@ -61,6 +62,12 @@ export class FileUploadService {
 
     static TARGET = 'target';
     static UPLOAD = 'upload';
+
+    protected readonly onDidUploadEmitter = new Emitter<string[]>();
+
+    get onDidUpload(): Event<string[]> {
+        return this.onDidUploadEmitter.event;
+    }
 
     protected uploadForm: FileUploadService.Form;
     protected deferredUpload?: Deferred<FileUploadResult>;
@@ -250,6 +257,7 @@ export class FileUploadService {
                 throw error;
             }
         }
+        this.onDidUploadEmitter.fire(result.uploaded);
         return result;
     }
 


### PR DESCRIPTION
#### What it does

When uploading a file to vscode web, the app automatically opens the newly uploaded file in an editor.
It also does this when overriding a file, replacing the current editor content, even if it's dirty.

This change aligns Theia to vscode's behavior and also opens the uploaded file. It first closes all widgets for this file and then reopens the editor.

#### How to test

1. Open a file in your workspace (text/code file or notebook)
2. Overwrite it with a different file (but same name) by uploading via the navigator widget (or use the `Upload Files...` command in the context menu of the navigator)
3. Confirm that the file is correctly updated (if it was open) or newly opened (if it wasn't previously)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
