### PR TITLE
Devcontainer workspaces openable through recent workspaces

### DIFF
--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -92,7 +92,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         };
         const files = await this.connectionProvider.getDevContainerFiles(uri.path.toString());
         const devcontainerFile = files.find(file => file.path === containerFilePath);
-        return `${uri.path.base} @ ${devcontainerFile?.name} [Dev Container]`;
+        return `${uri.path.base} [Dev Container: ${devcontainerFile?.name}]`;
     }
 
     async openInContainer(): Promise<void> {

--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -16,12 +16,14 @@
 
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { AbstractRemoteRegistryContribution, RemoteRegistry } from '@theia/remote/lib/electron-browser/remote-registry-contribution';
-import { LastContainerInfo, RemoteContainerConnectionProvider } from '../electron-common/remote-container-connection-provider';
+import { DevContainerFile, LastContainerInfo, RemoteContainerConnectionProvider } from '../electron-common/remote-container-connection-provider';
 import { RemotePreferences } from '@theia/remote/lib/electron-browser/remote-preferences';
 import { WorkspaceStorageService } from '@theia/workspace/lib/browser/workspace-storage-service';
-import { Command, QuickInputService } from '@theia/core';
-import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { Command, MaybePromise, QuickInputService, URI } from '@theia/core';
+import { WorkspaceInput, WorkspaceOpenHandlerContribution, WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { ContainerOutputProvider } from './container-output-provider';
+import { WorkspaceServer } from '@theia/workspace/lib/common';
+import { DEV_CONTAINER_PATH_QUERY, DEV_CONTAINER_WORKSPACE_SCHEME } from '../electron-common/dev-container-workspaces';
 
 export namespace RemoteContainerCommands {
     export const REOPEN_IN_CONTAINER = Command.toLocalizedCommand({
@@ -33,7 +35,7 @@ export namespace RemoteContainerCommands {
 
 const LAST_USED_CONTAINER = 'lastUsedContainer';
 @injectable()
-export class ContainerConnectionContribution extends AbstractRemoteRegistryContribution {
+export class ContainerConnectionContribution extends AbstractRemoteRegistryContribution implements WorkspaceOpenHandlerContribution {
 
     @inject(RemoteContainerConnectionProvider)
     protected readonly connectionProvider: RemoteContainerConnectionProvider;
@@ -47,6 +49,9 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
+    @inject(WorkspaceServer)
+    protected readonly workspaceServer: WorkspaceServer;
+
     @inject(QuickInputService)
     protected readonly quickInputService: QuickInputService;
 
@@ -59,11 +64,46 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         });
     }
 
+    canHandle(uri: URI): MaybePromise<boolean> {
+        return uri.scheme === DEV_CONTAINER_WORKSPACE_SCHEME;
+    }
+
+    async openWorkspace(uri: URI, options?: WorkspaceInput | undefined): Promise<void> {
+        const filePath = new URLSearchParams(uri.query).get(DEV_CONTAINER_PATH_QUERY);
+
+        if (!filePath) {
+            throw new Error('No devcontainer file specified for workspace');
+        }
+
+        const devcontainerFiles = await this.connectionProvider.getDevContainerFiles(uri.path.toString());
+        const devcontainerFile = devcontainerFiles.find(file => file.path === filePath);
+
+        if (!devcontainerFile) {
+            throw new Error(`Devcontainer file at ${filePath} not found in workspace`);
+        }
+
+        return this.doOpenInContainer(devcontainerFile);
+    }
+
+    async getWorkspaceLabel(uri: URI): Promise<string | undefined> {
+        const containerFilePath = new URLSearchParams(uri.query).get(DEV_CONTAINER_PATH_QUERY);
+        if (!containerFilePath) {
+            return;
+        };
+        const files = await this.connectionProvider.getDevContainerFiles(uri.path.toString());
+        const devcontainerFile = files.find(file => file.path === containerFilePath);
+        return `${uri.path.base} @ ${devcontainerFile?.name} [Dev Container]`;
+    }
+
     async openInContainer(): Promise<void> {
         const devcontainerFile = await this.getOrSelectDevcontainerFile();
         if (!devcontainerFile) {
             return;
         }
+        this.doOpenInContainer(devcontainerFile);
+    }
+
+    async doOpenInContainer(devcontainerFile: DevContainerFile): Promise<void> {
         const lastContainerInfoKey = `${LAST_USED_CONTAINER}:${devcontainerFile}`;
         const lastContainerInfo = await this.workspaceStorageService.getData<LastContainerInfo | undefined>(lastContainerInfoKey);
 
@@ -72,7 +112,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         const connectionResult = await this.connectionProvider.connectToContainer({
             nodeDownloadTemplate: this.remotePreferences['remote.nodeDownloadTemplate'],
             lastContainerInfo,
-            devcontainerFile
+            devcontainerFile: devcontainerFile.path
         });
 
         this.workspaceStorageService.setData<LastContainerInfo>(lastContainerInfoKey, {
@@ -80,10 +120,13 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
             lastUsed: Date.now()
         });
 
+        this.workspaceServer.setMostRecentlyUsedWorkspace(
+            `${DEV_CONTAINER_WORKSPACE_SCHEME}:${this.workspaceService.workspace?.resource.path}?${DEV_CONTAINER_PATH_QUERY}=${devcontainerFile.path}`);
+
         this.openRemote(connectionResult.port, false, connectionResult.workspacePath);
     }
 
-    async getOrSelectDevcontainerFile(): Promise<string | undefined> {
+    async getOrSelectDevcontainerFile(): Promise<DevContainerFile | undefined> {
         const workspace = this.workspaceService.workspace;
         if (!workspace) {
             return;
@@ -91,14 +134,14 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         const devcontainerFiles = await this.connectionProvider.getDevContainerFiles(workspace.resource.path.toString());
 
         if (devcontainerFiles.length === 1) {
-            return devcontainerFiles[0].path;
+            return devcontainerFiles[0];
         }
 
         return (await this.quickInputService.pick(devcontainerFiles.map(file => ({
             type: 'item',
             label: file.name,
             description: file.path,
-            file: file.path,
+            file: file,
         })), {
             title: 'Select a devcontainer.json file'
         }))?.file;

--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -104,7 +104,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
     }
 
     async doOpenInContainer(devcontainerFile: DevContainerFile): Promise<void> {
-        const lastContainerInfoKey = `${LAST_USED_CONTAINER}:${devcontainerFile}`;
+        const lastContainerInfoKey = `${LAST_USED_CONTAINER}:${devcontainerFile.path}`;
         const lastContainerInfo = await this.workspaceStorageService.getData<LastContainerInfo | undefined>(lastContainerInfoKey);
 
         this.containerOutputProvider.openChannel();

--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -82,7 +82,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
             throw new Error(`Devcontainer file at ${filePath} not found in workspace`);
         }
 
-        return this.doOpenInContainer(devcontainerFile);
+        return this.doOpenInContainer(devcontainerFile, uri.toString());
     }
 
     async getWorkspaceLabel(uri: URI): Promise<string | undefined> {
@@ -103,7 +103,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         this.doOpenInContainer(devcontainerFile);
     }
 
-    async doOpenInContainer(devcontainerFile: DevContainerFile): Promise<void> {
+    async doOpenInContainer(devcontainerFile: DevContainerFile, workspaceUri?: string): Promise<void> {
         const lastContainerInfoKey = `${LAST_USED_CONTAINER}:${devcontainerFile.path}`;
         const lastContainerInfo = await this.workspaceStorageService.getData<LastContainerInfo | undefined>(lastContainerInfoKey);
 
@@ -112,7 +112,8 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         const connectionResult = await this.connectionProvider.connectToContainer({
             nodeDownloadTemplate: this.remotePreferences['remote.nodeDownloadTemplate'],
             lastContainerInfo,
-            devcontainerFile: devcontainerFile.path
+            devcontainerFile: devcontainerFile.path,
+            workspaceUri
         });
 
         this.workspaceStorageService.setData<LastContainerInfo>(lastContainerInfoKey, {

--- a/packages/dev-container/src/electron-browser/dev-container-frontend-module.ts
+++ b/packages/dev-container/src/electron-browser/dev-container-frontend-module.ts
@@ -21,10 +21,12 @@ import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/ser
 import { ContainerOutputProvider } from './container-output-provider';
 import { ContainerInfoContribution } from './container-info-contribution';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { WorkspaceOpenHandlerContribution } from '@theia/workspace/lib/browser/workspace-service';
 
 export default new ContainerModule(bind => {
     bind(ContainerConnectionContribution).toSelf().inSingletonScope();
     bind(RemoteRegistryContribution).toService(ContainerConnectionContribution);
+    bind(WorkspaceOpenHandlerContribution).toService(ContainerConnectionContribution);
 
     bind(ContainerOutputProvider).toSelf().inSingletonScope();
 

--- a/packages/dev-container/src/electron-common/dev-container-workspaces.ts
+++ b/packages/dev-container/src/electron-common/dev-container-workspaces.ts
@@ -1,0 +1,18 @@
+// *****************************************************************************
+// Copyright (C) 2024 Typefox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export const DEV_CONTAINER_WORKSPACE_SCHEME = 'devcontainer';
+export const DEV_CONTAINER_PATH_QUERY = 'containerfile';

--- a/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
@@ -26,6 +26,7 @@ export interface ContainerConnectionOptions {
     nodeDownloadTemplate?: string;
     lastContainerInfo?: LastContainerInfo
     devcontainerFile: string;
+    workspaceUri?: string;
 }
 
 export interface LastContainerInfo {

--- a/packages/dev-container/src/electron-node/dev-container-backend-module.ts
+++ b/packages/dev-container/src/electron-node/dev-container-backend-module.ts
@@ -26,6 +26,8 @@ import { ContainerOutputProvider } from '../electron-common/container-output-pro
 import { ExtensionsContribution, registerTheiaStartOptionsContributions, SettingsContribution } from './devcontainer-contributions/cli-enhancing-creation-contributions';
 import { RemoteCliContribution } from '@theia/core/lib/node/remote/remote-cli-contribution';
 import { ProfileFileModificationContribution } from './devcontainer-contributions/profile-file-modification-contribution';
+import { DevContainerWorkspaceHandler } from './dev-container-workspace-handler';
+import { WorkspaceHandlerContribution } from '@theia/workspace/lib/node/default-workspace-server';
 
 export const remoteConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService }) => {
     bindContributionProvider(bind, ContainerCreationContribution);
@@ -55,4 +57,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(SettingsContribution).toSelf().inSingletonScope();
     bind(RemoteCliContribution).toService(ExtensionsContribution);
     bind(RemoteCliContribution).toService(SettingsContribution);
+
+    bind(DevContainerWorkspaceHandler).toSelf().inSingletonScope();
+    bind(WorkspaceHandlerContribution).toService(DevContainerWorkspaceHandler);
 });

--- a/packages/dev-container/src/electron-node/dev-container-workspace-handler.ts
+++ b/packages/dev-container/src/electron-node/dev-container-workspace-handler.ts
@@ -1,0 +1,33 @@
+// *****************************************************************************
+// Copyright (C) 2024 Typefox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { URI } from '@theia/core';
+import * as fs from '@theia/core/shared/fs-extra';
+import { injectable } from '@theia/core/shared/inversify';
+import { WorkspaceHandlerContribution } from '@theia/workspace/lib/node/default-workspace-server';
+import { DEV_CONTAINER_PATH_QUERY, DEV_CONTAINER_WORKSPACE_SCHEME } from '../electron-common/dev-container-workspaces';
+
+@injectable()
+export class DevContainerWorkspaceHandler implements WorkspaceHandlerContribution {
+
+    canHandle(uri: URI): boolean {
+        return uri.scheme === DEV_CONTAINER_WORKSPACE_SCHEME;
+    }
+
+    async workspaceStillExists(uri: URI): Promise<boolean> {
+        const devcontainerFile = new URLSearchParams(uri.query).get(DEV_CONTAINER_PATH_QUERY);
+        return await fs.pathExists(uri.path.fsPath()) && !!devcontainerFile && fs.pathExists(devcontainerFile);
+    }
+}

--- a/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
@@ -79,7 +79,7 @@ export class DevContainerConnectionProvider implements RemoteContainerConnection
             text: 'Creating container',
         });
         try {
-            const container = await this.containerService.getOrCreateContainer(dockerConnection, options.devcontainerFile, options.lastContainerInfo, this.outputProvider);
+            const container = await this.containerService.getOrCreateContainer(dockerConnection, options, this.outputProvider);
             const devContainerConfig = await this.devContainerFileService.getConfiguration(options.devcontainerFile);
 
             // create actual connection

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
-import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
+import { CommandContribution, MenuContribution, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider, FrontendApplicationContribution, KeybindingContribution } from '@theia/core/lib/browser';
 import {
     OpenFileDialogFactory,
@@ -32,7 +32,7 @@ import { LabelProviderContribution } from '@theia/core/lib/browser/label-provide
 import { VariableContribution } from '@theia/variable-resolver/lib/browser';
 import { WorkspaceServer, workspacePath, UntitledWorkspaceService, WorkspaceFileService } from '../common';
 import { WorkspaceFrontendContribution } from './workspace-frontend-contribution';
-import { WorkspaceService } from './workspace-service';
+import { WorkspaceOpenHandlerContribution, WorkspaceService } from './workspace-service';
 import { WorkspaceCommandContribution, FileMenuContribution, EditMenuContribution } from './workspace-commands';
 import { WorkspaceVariableContribution } from './workspace-variable-contribution';
 import { WorkspaceStorageService } from './workspace-storage-service';
@@ -59,9 +59,11 @@ import { CanonicalUriService } from './canonical-uri-service';
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
     bindWorkspaceTrustPreferences(bind);
+    bindContributionProvider(bind, WorkspaceOpenHandlerContribution);
 
     bind(WorkspaceService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(WorkspaceService);
+
     bind(CanonicalUriService).toSelf().inSingletonScope();
     bind(WorkspaceServer).toDynamicValue(ctx => {
         const provider = ctx.container.get(WebSocketConnectionProvider);

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { injectable, inject, postConstruct, named } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceServer, UntitledWorkspaceService, WorkspaceFileService } from '../common';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
@@ -24,7 +24,7 @@ import {
 } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
-import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise, MessageService, nls } from '@theia/core';
+import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise, MessageService, nls, ContributionProvider } from '@theia/core';
 import { WorkspacePreferences } from './workspace-preferences';
 import * as jsoncparser from 'jsonc-parser';
 import * as Ajv from '@theia/core/shared/ajv';
@@ -36,11 +36,19 @@ import { workspaceSchema, WorkspaceSchemaUpdater } from './workspace-schema-upda
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import { StopReason } from '@theia/core/lib/common/frontend-application-state';
 
+export const WorkspaceOpenHandlerContribution = Symbol('WorkspaceOpenHandlerContribution');
+
+export interface WorkspaceOpenHandlerContribution {
+    canHandle(uri: URI): MaybePromise<boolean>;
+    openWorkspace(uri: URI, options?: WorkspaceInput): MaybePromise<void>;
+    getWorkspaceLabel?(uri: URI): MaybePromise<string | undefined>;
+}
+
 /**
  * The workspace service.
  */
 @injectable()
-export class WorkspaceService implements FrontendApplicationContribution {
+export class WorkspaceService implements FrontendApplicationContribution, WorkspaceOpenHandlerContribution {
 
     protected _workspace: FileStat | undefined;
 
@@ -91,6 +99,9 @@ export class WorkspaceService implements FrontendApplicationContribution {
 
     @inject(WindowTitleService)
     protected readonly windowTitleService: WindowTitleService;
+
+    @inject(ContributionProvider) @named(WorkspaceOpenHandlerContribution)
+    protected readonly openHandlerContribution: ContributionProvider<WorkspaceOpenHandlerContribution>;
 
     protected _ready = new Deferred<void>();
     get ready(): Promise<void> {
@@ -350,7 +361,21 @@ export class WorkspaceService implements FrontendApplicationContribution {
         this.doOpen(uri, options);
     }
 
-    protected async doOpen(uri: URI, options?: WorkspaceInput): Promise<URI | undefined> {
+    protected async doOpen(uri: URI, options?: WorkspaceInput): Promise<void> {
+        for (const handler of [...this.openHandlerContribution.getContributions(), this]) {
+            if (await handler.canHandle(uri)) {
+                handler.openWorkspace(uri, options);
+                return;
+            }
+        }
+        throw new Error(`Could not find a handler to open the workspace with uri ${uri.toString()}.`);
+    }
+
+    async canHandle(uri: URI): Promise<boolean> {
+        return uri.scheme === 'file';
+    }
+
+    async openWorkspace(uri: URI, options?: WorkspaceInput): Promise<void> {
         const stat = await this.toFileStat(uri);
         if (stat) {
             if (!stat.isDirectory && !this.isWorkspaceFile(stat)) {

--- a/packages/workspace/src/node/workspace-backend-module.ts
+++ b/packages/workspace/src/node/workspace-backend-module.ts
@@ -15,9 +15,9 @@
 // *****************************************************************************
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common';
+import { ConnectionHandler, RpcConnectionHandler, bindContributionProvider } from '@theia/core/lib/common';
 import { WorkspaceServer, workspacePath, UntitledWorkspaceService, WorkspaceFileService } from '../common';
-import { DefaultWorkspaceServer, WorkspaceCliContribution } from './default-workspace-server';
+import { DefaultWorkspaceServer, FileWorkspaceHandlerContribution, WorkspaceCliContribution, WorkspaceHandlerContribution } from './default-workspace-server';
 import { CliContribution } from '@theia/core/lib/node/cli';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 
@@ -29,6 +29,11 @@ export default new ContainerModule(bind => {
     bind(BackendApplicationContribution).toService(WorkspaceServer);
     bind(UntitledWorkspaceService).toSelf().inSingletonScope();
     bind(WorkspaceFileService).toSelf().inSingletonScope();
+
+    bindContributionProvider(bind, WorkspaceHandlerContribution);
+
+    bind(FileWorkspaceHandlerContribution).toSelf().inSingletonScope();
+    bind(WorkspaceHandlerContribution).toService(FileWorkspaceHandlerContribution);
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new RpcConnectionHandler(workspacePath, () =>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This adds devcontainer workspaces to the recent workspaces so they can be opened from there. 
Also adds the ability to add custom workspace types through contributions to theia in general

Maybe the `workspaceServer` should be a `localProxy` so that it still shows local workspaces even when connected to a remote? Any comments regarding this would be appreciated.

Implements #14292

#### How to test

Open a dev-container. After disconnecting again the workspace should appear in recent workspaces as `workspace name  devcontainer name [Dev Container]`. Selecting it should directly open the devcontainer.

#### Follow-ups

Since devcontainers is using the WorkspaceStorageService to store the last container info, its different based on what workspace is open. So if no workspace is open it will create a new container instead of reusing the initially created one.
We need some other place to store this info workspace independent.

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
