### PR TITLE
Orchestrator logs its own requests

### DIFF
--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -73,6 +73,7 @@ export interface ChatRequestModel {
     readonly response: ChatResponseModel;
     readonly message: ParsedChatRequest;
     readonly agentId?: string;
+    readonly data?: { [key: string]: unknown };
 }
 
 export interface ChatProgressMessage {
@@ -342,14 +343,29 @@ export class ChatRequestModelImpl implements ChatRequestModel {
     protected _request: ChatRequest;
     protected _response: ChatResponseModelImpl;
     protected _agentId?: string;
+    protected _data: { [key: string]: unknown };
 
-    constructor(session: ChatModel, public readonly message: ParsedChatRequest, agentId?: string) {
+    constructor(session: ChatModel, public readonly message: ParsedChatRequest, agentId?: string,
+        data: { [key: string]: unknown } = {}) {
         // TODO accept serialized data as a parameter to restore a previously saved ChatRequestModel
         this._request = message.request;
         this._id = generateUuid();
         this._session = session;
         this._response = new ChatResponseModelImpl(this._id, agentId);
         this._agentId = agentId;
+        this._data = data;
+    }
+
+    get data(): { [key: string]: unknown } | undefined {
+        return this._data;
+    }
+
+    addData(key: string, blob: unknown): void {
+        this._data[key] = blob;
+    }
+
+    getDataByKey(key: string): unknown | undefined {
+        return this._data[key];
     }
 
     get id(): string {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -360,8 +360,8 @@ export class ChatRequestModelImpl implements ChatRequestModel {
         return this._data;
     }
 
-    addData(key: string, blob: unknown): void {
-        this._data[key] = blob;
+    addData(key: string, value: unknown): void {
+        this._data[key] = value;
     }
 
     getDataByKey(key: string): unknown {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -364,7 +364,7 @@ export class ChatRequestModelImpl implements ChatRequestModel {
         this._data[key] = blob;
     }
 
-    getDataByKey(key: string): unknown | undefined {
+    getDataByKey(key: string): unknown {
         return this._data[key];
     }
 

--- a/packages/ai-chat/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-chat/src/common/orchestrator-chat-agent.ts
@@ -100,7 +100,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent implem
             agentId: this.id,
             sessionId: request.session.id,
             timestamp: Date.now(),
-            requestId: orchestartorRequestID,
+            requestId: orchestartorRequestId,
             request: userPrompt,
         });
         return super.invoke(request);

--- a/packages/ai-chat/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-chat/src/common/orchestrator-chat-agent.ts
@@ -94,7 +94,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent implem
         request.response.addProgressMessage({ content: 'Determining the most appropriate agent', status: 'inProgress' });
         // We generate a dedicated ID for recording the orchestrator request/response, as we will forward the original request to another agent
         const orchestartorRequestID = generateUuid();
-        request.addData(OrchestatorRequestIDKey, orchestartorRequestID);
+        request.addData(OrchestatorRequestIdKey, orchestartorRequestId);
         const userPrompt = request.request.text;
         this.recordingService.recordRequest({
             agentId: this.id,

--- a/packages/ai-chat/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-chat/src/common/orchestrator-chat-agent.ts
@@ -115,7 +115,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent implem
         let agentIds: string[] = [];
         const responseText = await getTextOfResponse(response);
         // We use the previously generated, dedicated ID to log the orchestrator response before we forward the original request
-        const orchestratorRequestID = request.getDataByKey(OrchestatorRequestIDKey);
+        const orchestratorRequestId = request.getDataByKey(OrchestatorRequestIdKey);
         if (typeof orchestratorRequestID === 'string') {
             this.recordingService.recordResponse({
                 agentId: this.id,

--- a/packages/ai-chat/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-chat/src/common/orchestrator-chat-agent.ts
@@ -116,7 +116,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent implem
         const responseText = await getTextOfResponse(response);
         // We use the previously generated, dedicated ID to log the orchestrator response before we forward the original request
         const orchestratorRequestId = request.getDataByKey(OrchestatorRequestIdKey);
-        if (typeof orchestratorRequestID === 'string') {
+        if (typeof orchestratorRequestId === 'string') {
             this.recordingService.recordResponse({
                 agentId: this.id,
                 sessionId: request.session.id,

--- a/packages/ai-chat/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-chat/src/common/orchestrator-chat-agent.ts
@@ -121,7 +121,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent implem
                 agentId: this.id,
                 sessionId: request.session.id,
                 timestamp: Date.now(),
-                requestId: orchestratorRequestID,
+                requestId: orchestratorRequestId,
                 response: responseText,
             });
         }

--- a/packages/ai-chat/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-chat/src/common/orchestrator-chat-agent.ts
@@ -93,7 +93,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent implem
     override async invoke(request: ChatRequestModelImpl): Promise<void> {
         request.response.addProgressMessage({ content: 'Determining the most appropriate agent', status: 'inProgress' });
         // We generate a dedicated ID for recording the orchestrator request/response, as we will forward the original request to another agent
-        const orchestartorRequestID = generateUuid();
+        const orchestartorRequestId = generateUuid();
         request.addData(OrchestatorRequestIdKey, orchestartorRequestId);
         const userPrompt = request.request.text;
         this.recordingService.recordRequest({

--- a/packages/ai-chat/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-chat/src/common/orchestrator-chat-agent.ts
@@ -60,7 +60,7 @@ You must only use the \`id\` attribute of the agent, never the name.
 `};
 
 export const OrchestratorChatAgentId = 'Orchestrator';
-const OrchestatorRequestIDKey = 'orchestatorRequestIDKey';
+const OrchestatorRequestIdKey = 'orchestatorRequestIdKey';
 
 @injectable()
 export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent implements ChatAgent {


### PR DESCRIPTION
- add data field to request
- add option to turn off default logging
- extracted getJsonOfText
- add docu for getTextOfResponse

fixed #14252

#### What it does

Orchestrator logs its own requests separatly from the agent it delegates to.

It also adds a data field to 'request' to remember the orchestrator request id which is manually generated.

It refactors getJsonOfResponse and adds getJsonOfText

It adds documentation to getTextOfResponse to avoid other people falling into this trap: " **Important:** For stream responses, the stream can only be consumed once. Calling this function multiple times on the same stream response will return an empty string (`''`) on subsequent calls, as the stream will have already been consumed."

#### How to test

Do any chat requests and check the history view. For the orchestrator it should log the user requests and then the choosen agent. For the choosen agent, it should log the user request and they actual answer.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
