### PR TITLE
[vscode] Bump API version to 1.91.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 <!-- ## not yet released 
 
+- [application-package] bumped the default supported API from `1.90.2` to `1.91.1` [#]() - Contributed on behalf of STMicroelectronics
 - [core] introduce `FRONTEND_CONNECTION_TIMEOUT` environment variable to override application connexion settings. [#13936](https://github.com/eclipse-theia/theia/pull/13936) - Contributed on behalf of STMicroelectronics
 - [core] tab selected should be adjacent when closing last one [#13912](https://github.com/eclipse-theia/theia/pull/13912) - contributed on behalf of STMicroelectronics
 - [core] upgraded ws to 8.18.0 [#13903](https://github.com/eclipse-theia/theia/pull/13903) - contributed on behalf of STMicroelectronics

--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.90.2';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.91.1';


### PR DESCRIPTION
#### What it does

Increase compatibility version to 1.91.1 as implementation tasks from task #13873 are closed.

Fixes #13954

Contributed on behalf of STMicroelectronics

#### How to test

Make sure the system starts and built-ins work as expected as described in https://github.com/eclipse-theia/vscode-builtin-extensions/wiki/Produce-and-Publish-the-set-of-vscode-built-in-extensions#local-testing with version 1.91.1

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)