### PR TITLE
Add preference to ignore files in workspace functions

### DIFF
--- a/packages/ai-workspace-agent/package.json
+++ b/packages/ai-workspace-agent/package.json
@@ -21,7 +21,9 @@
     "@theia/navigator": "1.55.0",
     "@theia/terminal": "1.55.0",
     "@theia/ai-core": "1.55.0",
-    "@theia/ai-chat": "1.55.0"
+    "@theia/ai-chat": "1.55.0",
+    "ignore": "^6.0.0",
+    "minimatch": "^10.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai-workspace-agent/package.json
+++ b/packages/ai-workspace-agent/package.json
@@ -23,7 +23,7 @@
     "@theia/ai-core": "1.55.0",
     "@theia/ai-chat": "1.55.0",
     "ignore": "^6.0.0",
-    "minimatch": "^10.0.0"
+    "minimatch": "^9.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai-workspace-agent/src/browser/frontend-module.ts
+++ b/packages/ai-workspace-agent/src/browser/frontend-module.ts
@@ -18,8 +18,11 @@ import { ChatAgent } from '@theia/ai-chat/lib/common';
 import { Agent, ToolProvider } from '@theia/ai-core/lib/common';
 import { WorkspaceAgent } from './workspace-agent';
 import { FileContentFunction, GetWorkspaceDirectoryStructure, GetWorkspaceFileList, WorkspaceFunctionScope } from './functions';
