### PR TITLE
Fix flaky playwright Theia Main Menu test

### DIFF
--- a/examples/playwright/src/tests/theia-main-menu.test.ts
+++ b/examples/playwright/src/tests/theia-main-menu.test.ts
@@ -97,7 +97,7 @@ test.describe('Theia Main Menu', () => {
         await (await menuBar.openMenu('Help')).clickMenuItem('About');
         const aboutDialog = new TheiaAboutDialog(app);
         expect(await aboutDialog.isVisible()).toBe(true);
-        await aboutDialog.page.getByRole('button', { name: 'OK' }).click();
+        await aboutDialog.page.locator('#theia-dialog-shell').getByRole('button', { name: 'OK' }).click();
         expect(await aboutDialog.isVisible()).toBe(false);
     });
 


### PR DESCRIPTION
#### What it does

We are observing cases where the `.getByRole('button', { name: 'OK' })` resolved to multiple elements (e.g. [here](https://github.com/eclipse-theia/theia/actions/runs/10025491100)).

With this change we limit the selection to the dialog shell and hopefully remove this ambiguity.

Contributed on behalf of STMicroelectronics.

#### How to test

Check that the Playwright test check in the CI works for this PR.
We will continue to observe the stability after merging this PR.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
