### PR TITLE
Gh 14505

### DIFF
--- a/packages/ai-chat/src/common/universal-chat-agent.ts
+++ b/packages/ai-chat/src/common/universal-chat-agent.ts
@@ -78,6 +78,12 @@ simple solutions.
 `
 };
 
+export const universalTemplateVariant: PromptTemplate = {
+   id: 'universal-system-empty',
+   template: '',
+   variantOf: universalTemplate.id,
+};
+
 @injectable()
 export class UniversalChatAgent extends AbstractStreamParsingChatAgent implements ChatAgent {
    name: string;
@@ -98,7 +104,7 @@ export class UniversalChatAgent extends AbstractStreamParsingChatAgent implement
          + 'questions the user might ask. The universal agent currently does not have any context by default, i.e. it cannot '
          + 'access the current user context or the workspace.';
       this.variables = [];
-      this.promptTemplates = [universalTemplate];
+      this.promptTemplates = [universalTemplate, universalTemplateVariant];
       this.functions = [];
       this.agentSpecificVariables = [];
    }

--- a/packages/ai-code-completion/package.json
+++ b/packages/ai-code-completion/package.json
@@ -10,7 +10,8 @@
     "@theia/output": "1.55.0",
     "@theia/workspace": "1.55.0",
     "minimatch": "^5.1.0",
-    "tslib": "^2.6.2"
+    "tslib": "^2.6.2",
+    "js-yaml": "^4.1.0"
   },
   "main": "lib/common",
   "publishConfig": {

--- a/packages/ai-code-completion/src/browser/ai-code-completion-frontend-module.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-frontend-module.ts
@@ -22,6 +22,7 @@ import { FrontendApplicationContribution, KeybindingContribution, PreferenceCont
 import { Agent } from '@theia/ai-core';
 import { AICodeCompletionPreferencesSchema } from './ai-code-completion-preference';
 import { AICodeInlineCompletionsProvider } from './ai-code-inline-completion-provider';
+import { CodeCompletionPromptParserService, DefaultCodeCompletionPromptParserService } from '../common/prompt-metadata-parsing-service';
 
 export default new ContainerModule(bind => {
     bind(ILogger).toDynamicValue(ctx => {
@@ -36,4 +37,5 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).to(AIFrontendApplicationContribution);
     bind(KeybindingContribution).toService(AIFrontendApplicationContribution);
     bind(PreferenceContribution).toConstantValue({ schema: AICodeCompletionPreferencesSchema });
+    bind(CodeCompletionPromptParserService).to(DefaultCodeCompletionPromptParserService).inSingletonScope();
 });

--- a/packages/ai-code-completion/src/common/prompt-metadata-parsing-service.spec.ts
+++ b/packages/ai-code-completion/src/common/prompt-metadata-parsing-service.spec.ts
@@ -1,0 +1,224 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import 'reflect-metadata';
+import { expect } from 'chai';
+import { CodeCompletionPromptMetaData, DefaultCodeCompletionPromptParserService } from './prompt-metadata-parsing-service';
+
+describe('DefaultCodeCompletionPromptParserService', () => {
+    let parserService: DefaultCodeCompletionPromptParserService;
+
+    beforeEach(() => {
+        parserService = new DefaultCodeCompletionPromptParserService();
+    });
+
+    it('should parse valid metadata with requestSettings and return the modified prompt', () => {
+        const input = `---
+requestSettings:
+  max_new_tokens: 2024
+  stop: ['<|im_end|>']
+---
+Some other content.`;
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: {
+                requestSettings: {
+                    max_new_tokens: 2024,
+                    stop: ['<|im_end|>']
+                }
+            },
+            prompt: 'Some other content.'
+        });
+    });
+
+    it('should return undefined metadata and original prompt if metadata does not start on the first line', () => {
+        const input = `
+---
+requestSettings:
+  max_new_tokens: 2024
+---
+Some other content.`;
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: undefined,
+            prompt: input
+        });
+    });
+
+    it('should return undefined metadata and original prompt if metadata is not closed correctly', () => {
+        const input = `---
+requestSettings:
+  max_new_tokens: 2024
+Some other content.`;
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: undefined,
+            prompt: input
+        });
+    });
+
+    it('should return undefined metadata and original prompt if metadata is invalid YAML', () => {
+        const input = `---
+requestSettings:
+  max_new_tokens: 2024
+  stop: ['<|im_end|>
+---
+Some other content.`;
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: undefined,
+            prompt: input
+        });
+    });
+
+    it('should return undefined metadata and original prompt if there is no metadata', () => {
+        const input = 'Some other content.';
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: undefined,
+            prompt: input
+        });
+    });
+
+    it('should return undefined metadata and original prompt for valid but empty metadata', () => {
+        const input = `---
+---
+Some other content.`;
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: undefined,
+            prompt: input
+        });
+    });
+
+    it('should return undefined metadata and original prompt if metadata contains non-object content', () => {
+        const input = `---
+- some
+- list
+---
+Some other content.`;
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: undefined,
+            prompt: input
+        });
+    });
+
+    it('should correctly handle metadata followed by an empty prompt', () => {
+        const input = `---
+requestSettings:
+  max_new_tokens: 2024
+---
+`;
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: {
+                requestSettings: {
+                    max_new_tokens: 2024
+                }
+            },
+            prompt: ''
+        });
+    });
+
+    it('should correctly handle a prompt with no content after valid metadata', () => {
+        const input = `---
+requestSettings:
+  max_new_tokens: 2024
+---`;
+        const result = parserService.parse(input);
+        expect(result).to.deep.equal({
+            metadata: {
+                requestSettings: {
+                    max_new_tokens: 2024
+                }
+            },
+            prompt: ''
+        });
+    });
+});
+describe('CodeCompletionPromptMetaData', () => {
+    it('should return true for a valid metadata object with requestSettings', () => {
+        const validObject = {
+            requestSettings: { key1: 'value1', key2: 42 },
+        };
+        expect(CodeCompletionPromptMetaData.isStrict(validObject)).to.be.true;
+    });
+
+    it('should return true for a valid metadata object without requestSettings', () => {
+        const validObject = {};
+        expect(CodeCompletionPromptMetaData.isStrict(validObject)).to.be.true;
+    });
+
+    it('should return false for an object with additional unknown properties', () => {
+        const invalidObject = {
+            requestSettings: { key1: 'value1' },
+            extraKey: 'unexpected',
+        };
+        expect(CodeCompletionPromptMetaData.isStrict(invalidObject)).to.be.false;
+    });
+
+    it('should return false for an object where requestSettings is not an object', () => {
+        const invalidObject = {
+            requestSettings: 'invalid',
+        };
+        expect(CodeCompletionPromptMetaData.isStrict(invalidObject)).to.be.false;
+    });
+
+    it('should return false for an object where requestSettings is null', () => {
+        const invalidObject = {
+            // eslint-disable-next-line no-null/no-null
+            requestSettings: null,
+        };
+        expect(CodeCompletionPromptMetaData.isStrict(invalidObject)).to.be.false;
+    });
+
+    it('should return false for an object where requestSettings is an array', () => {
+        const invalidObject = {
+            requestSettings: ['invalid'],
+        };
+        expect(CodeCompletionPromptMetaData.isStrict(invalidObject)).to.be.false;
+    });
+
+    it('should return false for null', () => {
+        // eslint-disable-next-line no-null/no-null
+        expect(CodeCompletionPromptMetaData.isStrict(null)).to.be.false;
+    });
+
+    it('should return false for undefined', () => {
+        expect(CodeCompletionPromptMetaData.isStrict(undefined)).to.be.false;
+    });
+
+    it('should return false for a number', () => {
+        expect(CodeCompletionPromptMetaData.isStrict(42)).to.be.false;
+    });
+
+    it('should return false for a string', () => {
+        expect(CodeCompletionPromptMetaData.isStrict('string')).to.be.false;
+    });
+
+    it('should return false for an array', () => {
+        expect(CodeCompletionPromptMetaData.isStrict([])).to.be.false;
+    });
+
+    it('should return false for an object wit only unknown properties', () => {
+        const invalidObject = {
+            unknownKey: 'invalid',
+        };
+        expect(CodeCompletionPromptMetaData.isStrict(invalidObject)).to.be.false;
+    });
+
+});

--- a/packages/ai-code-completion/src/common/prompt-metadata-parsing-service.ts
+++ b/packages/ai-code-completion/src/common/prompt-metadata-parsing-service.ts
@@ -1,0 +1,99 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+//
+
+import { injectable } from '@theia/core/shared/inversify';
+import * as yaml from 'js-yaml';
+
+export interface CodeCompletionPromptMetaData {
+    requestSettings?: Record<string, unknown>;
+}
+
+export namespace CodeCompletionPromptMetaData {
+    export function isStrict(entry: unknown): entry is CodeCompletionPromptMetaData {
+        // eslint-disable-next-line no-null/no-null
+        if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+            return false;
+        }
+
+        const keys = Object.keys(entry);
+
+        const validKeys = ['requestSettings'];
+        if (!keys.every(key => validKeys.includes(key))) {
+            return false;
+        }
+
+        if ('requestSettings' in entry) {
+            const requestSettings = (entry as CodeCompletionPromptMetaData).requestSettings;
+            // eslint-disable-next-line no-null/no-null
+            if (requestSettings === null || typeof requestSettings !== 'object' || Array.isArray(requestSettings)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+export const CodeCompletionPromptParserService = Symbol('CodeCompletionPromptParserService');
+
+export interface CodeCompletionPromptParserService {
+    /**
+     * Parses a prompt template as a string input.
+     * If valid metadata is found, it is returned, and the metadata section is removed from the prompt.
+     * @param prompt - The prompt template to parse.
+     * @returns An object containing:
+     *   - `metadata`: The parsed CodeCompletionPromptMetaData or undefined if no valid metadata is found.
+     *   - `prompt`: The modified prompt string with the metadata section removed (if valid metadata was found).
+     */
+    parse(prompt: string): { metadata: CodeCompletionPromptMetaData | undefined; prompt: string };
+}
+
+@injectable()
+export class DefaultCodeCompletionPromptParserService implements CodeCompletionPromptParserService {
+    parse(prompt: string): { metadata: CodeCompletionPromptMetaData | undefined; prompt: string } {
+        if (!prompt) {
+            return { metadata: undefined, prompt };
+        }
+
+        const lines = prompt.split('\n');
+
+        if (!lines[0].trim().startsWith('---')) {
+            return { metadata: undefined, prompt };
+        }
+
+        const closingIndex = lines.indexOf('---', 1);
+        if (closingIndex === -1) {
+            return { metadata: undefined, prompt };
+        }
+
+        const metaDataLines = lines.slice(1, closingIndex).join('\n');
+
+        try {
+            const parsedData = yaml.load(metaDataLines);
+
+            if (!CodeCompletionPromptMetaData.isStrict(parsedData)) {
+                return { metadata: undefined, prompt };
+            }
+
+            // Remove the metadata section from the prompt
+            const modifiedPrompt = lines.slice(closingIndex + 1).join('\n');
+
+            return { metadata: parsedData, prompt: modifiedPrompt };
+        } catch {
+            return { metadata: undefined, prompt };
+        }
+    }
+}

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -137,14 +137,31 @@ export class AIAgentConfigurationWidget extends ReactWidget {
                     Enable Agent
                 </label>
             </div>
-            <div className='ai-templates'>
-                {agent.promptTemplates?.map(template =>
-                    <TemplateRenderer
-                        key={agent?.id + '.' + template.id}
-                        agentId={agent.id}
-                        template={template}
-                        promptCustomizationService={this.promptCustomizationService} />)}
+            <div className="settings-section-subcategory-title ai-settings-section-subcategory-title">
+                Prompt Templates
             </div>
+            <div className="ai-templates">
+                {(() => {
+                    const defaultTemplates = agent.promptTemplates?.filter(template => !template.variantOf) || [];
+                    return defaultTemplates.length > 0 ? (
+                        defaultTemplates.map(template => (
+                            <div key={agent.id + '.' + template.id}>
+                                <TemplateRenderer
+                                    key={agent.id + '.' + template.id}
+                                    agentId={agent.id}
+                                    template={template}
+                                    promptService={this.promptService}
+                                    aiSettingsService={this.aiSettingsService}
+                                    promptCustomizationService={this.promptCustomizationService}
+                                />
+                            </div>
+                        ))
+                    ) : (
+                        <div>No default template available</div>
+                    );
+                })()}
+            </div>
+
             <div className='ai-lm-requirements'>
                 <LanguageModelRenderer
                     agent={agent}

--- a/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -197,7 +197,7 @@ export class AIAgentConfigurationWidget extends ReactWidget {
         const promptTemplates = agent.promptTemplates;
         const result: ParsedPrompt = { functions: [], globalVariables: [], agentSpecificVariables: [] };
         promptTemplates.forEach(template => {
-            const storedPrompt = this.promptService.getUnresolvedPrompt(template.id);
+            const storedPrompt = this.promptService.getUnresolvedMainPrompt(template.id);
             const prompt = storedPrompt?.template ?? template.template;
             const variableMatches = matchVariablesRegEx(prompt);
 

--- a/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
@@ -14,26 +14,103 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import * as React from '@theia/core/shared/react';
-import { PromptCustomizationService } from '../../common/prompt-service';
-import { PromptTemplate } from '../../common';
+import { PromptCustomizationService, PromptService } from '../../common/prompt-service';
+import { AISettingsService, PromptTemplate } from '../../common';
 
-export interface TemplateSettingProps {
+const DEFAULT_VARIANT = 'default';
+
+export interface TemplateRendererProps {
     agentId: string;
     template: PromptTemplate;
     promptCustomizationService: PromptCustomizationService;
+    promptService: PromptService;
+    aiSettingsService: AISettingsService;
 }
 
-export const TemplateRenderer: React.FC<TemplateSettingProps> = ({ agentId, template, promptCustomizationService }) => {
-    const openTemplate = React.useCallback(async () => {
-        promptCustomizationService.editTemplate(template.id, template.template);
-    }, [template, promptCustomizationService]);
-    const resetTemplate = React.useCallback(async () => {
-        promptCustomizationService.resetTemplate(template.id);
-    }, [promptCustomizationService, template]);
+export const TemplateRenderer: React.FC<TemplateRendererProps> = ({
+    agentId,
+    template,
+    promptCustomizationService,
+    promptService,
+    aiSettingsService,
+}) => {
+    const [variantIds, setVariantIds] = React.useState<string[]>([]);
+    const [selectedVariant, setSelectedVariant] = React.useState<string>(DEFAULT_VARIANT);
 
-    return <>
-        {template.id}
-        <button className='theia-button main' onClick={openTemplate}>Edit</button>
-        <button className='theia-button secondary' onClick={resetTemplate}>Reset</button>
-    </>;
+    React.useEffect(() => {
+        (async () => {
+            const variants = promptService.getVariantIds(template.id);
+            setVariantIds([DEFAULT_VARIANT, ...variants]);
+
+            const agentSettings = await aiSettingsService.getAgentSettings(agentId);
+            const currentVariant =
+                agentSettings?.selectedVariants?.[template.id] || DEFAULT_VARIANT;
+            setSelectedVariant(currentVariant);
+        })();
+    }, [template.id, promptService, aiSettingsService, agentId]);
+
+    const handleVariantChange = async (event: React.ChangeEvent<HTMLSelectElement>) => {
+        const newVariant = event.target.value;
+        setSelectedVariant(newVariant);
+
+        const agentSettings = await aiSettingsService.getAgentSettings(agentId);
+        const selectedVariants = agentSettings?.selectedVariants || {};
+
+        const updatedVariants = { ...selectedVariants };
+        if (newVariant === DEFAULT_VARIANT) {
+            delete updatedVariants[template.id];
+        } else {
+            updatedVariants[template.id] = newVariant;
+        }
+
+        await aiSettingsService.updateAgentSettings(agentId, {
+            selectedVariants: updatedVariants,
+        });
+    };
+
+    const openTemplate = React.useCallback(async () => {
+        const templateId = selectedVariant === DEFAULT_VARIANT ? template.id : selectedVariant;
+        const selectedTemplate = promptService.getRawPrompt(templateId);
+        promptCustomizationService.editTemplate(templateId, selectedTemplate?.template || '');
+    }, [selectedVariant, template.id, promptService, promptCustomizationService]);
+
+    const resetTemplate = React.useCallback(async () => {
+        const templateId = selectedVariant === DEFAULT_VARIANT ? template.id : selectedVariant;
+        promptCustomizationService.resetTemplate(templateId);
+    }, [selectedVariant, template.id, promptCustomizationService]);
+
+    return (
+        <div className="template-renderer">
+            <div className="settings-section-title template-header">
+                <strong>{template.id}</strong>
+            </div>
+            <div className="template-controls">
+                {variantIds.length > 1 && (
+                    <>
+                        <label htmlFor={`variant-selector-${template.id}`} className="template-select-label">
+                            Select Variant:
+                        </label>
+                        <select
+                            id={`variant-selector-${template.id}`}
+                            className="theia-select template-variant-selector"
+                            value={selectedVariant}
+                            onChange={handleVariantChange}
+                        >
+                            {variantIds.map(variantId => (
+                                <option key={variantId} value={variantId}>
+                                    {variantId}
+                                </option>
+                            ))}
+                        </select>
+                    </>
+                )}
+                <button className="theia-button main" onClick={openTemplate}>
+                    Edit
+                </button>
+                <button className="theia-button secondary" onClick={resetTemplate}>
+                    Reset
+                </button>
+            </div>
+        </div>
+    );
 };

--- a/packages/ai-core/src/browser/style/index.css
+++ b/packages/ai-core/src/browser/style/index.css
@@ -14,13 +14,41 @@
   margin-left: var(--theia-ui-padding);
 }
 
-.ai-templates {
-  display: grid;
-  /** Display content in 3 columns */
-  grid-template-columns: 1fr auto auto;
-  /** add a 3px gap between rows */
-  row-gap: 3px;
+.theia-settings-container .settings-section-subcategory-title.ai-settings-section-subcategory-title {
+  padding-left: 0;
 }
+
+.ai-templates {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.template-renderer {
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+}
+
+.template-header {
+  margin-bottom: 8px;
+}
+
+.template-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.template-select-label {
+  margin-right: 5px;
+}
+
+.template-variant-selector {
+  min-width: 120px;
+}
+
+
 
 #ai-variable-configuration-container-widget,
 #ai-agent-configuration-container-widget {

--- a/packages/ai-core/src/common/agent-service.ts
+++ b/packages/ai-core/src/common/agent-service.ts
@@ -99,7 +99,7 @@ export class AgentServiceImpl implements AgentService {
     registerAgent(agent: Agent): void {
         this._agents.push(agent);
         agent.promptTemplates.forEach(
-            template => this.promptService.storePrompt(template.id, template.template)
+            template => this.promptService.storePromptTemplate(template)
         );
         this.onDidChangeAgentsEmitter.fire();
     }

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -37,10 +37,10 @@ describe('PromptService', () => {
         container.bind<AIVariableService>(AIVariableService).toConstantValue(variableService);
 
         promptService = container.get<PromptService>(PromptService);
-        promptService.storePrompt('1', 'Hello, {{name}}!');
-        promptService.storePrompt('2', 'Goodbye, {{name}}!');
-        promptService.storePrompt('3', 'Ciao, {{invalid}}!');
-        promptService.storePrompt('8', 'Hello, {{{name}}}');
+        promptService.storePromptTemplate({ id: '1', template: 'Hello, {{name}}!' });
+        promptService.storePromptTemplate({ id: '2', template: 'Goodbye, {{name}}!' });
+        promptService.storePromptTemplate({ id: '3', template: 'Ciao, {{invalid}}!' });
+        promptService.storePromptTemplate({ id: '8', template: 'Hello, {{{name}}}' });
     });
 
     it('should initialize prompts from PromptCollectionService', () => {
@@ -62,7 +62,7 @@ describe('PromptService', () => {
     });
 
     it('should store a new prompt', () => {
-        promptService.storePrompt('3', 'Welcome, {{name}}!');
+        promptService.storePromptTemplate({ id: '3', template: 'Welcome, {{name}}!' });
         const newPrompt = promptService.getRawPrompt('3');
         expect(newPrompt?.template).to.equal('Welcome, {{name}}!');
     });
@@ -88,10 +88,10 @@ describe('PromptService', () => {
     });
 
     it('should ignore whitespace in variables', async () => {
-        promptService.storePrompt('4', 'Hello, {{name }}!');
-        promptService.storePrompt('5', 'Hello, {{ name}}!');
-        promptService.storePrompt('6', 'Hello, {{ name }}!');
-        promptService.storePrompt('7', 'Hello, {{       name           }}!');
+        promptService.storePromptTemplate({ id: '4', template: 'Hello, {{name }}!' });
+        promptService.storePromptTemplate({ id: '5', template: 'Hello, {{ name}}!' });
+        promptService.storePromptTemplate({ id: '6', template: 'Hello, {{ name }}!' });
+        promptService.storePromptTemplate({ id: '7', template: 'Hello, {{       name           }}!' });
         for (let i = 4; i <= 7; i++) {
             const prompt = await promptService.getPrompt(`${i}`, { name: 'John' });
             expect(prompt?.text).to.equal('Hello, John!');
@@ -109,10 +109,10 @@ describe('PromptService', () => {
     });
 
     it('should ignore whitespace in variables (three bracket)', async () => {
-        promptService.storePrompt('9', 'Hello, {{{name }}}');
-        promptService.storePrompt('10', 'Hello, {{{ name}}}');
-        promptService.storePrompt('11', 'Hello, {{{ name }}}');
-        promptService.storePrompt('12', 'Hello, {{{       name           }}}');
+        promptService.storePromptTemplate({ id: '9', template: 'Hello, {{{name }}}' });
+        promptService.storePromptTemplate({ id: '10', template: 'Hello, {{{ name}}}' });
+        promptService.storePromptTemplate({ id: '11', template: 'Hello, {{{ name }}}' });
+        promptService.storePromptTemplate({ id: '12', template: 'Hello, {{{       name           }}}' });
         for (let i = 9; i <= 12; i++) {
             const prompt = await promptService.getPrompt(`${i}`, { name: 'John' });
             expect(prompt?.text).to.equal('Hello, John');
@@ -120,26 +120,24 @@ describe('PromptService', () => {
     });
 
     it('should ignore invalid prompts with unmatched brackets', async () => {
-        promptService.storePrompt('9', 'Hello, {{name');
-        promptService.storePrompt('10', 'Hello, {{{name');
-        promptService.storePrompt('11', 'Hello, name}}}}');
+        promptService.storePromptTemplate({ id: '9', template: 'Hello, {{name' });
+        promptService.storePromptTemplate({ id: '10', template: 'Hello, {{{name' });
+        promptService.storePromptTemplate({ id: '11', template: 'Hello, name}}}}' });
         const prompt1 = await promptService.getPrompt('9', { name: 'John' });
         expect(prompt1?.text).to.equal('Hello, {{name'); // Not matching due to missing closing brackets
-
         const prompt2 = await promptService.getPrompt('10', { name: 'John' });
         expect(prompt2?.text).to.equal('Hello, {{{name'); // Matches pattern due to valid three-start-two-end brackets
-
         const prompt3 = await promptService.getPrompt('11', { name: 'John' });
         expect(prompt3?.text).to.equal('Hello, name}}}}'); // Extra closing bracket, does not match cleanly
     });
 
     it('should handle a mixture of two and three brackets correctly', async () => {
-        promptService.storePrompt('12', 'Hi, {{name}}}');            // (invalid)
-        promptService.storePrompt('13', 'Hello, {{{name}}');         // (invalid)
-        promptService.storePrompt('14', 'Greetings, {{{name}}}}');   // (invalid)
-        promptService.storePrompt('15', 'Bye, {{{{name}}}');         // (invalid)
-        promptService.storePrompt('16', 'Ciao, {{{{name}}}}');       // (invalid)
-        promptService.storePrompt('17', 'Hi, {{name}}! {{{name}}}'); // Mixed valid patterns
+        promptService.storePromptTemplate({ id: '12', template: 'Hi, {{name}}}' });            // (invalid)
+        promptService.storePromptTemplate({ id: '13', template: 'Hello, {{{name}}' });         // (invalid)
+        promptService.storePromptTemplate({ id: '14', template: 'Greetings, {{{name}}}}' });   // (invalid)
+        promptService.storePromptTemplate({ id: '15', template: 'Bye, {{{{name}}}' });         // (invalid)
+        promptService.storePromptTemplate({ id: '16', template: 'Ciao, {{{{name}}}}' });       // (invalid)
+        promptService.storePromptTemplate({ id: '17', template: 'Hi, {{name}}! {{{name}}}' }); // Mixed valid patterns
 
         const prompt12 = await promptService.getPrompt('12', { name: 'John' });
         expect(prompt12?.text).to.equal('Hi, {{name}}}');
@@ -161,87 +159,143 @@ describe('PromptService', () => {
     });
 
     it('should strip single-line comments at the start of the template', () => {
-        promptService.storePrompt('comment-basic', '{{!-- Comment --}}Hello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-basic', template: '{{!-- Comment --}}Hello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-basic');
         expect(prompt?.template).to.equal('Hello, {{name}}!');
     });
 
     it('should remove line break after first-line comment', () => {
-        promptService.storePrompt('comment-line-break', '{{!-- Comment --}}\nHello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-line-break', template: '{{!-- Comment --}}\nHello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-line-break');
         expect(prompt?.template).to.equal('Hello, {{name}}!');
     });
 
     it('should strip multiline comments at the start of the template', () => {
-        promptService.storePrompt('comment-multiline', '{{!--\nMultiline comment\n--}}\nGoodbye, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-multiline', template: '{{!--\nMultiline comment\n--}}\nGoodbye, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-multiline');
         expect(prompt?.template).to.equal('Goodbye, {{name}}!');
     });
 
     it('should not strip comments not in the first line', () => {
-        promptService.storePrompt('comment-second-line', 'Hello, {{name}}!\n{{!-- Comment --}}');
+        promptService.storePromptTemplate({ id: 'comment-second-line', template: 'Hello, {{name}}!\n{{!-- Comment --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-second-line');
         expect(prompt?.template).to.equal('Hello, {{name}}!\n{{!-- Comment --}}');
     });
 
     it('should treat unclosed comments as regular text', () => {
-        promptService.storePrompt('comment-unclosed', '{{!-- Unclosed comment');
+        promptService.storePromptTemplate({ id: 'comment-unclosed', template: '{{!-- Unclosed comment' });
         const prompt = promptService.getUnresolvedPrompt('comment-unclosed');
         expect(prompt?.template).to.equal('{{!-- Unclosed comment');
     });
 
     it('should treat standalone closing delimiters as regular text', () => {
-        promptService.storePrompt('comment-standalone', '--}} Hello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-standalone', template: '--}} Hello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-standalone');
         expect(prompt?.template).to.equal('--}} Hello, {{name}}!');
     });
 
     it('should handle nested comments and stop at the first closing tag', () => {
-        promptService.storePrompt('nested-comment', '{{!-- {{!-- Nested comment --}} --}}text');
+        promptService.storePromptTemplate({ id: 'nested-comment', template: '{{!-- {{!-- Nested comment --}} --}}text' });
         const prompt = promptService.getUnresolvedPrompt('nested-comment');
         expect(prompt?.template).to.equal('--}}text');
     });
 
     it('should handle templates with only comments', () => {
-        promptService.storePrompt('comment-only', '{{!-- Only comments --}}');
+        promptService.storePromptTemplate({ id: 'comment-only', template: '{{!-- Only comments --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-only');
         expect(prompt?.template).to.equal('');
     });
 
     it('should handle mixed delimiters on the same line', () => {
-        promptService.storePrompt('comment-mixed', '{{!-- Unclosed comment --}}');
+        promptService.storePromptTemplate({ id: 'comment-mixed', template: '{{!-- Unclosed comment --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-mixed');
         expect(prompt?.template).to.equal('');
     });
 
     it('should resolve variables after stripping single-line comments', async () => {
-        promptService.storePrompt('comment-resolve', '{{!-- Comment --}}Hello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-resolve', template: '{{!-- Comment --}}Hello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-resolve', { name: 'John' });
         expect(prompt?.text).to.equal('Hello, John!');
     });
 
     it('should resolve variables in multiline templates with comments', async () => {
-        promptService.storePrompt('comment-multiline-vars', '{{!--\nMultiline comment\n--}}\nHello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-multiline-vars', template: '{{!--\nMultiline comment\n--}}\nHello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-multiline-vars', { name: 'John' });
         expect(prompt?.text).to.equal('Hello, John!');
     });
 
     it('should resolve variables with standalone closing delimiters', async () => {
-        promptService.storePrompt('comment-standalone-vars', '--}} Hello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-standalone-vars', template: '--}} Hello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-standalone-vars', { name: 'John' });
         expect(prompt?.text).to.equal('--}} Hello, John!');
     });
 
     it('should treat unclosed comments as text and resolve variables', async () => {
-        promptService.storePrompt('comment-unclosed-vars', '{{!-- Unclosed comment\nHello, {{name}}!');
+        promptService.storePromptTemplate({ id: 'comment-unclosed-vars', template: '{{!-- Unclosed comment\nHello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-unclosed-vars', { name: 'John' });
         expect(prompt?.text).to.equal('{{!-- Unclosed comment\nHello, John!');
     });
 
     it('should handle templates with mixed comments and variables', async () => {
-        promptService.storePrompt('comment-mixed-vars', '{{!-- Comment --}}Hi, {{name}}! {{!-- Another comment --}}');
+        promptService.storePromptTemplate({ id: 'comment-mixed-vars', template: '{{!-- Comment --}}Hi, {{name}}! {{!-- Another comment --}}' });
         const prompt = await promptService.getPrompt('comment-mixed-vars', { name: 'John' });
         expect(prompt?.text).to.equal('Hi, John! {{!-- Another comment --}}');
     });
 
+    it('should return all variant IDs of a given prompt', () => {
+        promptService.storePromptTemplate({ id: 'main', template: 'Main template' });
+
+        promptService.storePromptTemplate({
+            id: 'variant1',
+            template: 'Variant 1',
+            variantOf: 'main'
+        });
+        promptService.storePromptTemplate({
+            id: 'variant2',
+            template: 'Variant 2',
+            variantOf: 'main'
+        });
+        promptService.storePromptTemplate({
+            id: 'variant3',
+            template: 'Variant 3',
+            variantOf: 'main'
+        });
+
+        const variantIds = promptService.getVariantIds('main');
+        expect(variantIds).to.deep.equal(['variant1', 'variant2', 'variant3']);
+    });
+
+    it('should return an empty array if no variants exist for a given prompt', () => {
+        promptService.storePromptTemplate({ id: 'main', template: 'Main template' });
+
+        const variantIds = promptService.getVariantIds('main');
+        expect(variantIds).to.deep.equal([]);
+    });
+
+    it('should return an empty array if the main prompt ID does not exist', () => {
+        const variantIds = promptService.getVariantIds('nonExistent');
+        expect(variantIds).to.deep.equal([]);
+    });
+
+    it('should not influence prompts without variants when other prompts have variants', () => {
+        promptService.storePromptTemplate({ id: 'mainWithVariants', template: 'Main template with variants' });
+        promptService.storePromptTemplate({ id: 'mainWithoutVariants', template: 'Main template without variants' });
+
+        promptService.storePromptTemplate({
+            id: 'variant1',
+            template: 'Variant 1',
+            variantOf: 'mainWithVariants'
+        });
+        promptService.storePromptTemplate({
+            id: 'variant2',
+            template: 'Variant 2',
+            variantOf: 'mainWithVariants'
+        });
+
+        const variantsForMainWithVariants = promptService.getVariantIds('mainWithVariants');
+        const variantsForMainWithoutVariants = promptService.getVariantIds('mainWithoutVariants');
+
+        expect(variantsForMainWithVariants).to.deep.equal(['variant1', 'variant2']);
+        expect(variantsForMainWithoutVariants).to.deep.equal([]);
+    });
 });

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -160,55 +160,55 @@ describe('PromptService', () => {
 
     it('should strip single-line comments at the start of the template', () => {
         promptService.storePromptTemplate({ id: 'comment-basic', template: '{{!-- Comment --}}Hello, {{name}}!' });
-        const prompt = promptService.getUnresolvedPrompt('comment-basic');
+        const prompt = promptService.getUnresolvedMainPrompt('comment-basic');
         expect(prompt?.template).to.equal('Hello, {{name}}!');
     });
 
     it('should remove line break after first-line comment', () => {
         promptService.storePromptTemplate({ id: 'comment-line-break', template: '{{!-- Comment --}}\nHello, {{name}}!' });
-        const prompt = promptService.getUnresolvedPrompt('comment-line-break');
+        const prompt = promptService.getUnresolvedMainPrompt('comment-line-break');
         expect(prompt?.template).to.equal('Hello, {{name}}!');
     });
 
     it('should strip multiline comments at the start of the template', () => {
         promptService.storePromptTemplate({ id: 'comment-multiline', template: '{{!--\nMultiline comment\n--}}\nGoodbye, {{name}}!' });
-        const prompt = promptService.getUnresolvedPrompt('comment-multiline');
+        const prompt = promptService.getUnresolvedMainPrompt('comment-multiline');
         expect(prompt?.template).to.equal('Goodbye, {{name}}!');
     });
 
     it('should not strip comments not in the first line', () => {
         promptService.storePromptTemplate({ id: 'comment-second-line', template: 'Hello, {{name}}!\n{{!-- Comment --}}' });
-        const prompt = promptService.getUnresolvedPrompt('comment-second-line');
+        const prompt = promptService.getUnresolvedMainPrompt('comment-second-line');
         expect(prompt?.template).to.equal('Hello, {{name}}!\n{{!-- Comment --}}');
     });
 
     it('should treat unclosed comments as regular text', () => {
         promptService.storePromptTemplate({ id: 'comment-unclosed', template: '{{!-- Unclosed comment' });
-        const prompt = promptService.getUnresolvedPrompt('comment-unclosed');
+        const prompt = promptService.getUnresolvedMainPrompt('comment-unclosed');
         expect(prompt?.template).to.equal('{{!-- Unclosed comment');
     });
 
     it('should treat standalone closing delimiters as regular text', () => {
         promptService.storePromptTemplate({ id: 'comment-standalone', template: '--}} Hello, {{name}}!' });
-        const prompt = promptService.getUnresolvedPrompt('comment-standalone');
+        const prompt = promptService.getUnresolvedMainPrompt('comment-standalone');
         expect(prompt?.template).to.equal('--}} Hello, {{name}}!');
     });
 
     it('should handle nested comments and stop at the first closing tag', () => {
         promptService.storePromptTemplate({ id: 'nested-comment', template: '{{!-- {{!-- Nested comment --}} --}}text' });
-        const prompt = promptService.getUnresolvedPrompt('nested-comment');
+        const prompt = promptService.getUnresolvedMainPrompt('nested-comment');
         expect(prompt?.template).to.equal('--}}text');
     });
 
     it('should handle templates with only comments', () => {
         promptService.storePromptTemplate({ id: 'comment-only', template: '{{!-- Only comments --}}' });
-        const prompt = promptService.getUnresolvedPrompt('comment-only');
+        const prompt = promptService.getUnresolvedMainPrompt('comment-only');
         expect(prompt?.template).to.equal('');
     });
 
     it('should handle mixed delimiters on the same line', () => {
         promptService.storePromptTemplate({ id: 'comment-mixed', template: '{{!-- Unclosed comment --}}' });
-        const prompt = promptService.getUnresolvedPrompt('comment-mixed');
+        const prompt = promptService.getUnresolvedMainPrompt('comment-mixed');
         expect(prompt?.template).to.equal('');
     });
 
@@ -298,4 +298,5 @@ describe('PromptService', () => {
         expect(variantsForMainWithVariants).to.deep.equal(['variant1', 'variant2']);
         expect(variantsForMainWithoutVariants).to.deep.equal([]);
     });
+
 });

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -21,10 +21,16 @@ import { ToolInvocationRegistry } from './tool-invocation-registry';
 import { toolRequestToPromptText } from './language-model-util';
 import { ToolRequest } from './language-model';
 import { matchFunctionsRegEx, matchVariablesRegEx } from './prompt-service-util';
+import { AISettingsService } from './settings-service';
 
 export interface PromptTemplate {
     id: string;
     template: string;
+    /**
+     * (Optional) The ID of the main template for which this template is a variant.
+     * If present, this indicates that the current template represents an alternative version of the specified main template.
+     */
+    variantOf?: string;
 }
 
 export interface PromptMap { [id: string]: PromptTemplate }
@@ -63,11 +69,10 @@ export interface PromptService {
      */
     getPrompt(id: string, args?: { [key: string]: unknown }): Promise<ResolvedPromptTemplate | undefined>;
     /**
-     * Adds a prompt to the list of prompts.
-     * @param id the id of the prompt
-     * @param prompt the prompt template to store
+     * Adds a {@link PromptTemplate} to the list of prompts.
+     * @param promptTemplate the prompt template to store
      */
-    storePrompt(id: string, prompt: string): void;
+    storePromptTemplate(promptTemplate: PromptTemplate): void;
     /**
      * Removes a prompt from the list of prompts.
      * @param id the id of the prompt
@@ -77,6 +82,20 @@ export interface PromptService {
      * Return all known prompts as a {@link PromptMap map}.
      */
     getAllPrompts(): PromptMap;
+    /**
+     * Retrieve all variant IDs of a given {@link PromptTemplate}.
+     * @param id the id of the main {@link PromptTemplate}
+     * @returns an array of string IDs representing the variants of the given template
+     */
+    getVariantIds(id: string): string[];
+    /**
+     * Retrieve the currently selected variant ID for a given main prompt ID.
+     * If a variant is selected for the main prompt, it will be returned.
+     * Otherwise, the main prompt ID will be returned.
+     * @param id the id of the main prompt
+     * @returns the variant ID if one is selected, or the main prompt ID otherwise
+     */
+    getVariantId(id: string): Promise<string>;
 }
 
 export interface CustomAgentDescription {
@@ -163,6 +182,9 @@ export interface PromptCustomizationService {
 
 @injectable()
 export class PromptServiceImpl implements PromptService {
+    @inject(AISettingsService) @optional()
+    protected readonly settingsService: AISettingsService | undefined;
+
     @inject(PromptCustomizationService) @optional()
     protected readonly customizationService: PromptCustomizationService | undefined;
 
@@ -203,8 +225,22 @@ export class PromptServiceImpl implements PromptService {
         return commentRegex.test(template) ? template.replace(commentRegex, '').trimStart() : template;
     }
 
+    async getVariantId(id: string): Promise<string> {
+        if (this.settingsService !== undefined) {
+            const agentSettingsMap = await this.settingsService.getSettings();
+
+            for (const agentSettings of Object.values(agentSettingsMap)) {
+                if (agentSettings.selectedVariants && agentSettings.selectedVariants[id]) {
+                    return agentSettings.selectedVariants[id];
+                }
+            }
+        }
+        return id;
+    }
+
     async getPrompt(id: string, args?: { [key: string]: unknown }): Promise<ResolvedPromptTemplate | undefined> {
-        const prompt = this.getUnresolvedPrompt(id);
+        const variantId = await this.getVariantId(id);
+        const prompt = this.getUnresolvedPrompt(variantId);
         if (prompt === undefined) {
             return undefined;
         }
@@ -274,10 +310,15 @@ export class PromptServiceImpl implements PromptService {
             return { ...this._prompts };
         }
     }
-    storePrompt(id: string, prompt: string): void {
-        this._prompts[id] = { id, template: prompt };
-    }
     removePrompt(id: string): void {
         delete this._prompts[id];
+    }
+    getVariantIds(id: string): string[] {
+        return Object.values(this._prompts)
+            .filter(prompt => prompt.variantOf === id)
+            .map(variant => variant.id);
+    }
+    storePromptTemplate(promptTemplate: PromptTemplate): void {
+        this._prompts[promptTemplate.id] = promptTemplate;
     }
 }

--- a/packages/ai-core/src/common/settings-service.ts
+++ b/packages/ai-core/src/common/settings-service.ts
@@ -30,4 +30,9 @@ export type AISettings = Record<string, AgentSettings>;
 export interface AgentSettings {
     languageModelRequirements?: LanguageModelRequirement[];
     enable?: boolean;
+    /**
+     * A mapping of main template IDs to their selected variant IDs.
+     * If a main template is not present in this mapping, it means the main template is used.
+     */
+    selectedVariants?: Record<string, string>;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Allows to add request Settings to prompt templates used by the code completion agent in the following format:
---
requestSettings:
 stop: ['<file_sep>']
 ...otherSettings
---
actual prompt

If the metadata cannot be parsed, it will remain as plain text and not be considered at all.
Meta data must start in the first line.

**Note: This is meant as an early access feature to allow easily iterating over code completion prompts. We might change the format of the meta data or even move it somewhere else.**
The prompt editor is currently unaware of the meta data and will not highlight them.

The prompt service is adapted to:
- Also use variants on unresolved prompts
- Allow to resolve prompts manually

#### How to test
- There are automated tests
- Connect to StarCoder (e.g. bigcode/starcoder2-15b via HugginFace Serverless)
- Use it for the code completion agent
- Use this prompt (with and without the requestSettings)
---
requestSettings:
 stop: ['<file_sep>']
---
<fim_prefix>{{{prefix}}}<fim_suffix>{{{suffix}}}<fim_middle>

- A good case to produce <file_sep> is to remove and then autocomplete the line
bind(FrontendApplicationContribution).toService(OpenAiFrontendApplicationContribution);
in openai-frontend-module.ts

#### Follow-ups

We should consider allowing configuring default request parameters per model.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
