### PR TITLE
Fix running playwright test with npm and electron.

### DIFF
--- a/examples/playwright/src/theia-app-loader.ts
+++ b/examples/playwright/src/theia-app-loader.ts
@@ -101,7 +101,7 @@ namespace TheiaElectronAppLoader {
         const appPath = electronConfig.electronAppPath!;
         const pluginsPath = electronConfig.pluginsPath;
         const launchOptions = electronConfig.launchOptions ?? {
-            additionalArgs: ['--no-cluster'],
+            additionalArgs: ['--no-sandbox', '--no-cluster'],
             electronAppPath: appPath,
             pluginsPath: pluginsPath
         };
@@ -120,7 +120,7 @@ namespace TheiaElectronAppLoader {
         electronLaunchOptions: { additionalArgs: string[], electronAppPath: string, pluginsPath?: string } | object,
         workspace?: TheiaWorkspace
     ): {
-        args: string[], env: { [key: string]: string };
+        args: string[]
     } | object {
         if ('additionalArgs' in electronLaunchOptions && 'electronAppPath' in electronLaunchOptions) {
             const args = [
@@ -136,9 +136,7 @@ namespace TheiaElectronAppLoader {
             }
 
             return {
-                args: args, env: {
-                    'THEIA_NO_SPLASH': 'true'
-                }
+                args: args
             };
         }
         return electronLaunchOptions;
@@ -156,6 +154,7 @@ export namespace TheiaAppLoader {
             // disable native elements and early window to avoid issues with the electron app
             process.env.THEIA_ELECTRON_DISABLE_NATIVE_ELEMENTS = '1';
             process.env.THEIA_ELECTRON_NO_EARLY_WINDOW = '1';
+            process.env.THEIA_NO_SPLASH = 'true';
             return TheiaElectronAppLoader.load(args, initialWorkspace, factory);
         }
         const page = await args.browser.newPage();

--- a/examples/playwright/src/theia-workspace.ts
+++ b/examples/playwright/src/theia-workspace.ts
@@ -47,12 +47,14 @@ export class TheiaWorkspace {
 
     get path(): string {
         let workspacePath = this.workspacePath;
-        if (!OSUtil.osStartsWithFileSeparator(this.workspacePath)) {
-            workspacePath = `${OSUtil.fileSeparator}${workspacePath}`;
-        }
+
         if (OSUtil.isWindows) {
             // Drive letters in windows paths have to be lower case
             workspacePath = workspacePath.replace(/.:/, matchedChar => matchedChar.toLowerCase());
+        } else {
+            if (!OSUtil.osStartsWithFileSeparator(this.workspacePath)) {
+                workspacePath = `${OSUtil.fileSeparator}${workspacePath}`;
+            }
         }
         return workspacePath;
     }

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -396,7 +396,7 @@ export class ElectronMainApplication {
     }
 
     protected isShowSplashScreen(): boolean {
-        return typeof this.config.electron.splashScreenOptions === 'object' && !!this.config.electron.splashScreenOptions.content;
+        return !process.env.THEIA_NO_SPLASH && typeof this.config.electron.splashScreenOptions === 'object' && !!this.config.electron.splashScreenOptions.content;
     }
 
     protected getSplashScreenOptions(): ElectronFrontendApplicationConfig.SplashScreenOptions | undefined {
@@ -522,21 +522,21 @@ export class ElectronMainApplication {
     }
 
     protected async handleMainCommand(options: ElectronMainCommandOptions): Promise<void> {
-        if (options.secondInstance === false) {
-            await this.openWindowWithWorkspace(''); // restore previous workspace.
-        } else if (options.file === undefined) {
-            await this.openDefaultWindow();
-        } else {
-            let workspacePath: string | undefined;
+        let workspacePath: string | undefined;
+        if (options.file) {
             try {
                 workspacePath = await fs.realpath(path.resolve(options.cwd, options.file));
             } catch {
                 console.error(`Could not resolve the workspace path. "${options.file}" is not a valid 'file' option. Falling back to the default workspace location.`);
             }
-            if (workspacePath === undefined) {
+        }
+        if (workspacePath !== undefined) {
+            await this.openWindowWithWorkspace(workspacePath);
+        } else {
+            if (options.secondInstance === false) {
+                await this.openWindowWithWorkspace(''); // restore previous workspace.
+            } else if (options.file === undefined) {
                 await this.openDefaultWindow();
-            } else {
-                await this.openWindowWithWorkspace(workspacePath);
             }
         }
     }


### PR DESCRIPTION
#### What it does
This PR launches the electron playwright tests with the installed electron version. It also introduces an environment variable `THEIA_NO_SPLASH` to prevent showing a splash screen (which breaks the tests).

Fixes #14763

Contributed on behalf of STMicroelectronics

#### How to test
Run the playwright tests with electron. Note that we don't expect all of the tests to pass for electron.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
