### PR TITLE
Rely on IConfigurationService change event to update model options

### DIFF
--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -45,13 +45,6 @@ export interface MonacoEditorModelFactory {
 export class MonacoTextModelService implements ITextModelService {
     declare readonly _serviceBrand: undefined;
 
-    /**
-     * This component does some asynchronous work before being fully initialized.
-     *
-     * @deprecated since 1.25.0. Is instantly resolved.
-     */
-    readonly ready: Promise<void> = Promise.resolve();
-
     protected readonly _models = new ReferenceCollection<string, MonacoEditorModel>(
         uri => this.loadModel(new URI(uri))
     );
@@ -121,10 +114,6 @@ export class MonacoTextModelService implements ITextModelService {
         await this.editorPreferences.ready;
         const resource = await this.resourceProvider(uri);
         const model = await (await this.createModel(resource)).load();
-        this.updateModel(model);
-        model.textEditorModel.onDidChangeLanguage(() => this.updateModel(model));
-        const disposable = this.editorPreferences.onPreferenceChanged(change => this.updateModel(model, change));
-        model.onDispose(() => disposable.dispose());
         return model;
     }
 
@@ -152,37 +141,6 @@ export class MonacoTextModelService implements ITextModelService {
 
         }
         return undefined;
-    }
-
-    protected updateModel(model: MonacoEditorModel, change?: EditorPreferenceChange): void {
-        if (!change) {
-            model.textEditorModel.updateOptions(this.getModelOptions(model));
-        } else if (change.affects(model.uri, model.languageId)) {
-            const modelOption = this.toModelOption(change.preferenceName);
-            if (modelOption) {
-                model.textEditorModel.updateOptions(this.getModelOptions(model));
-            }
-        }
-    }
-
-    /** @deprecated pass MonacoEditorModel instead  */
-    protected getModelOptions(uri: string): ITextModelUpdateOptions;
-    protected getModelOptions(model: MonacoEditorModel): ITextModelUpdateOptions;
-    protected getModelOptions(arg: string | MonacoEditorModel): ITextModelUpdateOptions {
-        const uri = typeof arg === 'string' ? arg : arg.uri;
-        const overrideIdentifier = typeof arg === 'string' ? undefined : arg.languageId;
-        return {
-            tabSize: this.editorPreferences.get({ preferenceName: 'editor.tabSize', overrideIdentifier }, undefined, uri),
-            // @monaco-uplift: when available, switch to 'editor.indentSize' preference.
-            indentSize: this.editorPreferences.get({ preferenceName: 'editor.tabSize', overrideIdentifier }, undefined, uri),
-            insertSpaces: this.editorPreferences.get({ preferenceName: 'editor.insertSpaces', overrideIdentifier }, undefined, uri),
-            bracketColorizationOptions: {
-                enabled: this.editorPreferences.get({ preferenceName: 'editor.bracketPairColorization.enabled', overrideIdentifier }, undefined, uri),
-                independentColorPoolPerBracketType: this.editorPreferences.get(
-                    { preferenceName: 'editor.bracketPairColorization.independentColorPoolPerBracketType', overrideIdentifier }, undefined, uri),
-            },
-            trimAutoWhitespace: this.editorPreferences.get({ preferenceName: 'editor.trimAutoWhitespace', overrideIdentifier }, undefined, uri),
-        };
     }
 
     registerTextModelContentProvider(scheme: string, provider: ITextModelContentProvider): IDisposable {


### PR DESCRIPTION
#### What it does
We had code that would explicitly listen for preference changes and apply those settings to the editor text model. This code was not honoring the "editor.detectIndentation" preference. I don't believe we still need this code since the monaco `EditorModelService` ist listening for those changes in its injected `IConfigurationService` itself. A while back, we the system-wide injection infrastructure (part of https://github.com/eclipse-theia/theia/pull/13217), so this should work now.

Fixes #13920, #13929

Contributed on behalf of STMicroelectronics
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Repeat the failing scenarios from the linked issues, they should work now
2. Make sure editor preferences are still properly applied, for example, open a markdown file in an editor, then add the following section to your settings.json: 
   ```"[markdown]": {
        "editor.wordWrap": "off",
        "editor.insertSpaces": "false",
        "editor.tabSize": 10
    }
```
3. Observe: the changed settings are applied to the open editor

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
