### PR TITLE
feat(ai): Make response parsing extensible

### DIFF
--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -33,6 +33,7 @@ import { UniversalChatAgent } from '../common/universal-chat-agent';
 import { aiChatPreferences } from './ai-chat-preferences';
 import { ChatAgentsVariableContribution } from '../common/chat-agents-variable-contribution';
 import { FrontendChatServiceImpl } from './frontend-chat-service';
+import { DefaultResponseContentMatcherProvider, DefaultResponseContentFactory, ResponseContentMatcherProvider } from '../common/response-content-matcher';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -41,6 +42,11 @@ export default new ContainerModule(bind => {
     bind(ChatAgentServiceImpl).toSelf().inSingletonScope();
     bind(ChatAgentService).toService(ChatAgentServiceImpl);
     bind(DefaultChatAgentId).toConstantValue({ id: OrchestratorChatAgentId });
+
+    bindContributionProvider(bind, ResponseContentMatcherProvider);
+    bind(DefaultResponseContentMatcherProvider).toSelf().inSingletonScope();
+    bind(ResponseContentMatcherProvider).toService(DefaultResponseContentMatcherProvider);
+    bind(DefaultResponseContentFactory).toSelf().inSingletonScope();
 
     bind(AIVariableContribution).to(ChatAgentsVariableContribution).inSingletonScope();
 

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -371,7 +371,7 @@ export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
         const content = token.content;
         // eslint-disable-next-line no-null/no-null
         if (content !== undefined && content !== null) {
-            return this.defaultContentFactory?.create(content);
+            return this.defaultContentFactory.create(content);
         }
         const toolCalls = token.tool_calls;
         if (toolCalls !== undefined) {

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -25,6 +25,7 @@ import {
     LanguageModel,
     LanguageModelRequirement,
     LanguageModelResponse,
+    LanguageModelStreamResponse,
     PromptService,
     ResolvedPromptTemplate,
     ToolRequest,
@@ -37,19 +38,20 @@ import {
     LanguageModelStreamResponsePart,
     MessageActor,
 } from '@theia/ai-core/lib/common';
-import { CancellationToken, CancellationTokenSource, ILogger, isArray } from '@theia/core';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { CancellationToken, CancellationTokenSource, ContributionProvider, ILogger, isArray } from '@theia/core';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { ChatAgentService } from './chat-agent-service';
 import {
     ChatModel,
     ChatRequestModel,
     ChatRequestModelImpl,
     ChatResponseContent,
-    CodeChatResponseContentImpl,
     ErrorChatResponseContentImpl,
     MarkdownChatResponseContentImpl,
     ToolCallChatResponseContentImpl
 } from './chat-model';
+import { findEarliestMatch, parseContents } from './parse-contents';
+import { DefaultResponseContentFactory, ResponseContentMatcher, ResponseContentMatcherProvider } from './response-content-matcher';
 
 /**
  * A conversation consists of a sequence of ChatMessages.
@@ -121,6 +123,14 @@ export abstract class AbstractChatAgent {
     @inject(ILogger) protected logger: ILogger;
     @inject(CommunicationRecordingService) protected recordingService: CommunicationRecordingService;
     @inject(PromptService) protected promptService: PromptService;
+
+    @inject(ContributionProvider) @named(ResponseContentMatcherProvider)
+    protected contentMatcherProviders: ContributionProvider<ResponseContentMatcherProvider>;
+    protected contentMatchers: ResponseContentMatcher[] = [];
+
+    @inject(DefaultResponseContentFactory)
+    protected defaultContentFactory: DefaultResponseContentFactory;
+
     constructor(
         public id: string,
         public languageModelRequirements: LanguageModelRequirement[],
@@ -128,6 +138,11 @@ export abstract class AbstractChatAgent {
         public iconClass: string = 'codicon codicon-copilot',
         public locations: ChatAgentLocation[] = ChatAgentLocation.ALL,
         public tags: String[] = ['Chat']) {
+    }
+
+    @postConstruct()
+    init(): void {
+        this.contentMatchers = this.contentMatcherProviders.getContributions().flatMap(provider => provider.matchers);
     }
 
     async invoke(request: ChatRequestModelImpl): Promise<void> {
@@ -188,6 +203,14 @@ export abstract class AbstractChatAgent {
             this.handleError(request, e);
         }
     }
+
+    protected parseContents(text: string): ChatResponseContent[] {
+        return parseContents(
+            text,
+            this.contentMatchers,
+            this.defaultContentFactory?.create.bind(this.defaultContentFactory)
+        );
+    };
 
     protected handleError(request: ChatRequestModelImpl, error: Error): void {
         request.response.response.addContent(new ErrorChatResponseContentImpl(error));
@@ -281,9 +304,8 @@ export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
 
     protected override async addContentsToResponse(languageModelResponse: LanguageModelResponse, request: ChatRequestModelImpl): Promise<void> {
         if (isLanguageModelTextResponse(languageModelResponse)) {
-            request.response.response.addContent(
-                new MarkdownChatResponseContentImpl(languageModelResponse.text)
-            );
+            const contents = this.parseContents(languageModelResponse.text);
+            request.response.response.addContents(contents);
             request.response.complete();
             this.recordingService.recordResponse({
                 agentId: this.id,
@@ -295,57 +317,7 @@ export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
             return;
         }
         if (isLanguageModelStreamResponse(languageModelResponse)) {
-            for await (const token of languageModelResponse.stream) {
-                const newContents = this.parse(token, request.response.response.content);
-                if (isArray(newContents)) {
-                    newContents.forEach(newContent => request.response.response.addContent(newContent));
-                } else {
-                    request.response.response.addContent(newContents);
-                }
-
-                const lastContent = request.response.response.content.pop();
-                if (lastContent === undefined) {
-                    return;
-                }
-                const text = lastContent.asString?.();
-                if (text === undefined) {
-                    return;
-                }
-                let curSearchIndex = 0;
-                const result: ChatResponseContent[] = [];
-                while (curSearchIndex < text.length) {
-                    // find start of code block: ```[language]\n<code>[\n]```
-                    const codeStartIndex = text.indexOf('```', curSearchIndex);
-                    if (codeStartIndex === -1) {
-                        break;
-                    }
-
-                    // find language specifier if present
-                    const newLineIndex = text.indexOf('\n', codeStartIndex + 3);
-                    const language = codeStartIndex + 3 < newLineIndex ? text.substring(codeStartIndex + 3, newLineIndex) : undefined;
-
-                    // find end of code block
-                    const codeEndIndex = text.indexOf('```', codeStartIndex + 3);
-                    if (codeEndIndex === -1) {
-                        break;
-                    }
-
-                    // add text before code block as markdown content
-                    result.push(new MarkdownChatResponseContentImpl(text.substring(curSearchIndex, codeStartIndex)));
-                    // add code block as code content
-                    const codeText = text.substring(newLineIndex + 1, codeEndIndex).trimEnd();
-                    result.push(new CodeChatResponseContentImpl(codeText, language));
-                    curSearchIndex = codeEndIndex + 3;
-                }
-
-                if (result.length > 0) {
-                    result.forEach(r => {
-                        request.response.response.addContent(r);
-                    });
-                } else {
-                    request.response.response.addContent(lastContent);
-                }
-            }
+            await this.addStreamResponse(languageModelResponse, request);
             request.response.complete();
             this.recordingService.recordResponse({
                 agentId: this.id,
@@ -366,11 +338,40 @@ export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
         );
     }
 
-    private parse(token: LanguageModelStreamResponsePart, previousContent: ChatResponseContent[]): ChatResponseContent | ChatResponseContent[] {
+    protected async addStreamResponse(languageModelResponse: LanguageModelStreamResponse, request: ChatRequestModelImpl): Promise<void> {
+        for await (const token of languageModelResponse.stream) {
+            const newContents = this.parse(token, request.response.response.content);
+            if (isArray(newContents)) {
+                request.response.response.addContents(newContents);
+            } else {
+                request.response.response.addContent(newContents);
+            }
+
+            const lastContent = request.response.response.content.pop();
+            if (lastContent === undefined) {
+                return;
+            }
+            const text = lastContent.asString?.();
+            if (text === undefined) {
+                return;
+            }
+
+            const result: ChatResponseContent[] = findEarliestMatch(this.contentMatchers, text) ? this.parseContents(text) : [];
+            if (result.length > 0) {
+                result.forEach(r => {
+                    request.response.response.addContent(r);
+                });
+            } else {
+                request.response.response.addContent(lastContent);
+            }
+        }
+    }
+
+    protected parse(token: LanguageModelStreamResponsePart, previousContent: ChatResponseContent[]): ChatResponseContent | ChatResponseContent[] {
         const content = token.content;
         // eslint-disable-next-line no-null/no-null
         if (content !== undefined && content !== null) {
-            return new MarkdownChatResponseContentImpl(content);
+            return this.defaultContentFactory?.create(content);
         }
         const toolCalls = token.tool_calls;
         if (toolCalls !== undefined) {
@@ -378,7 +379,7 @@ export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
                 new ToolCallChatResponseContentImpl(toolCall.id, toolCall.function?.name, toolCall.function?.arguments, toolCall.finished, toolCall.result));
             return toolCallContents;
         }
-        return new MarkdownChatResponseContentImpl('');
+        return this.defaultContentFactory.create('');
     }
 
 }

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -50,7 +50,7 @@ import {
     MarkdownChatResponseContentImpl,
     ToolCallChatResponseContentImpl
 } from './chat-model';
-import { findEarliestMatch, parseContents } from './parse-contents';
+import { findFirstMatch, parseContents } from './parse-contents';
 import { DefaultResponseContentFactory, ResponseContentMatcher, ResponseContentMatcherProvider } from './response-content-matcher';
 
 /**
@@ -356,11 +356,9 @@ export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
                 return;
             }
 
-            const result: ChatResponseContent[] = findEarliestMatch(this.contentMatchers, text) ? this.parseContents(text) : [];
+            const result: ChatResponseContent[] = findFirstMatch(this.contentMatchers, text) ? this.parseContents(text) : [];
             if (result.length > 0) {
-                result.forEach(r => {
-                    request.response.response.addContent(r);
-                });
+                request.response.response.addContents(result);
             } else {
                 request.response.response.addContent(lastContent);
             }

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -601,6 +601,10 @@ class ChatResponseImpl implements ChatResponse {
         return this._content;
     }
 
+    addContents(contents: ChatResponseContent[]): void {
+        contents.forEach(c => this.addContent(c));
+    }
+
     addContent(nextContent: ChatResponseContent): void {
         // TODO: Support more complex merges affecting different content than the last, e.g. via some kind of ProcessorRegistry
         // TODO: Support more of the built-in VS Code behavior, see

--- a/packages/ai-chat/src/common/parse-contents.spec.ts
+++ b/packages/ai-chat/src/common/parse-contents.spec.ts
@@ -1,0 +1,142 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { ChatResponseContent, CodeChatResponseContentImpl, MarkdownChatResponseContentImpl } from './chat-model';
+import { parseContents } from './parse-contents';
+import { CodeContentMatcher, ResponseContentMatcher } from './response-content-matcher';
+
+export class CommandChatResponseContentImpl implements ChatResponseContent {
+    constructor(public readonly command: string) { }
+    kind = 'command';
+}
+
+export const CommandContentMatcher: ResponseContentMatcher = {
+    start: /^<command>$/m,
+    end: /^<\/command>$/m,
+    contentFactory: (content: string) => {
+        const code = content.replace(/^<command>\n|<\/command>$/g, '');
+        return new CommandChatResponseContentImpl(code.trim());
+    }
+};
+
+describe('parseContents', () => {
+    it('should parse code content', () => {
+        const text = '```typescript\nconsole.log("Hello World");\n```';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript')]);
+    });
+
+    it('should parse markdown content', () => {
+        const text = 'Hello **World**';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([new MarkdownChatResponseContentImpl('Hello **World**')]);
+    });
+
+    it('should parse multiple content blocks', () => {
+        const text = '```typescript\nconsole.log("Hello World");\n```\nHello **World**';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([
+            new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
+            new MarkdownChatResponseContentImpl('\nHello **World**')
+        ]);
+    });
+
+    it('should parse multiple content blocks with different languages', () => {
+        const text = '```typescript\nconsole.log("Hello World");\n```\n```python\nprint("Hello World")\n```';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([
+            new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
+            new CodeChatResponseContentImpl('print("Hello World")', 'python')
+        ]);
+    });
+
+    it('should parse multiple content blocks with different languages and markdown', () => {
+        const text = '```typescript\nconsole.log("Hello World");\n```\nHello **World**\n```python\nprint("Hello World")\n```';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([
+            new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
+            new MarkdownChatResponseContentImpl('\nHello **World**\n'),
+            new CodeChatResponseContentImpl('print("Hello World")', 'python')
+        ]);
+    });
+
+    it('should parse content blocks with empty content', () => {
+        const text = '```typescript\n```\nHello **World**\n```python\nprint("Hello World")\n```';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([
+            new CodeChatResponseContentImpl('', 'typescript'),
+            new MarkdownChatResponseContentImpl('\nHello **World**\n'),
+            new CodeChatResponseContentImpl('print("Hello World")', 'python')
+        ]);
+    });
+
+    it('should parse content with markdown, code, and markdown', () => {
+        const text = 'Hello **World**\n```typescript\nconsole.log("Hello World");\n```\nGoodbye **World**';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([
+            new MarkdownChatResponseContentImpl('Hello **World**\n'),
+            new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
+            new MarkdownChatResponseContentImpl('\nGoodbye **World**')
+        ]);
+    });
+
+    it('should handle text with no special content', () => {
+        const text = 'Just some plain text.';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([new MarkdownChatResponseContentImpl('Just some plain text.')]);
+    });
+
+    it('should handle text with only start code block', () => {
+        const text = '```typescript\nconsole.log("Hello World");';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([new MarkdownChatResponseContentImpl('```typescript\nconsole.log("Hello World");')]);
+    });
+
+    it('should handle text with only end code block', () => {
+        const text = 'console.log("Hello World");\n```';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([new MarkdownChatResponseContentImpl('console.log("Hello World");\n```')]);
+    });
+
+    it('should handle text with unmatched code block', () => {
+        const text = '```typescript\nconsole.log("Hello World");\n```\n```python\nprint("Hello World")';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([
+            new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
+            new MarkdownChatResponseContentImpl('\n```python\nprint("Hello World")')
+        ]);
+    });
+
+    it('should parse code block without newline after language', () => {
+        const text = '```typescript console.log("Hello World");```';
+        const result = parseContents(text);
+        expect(result).to.deep.equal([
+            new MarkdownChatResponseContentImpl('```typescript console.log("Hello World");```')
+        ]);
+    });
+
+    it('should parse with matches of multiple different matchers and default', () => {
+        const text = '<command>\nMY_SPECIAL_COMMAND\n</command>\nHello **World**\n```python\nprint("Hello World")\n```\n<command>\nMY_SPECIAL_COMMAND2\n</command>';
+        const result = parseContents(text, [CodeContentMatcher, CommandContentMatcher]);
+        expect(result).to.deep.equal([
+            new CommandChatResponseContentImpl('MY_SPECIAL_COMMAND'),
+            new MarkdownChatResponseContentImpl('\nHello **World**\n'),
+            new CodeChatResponseContentImpl('print("Hello World")', 'python'),
+            new CommandChatResponseContentImpl('MY_SPECIAL_COMMAND2'),
+        ]);
+    });
+});

--- a/packages/ai-chat/src/common/parse-contents.ts
+++ b/packages/ai-chat/src/common/parse-contents.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 EclipseSource GmbH.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ */
+import { ChatResponseContent } from './chat-model';
+import { CodeContentMatcher, MarkdownContentFactory, ResponseContentFactory, ResponseContentMatcher } from './response-content-matcher';
+
+interface Match {
+    matcher: ResponseContentMatcher;
+    index: number;
+    content: string;
+}
+
+export function parseContents(
+    text: string,
+    contentMatchers: ResponseContentMatcher[] = [CodeContentMatcher],
+    defaultContentFactory: ResponseContentFactory = MarkdownContentFactory
+): ChatResponseContent[] {
+    const result: ChatResponseContent[] = [];
+
+    let currentIndex = 0;
+    while (currentIndex < text.length) {
+        const remainingText = text.substring(currentIndex);
+        const match = findEarliestMatch(contentMatchers, remainingText);
+        if (match) {
+            // 1. Add preceding text as default content
+            if (match.index > 0) {
+                const precedingContent = remainingText.substring(0, match.index);
+                if (precedingContent.trim().length > 0) {
+                    result.push(defaultContentFactory(precedingContent));
+                }
+            }
+            // 2. Add the matched content object
+            result.push(match.matcher.contentFactory(match.content));
+            // Update currentIndex to the end of the end of the match
+            // And continue with the search after the end of the match
+            currentIndex += match.index + match.content.length;
+        } else {
+            // Add the remaining text as default content
+            if (remainingText.length > 0) {
+                result.push(defaultContentFactory(remainingText));
+            }
+            break;
+        }
+    }
+
+    return result;
+}
+
+export function findEarliestMatch(contentMatchers: ResponseContentMatcher[], text: string): Match | undefined {
+    let earliestMatch: { matcher: ResponseContentMatcher, index: number, content: string } | undefined;
+    for (const matcher of contentMatchers) {
+        const startMatch = matcher.start.exec(text);
+        if (startMatch) {
+            const endOfStartMatch = startMatch.index + startMatch[0].length;
+            if (endOfStartMatch < text.length) {
+                const remainingTextAfterStartMatch = text.substring(endOfStartMatch);
+                const endMatch = matcher.end.exec(remainingTextAfterStartMatch);
+                if (endMatch) {
+                    const index = startMatch.index;
+                    const contentEnd = index + startMatch[0].length + endMatch.index + endMatch[0].length;
+                    const content = text.substring(index, contentEnd);
+                    if (!earliestMatch || index < earliestMatch.index) {
+                        earliestMatch = { matcher, index, content };
+                    }
+                }
+            }
+        }
+    }
+    return earliestMatch;
+}
+

--- a/packages/ai-chat/src/common/parse-contents.ts
+++ b/packages/ai-chat/src/common/parse-contents.ts
@@ -33,26 +33,26 @@ export function parseContents(
     while (currentIndex < text.length) {
         const remainingText = text.substring(currentIndex);
         const match = findEarliestMatch(contentMatchers, remainingText);
-        if (match) {
-            // 1. Add preceding text as default content
-            if (match.index > 0) {
-                const precedingContent = remainingText.substring(0, match.index);
-                if (precedingContent.trim().length > 0) {
-                    result.push(defaultContentFactory(precedingContent));
-                }
-            }
-            // 2. Add the matched content object
-            result.push(match.matcher.contentFactory(match.content));
-            // Update currentIndex to the end of the end of the match
-            // And continue with the search after the end of the match
-            currentIndex += match.index + match.content.length;
-        } else {
+        if (!match) {
             // Add the remaining text as default content
             if (remainingText.length > 0) {
                 result.push(defaultContentFactory(remainingText));
             }
             break;
         }
+        // We have a match
+        // 1. Add preceding text as default content
+        if (match.index > 0) {
+            const precedingContent = remainingText.substring(0, match.index);
+            if (precedingContent.trim().length > 0) {
+                result.push(defaultContentFactory(precedingContent));
+            }
+        }
+        // 2. Add the matched content object
+        result.push(match.matcher.contentFactory(match.content));
+        // Update currentIndex to the end of the end of the match
+        // And continue with the search after the end of the match
+        currentIndex += match.index + match.content.length;
     }
 
     return result;
@@ -62,20 +62,29 @@ export function findEarliestMatch(contentMatchers: ResponseContentMatcher[], tex
     let earliestMatch: { matcher: ResponseContentMatcher, index: number, content: string } | undefined;
     for (const matcher of contentMatchers) {
         const startMatch = matcher.start.exec(text);
-        if (startMatch) {
-            const endOfStartMatch = startMatch.index + startMatch[0].length;
-            if (endOfStartMatch < text.length) {
-                const remainingTextAfterStartMatch = text.substring(endOfStartMatch);
-                const endMatch = matcher.end.exec(remainingTextAfterStartMatch);
-                if (endMatch) {
-                    const index = startMatch.index;
-                    const contentEnd = index + startMatch[0].length + endMatch.index + endMatch[0].length;
-                    const content = text.substring(index, contentEnd);
-                    if (!earliestMatch || index < earliestMatch.index) {
-                        earliestMatch = { matcher, index, content };
-                    }
-                }
-            }
+        if (!startMatch) {
+            // No start match found, try next matcher.
+            continue;
+        }
+        const endOfStartMatch = startMatch.index + startMatch[0].length;
+        if (endOfStartMatch >= text.length) {
+            // There is no text after the start match.
+            // No need to search for the end match yet, try next matcher.
+            continue;
+        }
+        const remainingTextAfterStartMatch = text.substring(endOfStartMatch);
+        const endMatch = matcher.end.exec(remainingTextAfterStartMatch);
+        if (!endMatch) {
+            // No end match found, try next matcher.
+            continue;
+        }
+        // Found start and end match.
+        // Record the full match, if it is the earliest found so far.
+        const index = startMatch.index;
+        const contentEnd = index + startMatch[0].length + endMatch.index + endMatch[0].length;
+        const content = text.substring(index, contentEnd);
+        if (!earliestMatch || index < earliestMatch.index) {
+            earliestMatch = { matcher, index, content };
         }
     }
     return earliestMatch;

--- a/packages/ai-chat/src/common/parse-contents.ts
+++ b/packages/ai-chat/src/common/parse-contents.ts
@@ -59,7 +59,7 @@ export function parseContents(
 }
 
 export function findFirstMatch(contentMatchers: ResponseContentMatcher[], text: string): Match | undefined {
-    let earliestMatch: { matcher: ResponseContentMatcher, index: number, content: string } | undefined;
+    let firstMatch: { matcher: ResponseContentMatcher, index: number, content: string } | undefined;
     for (const matcher of contentMatchers) {
         const startMatch = matcher.start.exec(text);
         if (!startMatch) {
@@ -83,10 +83,10 @@ export function findFirstMatch(contentMatchers: ResponseContentMatcher[], text: 
         const index = startMatch.index;
         const contentEnd = index + startMatch[0].length + endMatch.index + endMatch[0].length;
         const content = text.substring(index, contentEnd);
-        if (!earliestMatch || index < earliestMatch.index) {
-            earliestMatch = { matcher, index, content };
+        if (!firstMatch || index < firstMatch.index) {
+            firstMatch = { matcher, index, content };
         }
     }
-    return earliestMatch;
+    return firstMatch;
 }
 

--- a/packages/ai-chat/src/common/parse-contents.ts
+++ b/packages/ai-chat/src/common/parse-contents.ts
@@ -32,7 +32,7 @@ export function parseContents(
     let currentIndex = 0;
     while (currentIndex < text.length) {
         const remainingText = text.substring(currentIndex);
-        const match = findEarliestMatch(contentMatchers, remainingText);
+        const match = findFirstMatch(contentMatchers, remainingText);
         if (!match) {
             // Add the remaining text as default content
             if (remainingText.length > 0) {
@@ -58,7 +58,7 @@ export function parseContents(
     return result;
 }
 
-export function findEarliestMatch(contentMatchers: ResponseContentMatcher[], text: string): Match | undefined {
+export function findFirstMatch(contentMatchers: ResponseContentMatcher[], text: string): Match | undefined {
     let earliestMatch: { matcher: ResponseContentMatcher, index: number, content: string } | undefined;
     for (const matcher of contentMatchers) {
         const startMatch = matcher.start.exec(text);

--- a/packages/ai-chat/src/common/response-content-matcher.ts
+++ b/packages/ai-chat/src/common/response-content-matcher.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 EclipseSource GmbH.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ */
+import {
+    ChatResponseContent,
+    CodeChatResponseContentImpl,
+    MarkdownChatResponseContentImpl
+} from './chat-model';
+import { injectable } from '@theia/core/shared/inversify';
+
+export type ResponseContentFactory = (content: string) => ChatResponseContent;
+
+export const MarkdownContentFactory: ResponseContentFactory = (content: string) =>
+    new MarkdownChatResponseContentImpl(content);
+
+/**
+ * Default response content factory used if no other `ResponseContentMatcher` applies.
+ * By default, this factory creates a markdown content object.
+ *
+ * @see MarkdownChatResponseContentImpl
+ */
+@injectable()
+export class DefaultResponseContentFactory {
+    create(content: string): ChatResponseContent {
+        return MarkdownContentFactory(content);
+    }
+}
+
+/**
+ * Clients can contribute response content matchers to parse a chat response into specific
+ * `ChatResponseContent` instances.
+ */
+export interface ResponseContentMatcher {
+    /** Regular expression for finding the start delimiter. */
+    start: RegExp;
+    /** Regular expression for finding the start delimiter. */
+    end: RegExp;
+    /**
+     * The factory creating a response content from the matching content,
+     * from start index to end index of the match (including delimiters).
+     */
+    contentFactory: ResponseContentFactory;
+}
+
+export const CodeContentMatcher: ResponseContentMatcher = {
+    start: /^```.*?$/m,
+    end: /^```$/m,
+    contentFactory: (content: string) => {
+        const language = content.match(/^```(\w+)/)?.[1] || '';
+        const code = content.replace(/^```(\w+)\n|```$/g, '');
+        return new CodeChatResponseContentImpl(code.trim(), language);
+    }
+};
+
+/**
+ * Clients can contribute response content matchers to parse the response content.
+ *
+ * The default chat user interface will collect all contributed matchers and use them
+ * to parse the response into structured content parts (e.g. code blocks, markdown blocks),
+ * which are then rendered with a `ChatResponsePartRenderer` registered for the respective
+ * content part type.
+ *
+ * ### Example
+ * ```ts
+ * bind(ResponseContentMatcherProvider).to(MyResponseContentMatcherProvider);
+ * ...
+ * @injectable()
+ * export class MyResponseContentMatcherProvider implements ResponseContentMatcherProvider {
+ *     readonly matchers: ResponseContentMatcher[] = [{
+ *       start: /^<command>$/m,
+ *       end: /^</command>$/m,
+ *       contentFactory: (content: string) => {
+ *         const command = content.replace(/^<command>\n|<\/command>$/g, '');
+ *         return new MyChatResponseContentImpl(command.trim());
+ *       }
+ *   }];
+ * }
+ * ```
+ *
+ * @see ResponseContentMatcher
+ */
+export const ResponseContentMatcherProvider = Symbol('ResponseContentMatcherProvider');
+export interface ResponseContentMatcherProvider {
+    readonly matchers: ResponseContentMatcher[];
+}
+
+@injectable()
+export class DefaultResponseContentMatcherProvider implements ResponseContentMatcherProvider {
+    readonly matchers: ResponseContentMatcher[] = [CodeContentMatcher];
+}


### PR DESCRIPTION
#### What it does

Turns the response parsing method of the chat agents into a more flexible algorithm that can work with multiple response content matchers. Each response content matcher has a start and an end regexp to define a match, as well as a `contentFactory` function that is invoked to turn the matched content into a specific `ChatResponseContent` object.

This way, clients can add and combine multiple response content matchers to process LLM responses and turn them into custom response parts, while still keeping the generically useful ones, like the matcher for code blocks, etc.

Additionally, the parsing method has a fallback content factory that will be applied to all unmatched parts. By default, this is the existing markdown content part, but this can be customized if needed.

Both, the response content matchers and the fallback content factory are configurable via DI.

Contributed on behalf of STMicroelectronics.

#### How to test

Ensure normal behavior is still working as expected. That is, we should test the processing and rendering of plain chat responses that contain an arbitrary mixture of markdown parts, code parts, and tool call parts.

In addition, one could test to customize the `DefaultResponseContentFactory` or register additional `ResponseContentMatcherProvider`.

```ts
    // Change the default response part
    rebind(DefaultResponseContentMatcherProvider).to(YourDefaultPartCustomization);
    // Add additional matchers
    bind(ResponseContentMatcherProvider).to(YourAdditionalResponseContentMatcherProvider);
    // Change default matchers (code)
    rebind(DefaultResponseContentFactory).to(YourCustomization);
```

Since the parsing is a bit of a dense code, I added unit tests for it.

#### Follow-ups

I tried to simplify the parsing. However, there is one aspect, which I found a bit confusing but is not changed by this PR:
The fall back to markdown, handling of tool calls, or parsing into specific parts is a bit spread across the code
* 2x in [`parse()`](https://github.com/eclipse-theia/theia/blob/4a0228b362801af796c8596317b735860fc9e427/packages/ai-chat/src/common/chat-agents.ts#L369)
* 3x in [`addContentsToResponse`](https://github.com/eclipse-theia/theia/blob/4a0228b362801af796c8596317b735860fc9e427/packages/ai-chat/src/common/chat-agents.ts#L282C30-L282C51), where we currently need to ensure, we prevent parsing, if the previous content was a tool call, which is also somewhat hidden.

Maybe there is an opportunity to further simplify this and parse this all in one place and one go.

Also it was unclear to me why we don't parse for specific content parts in case we have a [`isLanguageModelTextResponse` === true](https://github.com/eclipse-theia/theia/blob/4a0228b362801af796c8596317b735860fc9e427/packages/ai-chat/src/common/chat-agents.ts#L282C30-L282C51) case. This is actually changed so that it now uses the `parseContents` function to obtain the content parts instead of creating a plain markdown part either way, which feels more consistent.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
