### PR TITLE
Fix for #14615: "Collapse Side Panel" tab bar context menu item is enabled even when panel is collapsed

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -924,7 +924,13 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             execute: () => this.shell.closeTabs('main', title => title.closable)
         });
         commandRegistry.registerCommand(CommonCommands.COLLAPSE_PANEL, new CurrentWidgetCommandAdapter(this.shell, {
-            isEnabled: (_title, tabbar) => Boolean(tabbar && ApplicationShell.isSideArea(this.shell.getAreaFor(tabbar))),
+            isEnabled: (_title, tabbar) => {
+                if (tabbar) {
+                    const area = this.shell.getAreaFor(tabbar);
+                    return ApplicationShell.isSideArea(area) && this.shell.isExpanded(area);
+                }
+                return false;
+            },
             isVisible: (_title, tabbar) => Boolean(tabbar && ApplicationShell.isSideArea(this.shell.getAreaFor(tabbar))),
             execute: (_title, tabbar) => tabbar && this.shell.collapsePanel(this.shell.getAreaFor(tabbar)!)
         }));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/14615. "Collapse Side Panel" tab bar context menu item is enabled even when side panel is collapsed. My fix will disable the context menu item if the panel is not expanded.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Expand left panel.
2. Right-click on the tab bar to open context menu.
3. Observe "Collapse Side Panel" menu item is enabled. Click this item to collapse panel.
4. Right-click on the tab bar again.
5. Observe "Collapse Side Panel" menu item is disabled.
6. Repeat steps 1-5 for the right panel.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Attribution

Contributed on behalf of Texas Instruments
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
