### PR TITLE
feat(plugin-ext): Fix instanceof check to handle VSCode URIs

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -275,6 +275,7 @@ import { NotebookKernelsExtImpl } from './notebook/notebook-kernels';
 import { NotebookDocumentsExtImpl } from './notebook/notebook-documents';
 import { NotebookEditorsExtImpl } from './notebook/notebook-editors';
 import { TestingExtImpl } from './tests';
+import { URI as CodeURI } from '@theia/core/shared/vscode-uri';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -439,7 +440,7 @@ export function createAPIFactory(
                 preserveFocus?: boolean
             ): Promise<theia.TextEditor> {
                 let documentOptions: theia.TextDocumentShowOptions | undefined;
-                const uri: URI = documentArg instanceof URI ? documentArg : documentArg.uri;
+                const uri: URI = documentArg instanceof CodeURI ? documentArg : documentArg.uri;
                 if (typeof columnOrOptions === 'number') {
                     documentOptions = {
                         viewColumn: columnOrOptions
@@ -717,7 +718,7 @@ export function createAPIFactory(
                 if (typeof uriOrFileNameOrOptions === 'string') {
                     uri = URI.file(uriOrFileNameOrOptions);
 
-                } else if (uriOrFileNameOrOptions instanceof URI) {
+                } else if (uriOrFileNameOrOptions instanceof CodeURI) {
                     uri = uriOrFileNameOrOptions;
 
                 } else if (!options || typeof options === 'object') {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Fixes #13949

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Follow the steps to reproduce in the issue and verify that it's fixed.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
There are more places in the `plugin-ext` package that have an `instanceof` check for Theia URIs. I have restricted my changes to the scope of the file `plugin-context.ts`.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
