### PR TITLE
Add manual AI code completion

### DIFF
--- a/packages/ai-code-completion/src/browser/ai-code-completion-frontend-module.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-frontend-module.ts
@@ -18,7 +18,7 @@ import { ILogger } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { CodeCompletionAgent, CodeCompletionAgentImpl } from '../common/code-completion-agent';
 import { AIFrontendApplicationContribution } from './ai-code-frontend-application-contribution';
-import { FrontendApplicationContribution, PreferenceContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, KeybindingContribution, PreferenceContribution } from '@theia/core/lib/browser';
 import { Agent } from '@theia/ai-core';
 import { AICodeCompletionPreferencesSchema } from './ai-code-completion-preference';
 import { AICodeInlineCompletionsProvider } from './ai-code-inline-completion-provider';
@@ -32,6 +32,8 @@ export default new ContainerModule(bind => {
     bind(CodeCompletionAgent).toService(CodeCompletionAgentImpl);
     bind(Agent).toService(CodeCompletionAgentImpl);
     bind(AICodeInlineCompletionsProvider).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).to(AIFrontendApplicationContribution).inSingletonScope();
+    bind(AIFrontendApplicationContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).to(AIFrontendApplicationContribution);
+    bind(KeybindingContribution).toService(AIFrontendApplicationContribution);
     bind(PreferenceContribution).toConstantValue({ schema: AICodeCompletionPreferencesSchema });
 });

--- a/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
@@ -18,6 +18,7 @@ import { PreferenceSchema } from '@theia/core/lib/browser/preferences/preference
 import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/browser/ai-core-preferences';
 
 export const PREF_AI_INLINE_COMPLETION_ENABLE = 'ai-features.codeCompletion.enableCodeCompletion';
+export const PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE = 'ai-features.codeCompletion.automaticCodeCompletion';
 export const PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS = 'ai-features.codeCompletion.excludedFileExtensions';
 
 export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
@@ -28,6 +29,12 @@ export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
             type: 'boolean',
             description: 'Enable AI completions inline within any (Monaco) editor.',
             default: false
