### PR TITLE
Prevent the rendering of the tab bar tooltip if no caption is provided

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -619,7 +619,7 @@ export class TabBarRenderer extends TabBar.Renderer {
                         cssClasses: ['extended-tab-preview'],
                         visualPreview: this.corePreferences?.['window.tabbar.enhancedPreview'] === 'visual' ? width => this.renderVisualPreview(width, title) : undefined
                     });
-                } else {
+                } else if (title.caption) {
                     this.hoverService.requestHover({
                         content: title.caption,
                         target: event.currentTarget,

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -78,6 +78,7 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
     protected init(): void {
         this.id = PreferencesWidget.ID;
         this.title.label = PreferencesWidget.LABEL;
+        this.title.caption = PreferencesWidget.LABEL;
         this.title.closable = true;
         this.addClass('theia-settings-container');
         this.title.iconClass = codicon('settings');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Adds the caption label for the settings widget
- Prevent the rendering of the tooltip by the tab bar if no caption is available

Closes #13005.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Dock the settings widget and hover the icon.

Before:
![image](https://github.com/user-attachments/assets/cb27c948-eced-4303-99a4-1841763cfc1a)

Fix:
![image](https://github.com/user-attachments/assets/e73bd909-6051-409d-9ad6-783da6fdd207)


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
