### PR TITLE
Handle isFileSystemResource context key

### DIFF
--- a/packages/navigator/src/browser/navigator-context-key-service.ts
+++ b/packages/navigator/src/browser/navigator-context-key-service.ts
@@ -45,12 +45,22 @@ export class NavigatorContextKeyService {
         return this._explorerResourceIsFolder;
     }
 
+    protected _isFileSystemResource: ContextKey<boolean>;
+
+    /**
+     * True when the Explorer or editor file is a file system resource that can be handled from a file system provider.
+     */
+    get isFileSystemResource(): ContextKey<boolean> {
+        return this._isFileSystemResource;
+    }
+
     @postConstruct()
     protected init(): void {
         this._explorerViewletVisible = this.contextKeyService.createKey<boolean>('explorerViewletVisible', false);
         this._explorerViewletFocus = this.contextKeyService.createKey<boolean>('explorerViewletFocus', false);
         this._filesExplorerFocus = this.contextKeyService.createKey<boolean>('filesExplorerFocus', false);
         this._explorerResourceIsFolder = this.contextKeyService.createKey<boolean>('explorerResourceIsFolder', false);
+        this._isFileSystemResource = this.contextKeyService.createKey<boolean>('isFileSystemResource', false);
     }
 
 }

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -19,7 +19,7 @@ import { Message } from '@theia/core/shared/@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { CommandService } from '@theia/core/lib/common';
 import { Key, TreeModel, ContextMenuRenderer, ExpandableTreeNode, TreeProps, TreeNode } from '@theia/core/lib/browser';
-import { DirNode } from '@theia/filesystem/lib/browser';
+import { DirNode, FileStatNodeData } from '@theia/filesystem/lib/browser';
 import { WorkspaceService, WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { WorkspaceNode, WorkspaceRootNode } from './navigator-tree';
 import { FileNavigatorModel } from './navigator-model';
@@ -210,6 +210,10 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
 
     protected updateSelectionContextKeys(): void {
         this.contextKeyService.explorerResourceIsFolder.set(DirNode.is(this.model.selectedNodes[0]));
+        // As `FileStatNode` only created if `FileService.resolve` was successful, we can safely assume that
+        // a valid `FileSystemProvider` is available for the selected node. So we skip an additional check
+        // for provider availability here and check the node type.
+        this.contextKeyService.isFileSystemResource.set(FileStatNodeData.is(this.model.selectedNodes[0]));
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

As mentioned [here](https://github.com/eclipse-theia/theia/issues/13535#issuecomment-2066587202) the handling for the `isFileSystemResource` is missing in Theia. This prevents menu contributions that are using this key.  

Context key description: https://code.visualstudio.com/api/references/when-clause-contexts#available-context-keys


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Simplest way to test is to install the [Open In External App](https://open-vsx.org/extension/YuTengjing/open-in-external-app) extension as described in #13535. With this PR applied you should see the "Open in External App" Explorer context menu entry.
<img width="372" alt="Bildschirmfoto 2024-04-29 um 15 15 37" src="https://github.com/eclipse-theia/theia/assets/454322/1941b9dd-b8f2-41aa-a5ac-c4e780c4c29c">


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
