### PR TITLE
Allows comments in prompt templates

### DIFF
--- a/packages/ai-core/data/prompttemplate.tmLanguage.json
+++ b/packages/ai-core/data/prompttemplate.tmLanguage.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "comment.block.prompttemplate",
-      "begin": "^[\\t ]*{{!--",
+      "begin": "\\A{{!--",
       "beginCaptures": {
         "0": {
           "name": "punctuation.definition.comment.begin"

--- a/packages/ai-core/data/prompttemplate.tmLanguage.json
+++ b/packages/ai-core/data/prompttemplate.tmLanguage.json
@@ -20,6 +20,22 @@
       }
     },
     {
+      "name": "comment.block.prompttemplate",
+      "begin": "^[\\t ]*{{!--",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.begin"
+        }
+      },
+      "end": "--}}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.end"
+        }
+      },
+      "patterns": []
+    },
+    {
       "name": "variable.other.prompttemplate.double",
       "begin": "\\{\\{",
       "beginCaptures": {

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -180,7 +180,7 @@ export class AIAgentConfigurationWidget extends ReactWidget {
         const promptTemplates = agent.promptTemplates;
         const result: ParsedPrompt = { functions: [], globalVariables: [], agentSpecificVariables: [] };
         promptTemplates.forEach(template => {
-            const storedPrompt = this.promptService.getRawPrompt(template.id);
+            const storedPrompt = this.promptService.getUnresolvedPrompt(template.id);
             const prompt = storedPrompt?.template ?? template.template;
             const variableMatches = matchVariablesRegEx(prompt);
 

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -40,10 +40,15 @@ export interface ResolvedPromptTemplate {
 export const PromptService = Symbol('PromptService');
 export interface PromptService {
     /**
-     * Retrieve the raw {@link PromptTemplate} object.
+     * Retrieve the raw {@link PromptTemplate} object (unresolved variables, functions and including comments).
      * @param id the id of the {@link PromptTemplate}
      */
     getRawPrompt(id: string): PromptTemplate | undefined;
+    /**
+     * Retrieve the unresolved {@link PromptTemplate} object (unresolved variables, functions, excluding comments)
+     * @param id the id of the {@link PromptTemplate}
+     */
+    getUnresolvedPrompt(id: string): PromptTemplate | undefined;
     /**
      * Retrieve the default raw {@link PromptTemplate} object.
      * @param id the id of the {@link PromptTemplate}
@@ -182,8 +187,24 @@ export class PromptServiceImpl implements PromptService {
         return this._prompts[id];
     }
 
+    getUnresolvedPrompt(id: string): PromptTemplate | undefined {
+        const rawPrompt = this.getRawPrompt(id);
+        if (!rawPrompt) {
+            return undefined;
+        }
+        return {
+            id: rawPrompt.id,
+            template: this.stripComments(rawPrompt.template)
+        };
+    }
+
+    protected stripComments(template: string): string {
+        const commentRegex = /^\s*{{!--[\s\S]*?--}}\s*\n?/;
+        return commentRegex.test(template) ? template.replace(commentRegex, '').trimStart() : template;
+    }
+
     async getPrompt(id: string, args?: { [key: string]: unknown }): Promise<ResolvedPromptTemplate | undefined> {
-        const prompt = this.getRawPrompt(id);
+        const prompt = this.getUnresolvedPrompt(id);
         if (prompt === undefined) {
             return undefined;
         }


### PR DESCRIPTION
This should be reviewed first: https://github.com/eclipse-theia/theia/pull/14465

fixed #14469 

#### What it does

Allows comments in prompt templates
- Comments must start in the first line only, but can then be multile lines
- Comments are {{!-- comment --}}

#### How to test
There are automated tests.

Manual test:
Add comments and observe no effect on:
- LLM requests
- Variable detection in the AI configuration view

Check comments are highlighted correctly in the prompt editor:
![image](https://github.com/user-attachments/assets/66be4452-df80-4930-ae62-bd8ad52adfc6)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
