### PR TITLE
Fix override of default key bindings

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -622,13 +622,13 @@ export class KeybindingRegistry {
     matchKeybinding(keySequence: KeySequence, event?: KeyboardEvent): KeybindingRegistry.Match {
         let disabled: Set<string> | undefined;
         const isEnabled = (binding: ScopedKeybinding) => {
-            if (event && !this.isEnabled(binding, event)) {
-                return false;
-            }
             const { command, context, when, keybinding } = binding;
             if (!this.isUsable(binding)) {
                 disabled = disabled || new Set<string>();
                 disabled.add(JSON.stringify({ command: command.substring(1), context, when, keybinding }));
+                return false;
+            }
+            if (event && !this.isEnabled(binding, event)) {
                 return false;
             }
             return !disabled?.has(JSON.stringify({ command, context, when, keybinding }));


### PR DESCRIPTION
fixed #14667

#### What it does

fixes #14667
If a key binding is overridden by the user, an entry like this is added to the keymaps.json to indicate that the original keybinding is not valid anymore (with a '-' in the beginning of the command id:
```
    {
        "command": "-editor.action.inlineSuggest.trigger",
        "keybinding": "Shift+Space",
        "when": "!editorReadonly && editorTextFocus"
    }
```
The code in 'matchKeybinding' (see only change in this PR) records this and makes the key binding invalid also in upper contexts. However, it first checks "isEnabled" which in 'isEnabledInScope' checks 'this.commandRegistry.isEnabled(binding.command, binding.args)'
This is always false for invalid commands and the '-' makes commands invalid. As a consequence, 'isUsable' is not checked anymore, and the isUsable list is not correctly filled.
Therefore, turning the checks around, i.e. first checking isUsable fixes the issues, as overriden commands are now correctly remembers.

#### How to test

see #14667

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
