### PR TITLE
Pin Ubuntu CI versions to 22.04

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,7 +13,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, ubuntu-latest, macos-14]
+        os: [windows-2019, ubuntu-22.04, macos-14]
         node: [18.x, 20.x]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         node: ['20.x']
         java: ['11']
 

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -7,7 +7,7 @@ jobs:
   build-and-test-performance:
     name: Performance Tests
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,9 +13,9 @@ on:
 
 jobs:
   build-and-test-playwright:
-    name: Playwright Tests (ubuntu-latest,  Node.js 18.x)
+    name: Playwright Tests (ubuntu-22.04,  Node.js 18.x)
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/production-smoke-test.yml
+++ b/.github/workflows/production-smoke-test.yml
@@ -11,9 +11,9 @@ on:
 
 jobs:
   build-and-test-playwright:
-    name: Smoke Test for Browser Example Production Build on ubuntu-latest with Node.js 18.x
+    name: Smoke Test for Browser Example Production Build on ubuntu-22.04 with Node.js 18.x
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     name: Publish to NPM and GitHub pages
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # The current approach is silly. We should be smarter and use `actions/upload-artifact` and `actions/download-artifact` instead of rebuilding
     # everything from scratch again. (git checkout, Node.js install, yarn, etc.) It was not possible to share artifacts on Travis CI without an

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -8,7 +8,7 @@ on: workflow_dispatch
 jobs:
   publish:
     name: Perform Publishing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   publish:
     name: Perform Publishing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/set-milestone-on-pr.yml
+++ b/.github/workflows/set-milestone-on-pr.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   set-milestone:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
   translation:
     name: Translation Update
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
#### What it does

Related to https://github.com/eclipse-theia/theia/issues/14274.

Pins our versions of Ubuntu to ensure that `libsecret-1-dev` is installed.

#### How to test

Assert that the CI is green

#### Follow-ups

We should fix https://github.com/eclipse-theia/theia/issues/14274 by removing keytar from our dependencies. See also https://github.com/eclipse-theia/theia/issues/13593.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