+import { PreferenceContribution } from '@theia/core/lib/browser';
+import { WorkspacePreferencesSchema } from './workspace-preferences';
 
 export default new ContainerModule(bind => {
+    bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
     bind(WorkspaceAgent).toSelf().inSingletonScope();
     bind(Agent).toService(WorkspaceAgent);
     bind(ChatAgent).toService(WorkspaceAgent);

--- a/packages/ai-workspace-agent/src/browser/functions.ts
+++ b/packages/ai-workspace-agent/src/browser/functions.ts
@@ -87,11 +87,11 @@ export class WorkspaceFunctionScope {
         return false;
     }
 
-    private isUserExcluded(fileName: string, userExcludePatterns: string[]): boolean {
+    protected isUserExcluded(fileName: string, userExcludePatterns: string[]): boolean {
         return userExcludePatterns.some(pattern => new Minimatch(pattern, { dot: true }).match(fileName));
     }
 
-    private async isGitIgnored(stat: FileStat, workspaceRoot: URI): Promise<boolean> {
+    protected async isGitIgnored(stat: FileStat, workspaceRoot: URI): Promise<boolean> {
         await this.initializeGitignoreWatcher(workspaceRoot);
 
         const gitignoreUri = workspaceRoot.resolve(this.GITIGNORE_FILE_NAME);

--- a/packages/ai-workspace-agent/src/browser/functions.ts
+++ b/packages/ai-workspace-agent/src/browser/functions.ts
@@ -24,6 +24,7 @@ import ignore from 'ignore';
 import { Minimatch } from 'minimatch';
 import { PreferenceService } from '@theia/core/lib/browser';
 import { CONSIDER_GITIGNORE_PREF, USER_EXCLUDE_PATTERN_PREF } from './workspace-preferences';
+
 @injectable()
 export class WorkspaceFunctionScope {
     protected readonly GITIGNORE_FILE_NAME = '.gitignore';

--- a/packages/ai-workspace-agent/src/browser/functions.ts
+++ b/packages/ai-workspace-agent/src/browser/functions.ts
@@ -98,13 +98,18 @@ export class WorkspaceFunctionScope {
 
         try {
             const fileStat = await this.fileService.resolve(gitignoreUri);
-            if (fileStat && !fileStat.isDirectory) {
+            if (fileStat) {
                 if (!this.gitignoreMatcher) {
                     const gitignoreContent = await this.fileService.read(gitignoreUri);
                     this.gitignoreMatcher = ignore().add(gitignoreContent.value);
                 }
                 const relativePath = workspaceRoot.relative(stat.resource);
-                if (relativePath && this.gitignoreMatcher.ignores(relativePath.toString())) { return true; }
+                if (relativePath) {
+                    const relativePathStr = relativePath.toString() + (stat.isDirectory ? '/' : '');
+                    if (this.gitignoreMatcher.ignores(relativePathStr)) {
+                        return true;
+                    }
+                }
             }
         } catch {
             // If .gitignore does not exist or cannot be read, continue without error

--- a/packages/ai-workspace-agent/src/browser/functions.ts
+++ b/packages/ai-workspace-agent/src/browser/functions.ts
@@ -100,7 +100,7 @@ export class WorkspaceFunctionScope {
                         return true;
                     }
                 }
-            } catch (error) {
+            } catch {
                 // If .gitignore does not exist or cannot be read, continue without error
             }
         }

--- a/packages/ai-workspace-agent/src/browser/workspace-preferences.ts
+++ b/packages/ai-workspace-agent/src/browser/workspace-preferences.ts
@@ -16,8 +16,8 @@
 
 import { PreferenceSchema } from '@theia/core/lib/browser/preferences/preference-contribution';
 
-export const CONSIDER_GITIGNORE_PREF = 'ai-features.workspace-functions.considerGitIgnore';
-export const USER_EXCLUDES_PREF = 'ai-features.workspace-functions.userExcludes';
+export const CONSIDER_GITIGNORE_PREF = 'ai-features.workspaceFunctions.considerGitIgnore';
+export const USER_EXCLUDE_PATTERN_PREF = 'ai-features.workspaceFunctions.userExcludes';
 
 export const WorkspacePreferencesSchema: PreferenceSchema = {
     type: 'object',
@@ -28,9 +28,9 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
             description: 'If enabled, excludes files/folders specified in a global .gitignore file (expected location is the workspace root).',
             default: false
         },
-        [USER_EXCLUDES_PREF]: {
+        [USER_EXCLUDE_PATTERN_PREF]: {
             type: 'array',
-            title: 'User Excludes',
+            title: 'Excluded File Patterns',
             description: 'List of patterns (glob or regex) for files/folders to exclude.',
             default: ['node_modules', 'lib', '.*'],
             items: {

--- a/packages/ai-workspace-agent/src/browser/workspace-preferences.ts
+++ b/packages/ai-workspace-agent/src/browser/workspace-preferences.ts
@@ -1,0 +1,41 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceSchema } from '@theia/core/lib/browser/preferences/preference-contribution';
+
+export const CONSIDER_GITIGNORE_PREF = 'ai-features.workspace-functions.considerGitIgnore';
+export const USER_EXCLUDES_PREF = 'ai-features.workspace-functions.userExcludes';
+
+export const WorkspacePreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        [CONSIDER_GITIGNORE_PREF]: {
+            type: 'boolean',
+            title: 'Consider .gitignore',
+            description: 'If enabled, excludes files/folders specified in a global .gitignore file (expected location is the workspace root).',
+            default: false
+        },
+        [USER_EXCLUDES_PREF]: {
+            type: 'array',
+            title: 'User Excludes',
+            description: 'List of patterns (glob or regex) for files/folders to exclude by default.',
+            default: ['node_modules', 'lib', '.*'],
+            items: {
+                type: 'string'
+            }
+        }
+    }
+};

--- a/packages/ai-workspace-agent/src/browser/workspace-preferences.ts
+++ b/packages/ai-workspace-agent/src/browser/workspace-preferences.ts
@@ -31,7 +31,7 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
         [USER_EXCLUDES_PREF]: {
             type: 'array',
             title: 'User Excludes',
-            description: 'List of patterns (glob or regex) for files/folders to exclude by default.',
+            description: 'List of patterns (glob or regex) for files/folders to exclude.',
             default: ['node_modules', 'lib', '.*'],
             items: {
                 type: 'string'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6953,6 +6953,11 @@ ignore@^5.0.4, ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
+ignore@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-6.0.2.tgz#77cccb72a55796af1b6d2f9eb14fa326d24f4283"
+  integrity sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==
+
 image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
@@ -8471,6 +8476,13 @@ minimatch@9.0.3, minimatch@^9.0.0, minimatch@^9.0.1:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
   integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
+  integrity sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==
   dependencies:
     brace-expansion "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8479,13 +8479,6 @@ minimatch@9.0.3, minimatch@^9.0.0, minimatch@^9.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
-  integrity sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"


### PR DESCRIPTION
fixed #14448

#### What it does

adds two settings to specify fles an directories to be ignored by the workspace functions:
- gitignore : Will respect the gitignore file
- User defined list of files or folders

#### How to test

Ignore files in both settings. Ask the workspace agent "is the a file/folder XYZ in the workspace". Specifically change the .gitignore at runtime to test file watching.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
