### PR TITLE
Add Hugging Face Provider to Electron example

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -31,6 +31,7 @@
     "@theia/ai-code-completion": "1.56.0",
     "@theia/ai-core": "1.56.0",
     "@theia/ai-history": "1.56.0",
+    "@theia/ai-huggingface": "1.56.0",
     "@theia/ai-llamafile": "1.56.0",
     "@theia/ai-ollama": "1.56.0",
     "@theia/ai-openai": "1.56.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../../packages/ai-history"
     },
     {
+      "path": "../../packages/ai-hugging-face"
+    },
+    {
       "path": "../../packages/ai-llamafile"
     },
     {


### PR DESCRIPTION
fixed #14569

#### What it does

Adds Hugging face to Electron example

#### How to test

Start the Electron example and see that the settings for Hugging face are there.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
