### PR TITLE
fix: hide "Generating..." while waiting on input

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -303,7 +303,7 @@ export class ChatViewTreeWidget extends TreeWidget {
                     }}>
                     {this.getAgentLabel(node)}
                 </h3>
-                {inProgress && <span className='theia-ChatContentInProgress'>Generating</span>}
+                {inProgress && !waitingForInput && <span className='theia-ChatContentInProgress'>Generating</span>}
                 {inProgress && waitingForInput && <span className='theia-ChatContentInProgress'>Waiting for input</span>}
                 <div className='theia-ChatNodeToolbar'>
                     {!inProgress &&


### PR DESCRIPTION
#### What it does

Hides "Generating..." while waiting on input.

#### How to test

You can use the `@AskAndContinue` agent in the API examples to test this.

![image](https://github.com/user-attachments/assets/110fa963-3866-41d8-80a6-2fab6df71bff)

#### Follow-ups

None

#### Breaking changes

- [X] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
