### PR TITLE
Add task related context keys

### DIFF
--- a/packages/task/src/browser/task-context-key-service.ts
+++ b/packages/task/src/browser/task-context-key-service.ts
@@ -1,0 +1,72 @@
+// *****************************************************************************
+// Copyright (C) 2024 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { ContextKeyService, ContextKey } from '@theia/core/lib/browser/context-key-service';
+import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
+
+@injectable()
+export class TaskContextKeyService {
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
+    @inject(ApplicationServer)
+    protected readonly applicationServer: ApplicationServer;
+
+    protected customExecutionSupported: ContextKey<boolean>;
+    protected shellExecutionSupported: ContextKey<boolean>;
+    protected processExecutionSupported: ContextKey<boolean>;
+    protected serverlessWebContext: ContextKey<boolean>;
+    protected taskCommandsRegistered: ContextKey<boolean>;
+
+    @postConstruct()
+    protected init(): void {
+        this.customExecutionSupported = this.contextKeyService.createKey('customExecutionSupported', true);
+        this.shellExecutionSupported = this.contextKeyService.createKey('shellExecutionSupported', true);
+        this.processExecutionSupported = this.contextKeyService.createKey('processExecutionSupported', true);
+        this.serverlessWebContext = this.contextKeyService.createKey('serverlessWebContext', false);
+        this.taskCommandsRegistered = this.contextKeyService.createKey('taskCommandsRegistered', true);
+        this.applicationServer.getApplicationPlatform().then(platform => {
+            if (platform === 'web') {
+                this.setShellExecutionSupported(false);
+                this.setProcessExecutionSupported(false);
+                this.setServerlessWebContext(true);
+            }
+        });
+    }
+
+    setCustomExecutionSupported(customExecutionSupported: boolean): void {
+        this.customExecutionSupported.set(customExecutionSupported);
+    }
+
+    setShellExecutionSupported(shellExecutionSupported: boolean): void {
+        this.shellExecutionSupported.set(shellExecutionSupported);
+    }
+
+    setProcessExecutionSupported(processExecutionSupported: boolean): void {
+        this.processExecutionSupported.set(processExecutionSupported);
+    }
+
+    setServerlessWebContext(serverlessWebContext: boolean): void {
+        this.serverlessWebContext.set(serverlessWebContext);
+    }
+
+    setTaskCommandsRegistered(taskCommandsRegistered: boolean): void {
+        this.taskCommandsRegistered.set(taskCommandsRegistered);
+    }
+
+}

--- a/packages/task/src/browser/task-context-key-service.ts
+++ b/packages/task/src/browser/task-context-key-service.ts
@@ -27,6 +27,8 @@ export class TaskContextKeyService {
     @inject(ApplicationServer)
     protected readonly applicationServer: ApplicationServer;
 
+    // The context keys are supposed to be aligned with VS Code. See also:
+    // https://github.com/microsoft/vscode/blob/e6125a356ff6ebe7214b183ee1b5fb009a2b8d31/src/vs/workbench/contrib/tasks/common/taskService.ts#L20-L24
     protected customExecutionSupported: ContextKey<boolean>;
     protected shellExecutionSupported: ContextKey<boolean>;
     protected processExecutionSupported: ContextKey<boolean>;

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -42,6 +42,7 @@ import { TaskTemplateSelector } from './task-templates';
 import { TaskTerminalWidgetManager } from './task-terminal-widget-manager';
 import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
 import { QuickAccessContribution } from '@theia/core/lib/browser/quick-input/quick-access';
+import { TaskContextKeyService } from './task-context-key-service';
 
 export default new ContainerModule(bind => {
     bind(TaskFrontendContribution).toSelf().inSingletonScope();
@@ -80,6 +81,7 @@ export default new ContainerModule(bind => {
     bind(TaskSourceResolver).toSelf().inSingletonScope();
     bind(TaskTemplateSelector).toSelf().inSingletonScope();
     bind(TaskTerminalWidgetManager).toSelf().inSingletonScope();
+    bind(TaskContextKeyService).toSelf().inSingletonScope();
 
     bindProcessTaskModule(bind);
     bindTaskPreferences(bind);

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -67,6 +67,7 @@ import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { TaskTerminalWidgetManager } from './task-terminal-widget-manager';
 import { ShellTerminalServerProxy } from '@theia/terminal/lib/common/shell-terminal-protocol';
 import { Mutex } from 'async-mutex';
+import { TaskContextKeyService } from './task-context-key-service';
 
 export interface QuickPickProblemMatcherItem {
     problemMatchers: NamedProblemMatcher[] | undefined;
@@ -192,6 +193,9 @@ export class TaskService implements TaskConfigurationClient {
 
     @inject(TaskTerminalWidgetManager)
     protected readonly taskTerminalWidgetManager: TaskTerminalWidgetManager;
+
+    @inject(TaskContextKeyService)
+    protected readonly taskContextKeyService: TaskContextKeyService;
 
     @postConstruct()
     protected init(): void {


### PR DESCRIPTION
#### What it does

Addresses an issue found in https://github.com/eclipse-theia/theia/discussions/14725#discussioncomment-11894424.

Adds a few new task related context keys that are in use by the Python extension. See [here](https://github.com/microsoft/vscode-python/blob/f0962971ffe3c46184cb941907ddef0cce3aff77/package.json#L1468).

#### How to test

1. Open a python file that simply contains a `print("hello world")` script.
2. Assert that the `editor/title/run` menu contains all expected entries:
![image](https://github.com/user-attachments/assets/0c9c4c91-6178-4b8b-bf27-a3fa0a6780df)
3. Assert that these entries work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
