### PR TITLE
Improved Upload Command

### DIFF
--- a/packages/filesystem/src/browser/filesystem-frontend-contribution.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-contribution.ts
@@ -145,7 +145,7 @@ export class FileSystemFrontendContribution implements FrontendApplicationContri
         commands.registerCommand(FileSystemCommands.UPLOAD, {
             isEnabled: (...args: unknown[]) => {
                 const selection = this.getSelection(...args);
-                return !!selection && this.canUpload(selection);
+                return !!selection && !environment.electron.is();
             },
             isVisible: () => !environment.electron.is(),
             execute: (...args: unknown[]) => {
@@ -162,14 +162,10 @@ export class FileSystemFrontendContribution implements FrontendApplicationContri
         });
     }
 
-    protected canUpload({ fileStat }: FileSelection): boolean {
-        return !environment.electron.is() && fileStat.isDirectory;
-    }
-
     protected async upload(selection: FileSelection): Promise<FileUploadResult | undefined> {
         try {
             const source = TreeWidgetSelection.getSource(this.selectionService.selection);
-            const fileUploadResult = await this.uploadService.upload(selection.fileStat.resource);
+            const fileUploadResult = await this.uploadService.upload(selection.fileStat.isDirectory ? selection.fileStat.resource : selection.fileStat.resource.parent);
             if (ExpandableTreeNode.is(selection) && source) {
                 await source.model.expandNode(selection);
             }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #5739

Upload files command is now always visible in the browser.
- if nothing is selected uploads to the workspace root
- if a folder is selected uploads to that folder
- if a file is selected uploads to the parent folder

This seemed like the most intuitive way for me.

#### How to test

1. Start theia as browser
2. Either right click in the navigator or use the file menu
3. upload a file with different selections, see description above

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
