### PR TITLE
Improved notebook cell drag images

### DIFF
--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -286,6 +286,7 @@
   position: absolute;
   top: -99999px;
   left: -99999px;
-  height: 500px;
-  width: 500px;
+  max-height: 500px;
+  min-height: 100px;
+  background-color: var(--theia-editor-background);
 }

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -96,6 +96,7 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
                                 this.props.notebookModel.setSelectedCell(cell, false);
                             }}
                             onDragStart={e => this.onDragStart(e, index, cell)}
+                            onDragEnd={e => NotebookCellListView.dragGhost?.remove()}
                             onDragOver={e => this.onDragOver(e, cell)}
                             onDrop={e => this.onDrop(e, index)}
                             draggable={true}
@@ -137,9 +138,6 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
             return;
         }
 
-        if (NotebookCellListView.dragGhost) {
-            NotebookCellListView.dragGhost.remove();
-        }
         NotebookCellListView.dragGhost = document.createElement('div');
         NotebookCellListView.dragGhost.classList.add('theia-notebook-drag-ghost-image');
         NotebookCellListView.dragGhost.appendChild(this.props.renderers.get(cell.cellKind)?.renderDragImage(cell) ?? document.createElement('div'));

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -96,7 +96,10 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
                                 this.props.notebookModel.setSelectedCell(cell, false);
                             }}
                             onDragStart={e => this.onDragStart(e, index, cell)}
-                            onDragEnd={e => NotebookCellListView.dragGhost?.remove()}
+                            onDragEnd={e => {
+                                NotebookCellListView.dragGhost?.remove();
+                                this.setState({ ...this.state, dragOverIndicator: undefined });
+                            }}
                             onDragOver={e => this.onDragOver(e, cell)}
                             onDrop={e => this.onDrop(e, index)}
                             draggable={true}

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -45,7 +45,7 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
 
     protected toDispose = new DisposableCollection();
 
-    protected dragGhost: HTMLElement | undefined;
+    protected static dragGhost: HTMLElement | undefined;
 
     constructor(props: CellListProps) {
         super(props);
@@ -137,14 +137,14 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
             return;
         }
 
