### PR TITLE
Fix remote support in packaged apps

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -52,10 +52,12 @@ if (process.env.LC_ALL) {
 }
 process.env.LC_NUMERIC = 'C';
 
+const { resolve } = require('path');
+const theiaAppProjectPath = resolve(__dirname, '..', '..');
+process.env.THEIA_APP_PROJECT_PATH = theiaAppProjectPath;
 const { default: electronMainApplicationModule } = require('@theia/core/lib/electron-main/electron-main-application-module');
 const { ElectronMainApplication, ElectronMainApplicationGlobals } = require('@theia/core/lib/electron-main/electron-main-application');
 const { Container } = require('inversify');
-const { resolve } = require('path');
 const { app } = require('electron');
 
 const config = ${this.prettyStringify(this.pck.props.frontend.config)};
@@ -71,7 +73,7 @@ const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true
     const container = new Container();
     container.load(electronMainApplicationModule);
     container.bind(ElectronMainApplicationGlobals).toConstantValue({
-        THEIA_APP_PROJECT_PATH: resolve(__dirname, '..', '..'),
+        THEIA_APP_PROJECT_PATH: theiaAppProjectPath,
         THEIA_BACKEND_MAIN_PATH: resolve(__dirname, 'main.js'),
         THEIA_FRONTEND_HTML_PATH: resolve(__dirname, '..', '..', 'lib', 'frontend', 'index.html'),
     });
@@ -119,6 +121,7 @@ if ('ELECTRON_RUN_AS_NODE' in process.env) {
 }
 
 const path = require('path');
+process.env.THEIA_APP_PROJECT_PATH = path.resolve(__dirname, '..', '..')
 const express = require('express');
 const { Container } = require('inversify');
 const { BackendApplication, BackendApplicationServer, CliManager } = require('@theia/core/lib/node');

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -548,10 +548,6 @@ export class ElectronMainApplication {
     protected async startBackend(): Promise<number> {
         // Check if we should run everything as one process.
         const noBackendFork = process.argv.indexOf('--no-cluster') !== -1;
-        // We cannot use the `process.cwd()` as the application project path (the location of the `package.json` in other words)
-        // in a bundled electron application because it depends on the way we start it. For instance, on OS X, these are a differences:
-        // https://github.com/eclipse-theia/theia/issues/3297#issuecomment-439172274
-        process.env.THEIA_APP_PROJECT_PATH = this.globals.THEIA_APP_PROJECT_PATH;
         // Set the electron version for both the dev and the production mode. (https://github.com/eclipse-theia/theia/issues/3254)
         // Otherwise, the forked backend processes will not know that they're serving the electron frontend.
         process.env.THEIA_ELECTRON_VERSION = process.versions.electron;

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -21,7 +21,7 @@ import {
     bindContributionProvider, MessageService, MessageClient, ConnectionHandler, RpcConnectionHandler,
     CommandService, commandServicePath, messageServicePath, OSBackendProvider, OSBackendProviderPath
 } from '../common';
-import { BackendApplication, BackendApplicationContribution, BackendApplicationCliContribution, BackendApplicationServer } from './backend-application';
+import { BackendApplication, BackendApplicationContribution, BackendApplicationCliContribution, BackendApplicationServer, BackendApplicationPath } from './backend-application';
 import { CliManager, CliContribution } from './cli';
 import { IPCConnectionProvider } from './messaging';
 import { ApplicationServerImpl } from './application-server';
@@ -101,10 +101,7 @@ export const backendApplicationModule = new ContainerModule(bind => {
         })
     ).inSingletonScope();
 
-    bind(ApplicationPackage).toDynamicValue(({ container }) => {
-        const { projectPath } = container.get(BackendApplicationCliContribution);
-        return new ApplicationPackage({ projectPath });
-    }).inSingletonScope();
+    bind(ApplicationPackage).toConstantValue(new ApplicationPackage({ projectPath: BackendApplicationPath }));
 
     bind(WsRequestValidator).toSelf().inSingletonScope();
     bindContributionProvider(bind, WsRequestValidatorContribution);

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -22,6 +22,7 @@ import { pathExists, mkdir } from 'fs-extra';
 import { EnvVariable, EnvVariablesServer } from '../../common/env-variables';
 import { isWindows } from '../../common/os';
 import { FileUri } from '../../common/file-uri';
+import { BackendApplicationPath } from '../backend-application';
 
 @injectable()
 export class EnvVariablesServerImpl implements EnvVariablesServer {
@@ -45,10 +46,7 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
     }
 
     protected async createConfigDirUri(): Promise<string> {
-        let dataFolderPath: string = '';
-        if (process.env.THEIA_APP_PROJECT_PATH) {
-            dataFolderPath = join(process.env.THEIA_APP_PROJECT_PATH, 'data');
-        }
+        const dataFolderPath = join(BackendApplicationPath, 'data');
         const userDataPath = join(dataFolderPath, 'user-data');
         const dataFolderExists = this.pathExistenceCache[dataFolderPath] ??= await pathExists(dataFolderPath);
         if (dataFolderExists) {

--- a/packages/remote/src/electron-node/setup/remote-copy-contribution.ts
+++ b/packages/remote/src/electron-node/setup/remote-copy-contribution.ts
@@ -61,8 +61,7 @@ export class RemoteCopyRegistry {
         const globResult = await promiseGlob(pattern, {
             cwd: projectPath
         });
-        const relativeFiles = globResult.map(file => path.relative(projectPath, file));
-        for (const file of relativeFiles) {
+        for (const file of globResult) {
             const targetFile = this.withTarget(file, target);
             this.files.push({
                 path: file,


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13140

Currently. the `ApplicationPackage` service is bound this way:

```ts
bind(ApplicationPackage).toDynamicValue(({ container }) => {
  const { projectPath } = container.get(BackendApplicationCliContribution);
  return new ApplicationPackage({ projectPath });
}).inSingletonScope();
```

However, the `projectPath` remains undefined, until the CLI app lifecycle has completed. This means that the `ApplicationPackage` may already be injected into other services with its `projectPath` undefined. This seems to be the case in https://github.com/eclipse-theia/theia-blueprint/pull/350 and in https://github.com/eclipse-theia/theia/issues/13140.

This change changes the way the `projectPath` is set. Instead of waiting until the CLI lifecycle completes, we set the `BackendApplicationPath` as soon as possible (at js load time). It didn't really make a lot of sense for the `projectPath` to be a CLI setting anyway, given that we use it to find our own code.

#### How to test

1. Use the SSH remote feature and assert that it works as expected
2. Open a webview from a plugin and assert that it loads and works as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
