### PR TITLE
Fix an API test failure on macOS

### DIFF
--- a/examples/api-tests/src/monaco-api.spec.js
+++ b/examples/api-tests/src/monaco-api.spec.js
@@ -87,7 +87,6 @@ describe('Monaco API', async function () {
                     electronAccelerator: 'Ctrl+Shift+Alt+Cmd+K',
                     userSettingsLabel: 'ctrl+shift+alt+cmd+K',
                     WYSIWYG: true,
-                    chord: false,
                     parts: [new ResolvedChord(
                         true,
                         true,


### PR DESCRIPTION
#### What it does

Before this fix, Monaco API KeybindingService.resolveKeybinding test was failing on macOS with

```
AssertionError: expected { label: '⌃⇧⌥⌘K', …(6) } to deeply equal { label: '⌃⇧⌥⌘K', …(7) }
+ expected - actual

{
 "WYSIWYG": true
 "ariaLabel": "⌃⇧⌥⌘K"
+  "chord": false
 "dispatchParts": [
   "ctrl+shift+alt+meta+K"
 ]
 "electronAccelerator": "Ctrl+Shift+Alt+Cmd+K"
```

The `chord: false` was [removed](https://github.com/eclipse-theia/theia/pull/13217/files#diff-7fc34d750e96963603d174fcb7ade87cf355b834c85f2187896568d4f6ee90d3L111) from the expected object for other platforms as part of #13217.

This fix removes it from the expected object for macOS.

#### How to test

Run `yarn test` on macOS.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
