### PR TITLE
Add an indicator for loading notebooks

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -233,7 +233,9 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
                 </div>
             </div >;
         } else {
-            return <div></div>;
+            return <div className='theia-notebook-main-container'>
+                <div className='theia-notebook-main-loading-indicator'></div>
+            </div>;
         }
     }
 

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -187,6 +187,14 @@
   overflow: hidden;
 }
 
+.theia-notebook-main-container .theia-notebook-main-loading-indicator {
+  /* `progress-animation` is defined in `packages/core/src/browser/style/progress-bar.css` */
+  animation: progress-animation 1.8s 0s infinite
+    cubic-bezier(0.645, 0.045, 0.355, 1);
+  background-color: var(--theia-progressBar-background);
+  height: 2px;
+}
+
 .theia-notebook-viewport {
   display: flex;
   overflow: hidden;


### PR DESCRIPTION
#### What it does

Adds a small loading indicator for notebook widgets. While the notebook is loading (which might include activating the corresponding extension and waiting until the notebook serializer is ready), we simply display the indicator to make it clear that the notebook is still loading.

#### How to test

1. Open a notebook
2. Assert that for a short duration, the indicator is visible at the top of the widget.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
