### PR TITLE
Fix unix terminals for bundled apps

### DIFF
--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -124,6 +124,10 @@ export class NativeWebpackPlugin {
             const dllFile = require.resolve('node-pty/build/Release/winpty.dll');
             const targetDllFile = path.join(targetDirectory, 'winpty.dll');
             await this.copyExecutable(dllFile, targetDllFile);
+        } else {
+            const sourceFile = require.resolve('node-pty/build/Release/spawn-helper');
+            const targetFile = path.join(targetDirectory, 'spawn-helper');
+            await this.copyExecutable(sourceFile, targetFile);
         }
     }
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13657

While updating the `node-pty` version in https://github.com/eclipse-theia/theia/pull/13614, I've removed code to copy the `spawn-helper` binary to the target directory, since the binary did no longer exist in `v1.0.0` of the library. However, after I downgraded to `v0.11.0.beta24`, I forgot to add the copy call again. This breaks unix terminal support in all bundled apps.

This change adds the copy code back.

#### How to test

Tests should be green (especially the playwright test) and terminal should work on unix platforms.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
