### PR TITLE
Fix notebook model/cell disposal

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -258,6 +258,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this.onDidReceiveKernelMessageEmitter.dispose();
         this.onPostRendererMessageEmitter.dispose();
         this.viewportService.dispose();
+        this._model?.dispose();
         super.dispose();
     }
 

--- a/packages/notebook/src/browser/service/notebook-service.ts
+++ b/packages/notebook/src/browser/service/notebook-service.ts
@@ -121,6 +121,10 @@ export class NotebookService implements Disposable {
         // This ensures that all text models are available in the plugin host
         this.textModelService.createTextModelsForNotebook(model);
         this.didAddNotebookDocumentEmitter.fire(model);
+        model.onDidDispose(() => {
+            this.notebookModels.delete(resource.uri.toString());
+            this.didRemoveNotebookDocumentEmitter.fire(model);
+        });
         return model;
     }
 

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -71,6 +71,9 @@ export class NotebookModel implements Saveable, Disposable {
     protected readonly onDidChangeSelectedCellEmitter = new Emitter<NotebookCellModel | undefined>();
     readonly onDidChangeSelectedCell = this.onDidChangeSelectedCellEmitter.event;
 
+    protected readonly onDidDisposeEmitter = new Emitter<void>();
+    readonly onDidDispose = this.onDidDisposeEmitter.event;
+
     get onDidChangeReadOnly(): Event<boolean | MarkdownString> {
         return this.props.resource.onDidChangeReadOnly ?? Event.None;
     }
@@ -150,6 +153,7 @@ export class NotebookModel implements Saveable, Disposable {
         this.onDidChangeContentEmitter.dispose();
         this.onDidChangeSelectedCellEmitter.dispose();
         this.cells.forEach(cell => cell.dispose());
+        this.onDidDisposeEmitter.fire();
     }
 
     async save(options: SaveOptions): Promise<void> {


### PR DESCRIPTION
#### What it does

Previously, when deleting a cell or a whole notebook, the deletion wasn't propagated to the documents-ext handler. Meaning that there was still a virtual document available in the plugin host for non-existing cell. This later on led to caching issues, for example accidentally executing outdated code cells.

Furthermore, closed notebooks didn't dispose their underlying model when the editor was closed. The model was always available in memory.

This change fixes the notebook document removal event and also simply deletes all cell documents from the plugin host.

#### How to test

1. Set a breakpoint in [here](https://github.com/eclipse-theia/theia/blob/fd5be308a0da5c1e9f660c3afa86ebe60fc5bf8e/packages/plugin-ext/src/plugin/editors-and-documents.ts#L53).
2. Open a notebook document and delete a cell.
3. Assert that the delta that is available in the debugger is a document deletion.
4. Close the notebook document.
5. All cells should now be removed from the documents.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
