### PR TITLE
[vscode] Support TestRunRequest.preserveFocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 <!-- ## not yet released 
 
 - [plugin] Avoid pollution of all toolbars by actions contributed by tree views in extensions [#13768](https://github.com/eclipse-theia/theia/pull/13768) - contributed on behalf of STMicroelectronics
+- [plugin] support TestRunRequest preserveFocus API [#13839](https://github.com/eclipse-theia/theia/pull/13839) - contributed on behalf of STMicroelectronics 
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2265,7 +2265,7 @@ export interface TestingMain {
 
     // Test runs
 
-    $notifyTestRunCreated(controllerId: string, run: TestRunDTO): void;
+    $notifyTestRunCreated(controllerId: string, run: TestRunDTO, preserveFocus: boolean): void;
     $notifyTestStateChanged(controllerId: string, runId: string, stateChanges: TestStateChangeDTO[], outputChanges: TestOutputDTO[]): void;
     $notifyTestRunEnded(controllerId: string, runId: string): void;
 }

--- a/packages/plugin-ext/src/common/test-types.ts
+++ b/packages/plugin-ext/src/common/test-types.ts
@@ -107,6 +107,7 @@ export interface TestRunRequestDTO {
     name: string;
     includedTests: string[][]; // array of paths
     excludedTests: string[][]; // array of paths
+    preserveFocus: boolean;
 }
 
 export interface TestItemReference {

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -3329,6 +3329,7 @@ export class TestRunRequest implements theia.TestRunRequest {
         public readonly exclude: theia.TestItem[] | undefined = undefined,
         public readonly profile: theia.TestRunProfile | undefined = undefined,
         public readonly continuous: boolean | undefined = undefined,
+        public readonly preserveFocus: boolean = true
     ) { }
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -16254,12 +16254,21 @@ export module '@theia/plugin' {
         readonly continuous?: boolean;
 
         /**
+         * Controls how test Test Results view is focused.  If true, the editor
+         * will keep the maintain the user's focus. If false, the editor will
+         * prefer to move focus into the Test Results view, although
+         * this may be configured by users.
+         */
+        readonly preserveFocus: boolean;
+
+        /**
          * @param include Array of specific tests to run, or undefined to run all tests
          * @param exclude An array of tests to exclude from the run.
          * @param profile The run profile used for this request.
          * @param continuous Whether to run tests continuously as source changes.
+         * @param preserveFocus Whether to preserve the user's focus when the run is started
          */
-        constructor(include?: readonly TestItem[], exclude?: readonly TestItem[], profile?: TestRunProfile, continuous?: boolean);
+        constructor(include?: readonly TestItem[], exclude?: readonly TestItem[], profile?: TestRunProfile, continuous?: boolean, preserveFocus?: boolean);
     }
 
     /**

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -67,6 +67,7 @@ export class PreferenceTreeGenerator {
         ['search', 'features'],
         ['task', 'features'],
         ['terminal', 'features'],
+        ['testing', 'features'],
         ['toolbar', 'features'],
         ['webview', 'features'],
         ['workspace', 'application'],

--- a/packages/test/src/browser/test-execution-progress-service.ts
+++ b/packages/test/src/browser/test-execution-progress-service.ts
@@ -1,0 +1,53 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { Widget } from '@theia/core/lib/browser';
+import { TestResultViewContribution } from './view/test-result-view-contribution';
+import { TestViewContribution } from './view/test-view-contribution';
+import { TestPreferences } from './test-preferences';
+
+export interface TestExecutionProgressService {
+    onTestRunRequested(preserveFocus: boolean): Promise<void>;
+}
+
+export const TestExecutionProgressService = Symbol('TestExecutionProgressService');
+
+@injectable()
+export class DefaultTestExecutionProgressService implements TestExecutionProgressService {
+
+    @inject(TestResultViewContribution)
+    protected readonly testResultView: TestResultViewContribution;
+
+    @inject(TestViewContribution)
+    protected readonly testView: TestViewContribution;
+
+    @inject(TestPreferences)
+    protected readonly testPreferences: TestPreferences;
+
+    async onTestRunRequested(preserveFocus: boolean): Promise<void> {
+        if (!preserveFocus) {
+            const openTesting = this.testPreferences['testing.openTesting'];
+            if (openTesting === 'openOnTestStart') {
+                this.openTestResultView();
+            }
+        }
+    }
+
+    async openTestResultView(): Promise<Widget> {
+        return this.testResultView.openView({ activate: true });
+    }
+}

--- a/packages/test/src/browser/test-preferences.ts
+++ b/packages/test/src/browser/test-preferences.ts
@@ -1,0 +1,58 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { interfaces } from '@theia/core/shared/inversify';
+import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/common/nls';
+
+export const TestConfigSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'testing.openTesting': {
+            type: 'string',
+            enum: ['neverOpen', 'openOnTestStart'],
+            enumDescriptions: [
+                nls.localizeByDefault('Never automatically open the testing views'),
+                nls.localizeByDefault('Open the test results view when tests start'),
+            ],
+            description: nls.localizeByDefault('Controls when the testing view should open.'),
+            default: 'neverOpen',
+            scope: 'resource',
+        }
+    }
+};
+
+export interface TestConfiguration {
+    'testing.openTesting': 'neverOpen' | 'openOnTestStart';
+}
+
+export const TestPreferenceContribution = Symbol('TestPreferenceContribution');
+export const TestPreferences = Symbol('TestPreferences');
+export type TestPreferences = PreferenceProxy<TestConfiguration>;
+
+export function createTestPreferences(preferences: PreferenceService, schema: PreferenceSchema = TestConfigSchema): TestPreferences {
+    return createPreferenceProxy(preferences, schema);
+}
+
+export const bindTestPreferences = (bind: interfaces.Bind): void => {
+    bind(TestPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        const contribution = ctx.container.get<PreferenceContribution>(TestPreferenceContribution);
+        return createTestPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(TestPreferenceContribution).toConstantValue({ schema: TestConfigSchema });
+    bind(PreferenceContribution).toService(TestPreferenceContribution);
+};

--- a/packages/test/src/browser/test-service.ts
+++ b/packages/test/src/browser/test-service.ts
@@ -35,7 +35,7 @@ export interface TestRunProfile {
     isDefault: boolean;
     readonly canConfigure: boolean;
     readonly tag: string;
-    run(name: string, included: readonly TestItem[], excluded: readonly TestItem[]): void;
+    run(name: string, included: readonly TestItem[], excluded: readonly TestItem[], preserveFocus: boolean): void;
     configure(): void;
 }
 
@@ -287,7 +287,7 @@ export class DefaultTestService implements TestService {
             }
         }
         if (activeProfile) {
-            activeProfile.run(`Test run #${this.testRunCounter++}`, items, []);
+            activeProfile.run(`Test run #${this.testRunCounter++}`, items, [], true);
         }
     }
 
@@ -343,7 +343,7 @@ export class DefaultTestService implements TestService {
             if (controller) {
                 this.pickProfile(controller.testRunProfiles, nls.localizeByDefault('Pick a test profile to use')).then(activeProfile => {
                     if (activeProfile) {
-                        activeProfile.run(`Test run #${this.testRunCounter++}`, items, []);
+                        activeProfile.run(`Test run #${this.testRunCounter++}`, items, [], true);
                     }
                 });
             }

--- a/packages/test/src/browser/view/test-view-frontend-module.ts
+++ b/packages/test/src/browser/view/test-view-frontend-module.ts
@@ -36,9 +36,11 @@ import { TestRunTree, TestRunTreeWidget } from './test-run-widget';
 import { TestResultViewContribution } from './test-result-view-contribution';
 import { TEST_RUNS_CONTEXT_MENU, TestRunViewContribution } from './test-run-view-contribution';
 import { TestContextKeyService } from './test-context-key-service';
+import { DefaultTestExecutionProgressService, TestExecutionProgressService } from '../test-execution-progress-service';
+import { bindTestPreferences } from '../test-preferences';
 
 export default new ContainerModule(bind => {
-
+    bindTestPreferences(bind);
     bindContributionProvider(bind, TestContribution);
     bind(TestContextKeyService).toSelf().inSingletonScope();
     bind(TestService).to(DefaultTestService).inSingletonScope();
@@ -105,7 +107,7 @@ export default new ContainerModule(bind => {
     bind(TabBarToolbarContribution).toService(TestRunViewContribution);
     bind(TestExecutionStateManager).toSelf().inSingletonScope();
     bind(TestOutputUIModel).toSelf().inSingletonScope();
-
+    bind(TestExecutionProgressService).to(DefaultTestExecutionProgressService).inSingletonScope();
 });
 
 export function createTestTreeContainer(parent: interfaces.Container): Container {


### PR DESCRIPTION
#### What it does

Add a progress service for tests to support activation of views
Support vscode API to listen for test run request preserveFocus:
- when preserve focus is true, nothing had to be done
- if preserveFocus is false, then the Test Results view shall be activated.

fixes #13759

contributed on behalf of STMicroelectronics

#### How to test

1. Start the theia browser example on master and install the following extension (derived from vscode sample extension test-provider-sample):
- src: [test-provider-sample-0.0.1-src.zip](https://github.com/user-attachments/files/15952608/test-provider-sample-0.0.1-src.zip)
- zip vsix: [test-provider-sample-0.0.1.zip](https://github.com/user-attachments/files/15952610/test-provider-sample-0.0.1.zip)

2. When starting extensions from Test UI, nothing should happen (as _preserveFocus_ is always true in this case)
3. With the PR and the extensions, 2 additional commands are available with the markdown tests: Test Sample: Trigger Tests (preserveFocus: **true/false**). With the one with true, nothing shall happen also. The Test Result view shall activate when using the command with the false preserve Focus. 

#### Follow-ups
The current implementation may be extended later based on preferences and test results status. In VS Code, when tests are started or failing, the Test Result view or the Test Explorer view can be activated based on user preferences (see https://github.com/microsoft/vscode/blob/f9238dd94a8b54dc3adb274927c7871e7c215300/src/vs/workbench/contrib/testing/browser/testingProgressUiService.ts#L49)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


