### PR TITLE
fix selection and improve active text editor behaviour

### DIFF
--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -109,7 +109,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_RENDERERS_MAIN, new NotebookRenderersMainImpl(rpc, container));
     const notebookEditorsMain = new NotebookEditorsMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_EDITORS_MAIN, notebookEditorsMain);
-    rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_AND_EDITORS_MAIN, new NotebooksAndEditorsMain(rpc, container, notebookDocumentsMain, notebookEditorsMain));
+    rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_AND_EDITORS_MAIN, new NotebooksAndEditorsMain(rpc, container, tabsMain, notebookDocumentsMain, notebookEditorsMain));
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_KERNELS_MAIN, new NotebookKernelsMainImpl(rpc, container));
 
     const editorsMain = new TextEditorsMainImpl(editorsAndDocuments, documentsMain, rpc, container);

--- a/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/notebook-documents-and-editors-main.ts
@@ -31,6 +31,7 @@ import { NotebookEditorsMainImpl } from './notebook-editors-main';
 import { NotebookDocumentsMainImpl } from './notebook-documents-main';
 import { diffMaps, diffSets } from '../../../common/collections';
 import { Mutex } from 'async-mutex';
+import { TabsMainImpl } from '../tabs/tabs-main';
 
 interface NotebookAndEditorDelta {
     removedDocuments: UriComponents[];
@@ -96,6 +97,7 @@ export class NotebooksAndEditorsMain implements NotebookDocumentsAndEditorsMain 
     constructor(
         rpc: RPCProtocol,
         container: interfaces.Container,
+        tabsMain: TabsMainImpl,
         protected readonly notebookDocumentsMain: NotebookDocumentsMainImpl,
         protected readonly notebookEditorsMain: NotebookEditorsMainImpl
     ) {
@@ -113,7 +115,12 @@ export class NotebooksAndEditorsMain implements NotebookDocumentsAndEditorsMain 
         // this.WidgetManager.onActiveEditorChanged(() => this.updateState(), this, this.disposables);
         this.notebookEditorService.onDidAddNotebookEditor(async editor => this.handleEditorAdd(editor), this, this.disposables);
         this.notebookEditorService.onDidRemoveNotebookEditor(async editor => this.handleEditorRemove(editor), this, this.disposables);
-        this.notebookEditorService.onDidChangeCurrentEditor(async editor => this.updateState(editor), this, this.disposables);
+        this.notebookEditorService.onDidChangeCurrentEditor(async editor => {
+            if (editor) {
+                await tabsMain.waitForWidget(editor);
+            }
+            this.updateState(editor);
+        }, this, this.disposables);
     }
 
     dispose(): void {

--- a/packages/plugin-ext/src/main/browser/text-editor-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-main.ts
@@ -388,11 +388,16 @@ export class TextEditorPropertiesMain {
         if (editor && editor instanceof MonacoEditor) {
             result = editor.getControl().getSelections() || undefined;
         } else if (editor && editor instanceof SimpleMonacoEditor) {
-            result = editor.getControl().getSelections()?.map(selection => new monaco.Selection(
-                selection.startLineNumber,
-                selection.startColumn,
-                selection.positionLineNumber,
-                selection.positionColumn));
+            result = editor.getControl().getSelections()?.map(selection => {
+                const monacoSelection = new monaco.Selection(
+                    selection.selectionStartLineNumber,
+                    selection.selectionStartColumn,
+                    selection.positionLineNumber,
+                    selection.positionColumn);
+                monacoSelection.setStartPosition(selection.startLineNumber, selection.startColumn);
+                monacoSelection.setEndPosition(selection.endLineNumber, selection.endColumn);
+                return monacoSelection;
+            });
         }
 
         if (!result && prevProperties) {

--- a/packages/plugin-ext/src/plugin/notebook/notebooks.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebooks.ts
@@ -20,7 +20,7 @@
 
 import { CancellationToken, Disposable, DisposableCollection, Emitter, Event, URI } from '@theia/core';
 import { URI as TheiaURI } from '../types-impl';
-import * as theia from '@theia/plugin';
+import type * as theia from '@theia/plugin';
 import {
     NotebookCellStatusBarListDto, NotebookDataDto,
     NotebookDocumentsAndEditorsDelta, NotebookDocumentShowOptions, NotebookDocumentsMain, NotebookEditorAddData, NotebookEditorsMain, NotebooksExt, NotebooksMain, Plugin,
@@ -337,12 +337,14 @@ export class NotebooksExtImpl implements NotebooksExt {
                 console.error(`FAILED to find active notebook editor ${delta.newActiveEditor}`);
             }
             this.activeNotebookEditor = this.editors.get(delta.newActiveEditor);
-            if (this.textDocumentsAndEditors.activeEditor()?.document.uri.path !== this.activeNotebookEditor?.notebookData.uri.path) {
-                this.textDocumentsAndEditors.acceptEditorsAndDocumentsDelta({
-                    newActiveEditor: null
-                });
-            }
             this.onDidChangeActiveNotebookEditorEmitter.fire(this.activeNotebookEditor?.apiEditor);
+
+            const newActiveCell = this.activeApiNotebookEditor?.notebook.cellAt(this.activeApiNotebookEditor.selection.start);
+            this.textDocumentsAndEditors.acceptEditorsAndDocumentsDelta({
+                newActiveEditor: newActiveCell?.kind === 2 /* code cell */ ?
+                    this.textDocumentsAndEditors.allEditors().find(editor => editor.document.uri.toString() === newActiveCell.document.uri.toString())?.id ?? null :
+                    null
+            });
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes the selection property in the vscode api of `SimpleMonacoEditors` when selecting text bottom to top and improves the `activeTextEditor` behaviour further to align it more to vscode.
Specificly this improves the case when switching from a different file to an already open notebook editor and the currently selected cell is a code cell, then the cell is set at the `activeTextEditor`

Fixes #14475
Fixes #14476
Fixes #14477

#### How to test

you can use [this extension](https://github.com/jonah-iden/theia-notebook-selection-test)
Both with the `Notebook-Test: get current selection` or the `Notebook-Test: get active text editor` command

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
