### PR TITLE
Fix rendering of output of cells added with already existing output

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -32,12 +32,12 @@ import { WebviewWidget } from '../../webview/webview';
 import { Message, WidgetManager } from '@theia/core/lib/browser';
 import { outputWebviewPreload, PreloadContext } from './output-webview-internal';
 import { WorkspaceTrustService } from '@theia/workspace/lib/browser';
-import { CellsChangedMessage, CellsMoved, CellsSpliced, ChangePreferredMimetypeMessage, FromWebviewMessage, OutputChangedMessage } from './webview-communication';
+import { CellOutputChange, CellsChangedMessage, CellsMoved, CellsSpliced, ChangePreferredMimetypeMessage, FromWebviewMessage, Output, OutputChangedMessage } from './webview-communication';
 import { Disposable, DisposableCollection, Emitter, QuickPickService, nls } from '@theia/core';
 import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
 import { NotebookOptionsService, NotebookOutputOptions } from '@theia/notebook/lib/browser/service/notebook-options';
 import { NotebookCellModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-model';
-import { NotebookCellsChangeType } from '@theia/notebook/lib/common';
+import { CellOutput, NotebookCellsChangeType } from '@theia/notebook/lib/common';
 import { NotebookCellOutputModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-output-model';
 
 export const AdditionalNotebookCellOutputCss = Symbol('AdditionalNotebookCellOutputCss');
@@ -363,12 +363,8 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 .filter(update => visibleCellHandleLookup.has(update.cellHandle))
                 .map(update => ({
                     cellHandle: update.cellHandle,
-                    newOutputs: update.newOutputs.map(output => ({
-                        id: output.outputId,
-                        items: output.outputs.map(item => ({ mime: item.mime, data: item.data.buffer })),
-                        metadata: output.metadata
-                    })),
-                    start: this.toVisibleCellIndex(update.start, visibleCells),
+                    newOutputs: this.mapCellOutputsToWebviewOutput(update.newOutputs),
+                    start: update.start,
                     deleteCount: update.deleteCount
                 }))
         };
@@ -380,6 +376,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
     cellsChanged(cellEvents: NotebookContentChangedEvent[]): void {
         const changes: Array<CellsMoved | CellsSpliced> = [];
+        const outputChanges: CellOutputChange[] = [];
 
         const visibleCells = this.notebook.getVisibleCells();
         const visibleCellLookup = new Set(visibleCells);
@@ -397,6 +394,15 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                     deleteCount: change.deleteCount,
                     newCells: change.newItems.filter(cell => visibleCellLookup.has(cell as NotebookCellModel)).map(cell => cell.handle)
                 } as CellsSpliced)));
+                outputChanges.push(...event.changes
+                    .flatMap(change => change.newItems)
+                    .filter(cell => visibleCellLookup.has(cell as NotebookCellModel) && cell.outputs.length)
+                    .map(newCell => ({
+                        start: 0,
+                        deleteCount: 0,
+                        cellHandle: newCell.handle,
+                        newOutputs: this.mapCellOutputsToWebviewOutput(newCell.outputs)
+                    })));
             }
         }
 
@@ -404,9 +410,23 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
             type: 'cellsChanged',
             changes: changes.filter(e => e)
         } as CellsChangedMessage);
+        if (outputChanges.length > 0) {
+            this.webviewWidget.sendMessage({
+                type: 'outputChanged',
+                changes: outputChanges
+            });
+        }
     }
 
-    toVisibleCellIndex(index: number, visibleCells: Array<NotebookCellModel>): number {
+    protected mapCellOutputsToWebviewOutput(outputs: CellOutput[]): Output[] {
+        return outputs.map(output => ({
+            id: output.outputId,
+            items: output.outputs.map(item => ({ mime: item.mime, data: item.data.buffer })),
+            metadata: output.metadata
+        }));
+    }
+
+    protected toVisibleCellIndex(index: number, visibleCells: Array<NotebookCellModel>): number {
         return visibleCells.indexOf(this.notebook.cells[index]);
     }
 

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -32,7 +32,10 @@ import { WebviewWidget } from '../../webview/webview';
 import { Message, WidgetManager } from '@theia/core/lib/browser';
 import { outputWebviewPreload, PreloadContext } from './output-webview-internal';
 import { WorkspaceTrustService } from '@theia/workspace/lib/browser';
-import { CellOutputChange, CellsChangedMessage, CellsMoved, CellsSpliced, ChangePreferredMimetypeMessage, FromWebviewMessage, Output, OutputChangedMessage } from './webview-communication';
+import {
+    CellOutputChange, CellsChangedMessage, CellsMoved, CellsSpliced,
+    ChangePreferredMimetypeMessage, FromWebviewMessage, Output, OutputChangedMessage
+} from './webview-communication';
 import { Disposable, DisposableCollection, Emitter, QuickPickService, nls } from '@theia/core';
 import { NotebookModel } from '@theia/notebook/lib/browser/view-model/notebook-model';
 import { NotebookOptionsService, NotebookOutputOptions } from '@theia/notebook/lib/browser/service/notebook-options';

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -613,6 +613,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             }
 
             cell.clearOutputs(cellChange.start, cellChange.deleteCount);
+
             for (const outputData of cellChange.newOutputs ?? []) {
                 const apiItems: rendererApi.OutputItem[] = outputData.items.map((item, index) => ({
                     id: `${outputData.id}-${index}`,

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -613,7 +613,6 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             }
 
             cell.clearOutputs(cellChange.start, cellChange.deleteCount);
-            console.log(cellChange.newOutputs);
             for (const outputData of cellChange.newOutputs ?? []) {
                 const apiItems: rendererApi.OutputItem[] = outputData.items.map((item, index) => ({
                     id: `${outputData.id}-${index}`,
@@ -633,10 +632,8 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                     },
 
                 }));
-                console.log('createOutputElement');
                 const output = cell.createOutputElement(cellChange.start, outputData, apiItems);
 
-                console.log('render');
                 await renderers.render(cell, output, undefined, undefined, new AbortController().signal);
 
                 theia.postMessage(<webviewCommunication.OnDidRenderOutput>{

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -613,7 +613,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             }
 
             cell.clearOutputs(cellChange.start, cellChange.deleteCount);
-
+            console.log(cellChange.newOutputs);
             for (const outputData of cellChange.newOutputs ?? []) {
                 const apiItems: rendererApi.OutputItem[] = outputData.items.map((item, index) => ({
                     id: `${outputData.id}-${index}`,
@@ -633,8 +633,10 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                     },
 
                 }));
+                console.log('createOutputElement');
                 const output = cell.createOutputElement(cellChange.start, outputData, apiItems);
 
+                console.log('render');
                 await renderers.render(cell, output, undefined, undefined, new AbortController().signal);
 
                 theia.postMessage(<webviewCommunication.OnDidRenderOutput>{


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This is a fix so that outputs of cells are rendered even when a new cell is added that already has outputs. This can for example happen in the case of undo.

#### How to test

- Open a notebook with at least one cell
- Execute it
- Delete the cell
- undo
- see that the output should be rendered correctly

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
