### PR TITLE
Avoid changing context key view when changing selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
-<!-- ## not yet released
+<!-- ## not yet released 
+
+- [plugin] Avoid pollution of all toolbars by actions contributed by tree views in extensions [#13768](https://github.com/eclipse-theia/theia/pull/13768) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
 

--- a/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
@@ -24,7 +24,6 @@ import {
     CompositeTreeNode,
     WidgetManager
 } from '@theia/core/lib/browser';
-import { ViewContextKeyService } from './view-context-key-service';
 import { Disposable, DisposableCollection } from '@theia/core';
 import { TreeViewWidget, TreeViewNode, PluginTreeModel, TreeViewWidgetOptions } from './tree-view-widget';
 import { PluginViewWidget } from './plugin-view-widget';
@@ -36,7 +35,6 @@ export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
 
     private readonly proxy: TreeViewsExt;
     private readonly viewRegistry: PluginViewRegistry;
-    private readonly contextKeys: ViewContextKeyService;
     private readonly widgetManager: WidgetManager;
     private readonly fileContentStore: DnDFileContentStore;
 
@@ -50,7 +48,6 @@ export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT);
         this.viewRegistry = container.get(PluginViewRegistry);
 
-        this.contextKeys = this.container.get(ViewContextKeyService);
         this.widgetManager = this.container.get(WidgetManager);
         this.fileContentStore = this.container.get(DnDFileContentStore);
     }
@@ -197,7 +194,6 @@ export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
         }));
 
         this.toDispose.push(treeViewWidget.model.onSelectionChanged(event => {
-            this.contextKeys.view.set(treeViewId);
             this.proxy.$setSelection(treeViewId, event.map((node: TreeViewNode) => node.id));
         }));
 

--- a/packages/plugin-ext/src/main/browser/view/view-context-key-service.ts
+++ b/packages/plugin-ext/src/main/browser/view/view-context-key-service.ts
@@ -19,11 +19,6 @@ import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-k
 
 @injectable()
 export class ViewContextKeyService {
-    protected _view: ContextKey<string>;
-    get view(): ContextKey<string> {
-        return this._view;
-    }
-
     protected _viewItem: ContextKey<string>;
     get viewItem(): ContextKey<string> {
         return this._viewItem;
@@ -56,7 +51,6 @@ export class ViewContextKeyService {
 
     @postConstruct()
     protected init(): void {
-        this._view = this.contextKeyService.createKey('view', '');
         this._viewItem = this.contextKeyService.createKey('viewItem', '');
         this._activeViewlet = this.contextKeyService.createKey('activeViewlet', '');
         this._activePanel = this.contextKeyService.createKey('activePanel', '');


### PR DESCRIPTION
#### What it does

Closes #13375

In a tree view provided by an extension, refreshing the tree node selection was changing the context key view. This was changing the view in the root context. So when the actions in toolbar were refreshed, the "when" rule was always returning `true` for any view, not only the concerned one.
Avoid changing the context key view should not be done on selection refresh in this case. 

#### How to test

1. Use the procedure described in 13375
2. Prior to the patch, when selecting elements in the NPM scripts view, the refresh icon was showing on every view.
3. With the patch, the refresh action does not show on every view.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