-        if (this.dragGhost) {
-            this.dragGhost.remove();
+        if (NotebookCellListView.dragGhost) {
+            NotebookCellListView.dragGhost.remove();
         }
-        this.dragGhost = document.createElement('div');
-        this.dragGhost.classList.add('theia-notebook-drag-ghost-image');
-        this.dragGhost.appendChild(this.props.renderers.get(cell.cellKind)?.renderDragImage(cell) ?? document.createElement('div'));
-        document.body.appendChild(this.dragGhost);
-        event.dataTransfer.setDragImage(this.dragGhost, -10, 0);
+        NotebookCellListView.dragGhost = document.createElement('div');
+        NotebookCellListView.dragGhost.classList.add('theia-notebook-drag-ghost-image');
+        NotebookCellListView.dragGhost.appendChild(this.props.renderers.get(cell.cellKind)?.renderDragImage(cell) ?? document.createElement('div'));
+        document.body.appendChild(NotebookCellListView.dragGhost);
+        event.dataTransfer.setDragImage(NotebookCellListView.dragGhost, -10, 0);
 
         event.dataTransfer.setData('text/theia-notebook-cell-index', index.toString());
         event.dataTransfer.setData('text/plain', this.props.notebookModel.cells[index].source);

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -33,6 +33,8 @@ import { NotebookContextManager } from '../service/notebook-context-manager';
 import { NotebookViewportService } from './notebook-viewport-service';
 import { EditorPreferences } from '@theia/editor/lib/browser';
 import { NotebookOptionsService } from '../service/notebook-options';
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { MarkdownString } from '@theia/monaco-editor-core/esm/vs/base/common/htmlContent';
 
 @injectable()
 export class NotebookCodeCellRenderer implements CellRenderer {
@@ -65,6 +67,9 @@ export class NotebookCodeCellRenderer implements CellRenderer {
 
     @inject(NotebookOptionsService)
     protected readonly notebookOptionsService: NotebookOptionsService;
+
+    @inject(MarkdownRenderer)
+    protected readonly markdownRenderer: MarkdownRenderer;
 
     render(notebookModel: NotebookModel, cell: NotebookCellModel, handle: number): React.ReactNode {
         return <div>
@@ -102,7 +107,20 @@ export class NotebookCodeCellRenderer implements CellRenderer {
     renderDragImage(cell: NotebookCellModel): HTMLElement {
         const dragImage = document.createElement('div');
         dragImage.className = 'theia-notebook-drag-image';
-        dragImage.textContent = nls.localize('theia/notebook/dragGhostImage/codeText', 'Code cell selected');
+        dragImage.style.width = this.notebookContextManager.context?.clientWidth + 'px';
+        dragImage.style.height = '100px';
+        dragImage.style.display = 'flex';
+
+        const fakeRunButton = document.createElement('span');
+        fakeRunButton.className = `${codicon('play')} theia-notebook-cell-status-item`;
+        dragImage.appendChild(fakeRunButton);
+
+        const fakeEditor = document.createElement('div');
+        dragImage.appendChild(fakeEditor);
+        const firstLine = new MarkdownString(`\`\`\`${cell.language}\n${cell.source.split('\n')[0]}\n\`\`\``, { supportHtml: true, isTrusted: false });
+        fakeEditor.appendChild(this.markdownRenderer.render(firstLine).element);
+        fakeEditor.classList.add('theia-notebook-cell-editor-container');
+        fakeEditor.style.padding = '10px';
         return dragImage;
     }
 

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -117,12 +117,23 @@ export class NotebookCodeCellRenderer implements CellRenderer {
 
         const fakeEditor = document.createElement('div');
         dragImage.appendChild(fakeEditor);
-        const lines = cell.source.split('\n').slice(0, 5).join('\n').replace(/```/g, '');
-        const firstLine = new MarkdownString(`\`\`\`${cell.language}\n${lines}\n\`\`\``, { supportHtml: true, isTrusted: false });
+        const lines = cell.source.split('\n').slice(0, 5).join('\n');
+        const codeSequence = this.getMarkdownCodeSequence(lines);
+        const firstLine = new MarkdownString(`${codeSequence}${cell.language}\n${lines}\n${codeSequence}`, { supportHtml: true, isTrusted: false });
         fakeEditor.appendChild(this.markdownRenderer.render(firstLine).element);
         fakeEditor.classList.add('theia-notebook-cell-editor-container');
         fakeEditor.style.padding = '10px';
         return dragImage;
+    }
+
+    protected getMarkdownCodeSequence(input: string): string {
+        for (let i = 3; i < 100; i++) {
+            const sequence = Array(i).fill('`').join('');
+            if (!input.includes(sequence)) {
+                return sequence;
+            }
+        }
+        return '```';
     }
 
 }

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -127,13 +127,21 @@ export class NotebookCodeCellRenderer implements CellRenderer {
     }
 
     protected getMarkdownCodeSequence(input: string): string {
-        for (let i = 3; i < 100; i++) {
-            const sequence = Array(i).fill('`').join('');
-            if (!input.includes(sequence)) {
-                return sequence;
+        // We need a minimum of 3 backticks to start a code block.
+        let longest = 2;
+        let current = 0;
+        for (let i = 0; i < input.length; i++) {
+            const char = input.charAt(i);
+            if (char === '`') {
+                current++;
+                if (current > longest) {
+                    longest = current;
+                }
+            } else {
+                current = 0;
             }
         }
-        return '```';
+        return Array(longest + 1).fill('`').join('');
     }
 
 }

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -117,7 +117,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
 
         const fakeEditor = document.createElement('div');
         dragImage.appendChild(fakeEditor);
-        const lines = cell.source.split('\n').slice(0, 5).join('\n');
+        const lines = cell.source.split('\n').slice(0, 5).join('\n').replace(/```/g, '');
         const firstLine = new MarkdownString(`\`\`\`${cell.language}\n${lines}\n\`\`\``, { supportHtml: true, isTrusted: false });
         fakeEditor.appendChild(this.markdownRenderer.render(firstLine).element);
         fakeEditor.classList.add('theia-notebook-cell-editor-container');

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -117,7 +117,8 @@ export class NotebookCodeCellRenderer implements CellRenderer {
 
         const fakeEditor = document.createElement('div');
         dragImage.appendChild(fakeEditor);
-        const firstLine = new MarkdownString(`\`\`\`${cell.language}\n${cell.source.split('\n')[0]}\n\`\`\``, { supportHtml: true, isTrusted: false });
+        const lines = cell.source.split('\n').slice(0, 5).join('\n');
+        const firstLine = new MarkdownString(`\`\`\`${cell.language}\n${lines}\n\`\`\``, { supportHtml: true, isTrusted: false });
         fakeEditor.appendChild(this.markdownRenderer.render(firstLine).element);
         fakeEditor.classList.add('theia-notebook-cell-editor-container');
         fakeEditor.style.padding = '10px';

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -44,8 +44,10 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
 
     renderDragImage(cell: NotebookCellModel): HTMLElement {
         const dragImage = document.createElement('div');
-        dragImage.className = 'theia-notebook-drag-image';
-        dragImage.textContent = nls.localize('theia/notebook/dragGhostImage/markdownText', 'Mardown cell selected');
+        dragImage.style.width = this.notebookContextManager.context?.clientWidth + 'px';
+        const markdownString = new MarkdownStringImpl(cell.source, { supportHtml: true, isTrusted: true });
+        const markdownElement = this.markdownRenderer.render(markdownString).element;
+        dragImage.appendChild(markdownElement);
         return dragImage;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This improves the rendering of drag images for notebook cells and aligns to more how they look in vscode.

#### How to test

Open notebook and try dragging a cell. 
Code and mardown cells have different drag image renderers

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
