### PR TITLE
Fix Enable continue command if the debbuger is active for pressing F5

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -666,8 +666,14 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             isEnabled: () => this.manager.state === DebugState.Stopped
         });
         registry.registerCommand(DebugCommands.CONTINUE, {
-            execute: () => this.manager.currentThread && this.manager.currentThread.continue(),
-            isEnabled: () => this.manager.state === DebugState.Stopped
+            execute: () => {
+                if (this.manager.state === DebugState.Stopped) {
+                    // eslint-disable-next-line no-unused-expressions
+                    this.manager.currentThread && this.manager.currentThread.continue();
+                }
+            },
+            // When there is a debug session, F5 should always be captured by this command
+            isEnabled: () => this.manager.state !== DebugState.Inactive
         });
         registry.registerCommand(DebugCommands.PAUSE, {
             execute: () => this.manager.currentThread && this.manager.currentThread.pause(),


### PR DESCRIPTION
#### What it does
This PR should solve the problem with the F5 key binding -> Issue: https://github.com/eclipse-theia/theia/issues/14639
By default the key f5 is registered to "start debugging", "continue" and "refresh/reload" (if it is a browser app).

The desired behavior should be as follows:
* No debugger is started, then F5 starts the debugger
* The debugger is started, then only 'continue' works

In none of the cases should F5 result in a reload of the application if it is running in a web browser.

All other shortcuts should continue to work.

#### How to test

* Start Theia (current: 1.56.2) in a webbrowser
* Please use 'Steps to Reproduce' from https://github.com/eclipse-theia/theia/issues/14639

#### Follow-ups

#### Breaking changes

#### Attribution

#### Review checklist

#### Reminder for reviewers
