### PR TITLE
Add support for 256 truecolor

### DIFF
--- a/packages/terminal/src/node/shell-process.ts
+++ b/packages/terminal/src/node/shell-process.ts
@@ -61,15 +61,16 @@ export class ShellProcess extends TerminalProcess {
         @inject(ILogger) @named('terminal') logger: ILogger,
         @inject(EnvironmentUtils) environmentUtils: EnvironmentUtils,
     ) {
+        const env = { 'COLORTERM': 'truecolor' };
         super(<TerminalProcessOptions>{
             command: options.shell || ShellProcess.getShellExecutablePath(),
             args: options.args || ShellProcess.getShellExecutableArgs(),
             options: {
-                name: 'xterm-color',
+                name: 'xterm-256color',
                 cols: options.cols || ShellProcess.defaultCols,
                 rows: options.rows || ShellProcess.defaultRows,
                 cwd: getRootPath(options.rootURI),
-                env: options.strictEnv !== true ? environmentUtils.mergeProcessEnv(options.env) : options.env,
+                env: options.strictEnv !== true ? Object.assign(env, environmentUtils.mergeProcessEnv(options.env)) : Object.assign(env, options.env),
             },
             isPseudo: options.isPseudo,
         }, processManager, ringBuffer, logger);


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Beforehand the `terminfo[colors]` and `COLORTERM` were not set properly. The terminal already supports 256 truecolor, but cli tools might not use it, as the env variables were not set correctly. This is fixed with this PR, the color is not set to `256` and `COLORTERM` is set to `truecolor`.

Fixes #13523.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Start the application
2. Open the terminal
3. Run `print $terminfo[colors]` and `echo $COLORTERM`
4. Observe that the output is `256` and `truecolor` respectively.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
