### PR TITLE
Don't reveal the focused element when updating the tree rows

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1575,9 +1575,9 @@ export namespace TreeWidget {
                 }}
                 totalCount={rows.length}
                 itemContent={index => this.props.renderNodeRow(rows[index])}
-                                width={width}
+                width={width}
                 height={height}
-            // This is a pixel value, it will scan 200px to the top and bottom of the current view
+                // This is a pixel value, it will scan 200px to the top and bottom of the current view
                 overscan={500}
             />;
         }

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -339,7 +339,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             }
         }
         this.rows = new Map(rowsToUpdate);
-        this.updateScrollToRow();
+        this.update();
     }
 
     protected getDepthForNode(node: TreeNode, depths: Map<CompositeTreeNode | undefined, number>): number {
@@ -1575,9 +1575,9 @@ export namespace TreeWidget {
                 }}
                 totalCount={rows.length}
                 itemContent={index => this.props.renderNodeRow(rows[index])}
-                width={width}
+                                width={width}
                 height={height}
-                // This is a pixel value, it will scan 200px to the top and bottom of the current view
+            // This is a pixel value, it will scan 200px to the top and bottom of the current view
                 overscan={500}
             />;
         }


### PR DESCRIPTION
#### What it does
Before this change, every time the rows in a tree widget were updated, the currently focused item in the tree would be revealed in the tree, i.e. the tree would be scrolled to make the item visible. Since the focused element does not change upon scrolling, this would lead to the tree scrolling up when the rows were updated. 
This change stops doing that: the consequence will be that when elements are added or removed _before_ the currently focused item, the item will be scrolled out of view. I would argue this is better than the current behaviour, which is super-annyoing. I guess we'll just have to give it a go and see whether we run into pathological cases.

Fixes #13461

Contributed on behalf of STMicroelectronics



#### How to test
Compare the behavior with and without the fix in the package in the explorer view.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
