### PR TITLE
Block local navigation and open new windows externally in electron

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -76,6 +76,7 @@ const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true
         THEIA_APP_PROJECT_PATH: theiaAppProjectPath,
         THEIA_BACKEND_MAIN_PATH: resolve(__dirname, 'main.js'),
         THEIA_FRONTEND_HTML_PATH: resolve(__dirname, '..', '..', 'lib', 'frontend', 'index.html'),
+        THEIA_SECONDARY_WINDOW_HTML_PATH: resolve(__dirname, '..', '..', 'lib', 'frontend', 'secondary-window.html')
     });
     
     function load(raw) {

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -15,7 +15,8 @@
 // *****************************************************************************
 
 import { inject, injectable, named } from 'inversify';
-import { screen, app, BrowserWindow, WebContents, Event as ElectronEvent, BrowserWindowConstructorOptions, nativeImage, nativeTheme } from '../../electron-shared/electron';
+import { screen, app, BrowserWindow, WebContents, Event as ElectronEvent, BrowserWindowConstructorOptions, nativeImage,
+    nativeTheme, shell, dialog } from '../../electron-shared/electron';
 import * as path from 'path';
 import { Argv } from 'yargs';
 import { AddressInfo } from 'net';
@@ -31,7 +32,7 @@ import { ContributionProvider } from '../common/contribution-provider';
 import { ElectronSecurityTokenService } from './electron-security-token-service';
 import { ElectronSecurityToken } from '../electron-common/electron-token';
 import Storage = require('electron-store');
-import { CancellationTokenSource, Disposable, DisposableCollection, isOSX, isWindows } from '../common';
+import { CancellationTokenSource, Disposable, DisposableCollection, Path, isOSX, isWindows, nls } from '../common';
 import { DEFAULT_WINDOW_HASH, WindowSearchParams } from '../common/window';
 import { TheiaBrowserWindowOptions, TheiaElectronWindow, TheiaElectronWindowFactory } from './theia-electron-window';
 import { ElectronMainApplicationGlobals } from './electron-main-constants';
@@ -144,6 +145,9 @@ export namespace ElectronMainProcessArgv {
         };
     }
 }
