### PR TITLE
fix: manage AI bindings separately per connection

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-backend-module.ts
+++ b/packages/ai-anthropic/src/node/anthropic-backend-module.ts
@@ -18,11 +18,17 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { ANTHROPIC_LANGUAGE_MODELS_MANAGER_PATH, AnthropicLanguageModelsManager } from '../common/anthropic-language-models-manager';
 import { ConnectionHandler, RpcConnectionHandler } from '@theia/core';
 import { AnthropicLanguageModelsManagerImpl } from './anthropic-language-models-manager-impl';
+import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 
-export default new ContainerModule(bind => {
+// We use a connection module to handle AI services separately for each frontend.
+const anthropicConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService, bindFrontendService }) => {
     bind(AnthropicLanguageModelsManagerImpl).toSelf().inSingletonScope();
     bind(AnthropicLanguageModelsManager).toService(AnthropicLanguageModelsManagerImpl);
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new RpcConnectionHandler(ANTHROPIC_LANGUAGE_MODELS_MANAGER_PATH, () => ctx.container.get(AnthropicLanguageModelsManager))
     ).inSingletonScope();
+});
+
+export default new ContainerModule(bind => {
+    bind(ConnectionContainerModule).toConstantValue(anthropicConnectionModule);
 });

--- a/packages/ai-core/src/node/ai-core-backend-module.ts
+++ b/packages/ai-core/src/node/ai-core-backend-module.ts
@@ -24,6 +24,9 @@ import {
     bindContributionProvider,
 } from '@theia/core';
 import {
+    ConnectionContainerModule
+} from '@theia/core/lib/node/messaging/connection-container-module';
+import {
     LanguageModelRegistry,
     LanguageModelProvider,
     PromptService,
@@ -37,7 +40,8 @@ import {
 } from '../common';
 import { BackendLanguageModelRegistry } from './backend-language-model-registry';
 
-export default new ContainerModule(bind => {
+// We use a connection module to handle AI services separately for each frontend.
+const aiCoreConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService, bindFrontendService }) => {
     bindContributionProvider(bind, LanguageModelProvider);
     bind(BackendLanguageModelRegistry).toSelf().inSingletonScope();
     bind(LanguageModelRegistry).toService(BackendLanguageModelRegistry);
@@ -80,4 +84,8 @@ export default new ContainerModule(bind => {
 
     bind(PromptServiceImpl).toSelf().inSingletonScope();
     bind(PromptService).toService(PromptServiceImpl);
+});
+
+export default new ContainerModule(bind => {
+    bind(ConnectionContainerModule).toConstantValue(aiCoreConnectionModule);
 });

--- a/packages/ai-llamafile/src/node/llamafile-backend-module.ts
+++ b/packages/ai-llamafile/src/node/llamafile-backend-module.ts
@@ -18,8 +18,10 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { LlamafileManagerImpl } from './llamafile-manager-impl';
 import { LlamafileManager, LlamafileServerManagerClient, LlamafileManagerPath } from '../common/llamafile-manager';
 import { ConnectionHandler, RpcConnectionHandler } from '@theia/core';
+import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 
-export default new ContainerModule(bind => {
+// We use a connection module to handle AI services separately for each frontend.
+const llamafileConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService, bindFrontendService }) => {
     bind(LlamafileManager).to(LlamafileManagerImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx => new RpcConnectionHandler<LlamafileServerManagerClient>(
         LlamafileManagerPath,
@@ -29,4 +31,8 @@ export default new ContainerModule(bind => {
             return service;
         }
     )).inSingletonScope();
+});
+
+export default new ContainerModule(bind => {
+    bind(ConnectionContainerModule).toConstantValue(llamafileConnectionModule);
 });

--- a/packages/ai-mcp/src/node/mcp-backend-module.ts
+++ b/packages/ai-mcp/src/node/mcp-backend-module.ts
@@ -18,8 +18,10 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { ConnectionHandler, RpcConnectionHandler } from '@theia/core';
 import { MCPServerManagerImpl } from './mcp-server-manager-impl';
 import { MCPServerManager, MCPServerManagerPath } from '../common/mcp-server-manager';
+import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 
-export default new ContainerModule(bind => {
+// We use a connection module to handle AI services separately for each frontend.
+const mcpConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService, bindFrontendService }) => {
     bind(MCPServerManager).to(MCPServerManagerImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx => new RpcConnectionHandler(
         MCPServerManagerPath,
@@ -28,4 +30,8 @@ export default new ContainerModule(bind => {
             return service;
         }
     )).inSingletonScope();
+});
+
+export default new ContainerModule(bind => {
+    bind(ConnectionContainerModule).toConstantValue(mcpConnectionModule);
 });


### PR DESCRIPTION
#### What it does

Moves all AI backend bindings into ConnectionContainerModules. Therefore these are now scoped per connection (i.e. frontend) instead of globally for all connections.

The global bindings lead to a lot of interference when multiple connections were open. In fact AI streaming did only work for the latest connection.

Related to https://github.com/eclipse-theia/theia/issues/14143

#### How to test

- Open multiple tabs/windows of Theia and verify that Theia AI works in all of them.
- Verify that AI features are connection scoped, e.g. use workspace preferences for AI models, open two different workspaces at the same time and observe that the expected models show up in the corresponding windows

#### Follow-ups

Related to https://github.com/eclipse-theia/theia/issues/14143 this prepares the code base to simplify / streamline a lot of the delegation mechanics.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
