### PR TITLE
feat(ai): add hovers for agents and variables

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -61,12 +61,12 @@ const MarkdownRender = ({ response }: { response: MarkdownChatResponseContent | 
 /**
  * This hook uses markdown-it directly to render markdown.
  * The reason to use markdown-it directly is that the MarkdownRenderer is
- * overriden by theia with a monaco version. This monaco version strips all html
+ * overridden by theia with a monaco version. This monaco version strips all html
  * tags from the markdown with empty content.
  * This leads to unexpected behavior when rendering markdown with html tags.
  *
  * @param markdown the string to render as markdown
- * @param skipSurroundingParagraph whether plain text should be surrounded by a paragraph (default: false)
+ * @param skipSurroundingParagraph whether to remove a surrounding paragraph element (default: false)
  * @returns the ref to use in an element to render the markdown
  */
 export const useMarkdownRendering = (markdown: string | MarkdownString, skipSurroundingParagraph: boolean = false) => {
@@ -76,6 +76,7 @@ export const useMarkdownRendering = (markdown: string | MarkdownString, skipSurr
     useEffect(() => {
         const markdownIt = markdownit();
         const host = document.createElement('div');
+        // markdownIt always puts the content in a paragraph element, so we remove it if we don't want it
         const html = skipSurroundingParagraph ? markdownIt.render(markdownString).replace(/^<p>|<\/p>|<p><\/p>$/g, '') : markdownIt.render(markdownString);
         host.innerHTML = DOMPurify.sanitize(html, {
             ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -66,16 +66,17 @@ const MarkdownRender = ({ response }: { response: MarkdownChatResponseContent | 
  * This leads to unexpected behavior when rendering markdown with html tags.
  *
  * @param markdown the string to render as markdown
+ * @param skipSurroundingParagraph whether plain text should be surrounded by a paragraph (default: false)
  * @returns the ref to use in an element to render the markdown
  */
-export const useMarkdownRendering = (markdown: string | MarkdownString) => {
+export const useMarkdownRendering = (markdown: string | MarkdownString, skipSurroundingParagraph: boolean = false) => {
     // eslint-disable-next-line no-null/no-null
     const ref = useRef<HTMLDivElement | null>(null);
     const markdownString = typeof markdown === 'string' ? markdown : markdown.value;
     useEffect(() => {
         const markdownIt = markdownit();
         const host = document.createElement('div');
-        const html = markdownIt.render(markdownString);
+        const html = skipSurroundingParagraph ? markdownIt.render(markdownString).replace(/^<p>|<\/p>|<p><\/p>$/g, '') : markdownIt.render(markdownString);
         host.innerHTML = DOMPurify.sanitize(html, {
             ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
         });

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -464,6 +464,7 @@ const ChatRequestRender = (
                             />
                         );
                     } else {
+                        // maintain the leading and trailing spaces with explicit `&nbsp;`, otherwise they would get trimmed by the markdown renderer
                         const ref = useMarkdownRendering(part.text.replace(/^\s|\s$/g, '&nbsp;'), true);
                         return (
                             <span key={index} ref={ref}></span>

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -14,12 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import {
+    ChatAgent,
     ChatAgentService,
     ChatModel,
     ChatProgressMessage,
     ChatRequestModel,
     ChatResponseContent,
     ChatResponseModel,
+    ParsedChatRequestAgentPart,
+    ParsedChatRequestVariablePart,
 } from '@theia/ai-chat';
 import { CommandRegistry, ContributionProvider } from '@theia/core';
 import {
@@ -27,6 +30,7 @@ import {
     CommonCommands,
     CompositeTreeNode,
     ContextMenuRenderer,
+    HoverService,
     Key,
     KeyCode,
     NodeProps,
@@ -46,6 +50,7 @@ import * as React from '@theia/core/shared/react';
 import { ChatNodeToolbarActionContribution } from '../chat-node-toolbar-action-contribution';
 import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
 import { useMarkdownRendering } from '../chat-response-renderer/markdown-part-renderer';
+import { AIVariableService } from '@theia/ai-core';
 
 // TODO Instead of directly operating on the ChatRequestModel we could use an intermediate view model
 export interface RequestNode extends TreeNode {
@@ -77,8 +82,14 @@ export class ChatViewTreeWidget extends TreeWidget {
     @inject(ChatAgentService)
     protected chatAgentService: ChatAgentService;
 
+    @inject(AIVariableService)
+    protected readonly variableService: AIVariableService;
+
     @inject(CommandRegistry)
     private commandRegistry: CommandRegistry;
+
+    @inject(HoverService)
+    private hoverService: HoverService;
 
     protected _shouldScrollToEnd = true;
 
@@ -273,10 +284,24 @@ export class ChatViewTreeWidget extends TreeWidget {
                 .filter(action => this.commandRegistry.isEnabled(action.commandId, node))
                 .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
             : [];
+        const agentLabel = React.createRef<HTMLHeadingElement>();
+        const agentDescription = this.getAgent(node)?.description;
         return <React.Fragment>
             <div className='theia-ChatNodeHeader'>
                 <div className={`theia-AgentAvatar ${this.getAgentIconClassName(node)}`}></div>
-                <h3 className='theia-AgentLabel'>{this.getAgentLabel(node)}</h3>
+                <h3 ref={agentLabel}
+                    className='theia-AgentLabel'
+                    onMouseEnter={() => {
+                        if (agentDescription) {
+                            this.hoverService.requestHover({
+                                content: agentDescription,
+                                target: agentLabel.current!,
+                                position: 'right'
+                            });
+                        }
+                    }}>
+                    {this.getAgentLabel(node)}
+                </h3>
                 {inProgress && <span className='theia-ChatContentInProgress'>Generating</span>}
                 <div className='theia-ChatNodeToolbar'>
                     {!inProgress &&
@@ -309,8 +334,14 @@ export class ChatViewTreeWidget extends TreeWidget {
             // TODO find user name
             return 'You';
         }
-        const agent = node.response.agentId ? this.chatAgentService.getAgent(node.response.agentId) : undefined;
-        return agent?.name ?? 'AI';
+        return this.getAgent(node)?.name ?? 'AI';
+    }
+
+    private getAgent(node: RequestNode | ResponseNode): ChatAgent | undefined {
+        if (isRequestNode(node)) {
+            return undefined;
+        }
+        return node.response.agentId ? this.chatAgentService.getAgent(node.response.agentId) : undefined;
     }
 
     private getAgentIconClassName(node: RequestNode | ResponseNode): string | undefined {
@@ -332,7 +363,12 @@ export class ChatViewTreeWidget extends TreeWidget {
     }
 
     private renderChatRequest(node: RequestNode): React.ReactNode {
-        return <ChatRequestRender node={node} />;
+        return <ChatRequestRender
+            node={node}
+            hoverService={this.hoverService}
+            chatAgentService={this.chatAgentService}
+            variableService={this.variableService}
+        />;
     }
 
     private renderChatResponse(node: ResponseNode): React.ReactNode {
@@ -376,11 +412,78 @@ export class ChatViewTreeWidget extends TreeWidget {
     }
 }
 
-const ChatRequestRender = ({ node }: { node: RequestNode }) => {
-    const text = node.request.request.displayText ?? node.request.request.text;
-    const ref = useMarkdownRendering(text);
+const ChatRequestRender = (
+    {
+        node, hoverService, chatAgentService, variableService
+    }: {
+        node: RequestNode,
+        hoverService: HoverService,
+        chatAgentService: ChatAgentService,
+        variableService: AIVariableService
+    }) => {
+    const parts = node.request.message.parts;
+    return (
+        <div className="theia-RequestNode">
+            <p>
+                {parts.map((part, index) => {
+                    if (part instanceof ParsedChatRequestAgentPart || part instanceof ParsedChatRequestVariablePart) {
+                        let description = undefined;
+                        let className = '';
+                        if (part instanceof ParsedChatRequestAgentPart) {
+                            description = chatAgentService.getAgent(part.agentId)?.description;
+                            className = 'theia-RequestNode-AgentLabel';
+                        } else if (part instanceof ParsedChatRequestVariablePart) {
+                            description = variableService.getVariable(part.variableName)?.description;
+                            className = 'theia-RequestNode-VariableLabel';
+                        }
+                        return (
+                            <HoverableLabel
+                                key={index}
+                                text={part.text}
+                                description={description}
+                                hoverService={hoverService}
+                                className={className}
+                            />
+                        );
+                    } else {
+                        const ref = useMarkdownRendering(part.text.replace(/^\s|\s$/g, '&nbsp;'), true);
+                        return (
+                            <span key={index} ref={ref}></span>
+                        );
+                    }
+                })}
+            </p>
+        </div>
+    );
+};
 
-    return <div className={'theia-RequestNode'} ref={ref}></div>;
+const HoverableLabel = (
+    {
+        text, description, hoverService, className
+    }: {
+        text: string,
+        description?: string,
+        hoverService: HoverService,
+        className: string
+    }) => {
+    const spanRef = React.createRef<HTMLSpanElement>();
+    return (
+        <span
+            className={className}
+            ref={spanRef}
+            onMouseEnter={() => {
+                if (description) {
+                    hoverService.requestHover({
+                        content: description,
+                        target: spanRef.current!,
+                        position: 'right'
+                    });
+                }
+            }}
+        >
+            {text}
+        </span>
+    );
 };
 
 const ProgressMessage = (c: ChatProgressMessage) => (

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -132,6 +132,20 @@ div:last-child > .theia-ChatNode {
   font-size: var(--theia-code-font-size);
 }
 
+.theia-RequestNode > p div {
+  display: inline;
+}
+
+.theia-RequestNode .theia-RequestNode-AgentLabel,
+.theia-RequestNode .theia-RequestNode-VariableLabel {
+  padding: calc(var(--theia-ui-padding) * 2 / 3);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  border-radius: calc(var(--theia-ui-padding) * 2 / 3);
+  background: var(--theia-badge-background);
+  color: var(--theia-badge-foreground);
+}
+
 .chat-input-widget {
   align-items: flex-end;
   display: flex;


### PR DESCRIPTION
#### What it does

* Highlights the parsed chat request agent and variable parts
* Adds hover information for the agent and variable parts
* Adds hover information for the agent label in response headers

![image](https://github.com/user-attachments/assets/4f25464d-c13f-4267-83b2-f15956e33938)

#### How to test

Use variables and agent references in your requests and check whether they are correctly rendered.
Check if they have hover information.
Make sure generic markdown formatting still works.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
