### PR TITLE
Disable editing of read only variables

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -161,6 +161,10 @@ export class DebugVariable extends ExpressionContainer {
         return this._value || this.variable.value;
     }
 
+    get readOnly(): boolean {
+        return this.variable.presentationHint?.attributes?.includes('readOnly') ?? false;
+    }
+
     override render(): React.ReactNode {
         const { type, value, name } = this;
         return <div className={this.variableClassName}>
@@ -234,7 +238,7 @@ export class DebugVariable extends ExpressionContainer {
     protected setNameRef = (nameRef: HTMLSpanElement | null) => this.nameRef = nameRef || undefined;
 
     async open(): Promise<void> {
-        if (!this.supportSetVariable) {
+        if (!this.supportSetVariable || this.readOnly) {
             return;
         }
         const input = new SingleTextInputDialog({

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -856,7 +856,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
         registry.registerCommand(DebugCommands.SET_VARIABLE_VALUE, {
             execute: () => this.selectedVariable && this.selectedVariable.open(),
-            isEnabled: () => !!this.selectedVariable && this.selectedVariable.supportSetVariable,
+            isEnabled: () => !!this.selectedVariable && this.selectedVariable.supportSetVariable && !this.selectedVariable.readOnly,
             isVisible: () => !!this.selectedVariable && this.selectedVariable.supportSetVariable
         });
         registry.registerCommand(DebugCommands.COPY_VARIABLE_VALUE, {


### PR DESCRIPTION

#### What it does

The debug UI allows to change the variable content. The DAP server provides information if the variable is editable. If the variable is not editable, we disable the functionality in the UI.

#### How to test

Create a .js file in your workspace and copy the following code:

```
function test(params) {
    let a = "Hello World"
}

test()
```

Set the breakpoint on the line `test()`
Launch debugging of the current file
Inspect Local variable "test" and it's children. When right clicking on arguments, the "Set Value" option should be disabled. Double clicking on the variable should not open the editing dialog.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [x] As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
