### PR TITLE
Support debug/createConfiguration proposed menu API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 <!-- ## Unreleased
 
+- [debug] support 'debug/createConfiguration' menu extension [14215](https://github.com/eclipse-theia/theia/pull/14215) - Contributed on behalf of STMicroelectronics
 - [plugin] move stubbed API TerminalShellIntegration into main API [#14168](https://github.com/eclipse-theia/theia/pull/14168) - Contributed on behalf of STMicroelectronics
 - [plugin] support evolution on proposed API extensionAny [#14199](https://github.com/eclipse-theia/theia/pull/14199) - Contributed on behalf of STMicroelectronics
 - [plugin] updated TreeView reveal options to be readonly [#14198](https://github.com/eclipse-theia/theia/pull/14198) - Contributed on behalf of STMicroelectronics

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -20,6 +20,7 @@ import { Navigatable } from '@theia/core/lib/browser/navigatable';
 import { injectable } from '@theia/core/shared/inversify';
 import { URI as CodeUri } from '@theia/core/shared/vscode-uri';
 import { DebugStackFramesWidget } from '@theia/debug/lib/browser/view/debug-stack-frames-widget';
+import { DEBUG_CREATE_CONFIGURATION_MENU } from '@theia/debug/lib/browser/debug-configuration-manager';
 import { DebugThreadsWidget } from '@theia/debug/lib/browser/view/debug-threads-widget';
 import { DebugToolBar } from '@theia/debug/lib/browser/view/debug-toolbar-widget';
 import { DebugVariablesWidget } from '@theia/debug/lib/browser/view/debug-variables-widget';
@@ -46,6 +47,7 @@ export const implementedVSCodeContributionPoints = [
     'comments/comment/title',
     'comments/commentThread/context',
     'debug/callstack/context',
+    'debug/createConfiguration',
     'debug/variables/context',
     'debug/toolBar',
     'editor/context',
@@ -79,6 +81,7 @@ export const codeToTheiaMappings = new Map<ContributionPoint, MenuPath[]>([
     ['comments/comment/title', [COMMENT_TITLE]],
     ['comments/commentThread/context', [COMMENT_THREAD_CONTEXT]],
     ['debug/callstack/context', [DebugStackFramesWidget.CONTEXT_MENU, DebugThreadsWidget.CONTEXT_MENU]],
+    ['debug/createConfiguration', [DEBUG_CREATE_CONFIGURATION_MENU]],
     ['debug/variables/context', [DebugVariablesWidget.CONTEXT_MENU]],
     ['debug/toolBar', [DebugToolBar.MENU]],
     ['editor/context', [EDITOR_CONTEXT_MENU]],


### PR DESCRIPTION
#### What it does

This PR adds the support of the newly introduced `debug/createConfiguration` menu. This menu is currently a proposed API. 

fixes #14114

contributed on behalf of STMicroelectronics
 
#### How to test

A test extension has been developed to test this feature:
- src: [scm-menu-sample-0.0.3-src.zip](https://github.com/user-attachments/files/17114099/scm-menu-sample-0.0.3-src.zip)
- zipped vsix: [scm-menu-sample-0.0.3.zip](https://github.com/user-attachments/files/17114102/scm-menu-sample-0.0.3.zip)

The steps to reproduce are almost the same as in VS code:
- delete the `launch.json` file from your `.theia/.code` folder
- Go to the debug view and click on the cog wheel that opens or create the `launch.json` file.
- if the extension is not installed, the behavior should be the same as usual, e.g. generate a skeleton of `launch.json` and edit it.
- if the extension is installed, some quick pick menu shall come, that allows you to select between the available commands from the new menu or the usual `launch.json` generation and edition.
- The command, once invoked, does not do anything currently except showing a notification. It would be up to the extension to generate a file as far as I understand the feature on vs code. 

https://github.com/user-attachments/assets/ec99fa6b-48bf-4bfc-863f-8d1b8a940de4

#### Follow-ups

None

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
