### PR TITLE
[vscode] Support evolution on proposed API extensionAny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 <!-- ## Unreleased
 
 - [plugin] move stubbed API TerminalShellIntegration into main API [#14168](https://github.com/eclipse-theia/theia/pull/14168) - Contributed on behalf of STMicroelectronics
+- [plugin] support evolution on proposed API extensionAny [#14199](https://github.com/eclipse-theia/theia/pull/14199) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.54.0">[Breaking Changes:](#breaking_changes_1.54.0)</a> -->
 - [core] Updated AuthenticationService to handle multiple accounts per provider [#14149](https://github.com/eclipse-theia/theia/pull/14149) - Contributed on behalf of STMicroelectronics

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -884,7 +884,7 @@ export function createAPIFactory(
 
         const extensions: typeof theia.extensions = Object.freeze({
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            getExtension<T = any>(extensionId: string, includeFromDifferentExtensionHosts: boolean = false): theia.Extension<T> | undefined {
+            getExtension<T = any>(extensionId: string, includeFromDifferentExtensionHosts: boolean = false): theia.Extension<T | undefined> | undefined {
                 includeFromDifferentExtensionHosts = false;
                 const plg = pluginManager.getPluginById(extensionId.toLowerCase());
                 if (plg) {

--- a/packages/plugin/src/theia.proposed.extensionsAny.d.ts
+++ b/packages/plugin/src/theia.proposed.extensionsAny.d.ts
@@ -41,9 +41,13 @@ export module '@theia/plugin' {
          * @param extensionId An extension identifier.
          * @param includeDifferentExtensionHosts Include extensions from different extension host
          * @return An extension or `undefined`.
+         *
+         * *Note* In Theia, includeDifferentExtensionHosts will always be set to false, as we only support one host currently.
          */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         export function getExtension<T = any>(extensionId: string, includeDifferentExtensionHosts: boolean): Extension<T> | undefined;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        export function getExtension<T = any>(extensionId: string, includeDifferentExtensionHosts: true): Extension<T | undefined> | undefined;
 
         /**
          * All extensions across all extension hosts.


### PR DESCRIPTION
#### What it does

Proposed API extensionsAny will now have a new signature for getExtension:
https://github.com/microsoft/vscode/blob/38c31bc77e0dd6ae88a4e9cc93428cc27a56ba40/src/vscode-dts/vscode.proposed.extensionsAny.d.ts#L31

This Pull Request adds this to the similar interface in Theia file, and also update getExtension from plugin-context to align with this new signature. 
Since https://github.com/eclipse-theia/theia/pull/12277, the `includeDifferentExtensionHosts` parameter is ignored, as there is only one host in Theia. So there should be no other change to support this evolution.

fixes #14115

contributed on behalf of STMicroelectronics

#### How to test

Use the builtins and assume they still work with this evolution. The html-language-feature is the only builtin relying on the extensionsAny proposed API.

#### Follow-ups

None

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
