### PR TITLE
Disable cell editor search widget

### DIFF
--- a/packages/monaco/src/browser/simple-monaco-editor.ts
+++ b/packages/monaco/src/browser/simple-monaco-editor.ts
@@ -16,7 +16,7 @@
 
 import { EditorServiceOverrides, MonacoEditor, MonacoEditorServices } from './monaco-editor';
 
-import { CodeEditorWidget } from '@theia/monaco-editor-core/esm/vs/editor/browser/widget/codeEditorWidget';
+import { CodeEditorWidget, ICodeEditorWidgetOptions } from '@theia/monaco-editor-core/esm/vs/editor/browser/widget/codeEditorWidget';
 import { IInstantiationService } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/instantiation';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import { ServiceCollection } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/serviceCollection';
@@ -51,7 +51,8 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
         readonly node: HTMLElement,
         services: MonacoEditorServices,
         options?: MonacoEditor.IOptions,
-        override?: EditorServiceOverrides
+        override?: EditorServiceOverrides,
+        widgetOptions?: ICodeEditorWidgetOptions
     ) {
         super(services);
         this.toDispose.pushAll([
@@ -66,7 +67,7 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
         this.toDispose.push(this.create({
             ...MonacoEditor.createReadOnlyOptions(document.readOnly),
             ...options
-        }, override));
+        }, override, widgetOptions));
         this.addHandlers(this.editor);
         this.editor.setModel(document.textEditorModel);
     }
@@ -75,7 +76,7 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
         return this.editor;
     }
 
-    protected create(options?: MonacoEditor.IOptions, override?: EditorServiceOverrides): Disposable {
+    protected create(options?: MonacoEditor.IOptions, override?: EditorServiceOverrides, widgetOptions?: ICodeEditorWidgetOptions): Disposable {
         const combinedOptions = {
             ...options,
             lightbulb: { enabled: true },
@@ -97,9 +98,7 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
                 width: 0,
                 height: 0
             },
-        }, {
-
-        });
+        }, widgetOptions ?? {});
     }
 
     protected addHandlers(codeEditor: CodeEditorWidget): void {

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -26,6 +26,7 @@ import { DisposableCollection, OS } from '@theia/core';
 import { NotebookViewportService } from './notebook-viewport-service';
 import { BareFontInfo } from '@theia/monaco-editor-core/esm/vs/editor/common/config/fontInfo';
 import { NOTEBOOK_CELL_CURSOR_FIRST_LINE, NOTEBOOK_CELL_CURSOR_LAST_LINE } from '../contributions/notebook-context-keys';
+import { EditorExtensionsRegistry } from '@theia/monaco-editor-core/esm/vs/editor/browser/editorExtensions';
 
 interface CellEditorProps {
     notebookModel: NotebookModel,
@@ -117,7 +118,8 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
                 editorNode,
                 monacoServices,
                 { ...DEFAULT_EDITOR_OPTIONS, ...cell.editorOptions },
-                [[IContextKeyService, this.props.notebookContextManager.scopedStore]]);
+                [[IContextKeyService, this.props.notebookContextManager.scopedStore]],
+                { contributions: EditorExtensionsRegistry.getEditorContributions().filter(c => c.id !== 'editor.contrib.findController') });
             this.toDispose.push(this.editor);
             this.editor.setLanguage(cell.language);
             this.toDispose.push(this.editor.getControl().onDidContentSizeChange(() => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Currently there is no search widget available for the notebook editor. pressing ctr+f while a cell editor was activated, did activate the search widget for this cell editor though which led to some problems with shortcuts. 
This PR disables the cell editor search widget

#### How to test

- Open a notebook with a code or markdown cell (markdown cell should be in edit mode)
- press ctrl/cmd+f
- nothing should happen

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
