### PR TITLE
Focus notebook cell container correctly

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -126,7 +126,7 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(NotebookCommands.ADD_NEW_CELL_COMMAND, {
-            execute: (notebookModel: NotebookModel, cellKind: CellKind = CellKind.Markup, index?: number | 'above' | 'below') => {
+            execute: (notebookModel: NotebookModel, cellKind: CellKind = CellKind.Markup, index?: number | 'above' | 'below', focusContainer?: boolean) => {
                 notebookModel = notebookModel ?? this.notebookEditorWidgetService.focusedEditor?.model;
 
                 let insertIndex: number = 0;
@@ -154,6 +154,9 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
                         metadata: {},
                     }]
                 }], true);
+                if (focusContainer) {
+                    notebookModel.selectedCell?.requestBlurEditor();
+                }
             }
         });
 

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -374,13 +374,13 @@ export class NotebookCellActionContribution implements MenuContribution, Command
             (_, __, output) => output?.requestOutputPresentationUpdate()
         ));
 
-        const insertCommand = (type: CellKind, index: number | 'above' | 'below'): CommandHandler => this.editableCellCommandHandler(() =>
-            commands.executeCommand(NotebookCommands.ADD_NEW_CELL_COMMAND.id, undefined, type, index)
+        const insertCommand = (type: CellKind, index: number | 'above' | 'below', focusContainer: boolean): CommandHandler => this.editableCellCommandHandler(() =>
+            commands.executeCommand(NotebookCommands.ADD_NEW_CELL_COMMAND.id, undefined, type, index, focusContainer)
         );
-        commands.registerCommand(NotebookCellCommands.INSERT_NEW_CELL_ABOVE_COMMAND, insertCommand(CellKind.Code, 'above'));
-        commands.registerCommand(NotebookCellCommands.INSERT_NEW_CELL_BELOW_COMMAND, insertCommand(CellKind.Code, 'below'));
-        commands.registerCommand(NotebookCellCommands.INSERT_MARKDOWN_CELL_ABOVE_COMMAND, insertCommand(CellKind.Markup, 'above'));
-        commands.registerCommand(NotebookCellCommands.INSERT_MARKDOWN_CELL_BELOW_COMMAND, insertCommand(CellKind.Markup, 'below'));
+        commands.registerCommand(NotebookCellCommands.INSERT_NEW_CELL_ABOVE_COMMAND, insertCommand(CellKind.Code, 'above', true));
+        commands.registerCommand(NotebookCellCommands.INSERT_NEW_CELL_BELOW_COMMAND, insertCommand(CellKind.Code, 'below', true));
+        commands.registerCommand(NotebookCellCommands.INSERT_MARKDOWN_CELL_ABOVE_COMMAND, insertCommand(CellKind.Markup, 'above', false));
+        commands.registerCommand(NotebookCellCommands.INSERT_MARKDOWN_CELL_BELOW_COMMAND, insertCommand(CellKind.Markup, 'below', false));
 
         commands.registerCommand(NotebookCellCommands.TO_CODE_CELL_COMMAND, this.editableCellCommandHandler((notebookModel, cell) => {
             changeCellType(notebookModel, cell, CellKind.Code, this.notebookService.getCodeCellLanguage(notebookModel));


### PR DESCRIPTION
#### What it does

When using the "Jupyter Keymap" plugin, pressing `B` should trigger the `notebook.cell.insertCodeCellBelowAndFocusContainer` command. However, this command **should not focus** the newly inserted cell.

This change adjusts the behavior of the command to ensure that `B` can be pressed repeatedly to create new cells.

#### How to test

1. Install the Jupyter Keymap plugin (comes with the `Jupyter` plugin)
2. Open a notebook and focus a cell (but not the editor within)
3. Press `B` to create a new cells below the current cell (or `A` to create one above)
4. Ensure that the focus doesn't go to the text editor.
5. Ensure that pressing the keybinding multiple times correctly creates a new cell each time.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
