### PR TITLE
Allow transitive binding for TerminalFrontendContribution

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -134,5 +134,5 @@ export default new ContainerModule(bind => {
         return new DefaultTerminalProfileService(userStore, contributedStore);
     }).inSingletonScope();
 
-    bind(FrontendApplicationContribution).to(TerminalFrontendContribution);
+    bind(FrontendApplicationContribution).toService(TerminalFrontendContribution);
 });


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Previously, the binding of `TerminalFrontendContribution` to `FrontendApplicationContribution` is done using the syntax `bind(FrontendApplicationContribution).to(TerminalFrontendContribution)`. This made it so that downstream adopters cannot customize the lifecycle behavior of `TerminalFrontendContribution` since `ContributionProvider.getContributions` will always resolve to the singleton `TerminalFrontendContribution` that was bound initially.

This change allows `TerminalFrontendContribution` to be resolved transitively, such that adopters can override it via the syntax `bind(TerminalFrontendContribution).toService(MyCustomTerminalFrontendContribution)`.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

- The Terminal package should behave as before.
- In a new theia extension, `bind(TerminalFrontendContribution).toService(MyCustomTerminalFrontendContribution)` should replace `TerminalFrontendContribution` with `MyCustomTerminalFrontendContribution` in `FrontendApplication.contributions.getContributions()`.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
