### PR TITLE
Use responsive design for the main notebook toolbar

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -286,6 +286,8 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
             order: '30',
             when: NOTEBOOK_HAS_OUTPUTS
         });
+
+        menus.registerIndependentSubmenu(NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_HIDDEN_ITEMS_CONTEXT_MENU, '');
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
@@ -326,4 +328,5 @@ export namespace NotebookMenus {
     export const NOTEBOOK_MAIN_TOOLBAR = 'notebook/toolbar';
     export const NOTEBOOK_MAIN_TOOLBAR_CELL_ADD_GROUP = [NOTEBOOK_MAIN_TOOLBAR, 'cell-add-group'];
     export const NOTEBOOK_MAIN_TOOLBAR_EXECUTION_GROUP = [NOTEBOOK_MAIN_TOOLBAR, 'cell-execution-group'];
+    export const NOTEBOOK_MAIN_TOOLBAR_HIDDEN_ITEMS_CONTEXT_MENU = 'notebook-main-toolbar-hidden-items-context-menu';
 }

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -225,6 +225,7 @@
 
 .theia-notebook-main-toolbar-item-text {
   padding: 0 4px;
+  white-space: nowrap;
 }
 
 .theia-notebook-toolbar-separator {

--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -129,8 +129,8 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
         if (this.gapElement && this.gapElement.getBoundingClientRect().width < NotebookMainToolbar.MIN_FREE_AREA && this.state.numberOfHiddenItems < numberOfMenuItems) {
             this.setState({ ...this.state, numberOfHiddenItems: this.state.numberOfHiddenItems + 1 });
             this.lastGapElementWidth = this.gapElement.getBoundingClientRect().width;
-        } else if (this.gapElement && this.gapElement.getBoundingClientRect().width > this.lastGapElementWidth) {
-            this.setState({ ...this.state, numberOfHiddenItems: this.state.numberOfHiddenItems <= 1 ? 0 : this.state.numberOfHiddenItems - 1 });
+        } else if (this.gapElement && this.gapElement.getBoundingClientRect().width > this.lastGapElementWidth && this.state.numberOfHiddenItems > 0) {
+            this.setState({ ...this.state, numberOfHiddenItems: 0 });
             this.lastGapElementWidth = this.gapElement.getBoundingClientRect().width;
         }
     }

--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -75,6 +75,8 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
     protected gapElement: HTMLDivElement | undefined;
     protected lastGapElementWidth: number = 0;
 
+    protected resizeObserver: ResizeObserver = new ResizeObserver(() => this.calculateItemsToHide());
+
     constructor(props: NotebookMainToolbarProps) {
         super(props);
 
@@ -167,10 +169,13 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
     }
 
     protected gapElementChanged(element: HTMLDivElement | null): void {
+        if (this.gapElement) {
+            this.resizeObserver.unobserve(this.gapElement);
+        }
         this.gapElement = element ?? undefined;
         if (this.gapElement) {
             this.lastGapElementWidth = this.gapElement.getBoundingClientRect().width;
-            new ResizeObserver(() => this.calculateItemsToHide()).observe(this.gapElement);
+            this.resizeObserver.observe(this.gapElement);
         }
     }
 

--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 import { ArrayUtils, CommandRegistry, CompoundMenuNodeRole, DisposableCollection, MenuModelRegistry, MenuNode, nls } from '@theia/core';
 import * as React from '@theia/core/shared/react';
-import { codicon } from '@theia/core/lib/browser';
+import { codicon, ContextMenuRenderer } from '@theia/core/lib/browser';
 import { NotebookCommands, NotebookMenus } from '../contributions/notebook-actions-contribution';
 import { NotebookModel } from '../view-model/notebook-model';
 import { NotebookKernelService } from '../service/notebook-kernel-service';
@@ -32,6 +32,7 @@ export interface NotebookMainToolbarProps {
     contextKeyService: ContextKeyService;
     editorNode: HTMLElement;
     notebookContextManager: NotebookContextManager;
+    contextMenuRenderer: ContextMenuRenderer;
 }
 
 @injectable()
