### PR TITLE
Support `workbench.editorAssociations` preference

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -281,6 +281,15 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: 200,
             minimum: 10,
             description: nls.localize('theia/core/tabDefaultSize', 'Specifies the default size for tabs.')
+        },
+        'workbench.editorAssociations': {
+            type: 'object',
+            markdownDescription: nls.localizeByDefault('Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `"*.hex": "hexEditor.hexedit"`). These have precedence over the default behavior.'),
+            patternProperties: {
+                '.*': {
+                    type: 'string'
+                }
+            }
         }
     }
 };

--- a/packages/core/src/browser/opener-service.ts
+++ b/packages/core/src/browser/opener-service.ts
@@ -17,6 +17,8 @@
 import { named, injectable, inject } from 'inversify';
 import URI from '../common/uri';
 import { ContributionProvider, Prioritizeable, MaybePromise, Emitter, Event, Disposable } from '../common';
+import { PreferenceService } from './preferences';
+import { match } from '../common/glob';
 
 export interface OpenerOptions {
 }
@@ -95,6 +97,17 @@ export async function open(openerService: OpenerService, uri: URI, options?: Ope
     const opener = await openerService.getOpener(uri, options);
     return opener.open(uri, options);
 }
+
+export function getDefaultHandler(uri: URI, preferenceService: PreferenceService): string | undefined {
+    const associations = preferenceService.get('workbench.editorAssociations', {});
+    const defaultHandler = Object.entries(associations).find(([key]) => match(key, uri.path.base))?.[1];
+    if (typeof defaultHandler === 'string') {
+        return defaultHandler;
+    }
+    return undefined;
+}
+
+export const defaultHandlerPriority = 100_000;
 
 @injectable()
 export class DefaultOpenerService implements OpenerService {

--- a/packages/core/src/common/glob.ts
+++ b/packages/core/src/common/glob.ts
@@ -454,10 +454,10 @@ function toRegExp(pattern: string): ParsedStringPattern {
 
 /**
  * Simplified glob matching. Supports a subset of glob patterns:
- * - * matches anything inside a path segment
- * - ? matches 1 character inside a path segment
- * - ** matches anything including an empty path segment
- * - simple brace expansion ({js,ts} => js or ts)
+ * - `*` matches anything inside a path segment
+ * - `?` matches 1 character inside a path segment
+ * - `**` matches anything including an empty path segment
+ * - simple brace expansion (`{js,ts}` => js or ts)
  * - character ranges (using [...])
  */
 export function match(pattern: string | IRelativePattern, path: string): boolean;

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -17,7 +17,10 @@
 import { injectable, postConstruct, inject } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { RecursivePartial, Emitter, Event, MaybePromise, CommandService, nls } from '@theia/core/lib/common';
-import { WidgetOpenerOptions, NavigatableWidgetOpenHandler, NavigatableWidgetOptions, Widget, PreferenceService, CommonCommands, OpenWithService } from '@theia/core/lib/browser';
+import {
+    WidgetOpenerOptions, NavigatableWidgetOpenHandler, NavigatableWidgetOptions, Widget, PreferenceService, CommonCommands, OpenWithService, getDefaultHandler,
+    defaultHandlerPriority
+} from '@theia/core/lib/browser';
 import { EditorWidget } from './editor-widget';
 import { Range, Position, Location, TextEditor } from './editor';
 import { EditorWidgetFactory } from './editor-widget-factory';
@@ -86,12 +89,13 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
             }
         }
         this.openWithService.registerHandler({
-            id: this.id,
+            id: 'default',
             label: this.label,
             providerName: nls.localizeByDefault('Built-in'),
+            canHandle: () => 100,
             // Higher priority than any other handler
             // so that the text editor always appears first in the quick pick
-            canHandle: uri => this.canHandle(uri) * 100,
+            getOrder: () => 10000,
             open: uri => this.open(uri)
         });
         this.updateCurrentEditor();
@@ -198,6 +202,9 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     }
 
     canHandle(uri: URI, options?: WidgetOpenerOptions): number {
+        if (getDefaultHandler(uri, this.preferenceService) === 'default') {
+            return defaultHandlerPriority;
+        }
         return 100;
     }
 

--- a/packages/plugin-ext/src/main/browser/custom-editors/plugin-custom-editor-registry.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/plugin-custom-editor-registry.ts
@@ -20,7 +20,7 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposa
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { CustomEditorOpener } from './custom-editor-opener';
 import { Emitter } from '@theia/core';
-import { ApplicationShell, DefaultOpenerService, OpenWithService, WidgetManager } from '@theia/core/lib/browser';
+import { ApplicationShell, DefaultOpenerService, OpenWithService, PreferenceService, WidgetManager } from '@theia/core/lib/browser';
 import { CustomEditorWidget } from './custom-editor-widget';
 
 @injectable()
@@ -43,6 +43,9 @@ export class PluginCustomEditorRegistry {
 
     @inject(OpenWithService)
     protected readonly openWithService: OpenWithService;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
 
     @postConstruct()
     protected init(): void {
@@ -76,7 +79,8 @@ export class PluginCustomEditorRegistry {
             editor,
             this.shell,
             this.widgetManager,
-            this
+            this,
+            this.preferenceService
         );
         toDispose.push(this.defaultOpenerService.addHandler(editorOpenHandler));
         toDispose.push(
@@ -84,7 +88,7 @@ export class PluginCustomEditorRegistry {
                 id: editor.viewType,
                 label: editorOpenHandler.label,
                 providerName: plugin.metadata.model.displayName,
-                canHandle: uri => editorOpenHandler.canHandle(uri),
+                canHandle: uri => editorOpenHandler.canOpenWith(uri),
                 open: uri => editorOpenHandler.open(uri)
             })
         );


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14138

Extends the `OpenWithService` to allow to select the default editor for a specific file type. This decision is then stored in the `workbench.editorAssociations` preference.

Later on, in the respective open handlers, we use this preference to figure out whether the current handler is the "default handler". If it is, we return an absurdly high number for `canHandle` to ensure that the handler is the one with the highest priority.

#### How to test

For the following tests, I would recommend testing the [hex editor extension](https://open-vsx.org/extension/ms-vscode/hexeditor), notebooks and normal text files.

1. Run the `Open With...` command on a file.
2. Select the `Configure default editor` option in the quick pick
3. Select a new default.
4. Clicking on the file should open it every time with the newly selected default.
5. Using `Open With...` should also show that it is the default now. The ordering within the quick pick should not have changed.
6. The open handler is correctly registered in the `workbench.editorAssociations` preference in the user settings.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
