### PR TITLE
Drop support for Node 16.x

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Use Python 3.11
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, ubuntu-latest, macos-14]
-        node: [16.x, 18.x, 20.x]
+        node: [18.x, 20.x]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['18.x']
+        node: ['20.x']
         java: ['11']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.11

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Use Node.js "18.x"
+      - name: Use Node.js "20.x"
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.11

--- a/.github/workflows/production-smoke-test.yml
+++ b/.github/workflows/production-smoke-test.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Use Node.js "18.x"
+      - name: Use Node.js "20.x"
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.11

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 0 # To fetch all history for all branches and tags. (Will be required for caching with lerna: https://github.com/markuplint/markuplint/pull/111)
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Use Python 3.x

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -18,10 +18,10 @@ jobs:
           # Required for lerna to determine the version of the next package.
           fetch-depth: 0
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.11

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.11

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+<a name="breaking_changes_1.53.0">[Breaking Changes:](#breaking_changes_1.51.0)</a>
+- [dependencies] increased minimum node version to 18. [#14027](https://github.com/eclipse-theia/theia/pull/14027) - Contributed on behalf of STMicroelectronics
+
+
 ## 1.52.0 - 07/25/2024
 
 - [application-package] bumped the default supported API from `1.90.2` to `1.91.1` [#13955](https://github.com/eclipse-theia/theia/pull/13955) - Contributed on behalf of STMicroelectronics

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -508,7 +508,7 @@ etc.) by opening `packages/<package name>/coverage/index.html`.
 
  - Install [`scoop`](https://github.com/lukesampson/scoop#installation).
  - Install [`nvm`](https://github.com/coreybutler/nvm-windows) with scoop: `scoop install nvm`.
- - Install Node.js with `nvm`: `nvm install 18.17.0`, then use it: `nvm use 18.17.0`. You can list all available Node.js versions with `nvm list available` if you want to pick another version.
+ - Install Node.js with `nvm`: `nvm install lts`, then use it: `nvm use lts`. You can list all available Node.js versions with `nvm list available` if you want to pick another version.
  - Install `yarn`: `scoop install yarn`.
  - If you need to install `windows-build-tools`, see [`Installing Windows Build Tools`](#installing-windows-build-tools).
  - If you run into problems with installing the required build tools, the `node-gyp` documentation offers a useful [guide](https://github.com/nodejs/node-gyp#on-windows) how to install the dependencies manually. The versions required for building Theia are:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=16"
+    "node": ">=18"
   },
   "resolutions": {
     "**/@types/node": "18"


### PR DESCRIPTION
#### What it does
Fixes #13956

Contributed on behalf of STMicroelectronics

We're dropping support for Node 16 targets because it's out of maintenance and we'd like to update some packages to versions that are incompatible with Node 16.

Node that support for Node 22 is not working yet due to some incompatible packages we need to replace first.

#### How to test
Code needs to build on all platforms and do a general "smoke" test of programming functionality.

#### Follow-ups
- [ ] https://github.com/eclipse-theia/theia/issues/14026
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
