### PR TITLE
Expand plugin preferences on scroll correctly

### DIFF
--- a/packages/preferences/src/browser/preference-tree-model.ts
+++ b/packages/preferences/src/browser/preference-tree-model.ts
@@ -216,12 +216,15 @@ export class PreferenceTreeModel extends TreeModelImpl {
     }
 
     collapseAllExcept(openNode: TreeNode | undefined): void {
-        if (ExpandableTreeNode.is(openNode)) {
+        const openNodes: TreeNode[] = [];
+        while (ExpandableTreeNode.is(openNode)) {
+            openNodes.push(openNode);
             this.expandNode(openNode);
+            openNode = openNode.parent;
         }
         if (CompositeTreeNode.is(this.root)) {
             this.root.children.forEach(child => {
-                if (child !== openNode && ExpandableTreeNode.is(child)) {
+                if (!openNodes.includes(child) && ExpandableTreeNode.is(child)) {
                     this.collapseNode(child);
                 }
             });


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14157.

Adjusts our `collapseAllExcept` function to expand all parents of the selected node. Since we now have more than 2 levels of preference tree items, just expanding one item isn't enough.

#### How to test

Go through the reproduction steps of https://github.com/eclipse-theia/theia/issues/14157 and test whether the scrolling behaves as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
