### PR TITLE
Make sure notebook model created when calling openNotebookDocument

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-main.ts
@@ -169,6 +169,7 @@ export class NotebookDocumentsMainImpl implements NotebookDocumentsMain {
 
     async $tryOpenNotebook(uriComponents: UriComponents): Promise<UriComponents> {
         const uri = URI.fromComponents(uriComponents);
+        await this.notebookModelResolverService.resolve(uri);
         return uri.toComponents();
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -740,9 +740,8 @@ export function createAPIFactory(
                 } else {
                     throw new Error('Invalid arguments');
                 }
-                const result = await notebooksExt.waitForNotebookDocument(uri);
-                return result.apiNotebook;
-
+                // Notebook extension will create a document in openNotebookDocument() or create openNotebookDocument()
+                return notebooksExt.getNotebookDocument(uri).apiNotebook;
             },
             createFileSystemWatcher: (pattern, ignoreCreate, ignoreChange, ignoreDelete): theia.FileSystemWatcher =>
                 extHostFileSystemEvent.createFileSystemWatcher(fromGlobPattern(pattern), ignoreCreate, ignoreChange, ignoreDelete),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Fixes a bogus behavior when executing `openNotebookDocument()`.   
`openNotebookDocument` should create a NotebookModel (Document) so that a later call of e.g. `showNotebookDocument()` is able to open a new editor.
A use case is e.g. when you open a notebook file in a text editor and then use `Open in Notebook Editor` link in this text editor. Before this change text editor will be closed, but no new notebook editor will open.


#### How to test
In Explorer use "Open with..." to open a notebook file with a text editor use. If notebook extension is running "Open in Notebook Editor"  link should become visible in the editor. 
<img width="435" alt="Bildschirmfoto 2024-08-09 um 11 41 23" src="https://github.com/user-attachments/assets/2dceddcb-1125-4076-9768-d2696845a1f6">

Clicking this link should open a new Notebook editor.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
