### PR TITLE
Fix enablement of AI support

### DIFF
--- a/packages/ai-core/src/browser/ai-activation-service.ts
+++ b/packages/ai-core/src/browser/ai-activation-service.ts
@@ -19,7 +19,11 @@ import { Emitter, MaybePromise, Event, } from '@theia/core';
 import { ContextKeyService, ContextKey } from '@theia/core/lib/browser/context-key-service';
 import { PREFERENCE_NAME_ENABLE_EXPERIMENTAL } from './ai-core-preferences';
 
-export const EXPERIMENTAL_AI_CONTEXT_KEY = 'ai.experimental.enabled';
+/**
+ * Context key for the experimental AI feature. It is set to `true` if the feature is enabled.
+ */
+// We reuse the enablement preference for the context key
+export const EXPERIMENTAL_AI_CONTEXT_KEY = PREFERENCE_NAME_ENABLE_EXPERIMENTAL;
 
 @injectable()
 export class AIActivationService implements FrontendApplicationContribution {
@@ -41,7 +45,7 @@ export class AIActivationService implements FrontendApplicationContribution {
     }
 
     initialize(): MaybePromise<void> {
-        this.isExperimentalEnabledKey = this.contextKeyService.createKey(PREFERENCE_NAME_ENABLE_EXPERIMENTAL, false);
+        this.isExperimentalEnabledKey = this.contextKeyService.createKey(EXPERIMENTAL_AI_CONTEXT_KEY, false);
         this.preferenceService.onPreferenceChanged(e => {
             if (e.preferenceName === PREFERENCE_NAME_ENABLE_EXPERIMENTAL) {
                 this.isExperimentalEnabledKey.set(e.newValue);


### PR DESCRIPTION
#### What it does

The 'ai-core' package offers a preference context key, which is for example used in 'when' clauses for the AI terminal menu entries.

Due to an oversight in the AI contribution refactorings, this context key was never enabled. Therefore the Terminal AI support didn't show up anymore, even if the experimental AI support was enabled via the preferences. Neither the context menu nor the keyboard shortcut (Ctrl-I) was working. 

This is now fixed

#### How to test

* Ensure the AI experimental setting is enabled
* Open a terminal view
* Check that "Ask the AI" shows up in the context menu of the Terminal
* Check that Ctrl-I enables the assistant

* Disable the AI experimental setting
* Check that "Ask the AI" doesn't show up in the context menu of the Terminal
* Check that Ctrl-I does not enable the assistant

#### Follow-ups

N/A

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
