### PR TITLE
chore(ai): avoid line wrap in code response parts

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -176,7 +176,11 @@ export const CodeWrapper = (props: {
             scrollBeyondLastColumn: 0,
             renderFinalNewline: 'off',
             maxHeight: -1,
-            scrollbar: { vertical: 'hidden' },
+            scrollbar: {
+                vertical: 'hidden',
+                alwaysConsumeMouseWheel: false
+            },
+            wordWrap: 'off',
             codeLens: false,
             inlayHints: { enabled: 'off' },
             hover: { enabled: false }

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -125,6 +125,7 @@ div:last-child > .theia-ChatNode {
 
 .theia-ChatNode .theia-CodeWrapper {
   padding: 0.5em;
+  padding-bottom: 0;
   background-color: var(--theia-editor-background);
   border-radius: 6px;
   border: var(--theia-border-width) solid var(--theia-checkbox-border);


### PR DESCRIPTION
#### What it does

Line wrapping lead to cut off code. Instead, we now never wrap and show a horizontal bar. Moreover, this change ensures that mouse wheel events aren't caught be the code parts but always continue scrolling the chat view.

#### How to test

Get an LLM to print some code parts, e.g. the Universal chat agent with the message *Give me an example for a Typescript interface*. Once the code part is visible resize the chat widget in all directions and observe that it never cuts off the code. Also test whether scrolling of the chat widget is smooth, even if you hover above a code part.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
