### PR TITLE
Fix z-index overlay issue in dock panels

### DIFF
--- a/packages/core/src/browser/style/dockpanel.css
+++ b/packages/core/src/browser/style/dockpanel.css
@@ -14,6 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/*
+ * phosphor.js sets the z-index of its panels to 0, which causes overlay issues
+ * See also https://github.com/eclipse-theia/theia/issues/14290
+ */
+.p-SplitPanel-child,
+.p-DockPanel,
+.p-DockPanel-widget {
+  z-index: initial;
+}
+
 .p-DockPanel.p-SplitPanel-child {
   padding: 0px;
 }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14290

Phosphor.js automatically sets the `z-index: 0` css property on all dock panel items and children of split panels. However, this prevents the monaco editor popups from actually popping up on top of other panel items, therefore being partially hidden.

I've tested the fix suggested in the issue and found no further bugs with it. Completion, hover and diagnostics all seem to work as expected without any unexpected side effects.

#### How to test

See issue https://github.com/eclipse-theia/theia/issues/14290 for reproduction steps. Ensure that the popups are fully visible.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
