### PR TITLE
Fix RPC proxy handler notifications and requests order 

### DIFF
--- a/packages/plugin-ext/src/common/proxy-handler.ts
+++ b/packages/plugin-ext/src/common/proxy-handler.ts
@@ -135,7 +135,9 @@ export class RpcInvocationHandler {
     }
 
     protected onNotification(method: string, args: any[]): void {
-        this.target[method](...args);
+        this.rpcDeferred.promise.then(() => {
+            this.target[method](...args);
+        });
     }
 }
 

--- a/packages/plugin-ext/src/plugin/tests.ts
+++ b/packages/plugin-ext/src/plugin/tests.ts
@@ -469,13 +469,7 @@ export class TestRunProfile implements theia.TestRunProfile {
         isDefault = false,
         tag: theia.TestTag | undefined = undefined,
     ) {
-        this.proxy = proxy;
-        this.label = label;
-        this.tag = tag;
-        this.label = label;
-        this.isDefault = isDefault;
-
-        this.proxy.$notifyTestRunProfileCreated(controllerId, {
+        proxy.$notifyTestRunProfileCreated(controllerId, {
             id: profileId,
             kind: kind,
             tag: tag ? tag.toString() : '',
@@ -483,6 +477,11 @@ export class TestRunProfile implements theia.TestRunProfile {
             isDefault: isDefault,
             canConfigure: false,
         });
+        this.proxy = proxy;
+        this.label = label;
+        this.tag = tag;
+        this.label = label;
+        this.isDefault = isDefault;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Draft PR to discuss TestController initialization issues when dealing with extension

How to test:
- install test-extension-sample (a dummy mathematical expression tester in markdown files), from vscode extension samples:
  - src:  [test-provider-sample-0.0.1-src.zip](https://github.com/user-attachments/files/15815317/test-provider-sample-0.0.1-src.zip)
  - zip vsix: [test-provider-sample-0.0.1.zip](https://github.com/user-attachments/files/15815322/test-provider-sample-0.0.1.zip)

On theia master, the extension does not activate nicely. Error messages are displayed in the console, where I get some `No test controller with id mathTestController found`. Looking at the code, the extension registers at the same time the test controller, the test profile and some other things during activation. We get some race condition here between initialization of the TestController on main and its usage when the profile is registered. When profile is registered, testing main uses the withController, where it is not yet available. So the error messages.

I pushed a dirty fix, but I would like to discuss with you the best way to handle this issue. Timeout is probably not the best solution, or trying x times is not the best. What would you think as a good implementation here? Knowing of course that we cannot change the way the extension does its activation.


The fix on TestItem is also a test for some tree flickering I get on the Test Items => the extension keeps sending some updates on test items, and as far as I understand the framework, the notifyPropertyChange implementation does not take into account the case where the value is similar to the previous one, causing many tree refreshes. But this part can be ignored for now ;)