### PR TITLE
Allow opening changes for files associated with custom editors

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -350,3 +350,4 @@ button.secondary[disabled],
 @import "./progress-bar.css";
 @import "./breadcrumbs.css";
 @import "./tooltip.css";
+@import "./split-widget.css";

--- a/packages/core/src/browser/style/split-widget.css
+++ b/packages/core/src/browser/style/split-widget.css
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (C) 2024 1C-Soft LLC and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.theia-split-widget > .p-SplitPanel {
+  height: 100%;
+  width: 100%;
+  outline: none;
+}
+
+.theia-split-widget > .p-SplitPanel > .p-SplitPanel-child {
+  min-width: 50px;
+  min-height: var(--theia-content-line-height);
+}
+
+.theia-split-widget > .p-SplitPanel > .p-SplitPanel-handle {
+  box-sizing: border-box;
+}
+
+.theia-split-widget > .p-SplitPanel[data-orientation="horizontal"] > .p-SplitPanel-handle {
+  border-left: var(--theia-border-width) solid var(--theia-sideBarSectionHeader-border);
+}
+
+.theia-split-widget > .p-SplitPanel[data-orientation="vertical"] > .p-SplitPanel-handle {
+  border-top: var(--theia-border-width) solid var(--theia-sideBarSectionHeader-border);
+}

