### PR TITLE
Fix automated releases

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -39,9 +39,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
 
       - name: Publish NPM
-        shell: bash
-        run: |
-          yarn publish:next
+        # We need to retry the publish command in case of network errors.
+        # Those errors are usually due to rate limiting on the NPM registry.
+        uses: nick-invision/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 5
+          retry_wait_seconds: 30
+          max_attempts: 3
+          retry_on: error
+          command: yarn publish:next
+          on_retry_command: git reset --hard
         env:
           NPM_CONFIG_PROVENANCE: "true"
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,10 +45,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
 
       - name: Publish NPM
-        shell: bash
-        run: |
-          yarn publish:latest -- ${{ inputs.release_type }}
-          yarn publish:check
+        # We need to retry the publish command in case of network errors.
+        # Those errors are usually due to rate limiting on the NPM registry.
+        uses: nick-invision/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 5
+          retry_wait_seconds: 30
+          max_attempts: 3
+          retry_on: error
+          command: yarn publish:latest -- ${{ inputs.release_type }} && yarn publish:check
+          on_retry_command: git reset --hard
         env:
           NPM_CONFIG_PROVENANCE: "true" # enable provenance check
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
@@ -62,12 +68,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
+        with:
+          path: packages/core
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:
           commiter: ${{ github.actor }} <${{ fromJson(steps.actor_user_data.outputs.data).email }}>
           author: ${{ github.actor }} <${{ fromJson(steps.actor_user_data.outputs.data).email }}>
           branch: bot/package-update
-          title: Package update for version ${{ env.NEXT_VERSION_NUMBER }}
-          commit-message: Package update for version ${{ env.NEXT_VERSION_NUMBER }}
-          body: Automated package update for Theia version ${{ env.NEXT_VERSION_NUMBER }}. Triggered by @${{ github.actor }}.
+          title: Package update for version ${{ steps.package-version.outputs.current-version}}
+          commit-message: Package update for version ${{ steps.package-version.outputs.current-version}}
+          body: Automated package update for Theia version ${{ steps.package-version.outputs.current-version}}. Triggered by @${{ github.actor }}.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "postinstall": "theia-patch",
     "prepare": "yarn -s compile:references && lerna run prepare && yarn -s compile",
     "publish:latest": "lerna publish --exact --yes --no-push",
-    "publish:next": "lerna publish preminor --exact --canary --preid next --dist-tag next --no-git-reset --no-git-tag-version --no-push --yes && yarn -s publish:check",
+    "publish:next": "lerna publish preminor --exact --preid next --dist-tag next --no-git-reset --no-git-tag-version --no-push --yes && yarn -s publish:check",
     "publish:check": "node scripts/check-publish.js",
     "rebuild:clean": "rimraf .browser_modules",
     "test": "yarn -s test:theia && yarn -s electron test && yarn -s browser test",


### PR DESCRIPTION
#### What it does

Updates our GitHub actions to retry in case they hit network related errors like rate limiting. This was also used in the old `next` publishing action:

https://github.com/eclipse-theia/theia/blob/85f5e928ddfa650b5ba58a510a7db9532a392e7a/.github/workflows/ci-cd.yml#L164-L174

Also removes the `--canary` option. That should hopefully fix the issue of unexpected minor versions (we currently publish all `next` releases as `1.46.0-next`).

#### How to test

Nothing to test, we need to see whether it will work now :)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
