### PR TITLE
Fix onLanguage activation event

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -409,6 +409,7 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
     }
 
     async activateByLanguage(languageId: string): Promise<void> {
+        await this.activateByEvent('onLanguage');
         await this.activateByEvent(`onLanguage:${languageId}`);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
According to the the [VSCode documentation](https://code.visualstudio.com/api/references/activation-events#onLanguage) `onLanguage` (without any language specified) is a valid activation event.
This is used in the built-in emmet extension for example. 
Beforehand extensions with this event were not triggered. 
With this commit the extensions with `onLanguage` are activated, when the first language is loaded.

Fixes #13247
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Check that the built-in emmet extension is working by opening an empty `.jsx` file, typing `di` and triggering the suggestions (Ctrl+Space). You should get two suggestions from Emmet (`dir` and `div`).

Without this change you would get no suggestions, as the extension would not be activated.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
