### PR TITLE
Use notebook URI as context for toolbar commands

### DIFF
--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -127,7 +127,7 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
             return <div key={item.id} title={title} className={`theia-notebook-main-toolbar-item action-label${this.getAdditionalClasses(item)}`}
                 onClick={() => {
                     if (item.command && (!item.when || this.props.contextKeyService.match(item.when, this.props.editorNode))) {
-                        this.props.commandRegistry.executeCommand(item.command, this.props.notebookModel);
+                        this.props.commandRegistry.executeCommand(item.command, this.props.notebookModel.uri);
                     }
                 }}>
                 <span className={item.icon} />


### PR DESCRIPTION
#### What it does

Fixes the `Restart Kernel` command of the jupyter notebook extension. It expects a [URI as its argument](https://github.com/microsoft/vscode-jupyter/blob/efe0f5c797c0d0aa0108388a9705dd2f09bf6805/src/notebooks/notebookCommandListener.ts#L72). We used to pass in the whole notebook model.

#### How to test

1. Open a Jupyter notebook file
2. Run the `Restart Kernel` command from the main toolbar
3. The kernel should restart (see notification) and then work as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
