### PR TITLE
Fix `workbench.action.files.newUntitledFile`

### DIFF
--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -203,7 +203,7 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doCreateFile}
                 onKeyDown={this.doCreateFileEnter}>
-                {CommonCommands.NEW_UNTITLED_FILE.label ?? nls.localizeByDefault('New File...')}
+                {nls.localizeByDefault('New File...')}
             </a>
         </div>;
 
@@ -481,7 +481,7 @@ export class GettingStartedWidget extends ReactWidget {
     /**
      * Trigger the create file command.
      */
-    protected doCreateFile = () => this.commandRegistry.executeCommand(CommonCommands.NEW_UNTITLED_FILE.id);
+    protected doCreateFile = () => this.commandRegistry.executeCommand(CommonCommands.PICK_NEW_FILE.id);
     protected doCreateFileEnter = (e: React.KeyboardEvent) => {
         if (this.isEnterKey(e)) {
             this.doCreateFile();


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14743

The `Project Manager for Java` extension is using the `workbench.action.files.newUntitledFile` to instantly create a new untitled file and then set the language of that new file to `Java` (other extensions do it better btw). However, our `workbench.action.files.newUntitledFile` implementation used to open the quick pick instead of actually creating a new untitled file.

This change just aligns the implementation of the command to VS Code

#### How to test

1. Download and install the `Project Manager for Java` plugin
2. Open the `File` menu and run `New File...`. Select `New Java File`.
3. The file should open as expected and be correctly filled with some initial class construct.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
