### PR TITLE
Fix the onDidChangeActiveNotebookEditorEmitter to fire correctly

### DIFF
--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -330,6 +330,7 @@ export class NotebooksExtImpl implements NotebooksExt {
         if (delta.newActiveEditor === null) {
             // clear active notebook as current active editor is non-notebook editor
             this.activeNotebookEditor = undefined;
+            this.onDidChangeActiveNotebookEditorEmitter.fire(undefined);
         } else if (delta.newActiveEditor) {
             const activeEditor = this.editors.get(delta.newActiveEditor);
             if (!activeEditor) {
@@ -341,8 +342,6 @@ export class NotebooksExtImpl implements NotebooksExt {
                     newActiveEditor: null
                 });
             }
-        }
-        if (delta.newActiveEditor !== undefined && delta.newActiveEditor !== this.activeNotebookEditor?.id) {
             this.onDidChangeActiveNotebookEditorEmitter.fire(this.activeNotebookEditor?.apiEditor);
         }
     }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes the onDidChangeActiveNotebookEditorEmitter to fire correctly when the active notebook has been changed.
This should also fix the issue with the jupyter variables button not appearing

#### How to test

You can again test with my [notebook selection test extension](https://github.com/jonah-iden/theia-notebook-selection-test)
this should show that the active notebook editor should always be correct.
Also the jupyter variables button should now appear again

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

@dhuebner maybe good candidate for automated ui tests?

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
