### PR TITLE
Fixed storing of the notebook-outlineview state data

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-label-provider-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-label-provider-contribution.ts
@@ -43,7 +43,7 @@ export class NotebookLabelProviderContribution implements LabelProviderContribut
     }
 
     getIcon(element: NotebookCellOutlineNode): string {
-        const cell = this.findCellByUri(element.uri.toString());
+        const cell = this.findCellByUri(element.uri);
         if (cell) {
             return cell.cellKind === CellKind.Markup ? codicon('markdown') : codicon('code');
         }
@@ -51,7 +51,7 @@ export class NotebookLabelProviderContribution implements LabelProviderContribut
     }
 
     getName(element: NotebookCellOutlineNode): string {
-        const cell = this.findCellByUri(element.uri.toString());
+        const cell = this.findCellByUri(element.uri);
         if (cell) {
             return cell.cellKind === CellKind.Code ?
                 cell.text.split('\n')[0] :
@@ -74,8 +74,8 @@ export class NotebookLabelProviderContribution implements LabelProviderContribut
         return parsedMarkdown.map(token => token.children ? this.extractPlaintext(token.children) : token.content).join('');
     }
 
-    findCellByUri(uri: string): NotebookCellModel | undefined {
-        const parsed = CellUri.parse(new URI(uri));
+    findCellByUri(uri: URI): NotebookCellModel | undefined {
+        const parsed = CellUri.parse(uri);
         if (parsed) {
             return this.notebookService.getNotebookEditorModel(parsed.notebook)?.cells.find(cell => cell.handle === parsed?.handle);
         }

--- a/packages/notebook/src/browser/contributions/notebook-outline-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-outline-contribution.ts
@@ -33,8 +33,8 @@ export namespace NotebookCellOutlineNode {
         return TreeNode.is(element)
             && OutlineSymbolInformationNode.is(element)
             && isObject<NotebookCellOutlineNode>(element)
-            && typeof element.uri === 'object'
-            && (element as NotebookCellOutlineNode).uri.scheme === CellUri.cellUriScheme;
+            && element.uri instanceof URI
+            && element.uri.scheme === CellUri.cellUriScheme;
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes the notebook outline view so it does not break the layout storing on reload.
Previously this lead to the layout-restorer throwing a circular structure error.

#### How to test

Open a notebook and check the outline view is working.
Reload the page and confirm the layout is correctly restored

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
