### PR TITLE
Fix tab group API event order

### DIFF
--- a/examples/api-tests/src/typescript.spec.js
+++ b/examples/api-tests/src/typescript.spec.js
@@ -103,10 +103,9 @@ describe('TypeScript', function () {
         const editorWidget = widget instanceof EditorWidget ? widget : undefined;
         const editor = MonacoEditor.get(editorWidget);
         assert.isDefined(editor);
-        await timeout(1000); // workaround for https://github.com/eclipse-theia/theia/issues/13679
         // wait till tsserver is running, see:
         // https://github.com/microsoft/vscode/blob/93cbbc5cae50e9f5f5046343c751b6d010468200/extensions/typescript-language-features/src/extension.ts#L98-L103
-        // await waitForAnimation(() => contextKeyService.match('typescript.isManagedFile'));
+        await waitForAnimation(() => contextKeyService.match('typescript.isManagedFile'));
         // https://github.com/microsoft/vscode/blob/4aac84268c6226d23828cc6a1fe45ee3982927f0/extensions/typescript-language-features/src/typescriptServiceClient.ts#L911
         await waitForAnimation(() => !progressStatusBarItem.currentProgress);
         return /** @type {MonacoEditor} */ (editor);

--- a/packages/core/src/browser/shell/theia-dock-panel.ts
+++ b/packages/core/src/browser/shell/theia-dock-panel.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { find, toArray, ArrayExt } from '@phosphor/algorithm';
+import { find, toArray } from '@phosphor/algorithm';
 import { TabBar, Widget, DockPanel, Title, DockLayout } from '@phosphor/widgets';
 import { Signal } from '@phosphor/signaling';
 import { Disposable, DisposableCollection } from '../../common/disposable';
@@ -103,7 +103,7 @@ export class TheiaDockPanel extends DockPanel {
     }
 
     findTabBar(title: Title<Widget>): TabBar<Widget> | undefined {
-        return find(this.tabBars(), bar => ArrayExt.firstIndexOf(bar.titles, title) > -1);
+        return find(this.tabBars(), bar => bar.titles.includes(title));
     }
 
     protected readonly toDisposeOnMarkAsCurrent = new DisposableCollection();

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -33,6 +33,7 @@ import { TextEditorMain } from './text-editor-main';
 import { DisposableCollection, Emitter, URI } from '@theia/core';
 import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
 import { SaveableService } from '@theia/core/lib/browser/saveable-service';
+import { TabsMainImpl } from './tabs/tabs-main';
 
 export class EditorsAndDocumentsMain implements Disposable {
 
@@ -59,14 +60,14 @@ export class EditorsAndDocumentsMain implements Disposable {
         Disposable.create(() => this.textEditors.clear())
     );
 
-    constructor(rpc: RPCProtocol, container: interfaces.Container) {
+    constructor(rpc: RPCProtocol, container: interfaces.Container, tabsMain: TabsMainImpl) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT);
 
         this.editorManager = container.get(EditorManager);
         this.modelService = container.get(EditorModelService);
         this.saveResourceService = container.get(SaveableService);
 
-        this.stateComputer = new EditorAndDocumentStateComputer(d => this.onDelta(d), this.editorManager, this.modelService);
+        this.stateComputer = new EditorAndDocumentStateComputer(d => this.onDelta(d), this.editorManager, this.modelService, tabsMain);
         this.toDispose.push(this.stateComputer);
         this.toDispose.push(this.onTextEditorAddEmitter);
         this.toDispose.push(this.onTextEditorRemoveEmitter);
@@ -217,18 +218,25 @@ class EditorAndDocumentStateComputer implements Disposable {
     constructor(
         private callback: (delta: EditorAndDocumentStateDelta) => void,
         private readonly editorService: EditorManager,
-        private readonly modelService: EditorModelService
+        private readonly modelService: EditorModelService,
+        private readonly tabsMain: TabsMainImpl
     ) { }
 
     listen(): void {
         if (this.toDispose.disposed) {
             return;
         }
-        this.toDispose.push(this.editorService.onCreated(widget => {
+        this.toDispose.push(this.editorService.onCreated(async widget => {
+            await this.tabsMain.waitForWidget(widget);
             this.onTextEditorAdd(widget);
             this.update();
         }));
-        this.toDispose.push(this.editorService.onCurrentEditorChanged(() => this.update()));
+        this.toDispose.push(this.editorService.onCurrentEditorChanged(async widget => {
+            if (widget) {
+                await this.tabsMain.waitForWidget(widget);
+            }
+            this.update();
+        }));
         this.toDispose.push(this.modelService.onModelAdded(this.onModelAdded, this));
         this.toDispose.push(this.modelService.onModelRemoved(() => this.update()));
 

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -88,7 +88,10 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const preferenceRegistryMain = new PreferenceRegistryMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.PREFERENCE_REGISTRY_MAIN, preferenceRegistryMain);
 
-    const editorsAndDocuments = new EditorsAndDocumentsMain(rpc, container);
+    const tabsMain = new TabsMainImpl(rpc, container);
+    rpc.set(PLUGIN_RPC_CONTEXT.TABS_MAIN, tabsMain);
+
+    const editorsAndDocuments = new EditorsAndDocumentsMain(rpc, container, tabsMain);
 
     const notebookDocumentsMain = new NotebookDocumentsMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_MAIN, notebookDocumentsMain);
@@ -199,9 +202,6 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const commentsMain = new CommentsMainImp(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.COMMENTS_MAIN, commentsMain);
-
-    const tabsMain = new TabsMainImpl(rpc, container);
-    rpc.set(PLUGIN_RPC_CONTEXT.TABS_MAIN, tabsMain);
 
     const localizationMain = new LocalizationMainImpl(container);
     rpc.set(PLUGIN_RPC_CONTEXT.LOCALIZATION_MAIN, localizationMain);

--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -25,7 +25,6 @@ import { toUriComponents } from '../hierarchy/hierarchy-types-converters';
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { DisposableCollection } from '@theia/core';
 import { NotebookEditorWidget } from '@theia/notebook/lib/browser';
-import { ViewColumnService } from '@theia/core/lib/browser/shell/view-column-service';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 
 interface TabInfo {
@@ -50,7 +49,6 @@ export class TabsMainImpl implements TabsMain, Disposable {
     private currentActiveGroup: TabGroupDto;
 
     private tabGroupChanged: boolean = false;
-    private viewColumnService: ViewColumnService;
 
     private readonly defaultTabGroup: TabGroupDto = {
         groupId: 0,
@@ -66,7 +64,6 @@ export class TabsMainImpl implements TabsMain, Disposable {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.TABS_EXT);
 
         this.applicationShell = container.get(ApplicationShell);
-        this.viewColumnService = container.get(ViewColumnService);
         this.createTabsModel();
 
         const tabBars = this.applicationShell.mainPanel.tabBars();
@@ -82,7 +79,6 @@ export class TabsMainImpl implements TabsMain, Disposable {
         );
 
         this.connectToSignal(this.toDisposeOnDestroy, this.applicationShell.mainPanel.widgetAdded, (mainPanel, widget) => {
-            this.viewColumnService.updateViewColumns();
             if (this.tabGroupChanged || this.tabGroupModel.size === 0) {
                 this.tabGroupChanged = false;
                 this.createTabsModel();
@@ -276,7 +272,6 @@ export class TabsMainImpl implements TabsMain, Disposable {
     }
 
     private onTabTitleChanged(title: Title<Widget>): void {
-        this.viewColumnService.updateViewColumns();
         const tabInfo = this.getOrRebuildModel(this.tabInfoLookup, title);
         if (!tabInfo) {
             return;

--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -119,7 +119,6 @@ export class TabsMainImpl implements TabsMain, Disposable {
 
         deferred.promise.then(() => {
             clearTimeout(timeout);
-            this.waitQueue.delete(widget);
         });
 
         return deferred.promise;
@@ -269,6 +268,7 @@ export class TabsMainImpl implements TabsMain, Disposable {
             groupId: group.groupId
         });
         this.waitQueue.get(args.title.owner)?.resolve();
+        this.waitQueue.delete(args.title.owner);
     }
 
     private onTabTitleChanged(title: Title<Widget>): void {
@@ -298,6 +298,7 @@ export class TabsMainImpl implements TabsMain, Disposable {
             });
         }
         this.waitQueue.get(title.owner)?.resolve();
+        this.waitQueue.delete(title.owner);
     }
 
     private onTabClosed(tabInfo: TabInfo, title: Title<Widget>): void {


### PR DESCRIPTION
#### What it does

Works around (but not actually closes) https://github.com/eclipse-theia/theia/issues/13679

This fixes the tab group API event order and ensures that the tab groups are always up-to-date on the plugin host by delaying the triggering of other events like `onDidChangeActiveEditor`.

This also sets all columns of groups to `0`. This should at least work around https://github.com/eclipse-theia/theia/issues/13679. See follow ups for more details on this.

#### How to test

1. Assert that the CI is green (TypeScript tests pass)
2. Open the App and open a TypeScript file
3. The TypeScript commands should be available
4. This should also work after switching between tabs and tab groups.

#### Follow-ups

The implementation of the `ViewColumnService` hasn't been kept up-to-date with the current requirements of Theia or VS Code. For example, it isn't aware of the position of tab groups (only of tabs) or of floating editor windows. And even for those tabs, it yields very much unexpected values. This needs an entire refactoring using something similar like VS Code's `EditorGroupService` implementation.

I'll probably get to this in a separate PR, but that's a larger issue so I'm not sure when I'll be able to do that.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
