### PR TITLE
Select next notebook cell on first or last line of editor

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-context-keys.ts
+++ b/packages/notebook/src/browser/contributions/notebook-context-keys.ts
@@ -58,6 +58,9 @@ export const NOTEBOOK_INTERRUPTIBLE_KERNEL = 'notebookInterruptibleKernel';
 export const NOTEBOOK_MISSING_KERNEL_EXTENSION = 'notebookMissingKernelExtension';
 export const NOTEBOOK_HAS_OUTPUTS = 'notebookHasOutputs';
 
+export const NOTEBOOK_CELL_CURSOR_FIRST_LINE = 'cellEditorCursorPositionFirstLine';
+export const NOTEBOOK_CELL_CURSOR_LAST_LINE = 'cellEditorCursorPositionLastLine';
+
 export namespace NotebookContextKeys {
     export function initNotebookContextKeys(service: ContextKeyService): void {
         service.createKey(HAS_OPENED_NOTEBOOK, false);
@@ -93,6 +96,8 @@ export namespace NotebookContextKeys {
         service.createKey(NOTEBOOK_CELL_INPUT_COLLAPSED, false);
         service.createKey(NOTEBOOK_CELL_OUTPUT_COLLAPSED, false);
         service.createKey(NOTEBOOK_CELL_RESOURCE, '');
+        service.createKey(NOTEBOOK_CELL_CURSOR_FIRST_LINE, false);
+        service.createKey(NOTEBOOK_CELL_CURSOR_LAST_LINE, false);
 
         // Kernels
         service.createKey(NOTEBOOK_KERNEL, undefined);

--- a/packages/notebook/src/browser/view-model/notebook-cell-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-cell-model.ts
@@ -36,6 +36,8 @@ import { LanguageService } from '@theia/core/lib/browser/language-service';
 export const NotebookCellModelFactory = Symbol('NotebookModelFactory');
 export type NotebookCellModelFactory = (props: NotebookCellModelProps) => NotebookCellModel;
 
+export type CellEditorFocusRequest = number | 'lastLine' | undefined;
+
 export function createNotebookCellModelContainer(parent: interfaces.Container, props: NotebookCellModelProps): interfaces.Container {
     const child = parent.createChild();
 
@@ -104,7 +106,7 @@ export class NotebookCellModel implements NotebookCell, Disposable {
     protected readonly onDidRequestCellEditChangeEmitter = new Emitter<boolean>();
     readonly onDidRequestCellEditChange = this.onDidRequestCellEditChangeEmitter.event;
 
-    protected readonly onWillFocusCellEditorEmitter = new Emitter<void>();
+    protected readonly onWillFocusCellEditorEmitter = new Emitter<CellEditorFocusRequest>();
     readonly onWillFocusCellEditor = this.onWillFocusCellEditorEmitter.event;
 
     protected readonly onWillBlurCellEditorEmitter = new Emitter<void>();
@@ -278,9 +280,9 @@ export class NotebookCellModel implements NotebookCell, Disposable {
         this.onDidRequestCellEditChangeEmitter.fire(false);
     }
 
-    requestFocusEditor(): void {
+    requestFocusEditor(focusRequest?: CellEditorFocusRequest): void {
         this.requestEdit();
-        this.onWillFocusCellEditorEmitter.fire();
+        this.onWillFocusCellEditorEmitter.fire(focusRequest);
     }
 
     requestBlurEditor(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This replicates the behaviour of vscode when having the cursor on the first or last line in a cell editor and pressing `up`/`down` it will select the next/previous cell as if it was one text editor.

#### How to test

Open or create a notebook with multiple cells. Focus an editor and move up down through the cells with the arrow key

#### Follow-ups

there is not really a difference between edit and command mode currently in theias notebook editor. So when getting to a markdown cell and then moving to a code cell, it will not focus the editor again

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
