### PR TITLE
feat: allow passing context to tool calls

### DIFF
--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -37,10 +37,13 @@ import { aiChatPreferences } from './ai-chat-preferences';
 import { AICustomAgentsFrontendApplicationContribution } from './custom-agent-frontend-application-contribution';
 import { FrontendChatServiceImpl } from './frontend-chat-service';
 import { CustomAgentFactory } from './custom-agent-factory';
+import { ChatToolRequestService } from '../common/chat-tool-request-service';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
     bindContributionProvider(bind, ChatAgent);
+
+    bind(ChatToolRequestService).toSelf().inSingletonScope();
 
     bind(ChatAgentServiceImpl).toSelf().inSingletonScope();
     bind(ChatAgentService).toService(ChatAgentServiceImpl);

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -76,6 +76,21 @@ export interface ChatRequestModel {
     readonly data?: { [key: string]: unknown };
 }
 
+export namespace ChatRequestModel {
+    export function is(request: unknown): request is ChatRequestModel {
+        return !!(
+            request &&
+            typeof request === 'object' &&
+            'id' in request &&
+            typeof (request as { id: unknown }).id === 'string' &&
+            'session' in request &&
+            'request' in request &&
+            'response' in request &&
+            'message' in request
+        );
+    }
+}
+
 export interface ChatProgressMessage {
     kind: 'progressMessage';
     id: string;

--- a/packages/ai-chat/src/common/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/common/chat-tool-request-service.ts
@@ -1,0 +1,59 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ToolRequest } from '@theia/ai-core';
+import { injectable } from '@theia/core/shared/inversify';
+import { ChatRequestModelImpl } from './chat-model';
+
+export interface ChatToolRequest extends ToolRequest {
+    handler: (
+        arg_string: string,
+        context: ChatRequestModelImpl,
+    ) => Promise<unknown>;
+}
+
+/**
+ * Wraps tool requests in a chat context.
+ *
+ * This service extracts tool requests from a given chat request model and wraps their
+ * handler functions to provide additional context, such as the chat request model.
+ */
+@injectable()
+export class ChatToolRequestService {
+
+    getChatToolRequests(request: ChatRequestModelImpl): ChatToolRequest[] {
+        const toolRequests = request.message.toolRequests.size > 0 ? [...request.message.toolRequests.values()] : undefined;
+        if (!toolRequests) {
+            return [];
+        }
+        return this.toChatToolRequests(toolRequests, request);
+    }
+
+    toChatToolRequests(toolRequests: ToolRequest[] | undefined, request: ChatRequestModelImpl): ChatToolRequest[] {
+        if (!toolRequests) {
+            return [];
+        }
+        return toolRequests.map(toolRequest => this.toChatToolRequest(toolRequest, request));
+    }
+
+    protected toChatToolRequest(toolRequest: ToolRequest, request: ChatRequestModelImpl): ChatToolRequest {
+        return {
+            ...toolRequest,
+            handler: async (arg_string: string) => toolRequest.handler(arg_string, request)
+        };
+    }
+
+}

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -43,7 +43,7 @@ export interface ToolRequest {
     name: string;
     parameters?: ToolRequestParameters
     description?: string;
-    handler: (arg_string: string) => Promise<unknown>;
+    handler: (arg_string: string, ctx?: unknown) => Promise<unknown>;
     providerName?: string;
 }
 


### PR DESCRIPTION
#### What it does

With this change we enable passing optional context to tool calls.

For tool calls in the context of a chat, we pass the chat request model. This way tool call handlers can retrieve additional information as a context or update the chat model directly. Note that this can also be used to receive the cancellation token via `request.response.cancellationToken` to be able to cancel long-running tool calls if the user hits cancel in the chat.

#### How to test

Create a tool call that receives and processes the optional second argument of its `handler` function.
E.g.

```ts
@injectable()
export class FileContentFunction implements ToolProvider {
    static ID = FILE_CONTENT_FUNCTION_ID;

    getTool(): ToolRequest {
        return {
            id: FileContentFunction.ID,
            name: FileContentFunction.ID,
            description: `The relative path to the target file within the workspace. This path is resolved from the workspace root, and only files within the workspace boundaries
             are accessible. Attempting to access paths outside the workspace will result in an error.`,
            parameters: {
                type: 'object',
                properties: {
                    file: {
                        type: 'string',
                        description: `Return the content of a specified file within the workspace. The file path must be provided relative to the workspace root. Only files within
                         workspace boundaries are accessible; attempting to access files outside the workspace will return an error.`,
                    }
                },
                required: ['file']
            },
            handler: (arg_string: string, ctx: ChatRequestModelImpl) => {
                // if it is a handler that should work in the context of a chat and outside too, it can receive `unknown`
                // and use an instanceof check or ChatRequestModel.is() to switch between cases
                const file = this.parseArg(arg_string);
                return this.getFileContent(file);
            }
        };
    }
...
```

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
