### PR TITLE
Allow to order and clear AI History view

### DIFF
--- a/packages/ai-core/src/common/communication-recording-service.ts
+++ b/packages/ai-core/src/common/communication-recording-service.ts
@@ -41,4 +41,7 @@ export interface CommunicationRecordingService {
     readonly onDidRecordResponse: Event<CommunicationResponseEntry>;
 
     getHistory(agentId: string): CommunicationHistory;
+
+    clearHistory(): void;
+    readonly onStructuralChange: Event<void>;
 }

--- a/packages/ai-history/src/browser/ai-history-contribution.ts
+++ b/packages/ai-history/src/browser/ai-history-contribution.ts
@@ -71,16 +71,16 @@ export class AIHistoryViewContribution extends AIViewContribution<AIHistoryView>
             execute: () => this.openView({ activate: true }),
         });
         registry.registerCommand(AI_HISTORY_VIEW_SORT_CHRONOLOGICALLY, {
-            isEnabled: widget => this.withHistoryWidget(widget, historyView => !historyView.isChronologial),
-            isVisible: widget => this.withHistoryWidget(widget, historyView => !historyView.isChronologial),
+            isEnabled: widget => this.withHistoryWidget(widget, historyView => !historyView.isChronological),
+            isVisible: widget => this.withHistoryWidget(widget, historyView => !historyView.isChronological),
             execute: widget => this.withHistoryWidget(widget, historyView => {
                 historyView.sortHistory(true);
                 return true;
             })
         });
         registry.registerCommand(AI_HISTORY_VIEW_SORT_REVERSE_CHRONOLOGICALLY, {
-            isEnabled: widget => this.withHistoryWidget(widget, historyView => historyView.isChronologial),
-            isVisible: widget => this.withHistoryWidget(widget, historyView => historyView.isChronologial),
+            isEnabled: widget => this.withHistoryWidget(widget, historyView => historyView.isChronological),
+            isVisible: widget => this.withHistoryWidget(widget, historyView => historyView.isChronological),
             execute: widget => this.withHistoryWidget(widget, historyView => {
                 historyView.sortHistory(false);
                 return true;

--- a/packages/ai-history/src/browser/ai-history-contribution.ts
+++ b/packages/ai-history/src/browser/ai-history-contribution.ts
@@ -47,7 +47,7 @@ export const AI_HISTORY_VIEW_CLEAR = Command.toLocalizedCommand({
 
 @injectable()
 export class AIHistoryViewContribution extends AIViewContribution<AIHistoryView> implements TabBarToolbarContribution {
-    @inject(CommunicationRecordingService) private recordingService: CommunicationRecordingService
+    @inject(CommunicationRecordingService) private recordingService: CommunicationRecordingService;
 
     constructor() {
         super({

--- a/packages/ai-history/src/browser/ai-history-frontend-module.ts
+++ b/packages/ai-history/src/browser/ai-history-frontend-module.ts
@@ -21,6 +21,7 @@ import { ILogger } from '@theia/core';
 import { AIHistoryViewContribution } from './ai-history-contribution';
 import { AIHistoryView } from './ai-history-widget';
 import '../../src/browser/style/ai-history.css';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 export default new ContainerModule(bind => {
     bind(DefaultCommunicationRecordingService).toSelf().inSingletonScope();
@@ -38,4 +39,6 @@ export default new ContainerModule(bind => {
         id: AIHistoryView.ID,
         createWidget: () => context.container.get<AIHistoryView>(AIHistoryView)
     })).inSingletonScope();
+    bind(TabBarToolbarContribution).toService(AIHistoryViewContribution);
+
 });

--- a/packages/ai-history/src/browser/ai-history-widget.tsx
+++ b/packages/ai-history/src/browser/ai-history-widget.tsx
@@ -19,9 +19,9 @@ import { inject, injectable, postConstruct } from '@theia/core/shared/inversify'
 import * as React from '@theia/core/shared/react';
 import { CommunicationCard } from './ai-history-communication-card';
 import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
-import { deepClone, Emitter, Event } from '@theia/core';
+import { deepClone, Emitter } from '@theia/core';
 
-export namespace AIHistoryView {
+namespace AIHistoryView {
     export interface State {
         chronological: boolean;
     }
@@ -41,6 +41,7 @@ export class AIHistoryView extends ReactWidget implements StatefulWidget {
 
     protected _state: AIHistoryView.State = { chronological: false };
     protected readonly onStateChangedEmitter = new Emitter<AIHistoryView.State>();
+    readonly onStateChanged = this.onStateChangedEmitter.event;
 
     constructor() {
         super();
@@ -58,10 +59,6 @@ export class AIHistoryView extends ReactWidget implements StatefulWidget {
     protected set state(state: AIHistoryView.State) {
         this._state = state;
         this.onStateChangedEmitter.fire(this._state);
-    }
-
-    get onStateChanged(): Event<AIHistoryView.State> {
-        return this.onStateChangedEmitter.event;
     }
 
     storeState(): object {
@@ -139,6 +136,6 @@ export class AIHistoryView extends ReactWidget implements StatefulWidget {
     }
 
     get isChronologial(): boolean {
-        return !!this.state.chronological;
+        return this.state.chronological === true;
     }
 }

--- a/packages/ai-history/src/browser/ai-history-widget.tsx
+++ b/packages/ai-history/src/browser/ai-history-widget.tsx
@@ -135,7 +135,7 @@ export class AIHistoryView extends ReactWidget implements StatefulWidget {
         this.state = { ...deepClone(this.state), chronological: chronological };
     }
 
-    get isChronologial(): boolean {
+    get isChronological(): boolean {
         return this.state.chronological === true;
     }
 }

--- a/packages/ai-history/src/common/communication-recording-service.ts
+++ b/packages/ai-history/src/common/communication-recording-service.ts
@@ -29,6 +29,9 @@ export class DefaultCommunicationRecordingService implements CommunicationRecord
     protected onDidRecordResponseEmitter = new Emitter<CommunicationResponseEntry>();
     readonly onDidRecordResponse: Event<CommunicationResponseEntry> = this.onDidRecordResponseEmitter.event;
 
+    protected onStructuralChangeEmitter = new Emitter<void>();
+    readonly onStructuralChange: Event<void> = this.onStructuralChangeEmitter.event;
+
     protected history: Map<string, CommunicationHistory> = new Map();
 
     getHistory(agentId: string): CommunicationHistory {
@@ -59,5 +62,10 @@ export class DefaultCommunicationRecordingService implements CommunicationRecord
                 this.onDidRecordResponseEmitter.fire(responseEntry);
             }
         }
+    }
+
+    clearHistory(): void {
+        this.history.clear();
+        this.onStructuralChangeEmitter.fire(undefined);
     }
 }


### PR DESCRIPTION
fixed #14183

#### What it does

Adds toolbar item to the AI History View allowing to clear the history and oder the view chronologically and reverse chronologically

#### How to test

Enter requests in the chat, e.g. 1, 2, 3 
Sort the entries in the History View
Clear the History View

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
