### PR TITLE
Ensure notebook document event registration

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
@@ -195,14 +195,16 @@ export class NotebooksAndEditorsMain implements NotebookDocumentsAndEditorsMain 
             addedEditors: delta.addedEditors.map(NotebooksAndEditorsMain.asEditorAddData),
         };
 
-        // send to extension FIRST
-        await this.proxy.$acceptDocumentsAndEditorsDelta(dto);
-
-        // handle internally
+        // Handle internally first
+        // In case the plugin wants to perform documents edits immediately
+        // we want to make sure that all events have already been setup
         this.notebookEditorsMain.handleEditorsRemoved(delta.removedEditors);
         this.notebookDocumentsMain.handleNotebooksRemoved(delta.removedDocuments);
         this.notebookDocumentsMain.handleNotebooksAdded(delta.addedDocuments);
         this.notebookEditorsMain.handleEditorsAdded(delta.addedEditors);
+
+        // Send to plugin last
+        await this.proxy.$acceptDocumentsAndEditorsDelta(dto);
     }
 
     private static isDeltaEmpty(delta: NotebookAndEditorDelta): boolean {


### PR DESCRIPTION
#### What it does

Ok, this one is a bit difficult to describe, but I will try my best:

The Jupyter plugin uses a context key called [`jupyter.ispythonnotebook` to determine whether to show the `jupyter.openVariableView` button](https://github.com/microsoft/vscode-jupyter/blob/4e9ebfd5906d28beaa5f7799969829b526631599/package.json#L902-L906).

This context key is set inside of the jupyter plugin, after encountering the `metadata.kernelSpec` property. This metadata property is set immediately when the notebook opens. This is done by performing a notebook metadata edit. This edit is performed correctly in the frontend notebook model, but since the necessary events aren't setup yet, the metadata edit isn't propagated back to the plugin host.

This change adjusts the order in which the service calls are happening to ensure that all events are properly setup before the notebook opening event is sent to the plugin host. This ensures that any edit operation on the frontend side is correctly propagated towards the plugin host.

#### How to test

Open a notebook editor for a `.ipynb` file and select a kernel. Reload the app and ensure that the `Variables` button is available in the notebook toolbar.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
