### PR TITLE
fix: avoid prompt template directory error

### DIFF
--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -116,6 +116,10 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
         }));
 
         this.onDidChangeCustomAgentsEmitter.fire();
+
+        if (!(await this.fileService.exists(templateURI))) {
+            return;
+        }
         const stat = await this.fileService.resolve(templateURI);
         if (stat.children === undefined) {
             return;


### PR DESCRIPTION
#### What it does

The prompt customization service tried to access the prompt template directory even if it did not exist (yet). This case is now checked.

#### How to test

Prerequisites: 
 - Delete the prompt-templates directory if it exists for you in the user `.theia` directory
 - Reset the template directory preference in case you customized it

To test:
 - Start an example application. Observe that there is no longer a template error like `Unable to resolve nonexistent file 'C:\Users\thomas\.theia\prompt-templates'` in the log

Fixes #14367

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
