### PR TITLE
Fix MeasurementNotificationService binding

### DIFF
--- a/packages/metrics/src/browser/metrics-frontend-module.ts
+++ b/packages/metrics/src/browser/metrics-frontend-module.ts
@@ -24,5 +24,5 @@ export default new ContainerModule(bind => {
     bind(MeasurementNotificationService).toDynamicValue(ctx => {
         const connection = ctx.container.get(WebSocketConnectionProvider);
         return connection.createProxy<MeasurementNotificationService>(measurementNotificationServicePath);
-    });
+    }).inSingletonScope();
 });


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Ensure that the `MeasurementNotificationService` identifer is bound in singleton scope.
Otherwise it can only be injected once i.e. if another service injects the `MeasurementNotificationService`
it would fail with an error like:
```ts
channel.ts:283 Uncaught (in promise) Error: Another channel with the id '/services/measurement-notification' is already open.
    at ChannelMultiplexer.open (channel.ts:283:19)
    at ServiceConnectionProvider.openChannel (service-connection-provider.ts:137:58)
```

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
