### PR TITLE
fix(ai): adjust chat input height dynamically

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -126,7 +126,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     const lastRequest = allRequests.length === 0 ? undefined : allRequests[allRequests.length - 1];
 
     const createInputElement = async () => {
-        const padding = 8;
+        const paddingTop = 8;
         const lineHeight = 20;
         const maxHeight = 240;
         const resource = await props.untitledResourceResolver.createUntitledResource('', CHAT_VIEW_LANGUAGE_EXTENSION);
@@ -148,7 +148,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
             automaticLayout: true,
             lineNumbers: 'off',
             lineHeight,
-            padding: { top: padding },
+            padding: { top: paddingTop },
             suggest: {
                 showIcons: true,
                 showSnippets: false,
@@ -162,12 +162,12 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
         });
 
         if (editorContainerRef.current) {
-            editorContainerRef.current.style.height = (lineHeight + (2 * padding)) + 'px';
+            editorContainerRef.current.style.height = (lineHeight + (2 * paddingTop)) + 'px';
         }
 
         const updateEditorHeight = () => {
             if (editorContainerRef.current) {
-                const contentHeight = editor.getControl().getContentHeight() + padding;
+                const contentHeight = editor.getControl().getContentHeight() + paddingTop;
                 editorContainerRef.current.style.height = `${Math.min(contentHeight, maxHeight)}px`;
             }
         };

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -163,6 +163,7 @@ div:last-child > .theia-ChatNode {
   display: flex;
   flex-direction: column-reverse;
   overflow: hidden;
+  transition: height 0.05s ease-in-out;
 }
 
 .theia-ChatInput-Editor:has(.monaco-editor.focused) {


### PR DESCRIPTION
#### What it does

So far the height of the chat input field only was increased with Ctrl+Enter, but not when the lines broke due to their length, or when the view was resized.

With this change, we adapt the height of the input also during normal typing when the content wraps into a new line. Moreover, we add a short transition when adjusting the height to make it look smoother.

#### How to test
[output2.webm](https://github.com/user-attachments/assets/1ba967fc-f87a-4485-88b1-f26b03349a99)

Type long text into the AI Chat input and observe how the height is adjusted up to a maximum height. Also resize the chat window until the line wrapping is affected, and type Ctrl+Enter.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
