### PR TITLE
New File dialog doesn't accept Enter for default

### DIFF
--- a/examples/playwright/src/tests/theia-main-menu.test.ts
+++ b/examples/playwright/src/tests/theia-main-menu.test.ts
@@ -110,18 +110,17 @@ test.describe('Theia Main Menu', () => {
         expect(await fileDialog.isVisible()).toBe(false);
     });
 
-    test('Create file via New File menu and cancel', async () => {
-        const openFileEntry = 'New File...';
-        await (await menuBar.openMenu('File')).clickMenuItem(openFileEntry);
+    test('Create file via New File menu and accept', async () => {
+        await (await menuBar.openMenu('File')).clickMenuItem('New File...');
         const quickPick = app.page.getByPlaceholder('Select File Type or Enter');
         // type file name and press enter
         await quickPick.fill('test.txt');
         await quickPick.press('Enter');
 
-        // check file dialog is opened and accept with "Create File" button
+        // check file dialog is opened and accept with ENTER
         const fileDialog = await app.page.waitForSelector('div[class="dialogBlock"]');
         expect(await fileDialog.isVisible()).toBe(true);
-        await app.page.locator('#theia-dialog-shell').getByRole('button', { name: 'Create File' }).click();
+        await app.page.locator('#theia-dialog-shell').press('Enter');
         expect(await fileDialog.isVisible()).toBe(false);
 
         // check file in workspace exists

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-widget.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-widget.ts
@@ -55,6 +55,17 @@ export class FileDialogWidget extends FileTreeWidget {
         return attr;
     }
 
+    protected override handleEnter(event: KeyboardEvent): boolean | void {
+        // Handle ENTER in the dialog to Accept.
+        // Tree view will just expand/collapse the node. This works also with arrow keys or SPACE.
+        return false;
+    }
+
+    protected override handleEscape(event: KeyboardEvent): boolean | void {
+        // Handle ESC in the dialog to Cancel and close the Dialog.
+        return false;
+    }
+
     protected override createNodeClassNames(node: TreeNode, props: NodeProps): string[] {
         const classNames = super.createNodeClassNames(node, props);
         if (this.shouldDisableSelection(node)) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Allow to accept the File Dialog by pressing `Enter` and canceling by pressing `Escape`. 

See #13582 

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
In `theia-main-menu.test.ts` the "Create file via New File menu and accept" test uses `Enter` to accept the File Dialog an save a file. 

Or follow the description in  #13582 



#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
