### PR TITLE
Imporve code completion variable naming

### DIFF
--- a/packages/ai-code-completion/src/common/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/common/code-completion-agent.ts
@@ -49,7 +49,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
         }
 
         // Get text until the given position
-        const textUntilCurrentPosition = model.getValueInRange({
+        const prefix = model.getValueInRange({
             startLineNumber: 1,
             startColumn: 1,
             endLineNumber: position.lineNumber,
@@ -57,7 +57,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
         });
 
         // Get text after the given position
-        const textAfterCurrentPosition = model.getValueInRange({
+        const suffix = model.getValueInRange({
             startLineNumber: position.lineNumber,
             startColumn: position.column,
             endLineNumber: model.getLineCount(),
@@ -71,7 +71,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
             return undefined;
         }
         const prompt = await this.promptService
-            .getPrompt('code-completion-prompt', { textUntilCurrentPosition, textAfterCurrentPosition, file, language })
+            .getPrompt('code-completion-prompt', { prefix, suffix, file, language })
             .then(p => p?.text);
         if (!prompt) {
             this.logger.error('No prompt found for code-completion-agent');
@@ -138,7 +138,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
 The language of the file is {{language}}. Return your result as plain text without markdown formatting.
 Finish the following code snippet.
 
-{{textUntilCurrentPosition}}[[MARKER]]{{textAfterCurrentPosition}}
+{{prefix}}[[MARKER]]{{suffix}}
 
 Only return the exact replacement for [[MARKER]] to complete the snippet.`,
         },
@@ -154,8 +154,8 @@ Only return the exact replacement for [[MARKER]] to complete the snippet.`,
     readonly agentSpecificVariables: AgentSpecificVariables[] = [
         { name: 'file', usedInPrompt: true, description: 'The uri of the file being edited.' },
         { name: 'language', usedInPrompt: true, description: 'The languageId of the file being edited.' },
-        { name: 'textUntilCurrentPosition', usedInPrompt: true, description: 'The code before the current position of the cursor.' },
-        { name: 'textAfterCurrentPosition', usedInPrompt: true, description: 'The code after the current position of the cursor.' }
+        { name: 'prefix', usedInPrompt: true, description: 'The code before the current position of the cursor.' },
+        { name: 'suffix', usedInPrompt: true, description: 'The code after the current position of the cursor.' }
     ];
     readonly tags?: string[] | undefined;
 }


### PR DESCRIPTION
fixed #14466

#### What it does

Rename textUntilCurrentPosition to prefix and textAfterCurrentPosition to suffix

#### How to test

Code completion shall still work, you might need to adapt custom prompts

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
