### PR TITLE
Set menu bar less often at startup

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -74,42 +74,45 @@ export type ElectronMenuItemRole = ('undo' | 'redo' | 'cut' | 'copy' | 'paste' |
 @injectable()
 export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
 
-    protected _menu?: MenuDto[];
-    protected _toggledCommands: Set<string> = new Set();
+    protected menu?: MenuDto[];
+    protected toggledCommands: Set<string> = new Set();
 
     @inject(PreferenceService)
     protected preferencesService: PreferenceService;
 
+    setMenuBar = debounce(() => this.doSetMenuBar());
+
     @postConstruct()
     postConstruct(): void {
-        this.preferencesService.onPreferenceChanged(
-            debounce(e => {
-                if (e.preferenceName === 'window.menuBarVisibility') {
-                    this.setMenuBar();
-                }
-                if (this._menu) {
-                    for (const cmd of this._toggledCommands) {
-                        const menuItem = this.findMenuById(this._menu, cmd);
-                        if (menuItem) {
-                            menuItem.checked = this.commandRegistry.isToggled(cmd);
-                        }
-                    }
-                    window.electronTheiaCore.setMenu(this._menu);
-                }
-            }, 10)
-        );
         this.keybindingRegistry.onKeybindingsChanged(() => {
             this.setMenuBar();
         });
         this.menuProvider.onDidChange(() => {
             this.setMenuBar();
         });
+        this.preferencesService.ready.then(() => {
+            this.preferencesService.onPreferenceChanged(
+                debounce(e => {
+                    if (e.preferenceName === 'window.menuBarVisibility') {
+                        this.doSetMenuBar();
+                    }
+                    if (this.menu) {
+                        for (const cmd of this.toggledCommands) {
+                            const menuItem = this.findMenuById(this.menu, cmd);
+                            if (menuItem && (!!menuItem.checked !== this.commandRegistry.isToggled(cmd))) {
+                                menuItem.checked = !menuItem.checked;
+                            }
+                        }
+                        window.electronTheiaCore.setMenu(this.menu);
+                    }
+                }, 10)
+            );
+        });
     }
 
-    async setMenuBar(): Promise<void> {
-        await this.preferencesService.ready;
-        const createdMenuBar = this.createElectronMenuBar();
-        window.electronTheiaCore.setMenu(createdMenuBar);
+    doSetMenuBar(): void {
+        this.menu = this.createElectronMenuBar();
+        window.electronTheiaCore.setMenu(this.menu);
     }
 
     createElectronMenuBar(): MenuDto[] | undefined {
@@ -117,14 +120,12 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
         const maxWidget = document.getElementsByClassName(MAXIMIZED_CLASS);
         if (preference === 'visible' || (preference === 'classic' && maxWidget.length === 0)) {
             const menuModel = this.menuProvider.getMenu(MAIN_MENU_BAR);
-            this._menu = this.fillMenuTemplate([], menuModel, [], { honorDisabled: false, rootMenuPath: MAIN_MENU_BAR }, false);
+            const menu = this.fillMenuTemplate([], menuModel, [], { honorDisabled: false, rootMenuPath: MAIN_MENU_BAR }, false);
             if (isOSX) {
-                this._menu.unshift(this.createOSXMenu());
+                menu.unshift(this.createOSXMenu());
             }
-            return this._menu;
+            return menu;
         }
-        this._menu = undefined;
-        // eslint-disable-next-line no-null/no-null
         return undefined;
     }
 
@@ -208,7 +209,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
             parentItems.push(menuItem);
 
             if (this.commandRegistry.getToggledHandler(commandId, ...args)) {
-                this._toggledCommands.add(commandId);
+                this.toggledCommands.add(commandId);
             }
         }
         return parentItems;
@@ -273,11 +274,11 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
             // We need to check if we can execute it.
             if (this.menuCommandExecutor.isEnabled(menuPath, cmd, ...args)) {
                 await this.menuCommandExecutor.executeCommand(menuPath, cmd, ...args);
-                if (this._menu && this.menuCommandExecutor.isVisible(menuPath, cmd, ...args)) {
-                    const item = this.findMenuById(this._menu, cmd);
+                if (this.menu && this.menuCommandExecutor.isVisible(menuPath, cmd, ...args)) {
+                    const item = this.findMenuById(this.menu, cmd);
                     if (item) {
                         item.checked = this.menuCommandExecutor.isToggled(menuPath, cmd, ...args);
-                        window.electronTheiaCore.setMenu(this._menu);
+                        window.electronTheiaCore.setMenu(this.menu);
                     }
                 }
             }

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -80,7 +80,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
     @inject(PreferenceService)
     protected preferencesService: PreferenceService;
 
-    setMenuBar = debounce(() => this.doSetMenuBar());
+    setMenuBar = debounce(() => this.doSetMenuBar(), 100);
 
     @postConstruct()
     postConstruct(): void {

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -29,7 +29,6 @@ import { WindowService } from '../../browser/window/window-service';
 import { WindowTitleService } from '../../browser/window/window-title-service';
 
 import '../../../src/electron-browser/menu/electron-menu-style.css';
-import { MenuDto } from '../../electron-common/electron-api';
 import { ThemeService } from '../../browser/theming';
 import { ThemeChangeEvent } from '../../common/theme';
 
@@ -203,7 +202,7 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
         }
     }
 
-    protected setMenu(app: FrontendApplication, electronMenu: MenuDto[] | undefined = this.factory.createElectronMenuBar()): void {
+    protected setMenu(app: FrontendApplication): void {
         if (!isOSX) {
             this.hideTopPanel(app);
             if (this.titleBarStyle === 'custom' && !this.menuBar) {
@@ -211,7 +210,7 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
                 return;
             }
         }
-        window.electronTheiaCore.setMenu(electronMenu);
+        this.factory.setMenuBar();
     }
 
     protected createCustomTitleBar(app: FrontendApplication): void {


### PR DESCRIPTION
#### What it does
Debugging some code, I found out we're setting the main menu bar about 400 times at startup. This change reduces the number to around 10.

Fixes #14280

Contributed on behalf of STMicroelectronics
#### How to test
Make sure the main menu bar is set correctly, including checkmarks (example "View->Toggle Minimap").
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
