### PR TITLE
Align to vscode notebook commands

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -69,17 +69,17 @@ export namespace NotebookCommands {
     });
 
     export const CUT_SELECTED_CELL = Command.toDefaultLocalizedCommand({
-        id: 'notebook.cut-selected-cell',
+        id: 'notebook.cell.cut',
         category: 'Notebook',
     });
 
     export const COPY_SELECTED_CELL = Command.toDefaultLocalizedCommand({
-        id: 'notebook.copy-selected-cell',
+        id: 'notebook.cell.copy',
         category: 'Notebook',
     });
 
     export const PASTE_CELL = Command.toDefaultLocalizedCommand({
-        id: 'notebook.paste-cell',
+        id: 'notebook.cell.paste',
         category: 'Notebook',
     });
 }

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -120,22 +120,22 @@ export namespace NotebookCellCommands {
         label: 'Change Cell to Mardown'
     });
 
-    export const COLLAPSE_CELL_OUTPUT = Command.toDefaultLocalizedCommand({
-        id: 'notebook.cell.collapseCellOutput',
+    export const TOGGLE_CELL_OUTPUT = Command.toDefaultLocalizedCommand({
+        id: 'notebook.cell.toggleOutputs',
         category: 'Notebook',
         label: 'Collapse Cell Output',
-    });
-
-    export const EXPAND_CELL_OUTPUT = Command.toDefaultLocalizedCommand({
-        id: 'notebook.cell.expandCellOutput',
-        category: 'Notebook',
-        label: 'Expand Cell Output',
     });
 
     export const CHANGE_CELL_LANGUAGE = Command.toDefaultLocalizedCommand({
         id: 'notebook.cell.changeLanguage',
         category: 'Notebook',
         label: 'Change Cell Language',
+    });
+
+    export const TOGGLE_LINE_NUMBERS = Command.toDefaultLocalizedCommand({
+        id: 'notebook.cell.toggleLineNumbers',
+        category: 'Notebook',
+        label: 'Show Cell Line Numbers',
     });
 
 }
@@ -351,20 +351,11 @@ export class NotebookCellActionContribution implements MenuContribution, Command
             changeCellType(notebookModel, cell, CellKind.Markup);
         }));
 
-        commands.registerCommand(NotebookCellCommands.COLLAPSE_CELL_OUTPUT, {
+        commands.registerCommand(NotebookCellCommands.TOGGLE_CELL_OUTPUT, {
             execute: () => {
                 const selectedCell = this.notebookEditorWidgetService.focusedEditor?.model?.selectedCell;
                 if (selectedCell) {
-                    selectedCell.outputVisible = false;
-                }
-            }
-        });
-
-        commands.registerCommand(NotebookCellCommands.EXPAND_CELL_OUTPUT, {
-            execute: () => {
-                const selectedCell = this.notebookEditorWidgetService.focusedEditor?.model?.selectedCell;
-                if (selectedCell) {
-                    selectedCell.outputVisible = true;
+                    selectedCell.outputVisible = !selectedCell.outputVisible;
                 }
             }
         });
@@ -383,6 +374,16 @@ export class NotebookCellActionContribution implements MenuContribution, Command
                             language: language.value.id
                         }], true);
                     }
+                }
+            }
+        });
+
+        commands.registerCommand(NotebookCellCommands.TOGGLE_LINE_NUMBERS, {
+            execute: () => {
+                const selectedCell = this.notebookEditorWidgetService.focusedEditor?.model?.selectedCell;
+                if (selectedCell) {
+                    const currentLineNumber = selectedCell.editorOptions?.lineNumbers;
+                    selectedCell.editorOptions = { ...selectedCell.editorOptions, lineNumbers: !currentLineNumber || currentLineNumber === 'off' ? 'on' : 'off' };
                 }
             }
         });

