### PR TITLE
feat(ai): Update OpenAI models supporting structured output

### DIFF
--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -134,9 +134,12 @@ export class OpenAiModel implements LanguageModel {
     }
 
     protected supportsStructuredOutput(): boolean {
-        // currently only the lastest 4o and 4o-mini models support structured output
-        // see https://platform.openai.com/docs/guides/structured-outputs
-        return this.model === 'gpt-4o-2024-08-06' || this.model === 'gpt-4o-mini';
+        // see https://platform.openai.com/docs/models/gpt-4o
+        return [
+            'gpt-4o',
+            'gpt-4o-2024-08-06',
+            'gpt-4o-mini'
+        ].includes(this.model);
     }
 
     protected async handleStructuredOutputRequest(openai: OpenAI, request: LanguageModelRequest): Promise<LanguageModelParsedResponse> {


### PR DESCRIPTION
#### What it does

Updates the list of OpenAI models supporting structured output. As `gpt-4o` now points to 'gpt-4o-2024-08-06', it now also support structured output. In addition, I added 'gpt-4o-latest', which always points to the latest release and thus supports structured output too.

#### How to test

Configure `gpt-4o` to be used for the terminal agent and test the terminal agent.
You can verify if it uses structured output by setting a breakpoint in `ai-terminal-agent.ts` at line 182.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
