### PR TITLE
Serialize saveables to disk for "Save As"

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -33,6 +33,7 @@ import { IModelService } from '@theia/monaco-editor-core/esm/vs/editor/common/se
 import { createTextBufferFactoryFromStream } from '@theia/monaco-editor-core/esm/vs/editor/common/model/textModel';
 import { editorGeneratedPreferenceProperties } from '@theia/editor/lib/browser/editor-generated-preference-schema';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 
 export {
     TextDocumentSaveReason
@@ -653,6 +654,10 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
     applySnapshot(snapshot: Saveable.Snapshot): void {
         const value = Saveable.Snapshot.read(snapshot) ?? '';
         this.model.setValue(value);
+    }
+
+    async serialize(): Promise<BinaryBuffer> {
+        return BinaryBuffer.fromString(this.model.getValue());
     }
 
     protected trace(loggable: Loggable): void {

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -34,6 +34,7 @@ import { inject, injectable, interfaces, postConstruct } from '@theia/core/share
 import { UndoRedoService } from '@theia/editor/lib/browser/undo-redo-service';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 import type { NotebookModelResolverService } from '../service/notebook-model-resolver-service';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 
 export const NotebookModelFactory = Symbol('NotebookModelFactory');
 
@@ -176,8 +177,7 @@ export class NotebookModel implements Saveable, Disposable {
         this.dirtyCells = [];
         this.dirty = false;
 
-        const data = this.getData();
-        const serializedNotebook = await this.props.serializer.fromNotebook(data);
+        const serializedNotebook = await this.serialize();
         this.fileService.writeFile(this.uri, serializedNotebook);
 
         this.onDidSaveNotebookEmitter.fire();
@@ -187,6 +187,10 @@ export class NotebookModel implements Saveable, Disposable {
         return {
             read: () => JSON.stringify(this.getData())
         };
+    }
+
+    serialize(): Promise<BinaryBuffer> {
+        return this.props.serializer.fromNotebook(this.getData());
     }
 
     async applySnapshot(snapshot: Saveable.Snapshot): Promise<void> {


### PR DESCRIPTION
#### What it does

Adds a new optional `serialize` method to all `Saveable` objects. This method will be used in case the saveable is not directly string-serializable (such as notebooks) for the "Save As" action.

#### How to test

1. Open a `ipynb` file, and edit it
2. Save it to a new file using `Save As...`
3. The new file should contain all old changes + new changes
4. The old file should be correctly reverted

Please also confirm that the "Save As" operation still works for normal text editors

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
