### PR TITLE
Optimize showing recent workspaces

### DIFF
--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -161,7 +161,12 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
     }
 
     protected async workspaceStillExist(workspaceRootUri: string): Promise<boolean> {
-        return fs.pathExists(FileUri.fsPath(workspaceRootUri));
+        const uri = new URI(workspaceRootUri);
+        // Non file system workspaces cannot be checked for existence
+        if (uri.scheme !== 'file') {
+            return false;
+        }
+        return fs.pathExists(uri.path.fsPath());
     }
 
     protected async getWorkspaceURIFromCli(): Promise<string | undefined> {


### PR DESCRIPTION
#### What it does

I've recently noticed that attempting to execute the "Open recent workspace" command takes a few seconds on Windows. This change optimizes quite a lot of the old code to improve the performance and also fix a few issues regarding incorrectly displayed paths. In order to get the most performance out of it, I had to remove the pretty expensive `FileService#resolve` calls which were used to differentiate between file and directory workspaces.

#### How to test

1. Run the "Open recent workspace" command.
2. Assert that it effectively instantly opens the quick pick for the workspaces
3. Assert that there are no regressions.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
