### PR TITLE
feat: add support for files.insertFinalNewline during formatOnSave

### DIFF
--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -95,6 +95,12 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
             description: nls.localizeByDefault('When enabled, will trim trailing whitespace when saving a file.'),
             scope: 'language-overridable'
         },
+        'files.insertFinalNewline': {
+            type: 'boolean',
+            default: false,
+            description: nls.localizeByDefault('When enabled, insert a final new line at the end of the file when saving it.'),
+            scope: 'language-overridable'
+        },
         'files.maxConcurrentUploads': {
             type: 'integer',
             default: 1,
@@ -116,6 +122,7 @@ export interface FileSystemConfiguration {
     'files.participants.timeout': number
     'files.maxFileSizeMB': number
     'files.trimTrailingWhitespace': boolean
+    'files.insertFinalNewline': boolean
     'files.maxConcurrentUploads': number
 }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
When the `files.insertFinalNewline` property is set to true, formatOnSave() will ensure that the file ends with a newline character instead of always removing a final empty line.

Fixes #13475 

Contributed on behalf of STMicroelectronics

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a workspace and set `"editor.formatOnSave"` to `true` in the workspace settings.
2. Edit a file that has a final empty line and save.
3. Verify that the empty line has been removed.
4. Set `"files.insertFinalNewline"` to `true` in the workspace settings.
5. Verify that final empty lines are kept or added when saving.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
