### PR TITLE
Notebooks: Aligned scroll into view behaviour with vscode

### DIFF
--- a/packages/notebook/src/browser/service/notebook-context-manager.ts
+++ b/packages/notebook/src/browser/service/notebook-context-manager.ts
@@ -88,6 +88,7 @@ export class NotebookContextManager {
         // Cell Selection realted keys
         this.scopedStore.setContext(NOTEBOOK_CELL_FOCUSED, !!widget.model?.selectedCell);
         widget.model?.onDidChangeSelectedCell(e => {
+            this.selectedCellChanged(e.cell);
             this.scopedStore.setContext(NOTEBOOK_CELL_FOCUSED, !!e);
             this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_CELL_FOCUSED]));
         });
@@ -99,8 +100,6 @@ export class NotebookContextManager {
                 this.onDidChangeContextEmitter.fire(this.createContextKeyChangedEvent([NOTEBOOK_CELL_EXECUTING, NOTEBOOK_CELL_EXECUTION_STATE]));
             }
         }));
-
-        widget.model?.onDidChangeSelectedCell(e => this.selectedCellChanged(e));
 
         widget.onDidChangeOutputInputFocus(focus => {
             this.scopedStore.setContext(NOTEBOOK_OUTPUT_INPUT_FOCUSED, focus);

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -290,9 +290,12 @@ export class NotebookModel implements Saveable, Disposable {
             if (cell) {
                 this.cellDirtyChanged(cell, true);
             }
+
+            let scrollIntoView = true;
             switch (edit.editType) {
                 case CellEditType.Replace:
                     this.replaceCells(edit.index, edit.count, edit.cells, computeUndoRedo);
+                    scrollIntoView = edit.cells.length > 0;
                     break;
                 case CellEditType.Output: {
                     if (edit.append) {
@@ -335,7 +338,7 @@ export class NotebookModel implements Saveable, Disposable {
 
             // if selected cell is affected update it because it can potentially have been replaced
             if (cell === this.selectedCell) {
-                this.setSelectedCell(this.cells[Math.min(cellIndex, this.cells.length - 1)]);
+                this.setSelectedCell(this.cells[Math.min(cellIndex, this.cells.length - 1)], scrollIntoView);
             }
         }
 

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -56,6 +56,11 @@ export interface NotebookModelProps {
     serializer: NotebookSerializer;
 }
 
+export interface SelectedCellChangeEvent {
+    cell: NotebookCellModel | undefined;
+    scrollIntoView: boolean;
+}
+
 @injectable()
 export class NotebookModel implements Saveable, Disposable {
 
@@ -74,7 +79,7 @@ export class NotebookModel implements Saveable, Disposable {
     protected readonly onContentChangedEmitter = new Emitter<void>();
     readonly onContentChanged = this.onContentChangedEmitter.event;
 
-    protected readonly onDidChangeSelectedCellEmitter = new Emitter<NotebookCellModel | undefined>();
+    protected readonly onDidChangeSelectedCellEmitter = new Emitter<SelectedCellChangeEvent>();
     readonly onDidChangeSelectedCell = this.onDidChangeSelectedCellEmitter.event;
 
     protected readonly onDidDisposeEmitter = new Emitter<void>();
@@ -246,10 +251,10 @@ export class NotebookModel implements Saveable, Disposable {
         this.undoRedoService.redo(this.uri);
     }
 
-    setSelectedCell(cell: NotebookCellModel): void {
+    setSelectedCell(cell: NotebookCellModel, scrollIntoView?: boolean): void {
         if (this.selectedCell !== cell) {
             this.selectedCell = cell;
-            this.onDidChangeSelectedCellEmitter.fire(cell);
+            this.onDidChangeSelectedCellEmitter.fire({ cell, scrollIntoView: scrollIntoView ?? true });
         }
     }
 

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -78,11 +78,9 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
             this.editor?.setLanguage(language);
         }));
 
-        this.toDispose.push(this.props.notebookModel.onDidChangeSelectedCell(() => {
-            if (this.props.notebookModel.selectedCell !== this.props.cell && this.editor?.getControl().hasTextFocus()) {
-                if (document.activeElement && 'blur' in document.activeElement) {
-                    (document.activeElement as HTMLElement).blur();
-                }
+        this.toDispose.push(this.props.notebookModel.onDidChangeSelectedCell(cell => {
+            if (cell !== this.props.cell && this.editor?.getControl().hasTextFocus()) {
+                this.props.notebookContextManager.context?.focus();
             }
         }));
         if (!this.props.notebookViewportService || (this.container && this.props.notebookViewportService.isElementInViewport(this.container))) {

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -129,7 +129,7 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
             }));
             this.toDispose.push(this.editor.getControl().onDidFocusEditorText(() => {
                 this.props.notebookContextManager.onDidEditorTextFocus(true);
-                this.props.notebookModel.setSelectedCell(cell);
+                this.props.notebookModel.setSelectedCell(cell, false);
             }));
             this.toDispose.push(this.editor.getControl().onDidBlurEditorText(() => {
                 this.props.notebookContextManager.onDidEditorTextFocus(false);

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -78,8 +78,8 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
             this.editor?.setLanguage(language);
         }));
 
-        this.toDispose.push(this.props.notebookModel.onDidChangeSelectedCell(cell => {
-            if (cell !== this.props.cell && this.editor?.getControl().hasTextFocus()) {
+        this.toDispose.push(this.props.notebookModel.onDidChangeSelectedCell(e => {
+            if (e.cell !== this.props.cell && this.editor?.getControl().hasTextFocus()) {
                 this.props.notebookContextManager.context?.focus();
             }
         }));

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -55,7 +55,7 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
                 this.setState({
                     ...this.state,
                     selectedCell: this.props.notebookModel.cells.find(model => model.handle === e.newCellIds![e.newCellIds!.length - 1]),
-                    scrollIntoView: false
+                    scrollIntoView: true
                 });
             } else {
                 this.setState({


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

As in vscode clicking a cell to select it or deleting a cell and changing the selection that way should not move the newly selected cell into view

#### How to test

In a notebook test:
1. clicking on a cell slightly outside of the view. Should not scroll
2. deleting a cell. Should not scroll
3. inserting new cell: Should scroll
4. arrow keys. With and without text focus. Should scroll

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
