### PR TITLE
Allow adding variant via prompttemplate files

### DIFF
--- a/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
@@ -84,7 +84,7 @@ export const TemplateRenderer: React.FC<TemplateRendererProps> = ({
                 <strong>{template.id}</strong>
             </div>
             <div className="template-controls">
-                {variantIds.length > 1 && (
+                {(variantIds.length > 1 || isInvalidVariant) && (
                     <>
                         <label htmlFor={`variant-selector-${template.id}`} className="template-select-label">
                             Select Variant:

--- a/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
+++ b/packages/ai-core/src/browser/ai-configuration/template-settings-renderer.tsx
@@ -37,7 +37,7 @@ export const TemplateRenderer: React.FC<TemplateRendererProps> = ({
     const variantIds = [DEFAULT_VARIANT, ...promptService.getVariantIds(template.id)];
     const [selectedVariant, setSelectedVariant] = React.useState<string>(DEFAULT_VARIANT);
 
-    React.useMemo(() => {
+    React.useEffect(() => {
         (async () => {
             const agentSettings = await aiSettingsService.getAgentSettings(agentId);
             const currentVariant =

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -169,6 +169,10 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
         return this.templates.get(id);
     }
 
+    getCustomPromptTemplateIDs(): string[] {
+        return Array.from(this.templates.keys());
+    }
+
     async editTemplate(id: string, defaultContent?: string): Promise<void> {
         const editorUri = await this.getTemplateURI(id);
         if (! await this.fileService.exists(editorUri)) {

--- a/packages/ai-core/src/browser/style/index.css
+++ b/packages/ai-core/src/browser/style/index.css
@@ -48,7 +48,11 @@
   min-width: 120px;
 }
 
-
+.template-variant-selector.error {
+  border-color: var(--theia-errorForeground);
+  background-color: var(--theia-errorBackground, rgba(255, 0, 0, 0.1));
+  color: var(--theia-errorForeground);
+}
 
 #ai-variable-configuration-container-widget,
 #ai-agent-configuration-container-widget {

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -136,6 +136,7 @@ export interface PromptCustomizationService {
      */
     getCustomizedPromptTemplate(id: string): string | undefined
 
+    getCustomPromptTemplateIDs(): string[];
     /**
      * Edit the template. If the content is specified, is will be
      * used to customize the template. Otherwise, the behavior depends
@@ -314,9 +315,18 @@ export class PromptServiceImpl implements PromptService {
         delete this._prompts[id];
     }
     getVariantIds(id: string): string[] {
-        return Object.values(this._prompts)
+        const allCustomPromptTemplateIds = this.customizationService?.getCustomPromptTemplateIDs() || [];
+        const knownPromptIds = Object.keys(this._prompts);
+
+        // We filter out known IDs from the custom prompt template IDs, these are no variants, but customizations. Then we retain IDs that start with the main ID
+        const customVariantIds = allCustomPromptTemplateIds.filter(customId =>
+            !knownPromptIds.includes(customId) && customId.startsWith(id)
+        );
+        const variantIds = Object.values(this._prompts)
             .filter(prompt => prompt.variantOf === id)
             .map(variant => variant.id);
+
+        return [...variantIds, ...customVariantIds];
     }
     storePromptTemplate(promptTemplate: PromptTemplate): void {
         this._prompts[promptTemplate.id] = promptTemplate;


### PR DESCRIPTION
fixed #14507

#### What it does

Allows users to add custom variants to existing main prompts via adding .prompttemplate files.
If the file name of a .prompttemplate file starts with the id of an existing main prompt, the custom prompt file is treated as a variant.

#### How to test

- Create a new .prompttemplate file which starts with the id of an existing main prompt template.
- Browse to the respective agent and select the variant
- Edit the variant
- No other prompt feature should be influenced

#### Follow-ups

we might allow users to create variants in the UI

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
