### PR TITLE
Notebook Cell Tag Support

### DIFF
--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -51,6 +51,7 @@ import { NotebookOptionsService } from './service/notebook-options';
 import { NotebookUndoRedoHandler } from './contributions/notebook-undo-redo-handler';
 import { NotebookStatusBarContribution } from './contributions/notebook-status-bar-contribution';
 import { NotebookCellEditorService } from './service/notebook-cell-editor-service';
+import { NotebookCellStatusBarService } from './service/notebook-cell-status-bar-service';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookColorContribution).toSelf().inSingletonScope();
@@ -74,6 +75,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(NotebookKernelQuickPickService).toSelf().inSingletonScope();
     bind(NotebookClipboardService).toSelf().inSingletonScope();
     bind(NotebookCellEditorService).toSelf().inSingletonScope();
+    bind(NotebookCellStatusBarService).toSelf().inSingletonScope();
 
     bind(NotebookCellResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(NotebookCellResourceResolver);

--- a/packages/notebook/src/browser/service/notebook-cell-status-bar-service.ts
+++ b/packages/notebook/src/browser/service/notebook-cell-status-bar-service.ts
@@ -32,7 +32,7 @@ export interface NotebookCellStatusBarItem {
     readonly color?: string | ThemeColor;
     readonly backgroundColor?: string | ThemeColor;
     readonly tooltip?: string | MarkdownString;
-    readonly command?: string | Command;
+    readonly command?: string | (Command & { arguments?: unknown[] });
     readonly accessibilityInformation?: AccessibilityInformation;
     readonly opacity?: string;
     readonly onlyShowWhenActive?: boolean;
@@ -75,11 +75,11 @@ export class NotebookCellStatusBarService implements Disposable {
         });
     }
 
