### PR TITLE
fix upper most context menu item sometimes not clickable in electron

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -23,7 +23,7 @@ import {
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 import { ContextMenuContext } from '../../browser/menu/context-menu-context';
 import { MenuPath, MenuContribution, MenuModelRegistry } from '../../common';
-import { BrowserContextMenuRenderer } from '../../browser/menu/browser-context-menu-renderer';
+import { BrowserContextMenuAccess, BrowserContextMenuRenderer } from '../../browser/menu/browser-context-menu-renderer';
 
 export class ElectronContextMenuAccess extends ContextMenuAccess {
     constructor(readonly menuHandle: Promise<number>) {
@@ -115,7 +115,14 @@ export class ElectronContextMenuRenderer extends BrowserContextMenuRenderer {
             this.context.resetAltPressed();
             return new ElectronContextMenuAccess(menuHandle);
         } else {
-            return super.doRender(options);
+            const menuAccess = super.doRender(options);
+            const node = (menuAccess as BrowserContextMenuAccess).menu.node;
+            // ensure the context menu is not displayed outside of the main area
+            if (node.style.top && parseInt(node.style.top.substring(0, node.style.top.length - 2)) < 32) {
+                node.style.top = '32px';
+                node.style.maxHeight = `calc(${node.style.maxHeight} - 32px)`;
+            }
+            return menuAccess;
         }
     }
 

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -117,10 +117,11 @@ export class ElectronContextMenuRenderer extends BrowserContextMenuRenderer {
         } else {
             const menuAccess = super.doRender(options);
             const node = (menuAccess as BrowserContextMenuAccess).menu.node;
+            const topPanelHeight = document.getElementById('theia-top-panel')?.clientHeight ?? 0;
             // ensure the context menu is not displayed outside of the main area
-            if (node.style.top && parseInt(node.style.top.substring(0, node.style.top.length - 2)) < 32) {
-                node.style.top = '32px';
-                node.style.maxHeight = `calc(${node.style.maxHeight} - 32px)`;
+            if (node.style.top && parseInt(node.style.top.substring(0, node.style.top.length - 2)) < topPanelHeight) {
+                node.style.top = `${topPanelHeight}px`;
+                node.style.maxHeight = `calc(${node.style.maxHeight} - ${topPanelHeight}px)`;
             }
             return menuAccess;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

In electron when the context menu overlaps the center of the top window toolbar as seen here
![grafik](https://github.com/user-attachments/assets/3b160475-3115-4365-aace-660641fcecba)
The overlapping element is not clickable. 
This PR fixes this issue similar to how vscode seems to fix it, by not allowing the context menu to overlap the window toolbar.

#### How to test

Open a file, open the context menu somewhere in the middle so that it would normally start at the top of the application. 
The upper most entry should still be clickable and it should start below the window toolbar.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
