### PR TITLE
Show error message when uploading fails

### DIFF
--- a/packages/filesystem/src/browser/file-upload-service.ts
+++ b/packages/filesystem/src/browser/file-upload-service.ts
@@ -254,6 +254,7 @@ export class FileUploadService {
         } catch (error) {
             uploadSemaphore.cancel();
             if (!isCancelled(error)) {
+                this.messageService.error(nls.localize('theia/filesystem/uploadFailed', 'An error occurred while uploading a file. {0}', error.message));
                 throw error;
             }
         }
@@ -348,6 +349,10 @@ export class FileUploadService {
                     unregister();
                     if (xhr.status === 200) {
                         resolve();
+                    } else if (xhr.status === 500 && xhr.statusText !== xhr.response) {
+                        // internal error with cause message
+                        // see packages/filesystem/src/node/node-file-upload-service.ts
+                        reject(new Error(`Internal server error: ${xhr.response}`));
                     } else {
                         reject(new Error(`POST request failed: ${xhr.status} ${xhr.statusText}`));
                     }

--- a/packages/filesystem/src/node/node-file-upload-service.ts
+++ b/packages/filesystem/src/node/node-file-upload-service.ts
@@ -73,7 +73,13 @@ export class NodeFileUploadService implements BackendApplicationContribution {
             response.status(200).send(target); // ok
         } catch (error) {
             console.error(error);
-            response.sendStatus(500); // internal server error
+            if (error.message) {
+                // internal server error with error message as response
+                response.status(500).send(error.message);
+            } else {
+                // default internal server error
+                response.sendStatus(500);
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Shows an error dialog when file upload fails, e.g. if no space left on target device. Before this commit upload progress dialog was just silently closed with no error reported to the user. This cause a bad user experience as the uploaded file is in most cases just corrupt.

#### How to test

Test using the browser version.

To test the issue one needs to simulate a file upload failure. The easiest way I found, is creating a small partition on an USB device and add the mounted device to the Theia workspace.  Now try to upload a file that is larger than the available space on the device to the mounted folder . You should see an error message popping up with a corresponding note.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
