### PR TITLE
fix: properly initialize custom agents

### DIFF
--- a/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
@@ -25,7 +25,7 @@ export interface TemplateSettingProps {
 
 export const TemplateRenderer: React.FC<TemplateSettingProps> = ({ agentId, template, promptCustomizationService }) => {
     const openTemplate = React.useCallback(async () => {
-        promptCustomizationService.editTemplate(template.id);
+        promptCustomizationService.editTemplate(template.id, template.template);
     }, [template, promptCustomizationService]);
     const resetTemplate = React.useCallback(async () => {
         promptCustomizationService.resetTemplate(template.id);

--- a/packages/ai-core/src/browser/ai-core-frontend-application-contribution.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-application-contribution.ts
@@ -15,23 +15,22 @@
 // *****************************************************************************
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { inject, injectable } from '@theia/core/shared/inversify';
-import { PromptService } from '../common';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { Agent } from '../common';
 import { AgentService } from '../common/agent-service';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 
 @injectable()
 export class AICoreFrontendApplicationContribution implements FrontendApplicationContribution {
     @inject(AgentService)
     private readonly agentService: AgentService;
 
-    @inject(PromptService)
-    private readonly promptService: PromptService;
+    @inject(ContributionProvider) @named(Agent)
+    protected readonly agentsProvider: ContributionProvider<Agent>;
 
     onStart(): void {
-        this.agentService.getAllAgents().forEach(a => {
-            a.promptTemplates.forEach(t => {
-                this.promptService.storePrompt(t.id, t.template);
-            });
+        this.agentsProvider.getContributions().forEach(agent => {
+            this.agentService.registerAgent(agent);
         });
     }
 

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -58,11 +58,16 @@ export interface PromptService {
      */
     getPrompt(id: string, args?: { [key: string]: unknown }): Promise<ResolvedPromptTemplate | undefined>;
     /**
-     * Manually add a prompt to the list of prompts.
+     * Adds a prompt to the list of prompts.
      * @param id the id of the prompt
      * @param prompt the prompt template to store
      */
     storePrompt(id: string, prompt: string): void;
+    /**
+     * Removes a prompt from the list of prompts.
+     * @param id the id of the prompt
+     */
+    removePrompt(id: string): void;
     /**
      * Return all known prompts as a {@link PromptMap map}.
      */
@@ -113,9 +118,9 @@ export interface PromptCustomizationService {
      * on the implementation. Implementation may for example decide to
      * open an editor, or request more information from the user, ...
      * @param id the template id.
-     * @param content optional content to customize the template.
+     * @param content optional default content to initialize the template
      */
-    editTemplate(id: string, content?: string): void;
+    editTemplate(id: string, defaultContent?: string): void;
 
     /**
      * Reset the template to its default value.
@@ -249,5 +254,8 @@ export class PromptServiceImpl implements PromptService {
     }
     storePrompt(id: string, prompt: string): void {
         this._prompts[id] = { id, template: prompt };
+    }
+    removePrompt(id: string): void {
+        delete this._prompts[id];
     }
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Prompt templates of newly added custom agents were not stored within the PromptService. As a consequence their prompt was ignored when invoked in Chat.

This issue is now fixed by restructuring the prompt storing mechanism. Prompts are now implicitly stored and removed based on all currently registered agents.

#### How to test

##### Use Case - Initial Prompt
- Add a new custom agent
- Adjust its prompt within the yaml file
- Verify that the prompt is actually used by invoking the agent in the chat

##### Use Case - Modified Prompt
- Open the custom agents yaml file (manually or by adding a new agent)
- Modify the prompt of an agent (whose prompt is not overriden)
- Verify that the prompt is actually used by invoking the agent in the chat

##### Use Case - Customized Prompt
- Edit the prompt of a custom agent via the "Edit" button, i.e. not via the yaml file
- Verify that the new prompt is actually used by invoking the agent in the chat
- Reset the prompt
- Verify that the initial prompt of the yaml file is used by invoking the agent in the chat

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
