### PR TITLE
fixed overlapping of outputs when creating a cell at the top

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -159,7 +159,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                 theia.postMessage({ type: 'cellFocusChanged', cellHandle: cellHandle });
             });
 
-            if (cellIndex && cellIndex < container.children.length) {
+            if (cellIndex !== undefined && cellIndex < container.children.length) {
                 container.insertBefore(this.element, container.children[cellIndex]);
             } else {
                 container.appendChild(this.element);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fix a bug that happened when creating a cell at the very top of the notebook which caused the next cell to overlap its output.

#### How to test

Open or Create a notebook. 
Ensure the first cell has output rendered. 
Create a cell above it.
This should still all look fine

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