--- a/packages/core/src/browser/widget-open-handler.ts
+++ b/packages/core/src/browser/widget-open-handler.ts
@@ -24,7 +24,10 @@ import { WidgetManager } from './widget-manager';
 
 export type WidgetOpenMode = 'open' | 'reveal' | 'activate';
 /**
- * `WidgetOpenerOptions` define serializable generic options used by the {@link WidgetOpenHandler}.
+ * `WidgetOpenerOptions` define generic options used by the {@link WidgetOpenHandler}.
+ *
+ * _Note:_ This object may contain references to widgets (e.g. `widgetOptions.ref`);
+ * these need to be transformed before it can be serialized.
  */
 export interface WidgetOpenerOptions extends OpenerOptions {
     /**

--- a/packages/core/src/browser/widgets/index.ts
+++ b/packages/core/src/browser/widgets/index.ts
@@ -18,3 +18,4 @@ export * from './widget';
 export * from './react-renderer';
 export * from './react-widget';
 export * from './extractable-widget';
+export * from './split-widget';

--- a/packages/core/src/browser/widgets/split-widget.ts
+++ b/packages/core/src/browser/widgets/split-widget.ts
@@ -1,0 +1,163 @@
+// *****************************************************************************
+// Copyright (C) 2024 1C-Soft LLC and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter } from 'vscode-languageserver-protocol';
+import { ApplicationShell, StatefulWidget } from '../shell';
+import { BaseWidget, Message, PanelLayout, SplitPanel, Widget } from './widget';
+import { CompositeSaveable, Saveable, SaveableSource } from '../saveable';
+import { Navigatable } from '../navigatable-types';
+import { URI } from '../../common';
+
+/**
+ * A widget containing a number of panes in a split layout.
+ */
+export class SplitWidget extends BaseWidget implements ApplicationShell.TrackableWidgetProvider, SaveableSource, Navigatable, StatefulWidget {
+
+    protected readonly splitPanel: SplitPanel;
+
+    protected readonly onDidChangeTrackableWidgetsEmitter = new Emitter<Widget[]>();
+    readonly onDidChangeTrackableWidgets = this.onDidChangeTrackableWidgetsEmitter.event;
+
+    protected readonly compositeSaveable = new CompositeSaveable();
+
+    protected navigatable?: Navigatable;
+
+    constructor(options?: SplitPanel.IOptions & { navigatable?: Navigatable }) {
+        super();
+
+        this.toDispose.pushAll([this.onDidChangeTrackableWidgetsEmitter]);
+
+        this.addClass('theia-split-widget');
+
+        const layout = new PanelLayout();
+        this.layout = layout;
+        const that = this;
+        this.splitPanel = new class extends SplitPanel {
+
+            protected override onChildAdded(msg: Widget.ChildMessage): void {
+                super.onChildAdded(msg);
+                that.onPaneAdded(msg.child);
+            }
+
+            protected override onChildRemoved(msg: Widget.ChildMessage): void {
+                super.onChildRemoved(msg);
+                that.onPaneRemoved(msg.child);
+            }
+        }({
+            spacing: 1, // --theia-border-width
+            ...options
+        });
+        this.splitPanel.node.tabIndex = -1;
+        layout.addWidget(this.splitPanel);
+
+        this.navigatable = options?.navigatable;
+    }
+
+    get orientation(): SplitPanel.Orientation {
+        return this.splitPanel.orientation;
+    }
+
+    set orientation(value: SplitPanel.Orientation) {
+        this.splitPanel.orientation = value;
+    }
+
+    relativeSizes(): number[] {
+        return this.splitPanel.relativeSizes();
+    }
+
+    setRelativeSizes(sizes: number[]): void {
+        this.splitPanel.setRelativeSizes(sizes);
+    }
+
+    get handles(): readonly HTMLDivElement[] {
+        return this.splitPanel.handles;
+    }
+
+    get saveable(): Saveable {
+        return this.compositeSaveable;
+    }
+
+    getResourceUri(): URI | undefined {
+        return this.navigatable?.getResourceUri();
+    }
+
+    createMoveToUri(resourceUri: URI): URI | undefined {
+        return this.navigatable?.createMoveToUri(resourceUri);
+    }
+
+    storeState(): SplitWidget.State {
+        return { orientation: this.orientation, widgets: this.panes, relativeSizes: this.relativeSizes() };
+    }
+
+    restoreState(oldState: SplitWidget.State): void {
+        const { orientation, widgets, relativeSizes } = oldState;
+        if (orientation) {
+            this.orientation = orientation;
+        }
+        for (const widget of widgets) {
+            this.addPane(widget);
+        }
+        if (relativeSizes) {
+            this.setRelativeSizes(relativeSizes);
+        }
+    }
+
+    get panes(): readonly Widget[] {
+        return this.splitPanel.widgets;
+    }
+
+    getTrackableWidgets(): Widget[] {
+        return [...this.panes];
+    }
+
+    protected fireDidChangeTrackableWidgets(): void {
+        this.onDidChangeTrackableWidgetsEmitter.fire(this.getTrackableWidgets());
+    }
+
+    addPane(pane: Widget): void {
+        this.splitPanel.addWidget(pane);
+    }
+
+    insertPane(index: number, pane: Widget): void {
+        this.splitPanel.insertWidget(index, pane);
+    }
+
+    protected onPaneAdded(pane: Widget): void {
+        if (Saveable.isSource(pane)) {
+            this.compositeSaveable.add(pane.saveable);
+        }
+        this.fireDidChangeTrackableWidgets();
+    }
+
+    protected onPaneRemoved(pane: Widget): void {
+        if (Saveable.isSource(pane)) {
+            this.compositeSaveable.remove(pane.saveable);
+        }
+        this.fireDidChangeTrackableWidgets();
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        this.splitPanel.node.focus();
+    }
+}
+
+export namespace SplitWidget {
+    export interface State {
+        orientation?: SplitPanel.Orientation;
+        widgets: readonly Widget[]; // note: don't rename this property; it has special meaning for `ShellLayoutRestorer`
+        relativeSizes?: number[];
+    }
+}

--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -89,6 +89,12 @@ export namespace Event {
         return new Promise(resolve => once(event)(resolve));
     }
 
+    export function filter<T>(event: Event<T>, predicate: (e: T) => unknown): Event<T>;
+    export function filter<T, S extends T>(event: Event<T>, predicate: (e: T) => e is S): Event<S>;
+    export function filter<T>(event: Event<T>, predicate: (e: T) => unknown): Event<T> {
+        return (listener, thisArg, disposables) => event(e => predicate(e) && listener.call(thisArg, e), undefined, disposables);
+    }
+
     /**
      * Given an event and a `map` function, returns another event which maps each element
      * through the mapping function.

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -419,6 +419,10 @@ export class FileService {
         return activation;
     }
 
+    hasProvider(scheme: string): boolean {
+        return this.providers.has(scheme);
+    }
+
     /**
      * Tests if the service (i.e. any of its registered {@link FileSystemProvider}s) can handle the given resource.
      * @param resource `URI` of the resource to test.

--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -23,9 +23,10 @@ import {
     MenuAction,
     MenuContribution,
     MenuModelRegistry,
+    MessageService,
     Mutable
 } from '@theia/core';
-import { codicon, DiffUris, Widget } from '@theia/core/lib/browser';
+import { codicon, DiffUris, Widget, open, OpenerService } from '@theia/core/lib/browser';
 import {
     TabBarToolbarContribution,
     TabBarToolbarItem,
@@ -281,6 +282,8 @@ export class GitContribution implements CommandContribution, MenuContribution, T
 
     protected toDispose = new DisposableCollection();
 
+    @inject(OpenerService) protected openerService: OpenerService;
+    @inject(MessageService) protected messageService: MessageService;
     @inject(EditorManager) protected readonly editorManager: EditorManager;
     @inject(GitQuickOpenService) protected readonly quickOpenService: GitQuickOpenService;
     @inject(GitRepositoryTracker) protected readonly repositoryTracker: GitRepositoryTracker;
@@ -562,7 +565,9 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         registry.registerCommand(GIT_COMMANDS.OPEN_CHANGED_FILE, {
             execute: (...arg: ScmResource[]) => {
                 for (const resource of arg) {
-                    this.editorManager.open(resource.sourceUri, { mode: 'reveal' });
+                    open(this.openerService, resource.sourceUri, { mode: 'reveal' }).catch(e => {
+                        this.messageService.error(e.message);
+                    });
                 }
             }
         });

--- a/packages/git/src/browser/git-file-service-contribution.ts
+++ b/packages/git/src/browser/git-file-service-contribution.ts
@@ -1,0 +1,33 @@
+// *****************************************************************************
+// Copyright (C) 2024 1C-Soft LLC and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { interfaces } from '@theia/core/shared/inversify';
+import { FileService, FileServiceContribution } from '@theia/filesystem/lib/browser/file-service';
+import { GitFileSystemProvider } from './git-file-system-provider';
+import { GIT_RESOURCE_SCHEME } from './git-resource';
+
+export class GitFileServiceContribution implements FileServiceContribution {
+
+    constructor(protected readonly container: interfaces.Container) { }
+
+    registerFileSystemProviders(service: FileService): void {
+        service.onWillActivateFileSystemProvider(event => {
+            if (event.scheme === GIT_RESOURCE_SCHEME) {
+                service.registerProvider(GIT_RESOURCE_SCHEME, this.container.get(GitFileSystemProvider));
+            }
+        });
+    }
+}

--- a/packages/git/src/browser/git-file-system-provider.ts
+++ b/packages/git/src/browser/git-file-system-provider.ts
@@ -1,0 +1,84 @@
+// *****************************************************************************
+// Copyright (C) 2024 1C-Soft LLC and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { Event, URI, Disposable } from '@theia/core';
+import {
+    FileChange,
+    FileDeleteOptions,
+    FileOverwriteOptions,
+    FileSystemProvider,
+    FileSystemProviderCapabilities,
+    FileType,
+    FileWriteOptions,
+    Stat,
+    WatchOptions
+} from '@theia/filesystem/lib/common/files';
+import { GitResourceResolver } from './git-resource-resolver';
+import { EncodingService } from '@theia/core/lib/common/encoding-service';
+
+@injectable()
+export class GitFileSystemProvider implements FileSystemProvider {
+
+    readonly capabilities = FileSystemProviderCapabilities.Readonly |
+        FileSystemProviderCapabilities.FileReadWrite | FileSystemProviderCapabilities.PathCaseSensitive;
+
+    readonly onDidChangeCapabilities: Event<void> = Event.None;
+    readonly onDidChangeFile: Event<readonly FileChange[]> = Event.None;
+    readonly onFileWatchError: Event<void> = Event.None;
+
+    @inject(GitResourceResolver)
+    protected readonly resourceResolver: GitResourceResolver;
+
+    @inject(EncodingService)
+    protected readonly encodingService: EncodingService;
+
+    watch(resource: URI, opts: WatchOptions): Disposable {
+        return Disposable.NULL;
+    }
+
+    async stat(resource: URI): Promise<Stat> {
+        const gitResource = await this.resourceResolver.getResource(resource);
+        const size = await gitResource.getSize();
+        return { type: FileType.File, mtime: 0, ctime: 0, size };
+    }
+
+    async readFile(resource: URI): Promise<Uint8Array> {
+        const gitResource = await this.resourceResolver.getResource(resource);
+        const contents = await gitResource.readContents({ encoding: 'binary' });
+        return this.encodingService.encode(contents, { encoding: 'binary', hasBOM: false }).buffer;
+    }
+
+    writeFile(resource: URI, content: Uint8Array, opts: FileWriteOptions): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    mkdir(resource: URI): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    readdir(resource: URI): Promise<[string, FileType][]> {
+        throw new Error('Method not implemented.');
+    }
+
+    delete(resource: URI, opts: FileDeleteOptions): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    rename(from: URI, to: URI, opts: FileOverwriteOptions): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -43,6 +43,9 @@ import { ScmHistorySupport } from '@theia/scm-extra/lib/browser/history/scm-hist
 import { ScmHistoryProvider } from '@theia/scm-extra/lib/browser/history';
 import { GitHistorySupport } from './history/git-history-support';
 import { GitDecorationProvider } from './git-decoration-provider';
+import { GitFileSystemProvider } from './git-file-system-provider';
+import { GitFileServiceContribution } from './git-file-service-contribution';
+import { FileServiceContribution } from '@theia/filesystem/lib/browser/file-service';
 
 export default new ContainerModule(bind => {
     bindGitPreferences(bind);
@@ -75,6 +78,10 @@ export default new ContainerModule(bind => {
 
     bind(GitSyncService).toSelf().inSingletonScope();
     bind(GitErrorHandler).toSelf().inSingletonScope();
+
+    bind(GitFileSystemProvider).toSelf().inSingletonScope();
+    bind(GitFileServiceContribution).toDynamicValue(ctx => new GitFileServiceContribution(ctx.container)).inSingletonScope();
+    bind(FileServiceContribution).toService(GitFileServiceContribution);
 });
 
 export function createGitScmProviderFactory(ctx: interfaces.Context): GitScmProvider.Factory {

--- a/packages/git/src/browser/git-repository-provider.spec.ts
+++ b/packages/git/src/browser/git-repository-provider.spec.ts
@@ -26,7 +26,7 @@ import { DugiteGit } from '../node/dugite-git';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { FileStat, FileChangesEvent } from '@theia/filesystem/lib/common/files';
 import { Emitter, CommandService, Disposable } from '@theia/core';
-import { LocalStorageService, StorageService, LabelProvider } from '@theia/core/lib/browser';
+import { LocalStorageService, StorageService, LabelProvider, OpenerService } from '@theia/core/lib/browser';
 import { GitRepositoryProvider } from './git-repository-provider';
 import * as sinon from 'sinon';
 import * as chai from 'chai';
@@ -97,6 +97,7 @@ describe('GitRepositoryProvider', () => {
         testContainer.bind(ScmContextKeyService).toSelf().inSingletonScope();
         testContainer.bind(ContextKeyService).to(ContextKeyServiceDummyImpl).inSingletonScope();
         testContainer.bind(GitCommitMessageValidator).toSelf().inSingletonScope();
+        testContainer.bind(OpenerService).toConstantValue(<OpenerService>{});
         testContainer.bind(EditorManager).toConstantValue(<EditorManager>{});
         testContainer.bind(GitErrorHandler).toConstantValue(<GitErrorHandler>{});
         testContainer.bind(CommandService).toConstantValue(<CommandService>{});

--- a/packages/git/src/browser/git-resource.ts
+++ b/packages/git/src/browser/git-resource.ts
@@ -36,5 +36,20 @@ export class GitResource implements Resource {
         return '';
     }
 
+    async getSize(): Promise<number> {
+        if (this.repository) {
+            const path = Repository.relativePath(this.repository, this.uri.withScheme('file'))?.toString();
+            if (path) {
+                const commitish = this.uri.query || 'index';
+                const args = commitish !== 'index' ? ['ls-tree', '--format=%(objectsize)', commitish, path] : ['ls-files', '--format=%(objectsize)', '--', path];
+                const size = (await this.git.exec(this.repository, args)).stdout.split('\n').filter(line => !!line.trim())[0];
+                if (size) {
+                    return parseInt(size);
+                }
+            }
+        }
+        return 0;
+    }
+
     dispose(): void { }
 }

--- a/packages/git/src/browser/git-scm-provider.spec.ts
+++ b/packages/git/src/browser/git-scm-provider.spec.ts
@@ -21,7 +21,7 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { CommandService, Disposable, ILogger, MessageService } from '@theia/core';
-import { LabelProvider } from '@theia/core/lib/browser';
+import { LabelProvider, OpenerService } from '@theia/core/lib/browser';
 import { FileUri } from '@theia/core/lib/node';
 import { Container } from '@theia/core/shared/inversify';
 import { EditorManager } from '@theia/editor/lib/browser';
@@ -46,6 +46,7 @@ disableJSDOM();
 
 describe('GitScmProvider', () => {
     let testContainer: Container;
+    let mockOpenerService: OpenerService;
     let mockEditorManager: EditorManager;
     let mockGitErrorHandler: GitErrorHandler;
     let mockFileService: FileService;
@@ -65,6 +66,7 @@ describe('GitScmProvider', () => {
     });
 
     beforeEach(async () => {
+        mockOpenerService = {} as OpenerService;
         mockEditorManager = sinon.createStubInstance(EditorManager);
         mockGitErrorHandler = sinon.createStubInstance(GitErrorHandler);
         mockFileService = sinon.createStubInstance(FileService);
@@ -73,6 +75,7 @@ describe('GitScmProvider', () => {
         mockLabelProvider = sinon.createStubInstance(LabelProvider);
 
         testContainer = new Container();
+        testContainer.bind(OpenerService).toConstantValue(mockOpenerService);
         testContainer.bind(EditorManager).toConstantValue(mockEditorManager);
         testContainer.bind(GitErrorHandler).toConstantValue(mockGitErrorHandler);
         testContainer.bind(FileService).toConstantValue(mockFileService);

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -48,6 +48,8 @@ import { GitExecProvider } from './git-exec-provider';
 import { GitEnvProvider } from './env/git-env-provider';
 import { GitInit } from './init/git-init';
 
+import upath = require('upath');
+
 /**
  * Parsing and converting raw Git output into Git model instances.
  */
@@ -548,7 +550,9 @@ export class DugiteGit implements Git {
         const path = this.getFsPath(uri);
         const [exec, env] = await Promise.all([this.execProvider.exec(), this.gitEnv.promise]);
         if (encoding === 'binary') {
-            return (await getBlobContents(repositoryPath, commitish, path, { exec, env })).toString();
+            // note: contrary to what its jsdoc says, getBlobContents expects a (normalized) relative path
+            const relativePath = upath.normalizeSafe(Path.relative(repositoryPath, path));
+            return (await getBlobContents(repositoryPath, commitish, relativePath, { exec, env })).toString('binary');
         }
         return (await getTextContents(repositoryPath, commitish, path, { exec, env })).toString();
     }

--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -67,7 +67,7 @@ export class MonacoEditorService extends StandaloneCodeEditorService {
         let editor = MonacoEditor.getCurrent(this.editors);
         if (!editor && CustomEditorWidget.is(this.shell.activeWidget)) {
             const model = this.shell.activeWidget.modelRef.object;
-            if (model.editorTextModel instanceof MonacoEditorModel) {
+            if (model?.editorTextModel instanceof MonacoEditorModel) {
                 editor = MonacoEditor.findByDocument(this.editors, model.editorTextModel)[0];
             }
         }

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1882,7 +1882,7 @@ export interface CustomEditorsExt {
         newWebviewHandle: string,
         viewType: string,
         title: string,
-        widgetOpenerOptions: object | undefined,
+        position: number,
         options: theia.WebviewPanelOptions,
         cancellation: CancellationToken): Promise<void>;
     $createCustomDocument(resource: UriComponents, viewType: string, openContext: theia.CustomDocumentOpenContext, cancellation: CancellationToken): Promise<{ editable: boolean }>;
@@ -1905,7 +1905,6 @@ export interface CustomEditorsMain {
     $registerTextEditorProvider(viewType: string, options: theia.WebviewPanelOptions, capabilities: CustomTextEditorCapabilities): void;
     $registerCustomEditorProvider(viewType: string, options: theia.WebviewPanelOptions, supportsMultipleEditorsPerDocument: boolean): void;
     $unregisterEditorProvider(viewType: string): void;
-    $createCustomEditorPanel(handle: string, title: string, widgetOpenerOptions: object | undefined, options: theia.WebviewPanelOptions & theia.WebviewOptions): Promise<void>;
     $onDidEdit(resource: UriComponents, viewType: string, editId: number, label: string | undefined): void;
     $onContentChange(resource: UriComponents, viewType: string): void;
 }

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -209,7 +209,8 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
         this.notebookRendererMessagingService.onWillActivateRenderer(rendererId => this.activateByNotebookRenderer(rendererId));
 
         this.widgets.onDidCreateWidget(({ factoryId, widget }) => {
-            if ((factoryId === WebviewWidget.FACTORY_ID || factoryId === CustomEditorWidget.FACTORY_ID) && widget instanceof WebviewWidget) {
+            // note: state restoration of custom editors is handled in `PluginCustomEditorRegistry.init`
+            if (factoryId === WebviewWidget.FACTORY_ID && widget instanceof WebviewWidget) {
                 const storeState = widget.storeState.bind(widget);
                 const restoreState = widget.restoreState.bind(widget);
 

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
@@ -15,12 +15,12 @@
 // *****************************************************************************
 
 import URI from '@theia/core/lib/common/uri';
-import { ApplicationShell, OpenHandler, WidgetManager, WidgetOpenerOptions } from '@theia/core/lib/browser';
+import { ApplicationShell, DiffUris, OpenHandler, SplitWidget, Widget, WidgetManager, WidgetOpenerOptions } from '@theia/core/lib/browser';
 import { CustomEditor, CustomEditorPriority, CustomEditorSelector } from '../../../common';
 import { CustomEditorWidget } from './custom-editor-widget';
 import { PluginCustomEditorRegistry } from './plugin-custom-editor-registry';
 import { generateUuid } from '@theia/core/lib/common/uuid';
-import { Emitter } from '@theia/core';
+import { DisposableCollection, Emitter } from '@theia/core';
 import { match } from '@theia/core/lib/common/glob';
 
 export class CustomEditorOpener implements OpenHandler {
@@ -46,7 +46,13 @@ export class CustomEditorOpener implements OpenHandler {
     }
 
     canHandle(uri: URI): number {
-        if (this.matches(this.editor.selector, uri)) {
+        const { selector } = this.editor;
+        if (DiffUris.isDiffUri(uri)) {
+            const [left, right] = DiffUris.decode(uri);
+            if (this.matches(selector, right) && this.matches(selector, left)) {
+                return this.getPriority();
+            }
+        } else if (this.matches(selector, uri)) {
             return this.getPriority();
         }
         return 0;
@@ -63,9 +69,9 @@ export class CustomEditorOpener implements OpenHandler {
     }
 
     protected readonly pendingWidgetPromises = new Map<string, Promise<CustomEditorWidget>>();
-    async open(uri: URI, options?: WidgetOpenerOptions): Promise<CustomEditorWidget> {
+    protected async openCustomEditor(uri: URI, options?: WidgetOpenerOptions): Promise<CustomEditorWidget> {
         let widget: CustomEditorWidget | undefined;
-        let shouldNotify = false;
+        let isNewWidget = false;
         const uriString = uri.toString();
         let widgetPromise = this.pendingWidgetPromises.get(uriString);
         if (widgetPromise) {
@@ -74,14 +80,16 @@ export class CustomEditorOpener implements OpenHandler {
             const widgets = this.widgetManager.getWidgets(CustomEditorWidget.FACTORY_ID) as CustomEditorWidget[];
             widget = widgets.find(w => w.viewType === this.editor.viewType && w.resource.toString() === uriString);
             if (!widget) {
-                shouldNotify = true;
+                isNewWidget = true;
                 const id = generateUuid();
                 widgetPromise = this.widgetManager.getOrCreateWidget<CustomEditorWidget>(CustomEditorWidget.FACTORY_ID, { id }).then(async w => {
                     try {
                         w.viewType = this.editor.viewType;
                         w.resource = uri;
                         await this.editorRegistry.resolveWidget(w);
-                        await this.shell.addWidget(w, options?.widgetOptions);
+                        if (options?.widgetOptions) {
+                            await this.shell.addWidget(w, options.widgetOptions);
+                        }
                         return w;
                     } catch (e) {
                         w.dispose();
@@ -92,16 +100,79 @@ export class CustomEditorOpener implements OpenHandler {
                 widget = await widgetPromise;
             }
         }
-        const mode = options?.mode ?? 'activate';
-        if (mode === 'activate') {
+        if (options?.mode === 'activate') {
             await this.shell.activateWidget(widget.id);
-        } else if (mode === 'reveal') {
+        } else if (options?.mode === 'reveal') {
             await this.shell.revealWidget(widget.id);
         }
-        if (shouldNotify) {
+        if (isNewWidget) {
             this.onDidOpenCustomEditorEmitter.fire([widget, options]);
         }
         return widget;
+    }
+
+    protected async openSideBySide(uri: URI, options?: WidgetOpenerOptions): Promise<Widget | undefined> {
+        const [leftUri, rightUri] = DiffUris.decode(uri);
+        const widget = await this.widgetManager.getOrCreateWidget<SplitWidget>(
+            CustomEditorWidget.SIDE_BY_SIDE_FACTORY_ID, { uri: uri.toString(), viewType: this.editor.viewType });
+        if (!widget.panes.length) { // a new widget
+            const trackedDisposables = new DisposableCollection(widget);
+            try {
+                const createPane = async (paneUri: URI) => {
+                    let pane = await this.openCustomEditor(paneUri);
+                    if (pane.isAttached) {
+                        await this.shell.closeWidget(pane.id);
+                        if (!pane.isDisposed) { // user canceled
+                            return undefined;
+                        }
+                        pane = await this.openCustomEditor(paneUri);
+                    }
+                    return pane;
+                };
+
+                const rightPane = await createPane(rightUri);
+                if (!rightPane) {
+                    trackedDisposables.dispose();
+                    return undefined;
+                }
+                trackedDisposables.push(rightPane);
+
+                const leftPane = await createPane(leftUri);
+                if (!leftPane) {
+                    trackedDisposables.dispose();
+                    return undefined;
+                }
+                trackedDisposables.push(leftPane);
+
+                widget.addPane(leftPane);
+                widget.addPane(rightPane);
+
+                // dispose the widget if either of its panes gets externally disposed
+                leftPane.disposed.connect(() => widget.dispose());
+                rightPane.disposed.connect(() => widget.dispose());
+
+                if (options?.widgetOptions) {
+                    await this.shell.addWidget(widget, options.widgetOptions);
+                }
+            } catch (e) {
+                trackedDisposables.dispose();
+                console.error(e);
+                throw e;
+            }
+        }
+        if (options?.mode === 'activate') {
+            await this.shell.activateWidget(widget.id);
+        } else if (options?.mode === 'reveal') {
+            await this.shell.revealWidget(widget.id);
+        }
+        return widget;
+    }
+
+    async open(uri: URI, options?: WidgetOpenerOptions): Promise<Widget | undefined> {
+        options = { ...options };
+        options.mode ??= 'activate';
+        options.widgetOptions ??= { area: 'main' };
+        return DiffUris.isDiffUri(uri) ? this.openSideBySide(uri, options) : this.openCustomEditor(uri, options);
     }
 
     matches(selectors: CustomEditorSelector[], resource: URI): boolean {

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
@@ -27,6 +27,7 @@ import { CustomEditorWidget as CustomEditorWidgetShape } from '@theia/editor/lib
 @injectable()
 export class CustomEditorWidget extends WebviewWidget implements CustomEditorWidgetShape, SaveableSource, NavigatableWidget {
     static override FACTORY_ID = 'plugin-custom-editor';
+    static readonly SIDE_BY_SIDE_FACTORY_ID = CustomEditorWidget.FACTORY_ID + '.side-by-side';
 
     override id: string;
     resource: URI;
@@ -66,17 +67,15 @@ export class CustomEditorWidget extends WebviewWidget implements CustomEditorWid
     }
 
     undo(): void {
-        this._modelRef.object.undo();
+        this._modelRef.object?.undo();
     }
 
     redo(): void {
-        this._modelRef.object.redo();
+        this._modelRef.object?.redo();
     }
 
     async save(options?: SaveOptions): Promise<void> {
-        if (this._modelRef.object) {
-            await this._modelRef.object.saveCustomEditor(options);
-        }
+        await this._modelRef.object?.saveCustomEditor(options);
     }
 
     async saveAs(source: URI, target: URI, options?: SaveOptions): Promise<void> {

--- a/packages/plugin-ext/src/main/browser/webview/pre/service-worker.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/service-worker.js
@@ -226,7 +226,8 @@ async function processResourceRequest(event, requestUrl, resourceRoot) {
 
     parentClient.postMessage({
         channel: 'load-resource',
-        path: resourcePath
+        path: resourcePath,
+        query: requestUrl.search.replace(/^\?/, '')
     });
 
     return resourceRequestStore.create(webviewId, resourcePath)

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -48,7 +48,6 @@ import { isFirefox } from '@theia/core/lib/browser/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
 import { BinaryBufferReadableStream } from '@theia/core/lib/common/buffer';
-import { ViewColumn } from '../../../plugin/types-impl';
 import { ExtractableWidget } from '@theia/core/lib/browser/widgets/extractable-widget';
 import { BadgeWidget } from '@theia/core/lib/browser/view-container';
 import { MenuPath } from '@theia/core';
@@ -185,7 +184,6 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
     }
 
     viewType: string;
-    viewColumn: ViewColumn;
     options: WebviewPanelOptions = {};
 
     protected ready = new Deferred<void>();

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -191,7 +191,12 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async $postMessage(handle: string, value: any): Promise<boolean> {
-        const webview = await this.getWebview(handle);
+        // Due to async nature of $postMessage, the webview may have been disposed in the meantime.
+        // Therefore, don't throw an error if the webview is not found, but return false in this case.
+        const webview = await this.tryGetWebview(handle);
+        if (!webview) {
+            return false;
+        }
         webview.sendMessage(value);
         return true;
     }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -319,7 +319,7 @@ export function createAPIFactory(
     const themingExt = rpc.set(MAIN_RPC_CONTEXT.THEMING_EXT, new ThemingExtImpl(rpc));
     const commentsExt = rpc.set(MAIN_RPC_CONTEXT.COMMENTS_EXT, new CommentsExtImpl(rpc, commandRegistry, documents));
     const tabsExt = rpc.set(MAIN_RPC_CONTEXT.TABS_EXT, new TabsExtImpl(rpc));
-    const customEditorExt = rpc.set(MAIN_RPC_CONTEXT.CUSTOM_EDITORS_EXT, new CustomEditorsExtImpl(rpc, documents, webviewExt, workspaceExt));
+    const customEditorExt = rpc.set(MAIN_RPC_CONTEXT.CUSTOM_EDITORS_EXT, new CustomEditorsExtImpl(rpc, documents, webviewExt));
     const webviewViewsExt = rpc.set(MAIN_RPC_CONTEXT.WEBVIEW_VIEWS_EXT, new WebviewViewsExtImpl(rpc, webviewExt));
     const telemetryExt = rpc.set(MAIN_RPC_CONTEXT.TELEMETRY_EXT, new TelemetryExtImpl());
     const testingExt = rpc.set(MAIN_RPC_CONTEXT.TESTING_EXT, new TestingExtImpl(rpc, commandRegistry));

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -255,7 +255,7 @@ export class WebviewImpl implements theia.Webview {
             .replace('{{authority}}', resource.authority)
             .replace('{{path}}', resource.path.replace(/^\//, ''))
             .replace('{{uuid}}', this.origin ?? this.viewId);
-        return URI.parse(uri);
+        return URI.parse(uri).with({ query: resource.query });
     }
 
     get cspSource(): string {


### PR DESCRIPTION
#### What it does

Allows the user to visually compare two versions of a file that is associated with a custom editor. This is done by opening both versions of the file simultaneously in a side-by-side editor, with each version being opened in a separate custom editor contained in the side-by-side editor.

For example, this feature can be used to help spot the differences between two versions of an image file associated with the custom editor contributed by the VS Code `media-preview` plugin, as illustrated with the following screenshot:

<img width="2032" alt="Screenshot" src="https://github.com/eclipse-theia/theia/assets/8298491/8cdfe884-5718-4bf0-9bd0-f326b07b88e3">

More screenshots illustrating this feature being used with other custom editors:

<img width="1304" alt="Screenshot" src="https://github.com/eclipse-theia/theia/assets/8298491/9bcee523-5275-40e1-8954-ff3b7dab63a9">

<img width="1304" alt="Screenshot" src="https://github.com/eclipse-theia/theia/assets/8298491/8bb529f2-f769-45d0-9ca2-8d5599c52916">

This PR contains a series of individual commits that work together to make it possible for the `CustomEditorOpener` to open a diff-uri in a side-by-side editor containing the corresponding `CustomEditor`s. While the main functionality is contributed by the latest commit, the earlier commits provide various fixes and enhancements required to make it work.

Here is the sequence of commits:

- Fix loading of webview resources that depend on query params
    
    Some resource url (notably git) use the query part of the url to store additional information. The query part of the url was incorrectly being dropped while attempting to load these resources inside of webviews.

- Fix `Error: Unknown Webview` messages in the log

- Fix design and implementation issues surrounding `CustomEditorOpener`
    
    This commit ensures that the promise returned by `CustomEditorOpener.open` will only resolve to a properly initialized and opened `CustomEditorWidget`. In particular, it ensures that the widget is opened according to the specified `WidgetOpenerOptions`, including `widgetOptions.ref` and `mode`.
    
    Essentially, it revises the work done in #9671 and #10580.

- Restore custom editors as part of layout
    
    Fixes an incorrect assumption that a custom editor cannot be restored if no `WebviewPanelSerializer` is registered for its view type. (Actually, custom editors are created and restored using a custom editor provider.)
    
    Also, ensures that `CustomEditorWidget.modelRef` satisfies the shape for the `CustomEditorWidget` defined in `editor.ts` and cannot return `undefined`. (However, `CustomEditorWidget.modelRef.object` can be `undefined` until the custom editor is resolved.)
    
    Fixes #10787

- Fix a race condition when file system provider is activated
    
    When file system provider is activated, wait until it is registered.
    
- git: add support for custom editors
    
    * Uses `OpenerService` instead of `EditorManager` to open editors
    
    * Contributes a `FileSystemProvider` for git-resources
    
    * Fixes an issue with getting blob contents

- custom editor: open a diff-uri in a side-by-side editor
    
    `CustomEditorOpener` is now able to open a diff-uri in a side-by-side editor, which contains the corresponding `CustomEditor`s.
    
    Fixes #9079

#### How to test

There are various configurations that can be used for testing this feature:

* Windows vs. Linux vs. macOS

* Browser vs. Electron

* `vscode.git` vs. (now deprecated) `@theia/git`

This feature can be tested with any custom editor.

A basic test scenario involves making a change to a file associated with a custom editor (e.g., `.jpg`, `.png`, `.pawDraw`, or `.cscratch`) and then opening changes in a side-by-side editor by clicking on the file in the Source Control view.

Since this PR also fixes an issue with custom editors not being restored as part of layout, it is worth checking out that custom editors are now correctly restored, both standalone and as part of side-by-side editors.

Also, it is important to verify that there are no regressions, especially that standalone custom editors can still be opened and work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
