### PR TITLE
Stubs TestRunProfile loadDetailedCoverageForTest

### DIFF
--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -3417,6 +3417,7 @@ export class FileCoverage {
         public statementCoverage: TestCoverageCount,
         public branchCoverage?: TestCoverageCount,
         public declarationCoverage?: TestCoverageCount,
+        public includesTests?: theia.TestItem[],
     ) { }
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -16548,6 +16548,30 @@ export module '@theia/plugin' {
         loadDetailedCoverage?: (testRun: TestRun, fileCoverage: FileCoverage, token: CancellationToken) => Thenable<FileCoverageDetail[]>;
 
         /**
+         * An extension-provided function that provides detailed statement and
+         * function-level coverage for a single test in a file. This is the per-test
+         * sibling of {@link TestRunProfile.loadDetailedCoverage}, called only if
+         * a test item is provided in {@link FileCoverage.includesTests} and only
+         * for files where such data is reported.
+         *
+         * Often {@link TestRunProfile.loadDetailedCoverage} will be called first
+         * when a user opens a file, and then this method will be called if they
+         * drill down into specific per-test coverage information. This method
+         * should then return coverage data only for constructs the given test item
+         * executed during the test run.
+         *
+         * The {@link FileCoverage} object passed to this function is the same
+         * instance emitted on {@link TestRun.addCoverage} calls associated with this profile.
+         *
+         * @param testRun The test run that generated the coverage data.
+         * @param fileCoverage The file coverage object to load detailed coverage for.
+         * @param fromTestItem The test item to request coverage information for.
+         * @param token A cancellation token that indicates the operation should be cancelled.
+         * @stubbed
+         */
+        loadDetailedCoverageForTest?: (testRun: TestRun, fileCoverage: FileCoverage, fromTestItem: TestItem, token: CancellationToken) => Thenable<FileCoverageDetail[]>;
+
+        /**
          * Deletes the run profile.
          */
         dispose(): void;
@@ -17142,6 +17166,13 @@ export module '@theia/plugin' {
         declarationCoverage?: TestCoverageCount;
 
         /**
+         * A list of {@link TestItem test cases} that generated coverage in this
+         * file. If set, then {@link TestRunProfile.loadDetailedCoverageForTest}
+         * should also be defined in order to retrieve detailed coverage information.
+         */
+        includesTests?: TestItem[];
+
+        /**
          * Creates a {@link FileCoverage} instance with counts filled in from
          * the coverage details.
          * @param uri Covered file URI
@@ -17156,12 +17187,14 @@ export module '@theia/plugin' {
          * used to represent line coverage.
          * @param branchCoverage Branch coverage information
          * @param declarationCoverage Declaration coverage information
+         * @param includesTests Test cases included in this coverage report, see {@link includesTests}
          */
         constructor(
             uri: Uri,
             statementCoverage: TestCoverageCount,
             branchCoverage?: TestCoverageCount,
             declarationCoverage?: TestCoverageCount,
+            includesTests?: TestItem[],
         );
     }
 


### PR DESCRIPTION
#### What it does
Stubs FileCoverage TestItem and TestRunProfile loadCoverageWithTests. The FileCoverage support is already stubbed (#13631),  and its implementation is tracked here: #13858

fixes #14582

contributed on behalf of STMicroelectronics

#### How to test

None to test, stubbed API. 

#### Follow-ups

Implement the feature with #13858

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
