### PR TITLE
fix markdown request renderer

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -25,6 +25,7 @@ import { ReactNode, useEffect, useRef } from '@theia/core/shared/react';
 import * as React from '@theia/core/shared/react';
 import * as markdownit from '@theia/core/shared/markdown-it';
 import * as DOMPurify from '@theia/core/shared/dompurify';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 
 @injectable()
 export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownChatResponseContent | InformationalChatResponseContent> {
@@ -52,7 +53,7 @@ export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownCh
 }
 
 const MarkdownRender = ({ response }: { response: MarkdownChatResponseContent | InformationalChatResponseContent }) => {
-    const ref = useMarkdownRendering(response.content.value);
+    const ref = useMarkdownRendering(response.content);
 
     return <div ref={ref}></div>;
 };
@@ -67,13 +68,14 @@ const MarkdownRender = ({ response }: { response: MarkdownChatResponseContent | 
  * @param markdown the string to render as markdown
  * @returns the ref to use in an element to render the markdown
  */
-export const useMarkdownRendering = (markdown: string) => {
+export const useMarkdownRendering = (markdown: string | MarkdownString) => {
     // eslint-disable-next-line no-null/no-null
     const ref = useRef<HTMLDivElement | null>(null);
     useEffect(() => {
         const markdownIt = markdownit();
         const host = document.createElement('div');
-        const html = markdownIt.render(markdown);
+        const markdownString = typeof markdown === 'string' ? markdown : markdown.value;
+        const html = markdownIt.render(markdownString);
         host.innerHTML = DOMPurify.sanitize(html, {
             ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
         });

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -71,10 +71,10 @@ const MarkdownRender = ({ response }: { response: MarkdownChatResponseContent | 
 export const useMarkdownRendering = (markdown: string | MarkdownString) => {
     // eslint-disable-next-line no-null/no-null
     const ref = useRef<HTMLDivElement | null>(null);
+    const markdownString = typeof markdown === 'string' ? markdown : markdown.value;
     useEffect(() => {
         const markdownIt = markdownit();
         const host = document.createElement('div');
-        const markdownString = typeof markdown === 'string' ? markdown : markdown.value;
         const html = markdownIt.render(markdownString);
         host.innerHTML = DOMPurify.sanitize(html, {
             ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
@@ -84,7 +84,7 @@ export const useMarkdownRendering = (markdown: string | MarkdownString) => {
         }
 
         ref?.current?.appendChild(host);
-    }, [markdown]);
+    }, [markdownString]);
 
     return ref;
 };

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -46,7 +46,6 @@ export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownCh
             return null;
         }
 
-        // return <div ref={ref}></div>;
         return <MarkdownRender response={response} />;
     }
 

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -53,7 +53,6 @@ export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownCh
 }
 
 const MarkdownRender = ({ response }: { response: MarkdownChatResponseContent | InformationalChatResponseContent }) => {
-    // eslint-disable-next-line no-null/no-null
     const ref = useMarkdownRendering(response.content.value);
 
     return <div ref={ref}></div>;

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { injectable } from '@theia/core/shared/inversify';
 import {
     ChatResponseContent,
     InformationalChatResponseContent,
@@ -23,12 +23,12 @@ import {
 } from '@theia/ai-chat/lib/common';
 import { ReactNode, useEffect, useRef } from '@theia/core/shared/react';
 import * as React from '@theia/core/shared/react';
-import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
-import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import * as markdownit from '@theia/core/shared/markdown-it';
+import * as DOMPurify from '@theia/core/shared/dompurify';
 
 @injectable()
 export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownChatResponseContent | InformationalChatResponseContent> {
-    @inject(MarkdownRenderer) private renderer: MarkdownRenderer;
+    protected readonly markdownIt = markdownit();
     canHandle(response: ChatResponseContent): number {
         if (MarkdownChatResponseContent.is(response)) {
             return 10;
@@ -38,34 +38,51 @@ export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownCh
         }
         return -1;
     }
-    private renderMarkdown(md: MarkdownString): HTMLElement {
-        return this.renderer.render(md).element;
-    }
     render(response: MarkdownChatResponseContent | InformationalChatResponseContent): ReactNode {
+        // // eslint-disable-next-line no-null/no-null
+        // const ref: React.MutableRefObject<HTMLDivElement | null> = useRef(null);
+
+        // useEffect(() => {
+        //     const host = document.createElement('div');
+        //     const html = this.markdownIt.render(response.content);
+        //     host.innerHTML = DOMPurify.sanitize(html, {
+        //         ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
+        //     });
+        //     while (ref?.current?.firstChild) {
+        //         ref.current.removeChild(ref.current.firstChild);
+        //     }
+
+        //     ref?.current?.appendChild(host);
+        // }, [response.content]);
         // TODO let the user configure whether they want to see informational content
         if (InformationalChatResponseContent.is(response)) {
             // null is valid in React
             // eslint-disable-next-line no-null/no-null
             return null;
         }
-        return <MarkdownWrapper data={response.content} renderCallback={this.renderMarkdown.bind(this)}></MarkdownWrapper>;
+
+        // return <div ref={ref}></div>;
+        return <MarkdownRender response={response} />;
     }
 
 }
 
-export const MarkdownWrapper = (props: { data: MarkdownString, renderCallback: (md: MarkdownString) => HTMLElement }) => {
+const MarkdownRender = ({ response }: { response: MarkdownChatResponseContent | InformationalChatResponseContent }) => {
     // eslint-disable-next-line no-null/no-null
     const ref: React.MutableRefObject<HTMLDivElement | null> = useRef(null);
-
     useEffect(() => {
-        const myDomElement = props.renderCallback(props.data);
-
+        const markdownIt = markdownit();
+        const host = document.createElement('div');
+        const html = markdownIt.render(response.content);
+        host.innerHTML = DOMPurify.sanitize(html, {
+            ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
+        });
         while (ref?.current?.firstChild) {
             ref.current.removeChild(ref.current.firstChild);
         }
 
-        ref?.current?.appendChild(myDomElement);
-    }, [props.data.value]);
+        ref?.current?.appendChild(host);
+    }, [response.content]);
 
     return <div ref={ref}></div>;
 };

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -45,9 +45,7 @@ import * as React from '@theia/core/shared/react';
 
 import { ChatNodeToolbarActionContribution } from '../chat-node-toolbar-action-contribution';
 import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
-import * as markdownit from '@theia/core/shared/markdown-it';
-import * as DOMPurify from '@theia/core/shared/dompurify';
-import { useEffect, useRef } from '@theia/core/shared/react';
+import { useMarkdownRendering } from '../chat-response-renderer/markdown-part-renderer';
 
 // TODO Instead of directly operating on the ChatRequestModel we could use an intermediate view model
 export interface RequestNode extends TreeNode {
@@ -378,22 +376,8 @@ export class ChatViewTreeWidget extends TreeWidget {
 }
 
 const ChatRequestRender = ({ node }: { node: RequestNode }) => {
-    // eslint-disable-next-line no-null/no-null
-    const ref: React.MutableRefObject<HTMLDivElement | null> = useRef(null);
-    useEffect(() => {
-        const markdownIt = markdownit();
-        const text = node.request.request.displayText ?? node.request.request.text;
-        const host = document.createElement('div');
-        const html = markdownIt.render(text);
-        host.innerHTML = DOMPurify.sanitize(html, {
-            ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
-        });
-        while (ref?.current?.firstChild) {
-            ref.current.removeChild(ref.current.firstChild);
-        }
-
-        ref?.current?.appendChild(host);
-    }, [node.request]);
+    const text = node.request.request.displayText ?? node.request.request.text;
+    const ref = useMarkdownRendering(text);
 
     return <div className={'theia-RequestNode'} ref={ref}></div>;
 };

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -20,7 +20,6 @@
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatModel.ts
 
 import { Command, Emitter, Event, generateUuid, URI } from '@theia/core';
-import { MarkdownString, MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { Position } from '@theia/core/shared/vscode-languageserver-protocol';
 import { ChatAgentLocation } from './chat-agents';
 import { ParsedChatRequest } from './parsed-chat-request';
@@ -128,7 +127,7 @@ export interface ErrorChatResponseContent extends ChatResponseContent {
 export interface MarkdownChatResponseContent
     extends Required<ChatResponseContent> {
     kind: 'markdownContent';
-    content: MarkdownString;
+    content: string;
 }
 
 export interface CodeChatResponseContent
@@ -187,7 +186,7 @@ export interface CommandChatResponseContent extends ChatResponseContent {
  */
 export interface InformationalChatResponseContent extends ChatResponseContent {
     kind: 'informational';
-    content: MarkdownString;
+    content: string;
 }
 
 export namespace TextChatResponseContent {
@@ -207,7 +206,7 @@ export namespace MarkdownChatResponseContent {
             ChatResponseContent.is(obj) &&
             obj.kind === 'markdownContent' &&
             'content' in obj &&
-            MarkdownString.is((obj as { content: unknown }).content)
+            typeof (obj as { content: unknown }).content === 'string'
         );
     }
 }
@@ -218,7 +217,7 @@ export namespace InformationalChatResponseContent {
             ChatResponseContent.is(obj) &&
             obj.kind === 'informational' &&
             'content' in obj &&
-            MarkdownString.is((obj as { content: unknown }).content)
+            typeof (obj as { content: unknown }).content === 'string'
         );
     }
 }
@@ -411,35 +410,35 @@ export class TextChatResponseContentImpl implements TextChatResponseContent {
 
 export class MarkdownChatResponseContentImpl implements MarkdownChatResponseContent {
     readonly kind = 'markdownContent';
-    protected _content: MarkdownStringImpl = new MarkdownStringImpl();
+    protected _content: string;
 
     constructor(content: string) {
-        this._content.appendMarkdown(content);
+        this._content = content;
     }
 
-    get content(): MarkdownString {
+    get content(): string {
         return this._content;
     }
 
     asString(): string {
-        return this._content.value;
+        return this._content;
     }
 
     merge(nextChatResponseContent: MarkdownChatResponseContent): boolean {
-        this._content.appendMarkdown(nextChatResponseContent.content.value);
+        this._content += nextChatResponseContent.content;
         return true;
     }
 }
 
 export class InformationalChatResponseContentImpl implements InformationalChatResponseContent {
     readonly kind = 'informational';
-    protected _content: MarkdownStringImpl;
+    protected _content: string;
 
     constructor(content: string) {
-        this._content = new MarkdownStringImpl(content);
+        this._content = content;
     }
 
-    get content(): MarkdownString {
+    get content(): string {
         return this._content;
     }
 
@@ -448,7 +447,7 @@ export class InformationalChatResponseContentImpl implements InformationalChatRe
     }
 
     merge(nextChatResponseContent: InformationalChatResponseContent): boolean {
-        this._content.appendMarkdown(nextChatResponseContent.content.value);
+        this._content += nextChatResponseContent.content;
         return true;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Currently requests in the ai chat view use a markdown renderer which parses html input and tries to render this. This leads to unexpected behavior when using html in the query.
By deactivating html support there, an alternative is needed as the markdown renderer just renders an empty paragraph if html is now passed to it. So to render the actual text, a span is created and filled with the text content.

fixes #14208
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Use a string like `<img src="../../enter-openai-key.png" alt="Theia IDE Screenshot" style="max-width: 525px">` in you query.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
