### PR TITLE
docs: reference THEIA_WEBVIEW_EXTERNAL_ENDPOINT

### DIFF
--- a/packages/plugin-ext/README.md
+++ b/packages/plugin-ext/README.md
@@ -20,7 +20,7 @@ The implementation is inspired from: https://blog.mattbierner.com/vscode-webview
 
 ## Environment Variables
 
-- `THEIA_WEBVIEW_ENDPOINT_PATTERN`
+- `THEIA_WEBVIEW_EXTERNAL_ENDPOINT`
 
   A string pattern possibly containing `{{uuid}}` and `{{hostname}}` which will be replaced. This is the host for which the `webviews` will be served on.
   It is a good practice to host the `webview` handlers on a sub-domain as it is more secure.
@@ -30,7 +30,7 @@ The implementation is inspired from: https://blog.mattbierner.com/vscode-webview
 
 - Potentially Insecure Host Pattern
 
-  When you change the host pattern via the `THEIA_WEBVIEW_ENDPOINT_PATTERN` environment variable warning will be emitted both from the frontend and from the backend.
+  When you change the host pattern via the `THEIA_WEBVIEW_EXTERNAL_ENDPOINT` environment variable warning will be emitted both from the frontend and from the backend.
   You can disable those warnings by setting `warnOnPotentiallyInsecureHostPattern: false` in the appropriate application configurations in your application's `package.json`.
 
 ## Runtime System Plugin Resolvement


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The 'THEIA_WEBVIEW_EXTERNAL_ENDPOINT' environment variable configures the webview host pattern. The '@theia/plugins-ext' README referred to 'THEIA_WEBVIEW_ENDPOINT_PATTERN' in error. This has now been corrected.

#### How to test

This is just a documentation change. Make sure that the new documentation is correct.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
