### PR TITLE
Revert "Pin perfect-scrollbar to 1.5.5"

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "markdown-it": "^12.3.2",
     "msgpackr": "^1.10.2",
     "p-debounce": "^2.1.0",
-    "perfect-scrollbar": "1.5.5",
+    "perfect-scrollbar": "^1.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-tooltip": "^4.2.21",

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -8,9 +8,6 @@
     "ts-md5": "^1.2.2",
     "tslib": "^2.6.2"
   },
-  "resolutions": {
-    "perfect-scrollbar": "1.5.5"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -13,10 +13,6 @@
     "react-perfect-scrollbar": "^1.5.8",
     "tslib": "^2.6.2"
   },
-
-  "resolutions": {
-    "perfect-scrollbar": "1.5.5"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -38,7 +38,7 @@
     "@theia/workspace": "1.56.0",
     "ajv": "^6.5.3",
     "jsonc-parser": "^2.2.0",
-    "perfect-scrollbar": "1.5.5",
+    "perfect-scrollbar": "^1.3.0",
     "tslib": "^2.6.2"
   },
   "theiaExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9893,7 +9893,7 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-perfect-scrollbar@1.5.5, perfect-scrollbar@^1.5.0:
+perfect-scrollbar@^1.3.0, perfect-scrollbar@^1.5.0:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz#41a211a2fb52a7191eff301432134ea47052b27f"
   integrity sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==


### PR DESCRIPTION
Reverts eclipse-theia/theia#14587

We found out that it doesn't guarantee that adopters get the right version, so let's revert it.