### PR TITLE
Delegate showing help to the back end process.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -153,6 +153,9 @@
       "frontendElectron": "lib/electron-browser/window/electron-window-module"
     },
     {
+      "backendElectron": "lib/electron-node/cli/electron-backend-cli-module"
+    },
+    {
       "frontend": "lib/browser/keyboard/browser-keyboard-module",
       "frontendElectron": "lib/electron-browser/keyboard/electron-keyboard-module",
       "backendElectron": "lib/electron-node/keyboard/electron-backend-keyboard-module"

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -209,6 +209,7 @@ export class ElectronMainApplication {
     async start(config: FrontendApplicationConfig): Promise<void> {
         const argv = this.processArgv.getProcessArgvWithoutBin(process.argv);
         createYargs(argv, process.cwd())
+            .help(false)
             .command('$0 [file]', false,
                 cmd => cmd
                     .option('electronUserData', {

--- a/packages/core/src/electron-node/cli/electron-backend-cli-module.ts
+++ b/packages/core/src/electron-node/cli/electron-backend-cli-module.ts
@@ -1,0 +1,24 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContainerModule } from 'inversify';
+import { ElectronCliContribution } from './electron-cli-contribution';
+import { CliContribution } from '../../node';
+
+export default new ContainerModule(bind => {
+    bind(ElectronCliContribution).toSelf().inSingletonScope();
+    bind(CliContribution).toService(ElectronCliContribution);
+});

--- a/packages/core/src/electron-node/cli/electron-cli-contribution.ts
+++ b/packages/core/src/electron-node/cli/electron-cli-contribution.ts
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (C) 2024 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Argv, Arguments } from 'yargs';
+import { CliContribution } from '../../node';
+import { MaybePromise } from '../../common';
+
+@injectable()
+export class ElectronCliContribution implements CliContribution {
+
+    configure(conf: Argv): void {
+        conf.option('electronUserData', {
+            type: 'string',
+            describe: 'The area where the electron main process puts its data'
+        });
+    }
+
+    setArguments(args: Arguments): MaybePromise<void> {
+    }
+
+}

--- a/packages/core/src/node/cli.ts
+++ b/packages/core/src/node/cli.ts
@@ -38,7 +38,7 @@ export class CliManager {
     async initializeCli<T>(argv: string[], postSetArguments: () => Promise<void>, defaultCommand: () => Promise<void>): Promise<void> {
         const pack = require('../../package.json');
         const version = pack.version;
-        const command = yargs.version(version);
+        const command = yargs(argv, process.cwd()).version(version);
         command.exitProcess(this.isExit());
         for (const contrib of this.contributionsProvider.getContributions()) {
             contrib.configure(command);
@@ -54,7 +54,7 @@ export class CliManager {
                 await postSetArguments();
             })
             .command('$0', false, () => { }, defaultCommand)
-            .parse(argv);
+            .parse();
     }
 
     protected isExit(): boolean {


### PR DESCRIPTION


#### What it does
Fixes #13727

The approach is to add non-functional cli contributions for any arguments that concern only the electron-main process. Currently, we have a bit of confusion between the `theia` cli tool, which is mostly a development-time tool (`theia build`, etc.) and the actual Theia application executable (`TheiaIde.exe`). It would probably make sense to evolve the architecture in a way that all possible command line options are available to all "customer-facing" cli tools and can be selectively forwarded to the back-end, plugin-process and any other processes making up Theia. 

Contributed on behalf of STMicroelectronics

#### How to test
The closest equivalent to what the `TheiaIDE.exe` does is the "Launch electron back end" launch configuration. To test, you can add parameters after the initial `.` parameter (which is a parameter to Electron). One can also use `npx theia start <...params>` on the command line in the electron or browser example.
In these way, test that the help commands output reasonable advice and that start parameters are properly handled.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
