### PR TITLE
Support proxy env variable for schema catalog download

### DIFF
--- a/packages/core/scripts/download-catalog.js
+++ b/packages/core/scripts/download-catalog.js
@@ -21,7 +21,11 @@ new Downloader({
     directory: './lib/browser',
     fileName: 'catalog.json',
     timeout: 60000,
-    proxy: process.env.http_proxy || process.env.HTTP_PROXY,
+    proxy: process.env.http_proxy
+        || process.env.HTTP_PROXY
+        || process.env.https_proxy
+        || process.env.HTTPS_PROXY
+        || '',
     cloneFiles: false
 }).download();
 

--- a/packages/core/scripts/download-catalog.js
+++ b/packages/core/scripts/download-catalog.js
@@ -21,6 +21,7 @@ new Downloader({
     directory: './lib/browser',
     fileName: 'catalog.json',
     timeout: 60000,
+    proxy: process.env.http_proxy || process.env.HTTP_PROXY,
     cloneFiles: false
 }).download();
 


### PR DESCRIPTION
#### What it does
Fixes #14126 by using the system environment variables to set the proxy URL.

#### How to test
Run `yarn` behind a proxy, or run `node /packages/core/scripts/download-catalog.js`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
