### PR TITLE
Dev Container uses the right workspace now

### DIFF
--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -84,8 +84,8 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
     }
 
     async getOrSelectDevcontainerFile(): Promise<string | undefined> {
-        const workspace = await this.workspaceService.workspace;
-        if(!workspace) {
+        const workspace = this.workspaceService.workspace;
+        if (!workspace) {
             return;
         }
         const devcontainerFiles = await this.connectionProvider.getDevContainerFiles(workspace.resource.path.toString());

--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -84,7 +84,11 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
     }
 
     async getOrSelectDevcontainerFile(): Promise<string | undefined> {
-        const devcontainerFiles = await this.connectionProvider.getDevContainerFiles();
+        const workspace = await this.workspaceService.workspace;
+        if(!workspace) {
+            return;
+        }
+        const devcontainerFiles = await this.connectionProvider.getDevContainerFiles(workspace.resource.path.toString());
 
         if (devcontainerFiles.length === 1) {
             return devcontainerFiles[0].path;

--- a/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
@@ -46,6 +46,6 @@ export interface DevContainerFile {
 
 export interface RemoteContainerConnectionProvider extends RpcServer<ContainerOutputProvider> {
     connectToContainer(options: ContainerConnectionOptions): Promise<ContainerConnectionResult>;
-    getDevContainerFiles(): Promise<DevContainerFile[]>;
+    getDevContainerFiles(workspacePath: string): Promise<DevContainerFile[]>;
     getCurrentContainerInfo(port: number): Promise<ContainerInspectInfo | undefined>;
 }

--- a/packages/dev-container/src/electron-node/dev-container-file-service.ts
+++ b/packages/dev-container/src/electron-node/dev-container-file-service.ts
@@ -38,12 +38,7 @@ export class DevContainerFileService {
         return configuration;
     }
 
-    async getAvailableFiles(): Promise<DevContainerFile[]> {
-        const workspace = await this.workspaceServer.getMostRecentlyUsedWorkspace();
-        if (!workspace) {
-            return [];
-        }
-
+    async getAvailableFiles(workspace: string): Promise<DevContainerFile[]> {
         const devcontainerPath = new URI(workspace).path.join('.devcontainer').fsPath();
 
         return (await this.searchForDevontainerJsonFiles(devcontainerPath, 1)).map(file => ({
@@ -54,7 +49,7 @@ export class DevContainerFileService {
     }
 
     protected async searchForDevontainerJsonFiles(directory: string, depth: number): Promise<string[]> {
-        if (depth < 0) {
+        if (depth < 0 || !fs.existsSync(directory)) {
             return [];
         }
         const filesPaths = (await fs.readdir(directory)).map(file => new Path(directory).join(file).fsPath());

--- a/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
@@ -121,8 +121,8 @@ export class DevContainerConnectionProvider implements RemoteContainerConnection
         }
     }
 
-    getDevContainerFiles(): Promise<DevContainerFile[]> {
-        return this.devContainerFileService.getAvailableFiles();
+    getDevContainerFiles(workspacePath: string): Promise<DevContainerFile[]> {
+        return this.devContainerFileService.getAvailableFiles(workspacePath);
     }
 
     async createContainerConnection(container: Docker.Container, docker: Docker, name?: string): Promise<RemoteDockerContainerConnection> {


### PR DESCRIPTION
#### What it does

When there are more than one workspaces open the config json is picked from the right workspace. 
Solves #14307

#### How to test

See #14307 and try to reproduce the issue. Should not be possible anymore. :-)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
