### PR TITLE
Fix notebook cell divider size

### DIFF
--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -171,7 +171,7 @@
 }
 
 .theia-notebook-cell-divider {
-  height: 20px;
+  height: 25px;
   width: 100%;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Previously the cell divider height was to small to contain the content so hovering over the last divider in a notebook resulted in a scrollbar being created which changed the width of the notebook editor widget.
This should be fixed now

#### How to test

1. open a notebook with more cells than fit on the screen.
2. Hover over the last cell divider at the bottom of the notebook
3. No extra scrollbar should appear, and the editor width should not change

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
