### PR TITLE
fixes clear cell outputs command and improves toolbar creation

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -324,7 +324,7 @@ export class NotebookCellActionContribution implements MenuContribution, Command
             }
         });
         commands.registerCommand(NotebookCellCommands.CLEAR_OUTPUTS_COMMAND, this.editableCellCommandHandler(
-            (notebook, cell) => notebook.applyEdits([{
+            (notebook, cell) => (notebook ?? this.notebookEditorWidgetService.focusedEditor?.model)?.applyEdits([{
                 editType: CellEditType.Output,
                 handle: cell.handle,
                 outputs: [],

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -90,7 +90,7 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
                             </div>
                             {this.state.selectedCell === cell &&
                                 this.props.toolbarRenderer.renderCellToolbar(NotebookCellActionContribution.ACTION_MENU, cell, {
-                                    contextMenuArgs: [cell], commandArgs: [this.props.notebookModel]
+                                    contextMenuArgs: () => [cell], commandArgs: () => [this.props.notebookModel]
                                 })
                             }
                         </li>

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -89,7 +89,10 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
                                 {this.renderCellContent(cell, index)}
                             </div>
                             {this.state.selectedCell === cell &&
-                                this.props.toolbarRenderer.renderCellToolbar(NotebookCellActionContribution.ACTION_MENU, this.props.notebookModel, cell)}
+                                this.props.toolbarRenderer.renderCellToolbar(NotebookCellActionContribution.ACTION_MENU, cell, {
+                                    contextMenuArgs: [cell], commandArgs: [this.props.notebookModel]
+                                })
+                            }
                         </li>
                         {this.shouldRenderDragOverIndicator(cell, 'bottom') && <CellDropIndicator />}
                     </React.Fragment>

--- a/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
@@ -33,8 +33,8 @@ export interface NotebookCellToolbarItem {
 }
 
 export interface toolbarItemOptions {
-    contextMenuArgs?: unknown[];
-    commandArgs?: unknown[];
+    contextMenuArgs?: () => unknown[];
+    commandArgs?: () => unknown[];
 }
 
 @injectable()
@@ -91,11 +91,11 @@ export class NotebookCellToolbarFactory {
                         anchor: e.nativeEvent,
                         menuPath,
                         includeAnchorArg: false,
-                        args: itemOptions.contextMenuArgs,
+                        args: itemOptions.contextMenuArgs?.(),
                         context: this.notebookContextManager.context
                     }) :
-                () => this.commandRegistry.executeCommand(menuNode.command!, ...(itemOptions.commandArgs ?? [])),
-            isVisible: () => menuPath ? true : Boolean(this.commandRegistry.getVisibleHandler(menuNode.command!, ...(itemOptions.commandArgs ?? []))),
+                () => this.commandRegistry.executeCommand(menuNode.command!, ...(itemOptions.commandArgs?.() ?? [])),
+            isVisible: () => menuPath ? true : Boolean(this.commandRegistry.getVisibleHandler(menuNode.command!, ...(itemOptions.commandArgs?.() ?? []))),
             contextKeys: menuNode.when ? this.contextKeyService.parseKeys(menuNode.when) : undefined
         };
     }

--- a/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
@@ -20,9 +20,7 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { NotebookCellSidebar, NotebookCellToolbar } from './notebook-cell-toolbar';
 import { ContextMenuRenderer } from '@theia/core/lib/browser';
-import { NotebookModel } from '../view-model/notebook-model';
 import { NotebookCellModel } from '../view-model/notebook-cell-model';
-import { NotebookCellOutputModel } from '../view-model/notebook-cell-output-model';
 import { NotebookContextManager } from '../service/notebook-context-manager';
 
 export interface NotebookCellToolbarItem {
@@ -32,6 +30,11 @@ export interface NotebookCellToolbarItem {
     onClick: (e: React.MouseEvent) => void;
     isVisible: () => boolean;
     contextKeys?: Set<string>
+}
+
+export interface toolbarItemOptions {
+    contextMenuArgs?: unknown[];
+    commandArgs?: unknown[];
 }
 
 @injectable()
@@ -52,31 +55,31 @@ export class NotebookCellToolbarFactory {
     @inject(NotebookContextManager)
     protected readonly notebookContextManager: NotebookContextManager;
 
-    renderCellToolbar(menuPath: string[], notebookModel: NotebookModel, cell: NotebookCellModel): React.ReactNode {
-        return <NotebookCellToolbar getMenuItems={() => this.getMenuItems(menuPath, notebookModel, cell)}
+    renderCellToolbar(menuPath: string[], cell: NotebookCellModel, itemOptions: toolbarItemOptions): React.ReactNode {
+        return <NotebookCellToolbar getMenuItems={() => this.getMenuItems(menuPath, cell, itemOptions)}
             onContextKeysChanged={this.notebookContextManager.onDidChangeContext} />;
     }
 
-    renderSidebar(menuPath: string[], notebookModel: NotebookModel, cell: NotebookCellModel, output?: NotebookCellOutputModel): React.ReactNode {
-        return <NotebookCellSidebar getMenuItems={() => this.getMenuItems(menuPath, notebookModel, cell, output)}
+    renderSidebar(menuPath: string[], cell: NotebookCellModel, itemOptions: toolbarItemOptions): React.ReactNode {
+        return <NotebookCellSidebar getMenuItems={() => this.getMenuItems(menuPath, cell, itemOptions)}
             onContextKeysChanged={this.notebookContextManager.onDidChangeContext} />;
     }
 
-    private getMenuItems(menuItemPath: string[], notebookModel: NotebookModel, cell: NotebookCellModel, output?: NotebookCellOutputModel): NotebookCellToolbarItem[] {
+    private getMenuItems(menuItemPath: string[], cell: NotebookCellModel, itemOptions: toolbarItemOptions): NotebookCellToolbarItem[] {
         const inlineItems: NotebookCellToolbarItem[] = [];
         for (const menuNode of this.menuRegistry.getMenu(menuItemPath).children) {
             if (!menuNode.when || this.notebookContextManager.getCellContext(cell.handle).match(menuNode.when, this.notebookContextManager.context)) {
                 if (menuNode.role === CompoundMenuNodeRole.Flat) {
-                    inlineItems.push(...menuNode.children?.map(child => this.createToolbarItem(child, notebookModel, cell, output)) ?? []);
+                    inlineItems.push(...menuNode.children?.map(child => this.createToolbarItem(child, itemOptions)) ?? []);
                 } else {
-                    inlineItems.push(this.createToolbarItem(menuNode, notebookModel, cell, output));
+                    inlineItems.push(this.createToolbarItem(menuNode, itemOptions));
                 }
             }
         }
         return inlineItems;
     }
 
-    private createToolbarItem(menuNode: MenuNode, notebookModel: NotebookModel, cell: NotebookCellModel, output?: NotebookCellOutputModel): NotebookCellToolbarItem {
+    private createToolbarItem(menuNode: MenuNode, itemOptions: toolbarItemOptions): NotebookCellToolbarItem {
         const menuPath = menuNode.role === CompoundMenuNodeRole.Submenu ? this.menuRegistry.getPath(menuNode) : undefined;
         return {
             id: menuNode.id,
@@ -88,11 +91,11 @@ export class NotebookCellToolbarFactory {
                         anchor: e.nativeEvent,
                         menuPath,
                         includeAnchorArg: false,
-                        args: [cell],
+                        args: itemOptions.contextMenuArgs,
                         context: this.notebookContextManager.context
                     }) :
-                () => this.commandRegistry.executeCommand(menuNode.command!, notebookModel, cell, output),
-            isVisible: () => menuPath ? true : Boolean(this.commandRegistry.getVisibleHandler(menuNode.command!, notebookModel, cell, output)),
+                () => this.commandRegistry.executeCommand(menuNode.command!, ...(itemOptions.commandArgs ?? [])),
+            isVisible: () => menuPath ? true : Boolean(this.commandRegistry.getVisibleHandler(menuNode.command!, ...(itemOptions.commandArgs ?? []))),
             contextKeys: menuNode.when ? this.contextKeyService.parseKeys(menuNode.when) : undefined
         };
     }

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -71,7 +71,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
             <div className='theia-notebook-cell-with-sidebar'>
                 <div className='theia-notebook-cell-sidebar'>
                     {this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.CODE_CELL_SIDEBAR_MENU, cell, {
-                        contextMenuArgs: [cell], commandArgs: [notebookModel, cell]
+                        contextMenuArgs: () => [cell], commandArgs: () => [notebookModel, cell]
                     })
                     }
                     <CodeCellExecutionOrder cell={cell} />
@@ -92,7 +92,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
                 <NotebookCodeCellOutputs cell={cell} notebook={notebookModel} outputWebviewFactory={this.cellOutputWebviewFactory}
                     renderSidebar={() =>
                         this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.OUTPUT_SIDEBAR_MENU, cell, {
-                            contextMenuArgs: [notebookModel, cell, cell.outputs[0]]
+                            contextMenuArgs: () => [notebookModel, cell, cell.outputs[0]]
                         })
                     } />
             </div>

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -70,7 +70,10 @@ export class NotebookCodeCellRenderer implements CellRenderer {
         return <div>
             <div className='theia-notebook-cell-with-sidebar'>
                 <div className='theia-notebook-cell-sidebar'>
-                    {this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.CODE_CELL_SIDEBAR_MENU, notebookModel, cell)}
+                    {this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.CODE_CELL_SIDEBAR_MENU, cell, {
+                        contextMenuArgs: [cell], commandArgs: [notebookModel, cell]
+                    })
+                    }
                     <CodeCellExecutionOrder cell={cell} />
                 </div>
                 <div className='theia-notebook-cell-editor-container'>
@@ -88,7 +91,10 @@ export class NotebookCodeCellRenderer implements CellRenderer {
             <div className='theia-notebook-cell-with-sidebar'>
                 <NotebookCodeCellOutputs cell={cell} notebook={notebookModel} outputWebviewFactory={this.cellOutputWebviewFactory}
                     renderSidebar={() =>
-                        this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.OUTPUT_SIDEBAR_MENU, notebookModel, cell, cell.outputs[0])} />
+                        this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.OUTPUT_SIDEBAR_MENU, cell, {
+                            contextMenuArgs: [notebookModel, cell, cell.outputs[0]]
+                        })
+                    } />
             </div>
         </div >;
     }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -377,7 +377,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
 
         private async doRender(item: rendererApi.OutputItem, element: HTMLElement, renderer: Renderer, signal: AbortSignal): Promise<{ continue: boolean }> {
             try {
-                console.log(item.mime, item.text());
                 (await renderer.getOrLoad())?.renderOutputItem(item, element, signal);
                 return { continue: false }; // We rendered successfully
             } catch (e) {

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -316,7 +316,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         }
 
         public async render(output: Output, preferredMimeType: string | undefined, preferredRendererId: string | undefined, signal: AbortSignal): Promise<void> {
-            console.log('render output ', output.outputId, preferredMimeType);
             const item = output.findItemToRender(preferredMimeType);
             const primaryRenderer = this.findRenderer(preferredRendererId, item);
             if (!primaryRenderer) {
@@ -378,6 +377,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
 
         private async doRender(item: rendererApi.OutputItem, element: HTMLElement, renderer: Renderer, signal: AbortSignal): Promise<{ continue: boolean }> {
             try {
+                console.log(item.mime, item.text());
                 (await renderer.getOrLoad())?.renderOutputItem(item, element, signal);
                 return { continue: false }; // We rendered successfully
             } catch (e) {
@@ -469,7 +469,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
     await Promise.all(ctx.staticPreloadsData.map(preload => kernelPreloads.load(preload)));
 
     function clearOutput(output: Output): void {
-        console.log('clear output ', output.outputId);
         output.clear();
         output.element.remove();
     }
@@ -557,7 +556,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             case 'changePreferredMimetype':
                 const mimeType = event.data.mimeType;
                 outputs.forEach(output => {
-                    output.clear();
+                    output.element.innerHTML = '';
                     renderers.render(output, mimeType, undefined, new AbortController().signal);
                 });
                 break;

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -316,6 +316,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         }
 
         public async render(output: Output, preferredMimeType: string | undefined, preferredRendererId: string | undefined, signal: AbortSignal): Promise<void> {
+            console.log('render output ', output.outputId, preferredMimeType);
             const item = output.findItemToRender(preferredMimeType);
             const primaryRenderer = this.findRenderer(preferredRendererId, item);
             if (!primaryRenderer) {
@@ -468,6 +469,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
     await Promise.all(ctx.staticPreloadsData.map(preload => kernelPreloads.load(preload)));
 
     function clearOutput(output: Output): void {
+        console.log('clear output ', output.outputId);
         output.clear();
         output.element.remove();
     }
@@ -553,11 +555,11 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                 renderers.getRenderer(event.data.rendererId)?.receiveMessage(event.data.message);
                 break;
             case 'changePreferredMimetype':
-                const outputId = event.data.outputId;
-                const index = outputs.findIndex(output => output.outputId === outputId);
-                outputs.splice(index, 1);
-                clearOutput(outputs.splice(index, 1)[0]);
-                renderers.render(outputs[index], event.data.mimeType, undefined, new AbortController().signal);
+                const mimeType = event.data.mimeType;
+                outputs.forEach(output => {
+                    output.clear();
+                    renderers.render(output, mimeType, undefined, new AbortController().signal);
+                });
                 break;
             case 'customKernelMessage':
                 onDidReceiveKernelMessage.fire(event.data.message);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes the `clear cell output` and `change presentation` from the cell sidebar context menu

#### How to test

Open or create a notebook including a cell with multiple output representations.
For example the following (requires PIL installed in the kernel)
```python
 from PIL import Image

img_1 = Image.new("RGBA", (1600, 200), color="red")

display(img_1)
```
Check that changing the ouptut presentation works.
Check that clearing the output works.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

There is currently no support for multiple outputs yet. So if you have two outputs both are affected by the actions.
Also it seems there is still a bug with going back to images after changing to text

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
