### PR TITLE
Improve preference renderer linking

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -98,7 +98,9 @@ export const corePreferenceSchema: PreferenceSchema = {
                 nls.localizeByDefault('Menu is displayed at the top of the window and only hidden in full screen mode.'),
                 nls.localizeByDefault('Menu is always visible at the top of the window even in full screen mode.'),
                 nls.localizeByDefault('Menu is always hidden.'),
-                nls.localizeByDefault('Menu is displayed as a compact button in the side bar. This value is ignored when {0} is {1}.', '`#window.titleBarStyle#`', '`native`')
+                environment.electron.is()
+                    ? nls.localizeByDefault('Menu is displayed as a compact button in the side bar. This value is ignored when {0} is {1}.', '`#window.titleBarStyle#`', '`native`')
+                    : nls.localizeByDefault('Menu is displayed as a compact button in the side bar.')
             ],
             default: 'classic',
             scope: 'application',

--- a/packages/editor/src/browser/editor-generated-preference-schema.ts
+++ b/packages/editor/src/browser/editor-generated-preference-schema.ts
@@ -759,7 +759,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             nls.localizeByDefault("`cursorSurroundingLines` is enforced only when triggered via the keyboard or API."),
             nls.localizeByDefault("`cursorSurroundingLines` is enforced always.")
         ],
-        "markdownDescription": nls.localize("theia/editor/editor.cursorSurroundingLinesStyle", "Controls when `#cursorSurroundingLines#` should be enforced."),
+        "markdownDescription": nls.localizeByDefault("Controls when `#editor.cursorSurroundingLines#` should be enforced."),
         "type": "string",
         "enum": [
             "default",

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -234,6 +234,11 @@
   text-decoration: none;
 }
 
+.theia-settings-container .disabled-link {
+  pointer-events: none;
+  cursor: default;
+}
+
 .theia-settings-container .settings-section a:hover {
   text-decoration: underline;
 }

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -234,9 +234,8 @@
   text-decoration: none;
 }
 
-.theia-settings-container .disabled-link {
-  pointer-events: none;
-  cursor: default;
+.theia-settings-container .command-link {
+  color: var(--theia-textLink-foreground);
 }
 
 .theia-settings-container .settings-section a:hover {

--- a/packages/preferences/src/browser/views/components/preference-markdown-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-markdown-renderer.ts
@@ -68,7 +68,7 @@ export class PreferenceMarkdownRenderer {
                 const command = this.commandRegistry.getCommand(id);
                 if (command) {
                     const name = `${command.category ? `${command.category}: ` : ''}${command.label}`;
-                    return `<a title="${id}">${name}</a>`;
+                    return `<a class="disabled-link" title="${id}">${name}</a>`;
                 }
                 // If nothing was found, print a warning
                 console.warn(`Linked preference "${id}" not found.`);

--- a/packages/preferences/src/browser/views/components/preference-markdown-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-markdown-renderer.ts
@@ -68,7 +68,7 @@ export class PreferenceMarkdownRenderer {
                 const command = this.commandRegistry.getCommand(id);
                 if (command) {
                     const name = `${command.category ? `${command.category}: ` : ''}${command.label}`;
-                    return `<a class="disabled-link" title="${id}">${name}</a>`;
+                    return `<span class="command-link" title="${id}">${name}</span>`;
                 }
                 // If nothing was found, print a warning
                 console.warn(`Linked preference "${id}" not found.`);

--- a/packages/preferences/src/browser/views/components/preference-markdown-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-markdown-renderer.ts
@@ -18,12 +18,17 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { PreferenceTreeModel } from '../../preference-tree-model';
 import { PreferenceTreeLabelProvider } from '../../util/preference-tree-label-provider';
 import * as markdownit from '@theia/core/shared/markdown-it';
+import { CommandRegistry } from '@theia/core';
 
 @injectable()
 export class PreferenceMarkdownRenderer {
 
-    @inject(PreferenceTreeModel) protected readonly model: PreferenceTreeModel;
-    @inject(PreferenceTreeLabelProvider) protected readonly labelProvider: PreferenceTreeLabelProvider;
+    @inject(PreferenceTreeModel)
+    protected readonly model: PreferenceTreeModel;
+    @inject(PreferenceTreeLabelProvider)
+    protected readonly labelProvider: PreferenceTreeLabelProvider;
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
 
     protected _renderer?: markdownit;
 
@@ -47,19 +52,26 @@ export class PreferenceMarkdownRenderer {
         engine.renderer.rules.code_inline = (tokens, idx, options, env, self) => {
             const token = tokens[idx];
             const content = token.content;
-            if (content.startsWith('#') && content.endsWith('#')) {
-                const preferenceId = content.substring(1, content.length - 1);
-                const preferenceNode = this.model.getNodeFromPreferenceId(preferenceId);
+            if (content.length > 2 && content.startsWith('#') && content.endsWith('#')) {
+                const id = content.substring(1, content.length - 1);
+                // First check whether there's a preference with the given ID
+                const preferenceNode = this.model.getNodeFromPreferenceId(id);
                 if (preferenceNode) {
                     let name = this.labelProvider.getName(preferenceNode);
                     const prefix = this.labelProvider.getPrefix(preferenceNode, true);
                     if (prefix) {
                         name = prefix + name;
                     }
-                    return `<a title="${preferenceId}" href="preference:${preferenceId}">${name}</a>`;
-                } else {
-                    console.warn(`Linked preference "${preferenceId}" not found.`);
+                    return `<a title="${id}" href="preference:${id}">${name}</a>`;
                 }
+                // If no preference was found, check whether there's a command with the given ID
+                const command = this.commandRegistry.getCommand(id);
+                if (command) {
+                    const name = `${command.category ? `${command.category}: ` : ''}${command.label}`;
+                    return `<a title="${id}">${name}</a>`;
+                }
+                // If nothing was found, print a warning
+                console.warn(`Linked preference "${id}" not found.`);
             }
             return inlineCode ? inlineCode(tokens, idx, options, env, self) : '';
         };


### PR DESCRIPTION
#### What it does

Fixes a few minor issues which should massively reduce the amount of `Linked preference "<id>" not found.` warnings printed to the console:

1. Don't use a link to `window.titleBarStyle` when not in Electron mode (the linked preference does only exist in Electron).
2. Use `editor.cursorSurroundingLines` instead of `cursorSurroundingLines` as a link.
3. Some extensions sometimes link commands in the preferences. We now also use the `CommandRegistry` to figure out the name of a linked command.
4. Caches the IDs of the tree nodes of every preference so that we can later find the tree ID again for any preference ID. That way, we don't have to recompute the ID to figure out the real name of a preference (and potentially do that incorrectly).

#### How to test

1. Open the application.
2. Open the settings/preference view
3. Assert that there are much fewer warnings in the console.
4. Assert that all links to other preferences are correctly rendered and actually make you jump to that preference.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
