### PR TITLE
DevContainers: Support THEIA_DEFAULT_PLUGINS

### DIFF
--- a/packages/plugin-ext/src/main/node/plugin-remote-cli-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-remote-cli-contribution.ts
@@ -27,10 +27,11 @@ export class PluginRemoteCliContribution implements RemoteCliContribution {
 
     enhanceArgs(context: RemoteCliContext): MaybePromise<string[]> {
         const pluginsFolder = this.pluginCliContribution.localDir();
-        if (!pluginsFolder) {
-            return [];
-        } else {
+        const defaultPlugins = process.env.THEIA_DEFAULT_PLUGINS;
+        if (pluginsFolder || defaultPlugins) {
             return ['--plugins=local-dir:./plugins'];
         }
+        return [];
+
     }
 }

--- a/packages/plugin-ext/src/main/node/plugin-remote-copy-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-remote-copy-contribution.ts
@@ -27,10 +27,13 @@ export class PluginRemoteCopyContribution implements RemoteCopyContribution {
 
     async copy(registry: RemoteCopyRegistry): Promise<void> {
         const localDir = this.pluginCliContribution.localDir();
-        if (localDir) {
-            const fsPath = FileUri.fsPath(localDir);
-            await registry.directory(fsPath, 'plugins');
-        }
+        const defaultPlugins = process.env.THEIA_DEFAULT_PLUGINS?.split(',') ?? [];
 
+        await Promise.all([localDir, ...defaultPlugins]
+            .filter(pluginDir => pluginDir && pluginDir.startsWith('local-dir:'))
+            .map(async (pluginDir: string) => {
+                const fsPath = FileUri.fsPath(pluginDir);
+                await registry.directory(fsPath, 'plugins');
+            }));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/14137

Adds support for copying and using plugins defined by local-dir through THEIA_DEFAULT_PLUGINS env variable

#### How to test

remove the "--plugins=local-dir:../../plugins" fro your start target, 
set THEIA_DEFAULT_PLUGINS environment variable to "--plugins=local-dir:../../plugins". 
reopen in any dev container. See that the plugins should be correctly applied

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
