### PR TITLE
doc: improve WebSocketConnectionProvider deprecation message

### DIFF
--- a/packages/core/src/browser/messaging/index.ts
+++ b/packages/core/src/browser/messaging/index.ts
@@ -15,3 +15,4 @@
 // *****************************************************************************
 
 export * from './ws-connection-provider';
+export * from './service-connection-provider';

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -22,7 +22,8 @@ decorate(injectable(), RpcProxyFactory);
 decorate(unmanaged(), RpcProxyFactory, 0);
 
 /**
- * @deprecated This class serves to keep API compatibility for a while. Use {@linkcode ServiceConnectionProvider} instead.
+ * @deprecated This class serves to keep API compatibility for a while.
+ * Use the {@linkcode RemoteConnectionProvider} as the injection symbol and {@linkcode ServiceConnectionProvider} as the type instead.
  */
 @injectable()
 export class WebSocketConnectionProvider {


### PR DESCRIPTION
The current deprecation message leads to confusion as the referenced class is not exported and not usable as an injection symbol. The message is improved and the new ServiceConnectionProvider is exported.

Contributed on behalf of STMicroelectronics

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
