### PR TITLE
Start menu handler ids at one, not zero

### DIFF
--- a/packages/core/src/electron-browser/preload.ts
+++ b/packages/core/src/electron-browser/preload.ts
@@ -35,8 +35,8 @@ const { ipcRenderer, contextBridge } = require('electron');
 
 // a map of menuId => map<handler id => handler>
 const commandHandlers = new Map<number, Map<number, () => void>>();
-let nextHandlerId = 0;
-const mainMenuId = 0;
+let nextHandlerId = 1;
+const mainMenuId = 1;
 let nextMenuId = mainMenuId + 1;
 
 let openUrlHandler: ((url: string) => Promise<boolean>) | undefined;


### PR DESCRIPTION
#### What it does
In order to handle native menu invocations on the browser side, we allocate handler ids when that we send over to the electron-main side. On the electron-main side, we check for the handler id with `if (menu.handlerId)` before invoking the menu action. Since the handler ids start at 0, the very first menu action created could never be invoked.

Fixes #14279

Contributed on behalf of STMicroelectronics


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
This can't really be tested in our example applications. But I think I can convince a reviewer that the change at least does no harm: we just need to make sure menus and context menus still work as advertised.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
