### PR TITLE
feat: support property ThemeColor id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 <!-- ## 1.56.0 - not yet released -->
 
+- [plugin] added support for ThemeColor property id [#14437](https://github.com/eclipse-theia/theia/pull/14437) - Contributed on behalf of STMicroelectronics
+
 ## 1.55.0 - 10/31/2024
 
 - [ai] added logic to allow to order and clear AI History view [#14233](https://github.com/eclipse-theia/theia/pull/14233)

--- a/packages/core/src/common/theme.ts
+++ b/packages/core/src/common/theme.ts
@@ -38,7 +38,7 @@ export interface ThemeChangeEvent {
 }
 
 export interface ThemeColor {
-    id: string;
+    readonly id: string;
 }
 
 export interface ThemeIcon {

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -725,7 +725,7 @@ export class SnippetString {
 
 @es5ClassCompat
 export class ThemeColor {
-    constructor(public id: string) { }
+    constructor(public readonly id: string) { }
 }
 
 @es5ClassCompat

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2697,6 +2697,11 @@ export module '@theia/plugin' {
      */
     export class ThemeColor {
         /**
+         * The id of this color.
+         */
+        readonly id: string;
+
+        /**
          * Creates a reference to a theme color.
          */
         constructor(id: string);


### PR DESCRIPTION
#### What it does

Adds the ThemeColor#id readonly property. This was already available as a parameter in the constructor of ThemeColor. 
It also forces the id to be readonly in Theia implementations of ThemeColor. 

fix #14404 

#### How to test

- install following extension: 
  - src: [theme-color-id-test-0.0.2-src.zip](https://github.com/user-attachments/files/17715477/theme-color-id-test-0.0.2-src.zip)
  - vsix: [theme-color-id-test-0.0.2.zip](https://github.com/user-attachments/files/17715479/theme-color-id-test-0.0.2.zip)
- The extension adds a command `Test: Show Theme Color` that opens a QuickInput dialog to ask for a ThemeColor id. When entered, a message is displayed as a notification and a text is also displayed for a short period of time in the status bar, with the given theme color. 

#### Follow-ups

None

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
