### PR TITLE
feat(ai): Allow customizing the LLM request settings

### DIFF
--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -279,11 +279,20 @@ export abstract class AbstractChatAgent {
         tools: ToolRequest[] | undefined,
         token: CancellationToken
     ): Promise<LanguageModelResponse> {
+        const settings = this.getLlmSettings();
         const languageModelResponse = languageModel.request({
             messages,
             tools,
+            settings,
         }, token);
         return languageModelResponse;
+    }
+
+    /**
+     * @returns the settings, such as `temperature`, to be used in all language model requests. Returns `undefined` by default.
+     */
+    protected getLlmSettings(): { [key: string]: unknown; } | undefined {
+        return undefined;
     }
 
     protected abstract addContentsToResponse(languageModelResponse: LanguageModelResponse, request: ChatRequestModelImpl): Promise<void>;


### PR DESCRIPTION
#### What it does

With this change, we enable more easily customizing the LLM settings, such as `temperature`, for the LLM requests in a chat agent.

Contributed on behalf of STMicroelectronics

#### How to test

Create or change a chat agent that subclasses `AbstractChatAgent` and provide custom settings, such as:

```ts
protected override getLlmSettings(): { [key: string]: unknown } {
    return { temperature: 0 };
}
```

Make sure those are passed to the language model correspondingly. This should be visible in the Output view of the LLM provider too.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
