### PR TITLE
fix: allow to reopen AI history widget

### DIFF
--- a/packages/ai-history/src/browser/ai-history-frontend-module.ts
+++ b/packages/ai-history/src/browser/ai-history-frontend-module.ts
@@ -34,7 +34,7 @@ export default new ContainerModule(bind => {
 
     bindViewContribution(bind, AIHistoryViewContribution);
 
-    bind(AIHistoryView).toSelf().inSingletonScope();
+    bind(AIHistoryView).toSelf();
     bind(WidgetFactory).toDynamicValue(context => ({
         id: AIHistoryView.ID,
         createWidget: () => context.container.get<AIHistoryView>(AIHistoryView)


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The AI history widget was bound as a singleton. Therefore once a new instance was requested, the old disposed instance was reused instead. This is now fixed by removing the singleton scope.

Fixes #14236

#### How to test

- Open the AI Agent history view
- Close the AI Agent history view
- Open the AI Agent history view

Observe that you are able to open the view as intendend, i.e. it is no longer broken.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
