### PR TITLE
Fix FileResource not adding event listener to the disposable collection

### DIFF
--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -97,11 +97,11 @@ export class FileResource implements Resource {
                 this.updateReadOnly();
             }
         }));
-        this.fileService.onDidChangeFileSystemProviderReadOnlyMessage(async e => {
+        this.toDispose.push(this.fileService.onDidChangeFileSystemProviderReadOnlyMessage(async e => {
             if (e.scheme === this.uri.scheme) {
                 this.updateReadOnly();
             }
-        });
+        }));
     }
 
     protected async updateReadOnly(): Promise<void> {


### PR DESCRIPTION
#### What it does

This PR fixes the constructor of FileResource so the listener of `this.fileService.onDidChangeFileSystemProviderReadOnlyMessage` is properly disposed when the resource is disposed.

Fixes #13877

#### How to test

You can run the playwright test in examples\playwright\src\tests\theia-application-shell.test.ts. Check the logs, you should not see any emitter memory leak warning related to `onDidChangeFileSystemProviderReadOnlyMessage` event.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
