### PR TITLE
Prevent tabbing outside of dialog overlay

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -236,8 +236,15 @@ export abstract class AbstractDialog<T> extends BaseWidget {
             this.addAcceptAction(this.acceptButton, 'click');
         }
         this.addCloseAction(this.closeCrossNode, 'click');
+        this.toDisposeOnDetach.push(this.preventTabbingOutsideDialog());
         // TODO: use DI always to create dialog instances
         this.toDisposeOnDetach.push(DialogOverlayService.get().push(this));
+    }
+
+    protected preventTabbingOutsideDialog(): Disposable {
+        const nonInertSiblings = Array.from(this.node.ownerDocument.body.children).filter(child => child !== this.node && !(child.hasAttribute('inert')));
+        nonInertSiblings.forEach(child => child.setAttribute('inert', ''));
+        return Disposable.create(() => nonInertSiblings.forEach(child => child.removeAttribute('inert')));
     }
 
     protected handleEscape(event: KeyboardEvent): boolean | void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/9894

#### How to test

- Use TAB and SHIFT+TAB to navigate through tabbable elements in the DOM
- Open a dialog (e.g., New Folder) and verify that if a dialog is open we only tab through elements within that dialog
- Close and re-open dialog to see if tabbing only every works on expected elements

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
