### PR TITLE
Do not let ai chat submit empty messages

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -131,6 +131,7 @@ interface ChatInputProperties {
 const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInputProperties) => {
 
     const [inProgress, setInProgress] = React.useState(false);
+const [isMessageEmpty, setIsMessageEmpty] = React.useState(true);
     // eslint-disable-next-line no-null/no-null
     const editorContainerRef = React.useRef<HTMLDivElement | null>(null);
     // eslint-disable-next-line no-null/no-null
@@ -225,6 +226,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     }, [lastRequest]);
 
     function submit(value: string): void {
+        if (value.trim() === '') { return; };
         setInProgress(true);
         props.onQuery(value);
         if (editorRef.current) {
@@ -239,7 +241,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
         if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
             submit(editorRef.current?.document.textEditorModel.getValue() || '');
-        }
+                    }
     }, [props.isEnabled]);
 
     const handleInputFocus = () => {
@@ -247,6 +249,8 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     };
 
     const handleOnChange = () => {
+const value = editorRef.current?.getControl().getValue() || '';
+        setIsMessageEmpty(value.trim().length === 0);
         showPlaceholderIfEditorEmpty();
         hidePlaceholderIfEditorFilled();
     };
@@ -288,8 +292,8 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
                     <span
                         className="codicon codicon-send option"
                         title="Send (Enter)"
-                        onClick={!props.isEnabled ? undefined : () => submit(editorRef.current?.document.textEditorModel.getValue() || '')}
-                        style={{ cursor: !props.isEnabled ? 'default' : 'pointer', opacity: !props.isEnabled ? 0.5 : 1 }}
+                        onClick={!props.isEnabled || isMessageEmpty ? undefined : () => submit(editorRef.current?.document.textEditorModel.getValue() || '')}
+                        style={{ cursor: !props.isEnabled || isMessageEmpty ? 'default' : 'pointer', opacity: !props.isEnabled || isMessageEmpty ? 0.5 : 1 }}
                     />
             }
         </div>


### PR DESCRIPTION
fixed #14755

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Do not submit empty message in the chat view.

#### How to test

Leave the message box empty, click submit or press enter. It should not submit, i.e. the submit button does not transform to "cancel" icon

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
