### PR TITLE
Provide node-pty package for plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30941,6 +30941,7 @@
         "lodash.clonedeep": "^4.5.0",
         "macaddress": "^0.5.3",
         "mime": "^2.4.4",
+        "node-pty": "1.1.0-beta27",
         "ps-tree": "^1.2.0",
         "semver": "^7.5.4",
         "tslib": "^2.6.2",

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -44,6 +44,7 @@
     "lodash.clonedeep": "^4.5.0",
     "macaddress": "^0.5.3",
     "mime": "^2.4.4",
+    "node-pty": "1.1.0-beta27",
     "ps-tree": "^1.2.0",
     "semver": "^7.5.4",
     "tslib": "^2.6.2",

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -19,7 +19,8 @@
 import { dynamicRequire, removeFromCache } from '@theia/core/lib/node/dynamic-require';
 import { ContainerModule, inject, injectable, postConstruct, unmanaged } from '@theia/core/shared/inversify';
 import { AbstractPluginManagerExtImpl, PluginHost, PluginManagerExtImpl } from '../../plugin/plugin-manager';
-import { MAIN_RPC_CONTEXT, Plugin, PluginAPIFactory, PluginManager,
+import {
+    MAIN_RPC_CONTEXT, Plugin, PluginAPIFactory, PluginManager,
     LocalizationExt
 } from '../../common/plugin-api-rpc';
 import { PluginMetadata, PluginModel } from '../../common/plugin-protocol';
@@ -41,6 +42,7 @@ import { connectProxyResolver } from './plugin-host-proxy';
 import { LocalizationExtImpl } from '../../plugin/localization-ext';
 import { RPCProtocol, ProxyIdentifier } from '../../common/rpc-protocol';
 import { PluginApiCache } from '../../plugin/node/plugin-container-module';
+import { overridePluginDependencies } from './plugin-require-override';
 
 /**
  * The full set of all possible `Ext` interfaces that a plugin manager can support.
@@ -107,6 +109,7 @@ export abstract class AbstractPluginHostRPC<PM extends AbstractPluginManagerExtI
 
     @postConstruct()
     initialize(): void {
+        overridePluginDependencies();
         this.pluginManager.setPluginHost(this.createPluginHost());
 
         const extInterfaces = this.createExtInterfaces();
@@ -273,7 +276,7 @@ export abstract class AbstractPluginHostRPC<PM extends AbstractPluginManagerExtI
      * @param extApi the extension API to initialize, if appropriate
      * @throws if any error occurs in initializing the extension API
      */
-     protected abstract initExtApi(extApi: ExtPluginApi): void;
+    protected abstract initExtApi(extApi: ExtPluginApi): void;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/plugin-require-override.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-require-override.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2024 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as nodePty from 'node-pty';
+
+const overrides = [
+    {
+        package: 'node-pty',
+        module: nodePty
+    }
+];
+
+/**
+ * Some plugins attempt to require some packages from VSCode's node_modules.
+ * Since we don't have node_modules usually, we need to override the require function to return the expected package.
+ *
+ * See also:
+ * https://github.com/eclipse-theia/theia/issues/14714
+ * https://github.com/eclipse-theia/theia/issues/13779
+ */
+export function overridePluginDependencies(): void {
+    const node_module = require('module');
+    const original = node_module._load;
+    node_module._load = function (request: string): unknown {
+        for (const filter of overrides) {
+            if (request === filter.package || request.endsWith(`node_modules/${filter.package}`) || request.endsWith(`node_modules\\${filter.package}`)) {
+                return filter.module;
+            }
+        }
+        return original.apply(this, arguments);
+    };
+}


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14714
Closes https://github.com/eclipse-theia/theia/issues/13779

Adds a further override of the `require` function to the plugin host. In case any `node-pty` package is required, it will simply return the node-pty package that is packaged with Theia.

#### How to test

Run the steps in https://github.com/eclipse-theia/theia/issues/14714 and see that you don't get the `require` error.

#### Follow-ups

We could add further dependencies in there.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
