### PR TITLE
Improve support for creating new notebooks

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -120,16 +120,17 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
                 notebookModel = notebookModel ?? this.notebookEditorWidgetService.focusedEditor?.model;
 
                 let insertIndex: number = 0;
-                if (index && index >= 0) {
-                    insertIndex = index as number;
+                if (typeof index === 'number' && index >= 0) {
+                    insertIndex = index;
                 } else if (notebookModel.selectedCell && typeof index === 'string') {
                     // if index is -1 insert below otherwise at the index of the selected cell which is above the selected.
                     insertIndex = notebookModel.cells.indexOf(notebookModel.selectedCell) + (index === 'below' ? 1 : 0);
                 }
 
-                let firstCodeCell;
+                let cellLanguage: string = 'markdown';
                 if (cellKind === CellKind.Code) {
-                    firstCodeCell = notebookModel.cells.find(cell => cell.cellKind === CellKind.Code);
+                    const firstCodeCell = notebookModel.cells.find(cell => cell.cellKind === CellKind.Code);
+                    cellLanguage = firstCodeCell?.language ?? 'plaintext';
                 }
 
                 notebookModel.applyEdits([{
@@ -138,7 +139,7 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
                     count: 0,
                     cells: [{
                         cellKind,
-                        language: firstCodeCell?.language ?? 'markdown',
+                        language: cellLanguage,
                         source: '',
                         outputs: [],
                         metadata: {},

--- a/packages/notebook/src/browser/notebook-editor-widget-factory.ts
+++ b/packages/notebook/src/browser/notebook-editor-widget-factory.ts
@@ -61,8 +61,7 @@ export class NotebookEditorWidgetFactory implements WidgetFactory {
         return editor;
     }
 
-    private async createEditor(uri: URI, notebookType: string): Promise<NotebookEditorWidget> {
-
+    protected async createEditor(uri: URI, notebookType: string): Promise<NotebookEditorWidget> {
         return this.createNotebookEditorWidget({
             uri,
             notebookType,
@@ -70,7 +69,7 @@ export class NotebookEditorWidgetFactory implements WidgetFactory {
         });
     }
 
-    private setLabels(editor: NotebookEditorWidget, uri: URI): void {
+    protected setLabels(editor: NotebookEditorWidget, uri: URI): void {
         editor.title.caption = uri.path.fsPath();
         if (editor.model?.readOnly) {
             editor.title.caption += ` • ${nls.localizeByDefault('Read-only')}`;

--- a/packages/notebook/src/browser/service/notebook-model-resolver-service.ts
+++ b/packages/notebook/src/browser/service/notebook-model-resolver-service.ts
@@ -14,11 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Emitter, Resource, ResourceProvider, URI } from '@theia/core';
+import { Emitter, Resource, ResourceProvider, UNTITLED_SCHEME, URI } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { UriComponents } from '@theia/core/lib/common/uri';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { CellKind, NotebookData } from '../../common';
+import { NotebookData } from '../../common';
 import { NotebookModel } from '../view-model/notebook-model';
 import { NotebookService } from './notebook-service';
 import { NotebookTypeRegistry } from '../notebook-type-registry';
@@ -28,6 +28,7 @@ import { match } from '@theia/core/lib/common/glob';
 export interface UntitledResource {
     untitledResource: URI | undefined
 }
+
 @injectable()
 export class NotebookModelResolverService {
 
@@ -49,14 +50,15 @@ export class NotebookModelResolverService {
     readonly onDidSaveNotebook = this.onDidSaveNotebookEmitter.event;
 
     async resolve(resource: URI, viewType?: string): Promise<NotebookModel> {
-
+        const existingModel = this.notebookService.getNotebookEditorModel(resource);
         if (!viewType) {
-            const existingViewType = this.notebookService.getNotebookEditorModel(resource)?.viewType;
-            if (existingViewType) {
-                viewType = existingViewType;
+            if (existingModel) {
+                return existingModel;
             } else {
                 viewType = this.findViewTypeForResource(resource);
             }
+        } else if (existingModel?.viewType === viewType) {
+            return existingModel;
         }
 
         if (!viewType) {
@@ -86,7 +88,7 @@ export class NotebookModelResolverService {
             const suffix = this.getPossibleFileEnding(notebookTypeInfo.selector ?? []) ?? '';
             for (let counter = 1; ; counter++) {
                 const candidate = new URI()
-                    .withScheme('untitled')
+                    .withScheme(UNTITLED_SCHEME)
                     .withPath(`Untitled-notebook-${counter}${suffix}`)
                     .withQuery(viewType);
                 if (!this.notebookService.getNotebookEditorModel(candidate)) {
@@ -94,7 +96,7 @@ export class NotebookModelResolverService {
                     break;
                 }
             }
-        } else if (arg.untitledResource.scheme === 'untitled') {
+        } else if (arg.untitledResource.scheme === UNTITLED_SCHEME) {
             resource = arg.untitledResource;
         } else {
             throw new Error('Invalid untitled resource: ' + arg.untitledResource.toString() + ' untitled resources with associated file path are not supported yet');
@@ -108,16 +110,8 @@ export class NotebookModelResolverService {
 
     protected async resolveExistingNotebookData(resource: Resource, viewType: string): Promise<NotebookData> {
         if (resource.uri.scheme === 'untitled') {
-
             return {
-                cells: [
-                    {
-                        cellKind: CellKind.Markup,
-                        language: 'markdown',
-                        outputs: [],
-                        source: ''
-                    }
-                ],
+                cells: [],
                 metadata: {}
             };
         } else {

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -156,7 +156,7 @@ export class NotebookModel implements Saveable, Disposable {
         this.onDidDisposeEmitter.fire();
     }
 
-    async save(options: SaveOptions): Promise<void> {
+    async save(options?: SaveOptions): Promise<void> {
         this.dirtyCells = [];
         this.dirty = false;
 
@@ -186,25 +186,8 @@ export class NotebookModel implements Saveable, Disposable {
         if (!rawData) {
             throw new Error('could not read notebook snapshot');
         }
-        const data = JSON.parse(rawData);
-        const cells = data.cells.map((cell: CellData, index: number) => {
-            const handle = this.nextHandle++;
-            return this.cellModelFactory({
-                uri: CellUri.generate(this.uri, handle),
-                handle: handle,
-                source: cell.source,
-                language: cell.language,
-                cellKind: cell.cellKind,
-                outputs: cell.outputs,
-                metadata: cell.metadata,
-                internalMetadata: cell.internalMetadata,
-                collapseState: cell.collapseState
-            });
-        });
-        this.addCellOutputListeners(cells);
-
-        this.metadata = data.metadata;
-
+        const data = JSON.parse(rawData) as NotebookData;
+        this.reset(data);
     }
 
     async revert(options?: Saveable.RevertOptions): Promise<void> {
@@ -227,6 +210,14 @@ export class NotebookModel implements Saveable, Disposable {
         if (this.dirty !== oldDirtyState) {
             this.onDirtyChangedEmitter.fire();
         }
+    }
+
+    reset(data: NotebookData): void {
+        // Replace all cells in the model
+        this.replaceCells(0, this.cells.length, data.cells, false);
+        this.metadata = data.metadata;
+        this.dirty = false;
+        this.onDidChangeContentEmitter.fire();
     }
 
     undo(): void {

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -187,7 +187,7 @@ export class NotebookModel implements Saveable, Disposable {
             throw new Error('could not read notebook snapshot');
         }
         const data = JSON.parse(rawData) as NotebookData;
-        this.reset(data);
+        this.setData(data);
     }
 
     async revert(options?: Saveable.RevertOptions): Promise<void> {
@@ -212,7 +212,7 @@ export class NotebookModel implements Saveable, Disposable {
         }
     }
 
-    reset(data: NotebookData): void {
+    setData(data: NotebookData): void {
         // Replace all cells in the model
         this.replaceCells(0, this.cells.length, data.cells, false);
         this.metadata = data.metadata;

--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-main.ts
@@ -162,7 +162,7 @@ export class NotebookDocumentsMainImpl implements NotebookDocumentsMain {
         // apply content changes... slightly HACKY -> this triggers a change event
         if (options.content) {
             const data = NotebookDto.fromNotebookDataDto(options.content);
-            ref.reset(data);
+            ref.setData(data);
         }
         return ref.uri.toComponents();
     }

--- a/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
@@ -58,7 +58,7 @@ export class NotebooksMainImpl implements NotebooksMain {
         const plugins = container.get(HostedPluginSupport);
 
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.NOTEBOOKS_EXT);
-        this.notebookService.onWillUseNotebookSerializer(async event => plugins.activateByNotebookSerializer(event));
+        this.notebookService.onWillUseNotebookSerializer(event => plugins.activateByNotebookSerializer(event));
         this.notebookService.markReady();
         commands.registerArgumentProcessor({
             processArgument: arg => {

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -372,6 +372,27 @@ export class NotebooksExtImpl implements NotebooksExt {
         this.editors.set(editorId, editor);
     }
 
+    private waitForNotebookEditor(editorId: string, duration = 2000): Promise<theia.NotebookEditor> {
+        const existing = this.editors.get(editorId);
+        if (existing) {
+            return Promise.resolve(existing.apiEditor);
+        }
+        return new Promise<theia.NotebookEditor>((resolve, reject) => {
+            const listener = this.onDidChangeVisibleNotebookEditors(() => {
+                const editor = this.editors.get(editorId);
+                if (editor) {
+                    clearTimeout(timeout);
+                    listener.dispose();
+                    resolve(editor.apiEditor);
+                }
+            });
+            const timeout = setTimeout(() => {
+                listener.dispose();
+                reject(new Error(`Notebook editor did NOT open in ${duration}ms: ${editorId}`));
+            }, duration);
+        });
+    }
+
     async createNotebookDocument(options: { viewType: string; content?: theia.NotebookData }): Promise<TheiaURI> {
         const canonicalUri = await this.notebookDocumentsProxy.$tryCreateNotebook({
             viewType: options.viewType,
@@ -395,7 +416,7 @@ export class NotebooksExtImpl implements NotebooksExt {
             notebookOrUri = await this.openNotebookDocument(notebookOrUri as TheiaURI);
         }
 
-        const notebook = notebookOrUri as theia.NotebookDocument;
+        const notebook = notebookOrUri;
 
         let resolvedOptions: NotebookDocumentShowOptions;
         if (typeof options === 'object') {
@@ -412,7 +433,7 @@ export class NotebooksExtImpl implements NotebooksExt {
         }
 
         const editorId = await this.notebookEditors.$tryShowNotebookDocument(notebook.uri, notebook.notebookType, resolvedOptions);
-        const editor = editorId && this.editors.get(editorId)?.apiEditor;
+        const editor = editorId && await this.waitForNotebookEditor(editorId);
 
         if (editor) {
             return editor;


### PR DESCRIPTION
#### What it does

Allows extensions to use the `openNotebookDocument` method with the `content` argument that is supposed to populate newly created notebooks.

#### How to test

1. Run the `New File...` command from the menu
2. Use `New Jupyter Notebook`
3. The created notebook should have a single, empty `Python` language cell

Note that in the current behavior, the new cell is marked with the `Markdown` language.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
