### PR TITLE
Fix notebook widget icon on reload

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget-factory.ts
+++ b/packages/notebook/src/browser/notebook-editor-widget-factory.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { URI } from '@theia/core';
+import { nls, URI } from '@theia/core';
 import { WidgetFactory, NavigatableWidgetOptions, LabelProvider } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { NotebookEditorWidget, NotebookEditorWidgetContainerFactory, NotebookEditorProps } from './notebook-editor-widget';
@@ -51,10 +51,13 @@ export class NotebookEditorWidgetFactory implements WidgetFactory {
 
         const editor = await this.createEditor(uri, options.notebookType);
 
-        const icon = this.labelProvider.getIcon(uri);
-        editor.title.label = this.labelProvider.getName(uri);
-        editor.title.iconClass = icon + ' file-icon';
-
+        this.setLabels(editor, uri);
+        const labelListener = this.labelProvider.onDidChange(event => {
+            if (event.affects(uri)) {
+                this.setLabels(editor, uri);
+            }
+        });
+        editor.onDidDispose(() => labelListener.dispose());
         return editor;
     }
 
@@ -65,6 +68,16 @@ export class NotebookEditorWidgetFactory implements WidgetFactory {
             notebookType,
             notebookData: this.notebookModelResolver.resolve(uri, notebookType),
         });
+    }
+
+    private setLabels(editor: NotebookEditorWidget, uri: URI): void {
+        editor.title.caption = uri.path.fsPath();
+        if (editor.model?.readOnly) {
+            editor.title.caption += ` • ${nls.localizeByDefault('Read-only')}`;
+        }
+        const icon = this.labelProvider.getIcon(uri);
+        editor.title.label = this.labelProvider.getName(uri);
+        editor.title.iconClass = icon + ' file-icon';
     }
 
 }

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -118,7 +118,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     readonly onPostRendererMessage = this.onPostRendererMessageEmitter.event;
 
     protected readonly onDidReceiveKernelMessageEmitter = new Emitter<unknown>();
-    readonly onDidRecieveKernelMessage = this.onDidReceiveKernelMessageEmitter.event;
+    readonly onDidReceiveKernelMessage = this.onDidReceiveKernelMessageEmitter.event;
 
     protected readonly renderers = new Map<CellKind, CellRenderer>();
     protected _model?: NotebookModel;

--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-kernels-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-kernels-main.ts
@@ -145,7 +145,7 @@ export class NotebookKernelsMainImpl implements NotebookKernelsMain {
         this.notebookEditorWidgetService = container.get(NotebookEditorWidgetService);
 
         this.notebookEditorWidgetService.onDidAddNotebookEditor(editor => {
-            editor.onDidRecieveKernelMessage(async message => {
+            editor.onDidReceiveKernelMessage(async message => {
                 const kernel = this.notebookKernelService.getSelectedOrSuggestedKernel(editor.model!);
                 if (kernel) {
                     this.proxy.$acceptKernelMessageFromRenderer(kernel.handle, editor.id, message);


### PR DESCRIPTION
#### What it does

When reloading the app while having a notebook widget open, the icon stays empty, as the icon is registered after the widget has been recreated. This change ensures that the widget icon is reloaded after changes in the label provider that affect the notebook widget.

#### How to test

1. Open a notebook editor and reload the app
2. The icon should be correctly set on the notebook editor (even though it might take a second or two)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
