### PR TITLE
Add settings to ignore backticks in AI code completion

### DIFF
--- a/packages/ai-code-completion/src/browser/ai-code-completion-frontend-module.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-frontend-module.ts
@@ -16,7 +16,7 @@
 
 import { ILogger } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { CodeCompletionAgent, CodeCompletionAgentImpl } from '../common/code-completion-agent';
+import { CodeCompletionAgent, CodeCompletionAgentImpl } from './code-completion-agent';
 import { AIFrontendApplicationContribution } from './ai-code-frontend-application-contribution';
 import { FrontendApplicationContribution, KeybindingContribution, PreferenceContribution } from '@theia/core/lib/browser';
 import { Agent } from '@theia/ai-core';

--- a/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
@@ -20,6 +20,7 @@ import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/browser/ai-core-pr
 export const PREF_AI_INLINE_COMPLETION_ENABLE = 'ai-features.codeCompletion.enableCodeCompletion';
 export const PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE = 'ai-features.codeCompletion.automaticCodeCompletion';
 export const PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS = 'ai-features.codeCompletion.excludedFileExtensions';
+export const PREF_AI_INLINE_COMPLETION_STRIP_BACKTICKS = 'ai-features.codeCompletion.stripBackticks';
 
 export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
     type: 'object',
@@ -40,6 +41,14 @@ export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
                 type: 'string'
             },
             default: []
+        },
+        [PREF_AI_INLINE_COMPLETION_STRIP_BACKTICKS]: {
+            title: 'Strip Backticks from Inline Completions',
+            type: 'boolean',
+            description: 'Remove surrounding backticks from the code returned by some LLMs. If a backtick is detected, all content after the closing\
+             backtick is stripped as well. This setting helps ensure plain code is returned when language models use markdown-like formatting.',
+            default: true
         }
+
     }
 };

--- a/packages/ai-code-completion/src/browser/ai-code-inline-completion-provider.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-inline-completion-provider.ts
@@ -17,7 +17,7 @@
 import * as monaco from '@theia/monaco-editor-core';
 
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { CodeCompletionAgent } from '../common/code-completion-agent';
+import { CodeCompletionAgent } from './code-completion-agent';
 import { AgentService } from '@theia/ai-core';
 
 @injectable()

--- a/packages/ai-code-completion/src/browser/code-completion-agent.spec.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.spec.ts
@@ -1,0 +1,67 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { CodeCompletionAgentImpl } from './code-completion-agent';
+
+describe('CodeCompletionAgentImpl', () => {
+    class TestableCodeCompletionAgent extends CodeCompletionAgentImpl {
+        public stripBackticksForTest(text: string): string {
+            return this.stripBackticks(text);
+        }
+    }
+    const agent = new TestableCodeCompletionAgent();
+
+    describe('stripBackticks', () => {
+
+        it('should remove surrounding backticks and language (TypeScript)', () => {
+            const input = '```TypeScript\nconsole.log(\"Hello, World!\");```';
+            const output = agent.stripBackticksForTest(input);
+            expect(output).to.equal('console.log("Hello, World!");');
+        });
+
+        it('should remove surrounding backticks and language (md)', () => {
+            const input = '```md\nconsole.log(\"Hello, World!\");```';
+            const output = agent.stripBackticksForTest(input);
+            expect(output).to.equal('console.log("Hello, World!");');
+        });
+
+        it('should remove all text after second occurrence of backticks', () => {
+            const input = '```js\nlet x = 10;\n```\nTrailing text should be removed```';
+            const output = agent.stripBackticksForTest(input);
+            expect(output).to.equal('let x = 10;');
+        });
+
+        it('should return the text unchanged if no surrounding backticks', () => {
+            const input = 'console.log(\"Hello, World!\");';
+            const output = agent.stripBackticksForTest(input);
+            expect(output).to.equal('console.log("Hello, World!");');
+        });
+
+        it('should remove surrounding backticks without language', () => {
+            const input = '```\nconsole.log(\"Hello, World!\");```';
+            const output = agent.stripBackticksForTest(input);
+            expect(output).to.equal('console.log("Hello, World!");');
+        });
+
+        it('should handle text starting with backticks but no second delimiter', () => {
+            const input = '```python\nprint(\"Hello, World!\")';
+            const output = agent.stripBackticksForTest(input);
+            expect(output).to.equal('print("Hello, World!")');
+        });
+
+    });
+});


### PR DESCRIPTION
fixed #14461

#### What it does

Adds a user setting to ignore backticks in LLM response for code completion. If a response starts with ```, it willremove opening and closing backticks and also remove any text after the closing backticks.

#### How to test

Use this prompt:
```
`\`\`\`
{{{prefix}}}[BLANK]{{{suffix}}}
\`\`\`

Fill in the blank to complete the code block. Your response should include only the code to replace [BLANK], without surrounding backticks.
```
Or tweak the existing prompt by removing the order to only return the code.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
