### PR TITLE
Show more dev container info in title bar

### DIFF
--- a/packages/core/src/browser/window/browser-window-module.ts
+++ b/packages/core/src/browser/window/browser-window-module.ts
@@ -22,6 +22,8 @@ import { ClipboardService } from '../clipboard-service';
 import { BrowserClipboardService } from '../browser-clipboard-service';
 import { SecondaryWindowService } from './secondary-window-service';
 import { DefaultSecondaryWindowService } from './default-secondary-window-service';
+import { bindContributionProvider } from '../../common';
+import { WindowTitleContribution } from './window-title-service';
 
 export default new ContainerModule(bind => {
     bind(DefaultWindowService).toSelf().inSingletonScope();
@@ -29,4 +31,5 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toService(DefaultWindowService);
     bind(ClipboardService).to(BrowserClipboardService).inSingletonScope();
     bind(SecondaryWindowService).to(DefaultSecondaryWindowService).inSingletonScope();
+    bindContributionProvider(bind, WindowTitleContribution);
 });

--- a/packages/core/src/browser/window/window-title-service.ts
+++ b/packages/core/src/browser/window/window-title-service.ts
@@ -14,11 +14,17 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable, postConstruct } from 'inversify';
+import { inject, injectable, named, postConstruct } from 'inversify';
 import { escapeRegExpCharacters } from '../../common/strings';
 import { Emitter, Event } from '../../common/event';
 import { CorePreferences } from '../core-preferences';
 import { FrontendApplicationConfigProvider } from '../frontend-application-config-provider';
+import { ContributionProvider } from '../../common';
+
+export const WindowTitleContribution = Symbol('WindowTitleAddOnContribution');
+export interface WindowTitleContribution {
+    enhanceTitle(title: string, parts: Map<string, string | undefined>): string;
+}
 
 export const InitialWindowTitleParts = {
     activeEditorShort: undefined,
@@ -42,6 +48,9 @@ export class WindowTitleService {
 
     @inject(CorePreferences)
     protected readonly preferences: CorePreferences;
+
+    @inject(ContributionProvider) @named(WindowTitleContribution)
+    protected readonly titleContributions: ContributionProvider<WindowTitleContribution>;
 
     protected _title = '';
     protected titleTemplate?: string;
@@ -95,14 +104,14 @@ export class WindowTitleService {
             }
             const separatedTitle = title.split('${separator}').filter(e => e.trim().length > 0);
             this._title = separatedTitle.join(this.separator);
+            const contributions = this.titleContributions.getContributions();
+            for (const contribution of contributions) {
+                this._title = contribution.enhanceTitle(this.title, this.titleParts);
+            }
         }
         const developmentHost = this.titleParts.get('developmentHost');
         if (developmentHost) {
             this._title = developmentHost + this.separator + this._title;
-        }
-        const devContainer = this.titleParts.get('devContainer');
-        if (devContainer) {
-            this._title = `${this._title} [${devContainer}]`;
         }
         document.title = this._title || FrontendApplicationConfigProvider.get().applicationName;
         this.onDidChangeTitleEmitter.fire(this._title);

--- a/packages/core/src/browser/window/window-title-service.ts
+++ b/packages/core/src/browser/window/window-title-service.ts
@@ -100,6 +100,10 @@ export class WindowTitleService {
         if (developmentHost) {
             this._title = developmentHost + this.separator + this._title;
         }
+        const devContainer = this.titleParts.get('devContainer');
+        if (devContainer) {
+            this._title = `${this._title} [${devContainer}]`;
+        }
         document.title = this._title || FrontendApplicationConfigProvider.get().applicationName;
         this.onDidChangeTitleEmitter.fire(this._title);
     }

--- a/packages/core/src/electron-browser/window/electron-window-module.ts
+++ b/packages/core/src/electron-browser/window/electron-window-module.ts
@@ -30,6 +30,8 @@ import { bindWindowPreferences } from './electron-window-preferences';
 import { ElectronWindowService } from './electron-window-service';
 import { ExternalAppOpenHandler } from './external-app-open-handler';
 import { ElectronUriHandlerContribution } from '../electron-uri-handler';
+import { bindContributionProvider } from '../../common';
+import { WindowTitleContribution } from '../../browser/window/window-title-service';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(ElectronMainWindowService).toDynamicValue(context =>
@@ -45,4 +47,5 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(SecondaryWindowService).to(ElectronSecondaryWindowService).inSingletonScope();
     bind(ExternalAppOpenHandler).toSelf().inSingletonScope();
     bind(OpenHandler).toService(ExternalAppOpenHandler);
+    bindContributionProvider(bind, WindowTitleContribution);
 });

--- a/packages/dev-container/src/electron-browser/dev-container-frontend-module.ts
+++ b/packages/dev-container/src/electron-browser/dev-container-frontend-module.ts
@@ -22,6 +22,7 @@ import { ContainerOutputProvider } from './container-output-provider';
 import { ContainerInfoContribution } from './container-info-contribution';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { WorkspaceOpenHandlerContribution } from '@theia/workspace/lib/browser/workspace-service';
+import { WindowTitleContribution } from '@theia/core/lib/browser/window/window-title-service';
 
 export default new ContainerModule(bind => {
     bind(ContainerConnectionContribution).toSelf().inSingletonScope();
@@ -37,4 +38,5 @@ export default new ContainerModule(bind => {
 
     bind(ContainerInfoContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(ContainerInfoContribution);
+    bind(WindowTitleContribution).toService(ContainerInfoContribution);
 });


### PR DESCRIPTION
#### What it does

Adds info to window title when workspace is loaded in Dev Container and which platform the container is running on.

#### How to test

Start a Dev Container and look up onto the title. There should additionally be something like `[Dev Container @ linux]` 

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
