### PR TITLE
Makes the cell editor border grey when not focused

### DIFF
--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -114,7 +114,8 @@
   margin: 0px 16px 0px 10px;
 }
 
-.theia-notebook-cell.focused .theia-notebook-cell-editor-container {
+/* Only mark an editor cell focused if the editor has focus */
+.theia-notebook-cell-editor-container:has(.monaco-editor.focused) {
   outline-color: var(--theia-notebook-focusedEditorBorder);
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Currently if a code cell is selected  (Blue line on the lefthand side)  but the cell editor itself has no focus - the editor has a focused (blue) border. This change makes the editor outline/border grey is the cell editor doesn't have focus. 
 
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

Open a notebook and select a cell editor. The editor should have a focus (blue) border. Press `ESC` - it turns off the edit mode and editor lose focus. The editor border should become grey.
 
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
