### PR TITLE
feat: update proposed API MappedEditProviders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 <!-- ## 1.56.0 - not yet released -->
 
+- [plugin] supported MappedEditProviders proposed API evolution [#14453](https://github.com/eclipse-theia/theia/pull/14453) - Contributed on behalf of STMicroelectronics
+
 ## 1.55.0 - 10/31/2024
 
 - [ai] added logic to allow to order and clear AI History view [#14233](https://github.com/eclipse-theia/theia/pull/14233)

--- a/packages/plugin/src/theia.proposed.mappedEditsProvider.d.ts
+++ b/packages/plugin/src/theia.proposed.mappedEditsProvider.d.ts
@@ -35,6 +35,7 @@ export module '@theia/plugin' {
     export interface ConversationResponse {
         readonly type: 'response';
         readonly message: string;
+        readonly result?: ChatResult;
         readonly references?: DocumentContextItem[];
     }
 
@@ -69,7 +70,7 @@ export module '@theia/plugin' {
     }
 
     export interface MappedEditsRequest {
-        readonly codeBlocks: { code: string; resource: Uri }[];
+        readonly codeBlocks: { code: string; resource: Uri; markdownBeforeBlock?: string }[];
         // for every prior response that contains codeblocks, make sure we pass the code as well as the resources based on the reported codemapper URIs
         readonly conversation: (ConversationRequest | ConversationResponse)[];
     }


### PR DESCRIPTION
#### What it does

Update proposed API used by TypeScript builtin extension. The API updated is currently stubbed in theia, so only the type definitions have to  be updated.

fix: #14451

contributed on behalf of STMicroelectronics

#### How to test

Build and install latest typescript builtins, or use this one: [typescript-language-features-1.95.2.zip](https://github.com/user-attachments/files/17746820/typescript-language-features-1.95.2.zip)

There should not be errors in console while working with ts files, but no additional behavior to test.

#### Follow-ups

None

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
