### PR TITLE
feat(ai): enable querying history by session

### DIFF
--- a/packages/ai-core/src/common/communication-recording-service.ts
+++ b/packages/ai-core/src/common/communication-recording-service.ts
@@ -42,6 +42,8 @@ export interface CommunicationRecordingService {
 
     getHistory(agentId: string): CommunicationHistory;
 
+    getSessionHistory(sessionId: string): CommunicationHistory;
+
     clearHistory(): void;
     readonly onStructuralChange: Event<void>;
 }

--- a/packages/ai-history/src/common/communication-recording-service.spec.ts
+++ b/packages/ai-history/src/common/communication-recording-service.spec.ts
@@ -34,4 +34,29 @@ describe('DefaultCommunicationRecordingService', () => {
         expect(history2[0].response).to.eq('dummy response');
     });
 
+    it('returns session history', () => {
+        const service = new DefaultCommunicationRecordingService();
+        (service as unknown as { logger: ILogger }).logger = new MockLogger();
+        // some requests and responses for session 1
+        service.recordRequest({ agentId: 'agent', requestId: '1', sessionId: '1', timestamp: 100, request: 'session 1 request 1' });
+        service.recordResponse({ agentId: 'agent', requestId: '1', sessionId: '1', timestamp: 200, response: 'session 1 response 1' });
+        service.recordRequest({ agentId: 'agent2', requestId: '2', sessionId: '1', timestamp: 100, request: 'session 1 request 2' });
+        service.recordResponse({ agentId: 'agent2', requestId: '2', sessionId: '1', timestamp: 200, response: 'session 1 response 2' });
+        // some requests and responses for session 2
+        service.recordRequest({ agentId: 'agent', requestId: '3', sessionId: '2', timestamp: 100, request: 'different session request' });
+        service.recordResponse({ agentId: 'agent', requestId: '3', sessionId: '2', timestamp: 200, response: 'different session request' });
+
+        const history1 = service.getSessionHistory('1');
+        expect(history1.length).to.eq(2);
+        expect(history1[0].request).to.eq('session 1 request 1');
+        expect(history1[0].response).to.eq('session 1 response 1');
+        expect(history1[1].request).to.eq('session 1 request 2');
+        expect(history1[1].response).to.eq('session 1 response 2');
+
+        const history2 = service.getSessionHistory('2');
+        expect(history2.length).to.eq(1);
+        expect(history2[0].request).to.eq('different session request');
+        expect(history2[0].response).to.eq('different session request');
+    });
+
 });

--- a/packages/ai-history/src/common/communication-recording-service.ts
+++ b/packages/ai-history/src/common/communication-recording-service.ts
@@ -38,6 +38,14 @@ export class DefaultCommunicationRecordingService implements CommunicationRecord
         return this.history.get(agentId) || [];
     }
 
+    getSessionHistory(sessionId: string): CommunicationHistory {
+        return Array.from(
+            this.history.values()
+        ).reduce((acc, current) =>
+            acc.concat(current.filter(entry => entry.sessionId === sessionId)), []
+        );
+    }
+
     recordRequest(requestEntry: CommunicationHistoryEntry): void {
         this.logger.debug('Recording request:', requestEntry.request);
         if (this.history.has(requestEntry.agentId)) {


### PR DESCRIPTION
#### What it does

In more complex scenarios, there are often multiple agents involved, which may call each other. In those cases it is crucial to allow tracing all LLM requests for a session across agents.

This change introduces a query to obtain all communication events across a session, irrespectively of the agent.

Contributed on behalf of STMicroelectronics.

#### How to test

This change includes a test case.

#### Follow-ups

We may want to improve the history view at some point to allow querying the events of a session also in the user interface.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
