### PR TITLE
Use `targetPlatform` when installing plugin from open-vsx

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,12 +58,13 @@
       "request": "launch",
       "name": "Launch Browser Backend",
       "program": "${workspaceFolder}/examples/browser/lib/backend/main.js",
+      "cwd": "${workspaceFolder}/examples/browser",
       "args": [
         "--hostname=0.0.0.0",
         "--port=3000",
         "--no-cluster",
         "--app-project-path=${workspaceFolder}/examples/browser",
-        "--plugins=local-dir:plugins",
+        "--plugins=local-dir:../../plugins",
         "--hosted-plugin-inspect=9339",
         "--ovsx-router-config=${workspaceFolder}/examples/ovsx-router-config.json"
       ],

--- a/dev-packages/ovsx-client/src/index.ts
+++ b/dev-packages/ovsx-client/src/index.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-export { OVSXApiFilter, OVSXApiFilterImpl } from './ovsx-api-filter';
+export { OVSXApiFilter, OVSXApiFilterImpl, OVSXApiFilterProvider } from './ovsx-api-filter';
 export { OVSXHttpClient } from './ovsx-http-client';
 export { OVSXMockClient } from './ovsx-mock-client';
 export { OVSXRouterClient, OVSXRouterConfig, OVSXRouterFilterFactory as FilterFactory } from './ovsx-router-client';

