### PR TITLE
Update Inversify to latest

### DIFF
--- a/dependency-check-baseline.json
+++ b/dependency-check-baseline.json
@@ -1,3 +1,7 @@
 {
-  "npm/npmjs/-/advanced-mark.js/2.6.0": "Manually approved"
+  "npm/npmjs/-/advanced-mark.js/2.6.0": "Manually approved",
+  "npm/npmjs/-/inversify/6.1.3": "Manually approved",
+  "npm/npmjs/@inversifyjs/common/1.3.2": "Manually approved",
+  "npm/npmjs/@inversifyjs/core/1.3.3": "Manually approved",
+  "npm/npmjs/@inversifyjs/reflect-metadata-utils/0.2.2": "Manually approved"
 }

--- a/examples/api-samples/src/common/vsx/sample-ovsx-client-factory.ts
+++ b/examples/api-samples/src/common/vsx/sample-ovsx-client-factory.ts
@@ -22,9 +22,9 @@ export function rebindOVSXClientFactory(rebind: interfaces.Rebind): void {
     // rebind the OVSX client factory so that we can replace patterns like "${self}" in the configs:
     rebind(OVSXUrlResolver)
         .toDynamicValue(ctx => {
-            const appInfo = ctx.container.get(SampleAppInfo);
+            const appInfo = ctx.container.get<SampleAppInfo>(SampleAppInfo);
             const selfOrigin = appInfo.getSelfOrigin();
-            return async url => url.replace('${self}', await selfOrigin);
+            return async (url: string) => url.replace('${self}', await selfOrigin);
         })
         .inSingletonScope();
 }

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -39,7 +39,7 @@ import {
     MessageActor,
 } from '@theia/ai-core/lib/common';
 import { CancellationToken, CancellationTokenSource, ContributionProvider, ILogger, isArray } from '@theia/core';
