### PR TITLE
Hide empty plugin view containers from user

### DIFF
--- a/examples/playwright/src/tests/theia-quick-command.test.ts
+++ b/examples/playwright/src/tests/theia-quick-command.test.ts
@@ -61,8 +61,8 @@ test.describe('Theia Quick Command', () => {
     });
 
     test('should trigger \'Toggle Explorer View\' command after typing', async () => {
-        await quickCommand.type('Toggle Explorer');
-        await quickCommand.trigger('Toggle Explorer View');
+        await quickCommand.type('Toggle Exp');
+        await quickCommand.trigger('View: Toggle Explorer');
         expect(await quickCommand.isOpen()).toBe(false);
         const explorerView = new TheiaExplorerView(app);
         expect(await explorerView.isDisplayed()).toBe(true);

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -18,7 +18,7 @@ import { injectable, inject, interfaces, optional } from 'inversify';
 import { Widget } from '@phosphor/widgets';
 import {
     MenuModelRegistry, Command, CommandContribution,
-    MenuContribution, CommandRegistry
+    MenuContribution, CommandRegistry, nls
 } from '../../common';
 import { KeybindingContribution, KeybindingRegistry } from '../keybinding';
 import { WidgetManager } from '../widget-manager';
@@ -69,7 +69,8 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
         if (options.toggleCommandId) {
             this.toggleCommand = {
                 id: options.toggleCommandId,
-                label: 'Toggle ' + this.viewLabel + ' View'
+                category: nls.localizeByDefault('View'),
+                label: nls.localizeByDefault('Toggle {0}', this.viewLabel)
             };
         }
     }


### PR DESCRIPTION
#### What it does

For some reason, the jupyter notebook extension registers an empty view container. See [here](https://github.com/microsoft/vscode-jupyter/blob/7d8d3274703ce1ceb46a04c9feb106e3d791a70e/package.json#L2014-L2020). Theia shows the empty container in the `Views` menu and even allows the user to open it (even though it is completely empty):

![image](https://github.com/eclipse-theia/theia/assets/4377073/f16f0d4f-9ce2-4f08-8e82-8d3e34a8e55e)

However, this doesn't matter in vscode, as empty view containers (i.e. view containers which never have a view registered to them) are just not visible to the user in any way.

This change aligns our UX to vscode and only registers the appropriate commands/menu entries once a view has been added to the view container.

#### How to test

1. Install the Jupyter plugin
2. Only one `Jupyter` entry should be visible in the `Views` menu
3. Only one `View: Toggle Jupyter` command should be visible
4. All other plugin view containers should work as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
