### PR TITLE
Improve widget specific status bar handling

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -144,6 +144,7 @@ import { bindTreePreferences } from './tree';
 import { OpenWithService } from './open-with-service';
 import { ViewColumnService } from './shell/view-column-service';
 import { DomInputUndoRedoHandler, UndoRedoHandler, UndoRedoHandlerService } from './undo-redo-handler';
+import { WidgetStatusBarContribution, WidgetStatusBarService } from './widget-status-bar-service';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -471,4 +472,8 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bindContributionProvider(bind, UndoRedoHandler);
     bind(DomInputUndoRedoHandler).toSelf().inSingletonScope();
     bind(UndoRedoHandler).toService(DomInputUndoRedoHandler);
+
+    bind(WidgetStatusBarService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(WidgetStatusBarService);
+    bindContributionProvider(bind, WidgetStatusBarContribution);
 });

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -48,3 +48,4 @@ export * from './styling-service';
 export * from './hover-service';
 export * from './saveable-service';
 export * from './undo-redo-handler';
+export * from './widget-status-bar-service';

--- a/packages/core/src/browser/widget-status-bar-service.ts
+++ b/packages/core/src/browser/widget-status-bar-service.ts
@@ -1,0 +1,84 @@
+// *****************************************************************************
+// Copyright (C) 2024 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, named } from 'inversify';
+import { Widget } from './widgets';
+import { StatusBar } from './status-bar';
+import { FrontendApplicationContribution } from './frontend-application-contribution';
+import { ContributionProvider } from '../common';
+import { FrontendApplication } from './frontend-application';
+
+export const WidgetStatusBarContribution = Symbol('WidgetStatusBarContribution');
+
+export interface WidgetStatusBarContribution<T extends Widget> {
+    canHandle(widget: Widget): widget is T;
+    activate(statusBar: StatusBar, widget: T): void;
+    deactivate(statusBar: StatusBar): void;
+}
+
+/**
+ * Creates an empty {@link WidgetStatusBarContribution} that does nothing.
+ * Useful for widgets that are not handled by any other contribution, for example:
+ * * Settings widget
+ * * Welcome widget
+ * * Webview widget
+ *
+ * @param prototype Prototype to identify the kind of the widget.
+ * @returns An empty {@link WidgetStatusBarContribution}.
+ */
+export function noopWidgetStatusBarContribution(prototype: Function): WidgetStatusBarContribution<Widget> {
+    return {
+        canHandle(widget: Widget): widget is Widget {
+            return widget instanceof prototype;
+        },
+        activate: () => { },
+        deactivate: () => { }
+    };
+}
+
+@injectable()
+export class WidgetStatusBarService implements FrontendApplicationContribution {
+
+    @inject(ContributionProvider) @named(WidgetStatusBarContribution)
+    protected readonly contributionProvider: ContributionProvider<WidgetStatusBarContribution<Widget>>;
+
+    @inject(StatusBar)
+    protected readonly statusBar: StatusBar;
+
+    onStart(app: FrontendApplication): void {
+        app.shell.onDidChangeCurrentWidget(event => {
+            if (event.newValue) {
+                this.show(event.newValue);
+            }
+        });
+    }
+
+    protected show(widget: Widget): void {
+        const contributions = this.contributionProvider.getContributions();
+        // If any contribution can handle the widget, activate it
+        // If none can, keep everything as is
+        if (contributions.some(contribution => contribution.canHandle(widget))) {
+            for (const contribution of contributions) {
+                // Deactivate all contributions
+                contribution.deactivate(this.statusBar);
+                if (contribution.canHandle(widget)) {
+                    // Selectively re-activate them
+                    contribution.activate(this.statusBar, widget);
+                }
+            }
+        }
+    }
+}

--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -19,7 +19,7 @@ import '../../src/browser/language-status/editor-language-status.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { OpenHandler, WidgetFactory, FrontendApplicationContribution, KeybindingContribution } from '@theia/core/lib/browser';
+import { OpenHandler, WidgetFactory, FrontendApplicationContribution, KeybindingContribution, WidgetStatusBarContribution } from '@theia/core/lib/browser';
 import { VariableContribution } from '@theia/variable-resolver/lib/browser';
 import { EditorManager, EditorAccess, ActiveEditorAccess, CurrentEditorAccess } from './editor-manager';
 import { EditorContribution } from './editor-contribution';
