### PR TITLE
Accept a string argument in env.openExternal API

### DIFF
--- a/packages/plugin-ext/src/plugin/window-state.ts
+++ b/packages/plugin-ext/src/plugin/window-state.ts
@@ -55,7 +55,13 @@ export class WindowStateExtImpl implements WindowStateExt {
         this.windowStateChangedEmitter.fire(this.windowStateCached);
     }
 
-    openUri(uri: URI): Promise<boolean> {
+    async openUri(uriOrString: URI | string): Promise<boolean> {
+        let uri: URI;
+        if (typeof uriOrString === 'string') {
+            uri = URI.parse(uriOrString);
+        } else {
+            uri = uriOrString;
+        }
         if (!uri.scheme.trim().length) {
             throw new Error('Invalid scheme - cannot be empty');
         }


### PR DESCRIPTION
#### What it does
Accepting a string argument allows Gitlens to invoke the log-in flow.

Fixes #14335

contributed on behalf of STMicroelectronics

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Make sure the "GitLens: Sign In to GitKraken" command works. 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
