### PR TITLE
fix: Support Azure OpenAI

### DIFF
--- a/packages/ai-openai/README.md
+++ b/packages/ai-openai/README.md
@@ -27,12 +27,66 @@ You can configure the end points via the `ai-features.openAiCustom.customOpenAiM
     url: string
     id?: string
     apiKey?: string | true
+    apiVersion?: string | true
+    supportsDeveloperMessage?: boolean
+    enableStreaming?: boolean
 }
 ```
 
 - `model` and `url` are mandatory attributes, indicating the end point and model to use
 - `id` is an optional attribute which is used in the UI to refer to this configuration
 - `apiKey` is either the key to access the API served at the given URL or `true` to use the global OpenAI API key. If not given 'no-key' will be used.
+- `apiVersion` is either the api version to access the API served at the given URL in Azure or `true` to use the global OpenAI API version.
+- `supportsDeveloperMessage` is a flag that indicates whether the model supports the `developer` role or not. `true` by default.
+- `enableStreaming` is a flag that indicates whether the streaming API shall be used or not. `true` by default.
+
+### Azure OpenAI
+
+To use a custom OpenAI model hosted on Azure, the `AzureOpenAI` class needs to be used, as described in the 
+[openai-node docs](https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai).
+
+Requests to an OpenAI model hosted on Azure need an `apiVersion`. To configure a custom OpenAI model in Theia you therefore need to configure the `apiVersion` with the end point.
+Note that if you don't configure an `apiVersion`, the default `OpenAI` object is used for initialization and a connection to an Azure hosted OpenAI model will fail.
+
+An OpenAI model version deployed on Azure might not support the `developer` role. In that case it is possible to configure whether the `developer` role is supported or not via the 
+`supportsDeveloperMessage` option, which defaults to `true`.
+
+The following snippet shows a possible configuration to access an OpenAI model hosted on Azure. The `AZURE_OPENAI_API_BASE_URL` needs to be given without the `/chat/completions` 
+path and without the `api-version` parameter, e.g. _`https://<my_prefix>.openai.azure.com/openai/deployments/<my_deployment>`_
+
+```json
+{
+  "ai-features.AiEnable.enableAI": true,
+  "ai-features.openAiCustom.customOpenAiModels": [
+    {
+      "model": "gpt4o",
+      "url": "<AZURE_OPENAI_API_BASE_URL>",
+      "id": "azure-deployment",
+      "apiKey": "<AZURE_OPENAI_API_KEY>",
+      "apiVersion": "<AZURE_OPENAI_API_VERSION>",
+      "supportsDeveloperMessage": false
+    }
+  ],
+  "ai-features.agentSettings": {
+    "Universal": {
+      "languageModelRequirements": [
+        {
+          "purpose": "chat",
+          "identifier": "azure-deployment"
+        }
+      ]
+    },
+    "Orchestrator": {
+      "languageModelRequirements": [
+        {
+          "purpose": "agent-selection",
+          "identifier": "azure-deployment"
+        }
+      ]
+    }
+  }
+}
+```
 
 ## Additional Information
 

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -91,6 +91,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                 model.model === newModel.model &&
                 model.url === newModel.url &&
                 model.apiKey === newModel.apiKey &&
+                model.apiVersion === newModel.apiVersion &&
+                model.supportsDeveloperMessage === newModel.supportsDeveloperMessage &&
                 model.enableStreaming === newModel.enableStreaming));
 
         this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
@@ -113,6 +115,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             id: id,
             model: modelId,
             apiKey: true,
+            apiVersion: true,
+            supportsDeveloperMessage: !openAIModelsSupportingDeveloperMessages.includes(modelId),
             enableStreaming: !openAIModelsWithDisabledStreaming.includes(modelId),
             defaultRequestSettings: modelRequestSetting?.requestSettings
         };
@@ -136,6 +140,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     model: pref.model,
                     url: pref.url,
                     apiKey: typeof pref.apiKey === 'string' || pref.apiKey === true ? pref.apiKey : undefined,
+                    apiVersion: typeof pref.apiVersion === 'string' || pref.apiVersion === true ? pref.apiVersion : undefined,
+                    supportsDeveloperMessage: pref.supportsDeveloperMessage ?? true,
                     enableStreaming: pref.enableStreaming ?? true,
                     defaultRequestSettings: modelRequestSetting?.requestSettings
                 }
@@ -160,3 +166,4 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
 }
 
 const openAIModelsWithDisabledStreaming = ['o1-preview', 'o1-mini'];
+const openAIModelsSupportingDeveloperMessages = ['o1-preview', 'o1-mini'];

