### PR TITLE
Fix preference tree for plugins

### DIFF
--- a/packages/core/src/common/json-schema.ts
+++ b/packages/core/src/common/json-schema.ts
@@ -36,6 +36,8 @@ export interface IJSONSchema {
     $id?: string;
     $schema?: string;
     type?: JsonType | JsonType[];
+    owner?: string;
+    group?: string;
     title?: string;
     default?: JSONValue;
     definitions?: IJSONSchemaMap;

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -192,11 +192,22 @@ export class TheiaPluginScanner extends AbstractPluginScanner {
         try {
             if (rawPlugin.contributes.configuration) {
                 const configurations = Array.isArray(rawPlugin.contributes.configuration) ? rawPlugin.contributes.configuration : [rawPlugin.contributes.configuration];
+                const hasMultipleConfigs = configurations.length > 1;
                 contributions.configuration = [];
                 for (const c of configurations) {
                     const config = this.readConfiguration(c, rawPlugin.packagePath);
                     if (config) {
-                        Object.values(config.properties).forEach(property => property.title = config.title);
+                        Object.values(config.properties).forEach(property => {
+                            if (hasMultipleConfigs) {
+                                // If there are multiple configuration contributions, we need to distinguish them by their title in the settings UI.
+                                // They are placed directly under the plugin's name in the settings UI.
+                                property.owner = rawPlugin.displayName;
+                                property.group = config.title;
+                            } else {
+                                // If there's only one configuration contribution, we display the title in the settings UI.
+                                property.owner = config.title;
+                            }
+                        });
                         contributions.configuration.push(config);
                     }
                 }

--- a/packages/preferences/src/browser/util/preference-tree-label-provider.ts
+++ b/packages/preferences/src/browser/util/preference-tree-label-provider.ts
@@ -30,19 +30,13 @@ export class PreferenceTreeLabelProvider implements LabelProviderContribution {
     }
 
     getName(node: Preference.TreeNode): string {
-        if (Preference.CompositeTreeNode.is(node) && node.label) {
+        if (Preference.TreeNode.is(node) && node.label) {
             return node.label;
         }
         const { id } = Preference.TreeNode.getGroupAndIdFromNodeId(node.id);
-        const layouts = this.layoutProvider.getLayout();
-        const layout = layouts.find(e => e.id === id);
-        if (layout) {
-            return layout.label;
-        } else {
-            const labels = id.split('.');
-            const groupName = labels[labels.length - 1];
-            return this.formatString(groupName);
-        }
+        const labels = id.split('.');
+        const groupName = labels[labels.length - 1];
+        return this.formatString(groupName);
     }
 
     getPrefix(node: Preference.TreeNode, fullPath = false): string | undefined {

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -18,7 +18,7 @@ import {
     PreferenceDataProperty,
     PreferenceScope,
     TreeNode as BaseTreeNode,
-    ExpandableTreeNode,
+    CompositeTreeNode as BaseCompositeTreeNode,
     SelectableTreeNode,
     PreferenceInspection,
     CommonCommands,
@@ -59,7 +59,8 @@ export namespace Preference {
         };
     }
 
-    export interface CompositeTreeNode extends ExpandableTreeNode, SelectableTreeNode {
+    export interface CompositeTreeNode extends BaseCompositeTreeNode, SelectableTreeNode {
+        expanded?: boolean;
         depth: number;
         label?: string;
     }
@@ -69,6 +70,7 @@ export namespace Preference {
     }
 
     export interface LeafNode extends BaseTreeNode {
+        label?: string;
         depth: number;
         preference: { data: PreferenceDataProperty };
         preferenceId: string;

--- a/packages/preferences/src/browser/views/preference-tree-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-tree-widget.tsx
@@ -24,6 +24,7 @@ import {
 } from '@theia/core/lib/browser';
 import React = require('@theia/core/shared/react');
 import { PreferenceTreeModel, PreferenceTreeNodeRow, PreferenceTreeNodeProps } from '../preference-tree-model';
+import { Preference } from '../util/preference-types';
 
 @injectable()
 export class PreferencesTreeWidget extends TreeWidget {
@@ -50,11 +51,26 @@ export class PreferencesTreeWidget extends TreeWidget {
         this.rows = new Map();
         let index = 0;
         for (const [id, nodeRow] of this.model.currentRows.entries()) {
-            if (nodeRow.visibleChildren > 0 && (ExpandableTreeNode.is(nodeRow.node) || ExpandableTreeNode.isExpanded(nodeRow.node.parent))) {
+            if (nodeRow.visibleChildren > 0 && this.isVisibleNode(nodeRow)) {
                 this.rows.set(id, { ...nodeRow, index: index++ });
             }
         }
         this.updateScrollToRow();
+    }
+
+    protected isVisibleNode(row: PreferenceTreeNodeRow): boolean {
+        const node = row.node;
+        if (Preference.TreeNode.isTopLevel(node)) {
+            return true;
+        }
+        let parent = node.parent;
+        while (parent) {
+            if (ExpandableTreeNode.isCollapsed(parent)) {
+                return false;
+            }
+            parent = parent.parent;
+        }
+        return true;
     }
 
     protected override doRenderNodeRow({ depth, visibleChildren, node, isExpansible }: PreferenceTreeNodeRow): React.ReactNode {

--- a/packages/preferences/src/browser/views/preference-tree-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-tree-widget.tsx
@@ -51,26 +51,19 @@ export class PreferencesTreeWidget extends TreeWidget {
         this.rows = new Map();
         let index = 0;
         for (const [id, nodeRow] of this.model.currentRows.entries()) {
-            if (nodeRow.visibleChildren > 0 && this.isVisibleNode(nodeRow)) {
+            if (nodeRow.visibleChildren > 0 && this.isVisibleNode(nodeRow.node)) {
                 this.rows.set(id, { ...nodeRow, index: index++ });
             }
         }
         this.updateScrollToRow();
     }
 
-    protected isVisibleNode(row: PreferenceTreeNodeRow): boolean {
-        const node = row.node;
+    protected isVisibleNode(node: Preference.TreeNode): boolean {
         if (Preference.TreeNode.isTopLevel(node)) {
             return true;
+        } else {
+            return ExpandableTreeNode.isExpanded(node.parent) && Preference.TreeNode.is(node.parent) && this.isVisibleNode(node.parent);
         }
-        let parent = node.parent;
-        while (parent) {
-            if (ExpandableTreeNode.isCollapsed(parent)) {
-                return false;
-            }
-            parent = parent.parent;
-        }
-        return true;
     }
 
     protected override doRenderNodeRow({ depth, visibleChildren, node, isExpansible }: PreferenceTreeNodeRow): React.ReactNode {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14034

I've figured out three configurations in which plugin preferences can appear:
1. Single array of preferences (no title) - generate a single entry for the plugin in the tree view
2. Single array of preferences (with a title) - generate a single entry for the plugin with the given title
3. Nested array of preferences - generate a parent entry for the plugin with sub entries for each array of preferences.

#### How to test

1. Install an extension that fits into the 3rd category. For example, the RedHat Java extension.
2. Open the settings view and expand the `Extensions` category
3. Assert that the tree nodes are rendered as expected.

It'd be best to compare the tree to whatever is rendered in VS Code.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
