### PR TITLE
feat: support models served via Open AI API

### DIFF
--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -101,7 +101,6 @@ export type LanguageModelProvider = () => Promise<LanguageModel[]>;
 // See also VS Code `ILanguageModelChatMetadata`
 export interface LanguageModelMetaData {
     readonly id: string;
-    readonly providerId: string;
     readonly name?: string;
     readonly vendor?: string;
     readonly version?: string;
@@ -112,7 +111,7 @@ export interface LanguageModelMetaData {
 
 export namespace LanguageModelMetaData {
     export function is(arg: unknown): arg is LanguageModelMetaData {
-        return isObject(arg) && 'id' in arg && 'providerId' in arg;
+        return isObject(arg) && 'id' in arg;
     }
 }
 
@@ -122,7 +121,7 @@ export interface LanguageModel extends LanguageModelMetaData {
 
 export namespace LanguageModel {
     export function is(arg: unknown): arg is LanguageModel {
-        return isObject(arg) && 'id' in arg && 'providerId' in arg && isFunction(arg.request);
+        return isObject(arg) && 'id' in arg && isFunction(arg.request);
     }
 }
 

--- a/packages/ai-core/src/node/backend-language-model-registry.ts
+++ b/packages/ai-core/src/node/backend-language-model-registry.ts
@@ -48,7 +48,6 @@ export class BackendLanguageModelRegistry extends DefaultLanguageModelRegistryIm
     mapToMetaData(model: LanguageModel): LanguageModelMetaData {
         return {
             id: model.id,
-            providerId: model.providerId,
             name: model.name,
             vendor: model.vendor,
             version: model.version,

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -16,8 +16,8 @@
 
 import { FrontendApplicationContribution, PreferenceService } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { OpenAiLanguageModelsManager } from '../common';
-import { API_KEY_PREF, MODELS_PREF } from './openai-preferences';
+import { OpenAiLanguageModelsManager, OpenAiModelDescription } from '../common';
+import { API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF } from './openai-preferences';
 
 @injectable()
 export class OpenAiFrontendApplicationContribution implements FrontendApplicationContribution {
@@ -30,6 +30,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
 
     // The preferenceChange.oldValue is always undefined for some reason
     protected prevModels: string[] = [];
+    protected prevCustomModels: Partial<OpenAiModelDescription>[] = [];
 
     onStart(): void {
         this.preferenceService.ready.then(() => {
@@ -37,8 +38,12 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             this.manager.setApiKey(apiKey);
 
             const models = this.preferenceService.get<string[]>(MODELS_PREF, []);
-            this.manager.createLanguageModels(...models);
+            this.manager.createOrUpdateLanguageModels(...models.map(createOpenAIModelDescription));
             this.prevModels = [...models];
+
+            const customModels = this.preferenceService.get<Partial<OpenAiModelDescription>[]>(CUSTOM_ENDPOINTS_PREF, []);
+            this.manager.createOrUpdateLanguageModels(...createCustomModelDescriptionsFromPreferences(customModels));
+            this.prevCustomModels = [...customModels];
 
             this.preferenceService.onPreferenceChanged(event => {
                 if (event.preferenceName === API_KEY_PREF) {
@@ -50,11 +55,44 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     const modelsToRemove = [...oldModels].filter(model => !newModels.has(model));
                     const modelsToAdd = [...newModels].filter(model => !oldModels.has(model));
 
-                    this.manager.removeLanguageModels(...modelsToRemove);
-                    this.manager.createLanguageModels(...modelsToAdd);
+                    this.manager.removeLanguageModels(...modelsToRemove.map(model => `openai/${model}`));
+                    this.manager.createOrUpdateLanguageModels(...modelsToAdd.map(createOpenAIModelDescription));
                     this.prevModels = [...event.newValue];
+                } else if (event.preferenceName === CUSTOM_ENDPOINTS_PREF) {
+                    const oldModels = createCustomModelDescriptionsFromPreferences(this.prevCustomModels);
+                    const newModels = createCustomModelDescriptionsFromPreferences(event.newValue);
+
+                    const modelsToRemove = oldModels.filter(model => !newModels.some(newModel => newModel.id === model.id));
+                    const modelsToAddOrUpdate = newModels.filter(newModel => !oldModels.some(model =>
+                        model.id === newModel.id && model.model === newModel.model && model.url === newModel.url));
+
+                    this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
+                    this.manager.createOrUpdateLanguageModels(...modelsToAddOrUpdate);
                 }
             });
         });
     }
+}
+
+function createOpenAIModelDescription(modelId: string): OpenAiModelDescription {
+    return {
+        id: `openai/${modelId}`,
+        model: modelId
+    };
+}
+
+function createCustomModelDescriptionsFromPreferences(preferences: Partial<OpenAiModelDescription>[]): OpenAiModelDescription[] {
+    return preferences.reduce((acc, pref) => {
+        if (!pref.model || !pref.url) {
+            return acc;
+        }
+        return [
+            ...acc,
+            {
+                id: pref.id ?? pref.model,
+                model: pref.model,
+                url: pref.url
+            }
+        ];
+    }, []);
 }

--- a/packages/ai-openai/src/browser/openai-preferences.ts
+++ b/packages/ai-openai/src/browser/openai-preferences.ts
@@ -43,7 +43,7 @@ export const OpenAiPreferencesSchema: PreferenceSchema = {
             type: 'array',
             title: AI_CORE_PREFERENCES_TITLE,
             markdownDescription: 'Integrate custom models compatible with the OpenAI API, for example via `vllm`. The required attributes are `model` and `url`.\
-            Optionally, you can provide an unique `id` to identify the custom model in the UI. If none is given `model` will be used as `id`',
+            Optionally, you can provide a unique `id` to identify the custom model in the UI. If none is given `model` will be used as `id`',
             default: [],
             items: {
                 type: 'object',

--- a/packages/ai-openai/src/browser/openai-preferences.ts
+++ b/packages/ai-openai/src/browser/openai-preferences.ts
@@ -19,21 +19,48 @@ import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/browser/ai-core-pr
 
 export const API_KEY_PREF = 'ai-features.openai.api-key';
 export const MODELS_PREF = 'ai-features.openai.models';
+export const CUSTOM_ENDPOINTS_PREF = 'ai-features.openai.models-custom';
 
 export const OpenAiPreferencesSchema: PreferenceSchema = {
     type: 'object',
     properties: {
         [API_KEY_PREF]: {
             type: 'string',
-            description: 'OpenAI API Key',
+            markdownDescription: '**Please note:** By using this preference the Open AI API key will be stored in clear text on the machine running Theia.\
+            Use the environment variable `OPENAI_API_KEY` to set the key securely.',
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [MODELS_PREF]: {
             type: 'array',
+            description: 'Official OpenAI models to use',
             title: AI_CORE_PREFERENCES_TITLE,
             default: ['gpt-4o', 'gpt-4o-2024-08-06', 'gpt-4o-2024-05-13', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo'],
             items: {
                 type: 'string'
+            }
+        },
+        [CUSTOM_ENDPOINTS_PREF]: {
+            type: 'array',
+            title: AI_CORE_PREFERENCES_TITLE,
+            markdownDescription: 'Integrate custom models compatible with the OpenAI API, for example via `vllm`. The required attributes are `model` and `url`.\
+            Optionally, you can provide an unique `id` to identify the custom model in the UI. If none is given `model` will be used as `id`',
+            default: [],
+            items: {
+                type: 'object',
+                properties: {
+                    model: {
+                        type: 'string',
+                        title: 'Model ID'
+                    },
+                    url: {
+                        type: 'string',
+                        title: 'The Open AI API compatible endpoint where the model is hosted'
+                    },
+                    id: {
+                        type: 'string',
+                        title: 'A unique identifier which is used in the UI to identify the custom model',
+                    }
+                }
             }
         }
     }

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -15,9 +15,23 @@
 // *****************************************************************************
 export const OPENAI_LANGUAGE_MODELS_MANAGER_PATH = '/services/open-ai/language-model-manager';
 export const OpenAiLanguageModelsManager = Symbol('OpenAiLanguageModelsManager');
+export interface OpenAiModelDescription {
+    /**
+     * The identifier of the model which will be shown in the UI.
+     */
+    id: string;
+    /**
+     * The model ID as used by the OpenAI API.
+     */
+    model: string;
+    /**
+     * The OpenAI API compatible endpoint where the model is hosted. If not provided the default OpenAI endpoint will be used.
+     */
+    url?: string;
+}
 export interface OpenAiLanguageModelsManager {
     apiKey: string | undefined;
     setApiKey(key: string | undefined): void;
-    createLanguageModels(...modelIds: string[]): Promise<void>;
+    createOrUpdateLanguageModels(...models: OpenAiModelDescription[]): Promise<void>;
     removeLanguageModels(...modelIds: string[]): void
 }

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -42,7 +42,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                     continue;
                 }
                 if (!modelDescription.url) {
-                    // This seems to be an official model, but it was already created. This can happen during the initializing of more than one frontends.
+                    // This seems to be an official model, but it was already created. This can happen during the initializing of more than one frontend.
                     console.info(`Open AI: skip creating model ${modelDescription.id} because it already exists`);
                     continue;
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The Open AI settings now allow to configure additional models and their associated endpoints. This can be used to integrate any custom model running locally or in the Cloud as long as it supports the Open AI API.

fixed #14174

#### How to test

1. Serve a model via the Open AI API. The following steps assume you run a model on [Runpod](https://www.runpod.io/) with [vllm](https://github.com/vllm-project/vllm)
2. Open "Open AI" preferences and add a custom model, e.g.
   ```
        {
            "model": "mistralai/Mistral-7B-Instruct-v0.2",
            "url": "https://<your-pod-id>-8000.proxy.runpod.net/v1",
            "id": "my-mistral2"
        }
   ```
3. Configure and use model

#### Follow-ups

- For now we disable "tool" usage for non-Open AI models. We should allow to enable / configure tool usage in some way in the future

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
