### PR TITLE
fix webview communication for safari

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/host.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/host.js
@@ -31,7 +31,7 @@
                 let sourceIsChildFrame = false;
                 for (let i = 0; i < window.frames.length; i++) {
                     const frame = window.frames[i];
-                    if (e.source === frame) {
+                    if (e.origin === frame.origin) {
                         sourceIsChildFrame = true;
                         break;
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes outgoing messages from webviews being forwarded correctly to theia in safari. 
while comparing a ProxyWindow with a Window object works in Firefox and Chrome In Safari they are never equal. Therefore this is now comparing the origin which since webviews are unique should be ok

#### How to test

Best way is probably through notebook outputs.

Start Theia in any browser you like, create a new notebook and add a simple `print('abc')` cell. Execute it (you need the jupyter and python extension for this). The output should appear. 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