-import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, named, postConstruct, unmanaged } from '@theia/core/shared/inversify';
 import { ChatAgentService } from './chat-agent-service';
 import {
     ChatModel,
@@ -133,13 +133,13 @@ export abstract class AbstractChatAgent {
     protected defaultContentFactory: DefaultResponseContentFactory;
 
     constructor(
-        public id: string,
-        public languageModelRequirements: LanguageModelRequirement[],
-        protected defaultLanguageModelPurpose: string,
-        public iconClass: string = 'codicon codicon-copilot',
-        public locations: ChatAgentLocation[] = ChatAgentLocation.ALL,
-        public tags: string[] = ['Chat'],
-        public defaultLogging: boolean = true) {
+        @unmanaged() public id: string,
+        @unmanaged() public languageModelRequirements: LanguageModelRequirement[],
+        @unmanaged() protected defaultLanguageModelPurpose: string,
+        @unmanaged() public iconClass: string = 'codicon codicon-copilot',
+        @unmanaged() public locations: ChatAgentLocation[] = ChatAgentLocation.ALL,
+        @unmanaged() public tags: string[] = ['Chat'],
+        @unmanaged() public defaultLogging: boolean = true) {
     }
 
     @postConstruct()

--- a/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject, optional } from '@theia/core/shared/inversify';
+import { injectable, inject, optional, postConstruct } from '@theia/core/shared/inversify';
 import { Widget } from '@theia/core/lib/browser/widgets/widget';
 import { CommandRegistry } from '@theia/core/lib/common';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
@@ -28,12 +28,15 @@ import { ResourceEdit } from '@theia/monaco-editor-core/esm/vs/editor/browser/se
 
 @injectable()
 export class BulkEditContribution extends AbstractViewContribution<BulkEditTreeWidget> implements TabBarToolbarContribution {
-    private edits: ResourceEdit[];
+    protected edits: ResourceEdit[];
 
     @inject(QuickViewService) @optional()
     protected override readonly quickView: QuickViewService;
 
-    constructor(private readonly bulkEditService: MonacoBulkEditService) {
+    @inject(MonacoBulkEditService)
+    protected readonly bulkEditService: MonacoBulkEditService;
+
+    constructor() {
         super({
             widgetId: BULK_EDIT_TREE_WIDGET_ID,
             widgetName: BULK_EDIT_WIDGET_NAME,
@@ -41,6 +44,10 @@ export class BulkEditContribution extends AbstractViewContribution<BulkEditTreeW
                 area: 'bottom'
             }
         });
+    }
+
+    @postConstruct()
+    protected init(): void {
         this.bulkEditService.setPreviewHandler((edits: ResourceEdit[]) => this.previewEdit(edits));
     }
 

--- a/packages/collaboration/src/browser/collaboration-file-system-provider.ts
+++ b/packages/collaboration/src/browser/collaboration-file-system-provider.ts
@@ -16,7 +16,6 @@
 
 import * as Y from 'yjs';
 import { Disposable, Emitter, Event, URI } from '@theia/core';
-import { injectable } from '@theia/core/shared/inversify';
 import {
     FileChange, FileDeleteOptions,
     FileOverwriteOptions, FileSystemProviderCapabilities, FileType, Stat, WatchOptions, FileSystemProviderWithFileReadWriteCapability, FileWriteOptions
@@ -32,7 +31,6 @@ export namespace CollaborationURI {
     }
 }
 
-@injectable()
 export class CollaborationFileSystemProvider implements FileSystemProviderWithFileReadWriteCapability {
 
     capabilities = FileSystemProviderCapabilities.FileReadWrite;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -92,7 +92,7 @@ export class SomeClass {
     - `@theia/request/lib/node-request-service` (from [`@theia/request@1.55.0`](https://www.npmjs.com/package/@theia/request/v/1.55.0))
     - `fs-extra` (from [`fs-extra@^4.0.2`](https://www.npmjs.com/package/fs-extra))
     - `fuzzy` (from [`fuzzy@^0.1.3`](https://www.npmjs.com/package/fuzzy))
-    - `inversify` (from [`inversify@^6.0.1`](https://www.npmjs.com/package/inversify))
+    - `inversify` (from [`inversify@^6.1.3`](https://www.npmjs.com/package/inversify))
     - `react-dom` (from [`react-dom@^18.2.0`](https://www.npmjs.com/package/react-dom))
     - `react-dom/client` (from [`react-dom@^18.2.0`](https://www.npmjs.com/package/react-dom))
     - `react-virtuoso` (from [`react-virtuoso@^2.17.0`](https://www.npmjs.com/package/react-virtuoso))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "iconv-lite": "^0.6.0",
-    "inversify": "^6.0.1",
+    "inversify": "^6.1.3",
     "jschardet": "^2.1.1",
     "keytar": "7.2.0",
     "lodash.debounce": "^4.0.8",

--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject } from 'inversify';
+import { injectable, inject, unmanaged } from 'inversify';
 import { Disposable, MaybePromise, CancellationTokenSource, nls } from '../common';
 import { Key } from './keyboard/keys';
 import { Widget, BaseWidget, Message, addKeyListener, codiconArray } from './widgets/widget';
@@ -151,8 +151,8 @@ export abstract class AbstractDialog<T> extends BaseWidget {
     protected activeElement: HTMLElement | undefined;
 
     constructor(
-        protected readonly props: DialogProps,
-        options?: Widget.IOptions
+        @unmanaged() protected readonly props: DialogProps,
+        @unmanaged() options?: Widget.IOptions
     ) {
         super(options);
         this.id = 'theia-dialog-shell';

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject, interfaces, optional } from 'inversify';
+import { injectable, inject, interfaces, optional, unmanaged } from 'inversify';
 import { Widget } from '@phosphor/widgets';
 import {
     MenuModelRegistry, Command, CommandContribution,
@@ -64,7 +64,7 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
     readonly toggleCommand?: Command;
 
     constructor(
-        protected readonly options: ViewContributionOptions
+        @unmanaged() protected readonly options: ViewContributionOptions
     ) {
         if (options.toggleCommandId) {
             this.toggleCommand = {

--- a/packages/core/src/browser/tree/tree-decorator.ts
+++ b/packages/core/src/browser/tree/tree-decorator.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from 'inversify';
+import { injectable, unmanaged } from 'inversify';
 import { Tree, TreeNode } from './tree';
 import { Event, Emitter, Disposable, DisposableCollection, MaybePromise } from '../../common';
 import { WidgetDecoration } from '../widget-decoration';
@@ -170,7 +170,7 @@ export abstract class AbstractTreeDecoratorService implements TreeDecoratorServi
 
     protected readonly toDispose = new DisposableCollection();
 
-    constructor(protected readonly decorators: ReadonlyArray<TreeDecorator>) {
+    constructor(@unmanaged() protected readonly decorators: ReadonlyArray<TreeDecorator>) {
         this.toDispose.push(this.onDidChangeDecorationsEmitter);
         this.toDispose.pushAll(this.decorators.map(decorator =>
             decorator.onDidChangeDecorations(data =>

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -117,7 +117,7 @@ export class BaseWidget extends Widget implements PreviewableWidget {
     protected scrollBar?: PerfectScrollbar;
     protected scrollOptions?: PerfectScrollbar.Options;
 
-    constructor(options?: Widget.IOptions) {
+    constructor(@unmanaged() options?: Widget.IOptions) {
         super(options);
     }
 

--- a/packages/core/src/common/performance/stopwatch.ts
+++ b/packages/core/src/common/performance/stopwatch.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, unmanaged } from 'inversify';
 import { ILogger, LogLevel } from '../logger';
 import { MaybePromise } from '../types';
 import { Measurement, MeasurementOptions, MeasurementResult } from './measurement';
@@ -58,7 +58,7 @@ export abstract class Stopwatch {
         return this.onDidAddMeasurementResultEmitter.event;
     }
 
-    constructor(protected readonly defaultLogOptions: LogOptions) {
+    constructor(@unmanaged() protected readonly defaultLogOptions: LogOptions) {
         if (!defaultLogOptions.defaultLogLevel) {
             defaultLogOptions.defaultLogLevel = DEFAULT_LOG_LEVEL;
         }

--- a/packages/git/src/browser/blame/blame-decorator.ts
+++ b/packages/git/src/browser/blame/blame-decorator.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, unmanaged } from '@theia/core/shared/inversify';
 import { EditorManager, TextEditor, EditorDecoration, EditorDecorationOptions, Range, Position, EditorDecorationStyle } from '@theia/editor/lib/browser';
 import { GitFileBlame } from '../../common';
 import { Disposable, DisposableCollection, nls } from '@theia/core';
@@ -28,7 +28,7 @@ import { LanguageSelector } from '@theia/monaco-editor-core/esm/vs/editor/common
 export class BlameDecorator implements monaco.languages.HoverProvider {
 
     constructor(
-        protected blameDecorationsStyleSheet: CSSStyleSheet = DecorationStyle.createStyleSheet('gitBlameDecorationsStyle')
+        @unmanaged() protected blameDecorationsStyleSheet: CSSStyleSheet = DecorationStyle.createStyleSheet('gitBlameDecorationsStyle')
     ) {
         DecorationStyle.getOrCreateStyleRule(`.${BlameDecorator.GIT_BLAME_HIGHLIGHT}`,
             this.blameDecorationsStyleSheet).style.backgroundColor = 'var(--theia-gitlens-lineHighlightBackgroundColor)';

--- a/packages/markers/src/browser/marker-tree.ts
+++ b/packages/markers/src/browser/marker-tree.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
+import { injectable, unmanaged } from '@theia/core/shared/inversify';
 import { TreeImpl, CompositeTreeNode, TreeNode, SelectableTreeNode, ExpandableTreeNode } from '@theia/core/lib/browser';
 import { MarkerManager } from './marker-manager';
 import { Marker } from '../common/marker';
@@ -32,8 +32,8 @@ export interface MarkerOptions {
 export abstract class MarkerTree<T extends object> extends TreeImpl {
 
     constructor(
-        protected readonly markerManager: MarkerManager<T>,
-        protected readonly markerOptions: MarkerOptions
+        @unmanaged() protected readonly markerManager: MarkerManager<T>,
+        @unmanaged() protected readonly markerOptions: MarkerOptions
     ) {
         super();
 

--- a/packages/memory-inspector/src/browser/memory-inspector-frontend-module.ts
+++ b/packages/memory-inspector/src/browser/memory-inspector-frontend-module.ts
@@ -113,6 +113,6 @@ export default new ContainerModule(bind => {
                 RegisterTableWidget,
                 RegisterWidgetOptions,
                 options,
-            ).get(MemoryWidget),
+            ).get<RegisterWidget>(MemoryWidget),
     }));
 });

--- a/packages/memory-inspector/src/browser/memory-widget/memory-widget.ts
+++ b/packages/memory-inspector/src/browser/memory-widget/memory-widget.ts
@@ -45,7 +45,7 @@ export class MemoryWidget<
         options?: MemoryWidgetOptions,
     ): MemoryWidget<Options, Table> {
         const child = MemoryWidget.createContainer(parent, optionsWidget, tableWidget, optionSymbol, options);
-        return child.get(MemoryWidget);
+        return child.get<MemoryWidget<Options, Table>>(MemoryWidget);
     }
 
     static createContainer(

--- a/packages/plugin-ext/src/hosted/common/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/common/hosted-plugin.ts
@@ -22,7 +22,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import debounce = require('@theia/core/shared/lodash.debounce');
-import { injectable, inject, interfaces, named, postConstruct } from '@theia/core/shared/inversify';
+import { injectable, inject, interfaces, named, postConstruct, unmanaged } from '@theia/core/shared/inversify';
 import { PluginMetadata, HostedPluginServer, DeployedPlugin, PluginServer, PluginIdentifiers } from '../../common/plugin-protocol';
 import { AbstractPluginManagerExt, ConfigStorage } from '../../common/plugin-api-rpc';
 import {
@@ -103,7 +103,7 @@ export abstract class AbstractHostedPluginSupport<PM extends AbstractPluginManag
         return this.deferredDidStart.promise;
     }
 
-    constructor(protected readonly clientId: string) { }
+    constructor(@unmanaged() protected readonly clientId: string) { }
 
     @postConstruct()
     protected init(): void {

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable @theia/localization-check */
 
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, unmanaged } from '@theia/core/shared/inversify';
 import {
     AutoClosingPair,
     AutoClosingPairConditional,
@@ -100,7 +100,10 @@ export abstract class AbstractPluginScanner implements PluginScanner {
     @inject(PluginUriFactory)
     protected readonly pluginUriFactory: PluginUriFactory;
 
-    constructor(private readonly _apiType: PluginEngine, private readonly _backendInitPath?: string) { }
+    constructor(
+        @unmanaged() private readonly _apiType: PluginEngine,
+        @unmanaged() private readonly _backendInitPath?: string) {
+    }
 
     get apiType(): PluginEngine {
         return this._apiType;

--- a/packages/plugin-ext/src/main/node/plugin-deployer-proxy-entry-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-proxy-entry-impl.ts
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { injectable } from '@theia/core/shared/inversify';
+import { injectable, unmanaged } from '@theia/core/shared/inversify';
 import { PluginDeployerEntry, PluginDeployerEntryType, PluginType } from '../../common/plugin-protocol';
 import { PluginDeployerEntryImpl } from './plugin-deployer-entry-impl';
 
@@ -25,7 +25,10 @@ export class ProxyPluginDeployerEntry<T> implements PluginDeployerEntry {
 
     private readonly deployerName: string;
 
-    constructor(readonly deployer: T, readonly delegate: PluginDeployerEntryImpl) {
+    constructor(
+        @unmanaged() readonly deployer: T,
+        @unmanaged() readonly delegate: PluginDeployerEntryImpl
+    ) {
         this.deployerName = (this.deployer as {}).constructor.name;
     }
 

--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -86,10 +86,10 @@ export abstract class Process implements ManagedProcess {
     abstract readonly inputStream: Writable;
 
     constructor(
-        protected readonly processManager: ManagedProcessManager,
-        protected readonly logger: ILogger,
+        @unmanaged() protected readonly processManager: ManagedProcessManager,
+        @unmanaged() protected readonly logger: ILogger,
         @unmanaged() protected readonly type: ProcessType,
-        protected readonly options: ProcessOptions | ForkOptions
+        @unmanaged() protected readonly options: ProcessOptions | ForkOptions
     ) {
         this.id = this.processManager.register(this);
         this.initialCwd = options && options.options && 'cwd' in options.options && options.options['cwd'].toString() || __dirname;

--- a/packages/task/src/node/task.ts
+++ b/packages/task/src/node/task.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
+import { injectable, unmanaged } from '@theia/core/shared/inversify';
 import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise } from '@theia/core/lib/common/';
 import { TaskInfo, TaskExitedEvent, TaskConfiguration, TaskOutputEvent, ManagedTask, ManagedTaskManager } from '../common/task-protocol';
 /**
@@ -43,9 +43,9 @@ export abstract class Task implements Disposable, ManagedTask {
     readonly outputEmitter: Emitter<TaskOutputEvent>;
 
     constructor(
-        protected readonly taskManager: ManagedTaskManager<Task>,
-        protected readonly logger: ILogger,
-        protected readonly options: TaskOptions
+        @unmanaged() protected readonly taskManager: ManagedTaskManager<Task>,
+        @unmanaged() protected readonly logger: ILogger,
+        @unmanaged() protected readonly options: TaskOptions
     ) {
         this.taskId = this.taskManager.register(this, this.options.context);
         this.exitEmitter = new Emitter<TaskExitedEvent>();

--- a/packages/terminal/src/browser/terminal-profile-service.ts
+++ b/packages/terminal/src/browser/terminal-profile-service.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { Emitter, Event } from '@theia/core';
-import { injectable } from '@theia/core/shared/inversify';
+import { injectable, unmanaged } from '@theia/core/shared/inversify';
 import { TerminalWidget } from './base/terminal-widget';
 import { ShellTerminalProfile } from './shell-terminal-profile';
 
@@ -95,7 +95,7 @@ export class DefaultTerminalProfileService implements TerminalProfileService {
     onRemoved: Event<string> = this.onRemovedEmitter.event;
     onDidChangeDefaultShell: Event<string> = this.onDidChangeDefaultShellEmitter.event;
 
-    constructor(...stores: TerminalProfileStore[]) {
+    constructor(@unmanaged() ...stores: TerminalProfileStore[]) {
         this.stores = stores;
         for (const store of this.stores) {
             store.onAdded(e => {

--- a/packages/vsx-registry/src/common/vsx-registry-common-module.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-common-module.ts
@@ -25,12 +25,12 @@ import { RateLimiter } from 'limiter';
 
 export default new ContainerModule(bind => {
     bind(OVSXUrlResolver)
-        .toFunction(url => url);
+        .toFunction((url: string) => url);
     bind(OVSXClientProvider)
         .toDynamicValue(ctx => {
             const vsxEnvironment = ctx.container.get<VSXEnvironment>(VSXEnvironment);
             const requestService = ctx.container.get<RequestService>(RequestService);
-            const urlResolver = ctx.container.get(OVSXUrlResolver);
+            const urlResolver = ctx.container.get<OVSXUrlResolver>(OVSXUrlResolver);
             const clientPromise = Promise
                 .all([
                     vsxEnvironment.getRegistryApiUri(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,6 +1054,24 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
+"@inversifyjs/common@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/common/-/common-1.3.2.tgz#883e5972b00e0065e21d300d6e959b188c42fc93"
+  integrity sha512-jIn8Kq8ZfQ/e6FrrKABS3Yju09PQ2L8tLSv+uoJPnBHhj2VHQYOB9qyvJvtCGIrvWC+mAvZ/5RmczXWyEioBjA==
+
+"@inversifyjs/core@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/core/-/core-1.3.3.tgz#e2da8192a9de39e4c6b3cea80b540e702b99cc55"
+  integrity sha512-kDj+ehYA8Q437eZO3gDVDfA/ZhEjRbgORH7kB/7G8JJ0Ij2As2Z3iwLLA9Px1AAOrfocK8JxvH6XAmKE0rALTA==
+  dependencies:
+    "@inversifyjs/common" "1.3.2"
+    "@inversifyjs/reflect-metadata-utils" "0.2.2"
+
+"@inversifyjs/reflect-metadata-utils@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.2.tgz#18eedd4f3a4083928772779668308c95a554cc12"
+  integrity sha512-LaiMbwe4XBzn3GJdYditg0TTSiDMDTY0WuwdQP2BmoGd1e2XSTCIpcjVNqbNLd2dhBLgAEcr7Ep17QLV+DVBAA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -7060,10 +7078,13 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-inversify@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.0.2.tgz#dc7fa0348213d789d35ffb719dea9685570989c7"
-  integrity sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==
+inversify@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.1.3.tgz#de94dd6979fb2cdc8c794481635bd82171a03610"
+  integrity sha512-B+rsxKIEh4wCj8gf3IjHSF/7lR02SepVa7b21AlYYp0JzRNzPIOC2V+1EWWzbRNj6WCbrF00XX9STDJdcCKjvg==
+  dependencies:
+    "@inversifyjs/common" "1.3.2"
+    "@inversifyjs/core" "1.3.3"
 
 ip-address@^9.0.5:
   version "9.0.5"
@@ -11489,7 +11510,7 @@ string-argv@^0.1.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.1.2.tgz#c5b7bc03fb2b11983ba3a72333dd0559e77e4738"
   integrity sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11506,15 +11527,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -11581,7 +11593,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11601,13 +11613,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -12861,7 +12866,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12874,15 +12879,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14431.

The latest minor version of Inversify (6.1.0) introduced some behavior changes with regards to injected base classes. Inversify validates that the constructor arguments are in some way satisfied (by asserting constructor function length). Since we sometimes use an inheritance pattern that breaks this assertion, this leads to runtime failures in newer versions of Inversify.

This change adds `@unmanaged()` decorations to all constructors that aren't injected. Also adds a few more type constraints during compile time where Inversify got more strict in its typing.

#### How to test

Assert that the CI is green, and the application builds and runs without any start error.

#### Follow-ups

I couldn't really find *all* places where we're using the above mentioned pattern, as I couldn't find a way to easily search for it.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
