### PR TITLE
Add DebugSessionOptions.testRun

### DIFF
--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.insertSpaces": true,
   "[typescript]": {
     "editor.tabSize": 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
-<!-- ## not yet released 
+## not yet released 
+- [test] Added `DebugSessionOptions.testRun` [#13939](https://github.com/eclipse-theia/theia/pull/13939) - Contributed on behalf of STMicroelectronics
 
 - [core] introduce `FRONTEND_CONNECTION_TIMEOUT` environment variable to override application connexion settings. [#13936](https://github.com/eclipse-theia/theia/pull/13936) - Contributed on behalf of STMicroelectronics
 - [core] tab selected should be adjacent when closing last one [#13912](https://github.com/eclipse-theia/theia/pull/13912) - contributed on behalf of STMicroelectronics
@@ -12,8 +13,6 @@
 - [debug] implement activeStackItem and related change event in debug namespace [#13900](https://github.com/eclipse-theia/theia/pull/13900) - contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_not_yet_released">[Breaking Changes:](#breaking_changes_not_yet_released)</a> 
-
- -->
 
 ## 1.50.0 - 06/27/2024
 

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -13,6 +13,7 @@
     "@theia/output": "1.51.0",
     "@theia/process": "1.51.0",
     "@theia/task": "1.51.0",
+    "@theia/test": "1.51.0",
     "@theia/terminal": "1.51.0",
     "@theia/variable-resolver": "1.51.0",
     "@theia/workspace": "1.51.0",

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -386,7 +386,7 @@ export class DebugSessionManager {
         const parentSession = options.configuration.parentSessionId ? this._sessions.get(options.configuration.parentSessionId) : undefined;
         const contrib = this.sessionContributionRegistry.get(options.configuration.type);
         const sessionFactory = contrib ? contrib.debugSessionFactory() : this.debugSessionFactory;
-        const session = sessionFactory.get(sessionId, options, parentSession);
+        const session = sessionFactory.get(this, sessionId, options, parentSession);
         this._sessions.set(sessionId, session);
 
         this.debugTypeKey.set(session.configuration.type);

--- a/packages/debug/src/browser/debug-session-options.ts
+++ b/packages/debug/src/browser/debug-session-options.ts
@@ -31,8 +31,14 @@ export class DebugCompoundRoot {
     }
 }
 
+export interface TestRunReference {
+    controllerId: string,
+    runId: string
+}
+
 export interface DebugSessionOptionsBase {
     workspaceFolderUri?: string,
+    testRun?: TestRunReference
 }
 
 export interface DebugConfigurationSessionOptions extends DebugSessionOptionsBase {

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -100,6 +100,10 @@ export interface DebugSessionOptions {
     suppressSaveBeforeStart?: boolean;
     suppressDebugStatusbar?: boolean;
     suppressDebugView?: boolean;
+    testRun?: {
+        controllerId: string,
+        runId: string
+    }
 }
 
 export enum DebugConsoleMode {

--- a/packages/debug/tsconfig.json
+++ b/packages/debug/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "../terminal"
     },
     {
+      "path": "../test"
+    },
+    {
       "path": "../variable-resolver"
     },
     {

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -58,6 +58,7 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { DebugSessionOptions as TheiaDebugSessionOptions } from '@theia/debug/lib/browser/debug-session-options';
 import { DebugStackFrame } from '@theia/debug/lib/browser/model/debug-stack-frame';
 import { DebugThread } from '@theia/debug/lib/browser/model/debug-thread';
+import { TestService } from '@theia/test/lib/browser/test-service';
 
 export class DebugMainImpl implements DebugMain, Disposable {
     private readonly debugExt: DebugExt;
@@ -77,6 +78,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
     private readonly fileService: FileService;
     private readonly pluginService: HostedPluginSupport;
     private readonly debugContributionProvider: ContributionProvider<DebugContribution>;
+    private readonly testService: TestService;
     private readonly workspaceService: WorkspaceService;
 
     private readonly debuggerContributions = new Map<string, DisposableCollection>();
@@ -100,6 +102,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
         this.debugContributionProvider = container.getNamed(ContributionProvider, DebugContribution);
         this.fileService = container.get(FileService);
         this.pluginService = container.get(HostedPluginSupport);
+        this.testService = container.get(TestService);
         this.workspaceService = container.get(WorkspaceService);
 
         const fireDidChangeBreakpoints = ({ added, removed, changed }: BreakpointsChangeEvent<SourceBreakpoint | FunctionBreakpoint>) => {
@@ -165,6 +168,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
             this.fileService,
             terminalOptionsExt,
             this.debugContributionProvider,
+            this.testService,
             this.workspaceService,
         );
 
@@ -327,6 +331,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
         } else {
             sessionOptions = { ...sessionOptions, ...options, workspaceFolderUri };
         }
+        sessionOptions.testRun = options.testRun;
 
         // start options
         const session = await this.sessionManager.start(sessionOptions);
@@ -345,7 +350,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
     }
 
     private toDebugStackFrameDTO(stackFrame: DebugStackFrame | undefined): DebugStackFrameDTO | undefined {
-        return stackFrame ?  {
+        return stackFrame ? {
             sessionId: stackFrame.session.id,
             frameId: stackFrame.frameId,
             threadId: stackFrame.thread.threadId

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12087,6 +12087,12 @@ export module '@theia/plugin' {
          * When true, the debug viewlet will not be automatically revealed for this session.
          */
         suppressDebugView?: boolean;
+        /**
+         * Signals to the editor that the debug session was started from a test run
+         * request. This is used to link the lifecycle of the debug session and
+         * test run in UI actions.
+         */
+        testRun?: TestRun;
     }
 
     /**

--- a/packages/test/src/browser/test-service.ts
+++ b/packages/test/src/browser/test-service.ts
@@ -96,6 +96,7 @@ export interface TestStateChangedEvent {
 
 export interface TestRun {
     cancel(): void;
+    readonly id: string;
     readonly name: string;
     readonly isRunning: boolean;
     readonly controller: TestController;
@@ -189,6 +190,20 @@ export interface TestService {
     cancelRefresh(): void;
     isRefreshing: boolean;
     onDidChangeIsRefreshing: Event<void>;
+}
+
+export namespace TestServices {
+    export function withTestRun(service: TestService, controllerId: string, runId: string): TestRun {
+        const controller = service.getControllers().find(c => c.id === controllerId);
+        if (!controller) {
+            throw new Error(`No test controller with id '${controllerId}' found`);
+        }
+        const run = controller.testRuns.find(r => r.id === runId);
+        if (!run) {
+            throw new Error(`No test run with id '${runId}' found`);
+        }
+        return run;
+    }
 }
 
 export const TestContribution = Symbol('TestContribution');

--- a/packages/test/src/browser/view/test-run-view-contribution.ts
+++ b/packages/test/src/browser/view/test-run-view-contribution.ts
@@ -62,10 +62,7 @@ export class TestRunViewContribution extends AbstractViewContribution<TestRunTre
     override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(TestViewCommands.CANCEL_RUN, {
-            isEnabled: t => {
-                console.log('is enabled');
-                return TestRun.is(t) && t.isRunning
-            },
+            isEnabled: t => TestRun.is(t) && t.isRunning,
             isVisible: t => TestRun.is(t),
             execute: t => {
                 if (TestRun.is(t)) {

--- a/packages/test/src/browser/view/test-run-view-contribution.ts
+++ b/packages/test/src/browser/view/test-run-view-contribution.ts
@@ -62,7 +62,10 @@ export class TestRunViewContribution extends AbstractViewContribution<TestRunTre
     override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(TestViewCommands.CANCEL_RUN, {
-            isEnabled: t => TestRun.is(t) && t.isRunning,
+            isEnabled: t => {
+                console.log('is enabled');
+                return TestRun.is(t) && t.isRunning
+            },
             isVisible: t => TestRun.is(t),
             execute: t => {
                 if (TestRun.is(t)) {


### PR DESCRIPTION
#### What it does
Adds the `DebugSessionOptions.testRun` field. The behavioral change associated with this is that a debug session that is started as part of test run will be terminated when the test run ends.

Fixes #13872

Contributed on behalf of STMicroelectronics

#### How to test
The attached plugin contributes a test controller with a single test. 
1. In the test explorer, click the "debug" icon on the line of the test
2. Observe: a test run is started and a nodejs program associated with test is started in the debugger
3. Select the test run in the test run view and choose "cancel test run" from the context menu
4. Observe: the debug session is terminated.


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
