### PR TITLE
Bind Extension search bar within view container so it is re-created

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -78,6 +78,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
                 progressLocationId: 'extensions'
             });
             child.bind(VSXExtensionsViewContainer).toSelf();
+            child.bind(VSXExtensionsSearchBar).toSelf().inSingletonScope();
             const viewContainer = child.get(VSXExtensionsViewContainer);
             const widgetManager = child.get(WidgetManager);
             for (const id of [
@@ -96,7 +97,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     })).inSingletonScope();
 
     bind(VSXExtensionsSearchModel).toSelf().inSingletonScope();
-    bind(VSXExtensionsSearchBar).toSelf().inSingletonScope();
 
     rebind(LanguageQuickPickService).to(VSXLanguageQuickPickService).inSingletonScope();
 


### PR DESCRIPTION
#### What it does
The search bar is disposed once the Extension view is closed. The binding as a "global" singleton prevents the disposed widget from properly showing up once the Extension view is opened again. We therefore bind the search bar within the child container together with the other UI components.

Fixes https://github.com/eclipse-theia/theia/issues/13622

#### How to test

1. Open the Extensions view - search bar is visible
2. Close the Extensions view
3. Re-open the Extensions view - search bar should be there

![search-bar-fixed](https://github.com/eclipse-theia/theia/assets/19170971/4bd46eaf-6458-4905-b066-bab00d9ce9ef)

#### Follow-ups

None.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
