### PR TITLE
Fix 429 errors on OVSX requests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,7 +86,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          yarn -s download:plugins --rate-limit 5
+          yarn -s download:plugins --rate-limit 3
 
       - name: Build
         shell: bash

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,7 +86,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          yarn -s download:plugins --rate-limit 3
+          yarn -s download:plugins --rate-limit 5
 
       - name: Build
         shell: bash

--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -55,8 +55,6 @@ export interface DownloadPluginsOptions {
      * Fetch plugins in parallel
      */
     parallel?: boolean;
-
-    rateLimit?: number;
 }
 
 interface PluginDownload {
@@ -65,16 +63,19 @@ interface PluginDownload {
     version?: string | undefined
 }
 
-export default async function downloadPlugins(ovsxClient: OVSXClient, requestService: RequestService, options: DownloadPluginsOptions = {}): Promise<void> {
+export default async function downloadPlugins(
+    ovsxClient: OVSXClient,
+    rateLimiter: RateLimiter,
+    requestService: RequestService,
+    options: DownloadPluginsOptions = {}
+): Promise<void> {
     const {
         packed = false,
         ignoreErrors = false,
         apiVersion = DEFAULT_SUPPORTED_API_VERSION,
-        rateLimit = 15,
         parallel = true
     } = options;
 
-    const rateLimiter = new RateLimiter({ tokensPerInterval: rateLimit, interval: 'second' });
     const apiFilter = new OVSXApiFilterImpl(ovsxClient, apiVersion);
 
     // Collect the list of failures to be appended at the end of the script.

--- a/dev-packages/ovsx-client/package.json
+++ b/dev-packages/ovsx-client/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@theia/request": "1.52.0",
+    "limiter": "^2.1.0",
     "semver": "^7.5.4",
     "tslib": "^2.6.2"
   }

--- a/dev-packages/ovsx-client/src/index.ts
+++ b/dev-packages/ovsx-client/src/index.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 export { OVSXApiFilter, OVSXApiFilterImpl, OVSXApiFilterProvider } from './ovsx-api-filter';
-export { OVSXHttpClient } from './ovsx-http-client';
+export { OVSXHttpClient, OVSX_RATE_LIMIT } from './ovsx-http-client';
 export { OVSXMockClient } from './ovsx-mock-client';
 export { OVSXRouterClient, OVSXRouterConfig, OVSXRouterFilterFactory as FilterFactory } from './ovsx-router-client';
 export * from './ovsx-router-filters';

--- a/dev-packages/ovsx-client/src/ovsx-api-filter.ts
+++ b/dev-packages/ovsx-client/src/ovsx-api-filter.ts
@@ -67,12 +67,13 @@ export class OVSXApiFilterImpl implements OVSXApiFilter {
 
     protected async queryLatestCompatibleExtension(query: VSXQueryOptions): Promise<VSXExtensionRaw | undefined> {
         let offset = 0;
+        let size = 5;
         let loop = true;
         while (loop) {
             const queryOptions: VSXQueryOptions = {
                 ...query,
                 offset,
-                size: 5 // there is a great chance that the newest version will work
+                size // there is a great chance that the newest version will work
             };
             const results = await this.client.query(queryOptions);
             const compatibleExtension = this.getLatestCompatibleExtension(results.extensions);
@@ -83,6 +84,8 @@ export class OVSXApiFilterImpl implements OVSXApiFilter {
             offset += results.extensions.length;
             // Continue querying if there are more extensions available
             loop = results.totalSize > offset;
+            // Adjust the size to fetch more extensions next time
+            size = Math.min(size * 2, 100);
         }
         return undefined;
     }

--- a/dev-packages/ovsx-client/src/ovsx-http-client.ts
+++ b/dev-packages/ovsx-client/src/ovsx-http-client.ts
@@ -52,17 +52,15 @@ export class OVSXHttpClient implements OVSXClient {
             // Use 1, 2, 4, 8, 16 tokens for each attempt
             const tokenCount = Math.pow(2, i);
             await this.rateLimiter.removeTokens(tokenCount);
-            console.log('Sending request at: ' + Date.now());
             const context = await this.requestService.request({
                 url,
                 headers: { 'Accept': 'application/json' }
             });
             if (context.res.statusCode === 429) {
+                console.warn('OVSX rate limit exceeded. Consider reducing the rate limit.');
                 // If there are still more attempts left, retry the request with a higher token count
                 if (i < attempts - 1) {
                     continue;
-                } else {
-                    console.warn('OVSX rate limit exceeded. Consider reducing the rate limit.');
                 }
             }
             return RequestContext.asJson<R>(context);

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -11,6 +11,7 @@
     "@theia/plugin-ext-vscode": "1.52.0",
     "@theia/preferences": "1.52.0",
     "@theia/workspace": "1.52.0",
+    "limiter": "^2.1.0",
     "luxon": "^2.4.0",
     "p-debounce": "^2.1.0",
     "semver": "^7.5.4",

--- a/packages/vsx-registry/src/common/vsx-environment.ts
+++ b/packages/vsx-registry/src/common/vsx-environment.ts
@@ -20,6 +20,7 @@ export const VSX_ENVIRONMENT_PATH = '/services/vsx-environment';
 
 export const VSXEnvironment = Symbol('VSXEnvironment');
 export interface VSXEnvironment {
+    getRateLimit(): Promise<number>;
     getRegistryUri(): Promise<string>;
     getRegistryApiUri(): Promise<string>;
     getVscodeApiVersion(): Promise<string>;

--- a/packages/vsx-registry/src/node/vsx-cli.ts
+++ b/packages/vsx-registry/src/node/vsx-cli.ts
@@ -17,17 +17,19 @@
 import { CliContribution } from '@theia/core/lib/node';
 import { injectable } from '@theia/core/shared/inversify';
 import { Argv } from '@theia/core/shared/yargs';
-import { OVSXRouterConfig } from '@theia/ovsx-client';
+import { OVSX_RATE_LIMIT, OVSXRouterConfig } from '@theia/ovsx-client';
 import * as fs from 'fs';
 
 @injectable()
 export class VsxCli implements CliContribution {
 
     ovsxRouterConfig: OVSXRouterConfig | undefined;
+    ovsxRateLimit: number;
     pluginsToInstall: string[] = [];
 
     configure(conf: Argv<{}>): void {
         conf.option('ovsx-router-config', { description: 'JSON configuration file for the OVSX router client', type: 'string' });
+        conf.option('ovsx-rate-limit', { description: 'Limits the number of requests to OVSX per second', type: 'number', default: OVSX_RATE_LIMIT });
         conf.option('install-plugin', {
             alias: 'install-extension',
             nargs: 1,
@@ -47,5 +49,7 @@ export class VsxCli implements CliContribution {
         if (Array.isArray(pluginsToInstall)) {
             this.pluginsToInstall = pluginsToInstall;
         }
+        const ovsxRateLimit = args.ovsxRateLimit;
+        this.ovsxRateLimit = typeof ovsxRateLimit === 'number' ? ovsxRateLimit : OVSX_RATE_LIMIT;
     }
 }

--- a/packages/vsx-registry/src/node/vsx-environment-impl.ts
+++ b/packages/vsx-registry/src/node/vsx-environment-impl.ts
@@ -32,6 +32,10 @@ export class VSXEnvironmentImpl implements VSXEnvironment {
     @inject(VsxCli)
     protected vsxCli: VsxCli;
 
+    async getRateLimit(): Promise<number> {
+        return this.vsxCli.ovsxRateLimit;
+    }
+
     async getRegistryUri(): Promise<string> {
         return this._registryUri.toString(true);
     }


### PR DESCRIPTION
#### What it does

After https://github.com/eclipse-theia/theia/pull/13825 we started having a few 429 errors (and adopters as well) when downloading plugins from extension packs. 

This change correctly propagates the OVSX rate limit through all layers of the application including the runtime. This can be seen in the `ovsx-http-client.ts` file changes. This should ensure that users never hit 429 errors from OVSX. If they do, they can use a lower rate limit via a CLI option.

#### How to test

I've upped the rate limit in the CI - the CI should run successfully.

Also, simply running the `theia download:plugins` CLI command should run without errors.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
