### PR TITLE
added alot more keybings to the notebook editor

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -211,7 +211,7 @@ export class MonacoEditorProvider {
         return editor;
     }
 
-    protected updateReadOnlyMessage(options: MonacoEditor.IOptions, readOnly: boolean | MarkdownString ): void {
+    protected updateReadOnlyMessage(options: MonacoEditor.IOptions, readOnly: boolean | MarkdownString): void {
         options.readOnlyMessage = MarkdownString.is(readOnly) ? readOnly : undefined;
     }
 

--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -25,6 +25,7 @@ import { NotebookExecutionService } from '../service/notebook-execution-service'
 import { NotebookEditorWidget } from '../notebook-editor-widget';
 import { NotebookEditorWidgetService } from '../service/notebook-editor-widget-service';
 import { NOTEBOOK_CELL_FOCUSED, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_HAS_OUTPUTS } from './notebook-context-keys';
+import { NotebookClipboardService } from '../service/notebook-clipboard-service';
 
 export namespace NotebookCommands {
     export const ADD_NEW_CELL_COMMAND = Command.toDefaultLocalizedCommand({
@@ -66,6 +67,21 @@ export namespace NotebookCommands {
         id: 'notebook.change-selected-cell',
         category: 'Notebook',
     });
+
+    export const CUT_SELECTED_CELL = Command.toDefaultLocalizedCommand({
+        id: 'notebook.cut-selected-cell',
+        category: 'Notebook',
+    });
+
+    export const COPY_SELECTED_CELL = Command.toDefaultLocalizedCommand({
+        id: 'notebook.copy-selected-cell',
+        category: 'Notebook',
+    });
+
+    export const PASTE_CELL = Command.toDefaultLocalizedCommand({
+        id: 'notebook.paste-cell',
+        category: 'Notebook',
+    });
 }
 
 export enum CellChangeDirection {
@@ -90,6 +106,9 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
 
     @inject(NotebookEditorWidgetService)
     protected notebookEditorWidgetService: NotebookEditorWidgetService;
+
+    @inject(NotebookClipboardService)
+    protected notebookClipboardService: NotebookClipboardService;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(NotebookCommands.ADD_NEW_CELL_COMMAND, {
@@ -180,6 +199,38 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
             execute: () => (this.shell.activeWidget as NotebookEditorWidget).redo()
         });
 
+        commands.registerCommand(NotebookCommands.CUT_SELECTED_CELL, this.editableCommandHandler(
+            () => {
+                const model = this.notebookEditorWidgetService.focusedEditor?.model;
+                const selectedCell = model?.selectedCell;
+                if (selectedCell) {
+                    model.applyEdits([{ editType: CellEditType.Replace, index: model.cells.indexOf(selectedCell), count: 1, cells: [] }], true);
+                    this.notebookClipboardService.copyCell(selectedCell);
+                }
+            }));
+
+        commands.registerCommand(NotebookCommands.COPY_SELECTED_CELL, {
+            execute: () => {
+                const model = this.notebookEditorWidgetService.focusedEditor?.model;
+                const selectedCell = model?.selectedCell;
+                if (selectedCell) {
+                    this.notebookClipboardService.copyCell(selectedCell);
+                }
+            }
+        });
+
+        commands.registerCommand(NotebookCommands.PASTE_CELL, {
+            isEnabled: () => !Boolean(this.notebookEditorWidgetService.focusedEditor?.model?.readOnly),
+            isVisible: () => !Boolean(this.notebookEditorWidgetService.focusedEditor?.model?.readOnly),
+            execute: (position: 'above' | 'below') => {
+                const copiedCell = this.notebookClipboardService.getCell();
+                if (copiedCell) {
+                    const model = this.notebookEditorWidgetService.focusedEditor?.model;
+                    const insertIndex = model?.selectedCell ? model.cells.indexOf(model.selectedCell) + (position === 'above' ? 0 : 1) : 0;
+                    model?.applyEdits([{ editType: CellEditType.Replace, index: insertIndex, count: 0, cells: [copiedCell] }], true);
+                }
+            }
+        });
     }
 
     protected editableCommandHandler(execute: (notebookModel: NotebookModel) => void): CommandHandler {
@@ -223,7 +274,6 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
             order: '30',
             when: NOTEBOOK_HAS_OUTPUTS
         });
-        // other items
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
@@ -239,6 +289,27 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
                 keybinding: 'down',
                 args: CellChangeDirection.Down,
                 when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`
+            },
+            {
+                command: NotebookCommands.CUT_SELECTED_CELL.id,
+                keybinding: 'x',
+                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`
+            },
+            {
+                command: NotebookCommands.COPY_SELECTED_CELL.id,
+                keybinding: 'c',
+                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`
+            },
+            {
+                command: NotebookCommands.PASTE_CELL.id,
+                keybinding: 'v',
+                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`
+            },
+            {
+                command: NotebookCommands.PASTE_CELL.id,
+                keybinding: 'shift+v',
+                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`,
+                args: 'above'
             },
         );
     }

--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -82,11 +82,6 @@ export namespace NotebookCommands {
         id: 'notebook.paste-cell',
         category: 'Notebook',
     });
-
-    export const NOTEBOOK_UNDO = Command.toDefaultLocalizedCommand({
-        id: 'notebook.undo',
-        category: 'Notebook',
-    });
 }
 
 export enum CellChangeDirection {
@@ -227,7 +222,7 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
         commands.registerCommand(NotebookCommands.PASTE_CELL, {
             isEnabled: () => !Boolean(this.notebookEditorWidgetService.focusedEditor?.model?.readOnly),
             isVisible: () => !Boolean(this.notebookEditorWidgetService.focusedEditor?.model?.readOnly),
-            execute: (position: 'above' | 'below') => {
+            execute: (position?: 'above') => {
                 const copiedCell = this.notebookClipboardService.getCell();
                 if (copiedCell) {
                     const model = this.notebookEditorWidgetService.focusedEditor?.model;
@@ -237,10 +232,6 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
             }
         });
 
-        commands.registerCommand(NotebookCommands.NOTEBOOK_UNDO, {
-            isEnabled: () => !Boolean(this.notebookEditorWidgetService.focusedEditor?.model?.readOnly),
-            execute: () => this.notebookEditorWidgetService.focusedEditor?.undo()
-        });
     }
 
     protected editableCommandHandler(execute: (notebookModel: NotebookModel) => void): CommandHandler {
@@ -302,32 +293,19 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
             },
             {
                 command: NotebookCommands.CUT_SELECTED_CELL.id,
-                keybinding: 'x',
+                keybinding: 'ctrlcmd+x',
                 when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`
             },
             {
                 command: NotebookCommands.COPY_SELECTED_CELL.id,
-                keybinding: 'c',
+                keybinding: 'ctrlcmd+c',
                 when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`
             },
             {
                 command: NotebookCommands.PASTE_CELL.id,
-                keybinding: 'v',
-                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`
+                keybinding: 'ctrlcmd+v',
+                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED}`
             },
-            {
-                command: NotebookCommands.PASTE_CELL.id,
-                keybinding: 'shift+v',
-                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`,
-                args: 'above'
-            },
-            {
-                command: NotebookCommands.NOTEBOOK_UNDO.id,
-                keybinding: 'z',
-                // notebook type check is to check that we are using the editors context
-                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && notebookType`
-            },
-
         );
     }
 

--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -82,6 +82,11 @@ export namespace NotebookCommands {
         id: 'notebook.paste-cell',
         category: 'Notebook',
     });
+
+    export const NOTEBOOK_UNDO = Command.toDefaultLocalizedCommand({
+        id: 'notebook.undo',
+        category: 'Notebook',
+    });
 }
 
 export enum CellChangeDirection {
@@ -231,6 +236,11 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
                 }
             }
         });
+
+        commands.registerCommand(NotebookCommands.NOTEBOOK_UNDO, {
+            isEnabled: () => !Boolean(this.notebookEditorWidgetService.focusedEditor?.model?.readOnly),
+            execute: () => this.notebookEditorWidgetService.focusedEditor?.undo()
+        });
     }
 
     protected editableCommandHandler(execute: (notebookModel: NotebookModel) => void): CommandHandler {
@@ -311,6 +321,13 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
                 when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED}`,
                 args: 'above'
             },
