### PR TITLE
chore(ai): enable chat input on chat widget activate

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 import { CommandService, deepClone, Emitter, Event, MessageService } from '@theia/core';
 import { ChatRequest, ChatRequestModel, ChatRequestModelImpl, ChatService, ChatSession } from '@theia/ai-chat';
-import { BaseWidget, codicon, ExtractableWidget, PanelLayout, PreferenceService, StatefulWidget } from '@theia/core/lib/browser';
+import { BaseWidget, codicon, ExtractableWidget, Message, PanelLayout, PreferenceService, StatefulWidget } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { AIChatInputWidget } from './chat-input-widget';
@@ -123,6 +123,11 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
                 }
             })
         );
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this.inputWidget.activate();
     }
 
     storeState(): object {


### PR DESCRIPTION
#### What it does

We get warnings in the console from the chat widget as it doesn't accept focus. More importantly, it is cumbersome having to click the input field to start typing.

This change therefore focuses the input field when the chat widget is activated. Also it shows the placeholder text until a text is entered, which is a nicer touch than before.

Contributed on behalf of STMicroelectronics.

#### How to test

Active, hide and reactive the chat window and observe how the input receives focus and you can immediately start typing.
Check if the placeholder shows and disappears nicely when you enter or delete text in the chat input.

#### Follow-ups

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
