### PR TITLE
Fix circular imports when importing ReactDialog

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -17,7 +17,7 @@
 import { injectable, inject } from 'inversify';
 import { Disposable, MaybePromise, CancellationTokenSource, nls } from '../common';
 import { Key } from './keyboard/keys';
-import { Widget, BaseWidget, Message, addKeyListener, codiconArray } from './widgets';
+import { Widget, BaseWidget, Message, addKeyListener, codiconArray } from './widgets/widget';
 import { FrontendApplicationContribution } from './frontend-application-contribution';
 
 @injectable()

--- a/packages/core/src/browser/dialogs/react-dialog.spec.tsx
+++ b/packages/core/src/browser/dialogs/react-dialog.spec.tsx
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import * as React from 'react';
+import { enableJSDOM } from '../test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { ReactDialog } from './react-dialog'
+
+class MyDialog extends ReactDialog<void> {
+    constructor() {
+        super({ title: '' })
+    }
+
+    override get value(): void {
+        return;
+    }
+
+    protected override render(): React.ReactNode {
+        return <></>
+    }
+}
+
+describe('ReactDialog', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    it('should be extended', () => {
+        const dialog = new MyDialog()
+        expect(dialog).to.be.instanceOf(ReactDialog)
+    })
+})

--- a/packages/core/src/browser/dialogs/react-dialog.spec.tsx
+++ b/packages/core/src/browser/dialogs/react-dialog.spec.tsx
@@ -1,14 +1,30 @@
-import { expect } from 'chai';
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as assert from 'assert';
 import * as React from 'react';
 import { enableJSDOM } from '../test/jsdom';
 
 let disableJSDOM = enableJSDOM();
 
-import { ReactDialog } from './react-dialog'
+import { ReactDialog } from './react-dialog';
 
 class MyDialog extends ReactDialog<void> {
     constructor() {
-        super({ title: '' })
+        super({ title: '' });
     }
 
     override get value(): void {
@@ -16,7 +32,7 @@ class MyDialog extends ReactDialog<void> {
     }
 
     protected override render(): React.ReactNode {
-        return <></>
+        return <></>;
     }
 }
 
@@ -25,7 +41,7 @@ describe('ReactDialog', () => {
     after(() => disableJSDOM());
 
     it('should be extended', () => {
-        const dialog = new MyDialog()
-        expect(dialog).to.be.instanceOf(ReactDialog)
-    })
-})
+        const dialog = new MyDialog();
+        assert.equal(dialog instanceof ReactDialog, true);
+    });
+});

--- a/packages/core/src/browser/dialogs/react-dialog.spec.tsx
+++ b/packages/core/src/browser/dialogs/react-dialog.spec.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2022 Ericsson and others.
+// Copyright (C) 2024 Toro Cloud Pty Ltd and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
#### What it does

This PR changes the import path from [dialogs.ts](https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/dialogs.ts#L20) to a specific path where the required types and methods are located to fix the circular dependency error.

Fixes #14347

Contributed on behalf of Toro Cloud

#### How to test

I added a unit test (packages/core/src/browser/dialogs/react-dialog.spec.tsx) to verify this fix.

#### Follow-ups

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
