### PR TITLE
fix: support scanoss bundling

### DIFF
--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -466,7 +466,10 @@ const config = {
         minimize: production,
         minimizer: [
             new TerserPlugin({
-                exclude: /^(lib|builtins)\\//
+                exclude: /^(lib|builtins)\\//${this.ifPackage(['@theia/scanoss', '@theia/ai-anthropic', '@theia/ai-openai'], () => `,
+                terserOptions: {
+                    keep_classnames: /AbortSignal/
+                }`)}
             })
         ]
     },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

scanoss depends on `node-fetch` <`3`. `node-fetch` in that version [fails their instance checks](https://github.com/node-fetch/node-fetch/blob/9b9d45881e5ca68757077726b3c0ecf8fdca1f29/src/request.js#L65), as it relies on constructor/class names which are removed by the backend bundling.

Adjusts the generated webpack configuration to keep the class name for AbortSignal as this is the name checked in node-fetch.

fixes #14648 

#### How to test

`yarn && yarn browser build:production`

![image](https://github.com/user-attachments/assets/3cba92ea-96b1-4c19-b315-2fe8a6b935e9)

Without the adjusted webpack generation, scanoss will fail

#### Follow-ups

As an alternative we could set a resolution to node-fetch >3, however
- this change will not be picked up by adopters automatically
- it produces warnings whenever scanoss is used as `node-fetch` in that version [deprecated support for `form-data`](https://github.com/node-fetch/node-fetch/issues/1167) dependency [which is used by `scanoss`](https://github.com/scanoss/scanoss.js/blob/b637e24da44d41cce7a872507aea6c3d8a5122f7/src/sdk/scanner/Dispatcher/DispatchableItem.ts#L33-L49).

So to get rid of this workaround we need to either
- encourage / support `scanoss` to migrate to `node-fetch` v`3` and replace `form-data` usage, AND/OR
- encourage / support `node-fetch` to backport their improved checks to version v`2`

Note that the `ai-openai` and `ai-anthropic` also have a dependency to `node-fetch` v`2`, however during regular use we don't seem to hit the problematic code paths in there, at least I was not able to trigger them.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
