### PR TITLE
fix(ai): invoke `OpenerService` for markdown links in chat UI

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -34,6 +34,7 @@ import {
     Key,
     KeyCode,
     NodeProps,
+    OpenerService,
     TreeModel,
     TreeNode,
     TreeProps,
@@ -87,6 +88,9 @@ export class ChatViewTreeWidget extends TreeWidget {
 
     @inject(CommandRegistry)
     private commandRegistry: CommandRegistry;
+
+    @inject(OpenerService)
+    protected readonly openerService: OpenerService;
 
     @inject(HoverService)
     private hoverService: HoverService;
@@ -370,6 +374,7 @@ export class ChatViewTreeWidget extends TreeWidget {
             hoverService={this.hoverService}
             chatAgentService={this.chatAgentService}
             variableService={this.variableService}
+            openerService={this.openerService}
         />;
     }
 
@@ -432,12 +437,13 @@ export class ChatViewTreeWidget extends TreeWidget {
 
 const ChatRequestRender = (
     {
-        node, hoverService, chatAgentService, variableService
+        node, hoverService, chatAgentService, variableService, openerService
     }: {
         node: RequestNode,
         hoverService: HoverService,
         chatAgentService: ChatAgentService,
-        variableService: AIVariableService
+        variableService: AIVariableService,
+        openerService: OpenerService
     }) => {
     const parts = node.request.message.parts;
     return (
@@ -465,7 +471,7 @@ const ChatRequestRender = (
                         );
                     } else {
                         // maintain the leading and trailing spaces with explicit `&nbsp;`, otherwise they would get trimmed by the markdown renderer
-                        const ref = useMarkdownRendering(part.text.replace(/^\s|\s$/g, '&nbsp;'), true);
+                        const ref = useMarkdownRendering(part.text.replace(/^\s|\s$/g, '&nbsp;'), openerService, true);
                         return (
                             <span key={index} ref={ref}></span>
                         );


### PR DESCRIPTION
#### What it does

Invoke Theia's `OpenerService` when users click a link in the chat UI. This enables registering custom implementations of `OpenHandler` for specific URIs used as `href` in markdown links.

Fixes https://github.com/eclipse-theia/theia/issues/14601

#### How to test

1. Let an LLM output a markdown link for which an `OpenHandler` is registered, e.g. `[test](command:sample-command)`
2. Click the rendered link in the chat UI
3. Observe that the `sample-command` is executed, as it is correctly handled by the `CommandOpenHandler`

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
