### PR TITLE
Return empty appRoot in web plugin host

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/worker/worker-env-ext.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-env-ext.ts
@@ -28,13 +28,6 @@ export class WorkerEnvExtImpl extends EnvExtImpl {
         super();
     }
 
-    /**
-     * Throw error for app-root as there is no filesystem in worker context
-     */
-    override get appRoot(): string {
-        throw new Error('There is no app root in worker context');
-    }
-
     get isNewAppInstall(): boolean {
         return false;
     }

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-env-ext.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-env-ext.ts
@@ -28,6 +28,11 @@ export class WorkerEnvExtImpl extends EnvExtImpl {
         super();
     }
 
+    override get appRoot(): string {
+        // The documentation indicates that this should be an empty string
+        return '';
+    }
+
     get isNewAppInstall(): boolean {
         return false;
     }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7734,6 +7734,9 @@ export module '@theia/plugin' {
 
         /**
          * The application root folder from which the editor is running.
+         *
+         * *Note* that the value is the empty string when running in an
+         * environment that has no representation of an application root folder.
          */
         export const appRoot: string;
 


### PR DESCRIPTION
#### What it does

Updates the documentation of `appRoot` and aligns the web-worker plugin host implementation to the documentation.

#### How to test

Assert that the method returns an empty string (?)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
