### PR TITLE
Add breaking change entry for `OpenWithService`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,8 @@
 <a name="breaking_changes_1.50.0">[Breaking Changes:](#breaking_changes_1.50.0)</a>
 
 - [core] Classes implementing the `Saveable` interface no longer need to implement the `autoSave` field. However, a new `onContentChanged` event has been added instead.
-
+- [navigator] The `Open With...` command now uses a dedicated `OpenWithHandler` to populate the quick pick. 
+  Adopters contributing an open handler need to explicitly add the handler to the `OpenWithHandler` ([#13573](https://github.com/eclipse-theia/theia/pull/13573)).
 
 ## v1.49.0 - 04/29/2024
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13837

Just adds the missing breaking change entry for https://github.com/eclipse-theia/theia/pull/13573 to the changelog.

#### How to test

Assert that the changelog entry is accurate.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
