### PR TITLE
Fixed focus loss of the notebook editor widget when bluring a cell editor

### DIFF
--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -78,11 +78,9 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
             this.editor?.setLanguage(language);
         }));
 
-        this.toDispose.push(this.props.notebookModel.onDidChangeSelectedCell(() => {
-            if (this.props.notebookModel.selectedCell !== this.props.cell && this.editor?.getControl().hasTextFocus()) {
-                if (document.activeElement && 'blur' in document.activeElement) {
-                    (document.activeElement as HTMLElement).blur();
-                }
+        this.toDispose.push(this.props.notebookModel.onDidChangeSelectedCell(cell => {
+            if (cell !== this.props.cell && this.editor?.getControl().hasTextFocus()) {
+                this.props.notebookContextManager.context?.focus();
             }
         }));
         if (!this.props.notebookViewportService || (this.container && this.props.notebookViewportService.isElementInViewport(this.container))) {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

When you had a cell editor focused but executed a command which changed the selection, further commands would not work because the cell editor blurred itself and so the widget itself was not focused anymore.

#### How to test

Best to test is with the shift+enter

1. Open a notebook with at least two code cells.
2. Focus the text of the first cell
3. shift+enter
4. cell should execute and the next cell should be selected (without focusing the text)
5. another shift+enter
6. next cell should be selected or created 

Step 5 was broken because widget focus was lost previous to this fix

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
