### PR TITLE
Fix vscode api notebook selection property

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
@@ -242,7 +242,7 @@ export class NotebooksAndEditorsMain implements NotebookDocumentsAndEditorsMain 
         return {
             id: notebookEditor.id,
             documentUri: uri.toComponents(),
-            selections: [],
+            selections: [{ start: 0, end: 0 }],
             visibleRanges: []
         };
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

fixes the selection property of the vscode api notebook  object

#### How to test

you can find a small test extension including vsix file here https://github.com/jonah-iden/theia-notebook-selection-test
This contains a command `Notebook-Test: Get Current Selection` to show current active notebook and its cell selection

#### Follow-ups

Theia notebooks do not support multi cell select yet. So there is always only one selection and start and end is equal.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