--- a/packages/notebook/src/browser/contributions/notebook-context-keys.ts
+++ b/packages/notebook/src/browser/contributions/notebook-context-keys.ts
@@ -30,6 +30,7 @@ export const KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED = 'notebookFindWidg
 export const NOTEBOOK_EDITOR_FOCUSED = 'notebookEditorFocused';
 export const NOTEBOOK_CELL_LIST_FOCUSED = 'notebookCellListFocused';
 export const NOTEBOOK_OUTPUT_FOCUSED = 'notebookOutputFocused';
+export const NOTEBOOK_OUTPUT_INPUT_FOCUSED = 'notebookOutputInputFocused';
 export const NOTEBOOK_EDITOR_EDITABLE = 'notebookEditable';
 export const NOTEBOOK_HAS_RUNNING_CELL = 'notebookHasRunningCell';
 export const NOTEBOOK_USE_CONSOLIDATED_OUTPUT_BUTTON = 'notebookUseConsolidatedOutputButton';
@@ -71,6 +72,7 @@ export namespace NotebookContextKeys {
         service.createKey(NOTEBOOK_EDITOR_FOCUSED, false);
         service.createKey(NOTEBOOK_CELL_LIST_FOCUSED, false);
         service.createKey(NOTEBOOK_OUTPUT_FOCUSED, false);
+        service.createKey(NOTEBOOK_OUTPUT_INPUT_FOCUSED, false);
         service.createKey(NOTEBOOK_EDITOR_EDITABLE, true);
         service.createKey(NOTEBOOK_HAS_RUNNING_CELL, false);
         service.createKey(NOTEBOOK_USE_CONSOLIDATED_OUTPUT_BUTTON, false);

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -264,7 +264,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this.onDidPostKernelMessageEmitter.dispose();
         this.onDidReceiveKernelMessageEmitter.dispose();
         this.onPostRendererMessageEmitter.dispose();
-        this.onDidChangeOutputInputFocusEmitter.dispose()
+        this.onDidChangeOutputInputFocusEmitter.dispose();
         this.viewportService.dispose();
         this._model?.dispose();
         super.dispose();

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -120,8 +120,8 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected readonly onDidReceiveKernelMessageEmitter = new Emitter<unknown>();
     readonly onDidReceiveKernelMessage = this.onDidReceiveKernelMessageEmitter.event;
 
-    protected readonly onDidChangeOutputInputFocuEmitter = new Emitter<boolean>();
-    readonly onDidChangeOutputInputFocus = this.onDidChangeOutputInputFocuEmitter.event;
+    protected readonly onDidChangeOutputInputFocusEmitter = new Emitter<boolean>();
+    readonly onDidChangeOutputInputFocus = this.onDidChangeOutputInputFocusEmitter.event;
 
     protected readonly renderers = new Map<CellKind, CellRenderer>();
     protected _model?: NotebookModel;
@@ -255,7 +255,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     }
 
     outputInputFocusChanged(focused: boolean): void {
-        this.onDidChangeOutputInputFocuEmitter.fire(focused);
+        this.onDidChangeOutputInputFocusEmitter.fire(focused);
     }
 
     override dispose(): void {
@@ -264,6 +264,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
         this.onDidPostKernelMessageEmitter.dispose();
         this.onDidReceiveKernelMessageEmitter.dispose();
         this.onPostRendererMessageEmitter.dispose();
+        this.onDidChangeOutputInputFocusEmitter.dispose()
         this.viewportService.dispose();
         this._model?.dispose();
         super.dispose();

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -120,6 +120,9 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected readonly onDidReceiveKernelMessageEmitter = new Emitter<unknown>();
     readonly onDidReceiveKernelMessage = this.onDidReceiveKernelMessageEmitter.event;
 
+    protected readonly onDidChangeOutputInputFocuEmitter = new Emitter<boolean>();
+    readonly onDidChangeOutputInputFocus = this.onDidChangeOutputInputFocuEmitter.event;
+
     protected readonly renderers = new Map<CellKind, CellRenderer>();
     protected _model?: NotebookModel;
     protected _ready: Deferred<NotebookModel> = new Deferred();
@@ -249,6 +252,10 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
 
     recieveKernelMessage(message: unknown): void {
         this.onDidReceiveKernelMessageEmitter.fire(message);
+    }
+
+    outputInputFocusChanged(focused: boolean): void {
+        this.onDidChangeOutputInputFocuEmitter.fire(focused);
     }
 
     override dispose(): void {

--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -23,6 +23,7 @@ import {
     NOTEBOOK_CELL_EXECUTING, NOTEBOOK_CELL_EXECUTION_STATE,
     NOTEBOOK_CELL_FOCUSED, NOTEBOOK_CELL_MARKDOWN_EDIT_MODE,
     NOTEBOOK_CELL_TYPE, NOTEBOOK_HAS_OUTPUTS, NOTEBOOK_KERNEL, NOTEBOOK_KERNEL_SELECTED,
+    NOTEBOOK_OUTPUT_INPUT_FOCUSED,
     NOTEBOOK_VIEW_TYPE
 } from '../contributions/notebook-context-keys';
 import { NotebookEditorWidget } from '../notebook-editor-widget';
@@ -100,6 +101,11 @@ export class NotebookContextManager {
         }));
 
         widget.model?.onDidChangeSelectedCell(e => this.selectedCellChanged(e));
