### PR TITLE
[vscode] Implement stubbed API for activeStackFrame API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [core] introduce `FRONTEND_CONNECTION_TIMEOUT` environment variable to override application connexion settings. [#13936](https://github.com/eclipse-theia/theia/pull/13936) - Contributed on behalf of STMicroelectronics
 - [core] tab selected should be adjacent when closing last one [#13912](https://github.com/eclipse-theia/theia/pull/13912) - contributed on behalf of STMicroelectronics
 - [core] upgraded ws to 8.18.0 [#13903](https://github.com/eclipse-theia/theia/pull/13903) - contributed on behalf of STMicroelectronics
+- [debug] implement activeStackItem and related change event in debug namespace [#13900](https://github.com/eclipse-theia/theia/pull/13900) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
 

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -55,11 +55,6 @@ export interface DidChangeBreakpointsEvent {
     uri: URI
 }
 
-export interface DidFocusStackFrameEvent {
-    session: DebugSession;
-    frame: DebugStackFrame | undefined;
-}
-
 export interface DebugSessionCustomEvent {
     readonly body?: any // eslint-disable-line @typescript-eslint/no-explicit-any
     readonly event: string
@@ -94,8 +89,11 @@ export class DebugSessionManager {
     protected readonly onDidReceiveDebugSessionCustomEventEmitter = new Emitter<DebugSessionCustomEvent>();
     readonly onDidReceiveDebugSessionCustomEvent: Event<DebugSessionCustomEvent> = this.onDidReceiveDebugSessionCustomEventEmitter.event;
 
-    protected readonly onDidFocusStackFrameEmitter = new Emitter<DidFocusStackFrameEvent>();
+    protected readonly onDidFocusStackFrameEmitter = new Emitter<DebugStackFrame | undefined>();
     readonly onDidFocusStackFrame = this.onDidFocusStackFrameEmitter.event;
+
+    protected readonly onDidFocusThreadEmitter = new Emitter<DebugThread | undefined>();
+    readonly onDidFocusThread = this.onDidFocusThreadEmitter.event;
 
     protected readonly onDidChangeBreakpointsEmitter = new Emitter<DidChangeBreakpointsEvent>();
     readonly onDidChangeBreakpoints = this.onDidChangeBreakpointsEmitter.event;
@@ -518,7 +516,10 @@ export class DebugSessionManager {
                 }
                 this.fireDidChange(current);
             }));
-            this.disposeOnCurrentSessionChanged.push(current.onDidFocusStackFrame(frame => this.onDidFocusStackFrameEmitter.fire({ session: current, frame })));
+            this.disposeOnCurrentSessionChanged.push(current.onDidFocusStackFrame(frame => this.onDidFocusStackFrameEmitter.fire(frame)));
+            this.disposeOnCurrentSessionChanged.push(current.onDidFocusThread(thread => this.onDidFocusThreadEmitter.fire(thread)));
+            const { currentThread } = current;
+            this.onDidFocusThreadEmitter.fire(currentThread);
         }
         this.updateBreakpoints(previous, current);
         this.open();

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -78,6 +78,11 @@ export class DebugSession implements CompositeTreeElement {
         return this.onDidFocusStackFrameEmitter.event;
     }
 
+    protected readonly onDidFocusThreadEmitter = new Emitter<DebugThread | undefined>();
+    get onDidFocusThread(): Event<DebugThread | undefined> {
+        return this.onDidFocusThreadEmitter.event;
+    }
+
     protected readonly onDidChangeBreakpointsEmitter = new Emitter<URI>();
     readonly onDidChangeBreakpoints: Event<URI> = this.onDidChangeBreakpointsEmitter.event;
     protected fireDidChangeBreakpoints(uri: URI): void {
@@ -254,8 +259,12 @@ export class DebugSession implements CompositeTreeElement {
         return this._currentThread;
     }
     set currentThread(thread: DebugThread | undefined) {
+        if (this._currentThread?.id === thread?.id) {
+            return;
+        }
         this.toDisposeOnCurrentThread.dispose();
         this._currentThread = thread;
+        this.onDidFocusThreadEmitter.fire(thread);
         this.fireDidChange();
         if (thread) {
             this.toDisposeOnCurrentThread.push(thread.onDidChanged(() => this.fireDidChange()));

--- a/packages/debug/src/browser/model/debug-stack-frame.tsx
+++ b/packages/debug/src/browser/model/debug-stack-frame.tsx
@@ -49,6 +49,13 @@ export class DebugStackFrame extends DebugStackFrameData implements TreeElement 
         return this.session.id + ':' + this.thread.id + ':' + this.raw.id;
     }
 
+    /**
+     * Returns the frame identifier from the debug protocol.
+     */
+    get frameId(): number {
+        return this.raw.id;
+    }
+
     protected _source: DebugSource | undefined;
     get source(): DebugSource | undefined {
         return this._source;

--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -56,11 +56,18 @@ export class DebugThread extends DebugThreadData implements TreeElement {
         return this.session.id + ':' + this.raw.id;
     }
 
+    get threadId(): number {
+        return this.raw.id;
+    }
+
     protected _currentFrame: DebugStackFrame | undefined;
     get currentFrame(): DebugStackFrame | undefined {
         return this._currentFrame;
     }
     set currentFrame(frame: DebugStackFrame | undefined) {
+        if (this._currentFrame?.id === frame?.id) {
+            return;
+        }
         this._currentFrame = frame;
         this.onDidChangedEmitter.fire(undefined);
         this.onDidFocusStackFrameEmitter.fire(frame);

--- a/packages/debug/src/browser/view/debug-threads-widget.ts
+++ b/packages/debug/src/browser/view/debug-threads-widget.ts
@@ -99,6 +99,7 @@ export class DebugThreadsWidget extends SourceTreeWidget {
                     this.viewModel.currentSession = node.element;
                     this.debugCallStackItemTypeKey.set('session');
                 } else if (node.element instanceof DebugThread) {
+                    this.viewModel.currentSession = node.element.session;
                     node.element.session.currentThread = node.element;
                     this.debugCallStackItemTypeKey.set('thread');
                 }

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -895,3 +895,13 @@ export interface InlineCompletionsProvider<T extends InlineCompletions = InlineC
     freeInlineCompletions(completions: T): void;
 }
 
+export interface DebugStackFrameDTO {
+    readonly sessionId: string,
+    readonly frameId: number,
+    readonly threadId: number
+}
+
+export interface DebugThreadDTO {
+    readonly sessionId: string,
+    readonly threadId: number
+}

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -89,7 +89,9 @@ import {
     InlineCompletionContext,
     DocumentDropEdit,
     DataTransferDTO,
-    DocumentDropEditProviderMetadata
+    DocumentDropEditProviderMetadata,
+    DebugStackFrameDTO,
+    DebugThreadDTO
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -1981,6 +1983,8 @@ export interface DebugExt {
         debugConfiguration: DebugConfiguration
     ): Promise<theia.DebugConfiguration | undefined | null>;
 
+    $onDidChangeActiveFrame(frame: DebugStackFrameDTO | undefined): void;
+    $onDidChangeActiveThread(thread: DebugThreadDTO | undefined): void;
     $createDebugSession(debugConfiguration: DebugConfiguration, workspaceFolder: string | undefined): Promise<string>;
     $terminateDebugSession(sessionId: string): Promise<void>;
     $getTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined>;

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -1101,13 +1101,11 @@ export function createAPIFactory(
             get onDidChangeBreakpoints(): theia.Event<theia.BreakpointsChangeEvent> {
                 return debugExt.onDidChangeBreakpoints;
             },
-            /** @stubbed */
             get activeStackItem(): DebugThread | DebugStackFrame | undefined {
-                return undefined;
+                return debugExt.activeStackItem;
             },
-            /** @stubbed */
             get onDidChangeActiveStackItem(): theia.Event<DebugThread | DebugStackFrame | undefined> {
-                return Event.None;
+                return debugExt.onDidChangeActiveStackItem;
             },
             registerDebugAdapterDescriptorFactory(debugType: string, factory: theia.DebugAdapterDescriptorFactory): Disposable {
                 return debugExt.registerDebugAdapterDescriptorFactory(debugType, factory);

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -3031,12 +3031,12 @@ export class FunctionBreakpoint extends Breakpoint {
     }
 }
 
-export class DebugThread {
-    private constructor(readonly session: theia.DebugSession, readonly threadId: number) { }
+export class DebugThread implements theia.DebugThread {
+    constructor(readonly session: theia.DebugSession, readonly threadId: number) { }
 }
 
-export class DebugStackFrame {
-    private constructor(readonly session: theia.DebugSession, readonly threadId: number, readonly frameId: number) { }
+export class DebugStackFrame implements theia.DebugStackFrame {
+      constructor(readonly session: theia.DebugSession, readonly threadId: number, readonly frameId: number) { }
 }
 
 @es5ClassCompat

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12548,13 +12548,11 @@ export module '@theia/plugin' {
          * thread or stack is focused. A thread can be focused any time there is
          * an active debug session, while a stack frame can only be focused when
          * a session is paused and the call stack has been retrieved.
-         * @stubbed
          */
         export const activeStackItem: DebugThread | DebugStackFrame | undefined;
 
         /**
          * An event which fires when the {@link debug.activeStackItem} has changed.
-         * @stubbed
          */
         export const onDidChangeActiveStackItem: Event<DebugThread | DebugStackFrame | undefined>;
 


### PR DESCRIPTION
#### What it does
Implement previously stubbed API for activeStackFrame API (DebugStackFrame & DebugThread)
Fixes #13846

Contributed on behalf of STMicroelectronics

#### How to test
1. Install the following extension, that adds the listener on the active Stack item:
- src: [debug-extension-sample-0.0.2-src.zip](https://github.com/user-attachments/files/16140775/debug-extension-sample-0.0.2-src.zip)
- zip vsix: [debug-extension-sample-0.0.2.zip](https://github.com/user-attachments/files/16140777/debug-extension-sample-0.0.2.zip)
2. Start debugging a project (I ran 2 simple hello world examples in the video)
3. Switching between stack frames in the Call Stack or to a DebugThread in the Threads view. Information message shall be displayed in the notification area, with the current stack item information. 

https://github.com/eclipse-theia/theia/assets/3964263/d36e75d7-9be3-4a2e-8f32-6ff59536ab55

We don't have exactly the same interface as in VS Code, so we get more easily the empty stack item message. That should not impact users, as selecting a thread or a stack frame still throws the active stack item change event.
  
#### Follow-ups
none

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