-    async getStatusBarItemsForCell(docUri: URI, cellIndex: number, viewType: string, token: CancellationToken): Promise<NotebookCellStatusBarItemList[]> {
+    async getStatusBarItemsForCell(notebookUri: URI, cellIndex: number, viewType: string, token: CancellationToken): Promise<NotebookCellStatusBarItemList[]> {
         const providers = this.providers.filter(p => p.viewType === viewType || p.viewType === '*');
         return Promise.all(providers.map(async p => {
             try {
-                return await p.provideCellStatusBarItems(docUri, cellIndex, token) ?? { items: [] };
+                return await p.provideCellStatusBarItems(notebookUri, cellIndex, token) ?? { items: [] };
             } catch (e) {
                 console.error(e);
                 return { items: [] };

--- a/packages/notebook/src/browser/service/notebook-cell-status-bar-service.ts
+++ b/packages/notebook/src/browser/service/notebook-cell-status-bar-service.ts
@@ -1,0 +1,94 @@
+// *****************************************************************************
+// Copyright (C) 2024 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken, Command, Disposable, Emitter, Event, URI } from '@theia/core';
+import { CellStatusbarAlignment } from '../../common';
+import { ThemeColor } from '@theia/core/lib/common/theme';
+import { AccessibilityInformation } from '@theia/core/lib/common/accessibility';
+import { injectable } from '@theia/core/shared/inversify';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
+
+export interface NotebookCellStatusBarItem {
+    readonly alignment: CellStatusbarAlignment;
+    readonly priority?: number;
+    readonly text: string;
+    readonly color?: string | ThemeColor;
+    readonly backgroundColor?: string | ThemeColor;
+    readonly tooltip?: string | MarkdownString;
+    readonly command?: string | Command;
+    readonly accessibilityInformation?: AccessibilityInformation;
+    readonly opacity?: string;
+    readonly onlyShowWhenActive?: boolean;
+}
+export interface NotebookCellStatusBarItemList {
+    items: NotebookCellStatusBarItem[];
+    dispose?(): void;
+}
+
+export interface NotebookCellStatusBarItemProvider {
+    viewType: string;
+    onDidChangeStatusBarItems?: Event<void>;
+    provideCellStatusBarItems(uri: URI, index: number, token: CancellationToken): Promise<NotebookCellStatusBarItemList | undefined>;
+}
+
+@injectable()
+export class NotebookCellStatusBarService implements Disposable {
+
+    protected readonly onDidChangeProvidersEmitter = new Emitter<void>();
+    readonly onDidChangeProviders: Event<void> = this.onDidChangeProvidersEmitter.event;
+
+    protected readonly onDidChangeItemsEmitter = new Emitter<void>();
+    readonly onDidChangeItems: Event<void> = this.onDidChangeItemsEmitter.event;
+
+    protected readonly providers: NotebookCellStatusBarItemProvider[] = [];
+
+    registerCellStatusBarItemProvider(provider: NotebookCellStatusBarItemProvider): Disposable {
+        this.providers.push(provider);
+        let changeListener: Disposable | undefined;
+        if (provider.onDidChangeStatusBarItems) {
+            changeListener = provider.onDidChangeStatusBarItems(() => this.onDidChangeItemsEmitter.fire());
+        }
+
+        this.onDidChangeProvidersEmitter.fire();
+
+        return Disposable.create(() => {
+            changeListener?.dispose();
+            const idx = this.providers.findIndex(p => p === provider);
+            this.providers.splice(idx, 1);
+        });
+    }
+
+    async getStatusBarItemsForCell(docUri: URI, cellIndex: number, viewType: string, token: CancellationToken): Promise<NotebookCellStatusBarItemList[]> {
+        const providers = this.providers.filter(p => p.viewType === viewType || p.viewType === '*');
+        return Promise.all(providers.map(async p => {
+            try {
+                return await p.provideCellStatusBarItems(docUri, cellIndex, token) ?? { items: [] };
+            } catch (e) {
+                console.error(e);
+                return { items: [] };
+            }
+        }));
+    }
+
+    dispose(): void {
+        this.onDidChangeItemsEmitter.dispose();
+        this.onDidChangeProvidersEmitter.dispose();
+    }
+}

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -508,3 +508,22 @@ mark.theia-find-match.theia-find-match-selected {
   color: var(--theia-editor-findMatchForeground);
   background-color: var(--theia-editor-findMatchBackground);
 }
+
+.cell-status-bar-item {
+  align-items: center;
+  display: flex;
+  height: 16px;
+  margin: 0 3px;
+  overflow: hidden;
+  padding: 0 3px;
+  text-overflow: clip;
+  white-space: pre;
+}
+
+.cell-status-item-has-command {
+  cursor: pointer;
+}
+
+.cell-status-item-has-command:hover {
+  background-color: var(--theia-toolbar-hoverBackground);
+}

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -30,6 +30,7 @@ import { NotebookCodeCellStatus } from './notebook-code-cell-view';
 import { NotebookEditorFindMatch, NotebookEditorFindMatchOptions } from './notebook-find-widget';
 import * as mark from 'advanced-mark.js';
 import { NotebookCellEditorService } from '../service/notebook-cell-editor-service';
+import { NotebookCellStatusBarService } from '../service/notebook-cell-status-bar-service';
 
 @injectable()
 export class NotebookMarkdownCellRenderer implements CellRenderer {
@@ -51,6 +52,9 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
     @inject(NotebookCellEditorService)
     protected readonly notebookCellEditorService: NotebookCellEditorService;
 
+    @inject(NotebookCellStatusBarService)
+    protected readonly notebookCellStatusBarService: NotebookCellStatusBarService;
+
     render(notebookModel: NotebookModel, cell: NotebookCellModel): React.ReactNode {
         return <MarkdownCell
             markdownRenderer={this.markdownRenderer}
@@ -60,7 +64,9 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
             cell={cell}
             notebookModel={notebookModel}
             notebookContextManager={this.notebookContextManager}
-            notebookCellEditorService={this.notebookCellEditorService} />;
+            notebookCellEditorService={this.notebookCellEditorService}
+            notebookCellStatusBarService={this.notebookCellStatusBarService}
+        />;
     }
 
     renderSidebar(notebookModel: NotebookModel, cell: NotebookCellModel): React.ReactNode {
@@ -86,11 +92,12 @@ interface MarkdownCellProps {
     notebookModel: NotebookModel;
     notebookContextManager: NotebookContextManager;
     notebookOptionsService: NotebookOptionsService;
-    notebookCellEditorService: NotebookCellEditorService
+    notebookCellEditorService: NotebookCellEditorService;
+    notebookCellStatusBarService: NotebookCellStatusBarService;
 }
 
 function MarkdownCell({
-    markdownRenderer, monacoServices, cell, notebookModel, notebookContextManager, notebookOptionsService, commandRegistry, notebookCellEditorService
+    markdownRenderer, monacoServices, cell, notebookModel, notebookContextManager, notebookOptionsService, commandRegistry, notebookCellEditorService, notebookCellStatusBarService
 }: MarkdownCellProps): React.JSX.Element {
     const [editMode, setEditMode] = React.useState(cell.editing);
     let empty = false;
@@ -147,6 +154,7 @@ function MarkdownCell({
                 fontInfo={notebookOptionsService.editorFontInfo} />
             <NotebookCodeCellStatus cell={cell} notebook={notebookModel}
                 commandRegistry={commandRegistry}
+                cellStatusBarService={notebookCellStatusBarService}
                 onClick={() => cell.requestFocusEditor()} />
         </div >) :
         (<div className='theia-notebook-markdown-content' key="markdown"

--- a/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-markdown-cell-view.tsx
@@ -31,6 +31,7 @@ import { NotebookEditorFindMatch, NotebookEditorFindMatchOptions } from './noteb
 import * as mark from 'advanced-mark.js';
 import { NotebookCellEditorService } from '../service/notebook-cell-editor-service';
 import { NotebookCellStatusBarService } from '../service/notebook-cell-status-bar-service';
+import { LabelParser } from '@theia/core/lib/browser/label-parser';
 
 @injectable()
 export class NotebookMarkdownCellRenderer implements CellRenderer {
@@ -55,6 +56,9 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
     @inject(NotebookCellStatusBarService)
     protected readonly notebookCellStatusBarService: NotebookCellStatusBarService;
 
+    @inject(LabelParser)
+    protected readonly labelParser: LabelParser;
+
     render(notebookModel: NotebookModel, cell: NotebookCellModel): React.ReactNode {
         return <MarkdownCell
             markdownRenderer={this.markdownRenderer}
@@ -66,6 +70,7 @@ export class NotebookMarkdownCellRenderer implements CellRenderer {
             notebookContextManager={this.notebookContextManager}
             notebookCellEditorService={this.notebookCellEditorService}
             notebookCellStatusBarService={this.notebookCellStatusBarService}
+            labelParser={this.labelParser}
         />;
     }
 
@@ -94,10 +99,13 @@ interface MarkdownCellProps {
     notebookOptionsService: NotebookOptionsService;
     notebookCellEditorService: NotebookCellEditorService;
     notebookCellStatusBarService: NotebookCellStatusBarService;
+    labelParser: LabelParser;
 }
 
 function MarkdownCell({
-    markdownRenderer, monacoServices, cell, notebookModel, notebookContextManager, notebookOptionsService, commandRegistry, notebookCellEditorService, notebookCellStatusBarService
+    markdownRenderer, monacoServices, cell, notebookModel, notebookContextManager,
+    notebookOptionsService, commandRegistry, notebookCellEditorService, notebookCellStatusBarService,
+    labelParser
 }: MarkdownCellProps): React.JSX.Element {
     const [editMode, setEditMode] = React.useState(cell.editing);
     let empty = false;
@@ -155,6 +163,7 @@ function MarkdownCell({
             <NotebookCodeCellStatus cell={cell} notebook={notebookModel}
                 commandRegistry={commandRegistry}
                 cellStatusBarService={notebookCellStatusBarService}
+                labelParser={labelParser}
                 onClick={() => cell.requestFocusEditor()} />
         </div >) :
         (<div className='theia-notebook-markdown-content' key="markdown"

--- a/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
@@ -14,36 +14,30 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { CancellationToken, DisposableCollection, Emitter, Event, URI } from '@theia/core';
+import { CancellationToken, DisposableCollection, Emitter, URI } from '@theia/core';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
-import { CellEditType, NotebookCellModelResource, NotebookCellStatusBarItem, NotebookData, NotebookModelResource, TransientOptions } from '@theia/notebook/lib/common';
+import { CellEditType, NotebookCellModelResource, NotebookData, NotebookModelResource, TransientOptions } from '@theia/notebook/lib/common';
 import { NotebookService, NotebookWorkspaceEdit } from '@theia/notebook/lib/browser';
 import { Disposable } from '@theia/plugin';
 import { CommandRegistryMain, MAIN_RPC_CONTEXT, NotebooksExt, NotebooksMain, WorkspaceEditDto, WorkspaceNotebookCellEditDto } from '../../../common';
 import { RPCProtocol } from '../../../common/rpc-protocol';
 import { NotebookDto } from './notebook-dto';
-import { UriComponents } from '@theia/core/lib/common/uri';
 import { HostedPluginSupport } from '../../../hosted/browser/hosted-plugin';
 import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
 import { NotebookCellModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-model';
 import { interfaces } from '@theia/core/shared/inversify';
-
-export interface NotebookCellStatusBarItemList {
-    items: NotebookCellStatusBarItem[];
-    dispose?(): void;
-}
-
-export interface NotebookCellStatusBarItemProvider {
-    viewType: string;
-    onDidChangeStatusBarItems?: Event<void>;
-    provideCellStatusBarItems(uri: UriComponents, index: number, token: CancellationToken): Promise<NotebookCellStatusBarItemList | undefined>;
-}
+import {
+    NotebookCellStatusBarItemProvider,
+    NotebookCellStatusBarItemList,
+    NotebookCellStatusBarService
+} from '@theia/notebook/lib/browser/service/notebook-cell-status-bar-service';
 
 export class NotebooksMainImpl implements NotebooksMain {
 
     protected readonly disposables = new DisposableCollection();
 
     protected notebookService: NotebookService;
+    protected cellStatusBarService: NotebookCellStatusBarService;
 
     protected readonly proxy: NotebooksExt;
     protected readonly notebookSerializer = new Map<number, Disposable>();
@@ -55,6 +49,7 @@ export class NotebooksMainImpl implements NotebooksMain {
         commands: CommandRegistryMain
     ) {
         this.notebookService = container.get(NotebookService);
+        this.cellStatusBarService = container.get(NotebookCellStatusBarService);
         const plugins = container.get(HostedPluginSupport);
 
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.NOTEBOOKS_EXT);
@@ -111,8 +106,8 @@ export class NotebooksMainImpl implements NotebooksMain {
     async $registerNotebookCellStatusBarItemProvider(handle: number, eventHandle: number | undefined, viewType: string): Promise<void> {
         const that = this;
         const provider: NotebookCellStatusBarItemProvider = {
-            async provideCellStatusBarItems(uri: UriComponents, index: number, token: CancellationToken): Promise<NotebookCellStatusBarItemList | undefined> {
-                const result = await that.proxy.$provideNotebookCellStatusBarItems(handle, uri, index, token);
+            async provideCellStatusBarItems(uri: URI, index: number, token: CancellationToken): Promise<NotebookCellStatusBarItemList | undefined> {
+                const result = await that.proxy.$provideNotebookCellStatusBarItems(handle, uri.toComponents(), index, token);
                 return {
                     items: result?.items ?? [],
                     dispose(): void {
@@ -131,8 +126,8 @@ export class NotebooksMainImpl implements NotebooksMain {
             provider.onDidChangeStatusBarItems = emitter.event;
         }
 
-        // const disposable = this._cellStatusBarService.registerCellStatusBarItemProvider(provider);
-        // this.notebookCellStatusBarRegistrations.set(handle, disposable);
+        const disposable = this.cellStatusBarService.registerCellStatusBarItemProvider(provider);
+        this.notebookCellStatusBarRegistrations.set(handle, disposable);
     }
 
     async $unregisterNotebookCellStatusBarItemProvider(handle: number, eventHandle: number | undefined): Promise<void> {

--- a/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebooks-main.ts
@@ -106,8 +106,8 @@ export class NotebooksMainImpl implements NotebooksMain {
     async $registerNotebookCellStatusBarItemProvider(handle: number, eventHandle: number | undefined, viewType: string): Promise<void> {
         const that = this;
         const provider: NotebookCellStatusBarItemProvider = {
-            async provideCellStatusBarItems(uri: URI, index: number, token: CancellationToken): Promise<NotebookCellStatusBarItemList | undefined> {
-                const result = await that.proxy.$provideNotebookCellStatusBarItems(handle, uri.toComponents(), index, token);
+            async provideCellStatusBarItems(notebookUri: URI, index: number, token: CancellationToken): Promise<NotebookCellStatusBarItemList | undefined> {
+                const result = await that.proxy.$provideNotebookCellStatusBarItems(handle, notebookUri.toComponents(), index, token);
                 return {
                     items: result?.items ?? [],
                     dispose(): void {

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -22,14 +22,14 @@ import { CancellationToken, Disposable, DisposableCollection, Emitter, Event, UR
 import { URI as TheiaURI } from '../types-impl';
 import * as theia from '@theia/plugin';
 import {
-    CommandRegistryExt, NotebookCellStatusBarListDto, NotebookDataDto,
+    NotebookCellStatusBarListDto, NotebookDataDto,
     NotebookDocumentsAndEditorsDelta, NotebookDocumentShowOptions, NotebookDocumentsMain, NotebookEditorAddData, NotebookEditorsMain, NotebooksExt, NotebooksMain, Plugin,
     PLUGIN_RPC_CONTEXT
 } from '../../common';
 import { Cache } from '../../common/cache';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { UriComponents } from '../../common/uri-components';
-import { CommandsConverter } from '../command-registry';
+import { CommandRegistryImpl, CommandsConverter } from '../command-registry';
 import * as typeConverters from '../type-converters';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { Cell, NotebookDocument } from './notebook-document';
@@ -74,10 +74,11 @@ export class NotebooksExtImpl implements NotebooksExt {
 
     constructor(
         rpc: RPCProtocol,
-        commands: CommandRegistryExt,
+        commands: CommandRegistryImpl,
         private textDocumentsAndEditors: EditorsAndDocumentsExtImpl,
         private textDocuments: DocumentsExtImpl,
     ) {
+        this.commandsConverter = commands.converter;
         this.notebookProxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.NOTEBOOKS_MAIN);
         this.notebookDocumentsProxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_MAIN);
         this.notebookEditors = rpc.getProxy(PLUGIN_RPC_CONTEXT.NOTEBOOK_EDITORS_MAIN);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Adds basic support for `NotebookCellStatusBarItemProviders` (see [here](https://code.visualstudio.com/api/references/vscode-api#NotebookCellStatusBarItemProvider)) and with that support for cell tags.

#### How to test

1. Ensure you have jupyter including the jupyter cell tags extension installed.
2. Open a notebook
3. Select a code cell and execute the `Add Cell Tag` command
4. You should see it appear in the cells status bar
5. Ensure the "+ Tag" button and removing a cell tag by clicking it works
6. Ensure everything works as well through the jupyter cell tags view

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