+
+        widget.onDidChangeOutputInputFocus(focus => {
+            this.scopedStore.setContext(NOTEBOOK_OUTPUT_INPUT_FOCUSED, focus);
+            this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_OUTPUT_INPUT_FOCUSED]));
+        });
 
         this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_VIEW_TYPE, NOTEBOOK_KERNEL_SELECTED, NOTEBOOK_KERNEL]));
     }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -216,6 +216,8 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 // console.log('from webview customKernelMessage ', JSON.stringify(message.message));
                 this.editor.recieveKernelMessage(message.message);
                 break;
+            case 'inputFocusChanged':
+                this.editor?.outputInputFocusChanged(message.focused);
         }
     }
 

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -581,5 +581,15 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         return this.originalAppendChild(node);
     };
 
+    const focusChange = (event: FocusEvent, focus: boolean) => {
+        if (event.target instanceof HTMLInputElement) {
+            theia.postMessage({ type: 'inputFocusChanged', focused: focus } as webviewCommunication.InputFocusChange);
+        }
+    };
+
+    window.addEventListener('focusin', (event: FocusEvent) => focusChange(event, true));
+
+    window.addEventListener('focusout', (event: FocusEvent) => focusChange(event, false));
+
     theia.postMessage(<webviewCommunication.WebviewInitialized>{ type: 'initialized' });
 }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -76,7 +76,12 @@ export interface WheelMessage {
     readonly deltaX: number;
 }
 
-export type FromWebviewMessage = WebviewInitialized | OnDidRenderOutput | WheelMessage | CustomRendererMessage | KernelMessage;
+export interface InputFocusChange {
+    readonly type: 'inputFocusChanged';
+    readonly focused: boolean;
+}
+
+export type FromWebviewMessage = WebviewInitialized | OnDidRenderOutput | WheelMessage | CustomRendererMessage | KernelMessage | InputFocusChange;
 
 export interface Output {
     id: string
@@ -88,3 +93,4 @@ export interface OutputItem {
     readonly mime: string;
     readonly data: Uint8Array;
 }
+


### PR DESCRIPTION
this makes more keybindings available.
Also implements to notbookOutputInputFocused context key

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

It aligns some commands with the ids from vscode so that shortcuts contributed by jupyter should work. 
Also implements the `notebookOutputInputFocused` context key which most of these shortcuts are using

#### How to test

open a notebook and create a cell like:
```python
import ipywidgets as widgets
widgets.Text()
```

The following shortcuts from jupyter should now work: `l`, `o`, `c`, `v`, `x`
Also when focusing the input fied in the cell output none of the shoudl activate

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
