### PR TITLE
Added basics for notebook cell drag image renderers

### DIFF
--- a/packages/core/i18n/nls.json
+++ b/packages/core/i18n/nls.json
@@ -341,6 +341,12 @@
       "reveal": "Reveal in Explorer",
       "toggleHiddenFiles": "Toggle Hidden Files"
     },
+    "notebook": {
+      "dragGhostImage": {
+        "markdownText": "Mardown Cell Selected",
+        "codeText": "Code Cell Selected"
+      }
+    },
     "output": {
       "clearOutputChannel": "Clear Output Channel...",
       "closeOutputChannel": "Close Output Channel...",

--- a/packages/core/i18n/nls.json
+++ b/packages/core/i18n/nls.json
@@ -341,12 +341,6 @@
       "reveal": "Reveal in Explorer",
       "toggleHiddenFiles": "Toggle Hidden Files"
     },
-    "notebook": {
-      "dragGhostImage": {
-        "markdownText": "Mardown Cell Selected",
-        "codeText": "Code Cell Selected"
-      }
-    },
     "output": {
       "clearOutputChannel": "Clear Output Channel...",
       "closeOutputChannel": "Close Output Channel...",

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -281,3 +281,11 @@
   line-height: 22px;
   opacity: 0.7;
 }
+
+.theia-notebook-drag-ghost-image {
+  position: absolute;
+  top: -99999px;
+  left: -99999px;
+  height: 500px;
+  width: 500px;
+}

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -25,6 +25,7 @@ import { NotebookCellActionContribution } from '../contributions/notebook-cell-a
 
 export interface CellRenderer {
     render(notebookData: NotebookModel, cell: NotebookCellModel, index: number): React.ReactNode
+    renderDragImage(cell: NotebookCellModel): HTMLElement
 }
 
 interface CellListProps {
@@ -42,6 +43,8 @@ interface NotebookCellListState {
 export class NotebookCellListView extends React.Component<CellListProps, NotebookCellListState> {
 
     protected toDispose = new DisposableCollection();
+
+    protected dragGhost: HTMLElement | undefined;
 
     constructor(props: CellListProps) {
         super(props);
@@ -79,7 +82,7 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
                                 this.setState({ ...this.state, selectedCell: cell });
                                 this.props.notebookModel.setSelectedCell(cell);
                             }}
-                            onDragStart={e => this.onDragStart(e, index)}
+                            onDragStart={e => this.onDragStart(e, index, cell)}
                             onDragOver={e => this.onDragOver(e, cell)}
                             onDrop={e => this.onDrop(e, index)}
                             draggable={true}
@@ -114,12 +117,23 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
         return renderer.render(this.props.notebookModel, cell, index);
     }
 
-    protected onDragStart(event: React.DragEvent<HTMLLIElement>, index: number): void {
+    protected onDragStart(event: React.DragEvent<HTMLLIElement>, index: number, cell: NotebookCellModel): void {
         event.stopPropagation();
         if (!this.isEnabled()) {
             event.preventDefault();
             return;
         }
+
+
+        if (this.dragGhost) {
+            this.dragGhost.remove();
+        }
+        this.dragGhost = document.createElement('div');
+        this.dragGhost.classList.add('theia-notebook-drag-ghost-image');
+        this.dragGhost.appendChild(this.props.renderers.get(cell.cellKind)?.renderDragImage(cell) ?? document.createElement('div'));
+        document.body.appendChild(this.dragGhost);
+        event.dataTransfer.setDragImage(this.dragGhost, -10, 0);
+
         event.dataTransfer.setData('text/theia-notebook-cell-index', index.toString());
         event.dataTransfer.setData('text/plain', this.props.notebookModel.cells[index].source);
     }

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -124,7 +124,6 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
             return;
         }
 
-
         if (this.dragGhost) {
             this.dragGhost.remove();
         }

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -99,6 +99,13 @@ export class NotebookCodeCellRenderer implements CellRenderer {
         </div >;
     }
 
+    renderDragImage(cell: NotebookCellModel): HTMLElement {
+        const dragImage = document.createElement('div');
+        dragImage.className = 'theia-notebook-drag-image';
+        dragImage.textContent = nls.localize('theia/notebooks/dragGhostImage/codeText', 'Code Cell Selected',);;
+        return dragImage;
+    }
+
     protected getOrCreateMonacoFontInfo(): BareFontInfo {
         if (!this.fontInfo) {
             this.fontInfo = this.createFontInfo();

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -102,7 +102,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
     renderDragImage(cell: NotebookCellModel): HTMLElement {
         const dragImage = document.createElement('div');
         dragImage.className = 'theia-notebook-drag-image';
-        dragImage.textContent = nls.localize('theia/notebooks/dragGhostImage/codeText', 'Code Cell Selected');
+        dragImage.textContent = nls.localize('theia/notebook/dragGhostImage/codeText', 'Code cell selected');
         return dragImage;
     }
 

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -102,7 +102,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
     renderDragImage(cell: NotebookCellModel): HTMLElement {
         const dragImage = document.createElement('div');
         dragImage.className = 'theia-notebook-drag-image';
-        dragImage.textContent = nls.localize('theia/notebooks/dragGhostImage/codeText', 'Code Cell Selected',);;
+        dragImage.textContent = nls.localize('theia/notebooks/dragGhostImage/codeText', 'Code Cell Selected');
         return dragImage;
     }
 

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -45,7 +45,7 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
     renderDragImage(cell: NotebookCellModel): HTMLElement {
         const dragImage = document.createElement('div');
         dragImage.className = 'theia-notebook-drag-image';
-        dragImage.textContent = nls.localize('theia/notebooks/dragGhostImage/markdownText', 'Mardown Cell Selected',);
+        dragImage.textContent = nls.localize('theia/notebooks/dragGhostImage/markdownText', 'Mardown Cell Selected');
         return dragImage;
     }
 }

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -45,7 +45,7 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
     renderDragImage(cell: NotebookCellModel): HTMLElement {
         const dragImage = document.createElement('div');
         dragImage.className = 'theia-notebook-drag-image';
-        dragImage.textContent = nls.localize('theia/notebooks/dragGhostImage/markdownText', 'Mardown Cell Selected');
+        dragImage.textContent = nls.localize('theia/notebook/dragGhostImage/markdownText', 'Mardown cell selected');
         return dragImage;
     }
 }

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -42,6 +42,12 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
             cell={cell} notebookModel={notebookModel} notebookContextManager={this.notebookContextManager} />;
     }
 
+    renderDragImage(cell: NotebookCellModel): HTMLElement {
+        const dragImage = document.createElement('div');
+        dragImage.className = 'theia-notebook-drag-image';
+        dragImage.textContent = nls.localize('theia/notebooks/dragGhostImage/markdownText', 'Mardown Cell Selected',);
+        return dragImage;
+    }
 }
 
 interface MarkdownCellProps {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This adds the basics for custom rendering of drag images similiar to how vscode does it. For now its just text showing what kind of cell is being dragged. This can be improved on later

#### How to test

Open a notebook and drag a cell. Should show a text now instead of the full cell list view

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
