### PR TITLE
Fix data race in problem view tree

### DIFF
--- a/packages/markers/src/browser/problem/problem-composite-tree-node.ts
+++ b/packages/markers/src/browser/problem/problem-composite-tree-node.ts
@@ -23,6 +23,11 @@ import { ProblemUtils } from './problem-utils';
 
 export namespace ProblemCompositeTreeNode {
 
+    export interface Child {
+        node: MarkerInfoNode;
+        markers: Marker<Diagnostic>[];
+    }
+
     export function setSeverity(parent: MarkerInfoNode, markers: Marker<Diagnostic>[]): void {
         let maxSeverity: DiagnosticSeverity | undefined;
         markers.forEach(marker => {
@@ -33,7 +38,7 @@ export namespace ProblemCompositeTreeNode {
         parent.severity = maxSeverity;
     };
 
-    export function addChildren(parent: CompositeTreeNode, insertChildren: { node: MarkerInfoNode, markers: Marker<Diagnostic>[] }[]): void {
+    export function addChildren(parent: CompositeTreeNode, insertChildren: ProblemCompositeTreeNode.Child[]): void {
         for (const { node, markers } of insertChildren) {
             ProblemCompositeTreeNode.setSeverity(node, markers);
         }

--- a/packages/markers/src/browser/problem/problem-tree-model.ts
+++ b/packages/markers/src/browser/problem/problem-tree-model.ts
@@ -38,11 +38,6 @@ export class ProblemTree extends MarkerTree<Diagnostic> {
         super(markerManager, markerOptions);
     }
 
-    override get root(): MarkerRootNode | undefined {
-        const superRoot = super.root;
-        return MarkerRootNode.is(superRoot) ? superRoot : undefined;
-    }
-
     protected override getMarkerNodes(parent: MarkerInfoNode, markers: Marker<Diagnostic>[]): MarkerNode[] {
         const nodes = super.getMarkerNodes(parent, markers);
         return nodes.sort((a, b) => this.sortMarkers(a, b));
@@ -92,11 +87,13 @@ export class ProblemTree extends MarkerTree<Diagnostic> {
     }
 
     protected doInsertNodesWithMarkers = debounce(() => {
-        if (!this.root) {
+        const root = this.root;
+        // Sanity check; This should always be of type `MarkerRootNode`
+        if (!MarkerRootNode.is(root)) {
             return;
         }
         const queuedItems = Array.from(this.queuedMarkers.values());
-        ProblemCompositeTreeNode.addChildren(this.root, queuedItems);
+        ProblemCompositeTreeNode.addChildren(root, queuedItems);
 
         for (const { node, markers } of queuedItems) {
             const children = this.getMarkerNodes(node, markers);


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13750
Closes https://github.com/eclipse-theia/theia/issues/13835

Whenever we encounter a new diagnostics collection for a given file (i.e. the diagnostics have been updated/replaced), we now simply replace the still waiting collection in the map. This ensures that the problem view tree stays consistent and outdated diagnostics get correctly replaced.

#### How to test

Run the test steps from https://github.com/eclipse-theia/theia/issues/13835 and assert that everything works as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
