### PR TITLE
fix: do not override user-defined THEIA_CONFIG_DIR

### DIFF
--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -46,6 +46,11 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
     }
 
     protected async createConfigDirUri(): Promise<string> {
+        if (process.env.THEIA_CONFIG_DIR) {
+            // this has been explicitly set by the user, so we do not override its value
+            return FileUri.create(process.env.THEIA_CONFIG_DIR).toString();
+        }
+
         const dataFolderPath = join(BackendApplicationPath, 'data');
         const userDataPath = join(dataFolderPath, 'user-data');
         const dataFolderExists = this.pathExistenceCache[dataFolderPath] ??= await pathExists(dataFolderPath);


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The current behavior of Theia is to ignore a user-defined `THEIA_CONFIG_DIR` environment variable, which is an unexpected regression from a user's point of view.

This patch ensures that a user-defined value has precedence over the `BackendApplicationPath/data/user-data` location and the default location `~/.theia`.

Fixes #13700

Contributed on behalf of STMicroelectronics

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Set the `THEIA_CONFIG_DIR` environment variable to a non-default value:
   `export THEIA_CONFIG_DIR=~/theia-test-data-dir` 
2. Start Theia (e.g., `yarn browser start`)
3. Confirm that you see a line similar to the following in stdout, indicating that the value you provided in step 1 is used as configuration directory:
```
Configuration directory URI: 'file:///home/xai/theia-test-data-dir'
```
4. Confirm that this directory has been created on your filesystem (if it has not already existed before)
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
