### PR TITLE
testing/profiles/context menu contribution

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -316,7 +316,11 @@ export class DynamicMenuWidget extends MenuWidget {
             }
         } else if (menu.command) {
             const node = menu.altNode && this.services.context.altPressed ? menu.altNode : (menu as MenuNode & CommandMenuNode);
-            if (commands.isVisible(node.command) && this.undefinedOrMatch(this.options.contextKeyService ?? this.services.contextKeyService, node.when, this.options.context)) {
+            let contextMatcher: ContextMatcher = this.options.contextKeyService || this.services.contextKeyService;
+            if (node.contextKeyOverlays) {
+                contextMatcher = this.services.contextKeyService.createOverlay(node.contextKeyOverlays.map(item => [item.key, item.value]));
+            }
+            if (commands.isVisible(node.command) && this.undefinedOrMatch(contextMatcher, node.when, this.options.context)) {
                 parentItems.push({
                     command: node.command,
                     type: 'command'

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.ts
@@ -27,5 +27,6 @@ export class ToolbarMenuNodeWrapper implements TabBarToolbarItem {
     get tooltip(): string | undefined { return this.menuNode.label; }
     get when(): string | undefined { return this.menuNode.when; }
     get text(): string | undefined { return (this.group === NAVIGATION || this.group === undefined) ? undefined : this.menuNode.label; }
+    get contextKeyOverlays(): { key: string, value: string }[] | undefined { return this.menuNode.contextKeyOverlays; }
 }
 

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -24,6 +24,7 @@ import { ACTION_ITEM, codicon, ReactWidget, Widget } from '../../widgets';
 import { TabBarToolbarRegistry } from './tab-bar-toolbar-registry';
 import { AnyToolbarItem, ReactTabBarToolbarItem, TabBarDelegator, TabBarToolbarItem, TAB_BAR_TOOLBAR_CONTEXT_MENU, MenuToolbarItem } from './tab-bar-toolbar-types';
 import { KeybindingRegistry } from '../..//keybinding';
+import { ToolbarMenuNodeWrapper } from './tab-bar-toolbar-menu-adapters';
 
 /**
  * Factory for instantiating tab-bar toolbars.
@@ -297,6 +298,7 @@ export class TabBarToolbar extends ReactWidget {
                         commandId: item.command,
                         when: item.when,
                         order: item.order,
+                        contextKeyOverlays: item instanceof ToolbarMenuNodeWrapper ? item.contextKeyOverlays : undefined
                     }));
                 }
             }

--- a/packages/core/src/common/menu/action-menu-node.ts
+++ b/packages/core/src/common/menu/action-menu-node.ts
@@ -39,6 +39,8 @@ export class ActionMenuNode implements MenuNode, CommandMenuNode, Partial<Altern
 
     get when(): string | undefined { return this.action.when; }
 
+    get contextKeyOverlays(): { key: string, value: string }[] | undefined { return this.action.contextKeyOverlays; }
+
     get id(): string { return this.action.commandId; }
 
     get label(): string {

--- a/packages/core/src/common/menu/menu-types.ts
+++ b/packages/core/src/common/menu/menu-types.ts
@@ -44,6 +44,11 @@ export interface MenuNodeMetadata {
      * A reference to the parent node - useful for determining the menu path by which the node can be accessed.
      */
     readonly parent?: MenuNode;
+
+    /**
+     * Set of context keys passed to the ContextKeyMatcher when evaluating visibility or enablement
+     */
+    readonly contextKeyOverlays?: { key: string, value: string }[]
 }
 
 /**
@@ -67,7 +72,8 @@ export interface MenuNodeBase extends MenuNodeMetadata, MenuNodeRenderingData { 
 /**
  * A menu entry representing an action, e.g. "New File".
  */
-export interface MenuAction extends MenuNodeRenderingData, Pick<MenuNodeMetadata, 'when'> {
+export interface MenuAction extends MenuNodeRenderingData, Pick<MenuNodeMetadata, 'when'>, Pick<MenuNodeMetadata, 'contextKeyOverlays'> {
+
     /**
      * The command to execute.
      */

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -25,13 +25,14 @@ import { ScmWidget } from '@theia/scm/lib/browser/scm-widget';
 import { QuickCommandService } from '@theia/core/lib/browser';
 import {
     CodeEditorWidgetUtil, codeToTheiaMappings, ContributionPoint,
-    PLUGIN_EDITOR_TITLE_MENU, PLUGIN_EDITOR_TITLE_RUN_MENU, PLUGIN_SCM_TITLE_MENU, PLUGIN_VIEW_TITLE_MENU
+    PLUGIN_EDITOR_TITLE_MENU, PLUGIN_EDITOR_TITLE_RUN_MENU, PLUGIN_SCM_TITLE_MENU, PLUGIN_TEST_VIEW_TITLE_MENU, PLUGIN_VIEW_TITLE_MENU
 } from './vscode-theia-menu-mappings';
 import { PluginMenuCommandAdapter, ReferenceCountingSet } from './plugin-menu-command-adapter';
 import { ContextKeyExpr } from '@theia/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { PluginSharedStyle } from '../plugin-shared-style';
 import { ThemeIcon } from '@theia/monaco-editor-core/esm/vs/base/common/themables';
+import { TestTreeWidget } from '@theia/test/lib/browser/view/test-tree-widget';
 
 @injectable()
 export class MenusContributionPointHandler {
@@ -62,6 +63,7 @@ export class MenusContributionPointHandler {
         });
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_SCM_TITLE_MENU, widget => widget instanceof ScmWidget);
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_VIEW_TITLE_MENU, widget => !this.codeEditorWidgetUtil.is(widget));
+        this.tabBarToolbar.registerMenuDelegate(PLUGIN_TEST_VIEW_TITLE_MENU, widget => widget instanceof TestTreeWidget);
         this.tabBarToolbar.registerItem({ id: 'plugin-menu-contribution-title-contribution', command: '_never_', onDidChange: this.onDidChangeTitleContributionEmitter.event });
         this.contextKeyService.onDidChange(event => {
             if (event.affects(this.titleContributionContextKeys)) {

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -24,7 +24,7 @@ import { DeployedPlugin, IconUrl, Menu } from '../../../common';
 import { ScmWidget } from '@theia/scm/lib/browser/scm-widget';
 import { QuickCommandService } from '@theia/core/lib/browser';
 import {
-    CodeEditorWidgetUtil, codeToTheiaMappings, ContributionPoint,
+    CodeEditorWidgetUtil, codeToTheiaMappings, codeToTheiaGroupProviders, ContributionPoint,
     PLUGIN_EDITOR_TITLE_MENU, PLUGIN_EDITOR_TITLE_RUN_MENU, PLUGIN_SCM_TITLE_MENU, PLUGIN_TEST_VIEW_TITLE_MENU, PLUGIN_VIEW_TITLE_MENU
 } from './vscode-theia-menu-mappings';
 import { PluginMenuCommandAdapter, ReferenceCountingSet } from './plugin-menu-command-adapter';
@@ -76,6 +76,10 @@ export class MenusContributionPointHandler {
         return codeToTheiaMappings.get(contributionPoint);
     }
 
+    private getMatchingGroup(contributionPoint: ContributionPoint, item: Menu): string | undefined {
+        return codeToTheiaGroupProviders.get(contributionPoint)?.(item) ?? item.group;
+    }
+
     handle(plugin: DeployedPlugin): Disposable {
         const allMenus = plugin.contributes?.menus;
         if (!allMenus) {
@@ -99,7 +103,8 @@ export class MenusContributionPointHandler {
                     } else {
                         this.checkTitleContribution(contributionPoint, item, toDispose);
                         const targets = this.getMatchingMenu(contributionPoint as ContributionPoint) ?? [contributionPoint];
-                        const { group, order } = this.parseGroup(item.group);
+                        const matchingGroup = this.getMatchingGroup(contributionPoint as ContributionPoint, item);
+                        const { group, order } = this.parseGroup(matchingGroup);
                         const { submenu, command } = item;
                         if (submenu && command) {
                             console.warn(

--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -108,6 +108,7 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
             ['scm/resourceState/context', toScmArgs],
             ['scm/title', () => [this.toScmArg(this.scmService.selectedRepository)]],
             ['testing/message/context', toTestMessageArgs],
+            ['testing/profiles/context', noArgs],
             ['scm/change/title', (...args) => this.toScmChangeArgs(...args)],
             ['timeline/item/context', (...args) => this.toTimelineArgs(...args)],
             ['view/item/context', (...args) => this.toTreeArgs(...args)],

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -35,6 +35,7 @@ import { EDITOR_LINENUMBER_CONTEXT_MENU } from '@theia/editor/lib/browser/editor
 import { TEST_VIEW_CONTEXT_MENU } from '@theia/test/lib/browser/view/test-view-contribution';
 import { TEST_RUNS_CONTEXT_MENU } from '@theia/test/lib/browser/view/test-run-view-contribution';
 import { TerminalMenus } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
+import { Menu } from '../../../common';
 
 export const PLUGIN_EDITOR_TITLE_MENU = ['plugin_editor/title'];
 export const PLUGIN_EDITOR_TITLE_RUN_MENU = ['plugin_editor/title/run'];
@@ -104,6 +105,10 @@ export const codeToTheiaMappings = new Map<ContributionPoint, MenuPath[]>([
     ['terminal/context', [TerminalMenus.TERMINAL_CONTRIBUTIONS]],
     ['terminal/title/context', [TerminalMenus.TERMINAL_TITLE_CONTRIBUTIONS]]
 
+]);
+
+export const codeToTheiaGroupProviders = new Map<string, (menu: Menu) => string>([
+    ['testing/profiles/context', () => 'configure']
 ]);
 
 type CodeEditorWidget = EditorWidget | WebviewWidget;

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -111,6 +111,10 @@ export const codeToTheiaGroupProviders = new Map<string, (menu: Menu) => string>
     ['testing/profiles/context', () => 'configure']
 ]);
 
+export const codeToTheiaContextKeyOverlays = new Map<string, { key: string, values: string[] }>([
+    ['testing/profiles/context', { key: 'testing.profile.context.group', values: ['run', 'debug', 'coverage'] }],
+]);
+
 type CodeEditorWidget = EditorWidget | WebviewWidget;
 @injectable()
 export class CodeEditorWidgetUtil {

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -40,6 +40,7 @@ export const PLUGIN_EDITOR_TITLE_MENU = ['plugin_editor/title'];
 export const PLUGIN_EDITOR_TITLE_RUN_MENU = ['plugin_editor/title/run'];
 export const PLUGIN_SCM_TITLE_MENU = ['plugin_scm/title'];
 export const PLUGIN_VIEW_TITLE_MENU = ['plugin_view/title'];
+export const PLUGIN_TEST_VIEW_TITLE_MENU = ['plugin_test/title'];
 
 export const implementedVSCodeContributionPoints = [
     'comments/comment/context',
@@ -62,6 +63,7 @@ export const implementedVSCodeContributionPoints = [
     'timeline/item/context',
     'testing/item/context',
     'testing/message/context',
+    'testing/profiles/context',
     'view/item/context',
     'view/title',
     'webview/context',
@@ -93,6 +95,7 @@ export const codeToTheiaMappings = new Map<ContributionPoint, MenuPath[]>([
     ['scm/title', [PLUGIN_SCM_TITLE_MENU]],
     ['testing/item/context', [TEST_VIEW_CONTEXT_MENU]],
     ['testing/message/context', [TEST_RUNS_CONTEXT_MENU]],
+    ['testing/profiles/context', [PLUGIN_TEST_VIEW_TITLE_MENU]],
     ['timeline/item/context', [TIMELINE_ITEM_CONTEXT_MENU]],
     ['view/item/context', [VIEW_ITEM_CONTEXT_MENU]],
     ['view/title', [PLUGIN_VIEW_TITLE_MENU]],


### PR DESCRIPTION
#### What it does
This Pull Request adds the support of the newly introduced menu contribution point 'testing/profiles/context'. This contribution point, despite being named 'context', is a contribution to the toolbar entries in the equivalent of the Test Explorer View... It was designed to get additional actions in the drop down menu of the tool bar items that runs Test, debug them or run them with Coverage. 

![sample-vscode](https://github.com/user-attachments/assets/fedb4ca6-2061-4cfd-a8ba-1ad2ba9445c4)

I created a small sample extension for testing:
- src: [testing-profile-menu-0.0.2-src.zip](https://github.com/user-attachments/files/16550438/testing-profile-menu-0.0.2-src.zip)
- zip vsix: [testing-profile-menu-0.0.2.zip](https://github.com/user-attachments/files/16550440/testing-profile-menu-0.0.2.zip)

This kind of toolbar button with drop-down in Theia does not exist yet as far as I could see, so I implemented as:
- a simple entry in the main toolbar for the Test Explorer view with a simple mapping (see  [Commit 23ea30b](https://github.com/eclipse-theia/theia/commit/23ea30bd9f90d0659838e9bf014a6b4c2ccf299d)). Unfortunately, this has several drawbacks, as for example polluting the main toolbar, where it would be nice to keep all contributed actions in submenus).
- I then introduced a new mapping in the vscode to Theia mappings, to move the action to the "..." more actions at the end of the toolbar. This solves the issue of cluttering the main toolbal, but this shows a new problem: There are new context keys that are added when building the menus, depending on the test action group: run, coverage or debug (see [testingExplorerView](https://github.com/microsoft/vscode/blob/b1c0a14de1414fcdaa400695b4db1c0799bc3124/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts#L356) in vscode). In VS Code, the context matcher may have a different overlay. With the [2nd commit](https://github.com/eclipse-theia/theia/commit/93c3d57a3db447a2e653c7331fddcd204b6d701e), the entries are now placed in the "..." at the end, when the `testing.profile.context.group` value is not checked in the command.
- So I introduced a new contextKeyOverlay entry on the `ActionMenuNode`, so the various values of the context key could be evaluated. This is the role of the [third commit](https://github.com/eclipse-theia/theia/commit/887b522b1c0aefd7588723114c5412b4f9194b1d). However, I feel like I introduce a lot of code only to support a menu entry from VS code extensions. With this one, the test sample displays nicely the 4 available actions, but this seems like a workaround rather than a proper framework. Maybe the support of the drop down toolbar button may be a better contribution here.

That is the reason why I introduced this PR with 3 different commits, representing the 3 different steps to implement from a lightweight version to a more complex one. 

Fixes #14013

Contributed on behalf of STMicroelectronics

#### How to test
Install the provided extension sample, and go to the Test Explorer View.
Additional menu entries will come, depending on the commit selected:
- first commit: the simple entry will be shown in the main toolbar of the Test Explorer view
- 2nd commit: the simple entry will be shown in the "..." menu at the end of the main toolbar of the Test Explorer View
- 3rd commit: All entries will be displayed in the "..." menu at the end of the main toolbar of the Test Explorer View

#### Follow-ups

none yet.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