--- a/packages/ai-openai/src/browser/openai-preferences.ts
+++ b/packages/ai-openai/src/browser/openai-preferences.ts
@@ -50,6 +50,10 @@ export const OpenAiPreferencesSchema: PreferenceSchema = {
             \n\
             - provide an `apiKey` to access the API served at the given url. Use `true` to indicate the use of the global OpenAI API key.\
             \n\
+            - provide an `apiVersion` to access the API served at the given url in Azure. Use `true` to indicate the use of the global OpenAI API version.\
+            \n\
+            - specify `supportsDeveloperMessage: false` to indicate that the developer role shall not be used.\
+            \n\
             - specify `enableStreaming: false` to indicate that streaming shall not be used.\
             \n\
             Refer to [our documentation](https://theia-ide.org/docs/user_ai/#openai-compatible-models-eg-via-vllm) for more information.',
@@ -72,6 +76,14 @@ export const OpenAiPreferencesSchema: PreferenceSchema = {
                     apiKey: {
                         type: ['string', 'boolean'],
                         title: 'Either the key to access the API served at the given url or `true` to use the global OpenAI API key',
+                    },
+                    apiVersion: {
+                        type: ['string', 'boolean'],
+                        title: 'Either the version to access the API served at the given url in Azure or `true` to use the global OpenAI API version',
+                    },
+                    supportsDeveloperMessage: {
+                        type: 'boolean',
+                        title: 'Indicates whether the model supports the `developer` role. `true` by default.',
                     },
                     enableStreaming: {
                         type: 'boolean',

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -33,9 +33,17 @@ export interface OpenAiModelDescription {
      */
     apiKey: string | true | undefined;
     /**
+     * The version for the api. If 'true' is provided the global OpenAI version will be used.
+     */
+    apiVersion: string | true | undefined;
+    /**
      * Indicate whether the streaming API shall be used.
      */
     enableStreaming: boolean;
+    /**
+     * Flag to configure whether the OpenAPI model supports the `developer` role. Default is `true`.
+     */
+    supportsDeveloperMessage: boolean;
     /**
      * Default request settings for the OpenAI model.
      */
@@ -44,6 +52,7 @@ export interface OpenAiModelDescription {
 export interface OpenAiLanguageModelsManager {
     apiKey: string | undefined;
     setApiKey(key: string | undefined): void;
+    setApiVersion(version: string | undefined): void;
     createOrUpdateLanguageModels(...models: OpenAiModelDescription[]): Promise<void>;
     removeLanguageModels(...modelIds: string[]): void
 }

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -23,12 +23,17 @@ import { OpenAiLanguageModelsManager, OpenAiModelDescription } from '../common';
 export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsManager {
 
     protected _apiKey: string | undefined;
+    protected _apiVersion: string | undefined;
 
     @inject(LanguageModelRegistry)
     protected readonly languageModelRegistry: LanguageModelRegistry;
 
     get apiKey(): string | undefined {
         return this._apiKey ?? process.env.OPENAI_API_KEY;
+    }
+
+    get apiVersion(): string | undefined {
+        return this._apiVersion ?? process.env.OPENAI_API_VERSION;
     }
 
     // Triggered from frontend. In case you want to use the models on the backend
@@ -45,6 +50,15 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                 }
                 return undefined;
             };
+            const apiVersionProvider = () => {
+                if (modelDescription.apiVersion === true) {
+                    return this.apiVersion;
+                }
+                if (modelDescription.apiVersion) {
+                    return modelDescription.apiVersion;
+                }
+                return undefined;
+            };
 
             if (model) {
                 if (!(model instanceof OpenAiModel)) {
@@ -55,6 +69,8 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                 model.enableStreaming = modelDescription.enableStreaming;
                 model.url = modelDescription.url;
                 model.apiKey = apiKeyProvider;
+                model.apiVersion = apiVersionProvider;
+                model.supportsDeveloperMessage = modelDescription.supportsDeveloperMessage;
                 model.defaultRequestSettings = modelDescription.defaultRequestSettings;
             } else {
                 this.languageModelRegistry.addLanguageModels([
@@ -63,6 +79,8 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                         modelDescription.model,
                         modelDescription.enableStreaming,
                         apiKeyProvider,
+                        apiVersionProvider,
+                        modelDescription.supportsDeveloperMessage,
                         modelDescription.url,
                         modelDescription.defaultRequestSettings
                     )
@@ -80,6 +98,14 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
             this._apiKey = apiKey;
         } else {
             this._apiKey = undefined;
+        }
+    }
+
+    setApiVersion(apiVersion: string | undefined): void {
+        if (apiVersion) {
+            this._apiVersion = apiVersion;
+        } else {
+            this._apiVersion = undefined;
         }
     }
 }


### PR DESCRIPTION
* Add configuration of OpenAI API version
* Add configuration of supportsDeveloperMessage
* If OpenAI API version is configured, use AzureOpenAI

Fixes #14711

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
It fixes #14711 and adds support for accessing an OpenAI model deployed on Azure.
To make this work, the `AzureOpenAI` class needs to be used, as described in the [openai-node docs](https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai).

To build up the request with `AzureOpenAI` you need to pass a `apiVersion`. This PR therefore adds the option to configure the `apiVersion` in the settings. If no `apiVersion` is configured, the default `OpenAI` object is used for initialization.

I also noticed that it can happen, that the OpenAI model version deployed on Azure might not yet support the developer role. Therefore I also added the option to configure whether the developer role is supported or not, which defaults to `true`.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The reviewer would need to have an OpenAI model available in Azure and then configure a custom openai model like this:

```json
{
  "ai-features.AiEnable.enableAI": true,
  "ai-features.openAiCustom.customOpenAiModels": [
    {
      "model": "gpt4o",
      "url": "<AZURE_OPENAI_API_BASE_URL>",
      "id": "azure-deployment",
      "apiKey": "<AZURE_OPENAI_API_KEY>",
      "apiVersion": "<AZURE_OPENAI_API_VERSION>",
      "supportsDeveloperMessage": false
    }
  ],
  "ai-features.agentSettings": {
    "Universal": {
      "languageModelRequirements": [
        {
          "purpose": "chat",
          "identifier": "azure-deployment"
        }
      ]
    },
    "Orchestrator": {
      "languageModelRequirements": [
        {
          "purpose": "agent-selection",
          "identifier": "azure-deployment"
        }
      ]
    }
  }
}
```

Of course a non Azure model deployment should still work as before.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
