### PR TITLE
Fix plugin version comparison

### DIFF
--- a/dev-packages/ovsx-client/src/ovsx-api-filter.ts
+++ b/dev-packages/ovsx-client/src/ovsx-api-filter.ts
@@ -127,7 +127,7 @@ export class OVSXApiFilterImpl implements OVSXApiFilter {
         if (!versionA || !versionB) {
             return false;
         }
-        return semver.lte(versionA, versionB);
+        return semver.gte(versionA, versionB);
     }
 
     protected supportedVscodeApiSatisfies(vscodeApiRange: string): boolean {

--- a/dev-packages/ovsx-client/src/ovsx-api-filter.ts
+++ b/dev-packages/ovsx-client/src/ovsx-api-filter.ts
@@ -90,7 +90,7 @@ export class OVSXApiFilterImpl implements OVSXApiFilter {
         if (extensions.length === 0) {
             return;
         } else if (this.isBuiltinNamespace(extensions[0].namespace.toLowerCase())) {
-            return extensions.find(extension => this.versionGreaterThanOrEqualTo(extension.version, this.supportedApiVersion));
+            return extensions.find(extension => this.versionGreaterThanOrEqualTo(this.supportedApiVersion, extension.version));
         } else {
             return extensions.find(extension => this.supportedVscodeApiSatisfies(extension.engines?.vscode ?? '*'));
         }
@@ -108,7 +108,7 @@ export class OVSXApiFilterImpl implements OVSXApiFilter {
             }
         }
         if (this.isBuiltinNamespace(searchEntry.namespace)) {
-            return getLatestCompatibleVersion(allVersions => this.versionGreaterThanOrEqualTo(allVersions.version, this.supportedApiVersion));
+            return getLatestCompatibleVersion(allVersions => this.versionGreaterThanOrEqualTo(this.supportedApiVersion, allVersions.version));
         } else {
             return getLatestCompatibleVersion(allVersions => this.supportedVscodeApiSatisfies(allVersions.engines?.vscode ?? '*'));
         }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13904

I'm confused by how this wasn't caught earlier. Even though our method was supposed to return `gte`, it did run `lte` internally. I've simply adjusted the called method to match the name and documentation. See also:

![image](https://github.com/eclipse-theia/theia/assets/4377073/b06f25f9-7fb9-4809-a6da-9d61e31233e9)

#### How to test

Try installing the [Astro](https://open-vsx.org/extension/astro-build/astro-vscode) VS Code extension via the vsx-registry view. It should work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
