### PR TITLE
Update perfect-scrollbar and pin version in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "resolutions": {
     "**/@types/node": "18",
-    "**/nan": "2.20.0"
+    "**/nan": "2.20.0",
+    "**/perfect-scrollbar": "1.5.5"
   },
   "devDependencies": {
     "@types/chai": "4.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "markdown-it": "^12.3.2",
     "msgpackr": "^1.10.2",
     "p-debounce": "^2.1.0",
-    "perfect-scrollbar": "1.5.5",
+    "perfect-scrollbar": "^1.5.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-tooltip": "^4.2.21",

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -8,9 +8,6 @@
     "ts-md5": "^1.2.2",
     "tslib": "^2.6.2"
   },
-  "resolutions": {
-    "perfect-scrollbar": "1.5.5"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -14,9 +14,6 @@
     "tslib": "^2.6.2"
   },
 
-  "resolutions": {
-    "perfect-scrollbar": "1.5.5"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -38,7 +38,7 @@
     "@theia/workspace": "1.56.0",
     "ajv": "^6.5.3",
     "jsonc-parser": "^2.2.0",
-    "perfect-scrollbar": "1.5.5",
+    "perfect-scrollbar": "^1.5.5",
     "tslib": "^2.6.2"
   },
   "theiaExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9893,7 +9893,7 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-perfect-scrollbar@1.5.5, perfect-scrollbar@^1.5.0:
+perfect-scrollbar@1.5.5, perfect-scrollbar@^1.5.0, perfect-scrollbar@^1.5.5:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz#41a211a2fb52a7191eff301432134ea47052b27f"
   integrity sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==


### PR DESCRIPTION
#### What it does
Updates the perfect-scrollbar dependency and pins it to version `1.5.5` in the root package.json becuase `1.5.6` does not work in Theia

Fixes #14586

contributed on behalf of STMicroelectronics
#### How to test

Make sure scrolling works in the explorer and other views even when changing the view size a little.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
