### PR TITLE
Fix Set Milestone on PR Workflow

### DIFF
--- a/.github/workflows/set-milestone-on-pr.yml
+++ b/.github/workflows/set-milestone-on-pr.yml
@@ -15,7 +15,7 @@
 # Set milestone on each pull request by using the next minor version
 # next version is computed using npm version tool
 on:
-  pull_request:
+  pull_request_target:
     branches: [master]
     types: [closed]
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Previously, PRs from forks were not assigned to a milestone due to using the `pull_request` trigger. This trigger runs in the context of the merge commit and cannot access the `GITHUB_TOKEN` for forks. Switching to the `pull_request_target` event allows access from the base context, enabling milestone assignment for forked PRs.

For more information, see the [GitHub documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target).
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
