### PR TITLE
fix cell height when updating output

### DIFF
--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -148,6 +148,8 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
         readonly element: HTMLElement;
         readonly outputElements: OutputContainer[] = [];
 
+        private cellHeight: number = 0;
+
         constructor(public cellHandle: number, cellIndex?: number) {
             this.element = document.createElement('div');
             this.element.style.outline = '0';
@@ -183,6 +185,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                 outputContainer = new OutputContainer(output, items, this);
                 this.element.appendChild(outputContainer.containerElement);
                 this.outputElements.splice(index, 0, outputContainer);
+                this.updateCellHeight(this.cellHeight);
             }
 
             return outputContainer;
@@ -206,7 +209,8 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             this.element.style.visibility = 'hidden';
         }
 
-        public updateCellHeight(cellKind: number, height: number): void {
+        public updateCellHeight(height: number): void {
+            this.cellHeight = height;
             let additionalHeight = 54.5;
             additionalHeight -= cells[0] === this ? 2.5 : 0; // first cell
             additionalHeight -= this.outputElements.length ? 0 : 5.5; // no outputs
@@ -763,7 +767,7 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
                 cellHandle = event.data.cellHandle;
                 const cell = cells.find(c => c.cellHandle === cellHandle);
                 if (cell) {
-                    cell.updateCellHeight(event.data.cellKind, event.data.height);
+                    cell.updateCellHeight(event.data.height);
                 }
                 break;
             case 'outputVisibilityChanged':


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes an issue that the cell height was not updated in the output webview after rendering an output. This lead to overlap of output with other cells

#### How to test

- Open a notebook 
- create a few cells and execute them
- validate that changing the cell height (by for example ading a line) the distance  between cell and output does not change anymore.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
