### PR TITLE
Support dragging files in browser

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -22,7 +22,7 @@ import {
 } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
 import { IDragEvent } from '@phosphor/dragdrop';
-import { RecursivePartial, Event as CommonEvent, DisposableCollection, Disposable, environment, isObject } from '../../common';
+import { RecursivePartial, Event as CommonEvent, DisposableCollection, Disposable, environment, isObject, UntitledResourceResolver, UNTITLED_SCHEME } from '../../common';
 import { animationFrame } from '../browser';
 import { Saveable, SaveableWidget, SaveOptions } from '../saveable';
 import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
@@ -231,6 +231,9 @@ export class ApplicationShell extends Widget {
 
     @inject(OpenerService)
     protected readonly openerService: OpenerService;
+
+    @inject(UntitledResourceResolver)
+    protected readonly untitledResourceResolver: UntitledResourceResolver;
 
     protected readonly onDidAddWidgetEmitter = new Emitter<Widget>();
     readonly onDidAddWidget = this.onDidAddWidgetEmitter.event;
@@ -572,10 +575,28 @@ export class ApplicationShell extends Widget {
                     uris.forEach(openUri);
                 } else if (event.dataTransfer.files?.length > 0) {
                     // the files were dragged from the outside the workspace
-                    Array.from(event.dataTransfer.files).forEach(file => {
-                        if (file.path) {
-                            const fileUri = URI.fromFilePath(file.path);
-                            openUri(fileUri);
+                    Array.from(event.dataTransfer.files).forEach(async file => {
+                        if (environment.electron.is()) {
+                            if (file.path) {
+                                const fileUri = URI.fromFilePath(file.path);
+                                openUri(fileUri);
+                            }
+                        } else {
+                            const fileContent = await file.text();
+                            const fileName = file.name;
+                            const uri = new URI(`${UNTITLED_SCHEME}:/${fileName}`);
+                            // Only create a new untitled resource if it doesn't already exist.
+                            // VS Code does the same thing, and there's not really a better solution,
+                            // since we want to keep the original name of the file,
+                            // but also to prevent duplicates of the same file.
+                            if (!this.untitledResourceResolver.has(uri)) {
+                                const untitledResource = await this.untitledResourceResolver.createUntitledResource(
+                                    fileContent,
+                                    undefined,
+                                    new URI(`${UNTITLED_SCHEME}:/${fileName}`)
+                                );
+                                openUri(untitledResource.uri);
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
#### What it does

Adds a feature that wasn't originally included in https://github.com/eclipse-theia/theia/pull/12065. We currently support dragging files from the OS explorer to the main area of Theia, which results in opening the exact file (via its original URI) that was dropped into the application.

This won't work in browser based Theia apps for obvious reasons. Instead, this PRs adjusts the behavior for non-Electron apps. We now simply read the file name and text data of the dropped file into an `untitled` resource that we then attempt to open. Reusing `untitled` resources has a few benefits, mainly that it automatically handles disposal in case the editor is closed and also that it has special behavior when it comes to saving the file (it will automatically open the "Save As..." dialog).

#### How to test

1. Open the browser example app
2. Drag & drop a text (!) file into the main area. Dropping a non-text file (like an image) into the editor will usually result in unexpected behavior. However, it seems like `vscode.dev` also struggles with that, so it's at least as good as VS Code.
3. The file should open, contain the expected file name and otherwise behave as any other `untitled` resource.

#### Follow-ups

We could potentially also support non-text files later on.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
