### PR TITLE
Show arguments in tool call response renderer

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -50,7 +50,7 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
     }
 
     protected renderCollapsibleArguments(args: string | undefined): ReactNode {
-        if (!args || !args.trim() || args.trim() === "{}") {
+        if (!args || !args.trim() || args.trim() === '{}') {
             return undefined;
         }
 

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -29,17 +29,45 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
         }
         return -1;
     }
-    render(response: ToolCallChatResponseContent): ReactNode {
-        return <h4 className='theia-toolCall'>
-            {response.finished ?
-                <details>
-                    <summary>Ran {response.name}</summary>
-                    <pre>{this.tryPrettyPrintJson(response)}</pre>
-                </details>
-                : <span><Spinner /> Running [{response.name}]</span>
-            }
-        </h4>;
 
+    renderCollapsibleArguments(args: string | undefined): ReactNode {
+        return (
+            args && (
+                <details style={{ display: 'inline' }}>
+                    <summary
+                        style={{
+                            display: 'inline',
+                            cursor: 'pointer',
+                            textDecoration: 'underline',
+                        }}>
+                        &gt;
+                    </summary>
+                    <span>{JSON.stringify(args, undefined, 2)}</span>
+                </details>
+            )
+        );
+    }
+
+    render(response: ToolCallChatResponseContent): ReactNode {
+        return (
+            <h4 className='theia-toolCall'>
+                {response.finished ? (
+                    <details>
+                        <summary>Ran [{response.name}
+                            {response.arguments && <>({this.renderCollapsibleArguments(response.arguments)})</>}
+                            ]</summary>
+                        <pre>{this.tryPrettyPrintJson(response)}</pre>
+                        {this.renderCollapsibleArguments(response.arguments)}
+                    </details>
+                ) : (
+                    <span>
+                        <Spinner /> Running [{response.name}
+                        {response.arguments && <>({this.renderCollapsibleArguments(response.arguments)})</>}
+                        ]
+                    </span>
+                )}
+            </h4>
+        );
     }
 
     private tryPrettyPrintJson(response: ToolCallChatResponseContent): string | undefined {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -30,44 +30,45 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
         return -1;
     }
 
-    renderCollapsibleArguments(args: string | undefined): ReactNode {
-        return (
-            args && (
-                <details style={{ display: 'inline' }}>
-                    <summary
-                        style={{
-                            display: 'inline',
-                            cursor: 'pointer',
-                            textDecoration: 'underline',
-                        }}>
-                        &gt;
-                    </summary>
-                    <span>{JSON.stringify(args, undefined, 2)}</span>
-                </details>
-            )
-        );
-    }
-
     render(response: ToolCallChatResponseContent): ReactNode {
         return (
             <h4 className='theia-toolCall'>
                 {response.finished ? (
                     <details>
-                        <summary>Ran [{response.name}
-                            {response.arguments && <>({this.renderCollapsibleArguments(response.arguments)})</>}
-                            ]</summary>
+                        <summary>Ran {response.name}
+                            ({this.renderCollapsibleArguments(response.arguments)})
+                        </summary>
                         <pre>{this.tryPrettyPrintJson(response)}</pre>
-                        {this.renderCollapsibleArguments(response.arguments)}
                     </details>
                 ) : (
                     <span>
-                        <Spinner /> Running [{response.name}
-                        {response.arguments && <>({this.renderCollapsibleArguments(response.arguments)})</>}
-                        ]
+                        <Spinner /> Running {response.name}({this.renderCollapsibleArguments(response.arguments)})
                     </span>
                 )}
             </h4>
         );
+    }
+
+    protected renderCollapsibleArguments(args: string | undefined): ReactNode {
+        if (!args || !args.trim() || args.trim() === "{}") {
+            return undefined;
+        }
+
+        return (
+            <details className="collapsible-arguments">
+                <summary className="collapsible-arguments-summary">...</summary>
+                <span>{this.prettyPrintArgs(args)}</span>
+            </details>
+        );
+    }
+
+    private prettyPrintArgs(args: string): string {
+        try {
+            return JSON.stringify(JSON.parse(args), undefined, 2);
+        } catch (e) {
+            // fall through
+            return args;
+        }
     }
 
     private tryPrettyPrintJson(response: ToolCallChatResponseContent): string | undefined {

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -289,12 +289,18 @@ div:last-child > .theia-ChatNode {
 }
 
 .collapsible-arguments {
-  display: inline;
+  display: inline-block;
 }
 
-.collapsible-arguments-summary {
-  display: inline;
+.collapsible-arguments .collapsible-arguments-summary {
+  display: inline-block;
+  white-space: nowrap;
   text-decoration: underline;
+}
+
+details[open].collapsible-arguments,
+details[open].collapsible-arguments .collapsible-arguments-summary {
+  display: unset;
 }
 
 .theia-ResponseNode-ProgressMessage {

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -288,6 +288,15 @@ div:last-child > .theia-ChatNode {
   overflow: auto;
 }
 
+.collapsible-arguments {
+  display: inline;
+}
+
+.collapsible-arguments-summary {
+  display: inline;
+  text-decoration: underline;
+}
+
 .theia-ResponseNode-ProgressMessage {
   font-weight: normal;
   color: var(--theia-descriptionForeground);


### PR DESCRIPTION
fixed #14423

#### What it does

Shows a expandable ">" on tool functions in the hat if they have arguments

#### How to test

run a tool call and look at the chat. E.g.: "How to build this project".
Use a long-running to see the arguments while progress is shown, e.g. "how many files are in the workspace" on a big project such as theia

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