+        },
+        [PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE]: {
+            title: AI_CORE_PREFERENCES_TITLE,
+            type: 'boolean',
+            description: 'Automatically trigger AI completions inline within any (Monaco) editor while editing.',
+            default: true
         },
         [PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS]: {
             title: 'Excluded File Extensions',

--- a/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
@@ -29,7 +29,7 @@ export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
             type: 'boolean',
             description: 'Automatically trigger AI completions inline within any (Monaco) editor while editing.\
             \n\
-            Alternativly, you can manually trigger the code via the command "Trigger Inline Suggestion" and the default shortcut "SHIFT+Space".',
+            Alternativly, you can manually trigger the code via the command "Trigger Inline Suggestion" or the default shortcut "SHIFT+Space".',
             default: true
         },
         [PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS]: {

--- a/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
@@ -24,16 +24,12 @@ export const PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS = 'ai-features.codeCo
 export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
     type: 'object',
     properties: {
-        [PREF_AI_INLINE_COMPLETION_ENABLE]: {
-            title: AI_CORE_PREFERENCES_TITLE,
-            type: 'boolean',
-            description: 'Enable AI completions inline within any (Monaco) editor.',
-            default: false
-        },
         [PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE]: {
             title: AI_CORE_PREFERENCES_TITLE,
             type: 'boolean',
-            description: 'Automatically trigger AI completions inline within any (Monaco) editor while editing.',
+            description: 'Automatically trigger AI completions inline within any (Monaco) editor while editing.\
+            \n\
+            Alternativly, you can manually trigger the code via the command "Trigger Inline Suggestion" and the default shortcut "SHIFT+Space".',
             default: true
         },
         [PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS]: {

--- a/packages/ai-code-completion/src/browser/ai-code-frontend-application-contribution.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-frontend-application-contribution.ts
@@ -16,15 +16,16 @@
 
 import * as monaco from '@theia/monaco-editor-core';
 
-import { FrontendApplicationContribution, PreferenceService } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, KeybindingContribution, KeybindingRegistry, PreferenceService } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { AIActivationService } from '@theia/ai-core/lib/browser';
 import { Disposable } from '@theia/core';
 import { AICodeInlineCompletionsProvider } from './ai-code-inline-completion-provider';
-import { PREF_AI_INLINE_COMPLETION_ENABLE, PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS } from './ai-code-completion-preference';
+import { PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE, PREF_AI_INLINE_COMPLETION_ENABLE, PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS } from './ai-code-completion-preference';
+import { InlineCompletionTriggerKind } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
 
 @injectable()
-export class AIFrontendApplicationContribution implements FrontendApplicationContribution {
+export class AIFrontendApplicationContribution implements FrontendApplicationContribution, KeybindingContribution {
     @inject(AICodeInlineCompletionsProvider)
     private inlineCodeCompletionProvider: AICodeInlineCompletionsProvider;
 
@@ -48,7 +49,9 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
         this.toDispose.set('inlineCompletions', handler());
 
         this.preferenceService.onPreferenceChanged(event => {
-            if (event.preferenceName === PREF_AI_INLINE_COMPLETION_ENABLE || event.preferenceName === PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS) {
+            if (event.preferenceName === PREF_AI_INLINE_COMPLETION_ENABLE
+                || event.preferenceName === PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE
+                || event.preferenceName === PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS) {
                 this.toDispose.get('inlineCompletions')?.dispose();
                 this.toDispose.set('inlineCompletions', handler());
             }
@@ -60,6 +63,14 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
         });
     }
 
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: 'editor.action.inlineSuggest.trigger',
+            keybinding: 'Ctrl+Shift+Space',
+            when: '!editorReadonly && editorTextFocus'
+        });
+    }
+
     protected handleInlineCompletions(): Disposable {
         const enable = this.preferenceService.get<boolean>(PREF_AI_INLINE_COMPLETION_ENABLE, false) && this.activationService.isActive;
 
@@ -67,14 +78,17 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
             return Disposable.NULL;
         }
 
+        const automatic = this.preferenceService.get<boolean>(PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE, true);
         const excludedExtensions = this.preferenceService.get<string[]>(PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS, []);
 
         return monaco.languages.registerInlineCompletionsProvider(
             { scheme: 'file' },
             {
                 provideInlineCompletions: (model, position, context, token) => {
+                    if (!automatic && context.triggerKind === InlineCompletionTriggerKind.Automatic) {
+                        return { items: [] };
+                    }
                     const fileName = model.uri.toString();
-
                     if (excludedExtensions.some(ext => fileName.endsWith(ext))) {
                         return { items: [] };
                     }

--- a/packages/ai-code-completion/src/browser/ai-code-frontend-application-contribution.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-frontend-application-contribution.ts
@@ -21,7 +21,7 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { AIActivationService } from '@theia/ai-core/lib/browser';
 import { Disposable } from '@theia/core';
 import { AICodeInlineCompletionsProvider } from './ai-code-inline-completion-provider';
-import { PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE, PREF_AI_INLINE_COMPLETION_ENABLE, PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS } from './ai-code-completion-preference';
+import { PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE, PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS } from './ai-code-completion-preference';
 import { InlineCompletionTriggerKind } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
 
 @injectable()
@@ -49,8 +49,7 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
         this.toDispose.set('inlineCompletions', handler());
 
         this.preferenceService.onPreferenceChanged(event => {
-            if (event.preferenceName === PREF_AI_INLINE_COMPLETION_ENABLE
-                || event.preferenceName === PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE
+            if (event.preferenceName === PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE
                 || event.preferenceName === PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS) {
                 this.toDispose.get('inlineCompletions')?.dispose();
                 this.toDispose.set('inlineCompletions', handler());
@@ -66,18 +65,15 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: 'editor.action.inlineSuggest.trigger',
-            keybinding: 'Ctrl+Shift+Space',
+            keybinding: 'Shift+Space',
             when: '!editorReadonly && editorTextFocus'
         });
     }
 
     protected handleInlineCompletions(): Disposable {
-        const enable = this.preferenceService.get<boolean>(PREF_AI_INLINE_COMPLETION_ENABLE, false) && this.activationService.isActive;
-
-        if (!enable) {
+        if (!this.activationService.isActive) {
             return Disposable.NULL;
         }
-
         const automatic = this.preferenceService.get<boolean>(PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE, true);
         const excludedExtensions = this.preferenceService.get<string[]>(PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS, []);
 


### PR DESCRIPTION
#### What it does

fixed #14392

- Remove enable setting for code completion
- Add setting whether the code completion is triggered automatically

#### How to test

Go to settings => code completion and toggle "Automatic Code Completion"
If "Automatic" => code completion immediatly appears
If Not "automatic" => code completion only appears on SHIFT+SPACE

If AI is generally disabled or the code completion agent is disabled, none of the two options trigger

#### Follow-ups

It might be nice to show some sort of progress for the non-automatic option, especially for slower LLMS.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
