### PR TITLE
fix: improve performance in AI request logging

### DIFF
--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -114,6 +114,9 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
             const requestId = generateUuid();
             const request: LanguageModelRequest = {
                 messages: [{ type: 'text', actor: 'user', query: prompt }],
+                settings: {
+                    stream: false
+                }
             };
             if (token.isCancellationRequested) {
                 return undefined;

--- a/packages/ai-core/src/browser/frontend-language-model-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-registry.ts
@@ -366,7 +366,7 @@ const languageModelOutputHandler = (
                     'Sending request:'
                 );
                 const formattedRequest = formatJsonWithIndentation(args[0]);
-                formattedRequest.forEach(line => outputChannel.appendLine(line));
+                outputChannel.append(formattedRequest.join('\n'));
                 if (args[1]) {
                     args[1] = new Proxy(args[1], {
                         get<CK extends keyof CancellationToken>(

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -66,7 +66,7 @@ export class OpenAiModel implements LanguageModel {
         const settings = this.getSettings(request);
         const openai = this.initializeOpenAi();
 
-        if (this.isNonStreamingModel(this.model)) {
+        if (this.isNonStreamingModel(this.model) || (typeof settings.stream === 'boolean' && !settings.stream)) {
             return this.handleNonStreamingRequest(openai, request);
         }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Instead of appending AI requests line by line to the output channel, we now append them in a single step. Since appending to a channel is a relatively expensive operation, this change significantly improves performance for large requests.

This is particularly noticeable when AI inline code completions are enabled for large files, as many requests with many lines may be sent during typing.

##### Performance Analysis when typing in average speed for 5 seconds in a large file (1000 lines) *without* this PR

![image](https://github.com/user-attachments/assets/f98c02a6-3d47-453a-add8-bd7ac8738f7f)
![image](https://github.com/user-attachments/assets/ad5a2f3e-591a-47f9-9ab7-998427eb8097)

- We do not spend any time being idle
- 92% of time is spent in `doAppend` of the output channel

##### Performance Analysis when typing in average speed for 5 seconds in a large file (1000 lines) *with* this PR

![image](https://github.com/user-attachments/assets/5633da87-b0e7-43ac-9a27-e20bcab7f623)
![image](https://github.com/user-attachments/assets/3da6e159-cd62-4c6c-8fc0-01fe56b9d1f7)
![image](https://github.com/user-attachments/assets/e54625f5-3751-4e69-ab25-aacf0215d5c5)

- A lot is going on but we also were idle 40% of the time
- Only 3% of the time is spent in `doAppend`
- Most time is spent in React and animations

##### Performance Analysis when typing in average speed for 5 seconds in a large file (1000 lines) without inline completions

![image](https://github.com/user-attachments/assets/04546aba-15fb-45da-8609-fe78f5e7d92a)
![image](https://github.com/user-attachments/assets/ec596ac0-9106-40cf-97d8-c0b77b8fad0e)

- Barely any difference compared to enabled completions with this PR

#### How to test

Enable automatic inline completions and feel the performance difference. Especially noticeable in large files

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