@@ -59,7 +59,6 @@ export default new ContainerModule(bind => {
     bind(KeybindingContribution).toService(EditorKeybindingContribution);
 
     bind(EditorContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(EditorContribution);
     bind(EditorLanguageStatusService).toSelf().inSingletonScope();
 
     bind(EditorLineNumberContribution).toSelf().inSingletonScope();
@@ -73,7 +72,13 @@ export default new ContainerModule(bind => {
 
     bind(VariableContribution).to(EditorVariableContribution).inSingletonScope();
 
-    [CommandContribution, KeybindingContribution, MenuContribution].forEach(serviceIdentifier => {
+    [
+        FrontendApplicationContribution,
+        WidgetStatusBarContribution,
+        CommandContribution,
+        KeybindingContribution,
+        MenuContribution
+    ].forEach(serviceIdentifier => {
         bind(serviceIdentifier).toService(EditorContribution);
     });
     bind(QuickEditorService).toSelf().inSingletonScope();

--- a/packages/getting-started/src/browser/getting-started-frontend-module.ts
+++ b/packages/getting-started/src/browser/getting-started-frontend-module.ts
@@ -17,13 +17,14 @@
 import { GettingStartedContribution } from './getting-started-contribution';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { GettingStartedWidget } from './getting-started-widget';
-import { WidgetFactory, FrontendApplicationContribution, bindViewContribution } from '@theia/core/lib/browser';
+import { WidgetFactory, FrontendApplicationContribution, bindViewContribution, noopWidgetStatusBarContribution, WidgetStatusBarContribution } from '@theia/core/lib/browser';
 import { bindGettingStartedPreferences } from './getting-started-preferences';
 import '../../src/browser/style/index.css';
 
 export default new ContainerModule((bind: interfaces.Bind) => {
     bindViewContribution(bind, GettingStartedContribution);
     bind(FrontendApplicationContribution).toService(GettingStartedContribution);
+    bind(WidgetStatusBarContribution).toConstantValue(noopWidgetStatusBarContribution(GettingStartedWidget));
     bind(GettingStartedWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(context => ({
         id: GettingStartedWidget.ID,

--- a/packages/keymaps/src/browser/keymaps-frontend-module.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-module.ts
@@ -22,7 +22,7 @@ import { KeymapsFrontendContribution } from './keymaps-frontend-contribution';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
 import { KeybindingContribution } from '@theia/core/lib/browser/keybinding';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
-import { WidgetFactory } from '@theia/core/lib/browser';
+import { noopWidgetStatusBarContribution, WidgetFactory, WidgetStatusBarContribution } from '@theia/core/lib/browser';
 import { KeybindingWidget } from './keybindings-widget';
 import { KeybindingSchemaUpdater } from './keybinding-schema-updater';
 import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
@@ -41,4 +41,5 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
     bind(KeybindingSchemaUpdater).toSelf().inSingletonScope();
     bind(JsonSchemaContribution).toService(KeybindingSchemaUpdater);
+    bind(WidgetStatusBarContribution).toConstantValue(noopWidgetStatusBarContribution(KeybindingWidget));
 });

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -21,7 +21,8 @@ import {
     FrontendApplicationContribution, KeybindingContribution,
     PreferenceService, PreferenceSchemaProvider, createPreferenceProxy,
     PreferenceScope, PreferenceChange, OVERRIDE_PROPERTY_PATTERN, QuickInputService, StylingParticipant, WebSocketConnectionProvider,
-    UndoRedoHandler
+    UndoRedoHandler,
+    WidgetStatusBarContribution
 } from '@theia/core/lib/browser';
 import { TextEditorProvider, DiffNavigatorProvider, TextEditor } from '@theia/editor/lib/browser';
 import { MonacoEditorProvider, MonacoEditorFactory } from './monaco-editor-provider';
@@ -135,7 +136,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(FrontendApplicationContribution).toService(MonacoFormattingConflictsContribution);
 
     bind(MonacoStatusBarContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(MonacoStatusBarContribution);
+    bind(WidgetStatusBarContribution).toService(MonacoStatusBarContribution);
 
     bind(MonacoCommandRegistry).toSelf().inSingletonScope();
     bind(MonacoEditorCommandHandlers).toSelf().inSingletonScope();

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -16,7 +16,9 @@
 import '../../src/browser/style/index.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { FrontendApplicationContribution, KeybindingContribution, LabelProviderContribution, OpenHandler, UndoRedoHandler, WidgetFactory } from '@theia/core/lib/browser';
+import {
+    FrontendApplicationContribution, KeybindingContribution, LabelProviderContribution, OpenHandler, UndoRedoHandler, WidgetFactory, WidgetStatusBarContribution
+} from '@theia/core/lib/browser';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { NotebookOpenHandler } from './notebook-open-handler';
 import { CommandContribution, MenuContribution, ResourceResolver, } from '@theia/core';
@@ -117,5 +119,5 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(UndoRedoHandler).toService(NotebookUndoRedoHandler);
 
     bind(NotebookStatusBarContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(NotebookStatusBarContribution);
+    bind(WidgetStatusBarContribution).toService(NotebookStatusBarContribution);
 });

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -22,7 +22,9 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import {
     FrontendApplicationContribution, WidgetFactory, bindViewContribution,
     ViewContainerIdentifier, ViewContainer, createTreeContainer, TreeWidget, LabelProviderContribution, LabelProvider,
-    UndoRedoHandler, DiffUris, Navigatable, SplitWidget
+    UndoRedoHandler, DiffUris, Navigatable, SplitWidget,
+    noopWidgetStatusBarContribution,
+    WidgetStatusBarContribution
 } from '@theia/core/lib/browser';
 import { MaybePromise, CommandContribution, ResourceResolver, bindContributionProvider, URI, generateUuid } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
@@ -191,6 +193,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(WebviewSecondaryWindowSupport).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(WebviewSecondaryWindowSupport);
     bind(FrontendApplicationContribution).toService(WebviewContextKeys);
+    bind(WidgetStatusBarContribution).toConstantValue(noopWidgetStatusBarContribution(WebviewWidget));
 
     bind(PluginCustomEditorRegistry).toSelf().inSingletonScope();
     bind(CustomEditorService).toSelf().inSingletonScope();

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -17,7 +17,7 @@
 import '../../src/browser/style/index.css';
 import './preferences-monaco-contribution';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
-import { bindViewContribution, FrontendApplicationContribution, OpenHandler } from '@theia/core/lib/browser';
+import { bindViewContribution, FrontendApplicationContribution, noopWidgetStatusBarContribution, OpenHandler, WidgetStatusBarContribution } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { PreferenceTreeGenerator } from './util/preference-tree-generator';
 import { bindPreferenceProviders } from './preference-bindings';
@@ -33,6 +33,7 @@ import { CliPreferences, CliPreferencesPath } from '../common/cli-preferences';
 import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { PreferenceFrontendContribution } from './preference-frontend-contribution';
 import { PreferenceLayoutProvider } from './util/preference-layout';
+import { PreferencesWidget } from './views/preference-widget';
 
 export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
     bindPreferenceProviders(bind, unbind);
@@ -59,6 +60,8 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
     bind(CliPreferences).toDynamicValue(ctx => ServiceConnectionProvider.createProxy<CliPreferences>(ctx.container, CliPreferencesPath)).inSingletonScope();
     bind(PreferenceFrontendContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(PreferenceFrontendContribution);
+
+    bind(WidgetStatusBarContribution).toConstantValue(noopWidgetStatusBarContribution(PreferencesWidget));
 }
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -18,7 +18,9 @@ import '../../src/browser/style/index.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import {
-    WidgetFactory, bindViewContribution, FrontendApplicationContribution, ViewContainerIdentifier, OpenHandler, WidgetManager, WebSocketConnectionProvider
+    WidgetFactory, bindViewContribution, FrontendApplicationContribution, ViewContainerIdentifier, OpenHandler, WidgetManager, WebSocketConnectionProvider,
+    WidgetStatusBarContribution,
+    noopWidgetStatusBarContribution
 } from '@theia/core/lib/browser';
 import { VSXExtensionsViewContainer } from './vsx-extensions-view-container';
 import { VSXExtensionsContribution } from './vsx-extensions-contribution';
@@ -64,6 +66,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     })).inSingletonScope();
     bind(VSXExtensionEditorManager).toSelf().inSingletonScope();
     bind(OpenHandler).toService(VSXExtensionEditorManager);
+    bind(WidgetStatusBarContribution).toConstantValue(noopWidgetStatusBarContribution(VSXExtensionEditor));
 
     bind(WidgetFactory).toDynamicValue(({ container }) => ({
         id: VSXExtensionsWidget.ID,


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14045

Adds a new dedicated `WidgetStatusBarService` (and associated `WidgetStatusBarContribution`) that enables showing status bar items for the currently selected widget.

If no `WidgetStatusBarContribution` matches the current widget (like if the Explorer was selected), the previous status bar items stay. If another widget like the notebook editor gains focus, the correct contribution is selected and the new status bar items are shown.

Some specific widgets (webview, custom editor, preferences, getting started, etc.) in vscode hide the previous status bar items. For this, we implement a `noopWidgetStatusBarContribution` function to enable easier disabling of status bar items.

#### How to test

1. Select a monaco editor widget.
2. Ensure that the expected status bar items appear
3. Select a different widget (like terminal, explorer)
4. Assert that the status bar items stay where they are
5. Select a notebook widget (and select a cell within)
6. Assert that the expected status bar items appear, and the editor ones disappear.
7. Select the getting started (or webview, custom editor, preferences, etc.) widget
8. Assert that all editor related status bar items disappear.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
