### PR TITLE
Enhance notebook cell divider

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -265,7 +265,8 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
                             notebookModel={this._model}
                             notebookContext={this.notebookContextManager}
                             toolbarRenderer={this.cellToolbarFactory}
-                            commandRegistry={this.commandRegistry} />
+                            commandRegistry={this.commandRegistry}
+                            menuRegistry={this.menuRegistry} />
                     </PerfectScrollbar>
                 </div>
             </div>;

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -272,10 +272,10 @@
   border: 1px solid var(--theia-notebook-cellToolbarSeparator);
   background-color: var(--theia-editor-background);
   color: var(--theia-foreground);
-  vertical-align: middle;
-  text-align: center;
+  display: flex;
   height: 24px;
   margin: 0 8px;
+  padding: 2px 4px;
 }
 
 .theia-notebook-add-cell-button:hover {
@@ -286,8 +286,16 @@
   background-color: var(--theia-toolbar-active);
 }
 
-.theia-notebook-add-cell-button-icon {
+.theia-notebook-add-cell-button>* {
   vertical-align: middle;
+}
+
+.theia-notebook-add-cell-button-icon::before {
+  font: normal normal normal 14px/1 codicon;
+}
+
+.theia-notebook-add-cell-button-text {
+  margin: 1px 0 0 4px;
 }
 
 .theia-notebook-cell-output-webview {


### PR DESCRIPTION
#### What it does

Enhances the notebook cell divider to not create a specific cell kind, but to instead invoke a specific command that then creates the cell. This allows to use the existing menu infrastructure to add new commands to the cell dividers.

Also slightly adjusts the CSS of the cell divider to look a bit nicer and more like in VS Code

#### How to test

The cell divider buttons should continue to work as expected. Nothing should have regressed.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