+            {
+                command: NotebookCommands.NOTEBOOK_UNDO.id,
+                keybinding: 'z',
+                // notebook type check is to check that we are using the editors context
+                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && notebookType`
+            },
+
         );
     }
 

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -110,23 +110,25 @@ export namespace NotebookCellCommands {
     });
 
     export const TO_CODE_CELL_COMMAND = Command.toLocalizedCommand({
-        id: 'notebook.cell.to-code-cell',
+        id: 'notebook.cell.changeToCode',
         label: 'Change Cell to Code'
     });
 
     export const TO_MARKDOWN_CELL_COMMAND = Command.toLocalizedCommand({
-        id: 'notebook.cell.to-markdown-cell',
+        id: 'notebook.cell.changeToMarkdown',
         label: 'Change Cell to Mardown'
     });
 
-    export const TOGGLE_LINE_NUMBERS = Command.toDefaultLocalizedCommand({
-        id: 'notebook.toggle-line-numbers',
+    export const COLLAPSE_CELL_OUTPUT = Command.toDefaultLocalizedCommand({
+        id: 'notebook.cell.expandCellOutput',
         category: 'Notebook',
+        label: 'Collapse Cell Output',
     });
 
-    export const TOOGLE_OUTPUTS = Command.toDefaultLocalizedCommand({
-        id: 'notebook.toggle-outputs',
+    export const EXPAND_CELL_OUTPUT = Command.toDefaultLocalizedCommand({
+        id: 'notebook.cell.expandCellOutput',
         category: 'Notebook',
+        label: 'Expand Cell Output',
     });
 
 }
@@ -339,20 +341,20 @@ export class NotebookCellActionContribution implements MenuContribution, Command
             changeCellType(notebookModel, cell, CellKind.Markup);
         }));
 
-        commands.registerCommand(NotebookCellCommands.TOGGLE_LINE_NUMBERS, {
+        commands.registerCommand(NotebookCellCommands.COLLAPSE_CELL_OUTPUT, {
             execute: () => {
                 const selectedCell = this.notebookEditorWidgetService.focusedEditor?.model?.selectedCell;
                 if (selectedCell) {
-                    selectedCell.editorOptions = { ...selectedCell.editorOptions, lineNumbers: selectedCell.editorOptions?.lineNumbers === 'on' ? 'off' : 'on' };
+                    selectedCell.outputVisible = false;
                 }
             }
         });
 
-        commands.registerCommand(NotebookCellCommands.TOOGLE_OUTPUTS, {
+        commands.registerCommand(NotebookCellCommands.EXPAND_CELL_OUTPUT, {
             execute: () => {
                 const selectedCell = this.notebookEditorWidgetService.focusedEditor?.model?.selectedCell;
                 if (selectedCell) {
-                    selectedCell.outputVisible = !selectedCell.outputVisible;
+                    selectedCell.outputVisible = true;
                 }
             }
         });
@@ -422,16 +424,6 @@ export class NotebookCellActionContribution implements MenuContribution, Command
                 keybinding: 'M',
                 when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED} && ${NOTEBOOK_CELL_TYPE} == 'code'`,
             },
