### PR TITLE
fixed reload for remote feature and added option to the electron window to add change url on reload

### DIFF
--- a/packages/core/src/electron-browser/preload.ts
+++ b/packages/core/src/electron-browser/preload.ts
@@ -199,7 +199,7 @@ const api: TheiaCoreAPI = {
         ipcRenderer.send(CHANNEL_TOGGLE_FULL_SCREEN);
     },
 
-    requestReload: () => ipcRenderer.send(CHANNEL_REQUEST_RELOAD),
+    requestReload: (newUrl?: string) => ipcRenderer.send(CHANNEL_REQUEST_RELOAD, newUrl),
     restart: () => ipcRenderer.send(CHANNEL_RESTART),
 
     applicationStateChanged: state => {

--- a/packages/core/src/electron-browser/window/electron-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-window-service.ts
@@ -100,7 +100,7 @@ export class ElectronWindowService extends DefaultWindowService {
             if (params.hash) {
                 newLocation.hash = '#' + params.hash;
             }
-            location.assign(newLocation);
+            window.electronTheiaCore.requestReload(newLocation.toString());
         } else {
             window.electronTheiaCore.requestReload();
         }

--- a/packages/core/src/electron-common/electron-api.ts
+++ b/packages/core/src/electron-common/electron-api.ts
@@ -84,7 +84,7 @@ export interface TheiaCoreAPI {
     isFullScreen(): boolean; // TODO: this should really be async, since it blocks the renderer process
     toggleFullScreen(): void;
 
-    requestReload(): void;
+    requestReload(newUrl?: string): void;
     restart(): void;
 
     applicationStateChanged(state: FrontendApplicationState): void;

--- a/packages/core/src/electron-main/theia-electron-window.ts
+++ b/packages/core/src/electron-main/theia-electron-window.ts
@@ -147,10 +147,14 @@ export class TheiaElectronWindow {
         return this.handleStopRequest(() => this.doCloseWindow(), reason);
     }
 
-    protected reload(): void {
+    protected reload(newUrl?: string): void {
         this.handleStopRequest(async () => {
             this.applicationState = 'init';
-            this._window.reload();
+            if (newUrl) {
+                this._window.loadURL(newUrl);
+            } else {
+                this._window.reload();
+            }
         }, StopReason.Reload);
     }
 
@@ -195,7 +199,7 @@ export class TheiaElectronWindow {
     }
 
     protected attachReloadListener(): void {
-        this.toDispose.push(TheiaRendererAPI.onRequestReload(this.window.webContents, () => this.reload()));
+        this.toDispose.push(TheiaRendererAPI.onRequestReload(this.window.webContents, (newUrl?: string) => this.reload(newUrl)));
     }
 
     dispose(): void {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes the remote feature when connecting current window to remote instance. 
Had to add the option for the electron window reload to add a new url.

Fixes #13888

#### How to test

Best tested with dev containers. Simple file like this should be enough.
```
{
    "image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
    "forwardPorts": [3000]
}
```
"Reopen in Container" command should now again work as expected

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
