### PR TITLE
Fix account menu order, icon and badge

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -61,7 +61,7 @@ import { ConfirmDialog, confirmExit, ConfirmSaveDialog, Dialog } from './dialogs
 import { WindowService } from './window/window-service';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 import { DecorationStyle } from './decoration-style';
-import { isPinned, Title, togglePinned, Widget } from './widgets';
+import { codicon, isPinned, Title, togglePinned, Widget } from './widgets';
 import { SaveableService } from './saveable-service';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
 import { UNTITLED_SCHEME, UntitledResourceResolver } from '../common';
@@ -472,17 +472,17 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
 
         app.shell.leftPanelHandler.addBottomMenu({
             id: 'settings-menu',
-            iconClass: 'codicon codicon-settings-gear',
+            iconClass: codicon('settings-gear'),
             title: nls.localizeByDefault(CommonCommands.MANAGE_CATEGORY),
             menuPath: MANAGE_MENU,
-            order: 1,
+            order: 0,
         });
         const accountsMenu = {
             id: 'accounts-menu',
-            iconClass: 'codicon codicon-person',
+            iconClass: codicon('account'),
             title: nls.localizeByDefault('Accounts'),
             menuPath: ACCOUNTS_MENU,
-            order: 0,
+            order: 1,
         };
         this.authenticationService.onDidRegisterAuthenticationProvider(() => {
             app.shell.leftPanelHandler.addBottomMenu(accountsMenu);
@@ -530,7 +530,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 if (newValue === 'compact') {
                     this.shell.leftPanelHandler.addTopMenu({
                         id: mainMenuId,
-                        iconClass: 'codicon codicon-menu',
+                        iconClass: codicon('menu'),
                         title: nls.localizeByDefault('Application Menu'),
                         menuPath: MAIN_MENU_BAR,
                         order: 0,

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -66,6 +66,7 @@ import { SaveableService } from './saveable-service';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
 import { UNTITLED_SCHEME, UntitledResourceResolver } from '../common';
 import { LanguageQuickPickService } from './i18n/language-quick-pick-service';
+import { SidebarMenu } from './shell/sidebar-menu-widget';
 
 export namespace CommonMenus {
 
@@ -477,12 +478,13 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             menuPath: MANAGE_MENU,
             order: 0,
         });
-        const accountsMenu = {
+        const accountsMenu: SidebarMenu = {
             id: 'accounts-menu',
             iconClass: codicon('account'),
             title: nls.localizeByDefault('Accounts'),
             menuPath: ACCOUNTS_MENU,
             order: 1,
+            onDidBadgeChange: this.authenticationService.onDidUpdateSignInCount
         };
         this.authenticationService.onDidRegisterAuthenticationProvider(() => {
             app.shell.leftPanelHandler.addBottomMenu(accountsMenu);

--- a/packages/core/src/browser/shell/sidebar-menu-widget.tsx
+++ b/packages/core/src/browser/shell/sidebar-menu-widget.tsx
@@ -20,6 +20,7 @@ import { ReactWidget } from '../widgets';
 import { ContextMenuRenderer } from '../context-menu-renderer';
 import { MenuPath } from '../../common/menu';
 import { HoverService } from '../hover-service';
+import { Event, Disposable, Emitter, DisposableCollection } from '../../common';
 
 export const SidebarTopMenuWidgetFactory = Symbol('SidebarTopMenuWidgetFactory');
 export const SidebarBottomMenuWidgetFactory = Symbol('SidebarBottomMenuWidgetFactory');
@@ -29,10 +30,46 @@ export interface SidebarMenu {
     iconClass: string;
     title: string;
     menuPath: MenuPath;
+    onDidBadgeChange?: Event<number>;
     /*
      * Used to sort menus. The lower the value the lower they are placed in the sidebar.
      */
     order: number;
+}
+
+export class SidebarMenuItem implements Disposable {
+
+    readonly menu: SidebarMenu;
+    get badge(): string {
+        if (this._badge <= 0) {
+            return '';
+        } else if (this._badge > 99) {
+            return '99+';
+        } else {
+            return this._badge.toString();
+        }
+    };
+    protected readonly onDidBadgeChangeEmitter = new Emitter<number>();
+    readonly onDidBadgeChange: Event<number> = this.onDidBadgeChangeEmitter.event;
+    protected _badge = 0;
+
+    protected readonly toDispose = new DisposableCollection();
+
+    constructor(menu: SidebarMenu) {
+        this.menu = menu;
+        if (menu.onDidBadgeChange) {
+            this.toDispose.push(menu.onDidBadgeChange(value => {
+                this._badge = value;
+                this.onDidBadgeChangeEmitter.fire(value);
+            }));
+        }
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+        this.onDidBadgeChangeEmitter.dispose();
+    }
+
 }
 
 /**
@@ -40,7 +77,7 @@ export interface SidebarMenu {
  */
 @injectable()
 export class SidebarMenuWidget extends ReactWidget {
-    protected readonly menus: SidebarMenu[];
+    protected readonly items: SidebarMenuItem[];
     /**
      * The element that had focus when a menu rendered by this widget was activated.
      */
@@ -58,27 +95,27 @@ export class SidebarMenuWidget extends ReactWidget {
 
     constructor() {
         super();
-        this.menus = [];
+        this.items = [];
     }
 
     addMenu(menu: SidebarMenu): void {
-        const exists = this.menus.find(m => m.id === menu.id);
+        const exists = this.items.find(item => item.menu.id === menu.id);
         if (exists) {
             return;
         }
-        this.menus.push(menu);
-        this.menus.sort((a, b) => a.order - b.order);
+        const newItem = new SidebarMenuItem(menu);
+        newItem.onDidBadgeChange(() => this.update());
+        this.items.push(newItem);
+        this.items.sort((a, b) => a.menu.order - b.menu.order);
         this.update();
     }
 
     removeMenu(menuId: string): void {
-        const menu = this.menus.find(m => m.id === menuId);
-        if (menu) {
-            const index = this.menus.indexOf(menu);
-            if (index !== -1) {
-                this.menus.splice(index, 1);
-                this.update();
-            }
+        const index = this.items.findIndex(m => m.menu.id === menuId);
+        if (index !== -1) {
+            this.items[index].dispose();
+            this.items.splice(index, 1);
+            this.update();
         }
     }
 
@@ -127,14 +164,21 @@ export class SidebarMenuWidget extends ReactWidget {
 
     protected render(): React.ReactNode {
         return <React.Fragment>
-            {this.menus.map(menu => <i
-                key={menu.id}
-                className={menu.iconClass}
-                onClick={e => this.onClick(e, menu.menuPath)}
-                onMouseDown={this.onMouseDown}
-                onMouseEnter={e => this.onMouseEnter(e, menu.title)}
-                onMouseLeave={this.onMouseOut}
-            />)}
+            {this.items.map(item => this.renderItem(item))}
         </React.Fragment>;
+    }
+
+    protected renderItem(item: SidebarMenuItem): React.ReactNode {
+        return <div className='theia-sidebar-menu-item'>
+            <i
+                key={item.menu.id}
+                className={item.menu.iconClass}
+                onClick={e => this.onClick(e, item.menu.menuPath)}
+                onMouseDown={this.onMouseDown}
+                onMouseEnter={e => this.onMouseEnter(e, item.menu.title)}
+                onMouseLeave={this.onMouseOut}
+            />
+            {item.badge && <div className='theia-badge-decorator-sidebar'>{item.badge}</div>}
+        </div>;
     }
 }

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -305,7 +305,7 @@
   display: none !important;
 }
 
-.p-TabBar .theia-badge-decorator-sidebar {
+.theia-badge-decorator-sidebar {
   background-color: var(--theia-activityBarBadge-background);
   border-radius: 20px;
   color: var(--theia-activityBarBadge-foreground);


### PR DESCRIPTION
#### What it does

Adjusts the account menu to look identical to VSCode:

![image](https://github.com/eclipse-theia/theia/assets/4377073/f05d326a-9a42-4823-bfc3-ed196af74695)


*theia (master)*:

![image](https://github.com/eclipse-theia/theia/assets/4377073/c37b6d1d-d887-49db-b089-047358409d2b)


*theia (PR)*:

![image](https://github.com/eclipse-theia/theia/assets/4377073/9b36dbf2-c4af-4f57-a989-e4d480ddf7a5)


#### How to test

1. Install an extension with a login function. Something like the [TabNine extension](https://open-vsx.org/extension/TabNine/tabnine-vscode).
2. Assert that the bottom left menu looks as expected.
3. If not logged it, the badge should show the amount of requested log ins.
4. Logging in should make the badge disappear.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
