### PR TITLE
[vscode] Add WindowState active in plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ## 1.50.0
 
+- [plugin] Support WindowState active API [#13718](https://github.com/eclipse-theia/theia/pull/13718) - contributed on behalf of STMicroelectronics
+
 <a name="breaking_changes_1.50.0">[Breaking Changes:](#breaking_changes_1.50.0)</a>
 
 - [core] Classes implementing the `Saveable` interface no longer need to implement the `autoSave` field. However, a new `onContentChanged` event has been added instead.

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -893,7 +893,8 @@ export interface WindowMain {
 }
 
 export interface WindowStateExt {
-    $onWindowStateChanged(focus: boolean): void;
+    $onDidChangeWindowFocus(focused: boolean): void;
+    $onDidChangeWindowActive(active: boolean): void;
 }
 
 export interface NotificationExt {

--- a/packages/plugin-ext/src/main/browser/window-activity-tracker.ts
+++ b/packages/plugin-ext/src/main/browser/window-activity-tracker.ts
@@ -1,0 +1,96 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Disposable, Emitter, Event } from '@theia/core';
+
+const CHECK_INACTIVITY_LIMIT = 30;
+const CHECK_INACTIVITY_INTERVAL = 1000;
+
+const eventListenerOptions: AddEventListenerOptions = {
+    passive: true,
+    capture: true
+};
+export class WindowActivityTracker implements Disposable {
+
+    private inactivityCounter = 0; // number of times inactivity was checked since last reset
+    private readonly inactivityLimit = CHECK_INACTIVITY_LIMIT; // number of inactivity checks done before sending inactive signal
+    private readonly checkInactivityInterval = CHECK_INACTIVITY_INTERVAL; // check interval in milliseconds
+    private interval: NodeJS.Timeout | undefined;
+
+    protected readonly onDidChangeActiveStateEmitter = new Emitter<boolean>();
+    private _activeState: boolean = true;
+
+    constructor(readonly win: Window) {
+        this.initializeListeners(this.win);
+    }
+
+    get onDidChangeActiveState(): Event<boolean> {
+        return this.onDidChangeActiveStateEmitter.event;
+    }
+
+    private set activeState(newState: boolean) {
+        if (this._activeState !== newState) {
+            this._activeState = newState;
+            this.onDidChangeActiveStateEmitter.fire(this._activeState);
+        }
+    }
+
+    private initializeListeners(win: Window): void {
+        // currently assumes activity based on key/mouse/touch pressed, not on mouse move or scrolling.
+        win.addEventListener('mousedown', this.resetInactivity, eventListenerOptions);
+        win.addEventListener('keydown', this.resetInactivity, eventListenerOptions);
+        win.addEventListener('touchstart', this.resetInactivity, eventListenerOptions);
+    }
+
+    dispose(): void {
+        this.stopTracking();
+        this.win.removeEventListener('mousedown', this.resetInactivity);
+        this.win.removeEventListener('keydown', this.resetInactivity);
+        this.win.removeEventListener('touchstart', this.resetInactivity);
+
+    }
+
+    // Reset inactivity time
+    private resetInactivity = (): void => {
+        this.inactivityCounter = 0;
+        if (!this.interval) {
+            // it was not active. Set as active and restart tracking inactivity
+            this.activeState = true;
+            this.startTracking();
+        }
+    };
+
+    // Check inactivity status
+    private checkInactivity = (): void => {
+        this.inactivityCounter++;
+        if (this.inactivityCounter >= this.inactivityLimit) {
+            this.activeState = false;
+            this.stopTracking();
+        }
+    };
+
+    public startTracking(): void {
+        this.stopTracking();
+        this.interval = setInterval(this.checkInactivity, this.checkInactivityInterval);
+    }
+
+    public stopTracking(): void {
+        if (this.interval) {
+            clearInterval(this.interval);
+            this.interval = undefined;
+        }
+    }
+}

--- a/packages/plugin-ext/src/plugin/window-state.ts
+++ b/packages/plugin-ext/src/plugin/window-state.ts
@@ -31,21 +31,28 @@ export class WindowStateExtImpl implements WindowStateExt {
 
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.WINDOW_MAIN);
-        this.windowStateCached = { focused: true }; // supposed tab is active on start
+        this.windowStateCached = { focused: true, active: true }; // supposed tab is active on start
     }
 
     getWindowState(): WindowState {
         return this.windowStateCached;
     }
 
-    $onWindowStateChanged(focused: boolean): void {
-        const state = { focused: focused };
-        if (state === this.windowStateCached) {
+    $onDidChangeWindowFocus(focused: boolean): void {
+        this.onDidChangeWindowProperty('focused', focused);
+    }
+
+    $onDidChangeWindowActive(active: boolean): void {
+        this.onDidChangeWindowProperty('active', active);
+    }
+
+    onDidChangeWindowProperty(property: keyof WindowState, value: boolean): void {
+        if (value === this.windowStateCached[property]) {
             return;
         }
 
-        this.windowStateCached = state;
-        this.windowStateChangedEmitter.fire(state);
+        this.windowStateCached = { ...this.windowStateCached, [property]: value };
+        this.windowStateChangedEmitter.fire(this.windowStateCached);
     }
 
     openUri(uri: URI): Promise<boolean> {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2741,6 +2741,12 @@ export module '@theia/plugin' {
          * Whether the current window is focused.
          */
         readonly focused: boolean;
+
+        /**
+         * Whether the window has been interacted with recently. This will change
+         * immediately on activity, or after a short time of user inactivity.
+         */
+        readonly active: boolean;
     }
 
     /**


### PR DESCRIPTION
#### What it does

Implements the new VS Code API WindowState Active

Fixes #13692 

Contributed on behalf of ST Microelectronics

#### How to test 
 
This can be tested with the following extension:
- src: [window-activestate-sample-0.0.1-src.zip](https://github.com/eclipse-theia/theia/files/15337523/window-activestate-sample-0.0.1-src.zip)
- zip vsix: [window-activestate-sample-0.0.1.zip](https://github.com/eclipse-theia/theia/files/15337526/window-activestate-sample-0.0.1.zip)

This extension will display a notification has soon as window state is changed, focus or active. To test, you can get or lose focus with any combination of idle time to check activity state. User is considered as inactive after 20sec of doing nothing, and this timer will be reset has soon as a mouse button is clicked / key stroke or touch gesture.

#### Follow-ups

None

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

