### PR TITLE
fixed README documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Eclipse Theia is an extensible framework to develop full-fledged multi-language 
 
 ## Website
 
-[Visit the Eclipse Theia website](http://www.theia-ide.org) for more information and [the Theia documentation](http://www.theia-ide.org/doc).
+[Visit the Eclipse Theia website](http://www.theia-ide.org) for more information and [the Theia documentation](http://www.theia-ide.org/docs).
 
 ## Repositories
 This is the main repository for the Eclipse Theia project, containing the sources of the Theia Platform. Please open generic discussions, bug reports and feature requests about Theia on this repository. The Theia project also includes additional repositories, e.g. for the [artifacts building the Theia IDE](https://github.com/eclipse-theia/theia-blueprint) and the [Theia website](https://github.com/eclipse-theia/theia-website). Please also see the [overview of all Theia project repositories](https://github.com/eclipse-theia).


### PR DESCRIPTION
Fixed broken link to Theia documentation as outlined in #13724 

`[the Theia documentation](http://www.theia-ide.org/doc)` -> `[the Theia documentation](http://www.theia-ide.org/docs)` 