### PR TITLE
Fixed notebook editor staying current even when selecting sidebar or bottom panel

### DIFF
--- a/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
+++ b/packages/notebook/src/browser/service/notebook-editor-widget-service.ts
@@ -45,12 +45,22 @@ export class NotebookEditorWidgetService {
     protected readonly onDidChangeFocusedEditorEmitter = new Emitter<NotebookEditorWidget | undefined>();
     readonly onDidChangeFocusedEditor = this.onDidChangeFocusedEditorEmitter.event;
 
+    protected readonly onDidChangeCurrentEditorEmitter = new Emitter<NotebookEditorWidget | undefined>();
+    readonly onDidChangeCurrentEditor = this.onDidChangeCurrentEditorEmitter.event;
+
     focusedEditor?: NotebookEditorWidget = undefined;
+
+    currentEditor?: NotebookEditorWidget = undefined;
 
     @postConstruct()
     protected init(): void {
         this.applicationShell.onDidChangeActiveWidget(event => {
             this.notebookEditorFocusChanged(event.newValue as NotebookEditorWidget, event.newValue instanceof NotebookEditorWidget);
+        });
+        this.applicationShell.onDidChangeCurrentWidget(event => {
+            if (event.newValue instanceof NotebookEditorWidget || event.oldValue instanceof NotebookEditorWidget) {
+                this.currentNotebookEditorChanged(event.newValue);
+            }
         });
     }
 
@@ -95,6 +105,16 @@ export class NotebookEditorWidgetService {
             this.focusedEditor = undefined;
             this.contextKeyService.setContext(NOTEBOOK_EDITOR_FOCUSED, false);
             this.onDidChangeFocusedEditorEmitter.fire(undefined);
+        }
+    }
+
+    currentNotebookEditorChanged(newEditor: unknown): void {
+        if (newEditor instanceof NotebookEditorWidget) {
+            this.currentEditor = newEditor;
+            this.onDidChangeCurrentEditorEmitter.fire(newEditor);
+        } else if (this.currentEditor?.isDisposed || !this.currentEditor?.isVisible) {
+            this.currentEditor = undefined;
+            this.onDidChangeCurrentEditorEmitter.fire(undefined);
         }
     }
 

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -250,7 +250,7 @@ class EditorAndDocumentStateComputer implements Disposable {
 
         this.toDispose.push(this.cellEditorService.onDidChangeCellEditors(() => this.update()));
 
-        this.toDispose.push(this.notebookWidgetService.onDidChangeFocusedEditor(() => {
+        this.toDispose.push(this.notebookWidgetService.onDidChangeCurrentEditor(() => {
             this.currentState = this.currentState && new EditorAndDocumentState(
                 this.currentState.documents,
                 this.currentState.editors,

--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
@@ -55,7 +55,6 @@ class NotebookAndEditorState {
         const documentDelta = diffSets(before.documents, after.documents);
         const editorDelta = diffMaps(before.textEditors, after.textEditors);
 
-        const newActiveEditor = before.activeEditor !== after.activeEditor ? after.activeEditor : undefined;
         const visibleEditorDelta = diffMaps(before.visibleEditors, after.visibleEditors);
 
         return {
@@ -63,7 +62,7 @@ class NotebookAndEditorState {
             removedDocuments: documentDelta.removed.map(e => e.uri.toComponents()),
             addedEditors: editorDelta.added,
             removedEditors: editorDelta.removed.map(removed => removed.id),
-            newActiveEditor: newActiveEditor,
+            newActiveEditor: after.activeEditor,
             visibleEditors: visibleEditorDelta.added.length === 0 && visibleEditorDelta.removed.length === 0
                 ? undefined
                 : [...after.visibleEditors].map(editor => editor[0])
@@ -114,7 +113,7 @@ export class NotebooksAndEditorsMain implements NotebookDocumentsAndEditorsMain 
         // this.WidgetManager.onActiveEditorChanged(() => this.updateState(), this, this.disposables);
         this.notebookEditorService.onDidAddNotebookEditor(async editor => this.handleEditorAdd(editor), this, this.disposables);
         this.notebookEditorService.onDidRemoveNotebookEditor(async editor => this.handleEditorRemove(editor), this, this.disposables);
-        this.notebookEditorService.onDidChangeFocusedEditor(async editor => this.updateState(editor), this, this.disposables);
+        this.notebookEditorService.onDidChangeCurrentEditor(async editor => this.updateState(editor), this, this.disposables);
     }
 
     dispose(): void {
@@ -221,7 +220,7 @@ export class NotebooksAndEditorsMain implements NotebookDocumentsAndEditorsMain 
         if (delta.visibleEditors?.length) {
             return false;
         }
-        if (delta.newActiveEditor) {
+        if (delta.newActiveEditor !== undefined) {
             return false;
         }
         return true;

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -341,7 +341,7 @@ export class NotebooksExtImpl implements NotebooksExt {
                 });
             }
         }
-        if (delta.newActiveEditor !== undefined) {
+        if (delta.newActiveEditor !== undefined && delta.newActiveEditor !== this.activeNotebookEditor?.id) {
             this.onDidChangeActiveNotebookEditorEmitter.fire(this.activeNotebookEditor?.apiEditor);
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This lets the current notebook editor stay as active in the plugin host even when selecting another widget as long as the notebook-editor is visible and no other text-editor is selected

#### How to test

you can find an vscoed extension [here](https://github.com/jonah-iden/theia-notebook-selection-test) which adds an output channel to show the cahnge events. See that the active notebook editor and cell editor should stay even when selecting another non text-editor widget.

#### Follow-ups

This still has the same issues as the text editor active handling. For example having a text or notebook editor open and a custom editor right beside it so both are visible, then focusing the custom editor does not change the vscode api `activeTextEditor` or `ActiveNotebookEditor`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