@@ -41,6 +42,7 @@ export class NotebookMainToolbarRenderer {
     @inject(MenuModelRegistry) protected readonly menuRegistry: MenuModelRegistry;
     @inject(ContextKeyService) protected readonly contextKeyService: ContextKeyService;
     @inject(NotebookContextManager) protected readonly notebookContextManager: NotebookContextManager;
+    @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer;
 
     render(notebookModel: NotebookModel, editorNode: HTMLElement): React.ReactNode {
         return <NotebookMainToolbar notebookModel={notebookModel}
@@ -49,11 +51,20 @@ export class NotebookMainToolbarRenderer {
             commandRegistry={this.commandRegistry}
             contextKeyService={this.contextKeyService}
             editorNode={editorNode}
-            notebookContextManager={this.notebookContextManager} />;
+            notebookContextManager={this.notebookContextManager}
+            contextMenuRenderer={this.contextMenuRenderer} />;
     }
 }
 
-export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProps, { selectedKernelLabel?: string }> {
+interface NotebookMainToolbarState {
+    selectedKernelLabel?: string;
+    numberOfHiddenItems: number;
+}
+
+export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProps, NotebookMainToolbarState> {
+
+    // The minimum area between items and kernel select before hiding items in a context menu
+    static readonly MIN_FREE_AREA = 10;
 
     protected toDispose = new DisposableCollection();
 
@@ -61,10 +72,16 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
         NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_CELL_ADD_GROUP[NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_CELL_ADD_GROUP.length - 1],
         NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_EXECUTION_GROUP[NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_EXECUTION_GROUP.length - 1]];
 
+    protected gapElement: HTMLDivElement | undefined;
+    protected lastGapElementWidth: number = 0;
+
     constructor(props: NotebookMainToolbarProps) {
         super(props);
 
-        this.state = { selectedKernelLabel: props.notebookKernelService.getSelectedOrSuggestedKernel(props.notebookModel)?.label };
+        this.state = {
+            selectedKernelLabel: props.notebookKernelService.getSelectedOrSuggestedKernel(props.notebookModel)?.label,
+            numberOfHiddenItems: 0,
+        };
         this.toDispose.push(props.notebookKernelService.onDidChangeSelectedKernel(event => {
             if (props.notebookModel.uri.isEqual(event.notebook)) {
                 this.setState({ selectedKernelLabel: props.notebookKernelService.getKernel(event.newKernel ?? '')?.label });
@@ -97,10 +114,48 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
         this.toDispose.dispose();
     }
 
+    override componentDidUpdate(): void {
+        this.calculateItemsToHide();
+    }
+
+    override componentDidMount(): void {
+        this.calculateItemsToHide();
+    }
+
+    protected calculateItemsToHide(): void {
+        if (this.gapElement && this.gapElement.getBoundingClientRect().width < NotebookMainToolbar.MIN_FREE_AREA) {
+            this.setState({ ...this.state, numberOfHiddenItems: this.state.numberOfHiddenItems + 1 });
+            this.lastGapElementWidth = this.gapElement.getBoundingClientRect().width;
+        } else if (this.gapElement && this.gapElement.getBoundingClientRect().width > this.lastGapElementWidth) {
+            this.setState({ ...this.state, numberOfHiddenItems: this.state.numberOfHiddenItems - 1 });
+            this.lastGapElementWidth = this.gapElement.getBoundingClientRect().width;
+        }
+    }
+
+    protected renderContextMenu(event: MouseEvent, menuItems: readonly MenuNode[]): void {
+        const hiddenItems = menuItems.slice(menuItems.length - this.state.numberOfHiddenItems);
+        const contextMenu = this.props.menuRegistry.getMenu([NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_HIDDEN_ITEMS_CONTEXT_MENU]);
+
+        contextMenu.children.map(item => item.id).forEach(id => contextMenu.removeNode(id));
+        hiddenItems.forEach(item => contextMenu.addNode(item));
+
+        this.props.contextMenuRenderer.render({
+            anchor: event,
+            menuPath: [NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_HIDDEN_ITEMS_CONTEXT_MENU],
+            context: this.props.editorNode,
+            args: [this.props.notebookModel.uri]
+        });
+    }
+
     override render(): React.ReactNode {
+        const menuItems = this.getMenuItems();
         return <div className='theia-notebook-main-toolbar'>
-            {this.getMenuItems().map(item => this.renderMenuItem(item))}
-            <div style={{ flexGrow: 1 }}></div>
+            {menuItems.slice(0, menuItems.length - this.state.numberOfHiddenItems).map(item => this.renderMenuItem(item))}
+            {
+                this.state.numberOfHiddenItems > 0 &&
+                <span className={`${codicon('ellipsis')} action-label theia-notebook-main-toolbar-item`} onClick={e => this.renderContextMenu(e.nativeEvent, menuItems)} />
+            }
+            <div ref={element => this.gapElementChanged(element)} style={{ flexGrow: 1 }}></div>
             <div className='theia-notebook-main-toolbar-item action-label'
                 onClick={() => this.props.commandRegistry.executeCommand(NotebookCommands.SELECT_KERNEL_COMMAND.id, this.props.notebookModel)}>
                 <span className={codicon('server-environment')} />
@@ -108,7 +163,15 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
                     {this.state.selectedKernelLabel ?? nls.localizeByDefault('Select Kernel')}
                 </span>
             </div>
-        </div>;
+        </div >;
+    }
+
+    protected gapElementChanged(element: HTMLDivElement | null): void {
+        this.gapElement = element ?? undefined;
+        if (this.gapElement) {
+            this.lastGapElementWidth = this.gapElement.getBoundingClientRect().width;
+            new ResizeObserver(() => this.calculateItemsToHide()).observe(this.gapElement);
+        }
     }
 
     protected renderMenuItem(item: MenuNode, submenu?: string): React.ReactNode {

--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -125,7 +125,7 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
     }
 
     protected calculateItemsToHide(): void {
-        const numberOfMenuItems = this.getMenuItems().length
+        const numberOfMenuItems = this.getMenuItems().length;
         if (this.gapElement && this.gapElement.getBoundingClientRect().width < NotebookMainToolbar.MIN_FREE_AREA && this.state.numberOfHiddenItems < numberOfMenuItems) {
             this.setState({ ...this.state, numberOfHiddenItems: this.state.numberOfHiddenItems + 1 });
             this.lastGapElementWidth = this.gapElement.getBoundingClientRect().width;


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

When the notebook editor widget in not wide enough to contain all main toolbar items it will now add a `...` menu containing all overflowing items

#### How to test

Open a notebook and adjust the widget size. You should see groups being added and removed again from the context menu. 


#### Follow-ups

Currently only the top level groups are added to context menu instead of singular `MenuAction`s like in vscode

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
