### PR TITLE
fix ai-settings retrieval

### DIFF
--- a/packages/ai-core/src/browser/ai-configuration/language-model-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/language-model-renderer.tsx
@@ -31,7 +31,7 @@ export const LanguageModelRenderer: React.FC<LanguageModelSettingsProps> = (
 
     const findLanguageModelRequirement = async (purpose: string): Promise<LanguageModelRequirement | undefined> => {
         const requirementSetting = await aiSettingsService.getAgentSettings(agent.id);
-        return requirementSetting?.languageModelRequirements.find(e => e.purpose === purpose);
+        return requirementSetting?.languageModelRequirements?.find(e => e.purpose === purpose);
     };
 
     const [lmRequirementMap, setLmRequirementMap] = React.useState<Record<string, LanguageModelRequirement>>({});

--- a/packages/ai-core/src/browser/frontend-language-model-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-registry.ts
@@ -288,7 +288,7 @@ export class FrontendLanguageModelRegistryImpl
 
     override async selectLanguageModels(request: LanguageModelSelector): Promise<LanguageModel[]> {
         await this.initialized;
-        const userSettings = (await this.settingsService.getAgentSettings(request.agent))?.languageModelRequirements.find(req => req.purpose === request.purpose);
+        const userSettings = (await this.settingsService.getAgentSettings(request.agent))?.languageModelRequirements?.find(req => req.purpose === request.purpose);
         if (userSettings?.identifier) {
             const model = await this.getLanguageModel(userSettings.identifier);
             if (model) {

--- a/packages/ai-core/src/common/settings-service.ts
+++ b/packages/ai-core/src/common/settings-service.ts
@@ -28,6 +28,6 @@ export interface AISettingsService {
 }
 export type AISettings = Record<string, AgentSettings>;
 export interface AgentSettings {
-    languageModelRequirements: LanguageModelRequirement[];
-    enable: boolean;
+    languageModelRequirements?: LanguageModelRequirement[];
+    enable?: boolean;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The languageModelRequirements can be undefined and this needs to be correctly handled by callers.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Check that your settings have no entries for ai-agents. Now just disable an ai-agent using the ai configuration view. Now try to use this agent. See an error.
With the fix, the language model is correctly resolved to a default value.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
