### PR TITLE
Added additional css to notebook output webviews

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -38,13 +38,13 @@ import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-m
 
 const CellModel = Symbol('CellModel');
 const Notebook = Symbol('NotebookModel');
-export const AdditionalOutputCss = Symbol('AdditionalOutputCss');
+export const AdditionalNotebookCellOutputCss = Symbol('AdditionalNotebookCellOutputCss');
 
 export function createCellOutputWebviewContainer(ctx: interfaces.Container, cell: NotebookCellModel, notebook: NotebookModel): interfaces.Container {
     const child = ctx.createChild();
     child.bind(CellModel).toConstantValue(cell);
     child.bind(Notebook).toConstantValue(notebook);
-    child.bind(AdditionalOutputCss).toConstantValue(DEFAULT_NOTEBOOK_OUTPUT_CSS);
+    child.bind(AdditionalNotebookCellOutputCss).toConstantValue(DEFAULT_NOTEBOOK_OUTPUT_CSS);
     child.bind(CellOutputWebviewImpl).toSelf().inSingletonScope();
     return child;
 }
@@ -144,7 +144,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     @inject(QuickPickService)
     protected readonly quickPickService: QuickPickService;
 
-    @inject(AdditionalOutputCss)
+    @inject(AdditionalNotebookCellOutputCss)
     protected readonly additionalOutputCss: string;
 
     readonly id = generateUuid();

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -38,14 +38,81 @@ import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-m
 
 const CellModel = Symbol('CellModel');
 const Notebook = Symbol('NotebookModel');
+export const AdditionalOutputCss = Symbol('AdditionalOutputCss');
 
 export function createCellOutputWebviewContainer(ctx: interfaces.Container, cell: NotebookCellModel, notebook: NotebookModel): interfaces.Container {
     const child = ctx.createChild();
     child.bind(CellModel).toConstantValue(cell);
     child.bind(Notebook).toConstantValue(notebook);
+    child.bind(AdditionalOutputCss).toConstantValue(DEFAULT_NOTEBOOK_OUTPUT_CSS);
     child.bind(CellOutputWebviewImpl).toSelf().inSingletonScope();
     return child;
 }
+
+export const DEFAULT_NOTEBOOK_OUTPUT_CSS = `
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}
+  
+table th,
+table td {
+    border: 1px solid;
+}
+
+table > thead > tr > th {
+    text-align: left;
+    border-bottom: 1px solid;
+}
+
+table > thead > tr > th,
+table > thead > tr > td,
+table > tbody > tr > th,
+table > tbody > tr > td {
+    padding: 5px 10px;
+}
+
+table > tbody > tr + tr > td {
+    border-top: 1px solid;
+}
+
+table,
+thead,
+tr,
+th,
+td,
+tbody {
+    border: none !important;
+    border-color: transparent;
+    border-spacing: 0;
+    border-collapse: collapse;
+}
+
+table,
+th,
+tr {
+    vertical-align: middle;
+    text-align: right;
+}
+
+thead {
+    font-weight: bold;
+    background-color: rgba(130, 130, 130, 0.16);
+}
+
+th,
+td {
+    padding: 4px 8px;
+}
+
+tr:nth-child(even) {
+    background-color: rgba(130, 130, 130, 0.08);
+}
+
+tbody th {
+    font-weight: normal;
+}
+`;
 
 @injectable()
 export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
@@ -76,6 +143,9 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
     @inject(QuickPickService)
     protected readonly quickPickService: QuickPickService;
+
+    @inject(AdditionalOutputCss)
+    protected readonly additionalOutputCss: string;
 
     readonly id = generateUuid();
 
@@ -129,7 +199,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 'jupyter.viewOutput',
                 'workbench.action.openLargeOutput',
                 'cellOutput.enableScrolling',
-            ]
+            ],
         });
         this.webviewWidget.setHTML(await this.createWebviewContent());
 
@@ -236,6 +306,9 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 <html>
                     <head>
                         <meta charset="UTF-8">
+                        <style>
+                            ${this.additionalOutputCss}
+                        </style>
                     </head>
                     <body>
                         <script type="module">${preloads}</script>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Added additional css for styling tables to notebook output webviews. Recreating the style vscode has. 
injectable so this can be more easily be overwritten to add addtional css in custom IDEs

#### How to test

Create a notebook with a cell like the following and execute it. The table should look nice

```python
import pandas as pd

pd.DataFrame(
    data={
        "Col1HasAVeryLongName": [1, 2, 4],
        "Col2MediumName": [4, 5, 6],
        "Col3": [7, 8, 11],
    }
)
```

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
