### PR TITLE
Support property Text in DocumentDropOrPasteEditKind

### DIFF
--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1647,6 +1647,7 @@ export class DocumentLink {
 @es5ClassCompat
 export class DocumentDropOrPasteEditKind {
     static readonly Empty: DocumentDropOrPasteEditKind = new DocumentDropOrPasteEditKind('');
+    static readonly Text: DocumentDropOrPasteEditKind = new DocumentDropOrPasteEditKind('text');
 
     private static sep = '.';
 

--- a/packages/plugin/src/theia.proposed.documentPaste.d.ts
+++ b/packages/plugin/src/theia.proposed.documentPaste.d.ts
@@ -28,6 +28,20 @@ export module '@theia/plugin' {
     class DocumentDropOrPasteEditKind {
         static readonly Empty: DocumentDropOrPasteEditKind;
 
+        /**
+         * The root kind for basic text edits.
+         *
+         * This kind should be used for edits that insert basic text into the document. A good example of this is
+         * an edit that pastes the clipboard text while also updating imports in the file based on the pasted text.
+         * For this we could use a kind such as `text.updateImports.someLanguageId`.
+         *
+         * Even though most drop/paste edits ultimately insert text, you should not use {@linkcode Text} as the base kind
+         * for every edit as this is redundant. Instead a more specific kind that describes the type of content being
+         * inserted should be used instead For example, if the edit adds a Markdown link, use `markdown.link` since even
+         * though the content being inserted is text, it's more important to know that the edit inserts Markdown syntax.
+         */
+        static readonly Text: DocumentDropOrPasteEditKind;
+
         private constructor(value: string);
 
         /**


### PR DESCRIPTION
#### What it does
This PR introduces the new static readonly TEXT property in DocumentDropOrPasteEditKind in the documentPaste proposed API. It is intialized to its value in types-impl file. It will be later used by other extensions to build additional kinds or to specifiy yieldTo informations. See for example:: 
- https://github.com/Microsoft/vscode/blob/5410686643f746d444c3379690113a84351ec9e5/extensions/markdown-language-features/src/languageFeatures/updateLinksOnPaste.ts#L70
- https://github.com/Microsoft/vscode/blob/5410686643f746d444c3379690113a84351ec9e5/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts#L45

fixes #14603

#### How to test

You can simply build the typescript or markdown extension using this API and check if errors are provided at startup or runtime. 

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated. - **NO breaking changes**

#### Attribution

contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
