### PR TITLE
Switch single instance on per default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
 
 - [filesystem] Adjusted the "Save As" mechanism. It now assumes that `Saveable.getSnapshot()` returns a full snapshot of the editor model [#13689](https://github.com/eclipse-theia/theia/pull/13689). 
-
--->
-
+- [electron] Switch single instance on per default [#13831](https://github.com/eclipse-theia/theia/pull/13831) - contributed on behalf of STMicroelectronics
+ -->
 ## 1.50.0 - 06/03/2024
 
 - [application-package] bumped the default supported API from `1.88.1` to `1.89.1` [#13738](https://github.com/eclipse-theia/theia/pull/13738) - contributed on behalf of STMicroelectronics

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -183,7 +183,7 @@ export namespace FrontendApplicationConfig {
 export type BackendApplicationConfig = RequiredRecursive<BackendApplicationConfig.Partial>;
 export namespace BackendApplicationConfig {
     export const DEFAULT: BackendApplicationConfig = {
-        singleInstance: false,
+        singleInstance: true,
         frontendConnectionTimeout: 0
     };
     export interface Partial extends ApplicationConfig {

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -721,14 +721,19 @@ export class ElectronMainApplication {
     }
 
     protected async onSecondInstance(event: ElectronEvent, argv: string[], cwd: string): Promise<void> {
-        const electronWindows = BrowserWindow.getAllWindows();
-        if (electronWindows.length > 0) {
-            const electronWindow = electronWindows[0];
-            if (electronWindow.isMinimized()) {
-                electronWindow.restore();
-            }
-            electronWindow.focus();
-        }
+        createYargs(this.processArgv.getProcessArgvWithoutBin(argv), process.cwd())
+        .help(false)
+        .command('$0 [file]', false,
+            cmd => cmd
+                .positional('file', { type: 'string' }),
+                async args => {
+                    this.handleMainCommand({
+                        file: args.file,
+                        cwd: process.cwd(),
+                        secondInstance: true
+                    });
+                },
+            ).parse();
     }
 
     protected onWindowAllClosed(event: ElectronEvent): void {

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -722,10 +722,10 @@ export class ElectronMainApplication {
 
     protected async onSecondInstance(event: ElectronEvent, argv: string[], cwd: string): Promise<void> {
         createYargs(this.processArgv.getProcessArgvWithoutBin(argv), process.cwd())
-        .help(false)
-        .command('$0 [file]', false,
-            cmd => cmd
-                .positional('file', { type: 'string' }),
+            .help(false)
+            .command('$0 [file]', false,
+                cmd => cmd
+                    .positional('file', { type: 'string' }),
                 async args => {
                     this.handleMainCommand({
                         file: args.file,


### PR DESCRIPTION
#### What it does
Turn on the `singleInstance` application config on in the default case. Invoking theia a second time will open a new window in the first instance when `singleInstance === true`. If a workspace directory is given as the first position argument, this workspace is opened, otherwise an empty window is opened.

Fixes #10890

Contributed on behalf of STMicroelectronics

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Invoke theia via `theia electron start` multiple times and with or without parameters. Make sure an independent instance is started when `singleInstance` is off. I use `theia electron start` and start the electron back end in the debugger to verify the behavior.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
