### PR TITLE
Fix duplicate text editor entry

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -35,6 +35,7 @@ import { ChatViewMenuContribution } from './chat-view-contribution';
 import { ChatViewLanguageContribution } from './chat-view-language-contribution';
 import { ChatViewWidget } from './chat-view-widget';
 import { ChatViewWidgetToolbarContribution } from './chat-view-widget-toolbar-contribution';
+import { EditorPreviewManager } from '@theia/editor-preview/lib/browser/editor-preview-manager';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindViewContribution(bind, AIChatContribution);
@@ -71,6 +72,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bind(AIEditorManager).toSelf().inSingletonScope();
     rebind(EditorManager).toService(AIEditorManager);
+    rebind(EditorPreviewManager).toService(AIEditorManager);
 
     bindContributionProvider(bind, AIEditorSelectionResolver);
     bind(AIEditorSelectionResolver).to(GitHubSelectionResolver).inSingletonScope();

--- a/packages/core/src/browser/open-with-service.ts
+++ b/packages/core/src/browser/open-with-service.ts
@@ -77,6 +77,10 @@ export class OpenWithService {
     protected readonly handlers: OpenWithHandler[] = [];
 
     registerHandler(handler: OpenWithHandler): Disposable {
+        if (this.handlers.some(h => h.id === handler.id)) {
+            console.warn('Duplicate OpenWithHandler registration: ' + handler.id);
+            return Disposable.NULL;
+        }
         this.handlers.push(handler);
         return Disposable.create(() => {
             const index = this.handlers.indexOf(handler);

--- a/packages/editor-preview/src/browser/editor-preview-tree-decorator.ts
+++ b/packages/editor-preview/src/browser/editor-preview-tree-decorator.ts
@@ -30,11 +30,10 @@ import {
 import { Disposable } from '@theia/core/lib/common';
 import { OpenEditorNode } from '@theia/navigator/lib/browser/open-editors-widget/navigator-open-editors-tree-model';
 import { EditorPreviewWidget } from './editor-preview-widget';
-import { EditorPreviewManager } from './editor-preview-manager';
 
 @injectable()
 export class EditorPreviewTreeDecorator implements TreeDecorator, FrontendApplicationContribution {
-    @inject(EditorPreviewManager) protected readonly editorPreviewManager: EditorPreviewManager;
+
     @inject(ApplicationShell) protected readonly shell: ApplicationShell;
 
     readonly id = 'theia-open-editors-file-decorator';


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14237

Fixes the issue by correctly rebinding the `EditorPreviewManager`, thereby preventing the `@postConstruct` method to run twice. Also removes an unnecessary `@inject` of the `EditorPreviewManager`.

Lastly, prevents duplicate entries from appearing in the `OpenWithService`.

#### How to test

Follow the steps from https://github.com/eclipse-theia/theia/issues/14237 and ensure that the entry is only shown once.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
