### PR TITLE
Fix incorrect import in `split-widget.ts`

### DIFF
--- a/packages/core/src/browser/widgets/split-widget.ts
+++ b/packages/core/src/browser/widgets/split-widget.ts
@@ -14,12 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Emitter } from 'vscode-languageserver-protocol';
 import { ApplicationShell, StatefulWidget } from '../shell';
 import { BaseWidget, Message, PanelLayout, SplitPanel, Widget } from './widget';
 import { CompositeSaveable, Saveable, SaveableSource } from '../saveable';
 import { Navigatable } from '../navigatable-types';
-import { URI } from '../../common';
+import { Emitter, URI } from '../../common';
 
 /**
  * A widget containing a number of panes in a split layout.


### PR DESCRIPTION
#### What it does

Updates imports in `split-widget.ts` where `Emitter` was incorrectly imported from 'vscode-languageserver-protocol' instead of 'common'.

#### How to test

This is a trivial change, which is not expected to cause any regressions.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
