### PR TITLE
Download json schema catalog at build-time instead of run-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ## Unreleased
+- [core] Download json schema catalog at build-time - [#14065](https://github.com/eclipse-theia/theia/pull/14065/) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.53.0">[Breaking Changes:](#breaking_changes_1.53.0)</a>
 - [dependencies] Updated electron to version 30.1.2 - [#14041](https://github.com/eclipse-theia/theia/pull/14041) - Contributed on behalf of STMicroelectronics

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -197,6 +197,7 @@
     "src"
   ],
   "scripts": {
+    "prebuild": "yarn download:json-schema",
     "build": "theiaext build",
     "clean": "theiaext clean",
     "compile": "theiaext compile",
@@ -204,6 +205,7 @@
     "generate-theia-re-exports": "theia-re-exports generate && theia-re-exports template README_TEMPLATE.md > README.md",
     "lint": "theiaext lint",
     "prepare": "yarn -s generate-theia-re-exports",
+    "download:json-schema": "node ./scripts/download-catalog.js",
     "test": "theiaext test",
     "version": "yarn -s generate-theia-re-exports",
     "watch": "theiaext watch"
@@ -211,7 +213,8 @@
   "devDependencies": {
     "@theia/ext-scripts": "1.52.0",
     "@theia/re-exports": "1.52.0",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "nodejs-file-downloader": "4.13.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -197,14 +197,13 @@
     "src"
   ],
   "scripts": {
-    "prebuild": "yarn download:json-schema",
     "build": "theiaext build",
     "clean": "theiaext clean",
     "compile": "theiaext compile",
     "generate-layout": "electron ./scripts/generate-layout",
     "generate-theia-re-exports": "theia-re-exports generate && theia-re-exports template README_TEMPLATE.md > README.md",
     "lint": "theiaext lint",
-    "prepare": "yarn -s generate-theia-re-exports",
+    "prepare": "yarn -s generate-theia-re-exports && yarn download:json-schema",
     "download:json-schema": "node ./scripts/download-catalog.js",
     "test": "theiaext test",
     "version": "yarn -s generate-theia-re-exports",

--- a/packages/core/scripts/download-catalog.js
+++ b/packages/core/scripts/download-catalog.js
@@ -20,6 +20,7 @@ new Downloader({
     url: 'https://schemastore.org/api/json/catalog.json',
     directory: './lib/browser',
     fileName: 'catalog.json',
-    timeout: 60000
+    timeout: 60000,
+    cloneFiles: false
 }).download();
 

--- a/packages/core/scripts/download-catalog.js
+++ b/packages/core/scripts/download-catalog.js
@@ -1,0 +1,25 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+const { Downloader } = require('nodejs-file-downloader');
+
+new Downloader({
+    url: 'https://schemastore.org/api/json/catalog.json',
+    directory: './lib/browser',
+    fileName: 'catalog.json',
+    timeout: 60000
+}).download();
+

--- a/packages/core/src/browser/json-schema-store.ts
+++ b/packages/core/src/browser/json-schema-store.ts
@@ -18,9 +18,7 @@ import { injectable, inject, named } from 'inversify';
 import { ContributionProvider } from '../common/contribution-provider';
 import { FrontendApplicationContribution } from './frontend-application-contribution';
 import { MaybePromise } from '../common';
-import { Endpoint } from './endpoint';
 import { timeout, Deferred } from '../common/promise-util';
-import { RequestContext, RequestService } from '@theia/request';
 
 export interface JsonSchemaConfiguration {
     fileMatch: string | string[];
@@ -95,16 +93,9 @@ export class JsonSchemaStore implements FrontendApplicationContribution {
 
 @injectable()
 export class DefaultJsonSchemaContribution implements JsonSchemaContribution {
-
-    @inject(RequestService)
-    protected readonly requestService: RequestService;
-
-    protected readonly jsonSchemaUrl = `${new Endpoint().httpScheme}//schemastore.org/api/json/catalog.json`;
-
     async registerSchemas(context: JsonSchemaRegisterContext): Promise<void> {
-        const response = await this.requestService.request({ url: this.jsonSchemaUrl });
-        const schemas = RequestContext.asJson<{ schemas: DefaultJsonSchemaContribution.SchemaData[] }>(response).schemas;
-        for (const s of schemas) {
+        const catalog = require('./catalog.json') as { schemas: DefaultJsonSchemaContribution.SchemaData[] };
+        for (const s of catalog.schemas) {
             if (s.fileMatch) {
                 context.registerSchema({
                     fileMatch: s.fileMatch,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5839,6 +5839,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.15.4:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
   integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
 font-awesome@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
@@ -8613,6 +8618,16 @@ node-ssh@^12.0.1:
     shell-escape "^0.2.0"
     ssh2 "^1.5.0"
 
+nodejs-file-downloader@4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz#da87c30081de5ff4e8b864062c98cdec03e66ad0"
+  integrity sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==
+  dependencies:
+    follow-redirects "^1.15.6"
+    https-proxy-agent "^5.0.0"
+    mime-types "^2.1.27"
+    sanitize-filename "^1.6.3"
+
 noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
@@ -10374,6 +10389,13 @@ safe-regex-test@^1.0.3:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sanitize-filename@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
+  integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
+
 sax@>=0.6.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
@@ -11451,6 +11473,13 @@ trim-repeated@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
 ts-api-utils@^1.0.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
@@ -11889,6 +11918,11 @@ user-home@^2.0.0:
   integrity sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==
   dependencies:
     os-homedir "^1.0.0"
+
+utf8-byte-length@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz#f9f63910d15536ee2b2d5dd4665389715eac5c1e"
+  integrity sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This fixes the problem where we run into timeout at front-end start time because downloading the json schema catalog takes longer than expected. We now download the catalog as part of the core package build and just `require()` the json file at run time.

Fixes #11881

Contributed on behalf of STMicroelectronics

#### How to test
Build Theia from source and make sure that there are no errors at startup. Also check that json files that are on the schemastore.org catalog have proper code assist according to their schema.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
