### PR TITLE
Improve implementation around widget management

### DIFF
--- a/packages/core/src/browser/widget-open-handler.ts
+++ b/packages/core/src/browser/widget-open-handler.ts
@@ -96,7 +96,7 @@ export abstract class WidgetOpenHandler<W extends BaseWidget> implements OpenHan
             ...options
         };
         if (!widget.isAttached) {
-            this.shell.addWidget(widget, op.widgetOptions || { area: 'main' });
+            await this.shell.addWidget(widget, op.widgetOptions || { area: 'main' });
         }
         if (op.mode === 'activate') {
             await this.shell.activateWidget(widget.id);
@@ -143,12 +143,12 @@ export abstract class WidgetOpenHandler<W extends BaseWidget> implements OpenHan
 
     protected getWidget(uri: URI, options?: WidgetOpenerOptions): Promise<W | undefined> {
         const widgetOptions = this.createWidgetOptions(uri, options);
-        return this.widgetManager.getWidget<W>(this.id, widgetOptions);
+        return this.widgetManager.getWidget(this.id, widgetOptions);
     }
 
     protected getOrCreateWidget(uri: URI, options?: WidgetOpenerOptions): Promise<W> {
         const widgetOptions = this.createWidgetOptions(uri, options);
-        return this.widgetManager.getOrCreateWidget<W>(this.id, widgetOptions);
+        return this.widgetManager.getOrCreateWidget(this.id, widgetOptions);
     }
 
     protected abstract createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): Object;


### PR DESCRIPTION
#### What it does

Mainly, this PR ensures that any widget promises returned by the `WidgetManager` will only resolve when the entire widget creation process has completed successfully, including the 'onWillCreateWidget` part.

(Prior to the fix, some widget promises returned by the `WidgetManager` could resolve as soon as the widget was created by its factory, which did not take into account the other parts of the widget creation process, such as the 'onWillCreateWidget' part.)

#### How to test

This PR is intended to be verified mainly by code inspection, but it is important to make sure that no regressions are introduced: all tests should still pass, and everything related to widget management should still work normally.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
