### PR TITLE
TreeWidget: Ensure globalSelection is correctly set when opening context menu

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -302,6 +302,12 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                     }
                 })
             ]);
+
+            this.node.addEventListener('focusin', (e) => {
+                if (this.model.selectedNodes.length && (!this.selectionService.selection || !TreeWidgetSelection.isSource(this.selectionService.selection, this))) {
+                    this.updateGlobalSelection();
+                }
+            })
         }
         this.toDispose.push(this.corePreferences.onPreferenceChanged(preference => {
             if (preference.preferenceName === 'workbench.tree.renderIndentGuides') {
@@ -1343,11 +1349,6 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             if (!this.props.multiSelect || !node.selected) {
                 const type = !!this.props.multiSelect && this.hasCtrlCmdMask(event) ? TreeSelection.SelectionType.TOGGLE : TreeSelection.SelectionType.DEFAULT;
                 this.model.addSelection({ node, type });
-            }
-
-            // set global selection for the case if the node is selected by for example restoring the layout but globalSelection is therefore not updated
-            if (this.props.globalSelection && (!this.selectionService.selection || !TreeWidgetSelection.is(this.selectionService.selection))) {
-                this.updateGlobalSelection()
             }
             this.focusService.setFocus(node);
             const contextMenuPath = this.props.contextMenuPath;

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1585,7 +1585,6 @@ export namespace TreeWidget {
                 height={height}
                 // This is a pixel value, it will scan 200px to the top and bottom of the current view
                 overscan={500}
-                foc
             />;
         }
     }

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1344,6 +1344,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 const type = !!this.props.multiSelect && this.hasCtrlCmdMask(event) ? TreeSelection.SelectionType.TOGGLE : TreeSelection.SelectionType.DEFAULT;
                 this.model.addSelection({ node, type });
             }
+
+            // set global selection for the case if the node is selected by for example restoring the layout but globalSelection is therefore not updated
+            if (this.props.globalSelection && (!this.selectionService.selection || !TreeWidgetSelection.is(this.selectionService.selection))) {
+                this.updateGlobalSelection()
+            }
             this.focusService.setFocus(node);
             const contextMenuPath = this.props.contextMenuPath;
             if (contextMenuPath) {
@@ -1579,6 +1584,7 @@ export namespace TreeWidget {
                 height={height}
                 // This is a pixel value, it will scan 200px to the top and bottom of the current view
                 overscan={500}
+                foc
             />;
         }
     }

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -303,11 +303,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 })
             ]);
 
-            this.node.addEventListener('focusin', (e) => {
+            this.node.addEventListener('focusin', e => {
                 if (this.model.selectedNodes.length && (!this.selectionService.selection || !TreeWidgetSelection.isSource(this.selectionService.selection, this))) {
                     this.updateGlobalSelection();
                 }
-            })
+            });
         }
         this.toDispose.push(this.corePreferences.onPreferenceChanged(preference => {
             if (preference.preferenceName === 'workbench.tree.renderIndentGuides') {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #12937

This ensures the globalSelection is set correctly when focusing a tree widget. There are cases where when restoring the layout the global selection is not set because the widget is not yet active and when opening the context menu there is no selection changed event so the global selection stays at the old value. See the linked issue

#### How to test

Taken from the linked issue


   1. Open a file 
   2. Click in the Navigator to give it focus (this is actually optional as long as the navigator is open)
   3. Reload the window
   4. Open the context menu for the already preselected file in the navigator widget


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
