### PR TITLE
[chore] upgrade express to 4.21.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13933,9 +13933,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -13957,7 +13957,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -22517,9 +22517,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -30177,7 +30177,7 @@
         "dompurify": "^2.2.9",
         "drivelist": "^12.0.2",
         "es6-promise": "^4.2.4",
-        "express": "^4.21.0",
+        "express": "^4.21.2",
         "fast-json-stable-stringify": "^2.1.0",
         "file-icons-js": "~1.0.3",
         "font-awesome": "^4.7.0",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -102,7 +102,7 @@ export class SomeClass {
   - `vscode-uri` (from [`vscode-uri@^2.1.1`](https://www.npmjs.com/package/vscode-uri))
   - `@parcel/watcher` (from [`@parcel/watcher@^2.5.0`](https://www.npmjs.com/package/@parcel/watcher))
   - `dompurify` (from [`dompurify@^2.2.9`](https://www.npmjs.com/package/dompurify))
-  - `express` (from [`express@^4.21.0`](https://www.npmjs.com/package/express))
+  - `express` (from [`express@^4.21.2`](https://www.npmjs.com/package/express))
   - `lodash.debounce` (from [`lodash.debounce@^4.0.8`](https://www.npmjs.com/package/lodash.debounce))
   - `lodash.throttle` (from [`lodash.throttle@^4.1.1`](https://www.npmjs.com/package/lodash.throttle))
   - `markdown-it` (from [`markdown-it@^12.3.2`](https://www.npmjs.com/package/markdown-it))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "dompurify": "^2.2.9",
     "drivelist": "^12.0.2",
     "es6-promise": "^4.2.4",
-    "express": "^4.21.0",
+    "express": "^4.21.2",
     "fast-json-stable-stringify": "^2.1.0",
     "file-icons-js": "~1.0.3",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
#### What it does

Updates `express` to latest version (4.21.2) to update transitive dependency path-to-regex from 0.1.10 to 0.1.12 to address CVE-2024-52798

fixes: #14718

Note: this is also the version used by the current draft PR 14710 - _run npm update_

#### How to test

Build and open the tool. It should behave as usual. 

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

contributed on behalf of STMicroelectronics

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
