### PR TITLE
Set notebook editor as active when opening in foreground

### DIFF
--- a/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
+++ b/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
@@ -62,6 +62,9 @@ export class NotebookEditorWidgetService {
         }
         this.notebookEditors.set(editor.id, editor);
         this.onNotebookEditorAddEmitter.fire(editor);
+        if (editor.isVisible) {
+            this.notebookEditorFocusChanged(editor, true);
+        }
     }
 
     removeNotebookEditor(editor: NotebookEditorWidget): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

When opening a visible notebook editor this is now set as the active one. This is important information for jupyter to set some context keys correctly and by that for example show the `restart kernel` option directly instead of first after focusing the widget initially.

#### How to test
You need the jupyter and python extensions installed

1. Open a notebook and ensure a kernel is selected.
2. close and reopen it. 
3. the `restart kernel` and `variables` toolbar entries should now be directly visible 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
