### PR TITLE
Add jump to cursor

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -67,8 +67,6 @@ export namespace DebugMenus {
     export const DEBUG_BREAKPOINTS = [...DEBUG, 'f_breakpoints'];
 }
 
-
-
 function nlsEditBreakpoint(breakpoint: string): string {
     return nls.localizeByDefault('Edit {0}...', nls.localizeByDefault(breakpoint));
 }
@@ -245,7 +243,8 @@ export namespace DebugCommands {
     });
     export const JUMP_TO_CURSOR = Command.toDefaultLocalizedCommand({
         id: 'editor.debug.action.jumpToCursor',
-        label: 'Debug: Jump to Cursor'
+        category: DEBUG_CATEGORY,
+        label: 'Jump to Cursor'
     });
 
     export const RESTART_FRAME = Command.toDefaultLocalizedCommand({

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -853,7 +853,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
         registry.registerCommand(DebugCommands.JUMP_TO_CURSOR, {
             execute: () => {
-                const model = this.editors.model
+                const model = this.editors.model;
                 if (model && this.manager.currentThread) {
                     this.manager.currentThread.jumpToCursor(
                         model.editor.getResourceUri(),

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -20,7 +20,7 @@ import {
 import { injectable, inject } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { MenuModelRegistry, CommandRegistry, MAIN_MENU_BAR, Command, Emitter, Mutable, CompoundMenuNodeRole } from '@theia/core/lib/common';
-import { EDITOR_LINENUMBER_CONTEXT_MENU, EditorManager } from '@theia/editor/lib/browser';
+import { EDITOR_CONTEXT_MENU, EDITOR_LINENUMBER_CONTEXT_MENU, EditorManager } from '@theia/editor/lib/browser';
 import { DebugSessionManager } from './debug-session-manager';
 import { DebugWidget } from './view/debug-widget';
 import { FunctionBreakpoint } from './breakpoint/breakpoint-marker';
@@ -66,6 +66,8 @@ export namespace DebugMenus {
     export const DEBUG_NEW_BREAKPOINT = [...DEBUG_BREAKPOINT, 'a_new_breakpoint'];
     export const DEBUG_BREAKPOINTS = [...DEBUG, 'f_breakpoints'];
 }
+
+
 
 function nlsEditBreakpoint(breakpoint: string): string {
     return nls.localizeByDefault('Edit {0}...', nls.localizeByDefault(breakpoint));
@@ -241,6 +243,10 @@ export namespace DebugCommands {
         id: 'editor.debug.action.showDebugHover',
         label: 'Debug: Show Hover'
     });
+    export const JUMP_TO_CURSOR = Command.toDefaultLocalizedCommand({
+        id: 'editor.debug.action.jumpToCursor',
+        label: 'Debug: Jump to Cursor'
+    });
 
     export const RESTART_FRAME = Command.toDefaultLocalizedCommand({
         id: 'debug.frame.restart',
@@ -375,6 +381,9 @@ export namespace DebugEditorContextCommands {
     };
     export const DISABLE_LOGPOINT = {
         id: 'debug.editor.context.logpoint.disable'
+    };
+    export const JUMP_TO_CURSOR = {
+        id: 'debug.editor.context.jumpToCursor'
     };
 }
 export namespace DebugBreakpointWidgetCommands {
@@ -613,6 +622,11 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             DebugCommands.DISABLE_ALL_BREAKPOINTS
         );
 
+        const DEBUG_EDITOR_CONTEXT_MENU_GROUP = [...EDITOR_CONTEXT_MENU, '2_debug'];
+        registerMenuActions(DEBUG_EDITOR_CONTEXT_MENU_GROUP,
+            DebugCommands.JUMP_TO_CURSOR
+        );
+
         registerMenuActions(DebugEditorModel.CONTEXT_MENU,
             { ...DebugEditorContextCommands.ADD_BREAKPOINT, label: nls.localizeByDefault('Add Breakpoint') },
             { ...DebugEditorContextCommands.ADD_CONDITIONAL_BREAKPOINT, label: DebugCommands.ADD_CONDITIONAL_BREAKPOINT.label },
@@ -624,7 +638,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             { ...DebugEditorContextCommands.REMOVE_LOGPOINT, label: DebugCommands.REMOVE_LOGPOINT.label },
             { ...DebugEditorContextCommands.EDIT_LOGPOINT, label: DebugCommands.EDIT_LOGPOINT.label },
             { ...DebugEditorContextCommands.ENABLE_LOGPOINT, label: nlsEnableBreakpoint('Logpoint') },
-            { ...DebugEditorContextCommands.DISABLE_LOGPOINT, label: nlsDisableBreakpoint('Logpoint') }
+            { ...DebugEditorContextCommands.DISABLE_LOGPOINT, label: nlsDisableBreakpoint('Logpoint') },
+            { ...DebugEditorContextCommands.JUMP_TO_CURSOR, label: nls.localizeByDefault('Jump to Cursor') }
         );
         menus.linkSubmenu(EDITOR_LINENUMBER_CONTEXT_MENU, DebugEditorModel.CONTEXT_MENU, { role: CompoundMenuNodeRole.Group });
     }
@@ -837,6 +852,20 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             isEnabled: () => this.editors.canShowHover()
         });
 
+        registry.registerCommand(DebugCommands.JUMP_TO_CURSOR, {
+            execute: () => {
+                const model = this.editors.model
+                if (model && this.manager.currentThread) {
+                    this.manager.currentThread.jumpToCursor(
+                        model.editor.getResourceUri(),
+                        model.position
+                    );
+                }
+            },
+            isEnabled: () => !!this.manager.currentThread && this.manager.currentThread.supportsGoto,
+            isVisible: () => !!this.manager.currentThread && this.manager.currentThread.supportsGoto
+        });
+
         registry.registerCommand(DebugCommands.RESTART_FRAME, {
             execute: () => this.selectedFrame && this.selectedFrame.restart(),
             isEnabled: () => !!this.selectedFrame
@@ -935,6 +964,15 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             execute: position => this.isPosition(position) && this.editors.setBreakpointEnabled(this.asPosition(position), false),
             isEnabled: position => this.isPosition(position) && !!this.editors.getLogpointEnabled(this.asPosition(position)),
             isVisible: position => this.isPosition(position) && !!this.editors.getLogpointEnabled(this.asPosition(position))
+        });
+        registry.registerCommand(DebugEditorContextCommands.JUMP_TO_CURSOR, {
+            execute: position => {
+                if (this.isPosition(position) && this.editors.currentUri && this.manager.currentThread) {
+                    this.manager.currentThread.jumpToCursor(this.editors.currentUri, this.asPosition(position));
+                }
+            },
+            isEnabled: () => !!this.manager.currentThread && this.manager.currentThread.supportsGoto,
+            isVisible: () => !!this.manager.currentThread && this.manager.currentThread.supportsGoto
         });
 
         registry.registerCommand(DebugBreakpointWidgetCommands.ACCEPT, {

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -312,6 +312,16 @@ export class DebugSession implements CompositeTreeElement {
         return currentFrame ? currentFrame.getScopes() : [];
     }
 
+    showMessage(messageType: MessageType, message: string): void {
+        this.messages.showMessage({
+            type: messageType,
+            text: message,
+            options: {
+                timeout: 10000
+            }
+        });
+    }
+
     async start(): Promise<void> {
         await this.initialize();
         await this.launchOrAttach();
@@ -343,13 +353,7 @@ export class DebugSession implements CompositeTreeElement {
         try {
             await this.sendRequest((this.configuration.request as keyof DebugRequestTypes), this.configuration);
         } catch (reason) {
-            this.messages.showMessage({
-                type: MessageType.Error,
-                text: reason.message || 'Debug session initialization failed. See console for details.',
-                options: {
-                    timeout: 10000
-                }
-            });
+            this.showMessage(MessageType.Error, reason.message || 'Debug session initialization failed. See console for details.');
             throw reason;
         }
     }

--- a/packages/debug/src/browser/editor/debug-editor-service.ts
+++ b/packages/debug/src/browser/editor/debug-editor-service.ts
@@ -24,6 +24,7 @@ import { DebugEditorModel, DebugEditorModelFactory } from './debug-editor-model'
 import { BreakpointManager, SourceBreakpointsChangeEvent } from '../breakpoint/breakpoint-manager';
 import { DebugSourceBreakpoint } from '../model/debug-source-breakpoint';
 import { DebugBreakpointWidget } from './debug-breakpoint-widget';
+import URI from '@theia/core/lib/common/uri';
 
 @injectable()
 export class DebugEditorService {
@@ -69,6 +70,11 @@ export class DebugEditorService {
         const { currentEditor } = this.editors;
         const uri = currentEditor && currentEditor.getResourceUri();
         return uri && this.models.get(uri.toString());
+    }
+
+    get currentUri(): URI | undefined {
+        const { currentEditor } = this.editors;
+        return currentEditor && currentEditor.getResourceUri();
     }
 
     getLogpoint(position: monaco.Position): DebugSourceBreakpoint | undefined {

--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -127,7 +127,7 @@ export class DebugThread extends DebugThreadData implements TreeElement {
         const response: DebugProtocol.GotoTargetsResponse = await this.session.sendRequest('gotoTargets', { source, line: position.lineNumber, column: position.column });
 
         if (response && response.body.targets.length === 0) {
-            this.session.showMessage(MessageType.Warning, "No executable code is associated at the current cursor position.");
+            this.session.showMessage(MessageType.Warning, 'No executable code is associated at the current cursor position.');
             return;
         }
 

--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import * as React from '@theia/core/shared/react';
-import { CancellationTokenSource, Emitter, Event, nls } from '@theia/core';
+import { CancellationTokenSource, Emitter, Event, MessageType, nls } from '@theia/core';
 import { DebugProtocol } from '@vscode/debugprotocol/lib/debugProtocol';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { DebugStackFrame } from './debug-stack-frame';
@@ -127,8 +127,10 @@ export class DebugThread extends DebugThreadData implements TreeElement {
         const response: DebugProtocol.GotoTargetsResponse = await this.session.sendRequest('gotoTargets', { source, line: position.lineNumber, column: position.column });
 
         if (response && response.body.targets.length === 0) {
-            throw new Error('Unable to perform Jump to Cursor as there were no targets');
+            this.session.showMessage(MessageType.Warning, "No executable code is associated at the current cursor position.");
+            return;
         }
+
         const targetId = response.body.targets[0].id;
         return this.session.sendRequest('goto', this.toArgs({ targetId }));
     }

--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -20,6 +20,8 @@ import { DebugProtocol } from '@vscode/debugprotocol/lib/debugProtocol';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { DebugStackFrame } from './debug-stack-frame';
 import { DebugSession } from '../debug-session';
+import * as monaco from '@theia/monaco-editor-core';
+import URI from '@theia/core/lib/common/uri';
 
 export type StoppedDetails = DebugProtocol.StoppedEvent['body'] & {
     framesErrorMessage?: string
@@ -109,6 +111,26 @@ export class DebugThread extends DebugThreadData implements TreeElement {
 
     pause(): Promise<DebugProtocol.PauseResponse> {
         return this.session.sendRequest('pause', this.toArgs());
+    }
+
+    get supportsGoto(): boolean {
+        return !!this.session.capabilities.supportsGotoTargetsRequest;
+    }
+
+    async jumpToCursor(uri: URI, position: monaco.Position): Promise<DebugProtocol.GotoResponse | undefined> {
+        const source = await this.session?.toDebugSource(uri);
+
+        if (!source) {
+            return undefined;
+        }
+
+        const response: DebugProtocol.GotoTargetsResponse = await this.session.sendRequest('gotoTargets', { source, line: position.lineNumber, column: position.column });
+
+        if (response && response.body.targets.length === 0) {
+            throw new Error('Unable to perform Jump to Cursor as there were no targets');
+        }
+        const targetId = response.body.targets[0].id;
+        return this.session.sendRequest('goto', this.toArgs({ targetId }));
     }
 
     async getExceptionInfo(): Promise<DebugExceptionInfo | undefined> {
@@ -261,8 +283,8 @@ export class DebugThread extends DebugThreadData implements TreeElement {
         const localizedReason = this.getLocalizedReason(reason);
 
         return reason
-                ? nls.localizeByDefault('Paused on {0}', localizedReason)
-                : nls.localizeByDefault('Paused');
+            ? nls.localizeByDefault('Paused on {0}', localizedReason)
+            : nls.localizeByDefault('Paused');
     }
 
     protected getLocalizedReason(reason: string | undefined): string {
@@ -281,7 +303,7 @@ export class DebugThread extends DebugThreadData implements TreeElement {
                 return nls.localize('theia/debug/goto', 'goto');
             case 'function breakpoint':
                 return nls.localize('theia/debug/functionBreakpoint', 'function breakpoint');
-             case 'data breakpoint':
+            case 'data breakpoint':
                 return nls.localize('theia/debug/dataBreakpoint', 'data breakpoint');
             case 'instruction breakpoint':
                 return nls.localize('theia/debug/instructionBreakpoint', 'instruction breakpoint');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Extend context menu of editor with jump to cursor option. Extend context menu of editor margin with jump to cursor option. The option is visible only during the debugging session and if the debug adapter supports this.

Fixes issue #14500

#### How to test

- Install python debugger extension
- Create a new .py file
- Copy the below lines, and add a break point in line 3
      a=1
      b=2
      c=3
      d=4
- When the debugger stops at line 3, open context menu on editor and click jump to cursor to move the instruction pointer to the desired valid line.
- The option is also available by opening the debugger context menu (right click on editor margin, normally where the break points appear)

#### Follow-ups


#### Breaking changes



#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
