### PR TITLE
Sort models in llm selection dialogue in AI Configuration View

### DIFF
--- a/packages/ai-core/src/browser/ai-configuration/language-model-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/language-model-renderer.tsx
@@ -99,7 +99,7 @@ export const LanguageModelRenderer: React.FC<LanguageModelSettingsProps> = (
                             onChange={event => onSelectedModelChange(requirements.purpose, event)}
                         >
                             <option value=""></option>
-                            {languageModels?.map(model => (
+                            {languageModels?.sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id)).map(model => (
                                 <option key={model.id} value={model.id}>{model.name ?? model.id}</option>
                             ))}
                         </select>


### PR DESCRIPTION
fixed #14441

#### What it does

Sort models in llm selection dialogue in AI Configuration View.
Sorts in the UI to not touch the underyling service. At the moment some parts may rely on the order there.

#### How to test

AI Configuration View => select agent => Open model selection drop down 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
