### PR TITLE
Generate Extension Info in server application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 ## not yet released
 
+- [application-manager] Generate Extension Info in server application to avoid empty About Dialog [#13590](https://github.com/eclipse-theia/theia/pull/13590) - contributed on behalf of STMicroelectronics
 - [scm] added support for dirty diff peek view [#13104](https://github.com/eclipse-theia/theia/pull/13104)
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a>
+
 - [scm] revised some of the dirty diff related types [#13104](https://github.com/eclipse-theia/theia/pull/13104)
   - replaced `DirtyDiff.added/removed/modified` with `changes`, which provides more detailed information about the changes
   - changed the semantics of `LineRange` to represent a range that spans up to but not including the `end` line (previously, it included the `end` line)

--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -185,6 +185,8 @@ const main = require('@theia/core/lib/node/main');
 
 BackendApplicationConfigProvider.set(${this.prettyStringify(this.pck.props.backend.config)});
 
+globalThis.extensionInfo = ${this.prettyStringify(this.pck.extensionPackages.map(({ name, version }) => ({ name, version }))) };
+
 const serverModule = require('./server');
 const serverAddress = main.start(serverModule());
 

--- a/packages/core/src/node/application-server.ts
+++ b/packages/core/src/node/application-server.ts
@@ -26,9 +26,9 @@ export class ApplicationServerImpl implements ApplicationServer {
     protected readonly applicationPackage: ApplicationPackage;
 
     getExtensionsInfos(): Promise<ExtensionInfo[]> {
-        const extensions = this.applicationPackage.extensionPackages;
-        const infos: ExtensionInfo[] = extensions.map(extension => ({ name: extension.name, version: extension.version }));
-        return Promise.resolve(infos);
+        // @ts-expect-error
+        const appInfo: ExtensionInfo[] = globalThis.extensionInfo;
+        return Promise.resolve(appInfo);
     }
 
     getApplicationInfo(): Promise<ApplicationInfo | undefined> {


### PR DESCRIPTION
#### What it does

Generate information about extension in server application rather than retrieving them in the about dialog at runtime. This was leading to missing information when an electron app was packaged. 

Fixes #13481

Contributed on behalf of STMicroelectronics
#### How to test

- Build the Theia Browser example app
- Delete the node_modules directory (it's not required as the backend is bundled by default)
- Run the example app (`node examples/browser/lib/backend/main.js`)
- Open the about dialog
- There should be the list of installed extensions.

The generation for Theia electron example app should also work. It is harder to test (from Stefan's comment on issue:  _you need to keep all Electron related dependencies in node_modules as they are not bundled with Theia._)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
