### PR TITLE
Properly support `executeDocumentSymbolProvider` command

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -44,7 +44,7 @@ import {
     DocumentHighlight
 } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
 import { DocumentsMainImpl } from '@theia/plugin-ext/lib/main/browser/documents-main';
-import { isUriComponents, toDocumentSymbol, toPosition } from '@theia/plugin-ext/lib/plugin/type-converters';
+import { isUriComponents, toMergedSymbol, toPosition } from '@theia/plugin-ext/lib/plugin/type-converters';
 import { ViewColumn } from '@theia/plugin-ext/lib/plugin/types-impl';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { WorkspaceService, WorkspaceInput } from '@theia/workspace/lib/browser/workspace-service';
@@ -628,7 +628,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     if (!Array.isArray(value) || value === undefined) {
                         return undefined;
                     }
-                    return value.map(loc => toDocumentSymbol(loc));
+                    return value.map(loc => toMergedSymbol(resource, loc));
                 })
             }
         );

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -737,39 +737,18 @@ export function toSymbolTag(kind: model.SymbolTag): types.SymbolTag {
  */
 export function toMergedSymbol(uri: UriComponents, symbol: model.DocumentSymbol): theia.SymbolInformation & theia.DocumentSymbol {
     const uriValue = URI.revive(uri);
-    const mergedSymbol = new MergedSymbol(
-        symbol.name,
-        SymbolKind.toSymbolKind(symbol.kind),
-        symbol.containerName ?? '',
-        new types.Location(uriValue, toRange(symbol.range))
-    );
-    mergedSymbol.detail = symbol.detail;
-    mergedSymbol.range = mergedSymbol.location.range;
-    mergedSymbol.selectionRange = toRange(symbol.selectionRange);
-    mergedSymbol.children = symbol.children?.map(child => toMergedSymbol(uri, child)) ?? [];
-    return mergedSymbol;
-}
-
-class MergedSymbol extends types.SymbolInformation implements theia.DocumentSymbol {
-    detail: string;
-    range: theia.Range;
-    selectionRange: theia.Range;
-    children: theia.DocumentSymbol[];
-    override containerName: string;
-
-    override toJSON(): object {
-        return {
-            name: this.name,
-            containerName: this.containerName,
-            kind: this.kind,
-            tags: this.tags,
-            location: this.location,
-            detail: this.detail,
-            range: this.range,
-            selectionRange: this.selectionRange,
-            children: this.children
-        };
-    }
+    const location = new types.Location(uriValue, toRange(symbol.range));
+    return {
+        name: symbol.name,
+        containerName: symbol.containerName ?? '',
+        kind: SymbolKind.toSymbolKind(symbol.kind),
+        tags: [],
+        location,
+        detail: symbol.detail,
+        range: location.range,
+        selectionRange: toRange(symbol.selectionRange),
+        children: symbol.children?.map(child => toMergedSymbol(uri, child)) ?? []
+    };
 }
 
 export function isModelLocation(arg: unknown): arg is model.Location {

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -756,6 +756,20 @@ class MergedSymbol extends types.SymbolInformation implements theia.DocumentSymb
     selectionRange: theia.Range;
     children: theia.DocumentSymbol[];
     override containerName: string;
+
+    override toJSON(): object {
+        return {
+            name: this.name,
+            containerName: this.containerName,
+            kind: this.kind,
+            tags: this.tags,
+            location: this.location,
+            detail: this.detail,
+            range: this.range,
+            selectionRange: this.selectionRange,
+            children: this.children
+        };
+    }
 }
 
 export function isModelLocation(arg: unknown): arg is model.Location {


### PR DESCRIPTION
#### What it does

Adjusts the array type returned by the `vscode.executeDocumentSymbolProvider` command. Previously, this returned only `theia.DocumentSymbol`. However, the VS Code documentation asserts that it should return `(theia.DocumentSymbol & theia.SymbolInformation)`:

> (returns) - A promise that resolves to an array of SymbolInformation and DocumentSymbol instances.

#### How to test

1. Download and install [this extension](https://github.com/user-attachments/files/17013128/notebook-selection-test-0.0.3.zip).
2. Open a file with document symbols like a TypeScript file.
3. Run the `executeDocumentSymbolProvider` command registered by the extension.
4. Assert that it displays something like this (properties like `location` were previously missing):
![image](https://github.com/user-attachments/assets/dd219a11-2cb5-4959-83d2-b2e8bb9ba252)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