-            {
-                command: NotebookCellCommands.TOGGLE_LINE_NUMBERS.id,
-                keybinding: 'L',
-                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED} && ${NOTEBOOK_CELL_TYPE} == 'code'`,
-            },
-            {
-                command: NotebookCellCommands.TOOGLE_OUTPUTS.id,
-                keybinding: 'O',
-                when: `!editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && ${NOTEBOOK_CELL_FOCUSED} && ${NOTEBOOK_CELL_TYPE} == 'code'`,
-            }
         );
     }
 }

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -120,7 +120,7 @@ export namespace NotebookCellCommands {
     });
 
     export const COLLAPSE_CELL_OUTPUT = Command.toDefaultLocalizedCommand({
-        id: 'notebook.cell.expandCellOutput',
+        id: 'notebook.cell.collapseCellOutput',
         category: 'Notebook',
         label: 'Collapse Cell Output',
     });

--- a/packages/notebook/src/browser/contributions/notebook-preferences.ts
+++ b/packages/notebook/src/browser/contributions/notebook-preferences.ts
@@ -1,0 +1,31 @@
+// *****************************************************************************
+// Copyright (C) 2024 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { PreferenceSchema } from '@theia/core/lib/browser';
+
+export const NOTEBOOK_LINE_NUMBERS = 'notebook.lineNumbers';
+
+export const notebookPreferenceSchema: PreferenceSchema = {
+    properties: {
+        [NOTEBOOK_LINE_NUMBERS]: {
+            type: 'string',
+            enum: ['on', 'off'],
+            default: 'off',
+            description: nls.localizeByDefault('Controls the display of line numbers in the cell editor.')
+        },
+    }
+};

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -160,6 +160,8 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
                 this.commandRegistry.executeCommand(NotebookCellCommands.EDIT_COMMAND.id, model, model.cells[0]);
                 model.setSelectedCell(model.cells[0]);
             }
+            model.cells.forEach(cell => cell.onWillBlurCellEditor(() => this.node.focus()));
+            model.onDidAddOrRemoveCell(e => e.newCellIds?.forEach(cellId => model.cells.find(cell => cell.handle === cellId)?.onWillBlurCellEditor(() => this.node.focus())));
         });
     }
 

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -16,7 +16,7 @@
 import '../../src/browser/style/index.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { FrontendApplicationContribution, KeybindingContribution, LabelProviderContribution, OpenHandler, WidgetFactory } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, KeybindingContribution, LabelProviderContribution, OpenHandler, PreferenceContribution, WidgetFactory } from '@theia/core/lib/browser';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { NotebookOpenHandler } from './notebook-open-handler';
 import { CommandContribution, MenuContribution, ResourceResolver, } from '@theia/core';
@@ -44,6 +44,7 @@ import { NotebookOutlineContribution } from './contributions/notebook-outline-co
 import { NotebookLabelProviderContribution } from './contributions/notebook-label-provider-contribution';
 import { NotebookOutputActionContribution } from './contributions/notebook-output-action-contribution';
 import { NotebookClipboardService } from './service/notebook-clipboard-service';
+import { notebookPreferenceSchema } from './contributions/notebook-preferences';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookColorContribution).toSelf().inSingletonScope();
@@ -102,4 +103,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(FrontendApplicationContribution).toService(NotebookOutlineContribution);
     bind(NotebookLabelProviderContribution).toSelf().inSingletonScope();
     bind(LabelProviderContribution).toService(NotebookLabelProviderContribution);
+
+    bind(PreferenceContribution).toConstantValue({ schema: notebookPreferenceSchema });
 });

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -43,6 +43,7 @@ import { NotebookMonacoTextModelService } from './service/notebook-monaco-text-m
 import { NotebookOutlineContribution } from './contributions/notebook-outline-contribution';
 import { NotebookLabelProviderContribution } from './contributions/notebook-label-provider-contribution';
 import { NotebookOutputActionContribution } from './contributions/notebook-output-action-contribution';
+import { NotebookClipboardService } from './service/notebook-clipboard-service';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookColorContribution).toSelf().inSingletonScope();
@@ -64,6 +65,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookRendererMessagingService).toSelf().inSingletonScope();
     bind(NotebookKernelHistoryService).toSelf().inSingletonScope();
     bind(NotebookKernelQuickPickService).toSelf().inSingletonScope();
+    bind(NotebookClipboardService).toSelf().inSingletonScope();
 
     bind(NotebookCellResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(NotebookCellResourceResolver);

--- a/packages/notebook/src/browser/service/notebook-clipboard-service.ts
+++ b/packages/notebook/src/browser/service/notebook-clipboard-service.ts
@@ -1,0 +1,43 @@
+// *****************************************************************************
+// Copyright (C) 2024 Typefox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
+import { NotebookCellModel } from '../view-model/notebook-cell-model';
+import { environment } from '@theia/core';
+import { CellData } from '../../common';
+
+@injectable()
+export class NotebookClipboardService {
+
+    protected copiedCell: CellData | undefined;
+
+    @inject(ClipboardService)
+    protected readonly clipboardService: ClipboardService;
+
+    copyCell(cell: NotebookCellModel): void {
+        this.copiedCell = cell.getData();
+
+        if (environment.electron.is()) {
+            this.clipboardService.writeText(cell.text);
+        }
+    }
+
+    getCell(): CellData | undefined {
+        return this.copiedCell;
+    }
+
+}

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -266,3 +266,12 @@
   background-color: var(--theia-notebook-focusedCellBorder);
   width: 100%;
 }
+
+.theia-notebook-collapsed-output {
+  padding: 4px 8px;
+  color: var(--theia-foreground);
+  margin-left: 30px;
+  font-size: 14px;
+  line-height: 22px;
+  opacity: 0.7;
+}

--- a/packages/notebook/src/browser/view-model/notebook-cell-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-cell-model.ts
@@ -29,6 +29,8 @@ import {
 import { NotebookCellOutputsSplice } from '../notebook-types';
 import { NotebookMonacoTextModelService } from '../service/notebook-monaco-text-model-service';
 import { NotebookCellOutputModel } from './notebook-cell-output-model';
+import { PreferenceService } from '@theia/core/lib/browser';
+import { NOTEBOOK_LINE_NUMBERS } from '../contributions/notebook-preferences';
 
 export const NotebookCellModelFactory = Symbol('NotebookModelFactory');
 export type NotebookCellModelFactory = (props: NotebookCellModelProps) => NotebookCellModel;
@@ -118,6 +120,9 @@ export class NotebookCellModel implements NotebookCell, Disposable {
 
     @inject(NotebookMonacoTextModelService)
     protected readonly textModelService: NotebookMonacoTextModelService;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
 
     get outputs(): NotebookCellOutputModel[] {
         return this._outputs;
@@ -229,6 +234,18 @@ export class NotebookCellModel implements NotebookCell, Disposable {
         this._outputs = this.props.outputs.map(op => new NotebookCellOutputModel(op));
         this._metadata = this.props.metadata ?? {};
         this._internalMetadata = this.props.internalMetadata ?? {};
+
+        this.editorOptions = {
+            lineNumbers: this.preferenceService.get(NOTEBOOK_LINE_NUMBERS)
+        };
+        this.toDispose.push(this.preferenceService.onPreferenceChanged(e => {
+            if (e.preferenceName === NOTEBOOK_LINE_NUMBERS) {
+                this.editorOptions = {
+                    ...this.editorOptions,
+                    lineNumbers: this.preferenceService.get(NOTEBOOK_LINE_NUMBERS)
+                };
+            }
+        }));
     }
 
     dispose(): void {

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 20023 Typefox and others.
+// Copyright (C) 2023 Typefox and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -42,7 +42,8 @@ const DEFAULT_EDITOR_OPTIONS: MonacoEditor.IOptions = {
     scrollbar: {
         ...MonacoEditorProvider.inlineOptions.scrollbar,
         alwaysConsumeMouseWheel: false
-    }
+    },
+    lineDecorationsWidth: 10,
 };
 
 export class CellEditor extends React.Component<CellEditorProps, {}> {
@@ -56,6 +57,11 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
         this.toDispose.push(this.props.cell.onWillFocusCellEditor(() => {
             this.editor?.getControl().focus();
         }));
+
+        this.toDispose.push(this.props.cell.onDidChangeEditorOptions(options => {
+            this.editor?.getControl().updateOptions(options);
+        }));
+
         this.toDispose.push(this.props.notebookModel.onDidChangeSelectedCell(() => {
             if (this.props.notebookModel.selectedCell !== this.props.cell && this.editor?.getControl().hasTextFocus()) {
                 if (document.activeElement && 'blur' in document.activeElement) {
@@ -96,7 +102,7 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
                 editorModel,
                 editorNode,
                 monacoServices,
-                DEFAULT_EDITOR_OPTIONS,
+                { ...DEFAULT_EDITOR_OPTIONS, ...cell.editorOptions },
                 [[IContextKeyService, this.props.notebookContextManager.scopedStore]]);
             this.toDispose.push(this.editor);
             this.editor.setLanguage(cell.language);

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -28,7 +28,7 @@ import { NotebookCellActionContribution } from '../contributions/notebook-cell-a
 import { CellExecution, NotebookExecutionStateService } from '../service/notebook-execution-state-service';
 import { codicon } from '@theia/core/lib/browser';
 import { NotebookCellExecutionState } from '../../common';
-import { DisposableCollection } from '@theia/core';
+import { DisposableCollection, nls } from '@theia/core';
 import { NotebookContextManager } from '../service/notebook-context-manager';
 import { NotebookViewportService } from './notebook-viewport-service';
 import { EditorPreferences } from '@theia/editor/lib/browser';
@@ -225,11 +225,11 @@ export class NotebookCodeCellOutputs extends React.Component<NotebookCellOutputP
         const { cell, notebook, outputWebviewFactory } = this.props;
         this.toDispose.push(cell.onDidChangeOutputs(() => this.updateOutputs()));
         this.toDispose.push(cell.onDidChangeOutputVisibility(visible => {
-            this.forceUpdate();
             if (!visible && this.outputsWebview) {
                 this.outputsWebview?.dispose();
                 this.outputsWebview = undefined;
                 this.outputsWebviewPromise = undefined;
+                this.forceUpdate();
             } else {
                 this.updateOutputs();
             }
@@ -277,7 +277,7 @@ export class NotebookCodeCellOutputs extends React.Component<NotebookCellOutputP
                 {this.props.renderSidebar()}
                 {this.outputsWebview.render()}
             </> :
-            <></>;
+            this.props.cell.outputs?.length ? <i className='theia-notebook-collapsed-output'>{nls.localizeByDefault('Outputs are collapsed')}</i> : <></>;
 
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This adds multiple new keybindings and some commands and preferences to the notebook editor that vscode supports as well:
- `ctrl+x` cut cell
- `ctrl+c` copy cell 
- `ctrl+v` paste cell
- `Enter` (new for code cells) focus editor
- `Esc` unfocus editor/stop markdown edit

- linenumber preference to activate and deactivate line numbers in cell editors

- collapse/expand cell ouptut command


#### How to test

Open a notebook and test the new commands

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
