### PR TITLE
Make Notebook preferences registration substitutable

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-preferences.ts
+++ b/packages/notebook/src/browser/contributions/notebook-preferences.ts
@@ -19,7 +19,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { nls } from '@theia/core';
-import { PreferenceSchema } from '@theia/core/lib/browser';
+import { interfaces } from '@theia/core/shared/inversify';
+import { PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser';
 
 export namespace NotebookPreferences {
     export const NOTEBOOK_LINE_NUMBERS = 'notebook.lineNumbers';
@@ -81,3 +82,11 @@ export const notebookPreferenceSchema: PreferenceSchema = {
 
     }
 };
+
+export const NotebookPreferenceContribution = Symbol('NotebookPreferenceContribution');
+
+export function bindNotebookPreferences(bind: interfaces.Bind): void {
+    // We don't need a NotebookPreferenceConfiguration class, so there's no preference proxy to bind
+    bind(NotebookPreferenceContribution).toConstantValue({ schema: notebookPreferenceSchema });
+    bind(PreferenceContribution).toService(NotebookPreferenceContribution);
+}

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -16,7 +16,7 @@
 import '../../src/browser/style/index.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { FrontendApplicationContribution, KeybindingContribution, LabelProviderContribution, OpenHandler, PreferenceContribution, WidgetFactory } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, KeybindingContribution, LabelProviderContribution, OpenHandler, WidgetFactory } from '@theia/core/lib/browser';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { NotebookOpenHandler } from './notebook-open-handler';
 import { CommandContribution, MenuContribution, ResourceResolver, } from '@theia/core';
@@ -44,7 +44,7 @@ import { NotebookOutlineContribution } from './contributions/notebook-outline-co
 import { NotebookLabelProviderContribution } from './contributions/notebook-label-provider-contribution';
 import { NotebookOutputActionContribution } from './contributions/notebook-output-action-contribution';
 import { NotebookClipboardService } from './service/notebook-clipboard-service';
-import { notebookPreferenceSchema } from './contributions/notebook-preferences';
+import { bindNotebookPreferences } from './contributions/notebook-preferences';
 import { NotebookOptionsService } from './service/notebook-options';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -106,6 +106,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookLabelProviderContribution).toSelf().inSingletonScope();
     bind(LabelProviderContribution).toService(NotebookLabelProviderContribution);
 
-    bind(PreferenceContribution).toConstantValue({ schema: notebookPreferenceSchema });
+    bindNotebookPreferences(bind);
     bind(NotebookOptionsService).toSelf().inSingletonScope();
 });


### PR DESCRIPTION
#### What it does

Implement the commonly employed pattern for preference contribution registration to enable substitution of the Notebook preference schema.

Fixes #13913

#### How to test

Verify that the Notebook preferences appear in the Settings panel as before.
Open some kind of notebook and verify that the specific preference settings have the expected effect on notebook behaviour, output, etc. For example, in a GitHub Issues Notebook, create a code cell, enter some code, and toggle the line numbers preference setting to see how line numbers appear or not in the cell editor.

#### Follow-ups

No follow-up is identified at this time.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
