### PR TITLE
fix: scanoss error on Windows

### DIFF
--- a/packages/scanoss/src/node/scanoss-service-impl.ts
+++ b/packages/scanoss/src/node/scanoss-service-impl.ts
@@ -93,8 +93,20 @@ export class ScanOSSServiceImpl implements ScanOSSService {
         // eslint-disable-next-line no-null/no-null
         console.log('SCANOSS results', JSON.stringify(results, null, 2));
 
+        let contentScanning: ScannerComponent[] | undefined = results['/content_scanning'];
+        if (!contentScanning) {
+            // #14648: The scanoss library prefixes the property with the path of a temporary file on Windows, so we need to search for it
+            contentScanning = Object.entries(results).find(([key]) => key.endsWith('content_scanning'))?.[1];
+        }
+        if (!contentScanning || contentScanning.length === 0) {
+            return {
+                type: 'error',
+                message: 'Scan request unsuccessful'
+            };
+        }
+
         // first result is the best result
-        const firstEntry = results['/content_scanning'][0];
+        const firstEntry = contentScanning[0];
         if (firstEntry.id === 'none') {
             return {
                 type: 'clean'


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

On Windows, the scanoss library returns its results in a different shape than on the other platforms.  We now anticipate this behavior.

fixes #14648

#### How to test

Try to execute the SCANOSS actions on Windows. For this you need to set SCANOSS to "manual" or "automatic" in the preferences.

#### Follow-ups

This should be fixed in the scanoss library as this is likely not the intended behavior. Once we consume that new version we can remove the workaround again.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.
#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
