### PR TITLE
Support manual override of text blocks

### DIFF
--- a/examples/api-samples/package.json
+++ b/examples/api-samples/package.json
@@ -35,6 +35,9 @@
     },
     {
       "frontendOnly": "lib/browser-only/api-samples-frontend-only-module"
+    },
+    {
+      "frontendPreload": "lib/browser/api-samples-preload-module"
     }
   ],
   "keywords": [

--- a/examples/api-samples/src/browser/api-samples-preload-module.ts
+++ b/examples/api-samples/src/browser/api-samples-preload-module.ts
@@ -1,0 +1,23 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { TextReplacementContribution } from '@theia/core/lib/browser/preload/text-replacement-contribution';
+import { TextSampleReplacementContribution } from './preload/text-replacement-sample';
+
+export default new ContainerModule(bind => {
+    bind(TextReplacementContribution).to(TextSampleReplacementContribution).inSingletonScope();
+});

--- a/examples/api-samples/src/browser/preload/text-replacement-sample.ts
+++ b/examples/api-samples/src/browser/preload/text-replacement-sample.ts
@@ -1,0 +1,37 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { TextReplacementContribution } from '@theia/core/lib/browser/preload/text-replacement-contribution';
+
+export class TextSampleReplacementContribution implements TextReplacementContribution {
+
+    getReplacement(locale: string): Record<string, string> {
+        switch (locale) {
+            case 'en': {
+                return {
+                    'About': 'About Theia',
+                };
+            }
+            case 'de': {
+                return {
+                    'About': 'Über Theia',
+                };
+            }
+        }
+        return {};
+    }
+
+}

--- a/examples/playwright/src/tests/theia-quick-command.test.ts
+++ b/examples/playwright/src/tests/theia-quick-command.test.ts
@@ -48,7 +48,7 @@ test.describe('Theia Quick Command', () => {
 
     test('should trigger \'About\' command after typing', async () => {
         await quickCommand.type('About');
-        await quickCommand.trigger('About');
+        await quickCommand.trigger('About Theia');
         expect(await quickCommand.isOpen()).toBe(false);
         const aboutDialog = new TheiaAboutDialog(app);
         expect(await aboutDialog.isVisible()).toBe(true);

--- a/packages/core/src/browser/preload/preload-module.ts
+++ b/packages/core/src/browser/preload/preload-module.ts
@@ -21,19 +21,21 @@ import { I18nPreloadContribution } from './i18n-preload-contribution';
 import { OSPreloadContribution } from './os-preload-contribution';
 import { ThemePreloadContribution } from './theme-preload-contribution';
 import { LocalizationServer, LocalizationServerPath } from '../../common/i18n/localization-server';
-import { WebSocketConnectionProvider } from '../messaging/ws-connection-provider';
+import { ServiceConnectionProvider } from '../messaging/service-connection-provider';
 import { OSBackendProvider, OSBackendProviderPath } from '../../common/os';
+import { TextReplacementContribution } from './text-replacement-contribution';
 
 export default new ContainerModule(bind => {
     bind(Preloader).toSelf().inSingletonScope();
     bindContributionProvider(bind, PreloadContribution);
+    bindContributionProvider(bind, TextReplacementContribution);
 
     bind(LocalizationServer).toDynamicValue(ctx =>
-        WebSocketConnectionProvider.createProxy<LocalizationServer>(ctx.container, LocalizationServerPath)
+        ServiceConnectionProvider.createProxy<LocalizationServer>(ctx.container, LocalizationServerPath)
     ).inSingletonScope();
 
     bind(OSBackendProvider).toDynamicValue(ctx =>
-        WebSocketConnectionProvider.createProxy<OSBackendProvider>(ctx.container, OSBackendProviderPath)
+        ServiceConnectionProvider.createProxy<OSBackendProvider>(ctx.container, OSBackendProviderPath)
     ).inSingletonScope();
 
     bind(I18nPreloadContribution).toSelf().inSingletonScope();

--- a/packages/core/src/browser/preload/text-replacement-contribution.ts
+++ b/packages/core/src/browser/preload/text-replacement-contribution.ts
@@ -1,0 +1,21 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export const TextReplacementContribution = Symbol('TextReplacementContribution');
+
+export interface TextReplacementContribution {
+    getReplacement(locale: string): Record<string, string>;
+}

--- a/packages/core/src/browser/preload/text-replacement-contribution.ts
+++ b/packages/core/src/browser/preload/text-replacement-contribution.ts
@@ -16,6 +16,38 @@
 
 export const TextReplacementContribution = Symbol('TextReplacementContribution');
 
+/**
+ * Enables adopters to override text in the application. All `TextReplacementContribution`s need to be bound in the `frontendPreload` scope of the package.json.
+ *
+ * @example Create a text replacement contribution
+ * ```typescript
+ *          import { TextReplacementContribution } from '@theia/core/lib/browser/preload/text-replacement-contribution';
+ *          export class TextSampleReplacementContribution implements TextReplacementContribution {
+ *              getReplacement(locale: string): Record<string, string> {
+ *                  switch (locale) {
+ *                      case 'en': {
+ *                          return {
+ *                              'About': 'About Theia',
+ *                          };
+ *                      }
+ *                      case 'de': {
+ *                          return {
+ *                              'About': 'Über Theia',
+ *                          };
+ *                      }
+ *                  }
+ *                  return {};
+ *              }
+ *          }
+ * ```
+ */
 export interface TextReplacementContribution {
+    /**
+     * This method returns a map of **default values** and their replacement values for the specified locale.
+     * **Do not** use the keys of the `nls.localization` call, but the English default values.
+     *
+     * @param locale The locale for which the replacement should be returned.
+     * @returns A map of default values and their replacement values.
+     */
     getReplacement(locale: string): Record<string, string>;
 }

--- a/packages/core/src/common/i18n/localization.ts
+++ b/packages/core/src/common/i18n/localization.ts
@@ -25,7 +25,8 @@ export interface AsyncLocalizationProvider {
 }
 
 export interface Localization extends LanguageInfo {
-    translations: { [key: string]: string };
+    translations: Record<string, string>;
+    replacements?: Record<string, string>;
 }
 
 export interface LanguageInfo {
@@ -50,9 +51,14 @@ export namespace Localization {
     export function localize(localization: Localization | undefined, key: string, defaultValue: string, ...args: FormatType[]): string {
         let value = defaultValue;
         if (localization) {
-            const translation = localization.translations[key];
-            if (translation) {
-                value = normalize(translation);
+            const replacement = localization.replacements?.[defaultValue];
+            if (typeof replacement === 'string') {
+                value = replacement;
+            } else {
+                const translation = localization.translations[key];
+                if (translation) {
+                    value = normalize(translation);
+                }
             }
         }
         return format(value, args);

--- a/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-cell-actions-contribution.ts
@@ -65,19 +65,19 @@ export namespace NotebookCellCommands {
     export const EXECUTE_SINGLE_CELL_COMMAND = Command.toDefaultLocalizedCommand({
         id: 'notebook.cell.execute-cell',
         category: 'Notebook',
-        label: nls.localizeByDefault('Execute Cell'),
+        label: 'Execute Cell',
         iconClass: codicon('play'),
     });
     /** Parameters: notebookModel: NotebookModel, cell: NotebookCellModel */
     export const EXECUTE_SINGLE_CELL_AND_FOCUS_NEXT_COMMAND = Command.toDefaultLocalizedCommand({
         id: 'notebook.cell.execute-cell-and-focus-next',
-        label: nls.localizeByDefault('Execute Notebook Cell and Select Below'),
+        label: 'Execute Notebook Cell and Select Below',
         category: 'Notebook',
     });
     /** Parameters: notebookModel: NotebookModel, cell: NotebookCellModel */
     export const EXECUTE_SINGLE_CELL_AND_INSERT_BELOW_COMMAND = Command.toDefaultLocalizedCommand({
         id: 'notebook.cell.execute-cell-and-insert-below',
-        label: nls.localizeByDefault('Execute Notebook Cell and Insert Below'),
+        label: 'Execute Notebook Cell and Insert Below',
         category: 'Notebook',
     });
 


### PR DESCRIPTION
#### What it does

Related to https://github.com/eclipse-theia/theia/discussions/14684

Allows to override any translatable text block within Theia by providing a replacement object. I've provided an example contribution `TextSampleReplacementContribution` to show how to use this. This is not limited to English, but extendable to any language available for Theia/VSCode. Since this replacement needs to happen at the same time as the localization, it is placed in the `frontendPreload` phase of the application lifecycle.

#### How to test

1. Open the "Help" menu
2. See that the "About" menu entry is now "About Theia"
3. Use the `Configure Display Language` command to switch to German
4. The "About" menu should now display "Über Theia" (instead of simply "Info")

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
