### PR TITLE
Add 'required' to tool call parameters

### DIFF
--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -35,7 +35,8 @@ export const isLanguageModelRequestMessage = (obj: unknown): obj is LanguageMode
 export type ToolRequestParametersProperties = Record<string, { type: string, [key: string]: unknown }>;
 export interface ToolRequestParameters {
     type?: 'object';
-    properties: ToolRequestParametersProperties
+    properties: ToolRequestParametersProperties;
+    required?: string[];
 }
 export interface ToolRequest {
     id: string;
@@ -62,7 +63,8 @@ export namespace ToolRequest {
     export function isToolRequestParameters(obj: unknown): obj is ToolRequestParameters {
         return !!obj && typeof obj === 'object' &&
             (!('type' in obj) || obj.type === 'object') &&
-            'properties' in obj && isToolRequestParametersProperties(obj.properties);
+            'properties' in obj && isToolRequestParametersProperties(obj.properties) &&
+            (!('required' in obj) || (Array.isArray(obj.required) && obj.required.every(prop => typeof prop === 'string')));
     }
 }
 

--- a/packages/ai-mcp/src/browser/mcp-command-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-command-contribution.ts
@@ -126,6 +126,7 @@ export class MCPCommandContribution implements CommandContribution {
             parameters: ToolRequest.isToolRequestParameters(tool.inputSchema) ? {
                 type: tool.inputSchema.type,
                 properties: tool.inputSchema.properties,
+                required: tool.inputSchema.required
             } : undefined,
             description: tool.description,
             handler: async (arg_string: string) => {

--- a/packages/ai-workspace-agent/src/browser/functions.ts
+++ b/packages/ai-workspace-agent/src/browser/functions.ts
@@ -186,7 +186,8 @@ export class FileContentFunction implements ToolProvider {
                         description: `Return the content of a specified file within the workspace. The file path must be provided relative to the workspace root. Only files within
                          workspace boundaries are accessible; attempting to access files outside the workspace will return an error.`,
                     }
-                }
+                },
+                required: ['file']
             },
             handler: (arg_string: string) => {
                 const file = this.parseArg(arg_string);
@@ -249,7 +250,8 @@ export class GetWorkspaceFileList implements ToolProvider {
                         description: `Optional relative path to a directory within the workspace. If no path is specified, the function lists contents directly in the workspace
                          root. Paths are resolved within workspace boundaries only; paths outside the workspace or unvalidated paths will result in an error.`
                     }
-                }
+                },
+                required: ['path']
             },
             description: `List files and directories within a specified workspace directory. Paths are relative to the workspace root, and only workspace-contained paths are
              allowed. If no path is provided, the root contents are listed. Paths outside the workspace will result in an error.`,


### PR DESCRIPTION
fixed #14672

#### What it does

- Adds 'required' to the schema for tool parameters
- Defines required for all existing functions with parameters
- Retrieves 'required' when converting tool functions from MCP servers

#### How to test

Try the existing tool functions and one MCP server.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
