### PR TITLE
fix kernel autobind for on startup opened notebooks

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-kernels-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-kernels-main.ts
@@ -209,9 +209,16 @@ export class NotebookKernelsMainImpl implements NotebookKernelsMain {
             }
         }(handle, data, this.languageService);
 
+        // this is for when a kernel is bound to a notebook while being registered
+        const autobindListener = this.notebookKernelService.onDidChangeSelectedKernel(e => {
+            if (e.newKernel === kernel.id) {
+                this.proxy.$acceptNotebookAssociation(handle, e.notebook.toComponents(), true);
+            }
+        });
+
         const registration = this.notebookKernelService.registerKernel(kernel);
         this.kernels.set(handle, [kernel, registration]);
-
+        autobindListener.dispose();
     }
 
     $updateKernel(handle: number, data: Partial<NotebookKernelDto>): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

this fixes the kernel autobind when a notebook is opened on startup.

#### How to test

1. open a notebook 
2. select a kernel
3. reload the window
4. notebook should open automaticly 
5. execute a cell
6. verify it worked correctly

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
