### PR TITLE
On darwin/arm64 force docker to pull amd64 image

### DIFF
--- a/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
@@ -37,7 +37,10 @@ export class ImageFileContribution implements ContainerCreationContribution {
     async handleContainerCreation(createOptions: Docker.ContainerCreateOptions, containerConfig: ImageContainer,
         api: Docker, outputprovider: ContainerOutputProvider): Promise<void> {
         if (containerConfig.image) {
-            await new Promise<void>((res, rej) => api.pull(containerConfig.image, {}, (err, stream) => {
+            const platform = process.platform;
+            const arch = process.arch;
+            const options = platform === 'darwin' && arch === 'arm64' ? { platform: 'amd64' } : {};
+            await new Promise<void>((res, rej) => api.pull(containerConfig.image, options, (err, stream) => {
                 if (err) {
                     rej(err);
                 } else {

--- a/packages/remote/src/electron-node/setup/remote-setup-service.ts
+++ b/packages/remote/src/electron-node/setup/remote-setup-service.ts
@@ -167,6 +167,8 @@ export class RemoteSetupService {
                 arch = 'x64';
             } else if (archResult.match(/i\d83/)) { // i386, i483, i683
                 arch = 'x86';
+            } else if (archResult.includes('aarch64')) {
+                arch = 'arm64';
             } else {
                 arch = archResult.trim();
             }


### PR DESCRIPTION
#### What it does
Using dev containers on a Mac with ARM architecture is currently only possible by pulling an image for AMD64 architecture. 
This workaround checks respective combination (darwin/arm64) and forces Docker to pull a AMD64 image. 
Note: DevContainer could work a bit slow but at least it will. 

#### How to test
Get yourself a Mac with at least a M1 chip. :-) 
Start theia as Electron app and connect to a dev container. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
