### PR TITLE
chore(ai): avoid conflicting keybinding for opening chat window

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -52,7 +52,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
                 rank: 100
             },
             toggleCommandId: AI_CHAT_TOGGLE_COMMAND_ID,
-            toggleKeybinding: 'ctrlcmd+shift+e'
+            toggleKeybinding: 'ctrlcmd+alt+i'
         });
     }
 


### PR DESCRIPTION
#### What it does

ctrlcmd+shift+e is actually used already for the navigator. VS Code uses ctrlcmd+alt+i. So I used that as a keybinding for the chat view instead.

#### How to test

Try the keybindings and see if the right widgets appear.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
