### PR TITLE
Support dynamic menu contributions

### DIFF
--- a/examples/api-tests/src/menus.spec.js
+++ b/examples/api-tests/src/menus.spec.js
@@ -44,8 +44,8 @@ describe('Menus', function () {
 
     const container = window.theia.container;
     const shell = container.get(ApplicationShell);
+    /** @type {BrowserMenuBarContribution} */
     const menuBarContribution = container.get(BrowserMenuBarContribution);
-    const menuBar = /** @type {import('@theia/core/lib/browser/menu/browser-menu-plugin').MenuBarWidget} */ (menuBarContribution.menuBar);
     const pluginService = container.get(HostedPluginSupport);
     const menus = container.get(MenuModelRegistry);
     const commands = container.get(CommandRegistry);
@@ -54,6 +54,9 @@ describe('Menus', function () {
     before(async function () {
         await pluginService.didStart;
         await pluginService.activateByViewContainer('explorer');
+        // Updating the menu interferes with our ability to programmatically test it
+        // We simply disable the menu updating
+        menus.isReady = false;
     });
 
     const toTearDown = new DisposableCollection();
@@ -73,7 +76,7 @@ describe('Menus', function () {
     ]) {
         it(`should toggle '${contribution.viewLabel}' view`, async () => {
             await contribution.closeView();
-            await menuBar.triggerMenuItem('View', contribution.viewLabel);
+            await menuBarContribution.menuBar.triggerMenuItem('View', contribution.viewLabel);
             await shell.waitForActivation(contribution.viewId);
         });
     }

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -192,13 +192,13 @@ export class DynamicMenuBarWidget extends MenuBarWidget {
         this.openActiveMenu();
         await waitForRevealed(menu);
 
-        const menuPath = [label];
+        const menuPath = [label, ...labels];
 
         let current = menu;
         for (const itemLabel of labels) {
             const item = current.items.find(i => i.label === itemLabel);
             if (!item || !item.submenu) {
-                throw new Error(`could not find '${label}' submenu in ${menuPath.map(l => "'" + l + "'").join(' -> ')} menu`);
+                throw new Error(`could not find '${itemLabel}' submenu in ${menuPath.map(l => "'" + l + "'").join(' -> ')} menu`);
             }
             current.activeItem = item;
             current.triggerActiveItem();
@@ -216,7 +216,7 @@ export class DynamicMenuBarWidget extends MenuBarWidget {
         const menu = await this.activateMenu(menuPath[0], ...menuPath.slice(1));
         const item = menu.items.find(i => i.label === labels[labels.length - 1]);
         if (!item) {
-            throw new Error(`could not find '${label}' item in ${menuPath.map(l => "'" + l + "'").join(' -> ')} menu`);
+            throw new Error(`could not find '${labels[labels.length - 1]}' item in ${menuPath.map(l => "'" + l + "'").join(' -> ')} menu`);
         }
         menu.activeItem = item;
         menu.triggerActiveItem();

--- a/packages/core/src/common/menu/menu-model-registry.ts
+++ b/packages/core/src/common/menu/menu-model-registry.ts
@@ -18,6 +18,7 @@ import { inject, injectable, named } from 'inversify';
 import { Command, CommandRegistry } from '../command';
 import { ContributionProvider } from '../contribution-provider';
 import { Disposable } from '../disposable';
+import { Emitter, Event } from '../event';
 import { ActionMenuNode } from './action-menu-node';
 import { CompositeMenuNode, CompositeMenuNodeWrapper } from './composite-menu-node';
 import { CompoundMenuNode, MenuAction, MenuNode, MenuNodeMetadata, MenuPath, MutableCompoundMenuNode, SubMenuOptions } from './menu-types';
@@ -68,6 +69,14 @@ export class MenuModelRegistry {
     protected readonly root = new CompositeMenuNode('');
     protected readonly independentSubmenus = new Map<string, MutableCompoundMenuNode>();
 
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+
+    get onDidChange(): Event<void> {
+        return this.onDidChangeEmitter.event;
+    }
+
+    protected isReady = false;
+
     constructor(
         @inject(ContributionProvider) @named(MenuContribution)
         protected readonly contributions: ContributionProvider<MenuContribution>,
@@ -78,6 +87,7 @@ export class MenuModelRegistry {
         for (const contrib of this.contributions.getContributions()) {
             contrib.registerMenus(this);
         }
+        this.isReady = true;
     }
 
     /**
@@ -97,7 +107,9 @@ export class MenuModelRegistry {
      */
     registerMenuNode(menuPath: MenuPath | string, menuNode: MenuNode, group?: string): Disposable {
         const parent = this.getMenuNode(menuPath, group);
-        return parent.addNode(menuNode);
+        const disposable = parent.addNode(menuNode);
+        this.fireChangeEvent();
+        return this.changeEventOnDispose(disposable);
     }
 
     getMenuNode(menuPath: MenuPath | string, group?: string): MutableCompoundMenuNode {
@@ -137,13 +149,15 @@ export class MenuModelRegistry {
         const groupPath = index === 0 ? [] : menuPath.slice(0, index);
         const parent = this.findGroup(groupPath, options);
         let groupNode = this.findSubMenu(parent, menuId, options);
+        let disposable = Disposable.NULL;
         if (!groupNode) {
             groupNode = new CompositeMenuNode(menuId, label, options, parent);
-            return parent.addNode(groupNode);
+            disposable = this.changeEventOnDispose(parent.addNode(groupNode));
         } else {
             groupNode.updateOptions({ ...options, label });
-            return Disposable.NULL;
         }
+        this.fireChangeEvent();
+        return disposable;
     }
 
     registerIndependentSubmenu(id: string, label: string, options?: SubMenuOptions): Disposable {
@@ -151,7 +165,7 @@ export class MenuModelRegistry {
             console.debug(`Independent submenu with path ${id} registered, but given ID already exists.`);
         }
         this.independentSubmenus.set(id, new CompositeMenuNode(id, label, options));
-        return { dispose: () => this.independentSubmenus.delete(id) };
+        return this.changeEventOnDispose(Disposable.create(() => this.independentSubmenus.delete(id)));
     }
 
     linkSubmenu(parentPath: MenuPath | string, childId: string | MenuPath, options?: SubMenuOptions, group?: string): Disposable {
@@ -175,7 +189,9 @@ export class MenuModelRegistry {
         }
 
         const wrapper = new CompositeMenuNodeWrapper(child, parent, options);
-        return parent.addNode(wrapper);
+        const disposable = parent.addNode(wrapper);
+        this.fireChangeEvent();
+        return this.changeEventOnDispose(disposable);
     }
 
     /**
@@ -228,6 +244,7 @@ export class MenuModelRegistry {
             });
         };
         recurse(this.root);
+        this.fireChangeEvent();
     }
 
     /**
@@ -319,6 +336,19 @@ export class MenuModelRegistry {
             }
         }
         return true;
+    }
+
+    protected changeEventOnDispose(disposable: Disposable): Disposable {
+        return Disposable.create(() => {
+            disposable.dispose();
+            this.fireChangeEvent();
+        });
+    }
+
+    protected fireChangeEvent(): void {
+        if (this.isReady) {
+            this.onDidChangeEmitter.fire();
+        }
     }
 
     /**

--- a/packages/core/src/common/menu/menu-model-registry.ts
+++ b/packages/core/src/common/menu/menu-model-registry.ts
@@ -223,6 +223,7 @@ export class MenuModelRegistry {
         if (menuPath) {
             const parent = this.findGroup(menuPath);
             parent.removeNode(id);
+            this.fireChangeEvent();
             return;
         }
 

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -101,6 +101,9 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
         this.keybindingRegistry.onKeybindingsChanged(() => {
             this.setMenuBar();
         });
+        this.menuProvider.onDidChange(() => {
+            this.setMenuBar();
+        });
     }
 
     async setMenuBar(): Promise<void> {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13719

Adds a new `onDidChange` event to the `MenuModelRegistry`. Any changes to the menus (i.e. registering, unregistering, disposal) fire this event now. Adds a listener to this event in the menu factories to ensure that the menus are correctly recreated.

#### How to test

1. Adjust some of the `sample-menu-contribution.ts` file:
```ts
setTimeout(() => {
  const disposable = menus.registerMenuAction(subSubMenuPath, {
    commandId: SampleCommand2.id,
    order: '3'
  });
  setTimeout(() => disposable.dispose(), 8000);
}, 8000);
```
2. After starting the app, open the `Sample Menu > Sample sub menu`
3. It should only show 2 entries
4. After a few seconds the menu should refresh showing an additional entry
5. A few seconds later the entry should disappear again.

#### Follow-ups

I've noticed that the menu flashes when the model is changed (i.e. any open main sub menus are closed). That's something that could maybe be addressed in a separate PR. A smart diffing of the menu bar HTML element would probably be appropriate here.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
