### PR TITLE
Pin electron version to 30.1.2

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -102,6 +102,6 @@
   },
   "devDependencies": {
     "@theia/cli": "1.55.0",
-    "electron": "^30.1.2"
+    "electron": "30.1.2"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -70,7 +70,7 @@ export class SomeClass {
 
 - `@theia/core/electron-shared/...`
     - `native-keymap` (from [`native-keymap@^2.2.1`](https://www.npmjs.com/package/native-keymap))
-    - `electron` (from [`electron@^30.1.2`](https://www.npmjs.com/package/electron))
+    - `electron` (from [`electron@30.1.2`](https://www.npmjs.com/package/electron/v/30.1.2))
     - `electron-store` (from [`electron-store@^8.0.0`](https://www.npmjs.com/package/electron-store))
     - `fix-path` (from [`fix-path@^3.0.0`](https://www.npmjs.com/package/fix-path))
 - `@theia/core/shared/...`

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -18,7 +18,7 @@ The `@theia/electron` extension bundles all Electron-specific dependencies and c
 
 - `@theia/electron/shared/...`
     - `native-keymap` (from [`native-keymap@^2.2.1`](https://www.npmjs.com/package/native-keymap))
-    - `electron` (from [`electron@^30.1.2`](https://www.npmjs.com/package/electron))
+    - `electron` (from [`electron@30.1.2`](https://www.npmjs.com/package/electron/v/30.1.2))
     - `electron-store` (from [`electron-store@^8.0.0`](https://www.npmjs.com/package/electron-store))
     - `fix-path` (from [`fix-path@^3.0.0`](https://www.npmjs.com/package/fix-path))
 

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -12,7 +12,7 @@
     "@theia/re-exports": "1.55.0"
   },
   "peerDependencies": {
-    "electron": "^30.1.2"
+    "electron": "30.1.2"
   },
   "theiaReExports": {
     "shared": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5155,10 +5155,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^30.1.2:
-  version "30.3.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-30.3.1.tgz#fe27ca2a4739bec832b2edd6f46140ab46bf53a0"
-  integrity sha512-Ai/OZ7VlbFAVYMn9J5lyvtr+ZWyEbXDVd5wBLb5EVrp4352SRmMAmN5chcIe3n9mjzcgehV9n4Hwy15CJW+YbA==
+electron@30.1.2:
+  version "30.1.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-30.1.2.tgz#9c8b9b0d0e3f07783d8c5dbd9519b3ffd11f1551"
+  integrity sha512-A5CFGwbA+HSXnzwjc8fP2GIezBcAb0uN/VbNGLOW8DHOYn07rvJ/1bAJECHUUzt5zbfohveG3hpMQiYpbktuDw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
#### What it does
Pins electron at a precise version: we can't use any of the newer incremental updates because they don't work on Mac x86 systems.

Fixes #14339

Contributed on behalf of STMicroelectronics

#### How to test

Build and run the electron version and make sure there are no new problems and error messages showing up.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
