### PR TITLE
Notebook webview output optimization

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -34,6 +34,7 @@ import { NotebookCommands } from './notebook-actions-contribution';
 import { changeCellType } from './cell-operations';
 import { EditorLanguageQuickPickService } from '@theia/editor/lib/browser/editor-language-quick-pick-service';
 import { NotebookService } from '../service/notebook-service';
+import { NOTEBOOK_EDITOR_ID_PREFIX } from '../notebook-editor-widget';
 
 export namespace NotebookCellCommands {
     /** Parameters: notebookModel: NotebookModel | undefined, cell: NotebookCellModel */
@@ -371,7 +372,9 @@ export class NotebookCellActionContribution implements MenuContribution, Command
             }], true)
         ));
         commands.registerCommand(NotebookCellCommands.CHANGE_OUTPUT_PRESENTATION_COMMAND, this.editableCellCommandHandler(
-            (_, __, output) => output?.requestOutputPresentationUpdate()
+            (notebook, cell, output) => {
+                this.notebookEditorWidgetService.getNotebookEditor(NOTEBOOK_EDITOR_ID_PREFIX + notebook.uri.toString())?.requestOuputPresentationChange(cell.handle, output);
+            }
         ));
 
         const insertCommand = (type: CellKind, index: number | 'above' | 'below', focusContainer: boolean): CommandHandler => this.editableCellCommandHandler(() =>

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -18,7 +18,7 @@ import * as React from '@theia/core/shared/react';
 import { CommandRegistry, MenuModelRegistry, URI } from '@theia/core';
 import { ReactWidget, Navigatable, SaveableSource, Message, DelegatingSaveable, lock, unlock, animationFrame } from '@theia/core/lib/browser';
 import { ReactNode } from '@theia/core/shared/react';
-import { CellKind } from '../common';
+import { CellKind, NotebookCellsChangeType } from '../common';
 import { CellRenderer as CellRenderer, NotebookCellListView } from './view/notebook-cell-list-view';
 import { NotebookCodeCellRenderer } from './view/notebook-code-cell-view';
 import { NotebookMarkdownCellRenderer } from './view/notebook-markdown-cell-view';
@@ -35,6 +35,7 @@ import { NotebookViewportService } from './view/notebook-viewport-service';
 import { NotebookCellCommands } from './contributions/notebook-cell-actions-contribution';
 import { NotebookFindWidget } from './view/notebook-find-widget';
 import debounce = require('lodash/debounce');
+import { CellOutputWebview, CellOutputWebviewFactory } from './renderers/cell-output-webview';
 const PerfectScrollbar = require('react-perfect-scrollbar');
 
 export const NotebookEditorWidgetContainerFactory = Symbol('NotebookEditorWidgetContainerFactory');
@@ -43,6 +44,9 @@ export function createNotebookEditorWidgetContainer(parent: interfaces.Container
     const child = parent.createChild();
 
     child.bind(NotebookEditorProps).toConstantValue(props);
+
+    const cellOutputWebviewFactory: CellOutputWebviewFactory = parent.get(CellOutputWebviewFactory);
+    child.bind(CellOutputWebview).toConstantValue(cellOutputWebviewFactory());
 
     child.bind(NotebookContextManager).toSelf().inSingletonScope();
     child.bind(NotebookMainToolbarRenderer).toSelf().inSingletonScope();
@@ -103,6 +107,9 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
 
     @inject(NotebookViewportService)
     protected readonly viewportService: NotebookViewportService;
+
+    @inject(CellOutputWebview)
+    protected readonly cellOutputWebview: CellOutputWebview;
 
     protected readonly onDidChangeModelEmitter = new Emitter<void>();
     readonly onDidChangeModel = this.onDidChangeModelEmitter.event;
@@ -173,11 +180,18 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
                 this.commandRegistry.executeCommand(NotebookCellCommands.EDIT_COMMAND.id, model, model.cells[0]);
                 model.setSelectedCell(model.cells[0]);
             }
+            model.onDidChangeContent(changeEvents => {
+                const cellEvent = changeEvents.filter(event => event.kind === NotebookCellsChangeType.Move || event.kind === NotebookCellsChangeType.ModelChange);
+                if (cellEvent.length > 0) {
+                    this.cellOutputWebview.cellsChanged(cellEvent);
+                }
+            });
         });
     }
 
     protected async waitForData(): Promise<NotebookModel> {
         this._model = await this.props.notebookData;
+        this.cellOutputWebview.init(this._model, this);
         this.saveable.delegate = this._model;
         this.toDispose.push(this._model);
         this.toDispose.push(this._model.onDidChangeContent(() => {
@@ -261,12 +275,15 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
                     <PerfectScrollbar className='theia-notebook-scroll-container'
                         ref={this.scrollBarRef}
                         onScrollY={(e: HTMLDivElement) => this.viewportService.onScroll(e)}>
-                        <NotebookCellListView renderers={this.renderers}
-                            notebookModel={this._model}
-                            notebookContext={this.notebookContextManager}
-                            toolbarRenderer={this.cellToolbarFactory}
-                            commandRegistry={this.commandRegistry}
-                            menuRegistry={this.menuRegistry} />
+                        <div className='theia-notebook-scroll-area'>
+                            {this.cellOutputWebview.render()}
+                            <NotebookCellListView renderers={this.renderers}
+                                notebookModel={this._model}
+                                notebookContext={this.notebookContextManager}
+                                toolbarRenderer={this.cellToolbarFactory}
+                                commandRegistry={this.commandRegistry}
+                                menuRegistry={this.menuRegistry} />
+                        </div>
                     </PerfectScrollbar>
                 </div>
             </div>;

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -36,6 +36,7 @@ import { NotebookCellCommands } from './contributions/notebook-cell-actions-cont
 import { NotebookFindWidget } from './view/notebook-find-widget';
 import debounce = require('lodash/debounce');
 import { CellOutputWebview, CellOutputWebviewFactory } from './renderers/cell-output-webview';
+import { NotebookCellOutputModel } from './view-model/notebook-cell-output-model';
 const PerfectScrollbar = require('react-perfect-scrollbar');
 
 export const NotebookEditorWidgetContainerFactory = Symbol('NotebookEditorWidgetContainerFactory');
@@ -297,6 +298,12 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     protected override onCloseRequest(msg: Message): void {
         super.onCloseRequest(msg);
         this.notebookEditorService.removeNotebookEditor(this);
+    }
+
+    requestOuputPresentationChange(cellHandle: number, output?: NotebookCellOutputModel): void {
+        if (output) {
+            this.cellOutputWebview.requestOutputPresentationUpdate(cellHandle, output);
+        }
     }
 
     postKernelMessage(message: unknown): void {

--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -331,6 +331,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
     }
 
     override dispose(): void {
+        this.cellOutputWebview.dispose();
         this.notebookContextManager.dispose();
         this.onDidChangeModelEmitter.dispose();
         this.onDidPostKernelMessageEmitter.dispose();

--- a/packages/notebook/src/browser/renderers/cell-output-webview.ts
+++ b/packages/notebook/src/browser/renderers/cell-output-webview.ts
@@ -14,19 +14,33 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Disposable } from '@theia/core';
-import { NotebookCellModel } from '../view-model/notebook-cell-model';
+import { Disposable, Event } from '@theia/core';
 import { NotebookModel } from '../view-model/notebook-model';
+import { NotebookEditorWidget } from '../notebook-editor-widget';
+import { NotebookContentChangedEvent } from '../notebook-types';
 
 export const CellOutputWebviewFactory = Symbol('outputWebviewFactory');
+export const CellOutputWebview = Symbol('outputWebview');
 
-export type CellOutputWebviewFactory = (cell: NotebookCellModel, notebook: NotebookModel) => Promise<CellOutputWebview>;
+export type CellOutputWebviewFactory = () => Promise<CellOutputWebview>;
+
+export interface OutputRenderEvent {
+    cellHandle: number;
+    outputId: string;
+    outputHeight: number;
+}
 
 export interface CellOutputWebview extends Disposable {
 
     readonly id: string;
 
+    init(notebook: NotebookModel, editor: NotebookEditorWidget): void;
+
     render(): React.ReactNode;
+
+    setCellHeight(cellHandle: number, height: number): void;
+    cellsChanged(cellEvent: NotebookContentChangedEvent[]): void;
+    onDidRenderOutput: Event<OutputRenderEvent>
 
     attachWebview(): void;
     isAttached(): boolean

--- a/packages/notebook/src/browser/renderers/cell-output-webview.ts
+++ b/packages/notebook/src/browser/renderers/cell-output-webview.ts
@@ -18,6 +18,7 @@ import { Disposable, Event } from '@theia/core';
 import { NotebookModel } from '../view-model/notebook-model';
 import { NotebookEditorWidget } from '../notebook-editor-widget';
 import { NotebookContentChangedEvent } from '../notebook-types';
+import { NotebookCellOutputModel } from '../view-model/notebook-cell-output-model';
 
 export const CellOutputWebviewFactory = Symbol('outputWebviewFactory');
 export const CellOutputWebview = Symbol('outputWebview');
@@ -41,6 +42,8 @@ export interface CellOutputWebview extends Disposable {
     setCellHeight(cellHandle: number, height: number): void;
     cellsChanged(cellEvent: NotebookContentChangedEvent[]): void;
     onDidRenderOutput: Event<OutputRenderEvent>
+
+    requestOutputPresentationUpdate(cellHandle: number, output: NotebookCellOutputModel): void;
 
     attachWebview(): void;
     isAttached(): boolean

--- a/packages/notebook/src/browser/renderers/cell-output-webview.ts
+++ b/packages/notebook/src/browser/renderers/cell-output-webview.ts
@@ -19,6 +19,7 @@ import { NotebookModel } from '../view-model/notebook-model';
 import { NotebookEditorWidget } from '../notebook-editor-widget';
 import { NotebookContentChangedEvent } from '../notebook-types';
 import { NotebookCellOutputModel } from '../view-model/notebook-cell-output-model';
+import { NotebookCellModel } from '../view-model/notebook-cell-model';
 
 export const CellOutputWebviewFactory = Symbol('outputWebviewFactory');
 export const CellOutputWebview = Symbol('outputWebview');
@@ -39,7 +40,7 @@ export interface CellOutputWebview extends Disposable {
 
     render(): React.ReactNode;
 
-    setCellHeight(cellHandle: number, height: number): void;
+    setCellHeight(cell: NotebookCellModel, height: number): void;
     cellsChanged(cellEvent: NotebookContentChangedEvent[]): void;
     onDidRenderOutput: Event<OutputRenderEvent>
 

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -335,7 +335,13 @@
   width: 100%;
 }
 
+.theia-notebook-collapsed-output-container {
+  width: 0;
+  overflow: visible;
+}
+
 .theia-notebook-collapsed-output {
+  text-wrap: nowrap;
   padding: 4px 8px;
   color: var(--theia-foreground);
   margin-left: 30px;

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -83,7 +83,8 @@
 /* Rendered Markdown Content */
 
 .theia-notebook-markdown-content {
-  padding: 8px 16px 8px 36px;
+  pointer-events: all;
+  padding: 8px 16px 8px 0px;
   font-size: var(--theia-notebook-markdown-size);
 }
 
@@ -101,10 +102,13 @@
   padding-bottom: 0;
 }
 
+.theia-notebook-markdown-sidebar {
+  width: 35px;
+}
+
 /* Markdown cell edit mode */
 .theia-notebook-cell-content:has(.theia-notebook-markdown-editor-container>.theia-notebook-cell-editor) {
   pointer-events: all;
-  margin-left: 36px;
   margin-right: var(--theia-notebook-cell-editor-margin-right);
   outline: 1px solid var(--theia-notebook-cellBorderColor);
 }

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -20,10 +20,23 @@
 }
 
 .theia-notebook-cell-list {
+  position: absolute;
+  top: 0;
+  width: 100%;
   overflow-y: auto;
   list-style: none;
   padding-left: 0px;
   background-color: var(--theia-notebook-editorBackground);
+  z-index: 0;
+}
+
+
+.theia-notebook-cell-output-webview {
+  padding: 5px 0px;
+  margin: 0px 15px 0px 50px;
+  width: 100%;
+  position: absolute;
+  z-index: 0;
 }
 
 .theia-notebook-cell {
@@ -161,7 +174,6 @@
   display: flex;
   flex-direction: column;
   padding: 2px;
-  background-color: var(--theia-editor-background);
   flex-grow: 1;
 }
 

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -28,13 +28,14 @@
   padding-left: 0px;
   background-color: var(--theia-notebook-editorBackground);
   z-index: 0;
+  pointer-events: none;
 }
 
 
 .theia-notebook-cell-output-webview {
   padding: 5px 0px;
   margin: 0px 15px 0px 50px;
-  width: 100%;
+  width: calc(100% - 60px);
   position: absolute;
   z-index: 0;
 }
@@ -102,6 +103,7 @@
 
 /* Markdown cell edit mode */
 .theia-notebook-cell-content:has(.theia-notebook-markdown-editor-container>.theia-notebook-cell-editor) {
+  pointer-events: all;
   margin-left: 36px;
   margin-right: var(--theia-notebook-cell-editor-margin-right);
   outline: 1px solid var(--theia-notebook-cellBorderColor);
@@ -121,6 +123,7 @@
 }
 
 .theia-notebook-cell-editor-container {
+  pointer-events: all;
   width: calc(100% - 46px);
   flex: 1;
   outline: 1px solid var(--theia-notebook-cellBorderColor);
@@ -162,6 +165,7 @@
 }
 
 .theia-notebook-cell-toolbar {
+  pointer-events: all;
   border: 1px solid var(--theia-notebook-cellToolbarSeparator);
   display: flex;
   position: absolute;
@@ -178,6 +182,11 @@
 }
 
 .theia-notebook-cell-sidebar {
+  pointer-events: all;
+  display: flex;
+}
+
+.theia-notebook-cell-sidebar-actions {
   display: flex;
   flex-direction: column;
 }
@@ -206,6 +215,7 @@
 }
 
 .theia-notebook-cell-divider {
+  pointer-events: all;
   height: 25px;
   width: 100%;
 }
@@ -313,12 +323,6 @@
 
 .theia-notebook-add-cell-button-text {
   margin: 1px 0 0 4px;
-}
-
-.theia-notebook-cell-output-webview {
-  padding: 5px 0px;
-  margin: 0px 15px 0px 9px;
-  width: 100%;
 }
 
 .theia-notebook-cell-drop-indicator {

--- a/packages/notebook/src/browser/view-model/notebook-cell-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-cell-model.ts
@@ -129,6 +129,9 @@ export class NotebookCellModel implements NotebookCell, Disposable {
     protected onDidRequestCenterEditorEmitter = new Emitter<void>();
     readonly onDidRequestCenterEditor = this.onDidRequestCenterEditorEmitter.event;
 
+    protected onDidCellHeightChangeEmitter = new Emitter<number>();
+    readonly onDidCellHeightChange = this.onDidCellHeightChangeEmitter.event;
+
     @inject(NotebookCellModelProps)
     protected readonly props: NotebookCellModelProps;
 
@@ -249,6 +252,16 @@ export class NotebookCellModel implements NotebookCell, Disposable {
             this._outputVisible = visible;
             this.outputVisibilityChangeEmitter.fire(visible);
         }
+    }
+
+    protected _cellheight: number = 0;
+    get cellHeight(): number {
+        return this._cellheight;
+    }
+
+    set cellHeight(height: number) {
+        this.onDidCellHeightChangeEmitter.fire(height);
+        this._cellheight = height;
     }
 
     @postConstruct()

--- a/packages/notebook/src/browser/view-model/notebook-cell-output-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-cell-output-model.ts
@@ -23,9 +23,6 @@ export class NotebookCellOutputModel implements Disposable {
     private didChangeDataEmitter = new Emitter<void>();
     readonly onDidChangeData = this.didChangeDataEmitter.event;
 
-    private requestOutputPresentationChangeEmitter = new Emitter<void>();
-    readonly onRequestOutputPresentationChange = this.requestOutputPresentationChangeEmitter.event;
-
     get outputId(): string {
         return this.rawOutput.outputId;
     }
@@ -54,11 +51,6 @@ export class NotebookCellOutputModel implements Disposable {
 
     dispose(): void {
         this.didChangeDataEmitter.dispose();
-        this.requestOutputPresentationChangeEmitter.dispose();
-    }
-
-    requestOutputPresentationUpdate(): void {
-        this.requestOutputPresentationChangeEmitter.fire();
     }
 
     getData(): CellOutput {

--- a/packages/notebook/src/browser/view-model/notebook-model.ts
+++ b/packages/notebook/src/browser/view-model/notebook-model.ts
@@ -509,8 +509,12 @@ export class NotebookModel implements Saveable, Disposable {
         return true;
     }
 
-    protected getCellIndexByHandle(handle: number): number {
+    getCellIndexByHandle(handle: number): number {
         return this.cells.findIndex(c => c.handle === handle);
+    }
+
+    getCellByHandle(handle: number): NotebookCellModel | undefined {
+        return this.cells.find(c => c.handle === handle);
     }
 
     protected isCellMetadataChanged(a: NotebookCellMetadata, b: NotebookCellMetadata): boolean {

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -147,12 +147,13 @@ export class NotebookCellListView extends React.Component<CellListProps, Noteboo
                                         ref.focus();
                                     }
                                 }
-                            }}>
-                            <div className='theia-notebook-cell-sidebar'
-                                onClick={e => {
-                                    this.setState({ ...this.state, selectedCell: cell });
-                                    this.props.notebookModel.setSelectedCell(cell, false);
-                                }}                            >
+                            }}
+                            onClick={e => {
+                                this.setState({ ...this.state, selectedCell: cell });
+                                this.props.notebookModel.setSelectedCell(cell, false);
+                            }}
+                        >
+                            <div className='theia-notebook-cell-sidebar'>
                                 <div className={'theia-notebook-cell-marker' + (this.state.selectedCell === cell ? ' theia-notebook-cell-marker-selected' : '')}></div>
                                 {this.renderCellSidebar(cell)}
                             </div>

--- a/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-code-cell-view.tsx
@@ -76,36 +76,40 @@ export class NotebookCodeCellRenderer implements CellRenderer {
     protected readonly outputWebview: CellOutputWebview;
 
     render(notebookModel: NotebookModel, cell: NotebookCellModel, handle: number): React.ReactNode {
-        return <div>
-            <div className='theia-notebook-cell-with-sidebar' ref={ref => {
-                if (ref) {
-                    this.outputWebview.setCellHeight(cell.handle, ref?.getBoundingClientRect().height ?? 0);
-                    new ResizeObserver(entries =>
-                        this.outputWebview.setCellHeight(cell.handle, ref?.getBoundingClientRect().height ?? 0)
-                    ).observe(ref);
-                }
-            }}>
-                <div className='theia-notebook-cell-sidebar'>
-                    {this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.CODE_CELL_SIDEBAR_MENU, cell, {
-                        contextMenuArgs: () => [cell], commandArgs: () => [notebookModel, cell]
-                    })
-                    }
-                    <CodeCellExecutionOrder cell={cell} />
-                </div>
-                <div className='theia-notebook-cell-editor-container'>
-                    <CellEditor notebookModel={notebookModel} cell={cell}
-                        monacoServices={this.monacoServices}
-                        notebookContextManager={this.notebookContextManager}
-                        notebookViewportService={this.notebookViewportService}
-                        notebookCellEditorService={this.notebookCellEditorService}
-                        fontInfo={this.notebookOptionsService.editorFontInfo} />
-                    <NotebookCodeCellStatus cell={cell} notebook={notebookModel}
-                        commandRegistry={this.commandRegistry}
-                        executionStateService={this.executionStateService}
-                        onClick={() => cell.requestFocusEditor()} />
-                </div >
+        return <div className='theia-notebook-cell-with-sidebar' ref={ref => {
+            if (ref) {
+                this.outputWebview.setCellHeight(cell.handle, ref?.getBoundingClientRect().height ?? 0);
+                new ResizeObserver(entries =>
+                    this.outputWebview.setCellHeight(cell.handle, ref?.getBoundingClientRect().height ?? 0)
+                ).observe(ref);
+            }
+        }}>
+
+            <div className='theia-notebook-cell-editor-container'>
+                <CellEditor notebookModel={notebookModel} cell={cell}
+                    monacoServices={this.monacoServices}
+                    notebookContextManager={this.notebookContextManager}
+                    notebookViewportService={this.notebookViewportService}
+                    notebookCellEditorService={this.notebookCellEditorService}
+                    fontInfo={this.notebookOptionsService.editorFontInfo} />
+                <NotebookCodeCellStatus cell={cell} notebook={notebookModel}
+                    commandRegistry={this.commandRegistry}
+                    executionStateService={this.executionStateService}
+                    onClick={() => cell.requestFocusEditor()} />
             </div >
-            <div className='theia-notebook-cell-with-sidebar'>
+        </div >;
+    }
+
+    renderSidebar(notebookModel: NotebookModel, cell: NotebookCellModel): React.ReactNode {
+        return <div>
+            <div className='theia-notebook-cell-sidebar-actions'>
+                {this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.CODE_CELL_SIDEBAR_MENU, cell, {
+                    contextMenuArgs: () => [cell], commandArgs: () => [notebookModel, cell]
+                })
+                }
+                <CodeCellExecutionOrder cell={cell} />
+            </div>
+            <div>
                 <NotebookCodeCellOutputs cell={cell} notebook={notebookModel} outputWebview={this.outputWebview}
                     renderSidebar={() =>
                         this.notebookCellToolbarFactory.renderSidebar(NotebookCellActionContribution.OUTPUT_SIDEBAR_MENU, cell, {
@@ -113,7 +117,8 @@ export class NotebookCodeCellRenderer implements CellRenderer {
                         })
                     } />
             </div>
-        </div >;
+        </div>;
+
     }
 
     renderDragImage(cell: NotebookCellModel): HTMLElement {
@@ -294,11 +299,9 @@ export class NotebookCodeCellOutputs extends React.Component<NotebookCellOutputP
 
     override render(): React.ReactNode {
         return this.props.cell.outputVisible ?
-            // TODO add here the output height
-            <>
+            <div style={{ minHeight: this.outputHeight }}>
                 {this.props.renderSidebar()}
-                <div style={{ marginBottom: this.outputHeight }}></div>
-            </> :
+            </div> :
             this.props.cell.outputs?.length ? <i className='theia-notebook-collapsed-output'>{nls.localizeByDefault('Outputs are collapsed')}</i> : <></>;
 
     }

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -18,7 +18,7 @@ import * as React from '@theia/core/shared/react';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
 import { NotebookModel } from '../view-model/notebook-model';
-import { CellRenderer } from './notebook-cell-list-view';
+import { CellRenderer, observeCellHeight } from './notebook-cell-list-view';
 import { NotebookCellModel } from '../view-model/notebook-cell-model';
 import { CellEditor } from './notebook-cell-editor';
 import { inject, injectable } from '@theia/core/shared/inversify';
@@ -139,7 +139,7 @@ function MarkdownCell({
     }
 
     return editMode ?
-        (<div className='theia-notebook-markdown-editor-container' key="code">
+        (<div className='theia-notebook-markdown-editor-container' key="code" ref={ref => observeCellHeight(ref, cell)}>
             <CellEditor notebookModel={notebookModel} cell={cell}
                 monacoServices={monacoServices}
                 notebookContextManager={notebookContextManager}
@@ -151,7 +151,10 @@ function MarkdownCell({
         </div >) :
         (<div className='theia-notebook-markdown-content' key="markdown"
             onDoubleClick={() => cell.requestEdit()}
-            ref={node => node?.replaceChildren(...markdownContent)}
+            ref={node => {
+                node?.replaceChildren(...markdownContent);
+                observeCellHeight(node, cell);
+            }}
         />);
 }
 

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -63,6 +63,10 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
             notebookCellEditorService={this.notebookCellEditorService} />;
     }
 
+    renderSidebar(notebookModel: NotebookModel, cell: NotebookCellModel): React.ReactNode {
+        return <div className='theia-notebook-markdown-sidebar'></div>;
+    }
+
     renderDragImage(cell: NotebookCellModel): HTMLElement {
         const dragImage = document.createElement('div');
         dragImage.style.width = this.notebookContextManager.context?.clientWidth + 'px';

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -337,8 +337,10 @@ class EditorAndDocumentStateComputer implements Disposable {
         }
 
         for (const editor of this.cellEditorService.allCellEditors) {
-            const editorSnapshot = new EditorSnapshot(editor);
-            editors.set(editorSnapshot.id, editorSnapshot);
+            if (editor.getControl()?.getModel()) {
+                const editorSnapshot = new EditorSnapshot(editor);
+                editors.set(editorSnapshot.id, editorSnapshot);
+            }
         };
 
         const newState = new EditorAndDocumentState(models, editors, activeId);

--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-kernels-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-kernels-main.ts
@@ -25,13 +25,13 @@ import { CellExecuteUpdateDto, CellExecutionCompleteDto, MAIN_RPC_CONTEXT, Noteb
 import { RPCProtocol } from '../../../common/rpc-protocol';
 import {
     CellExecution, NotebookEditorWidgetService, NotebookExecutionStateService,
-    NotebookKernelChangeEvent, NotebookKernelService, NotebookService
+    NotebookKernelChangeEvent, NotebookKernelService, NotebookService, NotebookKernel as NotebookKernelServiceKernel
 } from '@theia/notebook/lib/browser';
 import { interfaces } from '@theia/core/shared/inversify';
 import { NotebookKernelSourceAction } from '@theia/notebook/lib/common';
 import { NotebookDto } from './notebook-dto';
 
-abstract class NotebookKernel {
+abstract class NotebookKernel implements NotebookKernelServiceKernel {
     private readonly onDidChangeEmitter = new Emitter<NotebookKernelChangeEvent>();
     private readonly preloads: { uri: URI; provides: readonly string[] }[];
     readonly onDidChange: Event<NotebookKernelChangeEvent> = this.onDidChangeEmitter.event;

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -19,32 +19,30 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from '@theia/core/shared/react';
-import { inject, injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { generateUuid } from '@theia/core/lib/common/uuid';
 import {
     NotebookRendererMessagingService, CellOutputWebview, NotebookRendererRegistry,
-    NotebookEditorWidgetService, NotebookCellOutputsSplice, NOTEBOOK_EDITOR_ID_PREFIX, NotebookKernelService, NotebookEditorWidget
+    NotebookEditorWidgetService, NotebookKernelService, NotebookEditorWidget,
+    OutputRenderEvent,
+    NotebookCellOutputsSplice,
+    NotebookContentChangedEvent
 } from '@theia/notebook/lib/browser';
-import { NotebookCellModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-model';
 import { WebviewWidget } from '../../webview/webview';
 import { Message, WidgetManager } from '@theia/core/lib/browser';
 import { outputWebviewPreload, PreloadContext } from './output-webview-internal';
 import { WorkspaceTrustService } from '@theia/workspace/lib/browser';
-import { ChangePreferredMimetypeMessage, FromWebviewMessage, OutputChangedMessage } from './webview-communication';
-import { CellUri } from '@theia/notebook/lib/common';
-import { Disposable, DisposableCollection, nls, QuickPickService } from '@theia/core';
-import { NotebookCellOutputModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-output-model';
+import { CellsChangedMessage, FromWebviewMessage, OutputChangedMessage } from './webview-communication';
+import { Disposable, DisposableCollection, Emitter, QuickPickService } from '@theia/core';
 import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
 import { NotebookOptionsService, NotebookOutputOptions } from '@theia/notebook/lib/browser/service/notebook-options';
+import { NotebookCellModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-model';
+import { NotebookCellsChangeType } from '@theia/notebook/lib/common';
 
-const CellModel = Symbol('CellModel');
-const Notebook = Symbol('NotebookModel');
 export const AdditionalNotebookCellOutputCss = Symbol('AdditionalNotebookCellOutputCss');
 
-export function createCellOutputWebviewContainer(ctx: interfaces.Container, cell: NotebookCellModel, notebook: NotebookModel): interfaces.Container {
+export function createCellOutputWebviewContainer(ctx: interfaces.Container): interfaces.Container {
     const child = ctx.createChild();
-    child.bind(CellModel).toConstantValue(cell);
-    child.bind(Notebook).toConstantValue(notebook);
     child.bind(AdditionalNotebookCellOutputCss).toConstantValue(DEFAULT_NOTEBOOK_OUTPUT_CSS);
     child.bind(CellOutputWebviewImpl).toSelf().inSingletonScope();
     return child;
@@ -191,17 +189,15 @@ tbody th {
 }
 `;
 
+interface CellOutputUpdate extends NotebookCellOutputsSplice {
+    cellHandle: number
+}
+
 @injectable()
 export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
     @inject(NotebookRendererMessagingService)
     protected readonly messagingService: NotebookRendererMessagingService;
-
-    @inject(CellModel)
-    protected readonly cell: NotebookCellModel;
-
-    @inject(Notebook)
-    protected readonly notebook: NotebookModel;
 
     @inject(WidgetManager)
     protected readonly widgetManager: WidgetManager;
@@ -227,32 +223,59 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     @inject(NotebookOptionsService)
     protected readonly notebookOptionsService: NotebookOptionsService;
 
+    // returns the output Height
+    protected readonly onDidRenderOutputEmitter = new Emitter<OutputRenderEvent>();
+    readonly onDidRenderOutput = this.onDidRenderOutputEmitter.event;
+
+    protected notebook: NotebookModel;
+
     protected options: NotebookOutputOptions;
 
     readonly id = generateUuid();
 
     protected editor: NotebookEditorWidget | undefined;
 
-    protected readonly elementRef = React.createRef<HTMLDivElement>();
+    protected element?: HTMLDivElement; // React.createRef<HTMLDivElement>();
     protected outputPresentationListeners: DisposableCollection = new DisposableCollection();
 
     protected webviewWidget: WebviewWidget;
 
     protected toDispose = new DisposableCollection();
 
-    @postConstruct()
-    protected async init(): Promise<void> {
-        this.editor = this.notebookEditorWidgetService.getNotebookEditor(NOTEBOOK_EDITOR_ID_PREFIX + CellUri.parse(this.cell.uri)?.notebook);
+    async init(notebook: NotebookModel, editor: NotebookEditorWidget): Promise<void> {
+        this.notebook = notebook;
+        this.editor = editor;
         this.options = this.notebookOptionsService.computeOutputOptions();
         this.toDispose.push(this.notebookOptionsService.onDidChangeOutputOptions(options => {
             this.options = options;
             this.updateStyles();
         }));
 
-        this.toDispose.push(this.cell.onDidChangeOutputs(outputChange => this.updateOutput(outputChange)));
-        this.toDispose.push(this.cell.onDidChangeOutputItems(output => {
-            this.updateOutput({ start: this.cell.outputs.findIndex(o => o.outputId === output.outputId), deleteCount: 1, newOutputs: [output] });
-        }));
+        this.webviewWidget = await this.widgetManager.getOrCreateWidget(WebviewWidget.FACTORY_ID, { id: this.id });
+        // this.webviewWidget.parent = this.editor ?? null;
+        this.webviewWidget.setContentOptions({
+            allowScripts: true,
+            // eslint-disable-next-line max-len
+            // list taken from https://github.com/microsoft/vscode/blob/a27099233b956dddc2536d4a0d714ab36266d897/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts#L762-L774
+            enableCommandUris: [
+                'github-issues.authNow',
+                'workbench.extensions.search',
+                'workbench.action.openSettings',
+                '_notebook.selectKernel',
+                'jupyter.viewOutput',
+                'workbench.action.openLargeOutput',
+                'cellOutput.enableScrolling',
+            ],
+        });
+        this.webviewWidget.setHTML(await this.createWebviewContent());
+
+        this.notebook.onDidAddOrRemoveCell(e => {
+            if (e.newCellIds) {
+                const newCells = e.newCellIds.map(id => this.notebook.cells.find(cell => cell.handle === id)).filter(cell => !!cell) as NotebookCellModel[];
+                newCells.forEach(cell => this.attachCellOutputListeners(cell));
+            }
+        });
+        this.notebook.cells.forEach(cell => this.attachCellOutputListeners(cell));
 
         if (this.editor) {
             this.toDispose.push(this.editor.onDidPostKernelMessage(message => {
@@ -273,83 +296,122 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
         }
 
-        this.webviewWidget = await this.widgetManager.getOrCreateWidget(WebviewWidget.FACTORY_ID, { id: this.id });
-        this.webviewWidget.parent = this.editor ?? null;
-        this.webviewWidget.setContentOptions({
-            allowScripts: true,
-            // eslint-disable-next-line max-len
-            // list taken from https://github.com/microsoft/vscode/blob/a27099233b956dddc2536d4a0d714ab36266d897/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts#L762-L774
-            enableCommandUris: [
-                'github-issues.authNow',
-                'workbench.extensions.search',
-                'workbench.action.openSettings',
-                '_notebook.selectKernel',
-                'jupyter.viewOutput',
-                'workbench.action.openLargeOutput',
-                'cellOutput.enableScrolling',
-            ],
-        });
-        this.webviewWidget.setHTML(await this.createWebviewContent());
-
         this.webviewWidget.onMessage((message: FromWebviewMessage) => {
             this.handleWebviewMessage(message);
         });
     }
 
+    attachCellOutputListeners(cell: NotebookCellModel): void {
+        this.toDispose.push(cell.onDidChangeOutputs(outputChange => this.updateOutputs([{
+            newOutputs: outputChange.newOutputs,
+            start: outputChange.start,
+            deleteCount: outputChange.deleteCount,
+            cellHandle: cell.handle
+        }])));
+        this.toDispose.push(cell.onDidChangeOutputItems(output => {
+            const oldOutputIndex = cell.outputs.findIndex(o => o.outputId === output.outputId);
+            this.updateOutputs([{
+                cellHandle: cell.handle,
+                newOutputs: [output],
+                start: oldOutputIndex,
+                deleteCount: 1
+            }]);
+        }));
+
+    }
+
     render(): React.JSX.Element {
-        return <div className='theia-notebook-cell-output-webview' ref={this.elementRef}></div>;
+        return <div className='theia-notebook-cell-output-webview' ref={element => {
+            if (element) {
+                this.element = element;
+                this.attachWebview();
+            }
+        }}></div>;
     }
 
     attachWebview(): void {
-        if (this.elementRef.current) {
+        if (this.element) {
             this.webviewWidget.processMessage(new Message('before-attach'));
-            this.elementRef.current.appendChild(this.webviewWidget.node);
+            this.element.appendChild(this.webviewWidget.node);
             this.webviewWidget.processMessage(new Message('after-attach'));
             this.webviewWidget.setIframeHeight(0);
         }
     }
 
     isAttached(): boolean {
-        return this.elementRef.current?.contains(this.webviewWidget.node) ?? false;
+        return this.element?.contains(this.webviewWidget.node) ?? false;
     }
 
-    updateOutput(update: NotebookCellOutputsSplice): void {
+    updateOutputs(updates: CellOutputUpdate[]): void {
         if (this.webviewWidget.isHidden) {
             this.webviewWidget.show();
         }
 
         this.outputPresentationListeners.dispose();
         this.outputPresentationListeners = new DisposableCollection();
-        for (const output of this.cell.outputs) {
-            this.outputPresentationListeners.push(output.onRequestOutputPresentationChange(() => this.requestOutputPresentationUpdate(output)));
-        }
+        // for (const output of this.cell.outputs) {
+        //     this.outputPresentationListeners.push(output.onRequestOutputPresentationChange(() => this.requestOutputPresentationUpdate(output)));
+        // }
 
         const updateOutputMessage: OutputChangedMessage = {
             type: 'outputChanged',
-            newOutputs: update.newOutputs.map(output => ({
-                id: output.outputId,
-                items: output.outputs.map(item => ({ mime: item.mime, data: item.data.buffer })),
-                metadata: output.metadata
-            })),
-            deleteStart: update.start,
-            deleteCount: update.deleteCount
+            changes: updates.map(update => ({
+                cellHandle: update.cellHandle,
+                newOutputs: update.newOutputs.map(output => ({
+                    id: output.outputId,
+                    items: output.outputs.map(item => ({ mime: item.mime, data: item.data.buffer })),
+                    metadata: output.metadata
+                })),
+                start: update.start,
+                deleteCount: update.deleteCount
+            }))
         };
 
         this.webviewWidget.sendMessage(updateOutputMessage);
     }
 
-    private async requestOutputPresentationUpdate(output: NotebookCellOutputModel): Promise<void> {
-        const selectedMime = await this.quickPickService.show(
-            output.outputs.map(item => ({ label: item.mime })),
-            { description: nls.localizeByDefault('Select mimetype to render for current output') });
-        if (selectedMime) {
-            this.webviewWidget.sendMessage({
-                type: 'changePreferredMimetype',
-                outputId: output.outputId,
-                mimeType: selectedMime.label
-            } as ChangePreferredMimetypeMessage);
-        }
+    cellsChanged(cellEvent: NotebookContentChangedEvent[]): void {
+        this.webviewWidget.sendMessage({
+            type: 'cellsChanged',
+            changes: cellEvent.flatMap(event => {
+                if (event.kind === NotebookCellsChangeType.Move) {
+                    return event.cells.map((cell, i) => ({
+                        type: 'cellMoved',
+                        cellHandle: event.cells[0].handle,
+                        toIndex: event.newIdx + i,
+                    }));
+                } else if (event.kind === NotebookCellsChangeType.ModelChange) {
+                    event.changes.map(change => ({
+                        type: 'cellsSpliced',
+                        start: change.start,
+                        deleteCount: change.deleteCount,
+                        newCells: change.newItems.map(cell => cell.handle)
+                    }));
+                }
+            }).filter(e => !!e)
+        } as CellsChangedMessage);
     }
+
+    setCellHeight(cellHandle: number, height: number): void {
+        this.webviewWidget.sendMessage({
+            type: 'cellHeightUpdate',
+            cellHandle,
+            height
+        });
+    }
+
+    // private async requestOutputPresentationUpdate(output: NotebookCellOutputModel): Promise<void> {
+    //     const selectedMime = await this.quickPickService.show(
+    //         output.outputs.map(item => ({ label: item.mime })),
+    //         { description: nls.localizeByDefault('Select mimetype to render for current output') });
+    //     if (selectedMime) {
+    //         this.webviewWidget.sendMessage({
+    //             type: 'changePreferredMimetype',
+    //             outputId: output.outputId,
+    //             mimeType: selectedMime.label
+    //         } as ChangePreferredMimetypeMessage);
+    //     }
+    // }
 
     private handleWebviewMessage(message: FromWebviewMessage): void {
         if (!this.editor) {
@@ -358,7 +420,12 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
         switch (message.type) {
             case 'initialized':
-                this.updateOutput({ newOutputs: this.cell.outputs, start: 0, deleteCount: 0 });
+                this.updateOutputs(this.notebook.cells.map(cell => ({
+                    cellHandle: cell.handle,
+                    newOutputs: cell.outputs,
+                    start: 0,
+                    deleteCount: 0
+                })));
                 this.updateStyles();
                 break;
             case 'customRendererMessage':
@@ -367,6 +434,11 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 break;
             case 'didRenderOutput':
                 this.webviewWidget.setIframeHeight(message.contentHeight + 5);
+                this.onDidRenderOutputEmitter.fire({
+                    cellHandle: message.cellHandle,
+                    outputId: message.outputId,
+                    outputHeight: message.outputHeight
+                });
                 break;
             case 'did-scroll-wheel':
                 this.editor.node.getElementsByClassName('theia-notebook-viewport')[0].children[0].scrollBy(message.deltaX, message.deltaY);

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -396,12 +396,14 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     }
 
     setCellHeight(cell: NotebookCellModel, height: number): void {
-        this.webviewWidget.sendMessage({
-            type: 'cellHeightUpdate',
-            cellHandle: cell.handle,
-            cellKind: cell.cellKind,
-            height
-        });
+        if (!this.webviewWidget.disposed) {
+            this.webviewWidget.sendMessage({
+                type: 'cellHeightUpdate',
+                cellHandle: cell.handle,
+                cellKind: cell.cellKind,
+                height
+            });
+        }
     }
 
     async requestOutputPresentationUpdate(cellHandle: number, output: NotebookCellOutputModel): Promise<void> {

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -242,6 +242,8 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
     protected toDispose = new DisposableCollection();
 
+    protected isDisposed = false;
+
     async init(notebook: NotebookModel, editor: NotebookEditorWidget): Promise<void> {
         this.notebook = notebook;
         this.editor = editor;
@@ -396,7 +398,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     }
 
     setCellHeight(cell: NotebookCellModel, height: number): void {
-        if (!this.webviewWidget.disposed) {
+        if (!this.isDisposed) {
             this.webviewWidget.sendMessage({
                 type: 'cellHeightUpdate',
                 cellHandle: cell.handle,
@@ -535,6 +537,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     }
 
     dispose(): void {
+        this.isDisposed = true;
         this.toDispose.dispose();
         this.webviewWidget.dispose();
     }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -279,7 +279,6 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
         if (this.editor) {
             this.toDispose.push(this.editor.onDidPostKernelMessage(message => {
-                // console.log('from extension customKernelMessage ', JSON.stringify(message));
                 this.webviewWidget.sendMessage({
                     type: 'customKernelMessage',
                     message
@@ -287,7 +286,6 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
             }));
 
             this.toDispose.push(this.editor.onPostRendererMessage(messageObj => {
-                // console.log('from extension customRendererMessage ', JSON.stringify(messageObj));
                 this.webviewWidget.sendMessage({
                     type: 'customRendererMessage',
                     ...messageObj
@@ -436,13 +434,10 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 this.updateStyles();
                 break;
             case 'customRendererMessage':
-                // console.log('from webview customRendererMessage ', message.rendererId, '', JSON.stringify(message.message));
                 this.messagingService.getScoped(this.editor.id).postMessage(message.rendererId, message.message);
                 break;
             case 'didRenderOutput':
                 this.webviewWidget.setIframeHeight(message.bodyHeight);
-                console.log('setIframeHeight', message.bodyHeight);
-                console.log('didRenderOutput', message);
                 this.onDidRenderOutputEmitter.fire({
                     cellHandle: message.cellHandle,
                     outputId: message.outputId,
@@ -453,7 +448,6 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 this.editor.node.getElementsByClassName('theia-notebook-viewport')[0].children[0].scrollBy(message.deltaX, message.deltaY);
                 break;
             case 'customKernelMessage':
-                // console.log('from webview customKernelMessage ', JSON.stringify(message.message));
                 this.editor.recieveKernelMessage(message.message);
                 break;
             case 'inputFocusChanged':

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -317,7 +317,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 deleteCount: 1
             }]);
         }));
-        this.toDispose.push(cell.onDidCellHeightChange(height => this.setCellHeight(cell.handle, height)));
+        this.toDispose.push(cell.onDidCellHeightChange(height => this.setCellHeight(cell, height)));
     }
 
     render(): React.JSX.Element {
@@ -390,10 +390,11 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
         } as CellsChangedMessage);
     }
 
-    setCellHeight(cellHandle: number, height: number): void {
+    setCellHeight(cell: NotebookCellModel, height: number): void {
         this.webviewWidget.sendMessage({
             type: 'cellHeightUpdate',
-            cellHandle,
+            cellHandle: cell.handle,
+            cellKind: cell.cellKind,
             height
         });
     }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -462,6 +462,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 if (selectedCell) {
                     this.notebook.setSelectedCell(selectedCell);
                 }
+                break;
             case 'cellHeightRequest':
                 const cellHeight = this.notebook.getCellByHandle(message.cellHandle)?.cellHeight ?? 0;
                 this.webviewWidget.sendMessage({
@@ -469,6 +470,10 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                     cellHandle: message.cellHandle,
                     height: cellHeight
                 });
+                break;
+            case 'bodyHeightChange':
+                this.webviewWidget.setIframeHeight(message.height);
+                break;
         }
     }
 

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -318,6 +318,13 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
             }]);
         }));
         this.toDispose.push(cell.onDidCellHeightChange(height => this.setCellHeight(cell, height)));
+        this.toDispose.push(cell.onDidChangeOutputVisibility(visible => {
+            this.webviewWidget.sendMessage({
+                type: 'outputVisibilityChanged',
+                cellHandle: cell.handle,
+                visible
+            });
+        }));
     }
 
     render(): React.JSX.Element {

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -432,7 +432,9 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 this.messagingService.getScoped(this.editor.id).postMessage(message.rendererId, message.message);
                 break;
             case 'didRenderOutput':
-                this.webviewWidget.setIframeHeight(message.contentHeight + 5);
+                this.webviewWidget.setIframeHeight(message.bodyHeight);
+                console.log('setIframeHeight', message.bodyHeight);
+                console.log('didRenderOutput', message);
                 this.onDidRenderOutputEmitter.fire({
                     cellHandle: message.cellHandle,
                     outputId: message.outputId,

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -45,7 +45,7 @@ export const AdditionalNotebookCellOutputCss = Symbol('AdditionalNotebookCellOut
 export function createCellOutputWebviewContainer(ctx: interfaces.Container): interfaces.Container {
     const child = ctx.createChild();
     child.bind(AdditionalNotebookCellOutputCss).toConstantValue(DEFAULT_NOTEBOOK_OUTPUT_CSS);
-    child.bind(CellOutputWebviewImpl).toSelf().inSingletonScope();
+    child.bind(CellOutputWebviewImpl).toSelf();
     return child;
 }
 
@@ -539,6 +539,5 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     dispose(): void {
         this.isDisposed = true;
         this.toDispose.dispose();
-        this.webviewWidget.dispose();
     }
 }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -150,8 +150,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         constructor(public cellHandle: number, cellIndex?: number) {
 
             console.log('createNewCell', cellHandle, cellIndex);
-            // const upperWrapperElement = createFocusSink(cellId);
-            // container.appendChild(upperWrapperElement);
 
             this.element = document.createElement('div');
             this.element.style.outline = '0';
@@ -160,14 +158,15 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             this.element.classList.add('cell_container');
 
             if (cellIndex && cellIndex < container.children.length) {
-                container.insertBefore(container.children[cellIndex], this.element);
+                console.log('insertBefore', cellIndex, container.children.length);
+                container.insertBefore(this.element, container.children[cellIndex]);
             } else {
+                console.log('appendChild', container.children.length);
                 container.appendChild(this.element);
             }
             this.element = this.element;
 
-            // const lowerWrapperElement = createFocusSink(cellId, true);
-            // container.appendChild(lowerWrapperElement);
+            theia.postMessage({ type: 'cellHeightRequest', cellHandle: cellHandle });
         }
 
         public dispose(): void {
@@ -610,7 +609,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         }
     }
 
-    function cellsChanged(changes: (webviewCommunication.CellMoved | webviewCommunication.CellsSpliced)[]): void {
+    function cellsChanged(changes: (webviewCommunication.CellsMoved | webviewCommunication.CellsSpliced)[]): void {
         for (const change of changes) {
             if (change.type === 'cellMoved') {
                 const currentIndex = cells.findIndex(c => c.cellHandle === change.cellHandle);

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -511,7 +511,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
 
         private async doRender(item: rendererApi.OutputItem, element: HTMLElement, renderer: Renderer, signal: AbortSignal): Promise<{ continue: boolean }> {
             try {
-                (await renderer.getOrLoad())?.renderOutputItem(item, element, signal);
+                await (await renderer.getOrLoad())?.renderOutputItem(item, element, signal);
                 return { continue: false }; // We rendered successfully
             } catch (e) {
                 if (signal.aborted) {

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -207,8 +207,12 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             this.element.style.visibility = 'hidden';
         }
 
-        public updateCellHeight(height: number): void {
-            this.element.style.paddingTop = `${height + 52}px`;
+        public updateCellHeight(cellKind: number, height: number): void {
+            let additionalHeight = 54.5;
+            additionalHeight -= cells[0] === this ? 2.5 : 0; // first cell
+            additionalHeight -= cellKind === 1 ? 5 : 0; // markdown cell
+            additionalHeight -= this.outputElements.length ? 0 : 5.5; // no outputs
+            this.element.style.paddingTop = `${height + additionalHeight}px`;
         }
 
         // public updateScroll(request: webviewCommunication.IContentWidgetTopRequest): void {
@@ -741,7 +745,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                 const cellHandle = event.data.cellHandle;
                 const cell = cells.find(c => c.cellHandle === cellHandle);
                 if (cell) {
-                    cell.updateCellHeight(event.data.height);
+                    cell.updateCellHeight(event.data.cellKind, event.data.height);
                 }
                 break;
         }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -789,5 +789,12 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
 
     window.addEventListener('focusout', (event: FocusEvent) => focusChange(event, false));
 
+    new ResizeObserver(() => {
+        theia.postMessage({
+            type: 'bodyHeightChange',
+            height: document.body.clientHeight
+        } as webviewCommunication.BodyHeightChange);
+    }).observe(document.body);
+
     theia.postMessage(<webviewCommunication.WebviewInitialized>{ type: 'initialized' });
 }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -74,7 +74,7 @@ export interface CellHeigthsMessage {
     cellHeigths: Record<number, number>;
 }
 
-export interface CellMoved {
+export interface CellsMoved {
     type: 'cellMoved';
     cellHandle: number;
     toIndex: number;
@@ -89,7 +89,7 @@ export interface CellsSpliced {
 
 export interface CellsChangedMessage {
     type: 'cellsChanged';
-    changes: (CellMoved | CellsSpliced)[];
+    changes: Array<CellsMoved | CellsSpliced>;
 }
 
 export interface CellHeightUpdateMessage {
@@ -132,12 +132,18 @@ export interface InputFocusChange {
     readonly focused: boolean;
 }
 
+export interface CellHeightRequest {
+    readonly type: 'cellHeightRequest';
+    readonly cellHandle: number;
+}
+
 export type FromWebviewMessage = WebviewInitialized
     | OnDidRenderOutput
     | WheelMessage
     | CustomRendererMessage
     | KernelMessage
-    | InputFocusChange;
+    | InputFocusChange
+    | CellHeightRequest;
 
 export interface Output {
     id: string

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -50,6 +50,7 @@ export interface OutputChangedMessage {
 
 export interface ChangePreferredMimetypeMessage {
     readonly type: 'changePreferredMimetype';
+    readonly cellHandle: number;
     readonly outputId: string;
     readonly mimeType: string;
 }
@@ -132,6 +133,11 @@ export interface InputFocusChange {
     readonly focused: boolean;
 }
 
+export interface CellOuputFocus {
+    readonly type: 'cellFocusChanged';
+    readonly cellHandle: number;
+}
+
 export interface CellHeightRequest {
     readonly type: 'cellHeightRequest';
     readonly cellHandle: number;
@@ -143,6 +149,7 @@ export type FromWebviewMessage = WebviewInitialized
     | CustomRendererMessage
     | KernelMessage
     | InputFocusChange
+    | CellOuputFocus
     | CellHeightRequest;
 
 export interface Output {

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -95,6 +95,7 @@ export interface CellsChangedMessage {
 
 export interface CellHeightUpdateMessage {
     type: 'cellHeightUpdate';
+    cellKind: number;
     cellHandle: number;
     height: number;
 }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -151,6 +151,11 @@ export interface CellHeightRequest {
     readonly cellHandle: number;
 }
 
+export interface BodyHeightChange {
+    readonly type: 'bodyHeightChange';
+    readonly height: number;
+}
+
 export type FromWebviewMessage = WebviewInitialized
     | OnDidRenderOutput
     | WheelMessage
@@ -158,7 +163,8 @@ export type FromWebviewMessage = WebviewInitialized
     | KernelMessage
     | InputFocusChange
     | CellOuputFocus
-    | CellHeightRequest;
+    | CellHeightRequest
+    | BodyHeightChange;
 
 export interface Output {
     id: string

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -100,6 +100,12 @@ export interface CellHeightUpdateMessage {
     height: number;
 }
 
+export interface OutputVisibilityChangedMessage {
+    type: 'outputVisibilityChanged';
+    cellHandle: number;
+    visible: boolean;
+}
+
 export type ToWebviewMessage = UpdateRenderersMessage
     | OutputChangedMessage
     | ChangePreferredMimetypeMessage
@@ -109,7 +115,8 @@ export type ToWebviewMessage = UpdateRenderersMessage
     | notebookStylesMessage
     | CellHeigthsMessage
     | CellHeightUpdateMessage
-    | CellsChangedMessage;
+    | CellsChangedMessage
+    | OutputVisibilityChangedMessage;
 
 export interface WebviewInitialized {
     readonly type: 'initialized';

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -119,7 +119,7 @@ export interface OnDidRenderOutput {
     cellHandle: number;
     outputId: string;
     outputHeight: number;
-    contentHeight: number;
+    bodyHeight: number;
 }
 
 export interface WheelMessage {

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -36,11 +36,16 @@ export interface UpdateRenderersMessage {
     readonly rendererData: readonly RendererMetadata[];
 }
 
+export interface CellOutputChange {
+    readonly cellHandle: number;
+    readonly newOutputs?: Output[];
+    readonly start: number;
+    readonly deleteCount: number;
+}
+
 export interface OutputChangedMessage {
     readonly type: 'outputChanged';
-    readonly newOutputs?: Output[];
-    readonly deleteStart?: number;
-    readonly deleteCount?: number;
+    changes: CellOutputChange[];
 }
 
 export interface ChangePreferredMimetypeMessage {
@@ -64,13 +69,45 @@ export interface notebookStylesMessage {
     styles: Record<string, string>;
 }
 
+export interface CellHeigthsMessage {
+    type: 'cellHeigths';
+    cellHeigths: Record<number, number>;
+}
+
+export interface CellMoved {
+    type: 'cellMoved';
+    cellHandle: number;
+    toIndex: number;
+}
+
+export interface CellsSpliced {
+    type: 'cellsSpliced';
+    start: number;
+    deleteCount: number;
+    newCells: number[];
+}
+
+export interface CellsChangedMessage {
+    type: 'cellsChanged';
+    changes: (CellMoved | CellsSpliced)[];
+}
+
+export interface CellHeightUpdateMessage {
+    type: 'cellHeightUpdate';
+    cellHandle: number;
+    height: number;
+}
+
 export type ToWebviewMessage = UpdateRenderersMessage
     | OutputChangedMessage
     | ChangePreferredMimetypeMessage
     | CustomRendererMessage
     | KernelMessage
     | PreloadMessage
-    | notebookStylesMessage;
+    | notebookStylesMessage
+    | CellHeigthsMessage
+    | CellHeightUpdateMessage
+    | CellsChangedMessage;
 
 export interface WebviewInitialized {
     readonly type: 'initialized';
@@ -78,6 +115,9 @@ export interface WebviewInitialized {
 
 export interface OnDidRenderOutput {
     readonly type: 'didRenderOutput';
+    cellHandle: number;
+    outputId: string;
+    outputHeight: number;
     contentHeight: number;
 }
 
@@ -92,7 +132,12 @@ export interface InputFocusChange {
     readonly focused: boolean;
 }
 
-export type FromWebviewMessage = WebviewInitialized | OnDidRenderOutput | WheelMessage | CustomRendererMessage | KernelMessage | InputFocusChange;
+export type FromWebviewMessage = WebviewInitialized
+    | OnDidRenderOutput
+    | WheelMessage
+    | CustomRendererMessage
+    | KernelMessage
+    | InputFocusChange;
 
 export interface Output {
     id: string
@@ -104,4 +149,3 @@ export interface OutputItem {
     readonly mime: string;
     readonly data: Uint8Array;
 }
-

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -86,8 +86,6 @@ import { LanguagePackService, languagePackServicePath } from '../../common/langu
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { CellOutputWebviewFactory } from '@theia/notebook/lib/browser';
 import { CellOutputWebviewImpl, createCellOutputWebviewContainer } from './notebooks/renderers/cell-output-webview';
-import { NotebookCellModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-model';
-import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
 import { ArgumentProcessorContribution } from './command-registry-main';
 import { WebviewSecondaryWindowSupport } from './webview/webview-secondary-window-support';
 import { CustomEditorUndoRedoHandler } from './custom-editors/custom-editor-undo-redo-handler';
@@ -283,8 +281,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         return provider.createProxy<LanguagePackService>(languagePackServicePath);
     }).inSingletonScope();
 
-    bind(CellOutputWebviewFactory).toFactory(ctx => async (cell: NotebookCellModel, notebook: NotebookModel) =>
-        createCellOutputWebviewContainer(ctx.container, cell, notebook).getAsync(CellOutputWebviewImpl)
+    bind(CellOutputWebviewFactory).toFactory(ctx => () =>
+        createCellOutputWebviewContainer(ctx.container).get(CellOutputWebviewImpl)
     );
     bindContributionProvider(bind, ArgumentProcessorContribution);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/13015

Changes the notebook output rendering to only use a single webview for each editor.
This should also fix some previously existent issues like with moving cells having outputs and changing mime type.

#### How to test

Open a notebook and test that everything regarding rendering of outputs still works.
- opening notebooks with outputs
- executing cells
- moving/deleting cells with outputs
- creating new cells infornt/in between cells with outputs
- collapsing outputs
- clearing outputs
- chainging output presentation type

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
