### PR TITLE
Fix Console Scrolling

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -32,7 +32,7 @@ import { notEmpty } from '../../common/objects';
 import { isOSX } from '../../common/os';
 import { ReactWidget } from '../widgets/react-widget';
 import * as React from 'react';
-import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+import { Virtuoso, VirtuosoHandle, VirtuosoProps } from 'react-virtuoso';
 import { TopDownTreeIterator } from './tree-iterator';
 import { SearchBox, SearchBoxFactory, SearchBoxProps } from './search-box';
 import { TreeSearch } from './tree-search';
@@ -111,6 +111,10 @@ export interface TreeProps {
      */
     readonly expandOnlyOnExpansionToggleClick?: boolean;
 
+    /**
+     * Props that are forwarded to the virtuoso list rendered. Defaults to `{}`.
+     */
+    readonly viewProps?: VirtuosoProps<unknown, unknown>;
 }
 
 /**
@@ -498,6 +502,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 rows={rows}
                 renderNodeRow={this.renderNodeRow}
                 scrollToRow={this.scrollToRow}
+                {...this.props.viewProps}
             />;
         }
         // eslint-disable-next-line no-null/no-null
@@ -1546,7 +1551,7 @@ export namespace TreeWidget {
     /**
      * Representation of the tree view properties.
      */
-    export interface ViewProps {
+    export interface ViewProps extends VirtuosoProps<unknown, unknown> {
         /**
          * The width property.
          */
@@ -1568,7 +1573,7 @@ export namespace TreeWidget {
     export class View extends React.Component<ViewProps> {
         list: VirtuosoHandle | undefined;
         override render(): React.ReactNode {
-            const { rows, width, height, scrollToRow } = this.props;
+            const { rows, width, height, scrollToRow, renderNodeRow, ...other } = this.props;
             return <Virtuoso
                 ref={list => {
                     this.list = (list || undefined);
@@ -1580,11 +1585,12 @@ export namespace TreeWidget {
                     }
                 }}
                 totalCount={rows.length}
-                itemContent={index => this.props.renderNodeRow(rows[index])}
+                itemContent={index => renderNodeRow(rows[index])}
                 width={width}
                 height={height}
                 // This is a pixel value, it will scan 200px to the top and bottom of the current view
                 overscan={500}
+                {...other}
             />;
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes autoscrolling functionality in debug console. How this should work, is if the console is scrolled to the bottom, then when new content is output, it should be shown automatically, but if the user scrolls up, the view should stay put.

#### How to test

This functionality can be tested with any debuggable project. For example I used the [cpp-debug-workspace](https://github.com/eclipse-theia/theia-cpp-extensions/tree/master/examples/cpp-debug-workspace), which after installing [cdt-gdb-vscode](https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode), can be debugged following the instructions in the README.md file. To test, place a breakpoint within the main loop i.e. `a.cpp:35`. Allow the debugger to continue a few times. Each time it does, any new output to the debug console should be shown automatically. Then, scroll up a few lines and continue a few more times. Now the view should remain fixed.

#### Explanation

Here's how it worked previously:

When `ConsoleContentWidget.model.onChanged()` is fired, this triggers 3 notable events: `ConsoleWidget.revealLastOutputIfNeeded`, `TreeWidget.updateScrollToRow`, and `TreeWidget.updateRows` usually in that order. `revealLastOutputIfNeeded` uses the selection service to focus the newly added node. Next, `updateScrollToRow` attempts to find the row corresponding the the focused node, and fails to find it and thus doesn't scroll. Finally, after that happens `updateRows` creates the corresponding row. 

Furthermore, the logic to determine when the console should be scrolling or not uses the `onScrollUp`, and `onScrollYReachEnd` methods, which don't appear fire for tree widgets (they work for other widgets). I believe this is because it's not the root widget container that is scrolling, but one of it's child elements, but wasn't able to figure this out.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
