### PR TITLE
Fix active notebook editor staying active as long as the editor is active

### DIFF
--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -317,7 +317,7 @@ class EditorAndDocumentStateComputer implements Disposable {
         }
 
         let activeId: string | null = null;
-        const activeEditor = MonacoEditor.getCurrent(this.editorService);
+        const activeEditor = MonacoEditor.getCurrent(this.editorService) ?? this.cellEditorService.getActiveCell();
 
         const editors = new Map<string, EditorSnapshot>();
         for (const widget of this.editorService.all) {
@@ -340,6 +340,9 @@ class EditorAndDocumentStateComputer implements Disposable {
             if (editor.getControl()?.getModel()) {
                 const editorSnapshot = new EditorSnapshot(editor);
                 editors.set(editorSnapshot.id, editorSnapshot);
+                if (activeEditor === editor) {
+                    activeId = editorSnapshot.id;
+                }
             }
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes the activeTextEditor should stay as the active cell as long as the associated notebook editor is also active.
This is important for extensions with a chat window that want to access the current selected code while the chat input is active

#### How to test

You can find a test extension including vsix [here](https://github.com/jonah-iden/theia-notebook-selection-test)

You can use the `Notebook-Test: get current selection` to print out the current notebook selection or use the output channel to see the change events. 

Even when for example selecting the workspace search or debug side panels, the selection inside the cell should still be available in the extension.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
