### PR TITLE
Reorder back-end plugin deployment to prevent early promise resolution

### DIFF
--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -298,13 +298,12 @@ export class PluginDeployerImpl implements PluginDeployer {
         const pluginPaths = [...acceptedBackendPlugins, ...acceptedHeadlessPlugins].map(pluginEntry => pluginEntry.path());
         this.logger.debug('local path to deploy on remote instance', pluginPaths);
 
-        const deployments = await Promise.all([
-            // headless plugins are deployed like backend plugins
-            this.pluginDeployerHandler.deployBackendPlugins(acceptedHeadlessPlugins),
-            // start the backend plugins
-            this.pluginDeployerHandler.deployBackendPlugins(acceptedBackendPlugins),
-            this.pluginDeployerHandler.deployFrontendPlugins(acceptedFrontendPlugins)
-        ]);
+        const deployments = [];
+        // start the backend plugins
+        deployments.push(await this.pluginDeployerHandler.deployBackendPlugins(acceptedBackendPlugins));
+        // headless plugins are deployed like backend plugins
+        deployments.push(await this.pluginDeployerHandler.deployBackendPlugins(acceptedHeadlessPlugins));
+        deployments.push(await this.pluginDeployerHandler.deployFrontendPlugins(acceptedFrontendPlugins));
         this.onDidDeployEmitter.fire(undefined);
         return deployments.reduce<number>((accumulated, current) => accumulated += current ?? 0, 0);
     }


### PR DESCRIPTION
#### What it does
Upon startup, we the front end indirectly waits for the initial deployment of plugins before loading their contributions. Because of parallel execution of back end/headless deployment, the corresponding promise was resolved too early and the list of plugins was incomplete.

Workaround for #13638

Contributed on behalf of STMicroelectronics


#### How to test
Repeat the "how to reproduce" from the linked issue. The installed plugins should show up reliably in the UI.

#### Follow-ups
https://github.com/eclipse-theia/theia/issues/13641
https://github.com/eclipse-theia/theia/issues/13642

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
