### PR TITLE
Stop execution when deleting cell

### DIFF
--- a/packages/notebook/src/browser/service/notebook-execution-service.ts
+++ b/packages/notebook/src/browser/service/notebook-execution-service.ts
@@ -90,14 +90,13 @@ export class NotebookExecutionService {
         if (validCellExecutions.length > 0) {
             const cellRemoveListener = notebook.onDidAddOrRemoveCell(e => {
                 if (e.rawEvent.changes.some(c => c.deleteCount > 0)) {
-                    const executionsToCancel = validCellExecutions
-                        .filter(exec => !notebook.cells.find(cell => cell.handle === exec.cellHandle))
+                    const executionsToCancel = validCellExecutions.filter(exec => !notebook.cells.find(cell => cell.handle === exec.cellHandle));
                     if (executionsToCancel.length > 0) {
                         kernel.cancelNotebookCellExecution(notebook.uri, executionsToCancel.map(c => c.cellHandle));
                         executionsToCancel.forEach(exec => exec.complete({}));
                     }
                 }
-            })
+            });
             await this.runExecutionParticipants(validCellExecutions);
 
             this.notebookKernelService.selectKernelForNotebook(kernel, notebook);

--- a/packages/notebook/src/browser/service/notebook-execution-service.ts
+++ b/packages/notebook/src/browser/service/notebook-execution-service.ts
@@ -88,6 +88,16 @@ export class NotebookExecutionService {
 
         // request execution
         if (validCellExecutions.length > 0) {
+            const cellRemoveListener = notebook.onDidAddOrRemoveCell(e => {
+                if (e.rawEvent.changes.some(c => c.deleteCount > 0)) {
+                    const executionsToCancel = validCellExecutions
+                        .filter(exec => !notebook.cells.find(cell => cell.handle === exec.cellHandle))
+                    if (executionsToCancel.length > 0) {
+                        kernel.cancelNotebookCellExecution(notebook.uri, executionsToCancel.map(c => c.cellHandle));
+                        executionsToCancel.forEach(exec => exec.complete({}));
+                    }
+                }
+            })
             await this.runExecutionParticipants(validCellExecutions);
 
             this.notebookKernelService.selectKernelForNotebook(kernel, notebook);
@@ -97,6 +107,9 @@ export class NotebookExecutionService {
             if (unconfirmed.length) {
                 unconfirmed.forEach(exe => exe.complete({}));
             }
+
+            cellRemoveListener.dispose();
+
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This stops execution of cells when deleting them. Through this the kernel won't break and cells will executable normally after that.

#### How to test

Create or open a notebook with at least 2 cells.
have a longer running cell like:
```python
import time
for i in range(1,100): 
    print('gffff' + str(i))
    time.sleep(0.1)
```

execute the cell and delete it while it executes. After that the other cells should still be executable 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
