### PR TITLE
Leak fix in tabs-main.ts

### DIFF
--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -231,9 +231,13 @@ export class TabsMainImpl implements TabsMain, Disposable {
         return { kind: TabInputKind.UnknownInput };
     }
 
-    protected connectToSignal<T>(disposableList: DisposableCollection, signal: { connect(listener: T, context: unknown): void, disconnect(listener: T): void }, listener: T): void {
+    protected connectToSignal<T>(disposableList: DisposableCollection,
+        signal: {
+            connect(listener: T, context: unknown): void,
+            disconnect(listener: T, context: unknown): void
+        }, listener: T): void {
         signal.connect(listener, this);
-        disposableList.push(Disposable.create(() => signal.disconnect(listener)));
+        disposableList.push(Disposable.create(() => signal.disconnect(listener, this)));
     }
 
     protected tabDtosEqual(a: TabDto, b: TabDto): boolean {


### PR DESCRIPTION
The disconnect from the signal was not passing the this reference as it was used in the connect, hence the disconnect failed to find the handler.

When developing a theia based app we run into leaks due to TabsMainImpl keeping our custom control
in memory even when it was closed. The leak was through the controls title, through TabsMainImpl.
This PR fixes the main issue, which was leaking every control for us.

However the TabsMainImpl still is not optimal as it only releases references when it rebuilds its model,
and that does not happen when closing a tab.