--- a/dev-packages/ovsx-client/src/ovsx-api-filter.ts
+++ b/dev-packages/ovsx-client/src/ovsx-api-filter.ts
@@ -68,15 +68,15 @@ export class OVSXApiFilterImpl implements OVSXApiFilter {
     protected async queryLatestCompatibleExtension(query: VSXQueryOptions): Promise<VSXExtensionRaw | undefined> {
         let offset = 0;
         const size = 100;
-        let flag = true;
-        while (flag) {
+        let loop = true;
+        while (loop) {
             const queryOptions = {
                 ...query,
                 offset
             };
             offset += size;
             const results = await this.client.query(queryOptions);
-            flag = results.totalSize < offset;
+            loop = results.totalSize > offset;
             const compatibleExtension = this.getLatestCompatibleExtension(results.extensions);
             if (compatibleExtension) {
                 return compatibleExtension;

--- a/dev-packages/ovsx-client/src/ovsx-api-filter.ts
+++ b/dev-packages/ovsx-client/src/ovsx-api-filter.ts
@@ -80,8 +80,8 @@ export class OVSXApiFilterImpl implements OVSXApiFilter {
             }
             // Adjust offset by the amount of returned extensions
             offset += results.extensions.length;
-            // Abort once we have reached the last page
-            loop = results.totalSize >= offset;
+            // Continue querying if there are more extensions available
+            loop = results.totalSize > offset;
         }
         return undefined;
     }

--- a/dev-packages/ovsx-client/src/ovsx-http-client.ts
+++ b/dev-packages/ovsx-client/src/ovsx-http-client.ts
@@ -48,10 +48,12 @@ export class OVSXHttpClient implements OVSXClient {
 
     async query(queryOptions?: VSXQueryOptions): Promise<VSXQueryResult> {
         try {
-            return await this.requestJson(this.buildUrl('api/-/query', queryOptions));
+            return await this.requestJson(this.buildUrl('api/v2/-/query', queryOptions));
         } catch (error) {
             console.warn(error);
             return {
+                offset: 0,
+                totalSize: 0,
                 extensions: []
             };
         }

--- a/dev-packages/ovsx-client/src/ovsx-http-client.ts
+++ b/dev-packages/ovsx-client/src/ovsx-http-client.ts
@@ -50,7 +50,6 @@ export class OVSXHttpClient implements OVSXClient {
         try {
             return await this.requestJson(this.buildUrl('api/v2/-/query', queryOptions));
         } catch (error) {
-            console.warn(error);
             return {
                 offset: 0,
                 totalSize: 0,

--- a/dev-packages/ovsx-client/src/ovsx-mock-client.ts
+++ b/dev-packages/ovsx-client/src/ovsx-mock-client.ts
@@ -61,21 +61,26 @@ export class OVSXMockClient implements OVSXClient {
                 reviewsUrl: url.extensionReviewsUrl(namespace, name),
                 timestamp: new Date(now - ids.length + i + 1).toISOString(),
                 version,
-                description: `Mock VS Code Extension for ${id}`
+                description: `Mock VS Code Extension for ${id}`,
+                namespaceDisplayName: name,
+                preRelease: false
             };
         });
         return this;
     }
 
     async query(queryOptions?: VSXQueryOptions): Promise<VSXQueryResult> {
+        const extensions = this.extensions
+            .filter(extension => typeof queryOptions === 'object' && (
+                this.compare(queryOptions.extensionId, this.id(extension)) &&
+                this.compare(queryOptions.extensionName, extension.name) &&
+                this.compare(queryOptions.extensionVersion, extension.version) &&
+                this.compare(queryOptions.namespaceName, extension.namespace)
+            ));
         return {
-            extensions: this.extensions
-                .filter(extension => typeof queryOptions === 'object' && (
-                    this.compare(queryOptions.extensionId, this.id(extension)) &&
-                    this.compare(queryOptions.extensionName, extension.name) &&
-                    this.compare(queryOptions.extensionVersion, extension.version) &&
-                    this.compare(queryOptions.namespaceName, extension.namespace)
-                ))
+            offset: 0,
+            totalSize: extensions.length,
+            extensions
         };
     }
 

--- a/dev-packages/ovsx-client/src/ovsx-router-client.ts
+++ b/dev-packages/ovsx-client/src/ovsx-router-client.ts
@@ -152,6 +152,8 @@ export class OVSXRouterClient implements OVSXClient {
 
     protected emptyQueryResult(queryOptions?: VSXQueryOptions): VSXQueryResult {
         return {
+            offset: 0,
+            totalSize: 0,
             extensions: []
         };
     }
@@ -183,8 +185,11 @@ export class OVSXRouterClient implements OVSXClient {
         results.forEach((result, sourceUri) => {
             result.extensions.forEach(extension => filtering.push(this.filterExtension(sourceUri, extension)));
         });
+        const extensions = removeNullValues(await Promise.all(filtering));
         return {
-            extensions: removeNullValues(await Promise.all(filtering))
+            offset: 0,
+            totalSize: extensions.length,
+            extensions
         };
     }
 

--- a/dev-packages/ovsx-client/src/ovsx-types.ts
+++ b/dev-packages/ovsx-client/src/ovsx-types.ts
@@ -49,7 +49,7 @@ export interface OVSXClient {
      */
     search(searchOptions?: VSXSearchOptions): Promise<VSXSearchResult>;
     /**
-     * GET https://openvsx.org/api/-/query
+     * GET https://openvsx.org/api/v2/-/query
      *
      * Fetch one or all versions of an extension.
      */
@@ -110,8 +110,6 @@ export interface VSXSearchResult {
     extensions: VSXSearchEntry[];
 }
 
-/** @deprecated since 1.31.0 use {@link VSXQueryOptions} instead */
-export type VSXQueryParam = VSXQueryOptions;
 /**
  * The possible options when performing a search.
  *
@@ -126,10 +124,25 @@ export interface VSXQueryOptions {
     extensionId?: string;
     extensionUuid?: string;
     namespaceUuid?: string;
-    includeAllVersions?: boolean;
+    includeAllVersions?: boolean | 'links';
+    targetPlatform?: VSXTargetPlatform;
+    size?: number;
+    offset?: number;
 }
 
+export type VSXTargetPlatform =
+    'universal' | 'web' |
+    'win32-x64' | 'win32-ia32' | 'win32-arm64' |
+    'darwin-x64' | 'darwin-arm64' |
+    'linux-x64' | 'linux-arm64' | 'linux-armhf' |
+    'alpine-x64' | 'alpine-arm64' | (string & {});
+
 export interface VSXQueryResult {
+    success?: string;
+    warning?: string;
+    error?: string;
+    offset: number;
+    totalSize: number;
     extensions: VSXExtensionRaw[];
 }
 
@@ -199,12 +212,15 @@ export interface VSXExtensionRaw {
     reviewsUrl: string;
     name: string;
     namespace: string;
-    publishedBy: VSXUser
+    targetPlatform?: VSXTargetPlatform;
+    publishedBy: VSXUser;
+    preRelease: boolean;
     namespaceAccess: VSXExtensionNamespaceAccess;
     files: VSXExtensionRawFiles;
     allVersions: {
         [version: string]: string;
     };
+    allVersionsUrl?: string;
     averageRating?: number;
     downloadCount: number;
     reviewCount: number;
@@ -213,20 +229,46 @@ export interface VSXExtensionRaw {
     preview?: boolean;
     verified?: boolean;
     displayName?: string;
+    namespaceDisplayName: string;
     description?: string;
     categories?: string[];
+    extensionKind?: string[];
     tags?: string[];
     license?: string;
     homepage?: string;
     repository?: string;
+    sponsorLink?: string;
     bugs?: string;
     markdown?: string;
     galleryColor?: string;
     galleryTheme?: string;
+    localizedLanguages?: string[];
     qna?: string;
+    badges?: VSXBadge[];
+    dependencies?: VSXExtensionReference[];
+    bundledExtensions?: VSXExtensionReference[];
+    allTargetPlatformVersions?: VSXTargetPlatforms[];
+    url?: string;
     engines?: {
         [engine: string]: string;
     };
+}
+
+export interface VSXBadge {
+    url?: string;
+    href?: string;
+    description?: string;
+}
+
+export interface VSXExtensionReference {
+    url: string;
+    namespace: string;
+    extension: string;
+}
+
+export interface VSXTargetPlatforms {
+    version: string;
+    targetPlatforms: VSXTargetPlatform[];
 }
 
 export interface VSXResponseError extends Error {

--- a/examples/api-samples/src/node/sample-mock-open-vsx-server.ts
+++ b/examples/api-samples/src/node/sample-mock-open-vsx-server.ts
@@ -170,6 +170,8 @@ export class SampleMockOpenVsxServer implements BackendApplicationContribution {
                         reviewsUrl: url.extensionReviewsUrl(namespace, name),
                         timestamp: new Date().toISOString(),
                         version,
+                        namespaceDisplayName: name,
+                        preRelease: false
                     }
                 });
             }));

--- a/examples/api-samples/src/node/sample-mock-open-vsx-server.ts
+++ b/examples/api-samples/src/node/sample-mock-open-vsx-server.ts
@@ -69,7 +69,7 @@ export class SampleMockOpenVsxServer implements BackendApplicationContribution {
         app.use(
             this.mockServerPath + '/api',
             express.Router()
-                .get('/-/query', async (req, res) => {
+                .get('/v2/-/query', async (req, res) => {
                     await this.ready;
                     res.json(await this.mockClient.query(this.sanitizeQuery(req.query)));
                 })

--- a/packages/core/src/browser-only/frontend-only-application-module.ts
+++ b/packages/core/src/browser-only/frontend-only-application-module.ts
@@ -56,6 +56,7 @@ export const frontendOnlyApplicationModule = new ContainerModule((bind, unbind, 
         getExtensionsInfos: async (): Promise<ExtensionInfo[]> => [],
         getApplicationInfo: async (): Promise<ApplicationInfo | undefined> => undefined,
         getApplicationRoot: async (): Promise<string> => '',
+        getApplicationPlatform: () => Promise.resolve('web'),
         getBackendOS: async (): Promise<OS.Type> => OS.Type.Linux
     };
     if (isBound(ApplicationServer)) {

--- a/packages/core/src/common/application-protocol.ts
+++ b/packages/core/src/common/application-protocol.ts
@@ -24,6 +24,7 @@ export interface ApplicationServer {
     getExtensionsInfos(): Promise<ExtensionInfo[]>;
     getApplicationInfo(): Promise<ApplicationInfo | undefined>;
     getApplicationRoot(): Promise<string>;
+    getApplicationPlatform(): Promise<string>;
     /**
      * @deprecated since 1.25.0. Use `OS.backend.type()` instead.
      */

--- a/packages/core/src/node/application-server.ts
+++ b/packages/core/src/node/application-server.ts
@@ -49,6 +49,10 @@ export class ApplicationServerImpl implements ApplicationServer {
         return Promise.resolve(this.applicationPackage.projectPath);
     }
 
+    getApplicationPlatform(): Promise<string> {
+        return Promise.resolve(`${process.platform}-${process.arch}`);
+    }
+
     async getBackendOS(): Promise<OS.Type> {
         return OS.type();
     }

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -29,7 +29,7 @@ import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handl
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
 import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
-import { OVSXApiFilterProvider, VSXExtensionRaw, VSXTargetPlatform } from '@theia/ovsx-client';
+import { OVSXApiFilterProvider, VSXExtensionRaw } from '@theia/ovsx-client';
 import { VscodeCommands } from '@theia/plugin-ext-vscode/lib/browser/plugin-vscode-commands-contribution';
 import { DateTime } from 'luxon';
 import { OVSXClientProvider } from '../common/ovsx-client-provider';

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -262,8 +262,9 @@ export class VSXExtensionsModel {
 
     protected async fetchVerifiedStatus(id: string, client: OVSXClient, allVersions: VSXAllVersions): Promise<boolean | undefined> {
         const res = await client.query({ extensionId: id, extensionVersion: allVersions.version, includeAllVersions: true });
-        let verified = res.extensions?.[0].verified;
-        if (!verified && res.extensions?.[0].publishedBy.loginName === 'open-vsx') {
+        const extension = res.extensions?.[0];
+        let verified = extension?.verified;
+        if (!verified && extension?.publishedBy.loginName === 'open-vsx') {
             verified = true;
         }
         return verified;


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11291
Closes https://github.com/eclipse-theia/theia/issues/13558

For a while now open-vsx has offered to query plugins using the `targetPlatform` filter. This adjusts Theia's open-vsx integration to respect the backend's target platform. This is related to https://github.com/eclipse-theia/theia/pull/12410, which implemented this feature for the CLI.

When using the filter, only plugin entries with the specified target platform are actually returned. That's why we have to also query `universal` after querying the platform specific plugins to ensure that we actually install the newest available extension.

Also closes https://github.com/eclipse-theia/theia/issues/11291 by using the new `v2` API endpoint which returns more compact results.

#### How to test

Testing this works best when you have two different operating systems available. I used Windows (PC) and Ubuntu (Gitpod) to test this.

1. Install a plugin with native dependencies such as the [`rust-analyzer`](https://open-vsx.org/extension/rust-lang/rust-analyzer)
2. Assert that the plugin starts up when opening a `*.rs` file (it currently crashes on `master` if you aren't accidentally on the correct OS)
3. Assert that all the other plugin related features work as expected

#### Follow-ups

I'm not sure this is how the open-vsx API is intended to be used. Querying the API multiple times for different target platforms (i.e. the backend platform + `universal`) seems a bit counterintuitive. We can maybe improve on this.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
