### PR TITLE
Fix selection of contributed menu action argument adapters

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.ts
@@ -20,7 +20,7 @@ import { NAVIGATION, RenderedToolbarItem } from './tab-bar-toolbar-types';
 export const TOOLBAR_WRAPPER_ID_SUFFIX = '-as-tabbar-toolbar-item';
 
 export class ToolbarMenuNodeWrapper implements RenderedToolbarItem {
-    constructor(protected readonly menuNode: MenuNode, readonly group?: string, readonly menuPath?: MenuPath) { }
+    constructor(protected readonly menuNode: MenuNode, readonly group: string | undefined, readonly delegateMenuPath: MenuPath, readonly menuPath?: MenuPath) { }
     get id(): string { return this.menuNode.id + TOOLBAR_WRAPPER_ID_SUFFIX; }
     get command(): string { return this.menuNode.command ?? ''; };
     get icon(): string | undefined { return this.menuNode.icon; }

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-registry.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-registry.ts
@@ -116,11 +116,12 @@ export class TabBarToolbarRegistry implements FrontendApplicationContribution {
                             for (const grandchild of child.children) {
                                 if (!grandchild.when || this.contextKeyService.match(grandchild.when, widget.node)) {
                                     const menuPath = this.menuRegistry.getPath(grandchild);
-                                    result.push(new ToolbarMenuNodeWrapper(grandchild, child.id, menuPath));
+                                    result.push(new ToolbarMenuNodeWrapper(grandchild, child.id, delegate.menuPath, menuPath));
                                 }
                             }
                         } else if (child.command) {
-                            result.push(new ToolbarMenuNodeWrapper(child, ''));
+                            const menuPath = this.menuRegistry.getPath(child);
+                            result.push(new ToolbarMenuNodeWrapper(child, undefined, delegate.menuPath, menuPath));
                         }
                     }
                 }

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-types.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-types.ts
@@ -73,6 +73,10 @@ export interface TabBarToolbarItemBase {
      * If no command is present, this menu will be opened.
      */
     menuPath?: MenuPath;
+    /**
+     * The path of the menu delegate that contributed this toolbar item
+     */
+    delegateMenuPath?: MenuPath;
     contextKeyOverlays?: Record<string, string>;
     /**
      * Optional ordering string for placing the item within its group

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -405,8 +405,8 @@ export class TabBarToolbar extends ReactWidget {
             return;
         }
 
-        if (item.command && item.menuPath) {
-            this.menuCommandExecutor.executeCommand(item.menuPath, item.command, this.current);
+        if (item.command && item.delegateMenuPath) {
+            this.menuCommandExecutor.executeCommand(item.delegateMenuPath, item.command, this.current);
         } else if (item.command) {
             this.commands.executeCommand(item.command, this.current);
         } else if (item.menuPath) {

--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -169,7 +169,27 @@ export class PluginMenuCommandAdapter implements MenuCommandAdapter {
     }
 
     protected getArgumentAdapterForMenu(menuPath: MenuPath): ArgumentAdapter | undefined {
-        return this.argumentAdapters.get(menuPath.join(this.separator));
+        let result;
+        let length = 0;
+        for (const [key, value] of this.argumentAdapters.entries()) {
+            const candidate = key.split(this.separator);
+            if (this.isPrefixOf(candidate, menuPath) && candidate.length > length) {
+                result = value;
+                length = candidate.length;
+            }
+        }
+        return result;
+    }
+    isPrefixOf(candidate: string[], menuPath: MenuPath) {
+        if (candidate.length > menuPath.length) {
+            return false;
+        }
+        for (let i = 0; i < candidate.length; i++) {
+            if (candidate[i] !== menuPath[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     protected addArgumentAdapter(menuPath: MenuPath, adapter: ArgumentAdapter): void {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
The idea is that a toolbar item has two different 'menuPath' fields: one to pick the argument adapter for the toolbar item, the second is to display a drop-down menu for the toolbar item. Also, an argument adapter is selected for an item when the registered path for the adapter is a prefix of the toolbar item menu path field. This takes care of contributed items in toolbar drop downs like the gitlens editor toolbar menu.

Fixes #14072

Contributed on behalf of STMicroelectronics
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Test the various toolbar and context menus one can contribute to. Make sure the actions work and drop-downs are shown where appropriate. You can get an indication of the interesting locations in plugin-menu-command-adapter. 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
