### PR TITLE
Change trigger inline suggestion keybinding to Ctrl+Alt+Space

### DIFF
--- a/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
@@ -29,7 +29,7 @@ export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
             type: 'boolean',
             description: 'Automatically trigger AI completions inline within any (Monaco) editor while editing.\
             \n\
-            Alternatively, you can manually trigger the code via the command "Trigger Inline Suggestion" or the default shortcut "SHIFT+Space".',
+            Alternatively, you can manually trigger the code via the command "Trigger Inline Suggestion" or the default shortcut "CTRL+ALT+Space".',
             default: false
         },
         [PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS]: {

--- a/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
@@ -29,7 +29,7 @@ export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
             type: 'boolean',
             description: 'Automatically trigger AI completions inline within any (Monaco) editor while editing.\
             \n\
-            Alternatively, you can manually trigger the code via the command "Trigger Inline Suggestion" or the default shortcut "CTRL+ALT+Space".',
+            Alternatively, you can manually trigger the code via the command "Trigger Inline Suggestion" or the default shortcut "Ctrl+Alt+Space".',
             default: false
         },
         [PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS]: {

--- a/packages/ai-code-completion/src/browser/ai-code-frontend-application-contribution.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-frontend-application-contribution.ts
@@ -65,7 +65,7 @@ export class AIFrontendApplicationContribution implements FrontendApplicationCon
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: 'editor.action.inlineSuggest.trigger',
-            keybinding: 'Shift+Space',
+            keybinding: 'Ctrl+Alt+Space',
             when: '!editorReadonly && editorTextFocus'
         });
     }


### PR DESCRIPTION
fixed #14665

#### What it does

Due to #14665 we change the default key binding to trigger the line suggestion to Ctrl+Alt+Space. This is unused in Theia by default. In VS Code it toggles the focus in case a suggestion widget is open, so even if this would be added to theia, it is a different context.

#### How to test

Press Ctrl+Alt+Space and see the inline suggestion triggered.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
