### PR TITLE
tab selected should be adjacent when closing last one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 <!-- ## not yet released 
 
 - [core] introduce `FRONTEND_CONNECTION_TIMEOUT` environment variable to override application connexion settings. [#13936](https://github.com/eclipse-theia/theia/pull/13936) - Contributed on behalf of STMicroelectronics
+- [core] tab selected should be adjacent when closing last one [#13912](https://github.com/eclipse-theia/theia/pull/13912) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
 

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1896,6 +1896,10 @@ export class ApplicationShell extends Widget {
         if (index < current.titles.length - 1) {
             return index + 1;
         }
+        // last item in tab bar. select the previous one.
+        if (index === current.titles.length - 1) {
+            return index - 1;
+        }
         return 0;
     }
 


### PR DESCRIPTION
#### What it does
In the case the last tab is closed in a tab bar, the tab selected should be the last one instead of the first one, in case there is no focus history.
 
fixes #13886

contributed on behalf of STMicroelectronics

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Reproduce steps in the video in #13886: 
1. Open several editors (6 or more), select one in the middle, close it, 
2. Close some editors around, 
3. When  3 or more are still opened, close the last one in the bar.
4. The selected tab should be the new last one, and not the first one on the bar.

#### Follow-ups

no known follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
- 