### PR TITLE
add min height to cell outputs

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -290,6 +290,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         private createHtmlElement(): void {
             this.containerElement = document.createElement('div');
             this.containerElement.classList.add('output-container');
+            this.containerElement.style.minHeight = '20px';
             this.element = document.createElement('div');
             this.element.id = this.outputId;
             this.element.classList.add('output');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Adds a min height to cell outputs so that when an output rendering is smaller than that it does not move all the other outputs

#### How to test

create a cell that does render a too small output. For example i used 
```
import plotly.express as px
import pandas as pd
df =pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
px.scatter_mapbox(df, 'col1', 'col2')
```
create simple code cells below it like `print('test')`.
Execute all cells and validate that the text outputs are not moved into their cell editors space

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
