### PR TITLE
Do not dispose dialogs on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
 <!-- ## 1.56.0 - not yet released -->
+<a name="breaking_changes_1.56.0">[Breaking Changes:](#breaking_changes_1.56.0)</a>
+- [core] Do not dispose dialogs on close - [#14456](https://github.com/eclipse-theia/theia/pull/14456) - Contributed on behalf of STMicroelectronics 
 
 ## 1.55.0 - 10/31/2024
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1199,7 +1199,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     }
 
     protected async openAbout(): Promise<void> {
-        this.aboutDialog.open();
+        this.aboutDialog.open(false);
     }
 
     protected shouldPreventClose = false;

--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -285,9 +285,9 @@ export abstract class AbstractDialog<T> extends BaseWidget {
     protected override onCloseRequest(msg: Message): void {
         // super.onCloseRequest() would automatically dispose the dialog, which we don't want because we're reusing it
         if (this.parent) {
+            // eslint-disable-next-line no-null/no-null
             this.parent = null;
-        }
-        else if (this.isAttached) {
+        } else if (this.isAttached) {
             Widget.detach(this);
         }
     }


### PR DESCRIPTION
#### What it does
Fixes #12093

The about dialog in Theia is reopened and must no be disposed on close. This PR overrides the `onCloseRequest` method from `BaseWidget` to not invoke `dispose()`. In order to minimize impact for clients of the API, I've added an optional parameter to the `open()` method that controls whether the dialog is disposed when it is closed. 
This change might be breaking in the case where clients reuse dialog instances and do not rely on `open()` to show the dialog. In that case, they will have to dispose the dialog themselves now. That should be a very rare case, though.

Contributed on behalf of STMicroelectronics

#### How to test
- Open and close the about dialog at least three times. Make sure there are not messages and exceptions in the browser log.
- Test behavior of both dismissing and accepting dialogs, for example
   - ConfirmationDialog: I used the "Clear editor history" commnand
   - Add a function breapoint in the "breakpoints" view
   - Make an editor dirty and close it: there is a dialog asking whether to save
Ensure these scenarios work correctly in the browser and Electron case.

#### Follow-ups
- [ ] https://github.com/eclipse-theia/theia/issues/14455
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
