### PR TITLE
improved shown keybindings in context menu

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -470,7 +470,9 @@ export class MenuCommandRegistry extends PhosphorCommandRegistry {
         const bindings = keybindingRegistry.getKeybindingsForCommand(id);
         // Only consider the first active keybinding.
         if (bindings.length) {
-            const binding = bindings.find(b => !b.when || this.services.contextKeyService.match(b.when)) ?? bindings[0];
+            const binding = bindings.length > 1 ?
+                bindings.find(b => !b.when || this.services.contextKeyService.match(b.when)) ?? bindings[0] :
+                bindings[0];
             const keys = keybindingRegistry.acceleratorFor(binding, ' ', true);
             this.addKeyBinding({
                 command: id,

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -468,9 +468,9 @@ export class MenuCommandRegistry extends PhosphorCommandRegistry {
         });
 
         const bindings = keybindingRegistry.getKeybindingsForCommand(id);
-        // Only consider the first keybinding.
+        // Only consider the first active keybinding.
         if (bindings.length) {
-            const binding = bindings[0];
+            const binding = bindings.find(b => !b.when || this.services.contextKeyService.match(b.when)) ?? bindings[0];
             const keys = keybindingRegistry.acceleratorFor(binding, ' ', true);
             this.addKeyBinding({
                 command: id,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This improves the visible keybindings in context menus by not showing keybindings that are inactive in the current context.

#### How to test

For example add a keybinding like this to some keybinding contribution
```
 {
        command: CommonCommands.UNDO.id,
        keybinding: 'z',
        when: 'notebookEditorFocused',
}
```

previously this was the always shown as `Z` in the context menu regardless of if a notebook editor was focused.

Now this should still normally be `ctrl/cmd+z` but when a notebook editor is focused it should show as `Z`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
