### PR TITLE
Include build into publish GH pages workflow

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -4,14 +4,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
+  build:
     name: Publish to NPM and GitHub pages
-    needs: build
     runs-on: ubuntu-latest
-
-    # The current approach is silly. We should be smarter and use `actions/upload-artifact` and `actions/download-artifact` instead of rebuilding
-    # everything from scratch again. (git checkout, Node.js install, yarn, etc.) It was not possible to share artifacts on Travis CI without an
-    # external storage (such as S3), so we did rebuild everything before the npm publish. We should overcome this limitation with GH Actions.
 
     steps:
       - name: Checkout
@@ -29,6 +24,12 @@ jobs:
         uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
           python-version: '3.x'
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Build
+        run: yarn build
 
       - name: Pre-npm-Publish
         run: |


### PR DESCRIPTION
fixed #13821

#### What it does

Includes the build step into the publish Github Pages job for simplicity

#### How to test

I guess we have to run and see

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
