### PR TITLE
Support prompt variants

### DIFF
--- a/packages/ai-chat/src/common/universal-chat-agent.ts
+++ b/packages/ai-chat/src/common/universal-chat-agent.ts
@@ -76,6 +76,12 @@ simple solutions.
 `
 };
 
+export const universalTemplateVariant: PromptTemplate = {
+   id: 'universal-system-empty',
+   template: '',
+   variantOf: universalTemplate.id,
+};
+
 @injectable()
 export class UniversalChatAgent extends AbstractStreamParsingChatAgent implements ChatAgent {
    name: string;
@@ -96,7 +102,7 @@ export class UniversalChatAgent extends AbstractStreamParsingChatAgent implement
          + 'questions the user might ask. The universal agent currently does not have any context by default, i.e. it cannot '
          + 'access the current user context or the workspace.';
       this.variables = [];
-      this.promptTemplates = [universalTemplate];
+      this.promptTemplates = [universalTemplate, universalTemplateVariant];
       this.functions = [];
       this.agentSpecificVariables = [];
    }

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -137,14 +137,26 @@ export class AIAgentConfigurationWidget extends ReactWidget {
                     Enable Agent
                 </label>
             </div>
-            <div className='ai-templates'>
-                {agent.promptTemplates?.map(template =>
-                    <TemplateRenderer
-                        key={agent?.id + '.' + template.id}
-                        agentId={agent.id}
-                        template={template}
-                        promptCustomizationService={this.promptCustomizationService} />)}
+            <div className="settings-section-subcategory-title ai-settings-section-subcategory-title">
+                Prompt Templates
             </div>
+            <div className='ai-templates'>
+                {agent.promptTemplates
+                    ?.filter(template => !template.variantOf)
+                    .map(template => (
+                        <div key={agent.id + '.' + template.id}>
+                            <TemplateRenderer
+                                key={agent?.id + '.' + template.id}
+                                agentId={agent.id}
+                                template={template}
+                                promptService={this.promptService}
+                                aiSettingsService={this.aiSettingsService}
+                                promptCustomizationService={this.promptCustomizationService}
+                            />
+                        </div>
+                    ))}
+            </div>
+
             <div className='ai-lm-requirements'>
                 <LanguageModelRenderer
                     agent={agent}

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -140,22 +140,28 @@ export class AIAgentConfigurationWidget extends ReactWidget {
             <div className="settings-section-subcategory-title ai-settings-section-subcategory-title">
                 Prompt Templates
             </div>
-            <div className='ai-templates'>
-                {agent.promptTemplates
-                    ?.filter(template => !template.variantOf)
-                    .map(template => (
-                        <div key={agent.id + '.' + template.id}>
-                            <TemplateRenderer
-                                key={agent?.id + '.' + template.id}
-                                agentId={agent.id}
-                                template={template}
-                                promptService={this.promptService}
-                                aiSettingsService={this.aiSettingsService}
-                                promptCustomizationService={this.promptCustomizationService}
-                            />
-                        </div>
-                    ))}
+            <div className="ai-templates">
+                {(() => {
+                    const defaultTemplates = agent.promptTemplates?.filter(template => !template.variantOf) || [];
+                    return defaultTemplates.length > 0 ? (
+                        defaultTemplates.map(template => (
+                            <div key={agent.id + '.' + template.id}>
+                                <TemplateRenderer
+                                    key={agent.id + '.' + template.id}
+                                    agentId={agent.id}
+                                    template={template}
+                                    promptService={this.promptService}
+                                    aiSettingsService={this.aiSettingsService}
+                                    promptCustomizationService={this.promptCustomizationService}
+                                />
+                            </div>
+                        ))
+                    ) : (
+                        <div>No default template available</div>
+                    );
+                })()}
             </div>
+
 
             <div className='ai-lm-requirements'>
                 <LanguageModelRenderer

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -162,7 +162,6 @@ export class AIAgentConfigurationWidget extends ReactWidget {
                 })()}
             </div>
 
-
             <div className='ai-lm-requirements'>
                 <LanguageModelRenderer
                     agent={agent}

--- a/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
@@ -14,26 +14,103 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import * as React from '@theia/core/shared/react';
-import { PromptCustomizationService } from '../../common/prompt-service';
-import { PromptTemplate } from '../../common';
+import { PromptCustomizationService, PromptService } from '../../common/prompt-service';
+import { AISettingsService, PromptTemplate } from '../../common';
 
-export interface TemplateSettingProps {
+const DEFAULT_VARIANT = 'default';
+
+export interface TemplateRendererProps {
     agentId: string;
     template: PromptTemplate;
     promptCustomizationService: PromptCustomizationService;
+    promptService: PromptService;
+    aiSettingsService: AISettingsService;
 }
 
-export const TemplateRenderer: React.FC<TemplateSettingProps> = ({ agentId, template, promptCustomizationService }) => {
-    const openTemplate = React.useCallback(async () => {
-        promptCustomizationService.editTemplate(template.id, template.template);
-    }, [template, promptCustomizationService]);
-    const resetTemplate = React.useCallback(async () => {
-        promptCustomizationService.resetTemplate(template.id);
-    }, [promptCustomizationService, template]);
+export const TemplateRenderer: React.FC<TemplateRendererProps> = ({
+    agentId,
+    template,
+    promptCustomizationService,
+    promptService,
+    aiSettingsService,
+}) => {
+    const [variantIds, setVariantIds] = React.useState<string[]>([]);
+    const [selectedVariant, setSelectedVariant] = React.useState<string>(DEFAULT_VARIANT);
 
-    return <>
-        {template.id}
-        <button className='theia-button main' onClick={openTemplate}>Edit</button>
-        <button className='theia-button secondary' onClick={resetTemplate}>Reset</button>
-    </>;
+    React.useEffect(() => {
+        (async () => {
+            const variants = promptService.getVariantIds(template.id);
+            setVariantIds([DEFAULT_VARIANT, ...variants]);
+
+            const agentSettings = await aiSettingsService.getAgentSettings(agentId);
+            const currentVariant =
+                agentSettings?.selectedVariants?.[template.id] || DEFAULT_VARIANT;
+            setSelectedVariant(currentVariant);
+        })();
+    }, [template.id, promptService, aiSettingsService, agentId]);
+
+    const handleVariantChange = async (event: React.ChangeEvent<HTMLSelectElement>) => {
+        const newVariant = event.target.value;
+        setSelectedVariant(newVariant);
+
+        const agentSettings = await aiSettingsService.getAgentSettings(agentId);
+        const selectedVariants = agentSettings?.selectedVariants || {};
+
+        const updatedVariants = { ...selectedVariants };
+        if (newVariant === DEFAULT_VARIANT) {
+            delete updatedVariants[template.id];
+        } else {
+            updatedVariants[template.id] = newVariant;
+        }
+
+        await aiSettingsService.updateAgentSettings(agentId, {
+            selectedVariants: updatedVariants,
+        });
+    };
+
+    const openTemplate = React.useCallback(async () => {
+        const templateId = selectedVariant === DEFAULT_VARIANT ? template.id : selectedVariant;
+        const selectedTemplate = promptService.getRawPrompt(templateId);
+        promptCustomizationService.editTemplate(templateId, selectedTemplate?.template || '');
+    }, [selectedVariant, template.id, promptService, promptCustomizationService]);
+
+    const resetTemplate = React.useCallback(async () => {
+        const templateId = selectedVariant === DEFAULT_VARIANT ? template.id : selectedVariant;
+        promptCustomizationService.resetTemplate(templateId);
+    }, [selectedVariant, template.id, promptCustomizationService]);
+
+    return (
+        <div className="template-renderer">
+            <div className="settings-section-title template-header">
+                <strong>{template.id}</strong>
+            </div>
+            <div className="template-controls">
+                {variantIds.length > 1 && (
+                    <>
+                        <label htmlFor={`variant-selector-${template.id}`} className="template-select-label">
+                            Variant:
+                        </label>
+                        <select
+                            id={`variant-selector-${template.id}`}
+                            className="theia-select template-variant-selector"
+                            value={selectedVariant}
+                            onChange={handleVariantChange}
+                        >
+                            {variantIds.map(variantId => (
+                                <option key={variantId} value={variantId}>
+                                    {variantId}
+                                </option>
+                            ))}
+                        </select>
+                    </>
+                )}
+                <button className="theia-button main" onClick={openTemplate}>
+                    Edit
+                </button>
+                <button className="theia-button secondary" onClick={resetTemplate}>
+                    Reset
+                </button>
+            </div>
+        </div>
+    );
 };

--- a/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
@@ -88,7 +88,7 @@ export const TemplateRenderer: React.FC<TemplateRendererProps> = ({
                 {variantIds.length > 1 && (
                     <>
                         <label htmlFor={`variant-selector-${template.id}`} className="template-select-label">
-                            Variant:
+                            Select Variant:
                         </label>
                         <select
                             id={`variant-selector-${template.id}`}

--- a/packages/ai-core/src/browser/style/index.css
+++ b/packages/ai-core/src/browser/style/index.css
@@ -14,13 +14,41 @@
   margin-left: var(--theia-ui-padding);
 }
 
-.ai-templates {
-  display: grid;
-  /** Display content in 3 columns */
-  grid-template-columns: 1fr auto auto;
-  /** add a 3px gap between rows */
-  row-gap: 3px;
+.theia-settings-container .settings-section-subcategory-title.ai-settings-section-subcategory-title {
+  padding-left: 0;
 }
+
+.ai-templates {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.template-renderer {
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+}
+
+.template-header {
+  margin-bottom: 8px;
+}
+
+.template-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.template-select-label {
+  margin-right: 5px;
+}
+
+.template-variant-selector {
+  min-width: 120px;
+}
+
+
 
 #ai-variable-configuration-container-widget,
 #ai-agent-configuration-container-widget {

--- a/packages/ai-core/src/common/agent-service.ts
+++ b/packages/ai-core/src/common/agent-service.ts
@@ -99,7 +99,7 @@ export class AgentServiceImpl implements AgentService {
     registerAgent(agent: Agent): void {
         this._agents.push(agent);
         agent.promptTemplates.forEach(
-            template => this.promptService.storePrompt(template.id, template.template)
+            template => this.promptService.storePromptTemplate(template)
         );
         this.onDidChangeAgentsEmitter.fire();
     }

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -244,4 +244,60 @@ describe('PromptService', () => {
         expect(prompt?.text).to.equal('Hi, John! {{!-- Another comment --}}');
     });
 
+    it('should return all variant IDs of a given prompt', () => {
+        promptService.storePromptTemplate({ id: 'main', template: 'Main template' });
+
+        promptService.storePromptTemplate({
+            id: 'variant1',
+            template: 'Variant 1',
+            variantOf: 'main'
+        });
+        promptService.storePromptTemplate({
+            id: 'variant2',
+            template: 'Variant 2',
+            variantOf: 'main'
+        });
+        promptService.storePromptTemplate({
+            id: 'variant3',
+            template: 'Variant 3',
+            variantOf: 'main'
+        });
+
+        const variantIds = promptService.getVariantIds('main');
+        expect(variantIds).to.deep.equal(['variant1', 'variant2', 'variant3']);
+    });
+
+    it('should return an empty array if no variants exist for a given prompt', () => {
+        promptService.storePromptTemplate({ id: 'main', template: 'Main template' });
+
+        const variantIds = promptService.getVariantIds('main');
+        expect(variantIds).to.deep.equal([]);
+    });
+
+    it('should return an empty array if the main prompt ID does not exist', () => {
+        const variantIds = promptService.getVariantIds('nonExistent');
+        expect(variantIds).to.deep.equal([]);
+    });
+
+    it('should not influence prompts without variants when other prompts have variants', () => {
+        promptService.storePromptTemplate({ id: 'mainWithVariants', template: 'Main template with variants' });
+        promptService.storePromptTemplate({ id: 'mainWithoutVariants', template: 'Main template without variants' });
+
+        promptService.storePromptTemplate({
+            id: 'variant1',
+            template: 'Variant 1',
+            variantOf: 'mainWithVariants'
+        });
+        promptService.storePromptTemplate({
+            id: 'variant2',
+            template: 'Variant 2',
+            variantOf: 'mainWithVariants'
+        });
+
+        const variantsForMainWithVariants = promptService.getVariantIds('mainWithVariants');
+        const variantsForMainWithoutVariants = promptService.getVariantIds('mainWithoutVariants');
+
+        expect(variantsForMainWithVariants).to.deep.equal(['variant1', 'variant2']);
+        expect(variantsForMainWithoutVariants).to.deep.equal([]);
+    });
 });

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -37,10 +37,10 @@ describe('PromptService', () => {
         container.bind<AIVariableService>(AIVariableService).toConstantValue(variableService);
 
         promptService = container.get<PromptService>(PromptService);
-        promptService.storePrompt('1', 'Hello, {{name}}!');
-        promptService.storePrompt('2', 'Goodbye, {{name}}!');
-        promptService.storePrompt('3', 'Ciao, {{invalid}}!');
-        promptService.storePrompt('8', 'Hello, {{{name}}}');
+        promptService.storePromptTemplate({ id: '1', template: 'Hello, {{name}}!' });
+        promptService.storePromptTemplate({ id: '2', template: 'Goodbye, {{name}}!' });
+        promptService.storePromptTemplate({ id: '3', template: 'Ciao, {{invalid}}!' });
+        promptService.storePromptTemplate({ id: '8', template: 'Hello, {{{name}}}' });
     });
 
     it('should initialize prompts from PromptCollectionService', () => {
@@ -62,7 +62,7 @@ describe('PromptService', () => {
     });
 
     it('should store a new prompt', () => {
-        promptService.storePrompt('3', 'Welcome, {{name}}!');
+        promptService.storePromptTemplate({ id: '3', template: 'Welcome, {{name}}!' });
         const newPrompt = promptService.getRawPrompt('3');
         expect(newPrompt?.template).to.equal('Welcome, {{name}}!');
     });
@@ -88,10 +88,10 @@ describe('PromptService', () => {
     });
 
     it('should ignore whitespace in variables', async () => {
-        promptService.storePrompt('4', 'Hello, {{name }}!');
-        promptService.storePrompt('5', 'Hello, {{ name}}!');
-        promptService.storePrompt('6', 'Hello, {{ name }}!');
-        promptService.storePrompt('7', 'Hello, {{       name           }}!');
+        promptService.storePromptTemplate({ id: '4', template: 'Hello, {{name }}!' });
+        promptService.storePromptTemplate({ id: '5', template: 'Hello, {{ name}}!' });
+        promptService.storePromptTemplate({ id: '6', template: 'Hello, {{ name }}!' });
+        promptService.storePromptTemplate({ id: '7', template: 'Hello, {{       name           }}!' });
         for (let i = 4; i <= 7; i++) {
             const prompt = await promptService.getPrompt(`${i}`, { name: 'John' });
             expect(prompt?.text).to.equal('Hello, John!');
@@ -109,10 +109,10 @@ describe('PromptService', () => {
     });
 
     it('should ignore whitespace in variables (three bracket)', async () => {
-        promptService.storePrompt('9', 'Hello, {{{name }}}');
-        promptService.storePrompt('10', 'Hello, {{{ name}}}');
-        promptService.storePrompt('11', 'Hello, {{{ name }}}');
-        promptService.storePrompt('12', 'Hello, {{{       name           }}}');
+        promptService.storePromptTemplate({ id: '9', template: 'Hello, {{{name }}}' });
+        promptService.storePromptTemplate({ id: '10', template: 'Hello, {{{ name}}}' });
+        promptService.storePromptTemplate({ id: '11', template: 'Hello, {{{ name }}}' });
+        promptService.storePromptTemplate({ id: '12', template: 'Hello, {{{       name           }}}' });
         for (let i = 9; i <= 12; i++) {
             const prompt = await promptService.getPrompt(`${i}`, { name: 'John' });
             expect(prompt?.text).to.equal('Hello, John');
@@ -120,26 +120,24 @@ describe('PromptService', () => {
     });
 
     it('should ignore invalid prompts with unmatched brackets', async () => {
-        promptService.storePrompt('9', 'Hello, {{name');
-        promptService.storePrompt('10', 'Hello, {{{name');
-        promptService.storePrompt('11', 'Hello, name}}}}');
+        promptService.storePromptTemplate({ id: '9', template: 'Hello, {{name' });
+        promptService.storePromptTemplate({ id: '10', template: 'Hello, {{{name' });
+        promptService.storePromptTemplate({ id: '11', template: 'Hello, name}}}}' });
         const prompt1 = await promptService.getPrompt('9', { name: 'John' });
         expect(prompt1?.text).to.equal('Hello, {{name'); // Not matching due to missing closing brackets
-
         const prompt2 = await promptService.getPrompt('10', { name: 'John' });
         expect(prompt2?.text).to.equal('Hello, {{{name'); // Matches pattern due to valid three-start-two-end brackets
-
         const prompt3 = await promptService.getPrompt('11', { name: 'John' });
         expect(prompt3?.text).to.equal('Hello, name}}}}'); // Extra closing bracket, does not match cleanly
     });
 
     it('should handle a mixture of two and three brackets correctly', async () => {
-        promptService.storePrompt('12', 'Hi, {{name}}}');            // (invalid)
-        promptService.storePrompt('13', 'Hello, {{{name}}');         // (invalid)
-        promptService.storePrompt('14', 'Greetings, {{{name}}}}');   // (invalid)
-        promptService.storePrompt('15', 'Bye, {{{{name}}}');         // (invalid)
-        promptService.storePrompt('16', 'Ciao, {{{{name}}}}');       // (invalid)
-        promptService.storePrompt('17', 'Hi, {{name}}! {{{name}}}'); // Mixed valid patterns
+        promptService.storePromptTemplate({ id: '12', template: 'Hi, {{name}}}' });            // (invalid)
+        promptService.storePromptTemplate({ id: '13', template: 'Hello, {{{name}}' });         // (invalid)
+        promptService.storePromptTemplate({ id: '14', template: 'Greetings, {{{name}}}}' });   // (invalid)
+        promptService.storePromptTemplate({ id: '15', template: 'Bye, {{{{name}}}' });         // (invalid)
+        promptService.storePromptTemplate({ id: '16', template: 'Ciao, {{{{name}}}}' });       // (invalid)
+        promptService.storePromptTemplate({ id: '17', template: 'Hi, {{name}}! {{{name}}}' }); // Mixed valid patterns
 
         const prompt12 = await promptService.getPrompt('12', { name: 'John' });
         expect(prompt12?.text).to.equal('Hi, {{name}}}');
@@ -161,85 +159,85 @@ describe('PromptService', () => {
     });
 
     it('should strip single-line comments at the start of the template', () => {
-        promptService.storePrompt('comment-basic', '{{!-- Comment --}}Hello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-basic', template: '{{!-- Comment --}}Hello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-basic');
         expect(prompt?.template).to.equal('Hello, {{name}}!');
     });
 
     it('should remove line break after first-line comment', () => {
-        promptService.storePrompt('comment-line-break', '{{!-- Comment --}}\nHello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-line-break', template: '{{!-- Comment --}}\nHello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-line-break');
         expect(prompt?.template).to.equal('Hello, {{name}}!');
     });
 
     it('should strip multiline comments at the start of the template', () => {
-        promptService.storePrompt('comment-multiline', '{{!--\nMultiline comment\n--}}\nGoodbye, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-multiline', template: '{{!--\nMultiline comment\n--}}\nGoodbye, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-multiline');
         expect(prompt?.template).to.equal('Goodbye, {{name}}!');
     });
 
     it('should not strip comments not in the first line', () => {
-        promptService.storePrompt('comment-second-line', 'Hello, {{name}}!\n{{!-- Comment --}}');
+        promptService.storePromptTemplate({ id: 'comment-second-line', template: 'Hello, {{name}}!\n{{!-- Comment --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-second-line');
         expect(prompt?.template).to.equal('Hello, {{name}}!\n{{!-- Comment --}}');
     });
 
     it('should treat unclosed comments as regular text', () => {
-        promptService.storePrompt('comment-unclosed', '{{!-- Unclosed comment');
+        promptService.storePromptTemplate({ id: 'comment-unclosed', template: '{{!-- Unclosed comment' });
         const prompt = promptService.getUnresolvedPrompt('comment-unclosed');
         expect(prompt?.template).to.equal('{{!-- Unclosed comment');
     });
 
     it('should treat standalone closing delimiters as regular text', () => {
-        promptService.storePrompt('comment-standalone', '--}} Hello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-standalone', template: '--}} Hello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-standalone');
         expect(prompt?.template).to.equal('--}} Hello, {{name}}!');
     });
 
     it('should handle nested comments and stop at the first closing tag', () => {
-        promptService.storePrompt('nested-comment', '{{!-- {{!-- Nested comment --}} --}}text');
+        promptService.storePromptTemplate({ id: 'nested-comment', template: '{{!-- {{!-- Nested comment --}} --}}text' });
         const prompt = promptService.getUnresolvedPrompt('nested-comment');
         expect(prompt?.template).to.equal('--}}text');
     });
 
     it('should handle templates with only comments', () => {
-        promptService.storePrompt('comment-only', '{{!-- Only comments --}}');
+        promptService.storePromptTemplate({ id: 'comment-only', template: '{{!-- Only comments --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-only');
         expect(prompt?.template).to.equal('');
     });
 
     it('should handle mixed delimiters on the same line', () => {
-        promptService.storePrompt('comment-mixed', '{{!-- Unclosed comment --}}');
+        promptService.storePromptTemplate({ id: 'comment-mixed', template: '{{!-- Unclosed comment --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-mixed');
         expect(prompt?.template).to.equal('');
     });
 
     it('should resolve variables after stripping single-line comments', async () => {
-        promptService.storePrompt('comment-resolve', '{{!-- Comment --}}Hello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-resolve', template: '{{!-- Comment --}}Hello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-resolve', { name: 'John' });
         expect(prompt?.text).to.equal('Hello, John!');
     });
 
     it('should resolve variables in multiline templates with comments', async () => {
-        promptService.storePrompt('comment-multiline-vars', '{{!--\nMultiline comment\n--}}\nHello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-multiline-vars', template: '{{!--\nMultiline comment\n--}}\nHello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-multiline-vars', { name: 'John' });
         expect(prompt?.text).to.equal('Hello, John!');
     });
 
     it('should resolve variables with standalone closing delimiters', async () => {
-        promptService.storePrompt('comment-standalone-vars', '--}} Hello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-standalone-vars', template: '--}} Hello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-standalone-vars', { name: 'John' });
         expect(prompt?.text).to.equal('--}} Hello, John!');
     });
 
     it('should treat unclosed comments as text and resolve variables', async () => {
-        promptService.storePrompt('comment-unclosed-vars', '{{!-- Unclosed comment\nHello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-unclosed-vars', template: '{{!-- Unclosed comment\nHello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-unclosed-vars', { name: 'John' });
         expect(prompt?.text).to.equal('{{!-- Unclosed comment\nHello, John!');
     });
 
     it('should handle templates with mixed comments and variables', async () => {
-        promptService.storePrompt('comment-mixed-vars', '{{!-- Comment --}}Hi, {{name}}! {{!-- Another comment --}}');
+        promptService.storePromptTemplate({ id: 'comment-mixed-vars', template: '{{!-- Comment --}}Hi, {{name}}! {{!-- Another comment --}}' });
         const prompt = await promptService.getPrompt('comment-mixed-vars', { name: 'John' });
         expect(prompt?.text).to.equal('Hi, John! {{!-- Another comment --}}');
     });

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -69,12 +69,6 @@ export interface PromptService {
      */
     getPrompt(id: string, args?: { [key: string]: unknown }): Promise<ResolvedPromptTemplate | undefined>;
     /**
-     * Adds a prompt to the list of prompts.
-     * @param id the id of the prompt
-     * @param prompt the prompt template to store
-     */
-    storePrompt(id: string, prompt: string): void;
-    /**
      * Adds a {@link PromptTemplate} to the list of prompts.
      * @param promptTemplate the prompt template to store
      */
@@ -315,9 +309,6 @@ export class PromptServiceImpl implements PromptService {
         } else {
             return { ...this._prompts };
         }
-    }
-    storePrompt(id: string, prompt: string): void {
-        this._prompts[id] = { id, template: prompt };
     }
     removePrompt(id: string): void {
         delete this._prompts[id];

--- a/packages/ai-core/src/common/settings-service.ts
+++ b/packages/ai-core/src/common/settings-service.ts
@@ -30,4 +30,9 @@ export type AISettings = Record<string, AgentSettings>;
 export interface AgentSettings {
     languageModelRequirements?: LanguageModelRequirement[];
     enable?: boolean;
+    /**
+     * A mapping of main template IDs to their selected variant IDs.
+     * If a main template is not present in this mapping, it means the main template is used.
+     */
+    selectedVariants?: Record<string, string>;
 }


### PR DESCRIPTION
fixed #14485

#### What it does

Introduce the capability for prompt variants, i.e. variants of a main prompt to e.g. support specific LLMs.
There is always a main prompt (default) that can have multiple variants.
The currently selected variant is a setting.

- Extended prompt service to manage variants
- Extended AgentSettings to store if a variant for a main template is selected.
- Prompt Variants can be edited as well
- Add an empty prompt for the universal model (useful to talk to small models or just "diretcly" to an LLM)

#### How to test

- Switch the prompt template for the universal agent and check in History view that the system prompt is adapted
- Restart to check the the setting is persistent
- Modify the variant
- etc.

NOTE: There is an unrelated bug in the prompt watching. I can sometimes get into a state, where I change a prompt template, but the prompt customization service is not notified anymore. This usually happens during demos, but I have no reproducible path yet.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
