### PR TITLE
Refactor auto save mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> -->
 
+## 1.50.0
+
+<a name="breaking_changes_1.50.0">[Breaking Changes:](#breaking_changes_1.50.0)</a>
+
+- [core] Classes implementing the `Saveable` interface no longer need to implement the `autoSave` field. However, a new `onContentChanged` event has been added instead.
+
 ## v1.49.0 - 04/29/2024
 
 - [application-manager] added logic to generate Extension Info in server application to avoid empty About Dialog [#13590](https://github.com/eclipse-theia/theia/pull/13590) - contributed on behalf of STMicroelectronics

--- a/examples/api-tests/src/saveable.spec.js
+++ b/examples/api-tests/src/saveable.spec.js
@@ -81,13 +81,13 @@ describe('Saveable', function () {
 
     afterEach(async () => {
         toTearDown.dispose();
-        await preferences.set('files.autoSave', autoSave, undefined, rootUri.toString());
         // @ts-ignore
         editor = undefined;
         // @ts-ignore
         widget = undefined;
         await editorManager.closeAll({ save: false });
         await fileService.delete(fileUri.parent, { fromUserGesture: false, useTrash: false, recursive: true });
+        await preferences.set('files.autoSave', autoSave, undefined, rootUri.toString());
     });
 
     it('normal save', async function () {

--- a/examples/api-tests/src/typescript.spec.js
+++ b/examples/api-tests/src/typescript.spec.js
@@ -64,7 +64,7 @@ describe('TypeScript', function () {
     const rootUri = workspaceService.tryGetRoots()[0].resource;
     const demoFileUri = rootUri.resolveToAbsolute('../api-tests/test-ts-workspace/demo-file.ts');
     const definitionFileUri = rootUri.resolveToAbsolute('../api-tests/test-ts-workspace/demo-definitions-file.ts');
-    let originalAutoSaveValue = preferences.inspect('files.autoSave').globalValue;
+    let originalAutoSaveValue = preferences.get('files.autoSave');
 
     before(async function () {
         await pluginService.didStart;
@@ -73,8 +73,9 @@ describe('TypeScript', function () {
                 throw new Error(pluginId + ' should be started');
             }
             await pluginService.activatePlugin(pluginId);
-        }).concat(preferences.set('files.autoSave', 'off', PreferenceScope.User)));
-        await preferences.set('files.refactoring.autoSave', 'off', PreferenceScope.User);
+        }));
+        await preferences.set('files.autoSave', 'off');
+        await preferences.set('files.refactoring.autoSave', 'off');
     });
 
     beforeEach(async function () {
@@ -90,7 +91,7 @@ describe('TypeScript', function () {
     });
 
     after(async () => {
-        await preferences.set('files.autoSave', originalAutoSaveValue, PreferenceScope.User);
+        await preferences.set('files.autoSave', originalAutoSaveValue);
     })
 
     /**

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -62,7 +62,7 @@ import { WindowService } from './window/window-service';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 import { DecorationStyle } from './decoration-style';
 import { isPinned, Title, togglePinned, Widget } from './widgets';
-import { SaveResourceService } from './save-resource-service';
+import { SaveableService } from './saveable-service';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
 import { UNTITLED_SCHEME, UntitledResourceResolver } from '../common';
 import { LanguageQuickPickService } from './i18n/language-quick-pick-service';
@@ -385,7 +385,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(AboutDialog) protected readonly aboutDialog: AboutDialog,
         @inject(AsyncLocalizationProvider) protected readonly localizationProvider: AsyncLocalizationProvider,
-        @inject(SaveResourceService) protected readonly saveResourceService: SaveResourceService,
+        @inject(SaveableService) protected readonly saveResourceService: SaveableService,
     ) { }
 
     @inject(ContextKeyService)

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -450,6 +450,8 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bindBackendStopwatch(bind);
 
     bind(SaveResourceService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(SaveResourceService);
+
     bind(UserWorkingDirectoryProvider).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(UserWorkingDirectoryProvider);
 

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -126,7 +126,7 @@ import { DockPanel, RendererHost } from './widgets';
 import { TooltipService, TooltipServiceImpl } from './tooltip-service';
 import { BackendRequestService, RequestService, REQUEST_SERVICE_PATH } from '@theia/request';
 import { bindFrontendStopwatch, bindBackendStopwatch } from './performance';
-import { SaveResourceService } from './save-resource-service';
+import { SaveableService } from './saveable-service';
 import { SecondaryWindowHandler } from './secondary-window-handler';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
 import { WindowTitleService } from './window/window-title-service';
@@ -449,8 +449,8 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bindFrontendStopwatch(bind);
     bindBackendStopwatch(bind);
 
-    bind(SaveResourceService).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(SaveResourceService);
+    bind(SaveableService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(SaveableService);
 
     bind(UserWorkingDirectoryProvider).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(UserWorkingDirectoryProvider);

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -46,3 +46,4 @@ export * from './tooltip-service';
 export * from './decoration-style';
 export * from './styling-service';
 export * from './hover-service';
+export * from './save-resource-service';

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -46,4 +46,4 @@ export * from './tooltip-service';
 export * from './decoration-style';
 export * from './styling-service';
 export * from './hover-service';
-export * from './save-resource-service';
+export * from './saveable-service';

--- a/packages/core/src/browser/save-resource-service.ts
+++ b/packages/core/src/browser/save-resource-service.ts
@@ -14,15 +14,153 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from 'inversify';
-import { MessageService, UNTITLED_SCHEME, URI } from '../common';
+import type { ApplicationShell } from './shell';
+import { injectable } from 'inversify';
+import { UNTITLED_SCHEME, URI, Disposable, DisposableCollection } from '../common';
 import { Navigatable, NavigatableWidget } from './navigatable-types';
-import { Saveable, SaveableSource, SaveOptions } from './saveable';
+import { AutoSaveMode, Saveable, SaveableSource, SaveOptions, SaveReason } from './saveable';
 import { Widget } from './widgets';
+import { FrontendApplicationContribution } from './frontend-application-contribution';
+import { FrontendApplication } from './frontend-application';
+import throttle = require('lodash.throttle');
 
 @injectable()
-export class SaveResourceService {
-    @inject(MessageService) protected readonly messageService: MessageService;
+export class SaveResourceService implements FrontendApplicationContribution {
+
+    protected saveThrottles = new Map<Saveable, AutoSaveThrottle>();
+    protected saveMode: AutoSaveMode = 'off';
+    protected saveDelay = 1000;
+    protected shell: ApplicationShell;
+
+    get autoSave(): AutoSaveMode {
+        return this.saveMode;
+    }
+
+    set autoSave(value: AutoSaveMode) {
+        this.updateAutoSaveMode(value);
+    }
+
+    get autoSaveDelay(): number {
+        return this.saveDelay;
+    }
+
+    set autoSaveDelay(value: number) {
+        this.updateAutoSaveDelay(value);
+    }
+
+    onDidInitializeLayout(app: FrontendApplication): void {
+        this.shell = app.shell;
+        // Register restored editors first
+        for (const widget of this.shell.widgets) {
+            const saveable = Saveable.get(widget);
+            if (saveable) {
+                this.registerSaveable(widget, saveable);
+            }
+        }
+        this.shell.onDidAddWidget(e => {
+            const saveable = Saveable.get(e);
+            if (saveable) {
+                this.registerSaveable(e, saveable);
+            }
+        });
+        this.shell.onDidChangeCurrentWidget(e => {
+            if (this.saveMode === 'onFocusChange') {
+                const widget = e.oldValue;
+                const saveable = Saveable.get(widget);
+                if (saveable && widget && this.shouldAutoSave(widget, saveable)) {
+                    saveable.save({
+                        saveReason: SaveReason.FocusChange
+                    });
+                }
+            }
+        });
+        this.shell.onDidRemoveWidget(e => {
+            const saveable = Saveable.get(e);
+            if (saveable) {
+                this.saveThrottles.get(saveable)?.dispose();
+                this.saveThrottles.delete(saveable);
+            }
+        });
+    }
+
+    protected updateAutoSaveMode(mode: AutoSaveMode): void {
+        this.saveMode = mode;
+        for (const saveThrottle of this.saveThrottles.values()) {
+            saveThrottle.autoSave = mode;
+        }
+        if (mode === 'onFocusChange') {
+            // If the new mode is onFocusChange, we need to save all dirty documents that are not focused
+            const widgets = this.shell.widgets;
+            for (const widget of widgets) {
+                const saveable = Saveable.get(widget);
+                if (saveable && widget !== this.shell.currentWidget && this.shouldAutoSave(widget, saveable)) {
+                    saveable.save({
+                        saveReason: SaveReason.FocusChange
+                    });
+                }
+            }
+        }
+    }
+
+    protected updateAutoSaveDelay(delay: number): void {
+        this.saveDelay = delay;
+        for (const saveThrottle of this.saveThrottles.values()) {
+            saveThrottle.autoSaveDelay = delay;
+        }
+    }
+
+    registerSaveable(widget: Widget, saveable: Saveable): Disposable {
+        const saveThrottle = new AutoSaveThrottle(
+            saveable,
+            () => {
+                if (this.saveMode === 'afterDelay' && this.shouldAutoSave(widget, saveable)) {
+                    saveable.save({
+                        saveReason: SaveReason.AfterDelay
+                    });
+                }
+            },
+            this.addBlurListener(widget, saveable)
+        );
+        saveThrottle.autoSave = this.saveMode;
+        saveThrottle.autoSaveDelay = this.saveDelay;
+        this.saveThrottles.set(saveable, saveThrottle);
+        return saveThrottle;
+    }
+
+    protected addBlurListener(widget: Widget, saveable: Saveable): Disposable {
+        const document = widget.node.ownerDocument;
+        const listener = (() => {
+            if (this.saveMode === 'onWindowChange' && !this.windowHasFocus(document) && this.shouldAutoSave(widget, saveable)) {
+                saveable.save({
+                    saveReason: SaveReason.FocusChange
+                });
+            }
+        }).bind(this);
+        document.addEventListener('blur', listener);
+        return Disposable.create(() => {
+            document.removeEventListener('blur', listener);
+        });
+    }
+
+    protected windowHasFocus(document: Document): boolean {
+        if (document.visibilityState === 'hidden') {
+            return false;
+        } else if (document.hasFocus()) {
+            return true;
+        }
+        // TODO: Add support for iframes
+        return false;
+    }
+
+    protected shouldAutoSave(widget: Widget, saveable: Saveable): boolean {
+        const uri = NavigatableWidget.getUri(widget);
+        if (uri?.scheme === UNTITLED_SCHEME) {
+            // Never auto-save untitled documents
+            return false;
+        } else {
+            return saveable.dirty;
+        }
+    }
 
     /**
      * Indicate if the document can be saved ('Save' command should be disable if not).
@@ -57,4 +195,67 @@ export class SaveResourceService {
     saveAs(sourceWidget: Widget & SaveableSource & Navigatable, options?: SaveOptions): Promise<URI | undefined> {
         return Promise.reject('Unsupported: The base SaveResourceService does not support saveAs action.');
     }
+}
+
+export class AutoSaveThrottle implements Disposable {
+
+    private _saveable: Saveable;
+    private _cb: () => void;
+    private _disposable: DisposableCollection;
+    private _throttle?: ReturnType<typeof throttle>;
+    private _mode: AutoSaveMode = 'off';
+    private _autoSaveDelay = 1000;
+
+    get autoSave(): AutoSaveMode {
+        return this._mode;
+    }
+
+    set autoSave(value: AutoSaveMode) {
+        this._mode = value;
+        this.throttledSave();
+    }
+
+    get autoSaveDelay(): number {
+        return this._autoSaveDelay;
+    }
+
+    set autoSaveDelay(value: number) {
+        this._autoSaveDelay = value;
+        // Explicitly delete the throttle to recreate it with the new delay
+        this._throttle?.cancel();
+        this._throttle = undefined;
+        this.throttledSave();
+    }
+
+    constructor(saveable: Saveable, cb: () => void, ...disposables: Disposable[]) {
+        this._cb = cb;
+        this._saveable = saveable;
+        this._disposable = new DisposableCollection(
+            ...disposables,
+            saveable.onContentChanged(() => {
+                this.throttledSave();
+            }),
+            saveable.onDirtyChanged(() => {
+                this.throttledSave();
+            })
+        );
+    }
+
+    protected throttledSave(): void {
+        this._throttle?.cancel();
+        if (this._mode === 'afterDelay' && this._saveable.dirty) {
+            if (!this._throttle) {
+                this._throttle = throttle(() => this._cb(), this._autoSaveDelay, {
+                    leading: false,
+                    trailing: true
+                });
+            }
+            this._throttle();
+        }
+    }
+
+    dispose(): void {
+        this._disposable.dispose();
+    }
+
 }

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -24,7 +24,7 @@ import { Message } from '@phosphor/messaging';
 import { IDragEvent } from '@phosphor/dragdrop';
 import { RecursivePartial, Event as CommonEvent, DisposableCollection, Disposable, environment, isObject } from '../../common';
 import { animationFrame } from '../browser';
-import { Saveable, SaveableWidget, SaveOptions, SaveableSource } from '../saveable';
+import { Saveable, SaveableWidget, SaveOptions } from '../saveable';
 import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
 import { TheiaDockPanel, BOTTOM_AREA_ID, MAIN_AREA_ID } from './theia-dock-panel';
 import { SidePanelHandler, SidePanel, SidePanelHandlerFactory } from './side-panel-handler';
@@ -1233,7 +1233,8 @@ export class ApplicationShell extends Widget {
         this.checkActivation(widget);
         Saveable.apply(
             widget,
-            () => this.widgets.filter((maybeSaveable): maybeSaveable is Widget & SaveableSource => !!Saveable.get(maybeSaveable)),
+            () => this.saveResourceService.autoSave !== 'off',
+            () => this.widgets.filter(maybeSaveable => !!Saveable.get(maybeSaveable)),
             async (toSave, options) => {
                 await this.saveResourceService.save(toSave, options);
             },

--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -21,7 +21,7 @@ import { ApplicationShell } from '../shell';
 import { Saveable } from '../saveable';
 import { PreferenceService } from '../preferences';
 import { environment } from '../../common';
-import { SaveResourceService } from '../save-resource-service';
+import { SaveableService } from '../saveable-service';
 
 @injectable()
 export class DefaultSecondaryWindowService implements SecondaryWindowService {
@@ -44,8 +44,8 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
 
-    @inject(SaveResourceService)
-    protected readonly saveResourceService: SaveResourceService;
+    @inject(SaveableService)
+    protected readonly saveResourceService: SaveableService;
 
     @postConstruct()
     init(): void {

--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -21,6 +21,7 @@ import { ApplicationShell } from '../shell';
 import { Saveable } from '../saveable';
 import { PreferenceService } from '../preferences';
 import { environment } from '../../common';
+import { SaveResourceService } from '../save-resource-service';
 
 @injectable()
 export class DefaultSecondaryWindowService implements SecondaryWindowService {
@@ -42,6 +43,9 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
 
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
+
+    @inject(SaveResourceService)
+    protected readonly saveResourceService: SaveResourceService;
 
     @postConstruct()
     init(): void {
@@ -93,7 +97,7 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
             newWindow.addEventListener('DOMContentLoaded', () => {
                 newWindow.addEventListener('beforeunload', evt => {
                     const saveable = Saveable.get(widget);
-                    const wouldLoseState = !!saveable && saveable.dirty && saveable.autoSave === 'off';
+                    const wouldLoseState = !!saveable && saveable.dirty && this.saveResourceService.autoSave === 'off';
                     if (wouldLoseState) {
                         evt.returnValue = '';
                         evt.preventDefault();
@@ -104,7 +108,7 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
                 newWindow.addEventListener('unload', () => {
                     const saveable = Saveable.get(widget);
                     shell.closeWidget(widget.id, {
-                        save: !!saveable && saveable.dirty && saveable.autoSave !== 'off'
+                        save: !!saveable && saveable.dirty && this.saveResourceService.autoSave !== 'off'
                     });
 
                     const extIndex = this.secondaryWindows.indexOf(newWindow);

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -15,15 +15,12 @@
 // *****************************************************************************
 
 import { inject, injectable, optional, postConstruct } from '@theia/core/shared/inversify';
-import { CommandContribution, CommandRegistry, Command } from '@theia/core/lib/common';
-import { CommonCommands, PreferenceService, LabelProvider, ApplicationShell, QuickInputService, QuickPickValue } from '@theia/core/lib/browser';
+import { CommonCommands, PreferenceService, LabelProvider, ApplicationShell, QuickInputService, QuickPickValue, SaveResourceService } from '@theia/core/lib/browser';
 import { EditorManager } from './editor-manager';
-import { EditorPreferences } from './editor-preferences';
-import { ResourceProvider, MessageService } from '@theia/core';
+import { CommandContribution, CommandRegistry, Command, ResourceProvider, MessageService, nls } from '@theia/core';
 import { LanguageService } from '@theia/core/lib/browser/language-service';
 import { SUPPORTED_ENCODINGS } from '@theia/core/lib/browser/supported-encodings';
 import { EncodingMode } from './editor';
-import { nls } from '@theia/core/lib/common/nls';
 import { EditorLanguageQuickPickService } from './editor-language-quick-pick-service';
 
 export namespace EditorCommands {
@@ -209,7 +206,8 @@ export namespace EditorCommands {
 @injectable()
 export class EditorCommandContribution implements CommandContribution {
 
-    public static readonly AUTOSAVE_PREFERENCE: string = 'files.autoSave';
+    static readonly AUTOSAVE_PREFERENCE: string = 'files.autoSave';
+    static readonly AUTOSAVE_DELAY_PREFERENCE: string = 'files.autoSaveDelay';
 
     @inject(ApplicationShell)
     protected readonly shell: ApplicationShell;
@@ -217,13 +215,14 @@ export class EditorCommandContribution implements CommandContribution {
     @inject(PreferenceService)
     protected readonly preferencesService: PreferenceService;
 
-    @inject(EditorPreferences)
-    protected readonly editorPreferences: EditorPreferences;
+    @inject(SaveResourceService)
+    protected readonly saveResourceService: SaveResourceService;
 
     @inject(QuickInputService) @optional()
     protected readonly quickInputService: QuickInputService;
 
-    @inject(MessageService) protected readonly messageService: MessageService;
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
 
     @inject(LabelProvider)
     protected readonly labelProvider: LabelProvider;
@@ -242,9 +241,15 @@ export class EditorCommandContribution implements CommandContribution {
 
     @postConstruct()
     protected init(): void {
-        this.editorPreferences.onPreferenceChanged(e => {
-            if (e.preferenceName === 'files.autoSave' && e.newValue !== 'off') {
-                this.shell.saveAll();
+        this.preferencesService.ready.then(() => {
+            this.saveResourceService.autoSave = this.preferencesService.get(EditorCommandContribution.AUTOSAVE_PREFERENCE) || 'off';
+            this.saveResourceService.autoSaveDelay = this.preferencesService.get(EditorCommandContribution.AUTOSAVE_DELAY_PREFERENCE) || 1000;
+        });
+        this.preferencesService.onPreferenceChanged(e => {
+            if (e.preferenceName === EditorCommandContribution.AUTOSAVE_PREFERENCE) {
+                this.saveResourceService.autoSave = e.newValue;
+            } else if (e.preferenceName === EditorCommandContribution.AUTOSAVE_DELAY_PREFERENCE) {
+                this.saveResourceService.autoSaveDelay = e.newValue;
             }
         });
     }

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -242,14 +242,14 @@ export class EditorCommandContribution implements CommandContribution {
     @postConstruct()
     protected init(): void {
         this.preferencesService.ready.then(() => {
-            this.saveResourceService.autoSave = this.preferencesService.get(EditorCommandContribution.AUTOSAVE_PREFERENCE) || 'off';
-            this.saveResourceService.autoSaveDelay = this.preferencesService.get(EditorCommandContribution.AUTOSAVE_DELAY_PREFERENCE) || 1000;
+            this.saveResourceService.autoSave = this.preferencesService.get(EditorCommandContribution.AUTOSAVE_PREFERENCE) ?? 'off';
+            this.saveResourceService.autoSaveDelay = this.preferencesService.get(EditorCommandContribution.AUTOSAVE_DELAY_PREFERENCE) ?? 1000;
         });
         this.preferencesService.onPreferenceChanged(e => {
             if (e.preferenceName === EditorCommandContribution.AUTOSAVE_PREFERENCE) {
-                this.saveResourceService.autoSave = e.newValue;
+                this.saveResourceService.autoSave = this.preferencesService.get(EditorCommandContribution.AUTOSAVE_PREFERENCE) ?? 'off';
             } else if (e.preferenceName === EditorCommandContribution.AUTOSAVE_DELAY_PREFERENCE) {
-                this.saveResourceService.autoSaveDelay = e.newValue;
+                this.saveResourceService.autoSaveDelay = this.preferencesService.get(EditorCommandContribution.AUTOSAVE_DELAY_PREFERENCE) ?? 1000;
             }
         });
     }

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { inject, injectable, optional, postConstruct } from '@theia/core/shared/inversify';
-import { CommonCommands, PreferenceService, LabelProvider, ApplicationShell, QuickInputService, QuickPickValue, SaveResourceService } from '@theia/core/lib/browser';
+import { CommonCommands, PreferenceService, LabelProvider, ApplicationShell, QuickInputService, QuickPickValue, SaveableService } from '@theia/core/lib/browser';
 import { EditorManager } from './editor-manager';
 import { CommandContribution, CommandRegistry, Command, ResourceProvider, MessageService, nls } from '@theia/core';
 import { LanguageService } from '@theia/core/lib/browser/language-service';
@@ -215,8 +215,8 @@ export class EditorCommandContribution implements CommandContribution {
     @inject(PreferenceService)
     protected readonly preferencesService: PreferenceService;
 
-    @inject(SaveResourceService)
-    protected readonly saveResourceService: SaveResourceService;
+    @inject(SaveableService)
+    protected readonly saveResourceService: SaveableService;
 
     @inject(QuickInputService) @optional()
     protected readonly quickInputService: QuickInputService;

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -31,8 +31,8 @@ import { RemoteFileServiceContribution } from './remote-file-service-contributio
 import { FileSystemWatcherErrorHandler } from './filesystem-watcher-error-handler';
 import { FilepathBreadcrumbsContribution } from './breadcrumbs/filepath-breadcrumbs-contribution';
 import { BreadcrumbsFileTreeWidget, createFileTreeBreadcrumbsWidget } from './breadcrumbs/filepath-breadcrumbs-container';
-import { FilesystemSaveResourceService } from './filesystem-save-resource-service';
-import { SaveResourceService } from '@theia/core/lib/browser/save-resource-service';
+import { FilesystemSaveableService } from './filesystem-saveable-service';
+import { SaveableService } from '@theia/core/lib/browser/saveable-service';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindFileSystemPreferences(bind);
@@ -65,8 +65,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(FilepathBreadcrumbsContribution).toSelf().inSingletonScope();
     bind(BreadcrumbsContribution).toService(FilepathBreadcrumbsContribution);
 
-    bind(FilesystemSaveResourceService).toSelf().inSingletonScope();
-    rebind(SaveResourceService).toService(FilesystemSaveResourceService);
+    bind(FilesystemSaveableService).toSelf().inSingletonScope();
+    rebind(SaveableService).toService(FilesystemSaveableService);
 
     bind(FileTreeDecoratorAdapter).toSelf().inSingletonScope();
 });

--- a/packages/filesystem/src/browser/filesystem-save-resource-service.ts
+++ b/packages/filesystem/src/browser/filesystem-save-resource-service.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { environment, nls } from '@theia/core';
+import { environment, MessageService, nls } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { Navigatable, Saveable, SaveableSource, SaveOptions, Widget, open, OpenerService, ConfirmDialog, FormatType, CommonCommands } from '@theia/core/lib/browser';
 import { SaveResourceService } from '@theia/core/lib/browser/save-resource-service';
@@ -25,9 +25,14 @@ import { FileDialogService } from './file-dialog';
 @injectable()
 export class FilesystemSaveResourceService extends SaveResourceService {
 
-    @inject(FileService) protected readonly fileService: FileService;
-    @inject(FileDialogService) protected readonly fileDialogService: FileDialogService;
-    @inject(OpenerService) protected readonly openerService: OpenerService;
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+    @inject(FileService)
+    protected readonly fileService: FileService;
+    @inject(FileDialogService)
+    protected readonly fileDialogService: FileDialogService;
+    @inject(OpenerService)
+    protected readonly openerService: OpenerService;
 
     /**
      * This method ensures a few things about `widget`:

--- a/packages/filesystem/src/browser/filesystem-saveable-service.ts
+++ b/packages/filesystem/src/browser/filesystem-saveable-service.ts
@@ -17,13 +17,13 @@
 import { environment, MessageService, nls } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { Navigatable, Saveable, SaveableSource, SaveOptions, Widget, open, OpenerService, ConfirmDialog, FormatType, CommonCommands } from '@theia/core/lib/browser';
-import { SaveResourceService } from '@theia/core/lib/browser/save-resource-service';
+import { SaveableService } from '@theia/core/lib/browser/saveable-service';
 import URI from '@theia/core/lib/common/uri';
 import { FileService } from './file-service';
 import { FileDialogService } from './file-dialog';
 
 @injectable()
-export class FilesystemSaveResourceService extends SaveResourceService {
+export class FilesystemSaveableService extends SaveableService {
 
     @inject(MessageService)
     protected readonly messageService: MessageService;

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -156,16 +156,8 @@ export class MonacoTextModelService implements ITextModelService {
 
     protected updateModel(model: MonacoEditorModel, change?: EditorPreferenceChange): void {
         if (!change) {
-            model.autoSave = this.editorPreferences.get('files.autoSave', undefined, model.uri);
-            model.autoSaveDelay = this.editorPreferences.get('files.autoSaveDelay', undefined, model.uri);
             model.textEditorModel.updateOptions(this.getModelOptions(model));
         } else if (change.affects(model.uri, model.languageId)) {
-            if (change.preferenceName === 'files.autoSave') {
-                model.autoSave = this.editorPreferences.get('files.autoSave', undefined, model.uri);
-            }
-            if (change.preferenceName === 'files.autoSaveDelay') {
-                model.autoSaveDelay = this.editorPreferences.get('files.autoSaveDelay', undefined, model.uri);
-            }
             const modelOption = this.toModelOption(change.preferenceName);
             if (modelOption) {
                 model.textEditorModel.updateOptions(this.getModelOptions(model));

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -42,7 +42,7 @@ import { SnippetParser } from '@theia/monaco-editor-core/esm/vs/editor/contrib/s
 import { TextEdit } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
 import { SnippetController2 } from '@theia/monaco-editor-core/esm/vs/editor/contrib/snippet/browser/snippetController2';
 import { isObject, MaybePromise, nls } from '@theia/core/lib/common';
-import { SaveResourceService } from '@theia/core/lib/browser';
+import { SaveableService } from '@theia/core/lib/browser';
 
 export namespace WorkspaceFileEdit {
     export function is(arg: Edit): arg is monaco.languages.IWorkspaceFileEdit {
@@ -125,8 +125,8 @@ export class MonacoWorkspace {
     @inject(ProblemManager)
     protected readonly problems: ProblemManager;
 
-    @inject(SaveResourceService)
-    protected readonly saveService: SaveResourceService;
+    @inject(SaveableService)
+    protected readonly saveService: SaveableService;
 
     @postConstruct()
     protected init(): void {

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -42,6 +42,7 @@ import { SnippetParser } from '@theia/monaco-editor-core/esm/vs/editor/contrib/s
 import { TextEdit } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
 import { SnippetController2 } from '@theia/monaco-editor-core/esm/vs/editor/contrib/snippet/browser/snippetController2';
 import { isObject, MaybePromise, nls } from '@theia/core/lib/common';
+import { SaveResourceService } from '@theia/core/lib/browser';
 
 export namespace WorkspaceFileEdit {
     export function is(arg: Edit): arg is monaco.languages.IWorkspaceFileEdit {
@@ -124,6 +125,9 @@ export class MonacoWorkspace {
     @inject(ProblemManager)
     protected readonly problems: ProblemManager;
 
+    @inject(SaveResourceService)
+    protected readonly saveService: SaveResourceService;
+
     @postConstruct()
     protected init(): void {
         this.resolveReady();
@@ -192,7 +196,7 @@ export class MonacoWorkspace {
             // acquired by the editor, thus losing the changes that made it dirty.
             this.textModelService.createModelReference(model.textEditorModel.uri).then(ref => {
                 (
-                    model.autoSave !== 'off' ? new Promise(resolve => model.onDidSaveModel(resolve)) :
+                    this.saveService.autoSave !== 'off' ? new Promise(resolve => model.onDidSaveModel(resolve)) :
                         this.editorManager.open(new URI(model.uri), { mode: 'open' })
                 ).then(
                     () => ref.dispose()

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -27,7 +27,7 @@ import { NotebookEditorWidgetFactory } from './notebook-editor-widget-factory';
 import { NotebookCellResourceResolver, NotebookOutputResourceResolver } from './notebook-cell-resource-resolver';
 import { NotebookModelResolverService } from './service/notebook-model-resolver-service';
 import { NotebookCellActionContribution } from './contributions/notebook-cell-actions-contribution';
-import { createNotebookModelContainer, NotebookModel, NotebookModelFactory, NotebookModelProps } from './view-model/notebook-model';
+import { createNotebookModelContainer, NotebookModel, NotebookModelFactory, NotebookModelProps, NotebookModelResolverServiceProxy } from './view-model/notebook-model';
 import { createNotebookCellModelContainer, NotebookCellModel, NotebookCellModelFactory, NotebookCellModelProps } from './view-model/notebook-cell-model';
 import { createNotebookEditorWidgetContainer, NotebookEditorWidgetContainerFactory, NotebookEditorProps, NotebookEditorWidget } from './notebook-editor-widget';
 import { NotebookActionsContribution } from './contributions/notebook-actions-contribution';
@@ -71,6 +71,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookCellResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(NotebookCellResourceResolver);
     bind(NotebookModelResolverService).toSelf().inSingletonScope();
+    bind(NotebookModelResolverServiceProxy).toService(NotebookModelResolverService);
     bind(NotebookOutputResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(NotebookOutputResourceResolver);
 

--- a/packages/notebook/src/browser/service/notebook-model-resolver-service.ts
+++ b/packages/notebook/src/browser/service/notebook-model-resolver-service.ts
@@ -108,7 +108,7 @@ export class NotebookModelResolverService {
         return this.resolve(resource, viewType);
     }
 
-    protected async resolveExistingNotebookData(resource: Resource, viewType: string): Promise<NotebookData> {
+    async resolveExistingNotebookData(resource: Resource, viewType: string): Promise<NotebookData> {
         if (resource.uri.scheme === 'untitled') {
             return {
                 cells: [],

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -180,9 +180,7 @@ export class NotebookModel implements Saveable, Disposable {
 
     createSnapshot(): Saveable.Snapshot {
         return {
-            read: () => {
-                return JSON.stringify(this.getData());
-            }
+            read: () => JSON.stringify(this.getData())
         };
     }
 

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
@@ -38,13 +38,6 @@ export class CustomEditorWidget extends WebviewWidget implements SaveableSource,
     set modelRef(modelRef: Reference<CustomEditorModel>) {
         this._modelRef = modelRef;
         this.doUpdateContent();
-        Saveable.apply(
-            this,
-            () => this.shell.widgets.filter(widget => !!Saveable.get(widget)),
-            async (widget, options) => {
-                await this.saveService.save(widget, options);
-            },
-        );
     }
     get saveable(): Saveable {
         return this._modelRef.object;

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from '@theia/core/shared/inversify'
 import URI from '@theia/core/lib/common/uri';
 import { FileOperation } from '@theia/filesystem/lib/common/files';
 import { ApplicationShell, NavigatableWidget, Saveable, SaveableSource, SaveOptions } from '@theia/core/lib/browser';
-import { SaveResourceService } from '@theia/core/lib/browser/save-resource-service';
+import { SaveableService } from '@theia/core/lib/browser/saveable-service';
 import { Reference } from '@theia/core/lib/common/reference';
 import { WebviewWidget } from '../webview/webview';
 import { UndoRedoService } from '@theia/editor/lib/browser/undo-redo-service';
@@ -49,8 +49,8 @@ export class CustomEditorWidget extends WebviewWidget implements SaveableSource,
     @inject(ApplicationShell)
     protected readonly shell: ApplicationShell;
 
-    @inject(SaveResourceService)
-    protected readonly saveService: SaveResourceService;
+    @inject(SaveableService)
+    protected readonly saveService: SaveableService;
 
     @postConstruct()
     protected override init(): void {

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
@@ -25,7 +25,7 @@ import { RPCProtocol } from '../../../common/rpc-protocol';
 import { HostedPluginSupport } from '../../../hosted/browser/hosted-plugin';
 import { PluginCustomEditorRegistry } from './plugin-custom-editor-registry';
 import { CustomEditorWidget } from './custom-editor-widget';
-import { Emitter, UNTITLED_SCHEME } from '@theia/core';
+import { Emitter } from '@theia/core';
 import { UriComponents } from '../../../common/uri-components';
 import { URI } from '@theia/core/shared/vscode-uri';
 import TheiaURI from '@theia/core/lib/common/uri';
@@ -189,7 +189,7 @@ export class CustomEditorsMainImpl implements CustomEditorsMain, Disposable {
                 return this.customEditorService.models.add(resource, viewType, model);
             }
             case CustomEditorModelType.Custom: {
-                const model = MainCustomEditorModel.create(this.proxy, viewType, resource, this.undoRedoService, this.fileService, this.editorPreferences, cancellationToken);
+                const model = MainCustomEditorModel.create(this.proxy, viewType, resource, this.undoRedoService, this.fileService, cancellationToken);
                 return this.customEditorService.models.add(resource, viewType, model);
             }
         }
@@ -297,8 +297,8 @@ export class MainCustomEditorModel implements CustomEditorModel {
     private readonly onDirtyChangedEmitter = new Emitter<void>();
     readonly onDirtyChanged = this.onDirtyChangedEmitter.event;
 
-    autoSave: 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowChange';
-    autoSaveDelay: number;
+    private readonly onContentChangedEmitter = new Emitter<void>();
+    readonly onContentChanged = this.onContentChangedEmitter.event;
 
     static async create(
         proxy: CustomEditorsExt,
@@ -306,11 +306,10 @@ export class MainCustomEditorModel implements CustomEditorModel {
         resource: TheiaURI,
         undoRedoService: UndoRedoService,
         fileService: FileService,
-        editorPreferences: EditorPreferences,
         cancellation: CancellationToken,
     ): Promise<MainCustomEditorModel> {
         const { editable } = await proxy.$createCustomDocument(resource.toComponents(), viewType, {}, cancellation);
-        return new MainCustomEditorModel(proxy, viewType, resource, editable, undoRedoService, fileService, editorPreferences);
+        return new MainCustomEditorModel(proxy, viewType, resource, editable, undoRedoService, fileService);
     }
 
     constructor(
@@ -319,22 +318,8 @@ export class MainCustomEditorModel implements CustomEditorModel {
         private readonly editorResource: TheiaURI,
         private readonly editable: boolean,
         private readonly undoRedoService: UndoRedoService,
-        private readonly fileService: FileService,
-        private readonly editorPreferences: EditorPreferences
+        private readonly fileService: FileService
     ) {
-        this.autoSave = this.editorPreferences.get('files.autoSave', undefined, editorResource.toString());
-        this.autoSaveDelay = this.editorPreferences.get('files.autoSaveDelay', undefined, editorResource.toString());
-
-        this.toDispose.push(
-            this.editorPreferences.onPreferenceChanged(event => {
-                if (event.preferenceName === 'files.autoSave') {
-                    this.autoSave = this.editorPreferences.get('files.autoSave', undefined, editorResource.toString());
-                }
-                if (event.preferenceName === 'files.autoSaveDelay') {
-                    this.autoSaveDelay = this.editorPreferences.get('files.autoSaveDelay', undefined, editorResource.toString());
-                }
-            })
-        );
         this.toDispose.push(this.onDirtyChangedEmitter);
     }
 
@@ -505,13 +490,7 @@ export class MainCustomEditorModel implements CustomEditorModel {
         if (this.dirty !== wasDirty) {
             this.onDirtyChangedEmitter.fire();
         }
-
-        if (this.autoSave !== 'off' && this.dirty && this.resource.scheme !== UNTITLED_SCHEME) {
-            const handle = window.setTimeout(() => {
-                this.save();
-                window.clearTimeout(handle);
-            }, this.autoSaveDelay);
-        }
+        this.onContentChangedEmitter.fire();
     }
 
 }
@@ -521,6 +500,8 @@ export class CustomTextEditorModel implements CustomEditorModel {
     private readonly toDispose = new DisposableCollection();
     private readonly onDirtyChangedEmitter = new Emitter<void>();
     readonly onDirtyChanged = this.onDirtyChangedEmitter.event;
+    private readonly onContentChangedEmitter = new Emitter<void>();
+    readonly onContentChanged = this.onContentChangedEmitter.event;
 
     static async create(
         viewType: string,
@@ -544,15 +525,13 @@ export class CustomTextEditorModel implements CustomEditorModel {
                 this.onDirtyChangedEmitter.fire();
             })
         );
+        this.toDispose.push(
+            this.editorTextModel.onContentChanged(e => {
+                this.onContentChangedEmitter.fire();
+            })
+        );
         this.toDispose.push(this.onDirtyChangedEmitter);
-    }
-
-    get autoSave(): 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowChange' {
-        return this.editorTextModel.autoSave;
-    }
-
-    get autoSaveDelay(): number {
-        return this.editorTextModel.autoSaveDelay;
+        this.toDispose.push(this.onContentChangedEmitter);
     }
 
     dispose(): void {

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -32,7 +32,7 @@ import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { TextEditorMain } from './text-editor-main';
 import { DisposableCollection, Emitter, URI } from '@theia/core';
 import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
-import { SaveResourceService } from '@theia/core/lib/browser/save-resource-service';
+import { SaveableService } from '@theia/core/lib/browser/saveable-service';
 
 export class EditorsAndDocumentsMain implements Disposable {
 
@@ -43,7 +43,7 @@ export class EditorsAndDocumentsMain implements Disposable {
 
     private readonly modelService: EditorModelService;
     private readonly editorManager: EditorManager;
-    private readonly saveResourceService: SaveResourceService;
+    private readonly saveResourceService: SaveableService;
 
     private readonly onTextEditorAddEmitter = new Emitter<TextEditorMain[]>();
     private readonly onTextEditorRemoveEmitter = new Emitter<string[]>();
@@ -64,7 +64,7 @@ export class EditorsAndDocumentsMain implements Disposable {
 
         this.editorManager = container.get(EditorManager);
         this.modelService = container.get(EditorModelService);
-        this.saveResourceService = container.get(SaveResourceService);
+        this.saveResourceService = container.get(SaveableService);
 
         this.stateComputer = new EditorAndDocumentStateComputer(d => this.onDelta(d), this.editorManager, this.modelService);
         this.toDispose.push(this.stateComputer);

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -37,7 +37,7 @@ import { nls } from '@theia/core/lib/common/nls';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { UntitledWorkspaceExitDialog } from './untitled-workspace-exit-dialog';
-import { FilesystemSaveResourceService } from '@theia/filesystem/lib/browser/filesystem-save-resource-service';
+import { FilesystemSaveableService } from '@theia/filesystem/lib/browser/filesystem-saveable-service';
 import { StopReason } from '@theia/core/lib/common/frontend-application-state';
 
 export enum WorkspaceStates {
@@ -72,7 +72,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
     @inject(ContextKeyService) protected readonly contextKeyService: ContextKeyService;
     @inject(EncodingRegistry) protected readonly encodingRegistry: EncodingRegistry;
     @inject(PreferenceConfigurations) protected readonly preferenceConfigurations: PreferenceConfigurations;
-    @inject(FilesystemSaveResourceService) protected readonly saveService: FilesystemSaveResourceService;
+    @inject(FilesystemSaveableService) protected readonly saveService: FilesystemSaveableService;
     @inject(WorkspaceFileService) protected readonly workspaceFileService: WorkspaceFileService;
 
     configure(): void {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12863
Closes https://github.com/eclipse-theia/theia/issues/12844
Closes https://github.com/eclipse-theia/theia/issues/8722

Enhances the `SaveResourceService` to perform all the auto save preference work. Previously, all editor classes had to do their own handling of the `afterDelay` auto save functionality. This has been centralized into one service. Therefore, custom editors and notebook editors now behave exactly the same as monaco text editors in regards to auto saves.

This also fixes a long standing issue, where `onFocusChange` and `onWindowChange` have been handled as if `afterDelay` was selected as the auto save mode. These two values are now properly handled.

Note that `onWindowChange` doesn't work well with custom editors. This is due to the usage of `iframe` and the inability to look into an iframe. It still works, but is a bit too eager with them.

#### How to test

Basically, confirm that the auto save functionality behaves as expected with all different values of the enum preference. This should be tested for all 3 kinds of editors (text, notebook, custom editor).

Also test that closing unsaved editors prompts (or automatically saves) the user whether or not to save those files.

#### Follow-ups

We might want to find a way to fix `onWindowChange` for custom editors as well based on mouse position event information.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
