### PR TITLE
Fix notebook context selection

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -233,7 +233,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
 
     protected render(): ReactNode {
         if (this._model) {
-            return <div className='theia-notebook-main-container'>
+            return <div className='theia-notebook-main-container' tabIndex={-1}>
                 <div className='theia-notebook-overlay'>
                     <NotebookFindWidget
                         ref={this._findWidgetRef}

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -209,6 +209,10 @@
   overflow: hidden;
 }
 
+.theia-notebook-main-container:focus {
+  outline: none;
+}
+
 .theia-notebook-main-container .theia-notebook-main-loading-indicator {
   /* `progress-animation` is defined in `packages/core/src/browser/style/progress-bar.css` */
   animation: progress-animation 1.8s 0s infinite cubic-bezier(0.645, 0.045, 0.355, 1);


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14178

Adds a `tabIndex` to one of the rendered html nodes of the notebook editor. This ensures that the context key service can find the correct active element when clicking on the toolbar button. If no focusable element is available, the browser will instead select the `body` element, which is linked to a different context.

#### How to test

Follow the steps from https://github.com/eclipse-theia/theia/issues/14178 and ensure that things work as expected.

Please also ensure/test that all context key related stuff still works - i.e. `j`/`k`/`up`/`down` and `y`/`m` still work in command mode.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
