### PR TITLE
Fix updating breakpoints when debugging starts

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -373,11 +373,12 @@ export class DebugSession implements CompositeTreeElement {
             }
             this.breakpoints.setExceptionBreakpoints(exceptionBreakpoints);
         }
+        // mark as initialized, so updated breakpoints are shown in editor
+        this.initialized = true;
         await this.updateBreakpoints({ sourceModified: false });
         if (this.capabilities.supportsConfigurationDoneRequest) {
             await this.sendRequest('configurationDone', {});
         }
-        this.initialized = true;
         await this.updateThreads(undefined);
     }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Previously, when starting to debug, the breakpoints did not move to valid lines. The breakpoints were send to the debug adapter before configurationDone and some debug adapters (e. g. python) return updated positions directly. The updates were not visible in the editor, because the connection was not marked as initialized yet and events were ignored. The updates became only visible, when changing breakpoints later.

Fixes #14096

#### How to test

* Write a small python program with empty lines.
* Set a breakpoint on an empty line and another line above
* Start debugging, the program should stop at the first breakpoint
Now fixed:
* The breakpoint on the empty line should move to a valid line

#### Follow-ups


#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
