### PR TITLE
Aligned active text and notebook editor more towards vscode

### DIFF
--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -183,10 +183,8 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
         return this._currentEditor;
     }
     protected setCurrentEditor(current: EditorWidget | undefined): void {
-        if (this._currentEditor !== current) {
-            this._currentEditor = current;
-            this.onCurrentEditorChangedEmitter.fire(this._currentEditor);
-        }
+        this._currentEditor = current;
+        this.onCurrentEditorChangedEmitter.fire(this._currentEditor);
     }
     protected updateCurrentEditor(): void {
         const widget = this.shell.currentWidget;

--- a/packages/notebook/src/browser/index.ts
+++ b/packages/notebook/src/browser/index.ts
@@ -23,5 +23,6 @@ export * from './service/notebook-kernel-service';
 export * from './service/notebook-execution-state-service';
 export * from './service/notebook-model-resolver-service';
 export * from './service/notebook-renderer-messaging-service';
+export * from './service/notebook-cell-editor-service';
 export * from './renderers/cell-output-webview';
 export * from './notebook-types';

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -48,6 +48,7 @@ import { bindNotebookPreferences } from './contributions/notebook-preferences';
 import { NotebookOptionsService } from './service/notebook-options';
 import { NotebookUndoRedoHandler } from './contributions/notebook-undo-redo-handler';
 import { NotebookStatusBarContribution } from './contributions/notebook-status-bar-contribution';
+import { NotebookCellEditorService } from './service/notebook-cell-editor-service';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookColorContribution).toSelf().inSingletonScope();
@@ -70,6 +71,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookKernelHistoryService).toSelf().inSingletonScope();
     bind(NotebookKernelQuickPickService).toSelf().inSingletonScope();
     bind(NotebookClipboardService).toSelf().inSingletonScope();
+    bind(NotebookCellEditorService).toSelf().inSingletonScope();
 
     bind(NotebookCellResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(NotebookCellResourceResolver);

--- a/packages/notebook/src/browser/service/notebook-cell-editor-service.ts
+++ b/packages/notebook/src/browser/service/notebook-cell-editor-service.ts
@@ -1,0 +1,56 @@
+// *****************************************************************************
+// Copyright (C) 2024 Typefox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, URI } from '@theia/core';
+import { injectable } from '@theia/core/shared/inversify';
+import { SimpleMonacoEditor } from '@theia/monaco/lib/browser/simple-monaco-editor';
+
+@injectable()
+export class NotebookCellEditorService {
+
+    protected onDidChangeCellEditorsEmitter = new Emitter<void>();
+    readonly onDidChangeCellEditors = this.onDidChangeCellEditorsEmitter.event;
+
+    protected onDidChangeFocusedCellEditorEmitter = new Emitter<SimpleMonacoEditor | undefined>();
+    readonly onDidChangeFocusedCellEditor = this.onDidChangeFocusedCellEditorEmitter.event;
+
+    protected currentActiveCell?: SimpleMonacoEditor;
+
+    protected currentCellEditors: Map<string, SimpleMonacoEditor> = new Map();
+
+    get allCellEditors(): SimpleMonacoEditor[] {
+        return Array.from(this.currentCellEditors.values());
+    }
+
+    editorCreated(uri: URI, editor: SimpleMonacoEditor): void {
+        this.currentCellEditors.set(uri.toString(), editor);
+        this.onDidChangeCellEditorsEmitter.fire();
+    }
+
+    editorDisposed(uri: URI): void {
+        this.currentCellEditors.delete(uri.toString());
+        this.onDidChangeCellEditorsEmitter.fire();
+    }
+
+    editorFocusChanged(editor?: SimpleMonacoEditor): void {
+        this.currentActiveCell = editor;
+        this.onDidChangeFocusedCellEditorEmitter.fire(editor);
+    }
+
+    getActiveCell(): SimpleMonacoEditor | undefined {
+        return this.currentActiveCell;
+    }
+}

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -224,11 +224,11 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
                     this.props.notebookContextManager.scopedStore.setContext(NOTEBOOK_CELL_CURSOR_LAST_LINE, false);
                 }
             }));
+            this.props.notebookCellEditorService.editorCreated(uri, this.editor);
+            this.setMatches();
             if (cell.editing && notebookModel.selectedCell === cell) {
                 this.editor.getControl().focus();
             }
-            this.props.notebookCellEditorService.editorCreated(uri, this.editor);
-            this.setMatches();
         }
     }
 

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -35,6 +35,7 @@ import { EditorPreferences } from '@theia/editor/lib/browser';
 import { NotebookOptionsService } from '../service/notebook-options';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { MarkdownString } from '@theia/monaco-editor-core/esm/vs/base/common/htmlContent';
