### PR TITLE
Fixed container stopping on disconnect and application close

### DIFF
--- a/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
@@ -31,7 +31,7 @@ import { DockerContainerService } from './docker-container-service';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { WriteStream } from 'tty';
 import { PassThrough } from 'stream';
-import { exec } from 'child_process';
+import { exec, execSync } from 'child_process';
 import { DevContainerFileService } from './dev-container-file-service';
 import { ContainerOutputProvider } from '../electron-common/container-output-provider';
 
@@ -303,9 +303,13 @@ export class RemoteDockerContainerConnection implements RemoteConnection {
         return deferred.promise;
     }
 
-    async dispose(): Promise<void> {
+    disposeSync(): void {
         // cant use dockerrode here since this needs to happen on one tick
-        exec(`docker stop ${this.container.id}`);
+        execSync(`docker stop ${this.container.id}`);
+    }
+
+    async dispose(): Promise<void> {
+        return this.container.stop();
     }
 
 }

--- a/packages/remote/src/electron-browser/remote-frontend-contribution.ts
+++ b/packages/remote/src/electron-browser/remote-frontend-contribution.ts
@@ -105,10 +105,13 @@ export class RemoteFrontendContribution implements CommandContribution, Frontend
         });
     }
 
-    protected disconnectRemote(): void {
-        const port = new URLSearchParams(location.search).get('localPort');
-        if (port) {
-            this.windowService.reload({ search: { port } });
+    protected async disconnectRemote(): Promise<void> {
+        const searchParams = new URLSearchParams(location.search);
+        const localPort = searchParams.get('localPort');
+        if (localPort) {
+            const currentPort = searchParams.get('port');
+            this.remoteStatusService.connectionClosed(parseInt(currentPort ?? '0'));
+            this.windowService.reload({ search: { port: localPort } });
         }
     }
 

--- a/packages/remote/src/electron-common/remote-status-service.ts
+++ b/packages/remote/src/electron-common/remote-status-service.ts
@@ -31,5 +31,7 @@ export const RemoteStatusServicePath = '/remote/status';
 export const RemoteStatusService = Symbol('RemoteStatusService');
 
 export interface RemoteStatusService {
-    getStatus(localPort: number): Promise<RemoteStatus>
+    getStatus(localPort: number): Promise<RemoteStatus>;
+
+    connectionClosed(localPort: number): Promise<void>;
 }

--- a/packages/remote/src/electron-node/remote-connection-service.ts
+++ b/packages/remote/src/electron-node/remote-connection-service.ts
@@ -50,7 +50,11 @@ export class RemoteConnectionService implements BackendApplicationContribution {
 
     onStop(): void {
         for (const connection of this.connections.values()) {
-            connection.dispose();
+            if (connection.disposeSync) {
+                connection.disposeSync();
+            } else {
+                connection.dispose();
+            };
         }
     }
 }

--- a/packages/remote/src/electron-node/remote-status-service.ts
+++ b/packages/remote/src/electron-node/remote-status-service.ts
@@ -38,4 +38,11 @@ export class RemoteStatusServiceImpl implements RemoteStatusService {
             };
         }
     }
+
+    async connectionClosed(localPort: number): Promise<void> {
+        const connection = this.remoteConnectionService.getConnectionFromPort(localPort);
+        if (connection) {
+            connection.dispose();
+        }
+    }
 }

--- a/packages/remote/src/electron-node/remote-types.ts
+++ b/packages/remote/src/electron-node/remote-types.ts
@@ -61,4 +61,9 @@ export interface RemoteConnection extends Disposable {
      * copy files from local to remote
      */
     copy(localPath: string | Buffer | NodeJS.ReadableStream, remotePath: string): Promise<void>;
+
+    /**
+     * used for disposing when theia is shutting down
+     */
+    disposeSync?(): void;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes stopping dev-containers when the connection is closed or when theia is closed while the container is still running.
Fixes #14310

#### How to test

Connect to any dev-container. Use the `close remote connection`, see in docker that the container has been stopped after a few seconds.
Same with just closing the application while connected to a dev-container.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
