### PR TITLE
Add support for reverting a composite saveable

### DIFF
--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -135,6 +135,10 @@ export class CompositeSaveable implements Saveable {
         await Promise.all(this.saveables.map(saveable => saveable.save(options)));
     }
 
+    async revert(options?: Saveable.RevertOptions): Promise<void> {
+        await Promise.all(this.saveables.map(saveable => saveable.revert?.(options)));
+    }
+
     get saveables(): readonly Saveable[] {
         return Array.from(this.saveablesMap.keys());
     }


### PR DESCRIPTION
#### What it does

Ensures that a composite saveable can be correctly reverted.

Can be seen as a follow-up to #14062.

#### How to test

0. Clone https://github.com/microsoft/vscode-extension-samples.git, build the [custom-editor-sample](https://github.com/microsoft/vscode-extension-samples/tree/main/custom-editor-sample), and link it to your `theia/plugins` directory.

1. Build and start the Theia Electron or Browser app, and open the `custom-editor-sample` folder in it.

2. Open the `exampleFiles/example.pawDraw` file, and modify it using the custom editor. Save your changes.

3. In the Source Control view, click on the `example.pawDraw` file to open the changes in a side-by-side editor.

4. Using the right-hand side editor, modify the file again, then close the side-by-side editor without saving changes.

5. Open the example file again using either `Open File` or `Open Changes`. Verify that your latest changes have been correctly reverted and the editor is not marked as dirty.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
