### PR TITLE
Notebook: Escaping code completion pop-up disables cell edit mode

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -67,4 +67,4 @@ jobs:
           path: |
             examples/playwright/test-results/
             examples/playwright/playwright-report/
-          retention-days: 2
+          retention-days: 7

--- a/examples/playwright/src/theia-monaco-editor.ts
+++ b/examples/playwright/src/theia-monaco-editor.ts
@@ -104,6 +104,19 @@ export class TheiaMonacoEditor extends TheiaPageObject {
         await this.page.keyboard.type(text);
     }
 
+    /**
+     * @returns `true` if the editor is focused, `false` otherwise.
+     */
+    async isFocused(): Promise<boolean> {
+        const viewElement = await this.viewElement();
+        const monacoEditor = await viewElement?.$('div.monaco-editor');
+        if (!monacoEditor) {
+            throw new Error('Couldn\'t retrieve monaco editor element.');
+        }
+        const editorClass = await monacoEditor.getAttribute('class');
+        return editorClass?.includes('focused') ?? false;
+    }
+
     protected replaceEditorSymbolsWithSpace(content: string): string | Promise<string | undefined> {
         // [ ] &nbsp; => \u00a0 -- NO-BREAK SPACE
         // [·] &middot; => \u00b7 -- MIDDLE DOT

--- a/examples/playwright/src/theia-notebook-cell.ts
+++ b/examples/playwright/src/theia-notebook-cell.ts
@@ -198,7 +198,14 @@ export class TheiaNotebookCell extends TheiaPageObject {
         return spanTexts.join('');
     }
 
-    protected async outputContainer(): Promise<Locator> {
+    /**
+     * Selects the cell itself not it's editor. Important for shortcut usage like copy-, cut-, paste-cell.
+     */
+    async selectCell(): Promise<void> {
+        await this.sidebar().click();
+    }
+
+    async outputContainer(): Promise<Locator> {
         const outFrame = await this.outputFrame();
         // each cell has it's own output div with a unique id = cellHandle<handle>
         const cellOutput = outFrame.locator(`div#cellHandle${await this.cellHandle()}`);

--- a/examples/playwright/src/theia-notebook-cell.ts
+++ b/examples/playwright/src/theia-notebook-cell.ts
@@ -178,6 +178,14 @@ export class TheiaNotebookCell extends TheiaPageObject {
     }
 
     /**
+     * @returns `true` if the cell is selected (blue vertical line), `false` otherwise.
+     */
+    async isSelected(): Promise<boolean> {
+        const markerClass = await this.locator.locator('div.theia-notebook-cell-marker').getAttribute('class');
+        return markerClass?.includes('theia-notebook-cell-marker-selected') ?? false;
+    }
+
+    /**
      * @returns The output text of the cell.
      */
     async outputText(): Promise<string> {

--- a/examples/playwright/src/theia-notebook-editor.ts
+++ b/examples/playwright/src/theia-notebook-editor.ts
@@ -127,7 +127,7 @@ export class TheiaNotebookEditor extends TheiaEditor {
         await this.waitForCellCountChanged(currentCellsCount);
     }
 
-    protected async waitForCellCountChanged(prevCount: number): Promise<void> {
+    async waitForCellCountChanged(prevCount: number): Promise<void> {
         await this.viewLocator().locator('li.theia-notebook-cell').evaluateAll(
             (elements, currentCount) => elements.length !== currentCount, prevCount
         );

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -516,7 +516,7 @@ export class NotebookCellActionContribution implements MenuContribution, Command
             {
                 command: NotebookCellCommands.STOP_EDIT_COMMAND.id,
                 keybinding: 'esc',
-                when: `editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED}`,
+                when: `editorTextFocus && ${NOTEBOOK_EDITOR_FOCUSED} && !suggestWidgetVisible`,
             },
             {
                 command: NotebookCellCommands.EXECUTE_SINGLE_CELL_COMMAND.id,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Fixes the bogus behavior where the cell editor lose focus after closing the code completion widget with `Escape`.
Also adds some Playwright tests. 

See #14327
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Create a notebook an add `print("Test")` in a code cell.
2. In the next line press `Ctrl+Space` - a code completion widget should pop up.
3. Press `ESC`
4. Completion widget should close and the editor still be in edit mode. Means you can continue typing. Before this change the focus was lost and the user had to press `Enter` to continue typing.  


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