+
+const secondaryWindowHTML = FileUri.create(path.resolve('./lib/frontend/secondary-window.html')).toString();
+console.error(`secondary url: ${secondaryWindowHTML}`);
 
 @injectable()
 export class ElectronMainApplication {
@@ -410,7 +414,6 @@ export class ElectronMainApplication {
         electronWindow.window.on('unmaximize', () => TheiaRendererAPI.sendWindowEvent(electronWindow.window.webContents, 'unmaximize'));
         electronWindow.window.on('focus', () => TheiaRendererAPI.sendWindowEvent(electronWindow.window.webContents, 'focus'));
         this.attachSaveWindowState(electronWindow.window);
-        this.configureNativeSecondaryWindowCreation(electronWindow.window);
 
         return electronWindow.window;
     }
@@ -486,31 +489,6 @@ export class ElectronMainApplication {
         const window = this.initialWindow;
         this.initialWindow = undefined;
         return window;
-    }
-
-    /** Configures native window creation, i.e. using window.open or links with target "_blank" in the frontend. */
-    protected configureNativeSecondaryWindowCreation(electronWindow: BrowserWindow): void {
-        electronWindow.webContents.setWindowOpenHandler(() => {
-            const { minWidth, minHeight } = this.getDefaultOptions();
-            const options: BrowserWindowConstructorOptions = {
-                ...this.getDefaultTheiaSecondaryWindowBounds(),
-                // We always need the native window frame for now because the secondary window does not have Theia's title bar by default.
-                // In 'custom' title bar mode this would leave the window without any window controls (close, min, max)
-                // TODO set to this.useNativeWindowFrame when secondary windows support a custom title bar.
-                frame: true,
-                minWidth,
-                minHeight
-            };
-            if (!this.useNativeWindowFrame) {
-                // If the main window does not have a native window frame, do not show  an icon in the secondary window's native title bar.
-                // The data url is a 1x1 transparent png
-                options.icon = nativeImage.createFromDataURL('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12P4DwQACfsD/WMmxY8AAAAASUVORK5CYII=');
-            }
-            return {
-                action: 'allow',
-                overrideBrowserWindowOptions: options,
-            };
-        });
     }
 
     /**
@@ -714,6 +692,7 @@ export class ElectronMainApplication {
         app.on('will-quit', this.onWillQuit.bind(this));
         app.on('second-instance', this.onSecondInstance.bind(this));
         app.on('window-all-closed', this.onWindowAllClosed.bind(this));
+        app.on('web-contents-created', this.onWebContentsCreated.bind(this));
     }
 
     protected onWillQuit(event: ElectronEvent): void {
@@ -729,6 +708,60 @@ export class ElectronMainApplication {
             }
             electronWindow.focus();
         }
+    }
+
+    protected onWebContentsCreated(event: ElectronEvent, webContents: WebContents): void {
+        // Block any in-page navigation except loading the secondary window contents
+        webContents.on('will-navigate', evt => {
+            if (new URI(evt.url).path.fsPath() !== new Path(this.globals.THEIA_SECONDARY_WINDOW_HTML_PATH).fsPath()) {
+                evt.preventDefault();
+            }
+        });
+
+        webContents.setWindowOpenHandler(details => {
+            // if it's a secondary window, allow it to open
+            if (new URI(details.url).path.fsPath() === new Path(this.globals.THEIA_SECONDARY_WINDOW_HTML_PATH).fsPath()) {
+                const { minWidth, minHeight } = this.getDefaultOptions();
+                const options: BrowserWindowConstructorOptions = {
+                    ...this.getDefaultTheiaSecondaryWindowBounds(),
+                    // We always need the native window frame for now because the secondary window does not have Theia's title bar by default.
+                    // In 'custom' title bar mode this would leave the window without any window controls (close, min, max)
+                    // TODO set to this.useNativeWindowFrame when secondary windows support a custom title bar.
+                    frame: true,
+                    minWidth,
+                    minHeight
+                };
+                if (!this.useNativeWindowFrame) {
+                    // If the main window does not have a native window frame, do not show  an icon in the secondary window's native title bar.
+                    // The data url is a 1x1 transparent png
+                    options.icon = nativeImage.createFromDataURL(
+                        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12P4DwQACfsD/WMmxY8AAAAASUVORK5CYII=');
+                }
+                return {
+                    action: 'allow',
+                    overrideBrowserWindowOptions: options,
+                };
+            } else {
+                const uri: URI = new URI(details.url);
+                let okToOpen = uri.scheme === 'https' || uri.scheme === 'http';
+                if (!okToOpen) {
+                    const button = dialog.showMessageBoxSync(BrowserWindow.fromWebContents(webContents)!, {
+                        message: nls.localize('theia/core/openLink.message', 'Open link\n\n{0}\n\nin the system handler?', details.url),
+                        type: 'question',
+                        title: nls.localizeByDefault('Open Link'),
+                        buttons: [nls.localizeByDefault('OK'), nls.localizeByDefault('Cancel')],
+                        defaultId: 1,
+                        cancelId: 1
+                    });
+                    okToOpen = button === 0;
+                }
+                if (okToOpen) {
+                    shell.openExternal(details.url, {});
+                }
+
+                return { action: 'deny' };
+            }
+        });
     }
 
     protected onWindowAllClosed(event: ElectronEvent): void {

--- a/packages/core/src/electron-main/electron-main-constants.ts
+++ b/packages/core/src/electron-main/electron-main-constants.ts
@@ -16,7 +16,8 @@
 
 export const ElectronMainApplicationGlobals = Symbol('ElectronMainApplicationGlobals');
 export interface ElectronMainApplicationGlobals {
-    readonly THEIA_APP_PROJECT_PATH: string
-    readonly THEIA_BACKEND_MAIN_PATH: string
-    readonly THEIA_FRONTEND_HTML_PATH: string
+    readonly THEIA_APP_PROJECT_PATH: string;
+    readonly THEIA_BACKEND_MAIN_PATH: string;
+    readonly THEIA_FRONTEND_HTML_PATH: string;
+    readonly THEIA_SECONDARY_WINDOW_HTML_PATH: string
 }


### PR DESCRIPTION
#### What it does

Fixes #13592

Allow to open https/http links externally and ask the user for all other protocols.

Contributed on behalf of STMicroelectronics

#### How to test

I changed the `renderHeader` method in `about-dialog.tsx` to return a couple of naked `<a href=...` links:

`` 
        return <>
            <h3>{detailsLabel}</h3>
            <div className='about-details'>
                {applicationInfo && <p>{`${versionLabel}: ${applicationInfo.version}`}</p>}
                <p>{`${defaultApiLabel}: ${DEFAULT_SUPPORTED_API_VERSION}`}</p>
                <p>
                    <a href={ compatibilityUrl }>
                    { compatibilityLabel }
                    </a>
                </p>
                <p>
                    <a href="https://www.ethz.ch" target='_blank'>
                    ETH Zürich
                    </a>
                </p>
                <p>
                    <a href= "mailto:t.s.maeder@gmail.com" target='_blank'>
                    Send Mail
                    </a>
                </p>
            </div>
        </>;
```

The first one is a local navigation and is blocked. The second is a https link and is opened in the system browser. The third one provokes a dialog asking the user whether to open the link externally.


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
