### PR TITLE
Do not let ai chat submit empty messages

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -154,6 +154,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     const onDeleteChangeSetElement = (index: number) => props.onDeleteChangeSetElement(props.chatModel.id, index);
 
     const [inProgress, setInProgress] = React.useState(false);
+    const [isInputEmpty, setIsInputEmpty] = React.useState(true);
     const [changeSetUI, setChangeSetUI] = React.useState(
         () => props.chatModel.changeSet ? buildChangeSetUI(props.chatModel.changeSet, props.labelProvider, onDeleteChangeSet, onDeleteChangeSetElement) : undefined
     );
@@ -212,6 +213,8 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
                 }
             };
             editor.getControl().onDidChangeModelContent(() => {
+                const value = editor.getControl().getValue();
+                setIsInputEmpty(!value || value.length === 0);
                 updateEditorHeight();
                 handleOnChange();
             });
@@ -270,6 +273,9 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     }, [props.chatModel]);
 
     function submit(value: string): void {
+        if (!value || value.trim().length === 0) {
+            return;
+        }
         setInProgress(true);
         props.onQuery(value);
         if (editorRef.current) {
@@ -338,7 +344,8 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
                     submit(editorRef.current?.document.textEditorModel.getValue() || '');
                 }
             },
-            className: 'codicon-send'
+            className: 'codicon-send',
+            disabled: isInputEmpty || !props.isEnabled
         }];
 
     return <div className='theia-ChatInput'>
@@ -446,6 +453,7 @@ interface Option {
     title: string;
     handler: () => void;
     className: string;
+    disabled?: boolean;
 }
 
 const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({ leftOptions, rightOptions }) => (
@@ -454,7 +462,7 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({ left
             {leftOptions.map((option, index) => (
                 <span
                     key={index}
-                    className={`codicon ${option.className} option`}
+                    className={`codicon ${option.className} option ${option.disabled ? 'disabled' : ''}`}
                     title={option.title}
                     onClick={option.handler}
                 />
@@ -464,7 +472,7 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({ left
             {rightOptions.map((option, index) => (
                 <span
                     key={index}
-                    className={`codicon ${option.className} option`}
+                    className={`codicon ${option.className} option ${option.disabled ? 'disabled' : ''}`}
                     title={option.title}
                     onClick={option.handler}
                 />

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -394,6 +394,12 @@ div:last-child > .theia-ChatNode {
   cursor: pointer;
 }
 
+.theia-ChatInputOptions .option.disabled {
+  cursor: default;
+  opacity: var(--theia-mod-disabled-opacity);
+  pointer-events: none;
+}
+
 .theia-ChatInputOptions .option:hover {
   opacity: 1;
   background-color: var(--theia-toolbar-hoverBackground);


### PR DESCRIPTION
fixed #14755

What it does
Do not submit empty message in the chat view.

How to test
Leave the message box empty, click submit or press enter. It should not submit, i.e. the submit button does not transform to "cancel" icon. the submit button is disabled when no text is in the box.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
