### PR TITLE
Update Mac OS version to 14 in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, ubuntu-latest, macos-11]
+        os: [windows-2019, ubuntu-latest, macos-14]
         node: [16.x, 18.x, 20.x]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
#### What it does
Updates the target version for Mac CI test to 14. The v. 11 runners we now target are end of service.

(https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/)
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

n/a

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
