### PR TITLE
Introduce environment variable to override connexion settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 <!-- ## not yet released 
 
+- [core] introduce `FRONTEND_CONNECTION_TIMEOUT` environment variable to override application connexion settings. [#13936](https://github.com/eclipse-theia/theia/pull/13936) - Contributed on behalf of STMicroelectronics
+
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
 
  -->

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -152,6 +152,10 @@ Where `root` is the name of the logger and `INFO` is the log level. These are op
   - If possible, you should set this environment variable:
     - When not set, Theia will allow any origin to access the WebSocket services.
     - When set, Theia will only allow the origins defined in this environment variable.
+- `FRONTEND_CONNECTION_TIMEOUT`
+  - The duration in milliseconds during which the backend keeps the connexion contexts for the frontend to reconnect.
+  - This duration defaults to '0' if not set.
+  - If set to negative number, the backend will never close the connection.    
 
 ## Additional Information
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -153,7 +153,7 @@ Where `root` is the name of the logger and `INFO` is the log level. These are op
     - When not set, Theia will allow any origin to access the WebSocket services.
     - When set, Theia will only allow the origins defined in this environment variable.
 - `FRONTEND_CONNECTION_TIMEOUT`
-  - The duration in milliseconds during which the backend keeps the connexion contexts for the frontend to reconnect.
+  - The duration in milliseconds during which the backend keeps the connection contexts for the frontend to reconnect.
   - This duration defaults to '0' if not set.
   - If set to negative number, the backend will never close the connection.    
 

--- a/packages/core/README_TEMPLATE.md
+++ b/packages/core/README_TEMPLATE.md
@@ -121,6 +121,10 @@ Where `root` is the name of the logger and `INFO` is the log level. These are op
   - If possible, you should set this environment variable:
     - When not set, Theia will allow any origin to access the WebSocket services.
     - When set, Theia will only allow the origins defined in this environment variable.
+- `FRONTEND_CONNECTION_TIMEOUT`
+  - The duration in milliseconds during which the backend keeps the connexion contexts for the frontend to reconnect.
+  - This duration defaults to '0' if not set.
+  - If set to negative number, the backend will never close the connection.    
 
 ## Additional Information
 

--- a/packages/core/README_TEMPLATE.md
+++ b/packages/core/README_TEMPLATE.md
@@ -122,7 +122,7 @@ Where `root` is the name of the logger and `INFO` is the log level. These are op
     - When not set, Theia will allow any origin to access the WebSocket services.
     - When set, Theia will only allow the origins defined in this environment variable.
 - `FRONTEND_CONNECTION_TIMEOUT`
-  - The duration in milliseconds during which the backend keeps the connexion contexts for the frontend to reconnect.
+  - The duration in milliseconds during which the backend keeps the connection contexts for the frontend to reconnect.
   - This duration defaults to '0' if not set.
   - If set to negative number, the backend will never close the connection.    
 

--- a/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
+++ b/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
@@ -105,7 +105,8 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
         socket.on('disconnect', evt => {
             console.info('socked closed');
             channel.disconnect();
-            const timeout = BackendApplicationConfigProvider.get().frontendConnectionTimeout;
+
+            const timeout = this.frontendConnectionTimeout();
             const isMarkedForClose = this.channelsMarkedForClose.delete(frontEndId);
             if (timeout === 0 || isMarkedForClose) {
                 this.closeConnection(frontEndId, evt);
@@ -123,6 +124,16 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
 
     markForClose(channelId: string): void {
         this.channelsMarkedForClose.add(channelId);
+    }
+
+    private frontendConnectionTimeout(): number {
+        const envValue = Number(process.env['FRONTEND_CONNECTION_TIMEOUT']);
+        if (!isNaN(envValue)) {
+            return envValue;
+        }
+
+        const configValue = BackendApplicationConfigProvider.get().frontendConnectionTimeout;
+        return configValue;
     }
 }
 

--- a/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
+++ b/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
@@ -132,8 +132,7 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
             return envValue;
         }
 
-        const configValue = BackendApplicationConfigProvider.get().frontendConnectionTimeout;
-        return configValue;
+        return BackendApplicationConfigProvider.get().frontendConnectionTimeout;
     }
 }
 


### PR DESCRIPTION
#### What it does
Adds support for a `FRONTEND_CONNECTION_TIMEOUT` environment variable to override configuration setting for the backend.

fixes #13800

Contributed on behalf of STMicroelectronics

#### How to test
1. Start default browser example (`yarn browser start` from terminal). Open a browser window and access `localhost:3000`
2. Close this browser window and check the settings value for frontend connexion timeout on the log in debug console. This should be some entry like `setting close timeout for id fb80451d-10da-416b-b656-062c78ba408a to 3000`
3. Set the environment variable to another value, as for example `export FRONTEND_CONNECTION_TIMEOUT=10000`
4. restart the default browser example and close the browser again. this time, the close timeout log should be the one that you set.
5. Some other tests can be made with `-1`, closing directly the connection or with something else than a number. It should then turn back to default config, e.g. 3000.

#### Follow-ups

none

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
 