### PR TITLE
[vscode] Stub activeStackItem and related change event in debug namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 <!-- ## not yet released
 
+- [debug] stub activeStackItem and related change event in debug namespace [#13847](https://github.com/eclipse-theia/theia/pull/13847) - contributed on behalf of STMicroelectronics
+
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
 
 - [filesystem] Adjusted the "Save As" mechanism. It now assumes that `Saveable.getSnapshot()` returns a full snapshot of the editor model [#13689](https://github.com/eclipse-theia/theia/pull/13689). 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -124,6 +124,8 @@ import {
     Breakpoint,
     SourceBreakpoint,
     FunctionBreakpoint,
+    DebugStackFrame,
+    DebugThread,
     FoldingRange,
     FoldingRangeKind,
     SelectionRange,
@@ -1090,6 +1092,14 @@ export function createAPIFactory(
             get onDidChangeBreakpoints(): theia.Event<theia.BreakpointsChangeEvent> {
                 return debugExt.onDidChangeBreakpoints;
             },
+            /** @stubbed */
+            get activeStackItem(): DebugThread | DebugStackFrame | undefined {
+                return undefined;
+            },
+            /** @stubbed */
+            get onDidChangeActiveStackItem(): theia.Event<DebugThread | DebugStackFrame | undefined> {
+                return Event.None;
+            },
             registerDebugAdapterDescriptorFactory(debugType: string, factory: theia.DebugAdapterDescriptorFactory): Disposable {
                 return debugExt.registerDebugAdapterDescriptorFactory(debugType, factory);
             },
@@ -1372,6 +1382,8 @@ export function createAPIFactory(
             Breakpoint,
             SourceBreakpoint,
             FunctionBreakpoint,
+            DebugStackFrame,
+            DebugThread,
             Color,
             ColorInformation,
             ColorPresentation,

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -3028,6 +3028,14 @@ export class FunctionBreakpoint extends Breakpoint {
     }
 }
 
+export class DebugThread {
+    private constructor(readonly session: theia.DebugSession, readonly threadId: number) { }
+}
+
+export class DebugStackFrame {
+      private constructor(readonly session: theia.DebugSession, readonly threadId: number, readonly frameId: number) { }
+}
+
 @es5ClassCompat
 export class Color {
     readonly red: number;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12449,6 +12449,50 @@ export module '@theia/plugin' {
     }
 
     /**
+     * Represents a thread in a debug session.
+     */
+    export class DebugThread {
+        /**
+         * Debug session for thread.
+         */
+        readonly session: DebugSession;
+
+        /**
+         * ID of the associated thread in the debug protocol.
+         */
+        readonly threadId: number;
+
+        /**
+         * @hidden
+         */
+        private constructor(session: DebugSession, threadId: number);
+    }
+
+    /**
+     * Represents a stack frame in a debug session.
+     */
+    export class DebugStackFrame {
+        /**
+         * Debug session for thread.
+         */
+        readonly session: DebugSession;
+
+        /**
+         * ID of the associated thread in the debug protocol.
+         */
+        readonly threadId: number;
+        /**
+         * ID of the stack frame in the debug protocol.
+         */
+        readonly frameId: number;
+
+        /**
+         * @hidden
+         */
+        private constructor(session: DebugSession, threadId: number, frameId: number);
+    }
+
+    /**
      * Namespace for debug functionality.
      */
     export namespace debug {
@@ -12496,6 +12540,21 @@ export module '@theia/plugin' {
          * An {@link Event event} that is emitted when the set of breakpoints is added, removed, or changed.
          */
         export const onDidChangeBreakpoints: Event<BreakpointsChangeEvent>;
+
+        /**
+         * The currently focused thread or stack frame, or `undefined` if no
+         * thread or stack is focused. A thread can be focused any time there is
+         * an active debug session, while a stack frame can only be focused when
+         * a session is paused and the call stack has been retrieved.
+         * @stubbed
+         */
+        export const activeStackItem: DebugThread | DebugStackFrame | undefined;
+
+        /**
+         * An event which fires when the {@link debug.activeStackItem} has changed.
+         * @stubbed
+         */
+        export const onDidChangeActiveStackItem: Event<DebugThread | DebugStackFrame | undefined>;
 
         /**
          * Register a {@link DebugAdapterDescriptorFactory debug adapter descriptor factory} for a specific debug type.


### PR DESCRIPTION
#### What it does

Stubs the new API on debug namespace about activeStackItem and event when this value is changed.

fixes #13758

contributed on behalf of STMicroelectronics

#### How to test

1. Launch master theia browser example,  install the following extension
- src: [debug-extension-sample-0.0.1-src.zip](https://github.com/user-attachments/files/15986841/debug-extension-sample-0.0.1-src.zip)
- zip vsix: [debug-extension-sample-0.0.1.zip](https://github.com/user-attachments/files/15986839/debug-extension-sample-0.0.1.zip)
2. When starting the example, a message will be logged in the debug console: ` Activating extension 'debug-extension-sample' failed: TypeError: vscode.debug.onDidChangeActiveStackItem is not a function`
3. With the PR and the extension, no message is logged in the debug console. The extension is supposed to log in the console in case of selection change in the debug views, but obviously does nothing currently due to stub implementation  

#### Follow-ups
The current stub may be replaced by the real implementation. See #13846

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)