### PR TITLE
Remove stub tag from `TerminalOptions#color`

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3181,7 +3181,6 @@ export module '@theia/plugin' {
          * The icon {@link ThemeColor} for the terminal.
          * The `terminal.ansi*` theme keys are
          * recommended for the best contrast and consistency across themes.
-         * @stubbed
          */
         color?: ThemeColor;
     }


### PR DESCRIPTION
#### What it does

This property has been property implemented in https://github.com/eclipse-theia/theia/pull/13413, but we forgot to remove the `@stubbed` tag.

#### How to test

Item is no longer stubbed in the API coverage report.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
