### PR TITLE
Fix programmatic save for custom text editors

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1387,7 +1387,6 @@ export interface DocumentsMain {
     $tryShowDocument(uri: UriComponents, options?: TextDocumentShowOptions): Promise<void>;
     $tryOpenDocument(uri: UriComponents): Promise<boolean>;
     $trySaveDocument(uri: UriComponents): Promise<boolean>;
-    $tryCloseDocument(uri: UriComponents): Promise<boolean>;
 }
 
 export interface EnvMain {

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -20,10 +20,10 @@ import { DisposableCollection, Disposable, UntitledResourceResolver } from '@the
 import { MonacoEditorModel } from '@theia/monaco/lib/browser/monaco-editor-model';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { EditorModelService } from './text-editor-model-service';
-import { EditorManager, EditorOpenerOptions } from '@theia/editor/lib/browser';
+import { EditorOpenerOptions } from '@theia/editor/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { URI as CodeURI } from '@theia/core/shared/vscode-uri';
-import { ApplicationShell, Saveable } from '@theia/core/lib/browser';
+import { ApplicationShell } from '@theia/core/lib/browser';
 import { TextDocumentShowOptions } from '../../common/plugin-api-rpc-model';
 import { Range } from '@theia/core/shared/vscode-languageserver-protocol';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
@@ -94,7 +94,6 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
         notebookDocuments: NotebookDocumentsMainImpl,
         private readonly modelService: EditorModelService,
         rpc: RPCProtocol,
-        private editorManager: EditorManager,
         private openerService: OpenerService,
         private shell: ApplicationShell,
         private untitledResourceResolver: UntitledResourceResolver,
@@ -206,13 +205,7 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
     }
 
     async $trySaveDocument(uri: UriComponents): Promise<boolean> {
-        const widget = await this.editorManager.getByUri(new URI(CodeURI.revive(uri)));
-        if (widget) {
-            await Saveable.save(widget);
-            return true;
-        }
-
-        return false;
+        return this.modelService.save(new URI(CodeURI.revive(uri)));
     }
 
     async $tryOpenDocument(uri: UriComponents): Promise<boolean> {
@@ -224,17 +217,6 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
             ref.dispose();
             return false;
         }
-    }
-
-    async $tryCloseDocument(uri: UriComponents): Promise<boolean> {
-        const widget = await this.editorManager.getByUri(new URI(CodeURI.revive(uri)));
-        if (widget) {
-            await Saveable.save(widget);
-            widget.close();
-            return true;
-        }
-
-        return false;
     }
 
     static toEditorOpenerOptions(shell: ApplicationShell, options?: TextDocumentShowOptions): EditorOpenerOptions | undefined {

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -40,7 +40,6 @@ import { DecorationsMainImpl } from './decorations/decorations-main';
 import { ClipboardMainImpl } from './clipboard-main';
 import { DocumentsMainImpl } from './documents-main';
 import { TextEditorsMainImpl } from './text-editors-main';
-import { EditorManager } from '@theia/editor/lib/browser';
 import { EditorModelService } from './text-editor-model-service';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
@@ -94,13 +93,12 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_MAIN, notebookDocumentsMain);
 
     const modelService = container.get(EditorModelService);
-    const editorManager = container.get(EditorManager);
     const openerService = container.get<OpenerService>(OpenerService);
     const shell = container.get(ApplicationShell);
     const untitledResourceResolver = container.get(UntitledResourceResolver);
     const languageService = container.get(MonacoLanguages);
     const documentsMain = new DocumentsMainImpl(editorsAndDocuments, notebookDocumentsMain, modelService, rpc,
-        editorManager, openerService, shell, untitledResourceResolver, languageService);
+        openerService, shell, untitledResourceResolver, languageService);
     rpc.set(PLUGIN_RPC_CONTEXT.DOCUMENTS_MAIN, documentsMain);
 
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOKS_MAIN, new NotebooksMainImpl(rpc, container, commandRegistryMain));

--- a/packages/plugin-ext/src/main/browser/text-editor-model-service.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-model-service.ts
@@ -76,6 +76,15 @@ export class EditorModelService {
         return this.monacoModelService.models;
     }
 
+    async save(uri: URI): Promise<boolean> {
+        const model = this.monacoModelService.get(uri.toString());
+        if (model) {
+            await model.save();
+            return true;
+        }
+        return false;
+    }
+
     async saveAll(includeUntitled?: boolean): Promise<boolean> {
         const saves = [];
         for (const model of this.monacoModelService.models) {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/9230

Instead of using the `EditorManager` (that seemingly doesn't keep track of `CustomEditorWidget` instances), we simply use the monaco model service to save the underlying model.

Also removes an unused RPC method `$tryCloseDocument`.

#### How to test

Follow the instructions in https://github.com/eclipse-theia/theia/issues/9230 and confirm that manual saving works as expected. Alternatively, the extension in https://github.com/eclipse-theia/theia/issues/12979 should now also work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
