### PR TITLE
Support `PluginExt#extensionKind` properly

### DIFF
--- a/packages/core/src/browser/browser.ts
+++ b/packages/core/src/browser/browser.ts
@@ -34,9 +34,14 @@ export const isSafari = (userAgent.indexOf('Chrome') === -1) && (userAgent.index
 export const isIPad = (userAgent.indexOf('iPad') >= 0);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 /**
- * @deprecated us Environment.electron.is
+ * @deprecated use Environment.electron.is
  */
 export const isNative = environment.electron.is();
+/**
+ * Determines whether the backend is running in a remote environment.
+ * I.e. we use the browser version or connect to a remote Theia instance in Electron.
+ */
+export const isRemote = !environment.electron.is() || new URL(location.href).searchParams.has('localPort');
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isBasicWasmSupported = typeof (window as any).WebAssembly !== 'undefined';
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -159,6 +159,18 @@ export enum UIKind {
     Web = 2
 }
 
+export enum ExtensionKind {
+    /**
+     * Extension runs where the UI runs.
+     */
+    UI = 1,
+
+    /**
+     * Extension runs where the remote extension host runs.
+     */
+    Workspace = 2
+}
+
 export interface EnvInit {
     queryParams: QueryParameters;
     language: string;
@@ -178,6 +190,7 @@ export interface PluginManager {
     getAllPlugins(): Plugin[];
     getPluginById(pluginId: string): Plugin | undefined;
     getPluginExport(pluginId: string): PluginAPI | undefined;
+    getPluginKind(): theia.ExtensionKind;
     isRunning(pluginId: string): boolean;
     isActive(pluginId: string): boolean;
     activatePlugin(pluginId: string): PromiseLike<void>;
@@ -233,6 +246,7 @@ export interface PluginManagerInitializeParams {
     globalState: KeysToKeysToAnyValue
     workspaceState: KeysToKeysToAnyValue
     env: EnvInit
+    pluginKind: ExtensionKind
     extApi?: ExtPluginApi[]
     webview: WebviewInitData
     jsonValidation: PluginJsonValidationContribution[]

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -26,7 +26,7 @@ import { injectable, inject, postConstruct } from '@theia/core/shared/inversify'
 import { PluginWorker } from './plugin-worker';
 import { getPluginId, DeployedPlugin, HostedPluginServer } from '../../common/plugin-protocol';
 import { HostedPluginWatcher } from './hosted-plugin-watcher';
-import { MAIN_RPC_CONTEXT, PluginManagerExt, UIKind } from '../../common/plugin-api-rpc';
+import { ExtensionKind, MAIN_RPC_CONTEXT, PluginManagerExt, UIKind } from '../../common/plugin-api-rpc';
 import { setUpPluginApi } from '../../main/browser/main-context';
 import { RPCProtocol, RPCProtocolImpl } from '../../common/rpc-protocol';
 import {
@@ -71,6 +71,7 @@ import {
     AbstractHostedPluginSupport, PluginContributions, PluginHost,
     ALL_ACTIVATION_EVENT, isConnectionScopedBackendPlugin
 } from '../common/hosted-plugin';
+import { isRemote } from '@theia/core/lib/browser/browser';
 
 export type DebugActivationEvent = 'onDebugResolve' | 'onDebugInitialConfigurations' | 'onDebugAdapterProtocolTracker' | 'onDebugDynamicConfigurations';
 
@@ -334,6 +335,7 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
                     webviewCspSource
                 },
                 jsonValidation,
+                pluginKind: isRemote ? ExtensionKind.Workspace : ExtensionKind.UI,
                 supportedActivationEvents
             });
             if (toDisconnect.disposed) {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -1508,7 +1508,7 @@ export class PluginExt<T> extends Plugin<T> implements ExtensionPlugin<T> {
 
         this.extensionPath = this.pluginPath;
         this.extensionUri = this.pluginUri;
-        this.extensionKind = ExtensionKind.UI; // stub as a local extension (not running on a remote workspace)
+        this.extensionKind = pluginManager.getPluginKind();
         this.isFromDifferentExtensionHost = isFromDifferentExtensionHost;
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -29,7 +29,8 @@ import {
     PluginManagerInitializeParams,
     PluginManagerStartParams,
     TerminalServiceExt,
-    LocalizationExt
+    LocalizationExt,
+    ExtensionKind
 } from '../common/plugin-api-rpc';
 import { PluginMetadata, PluginJsonValidationContribution } from '../common/plugin-protocol';
 import * as theia from '@theia/plugin';
@@ -121,6 +122,7 @@ export abstract class AbstractPluginManagerExtImpl<P extends Record<string, any>
     private notificationMain: NotificationMain;
 
     protected jsonValidation: PluginJsonValidationContribution[] = [];
+    protected pluginKind = ExtensionKind.UI;
     protected ready = new Deferred();
 
     @postConstruct()
@@ -410,6 +412,10 @@ export abstract class AbstractPluginManagerExtImpl<P extends Record<string, any>
         }
     }
 
+    getPluginKind(): theia.ExtensionKind {
+        return this.pluginKind;
+    }
+
     getAllPlugins(): Plugin[] {
         return Array.from(this.registry.values());
     }
@@ -477,6 +483,7 @@ export class PluginManagerExtImpl extends AbstractPluginManagerExtImpl<PluginMan
 
         this.webview.init(params.webview);
         this.jsonValidation = params.jsonValidation;
+        this.pluginKind = params.pluginKind;
 
         this.supportedActivationEvents = new Set(params.supportedActivationEvents ?? []);
     }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/8871

Adds a new constant `isRemote` that identifies whether the backend lives on a remote system. We reuse this info to give the plugin host the correct information about the `extensionKind` property.

#### How to test

1. Download and install [this test plugin](https://github.com/user-attachments/files/15571395/extensionKind-0.0.1.zip)
2. Start Theia in browser mode and run the `Display Extension Kind` command. Assert that it shows `Workspace`.
3. Start Theia in Electron mode and run the same command. It shows `UI`.
4. From the Electron mode connect to a remote machine via SSH (or the dev-container feature). Running the command should show `Workspace`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
