### PR TITLE
Propagate "Save As" operation to plugin host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 <!-- ## not yet released
 
-<a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> -->
+<a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
+
+- [filesystem] Adjusted the "Save As" mechanism. It now assumes that `Saveable.getSnapshot()` returns a full snapshot of the editor model [#13689](https://github.com/eclipse-theia/theia/pull/13689). 
+
+-->
 
 ## 1.50.0 - 06/03/2024
 

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -46,7 +46,7 @@ export interface Saveable {
      */
     revert?(options?: Saveable.RevertOptions): Promise<void>;
     /**
-     * Creates a snapshot of the dirty state.
+     * Creates a snapshot of the dirty state. See also {@link Saveable.Snapshot}.
      */
     createSnapshot?(): Saveable.Snapshot;
     /**
@@ -114,6 +114,9 @@ export namespace Saveable {
         soft?: boolean
     }
 
+    /**
+     * A snapshot of a saveable item. Contains the full content of the saveable file in a string serializable format.
+     */
     export type Snapshot = { value: string } | { read(): string | null };
     export namespace Snapshot {
         export function read(snapshot: Snapshot): string | undefined {

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -115,6 +115,11 @@ export namespace Saveable {
     }
 
     export type Snapshot = { value: string } | { read(): string | null };
+    export namespace Snapshot {
+        export function read(snapshot: Snapshot): string | undefined {
+            return 'value' in snapshot ? snapshot.value : (snapshot.read() ?? undefined);
+        }
+    }
     export function isSource(arg: unknown): arg is SaveableSource {
         return isObject<SaveableSource>(arg) && is(arg.saveable);
     }

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -960,7 +960,7 @@ export class ApplicationShell extends Widget {
         }
     }
 
-    getInsertionOptions(options?: Readonly<ApplicationShell.WidgetOptions>): { area: string; addOptions: DockLayout.IAddOptions; } {
+    getInsertionOptions(options?: Readonly<ApplicationShell.WidgetOptions>): { area: string; addOptions: TheiaDockPanel.AddOptions; } {
         let ref: Widget | undefined = options?.ref;
         let area: ApplicationShell.Area = options?.area || 'main';
         if (!ref && (area === 'main' || area === 'bottom')) {
@@ -969,7 +969,7 @@ export class ApplicationShell extends Widget {
         }
         // make sure that ref belongs to area
         area = ref && this.getAreaFor(ref) || area;
-        const addOptions: DockPanel.IAddOptions = {};
+        const addOptions: TheiaDockPanel.AddOptions = {};
         if (ApplicationShell.isOpenToSideMode(options?.mode)) {
             const areaPanel = area === 'main' ? this.mainPanel : area === 'bottom' ? this.bottomPanel : undefined;
             const sideRef = areaPanel && ref && (options?.mode === 'open-to-left' ?
@@ -981,6 +981,10 @@ export class ApplicationShell extends Widget {
                 addOptions.ref = ref;
                 addOptions.mode = options?.mode === 'open-to-left' ? 'split-left' : 'split-right';
             }
+        } else if (ApplicationShell.isReplaceMode(options?.mode)) {
+            addOptions.ref = options?.ref;
+            addOptions.closeRef = true;
+            addOptions.mode = 'tab-after';
         } else {
             addOptions.ref = ref;
             addOptions.mode = options?.mode;
@@ -2173,6 +2177,15 @@ export namespace ApplicationShell {
     }
 
     /**
+     * Whether the `ref` of the options widget should be replaced.
+     */
+    export type ReplaceMode = 'tab-replace';
+
+    export function isReplaceMode(mode: unknown): mode is ReplaceMode {
+        return mode === 'tab-replace';
+    }
+
+    /**
      * Options for adding a widget to the application shell.
      */
     export interface WidgetOptions extends SidePanel.WidgetOptions {
@@ -2185,7 +2198,7 @@ export namespace ApplicationShell {
          *
          * The default is `'tab-after'`.
          */
-        mode?: DockLayout.InsertMode | OpenToSideMode
+        mode?: DockLayout.InsertMode | OpenToSideMode | ReplaceMode
         /**
          * The reference widget for the insert location.
          *

--- a/packages/core/src/browser/shell/theia-dock-panel.ts
+++ b/packages/core/src/browser/shell/theia-dock-panel.ts
@@ -133,11 +133,14 @@ export class TheiaDockPanel extends DockPanel {
         }
     }
 
-    override addWidget(widget: Widget, options?: DockPanel.IAddOptions): void {
+    override addWidget(widget: Widget, options?: TheiaDockPanel.AddOptions): void {
         if (this.mode === 'single-document' && widget.parent === this) {
             return;
         }
         super.addWidget(widget, options);
+        if (options?.closeRef) {
+            options.ref?.close();
+        }
         this.widgetAdded.emit(widget);
         this.markActiveTabBar(widget.title);
     }
@@ -251,5 +254,12 @@ export namespace TheiaDockPanel {
     export const Factory = Symbol('TheiaDockPanel#Factory');
     export interface Factory {
         (options?: DockPanel.IOptions): TheiaDockPanel;
+    }
+
+    export interface AddOptions extends DockPanel.IAddOptions {
+        /**
+         * Whether to also close the widget referenced by `ref`.
+         */
+        closeRef?: boolean
     }
 }

--- a/packages/core/src/browser/widgets/react-renderer.tsx
+++ b/packages/core/src/browser/widgets/react-renderer.tsx
@@ -41,7 +41,10 @@ export class ReactRenderer implements Disposable {
     }
 
     render(): void {
-        this.hostRoot.render(<React.Fragment>{this.doRender()}</React.Fragment>);
+        // Ignore all render calls after the host element has unmounted
+        if (!this.toDispose.disposed) {
+            this.hostRoot.render(<React.Fragment>{this.doRender()}</React.Fragment>);
+        }
     }
 
     protected doRender(): React.ReactNode {

--- a/packages/filesystem/src/browser/location/location-renderer.tsx
+++ b/packages/filesystem/src/browser/location/location-renderer.tsx
@@ -122,7 +122,9 @@ export class LocationListRenderer extends ReactRenderer {
     }
 
     override render(): void {
-        this.hostRoot.render(this.doRender());
+        if (!this.toDispose.disposed) {
+            this.hostRoot.render(this.doRender());
+        }
     }
 
     protected initResolveDirectoryCache(): void {

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -651,7 +651,7 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
     }
 
     applySnapshot(snapshot: Saveable.Snapshot): void {
-        const value = 'value' in snapshot ? snapshot.value : snapshot.read() ?? '';
+        const value = Saveable.Snapshot.read(snapshot) ?? '';
         this.model.setValue(value);
     }
 

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -190,7 +190,7 @@ export class NotebookModel implements Saveable, Disposable {
     }
 
     async applySnapshot(snapshot: Saveable.Snapshot): Promise<void> {
-        const rawData = 'read' in snapshot ? snapshot.read() : snapshot.value;
+        const rawData = Saveable.Snapshot.read(snapshot);
         if (!rawData) {
             throw new Error('could not read notebook snapshot');
         }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13688

Ensures that any new file created from a "Save As" operation correctly fires the `onDidCreateFiles` event in the plugin host. Also greatly simplifies the "Save As" operation logic.

#### How to test

1. Download and install the [test extension](https://github.com/eclipse-theia/theia/files/15219430/vscode-memfs-0.0.1.zip)
2. Open a file and change it.
3. Use the save as operation and point the file picker to a non-existing file.
4. Ensure that a notification pops up (triggered by `onDidCreateFiles`)
5. Ensure that the "Save As" operation behavior still works as expected
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