+import { NotebookCellEditorService } from '../service/notebook-cell-editor-service';
 
 @injectable()
 export class NotebookCodeCellRenderer implements CellRenderer {
@@ -62,6 +63,9 @@ export class NotebookCodeCellRenderer implements CellRenderer {
     @inject(EditorPreferences)
     protected readonly editorPreferences: EditorPreferences;
 
+    @inject(NotebookCellEditorService)
+    protected readonly notebookCellEditorService: NotebookCellEditorService;
+
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
 
@@ -86,6 +90,7 @@ export class NotebookCodeCellRenderer implements CellRenderer {
                         monacoServices={this.monacoServices}
                         notebookContextManager={this.notebookContextManager}
                         notebookViewportService={this.notebookViewportService}
+                        notebookCellEditorService={this.notebookCellEditorService}
                         fontInfo={this.notebookOptionsService.editorFontInfo} />
                     <NotebookCodeCellStatus cell={cell} notebook={notebookModel}
                         commandRegistry={this.commandRegistry}

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -29,6 +29,7 @@ import { NotebookOptionsService } from '../service/notebook-options';
 import { NotebookCodeCellStatus } from './notebook-code-cell-view';
 import { NotebookEditorFindMatch, NotebookEditorFindMatchOptions } from './notebook-find-widget';
 import * as mark from 'advanced-mark.js';
+import { NotebookCellEditorService } from '../service/notebook-cell-editor-service';
 
 @injectable()
 export class NotebookMarkdownCellRenderer implements CellRenderer {
@@ -47,6 +48,9 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
     @inject(NotebookOptionsService)
     protected readonly notebookOptionsService: NotebookOptionsService;
 
+    @inject(NotebookCellEditorService)
+    protected readonly notebookCellEditorService: NotebookCellEditorService;
+
     render(notebookModel: NotebookModel, cell: NotebookCellModel): React.ReactNode {
         return <MarkdownCell
             markdownRenderer={this.markdownRenderer}
@@ -55,7 +59,8 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
             notebookOptionsService={this.notebookOptionsService}
             cell={cell}
             notebookModel={notebookModel}
-            notebookContextManager={this.notebookContextManager} />;
+            notebookContextManager={this.notebookContextManager}
+            notebookCellEditorService={this.notebookCellEditorService} />;
     }
 
     renderDragImage(cell: NotebookCellModel): HTMLElement {
@@ -77,10 +82,11 @@ interface MarkdownCellProps {
     notebookModel: NotebookModel;
     notebookContextManager: NotebookContextManager;
     notebookOptionsService: NotebookOptionsService;
+    notebookCellEditorService: NotebookCellEditorService
 }
 
 function MarkdownCell({
-    markdownRenderer, monacoServices, cell, notebookModel, notebookContextManager, notebookOptionsService, commandRegistry
+    markdownRenderer, monacoServices, cell, notebookModel, notebookContextManager, notebookOptionsService, commandRegistry, notebookCellEditorService
 }: MarkdownCellProps): React.JSX.Element {
     const [editMode, setEditMode] = React.useState(cell.editing);
     let empty = false;
@@ -133,6 +139,7 @@ function MarkdownCell({
             <CellEditor notebookModel={notebookModel} cell={cell}
                 monacoServices={monacoServices}
                 notebookContextManager={notebookContextManager}
+                notebookCellEditorService={notebookCellEditorService}
                 fontInfo={notebookOptionsService.editorFontInfo} />
             <NotebookCodeCellStatus cell={cell} notebook={notebookModel}
                 commandRegistry={commandRegistry}

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2673,6 +2673,7 @@ export interface NotebookDocumentsExt {
 
 export interface NotebookDocumentsAndEditorsExt {
     $acceptDocumentsAndEditorsDelta(delta: NotebookDocumentsAndEditorsDelta): Promise<void>;
+    $acceptActiveCellEditorChange(newActiveEditor: string | null): void;
 }
 
 export interface NotebookDocumentsAndEditorsMain extends Disposable {

--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
@@ -21,7 +21,7 @@
 import { Disposable, DisposableCollection } from '@theia/core';
 import { interfaces } from '@theia/core/shared/inversify';
 import { UriComponents } from '@theia/core/lib/common/uri';
-import { NotebookEditorWidget, NotebookService, NotebookEditorWidgetService } from '@theia/notebook/lib/browser';
+import { NotebookEditorWidget, NotebookService, NotebookEditorWidgetService, NotebookCellEditorService } from '@theia/notebook/lib/browser';
 import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
 import { MAIN_RPC_CONTEXT, NotebookDocumentsAndEditorsDelta, NotebookDocumentsAndEditorsMain, NotebookEditorAddData, NotebookModelAddedData, NotebooksExt } from '../../../common';
 import { RPCProtocol } from '../../../common/rpc-protocol';
@@ -105,6 +105,9 @@ export class NotebooksAndEditorsMain implements NotebookDocumentsAndEditorsMain 
         this.notebookService = container.get(NotebookService);
         this.notebookEditorService = container.get(NotebookEditorWidgetService);
         this.WidgetManager = container.get(WidgetManager);
+        const notebookCellEditorService = container.get(NotebookCellEditorService);
+
+        notebookCellEditorService.onDidChangeFocusedCellEditor(editor => this.proxy.$acceptActiveCellEditorChange(editor?.uri.toString() ?? null), this, this.disposables);
 
         this.notebookService.onDidAddNotebookDocument(async () => this.updateState(), this, this.disposables);
         this.notebookService.onDidRemoveNotebookDocument(async () => this.updateState(), this, this.disposables);

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -97,6 +97,13 @@ export class NotebooksExtImpl implements NotebooksExt {
                 }
             }
         });
+
+        textDocumentsAndEditors.onDidChangeActiveTextEditor(e => {
+            if (e?.document.uri.scheme !== CellUri.cellUriScheme) {
+                this.activeNotebookEditor = undefined;
+                this.onDidChangeActiveNotebookEditorEmitter.fire(undefined);
+            }
+        });
     }
 
     async $provideNotebookCellStatusBarItems(handle: number, uri: UriComponents, index: number, token: CancellationToken): Promise<NotebookCellStatusBarListDto | undefined> {

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -335,7 +335,7 @@ export class NotebooksExtImpl implements NotebooksExt {
                 console.error(`FAILED to find active notebook editor ${delta.newActiveEditor}`);
             }
             this.activeNotebookEditor = this.editors.get(delta.newActiveEditor);
-            if (!(this.textDocumentsAndEditors.activeEditor()?.document.uri.path === this.activeNotebookEditor?.notebookData.uri.path)) {
+            if (this.textDocumentsAndEditors.activeEditor()?.document.uri.path !== this.activeNotebookEditor?.notebookData.uri.path) {
                 this.textDocumentsAndEditors.acceptEditorsAndDocumentsDelta({
                     newActiveEditor: null
                 });

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -99,7 +99,7 @@ export class NotebooksExtImpl implements NotebooksExt {
         });
 
         textDocumentsAndEditors.onDidChangeActiveTextEditor(e => {
-            if (e?.document.uri.scheme !== CellUri.cellUriScheme) {
+            if (e && e?.document.uri.scheme !== CellUri.cellUriScheme && this.activeNotebookEditor) {
                 this.activeNotebookEditor = undefined;
                 this.onDidChangeActiveNotebookEditorEmitter.fire(undefined);
             }
@@ -136,6 +136,15 @@ export class NotebooksExtImpl implements NotebooksExt {
 
     $releaseNotebookCellStatusBarItems(cacheId: number): void {
         this.statusBarRegistry.delete(cacheId);
+    }
+
+    $acceptActiveCellEditorChange(newActiveEditor: string | null): void {
+        const newActiveEditorId = this.textDocumentsAndEditors.allEditors().find(editor => editor.document.uri.toString() === newActiveEditor)?.id;
+        if (newActiveEditorId || newActiveEditor === null) {
+            this.textDocumentsAndEditors.acceptEditorsAndDocumentsDelta({
+                newActiveEditor: newActiveEditorId ?? null
+            });
+        }
     }
 
     // --- serialize/deserialize
@@ -326,6 +335,11 @@ export class NotebooksExtImpl implements NotebooksExt {
                 console.error(`FAILED to find active notebook editor ${delta.newActiveEditor}`);
             }
             this.activeNotebookEditor = this.editors.get(delta.newActiveEditor);
+            if (!(this.textDocumentsAndEditors.activeEditor()?.document.uri.path === this.activeNotebookEditor?.notebookData.uri.path)) {
+                this.textDocumentsAndEditors.acceptEditorsAndDocumentsDelta({
+                    newActiveEditor: null
+                });
+            }
         }
         if (delta.newActiveEditor !== undefined) {
             this.onDidChangeActiveNotebookEditorEmitter.fire(this.activeNotebookEditor?.apiEditor);

--- a/packages/plugin-ext/src/plugin/text-editor.ts
+++ b/packages/plugin-ext/src/plugin/text-editor.ts
@@ -30,7 +30,7 @@ export class TextEditorExt implements theia.TextEditor {
     private disposed = false;
     constructor(
         private readonly proxy: TextEditorsMain,
-        private readonly id: string,
+        readonly id: string,
         document: DocumentDataExt,
         private _selections: Selection[],
         options: TextEditorConfiguration,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

this aligns the vscode API's `activeTextEditor` and `activeNotebookEditor` more to how it is in Vscode
- `activeNotebookEditor` should always be undefined when a text editor is selcted.
- `activeNotebookEditor` should be set when a notebook editor is and `activeTextEditor` should be undefined as long as no cell is selected
-  `activeTextEditor` should be referencing the cell when a notebook is open and a cell is in edit mode

#### How to test

you can find and download a test extension [here](https://github.com/jonah-iden/theia-notebook-selection-test)

Open the outputs tab and select the `Notebook Selection Test` channel. Here you should see all editor change events.

#### Follow-ups

The endstate should be correct but the amount of events are a few more than in vscode. This requires a larger refactoring of the `editor-manager.ts` to fully fix. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
