### PR TITLE
Support `vscode` file system provider scheme

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -65,7 +65,7 @@ import { WebSocketConnectionProvider } from './messaging';
 import { AboutDialog, AboutDialogProps } from './about-dialog';
 import { EnvVariablesServer, envVariablesPath, EnvVariable } from './../common/env-variables';
 import { FrontendApplicationStateService } from './frontend-application-state';
-import { JsonSchemaStore, JsonSchemaContribution, DefaultJsonSchemaContribution } from './json-schema-store';
+import { JsonSchemaStore, JsonSchemaContribution, DefaultJsonSchemaContribution, JsonSchemaDataStore } from './json-schema-store';
 import { TabBarToolbarRegistry, TabBarToolbarContribution, TabBarToolbarFactory, TabBarToolbar } from './shell/tab-bar-toolbar';
 import { bindCorePreferences, CorePreferences } from './core-preferences';
 import { ContextKeyService, ContextKeyServiceDummyImpl } from './context-key-service';
@@ -342,6 +342,7 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bindContributionProvider(bind, JsonSchemaContribution);
     bind(JsonSchemaStore).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(JsonSchemaStore);
+    bind(JsonSchemaDataStore).toSelf().inSingletonScope();
     bind(DefaultJsonSchemaContribution).toSelf().inSingletonScope();
     bind(JsonSchemaContribution).toService(DefaultJsonSchemaContribution);
 

--- a/packages/debug/src/browser/debug-schema-updater.ts
+++ b/packages/debug/src/browser/debug-schema-updater.ts
@@ -15,8 +15,8 @@
 // *****************************************************************************
 
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
-import { JsonSchemaRegisterContext, JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
-import { InMemoryResources, deepClone, nls } from '@theia/core/lib/common';
+import { JsonSchemaRegisterContext, JsonSchemaContribution, JsonSchemaDataStore } from '@theia/core/lib/browser/json-schema-store';
+import { deepClone, nls } from '@theia/core/lib/common';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import URI from '@theia/core/lib/common/uri';
 import { DebugService } from '../common/debug-service';
@@ -30,13 +30,13 @@ export class DebugSchemaUpdater implements JsonSchemaContribution {
 
     protected readonly uri = new URI(launchSchemaId);
 
-    @inject(InMemoryResources) protected readonly inmemoryResources: InMemoryResources;
+    @inject(JsonSchemaDataStore) protected readonly jsonStorage: JsonSchemaDataStore;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(DebugService) protected readonly debug: DebugService;
 
     @postConstruct()
     protected init(): void {
-        this.inmemoryResources.add(this.uri, '');
+        this.jsonStorage.setSchema(this.uri, '');
     }
 
     registerSchemas(context: JsonSchemaRegisterContext): void {
@@ -64,9 +64,7 @@ export class DebugSchemaUpdater implements JsonSchemaContribution {
             }
         }
         items.defaultSnippets!.push(...await this.debug.getConfigurationSnippets());
-
-        const contents = JSON.stringify(schema);
-        this.inmemoryResources.update(this.uri, contents);
+        this.jsonStorage.setSchema(this.uri, schema);
     }
 }
 

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -33,6 +33,7 @@ import { FilepathBreadcrumbsContribution } from './breadcrumbs/filepath-breadcru
 import { BreadcrumbsFileTreeWidget, createFileTreeBreadcrumbsWidget } from './breadcrumbs/filepath-breadcrumbs-container';
 import { FilesystemSaveableService } from './filesystem-saveable-service';
 import { SaveableService } from '@theia/core/lib/browser/saveable-service';
+import { VSCodeFileServiceContribution, VSCodeFileSystemProvider } from './vscode-file-service-contribution';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindFileSystemPreferences(bind);
@@ -46,6 +47,9 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(RemoteFileSystemProvider).toSelf().inSingletonScope();
     bind(RemoteFileServiceContribution).toSelf().inSingletonScope();
     bind(FileServiceContribution).toService(RemoteFileServiceContribution);
+    bind(VSCodeFileSystemProvider).toSelf().inSingletonScope();
+    bind(VSCodeFileServiceContribution).toSelf().inSingletonScope();
+    bind(FileServiceContribution).toService(VSCodeFileServiceContribution);
 
     bind(FileSystemWatcherErrorHandler).toSelf().inSingletonScope();
 

--- a/packages/filesystem/src/browser/vscode-file-service-contribution.ts
+++ b/packages/filesystem/src/browser/vscode-file-service-contribution.ts
@@ -1,0 +1,93 @@
+// *****************************************************************************
+// Copyright (C) 2024 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { FileServiceContribution, FileService } from './file-service';
+import {
+    FileChange, FileDeleteOptions, FileOverwriteOptions, FilePermission, FileSystemProvider, FileSystemProviderCapabilities, FileType, FileWriteOptions, Stat, WatchOptions
+} from '../common/files';
+import { Event, URI, Disposable, Emitter } from '@theia/core';
+import { JsonSchemaDataStore } from '@theia/core/lib/browser/json-schema-store';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+
+@injectable()
+export class VSCodeFileSystemProvider implements FileSystemProvider {
+    readonly capabilities = FileSystemProviderCapabilities.Readonly + FileSystemProviderCapabilities.FileReadWrite;
+    readonly onDidChangeCapabilities = Event.None;
+    protected readonly onDidChangeFileEmitter = new Emitter<readonly FileChange[]>();
+    readonly onDidChangeFile = this.onDidChangeFileEmitter.event;
+    readonly onFileWatchError = Event.None;
+
+    @inject(JsonSchemaDataStore)
+    protected readonly store: JsonSchemaDataStore;
+
+    watch(resource: URI, opts: WatchOptions): Disposable {
+        return Disposable.NULL;
+    }
+    async stat(resource: URI): Promise<Stat> {
+        if (this.store.hasSchema(resource)) {
+            const currentTime = Date.now();
+            return {
+                type: FileType.File,
+                permissions: FilePermission.Readonly,
+                mtime: currentTime,
+                ctime: currentTime,
+                size: 0
+            };
+        }
+        throw new Error('Not Found!');
+    }
+    mkdir(resource: URI): Promise<void> {
+        return Promise.resolve();
+    }
+    readdir(resource: URI): Promise<[string, FileType][]> {
+        return Promise.resolve([]);
+    }
+    delete(resource: URI, opts: FileDeleteOptions): Promise<void> {
+        return Promise.resolve();
+    }
+    rename(from: URI, to: URI, opts: FileOverwriteOptions): Promise<void> {
+        return Promise.resolve();
+    }
+    async readFile(resource: URI): Promise<Uint8Array> {
+        if (resource.scheme !== 'vscode') {
+            throw new Error('Not Supported!');
+        }
+        let content: string | undefined;
+        if (resource.authority === 'schemas') {
+            content = this.store.getSchema(resource);
+        }
+        if (typeof content === 'string') {
+            return BinaryBuffer.fromString(content).buffer;
+        }
+        throw new Error('Not Found!');
+    }
+    writeFile(resource: URI, content: Uint8Array, opts: FileWriteOptions): Promise<void> {
+        throw new Error('Not Supported!');
+    }
+}
+
+@injectable()
+export class VSCodeFileServiceContribution implements FileServiceContribution {
+
+    @inject(VSCodeFileSystemProvider)
+    protected readonly provider: VSCodeFileSystemProvider;
+
+    registerFileSystemProviders(service: FileService): void {
+        service.registerProvider('vscode', this.provider);
+    }
+
+}

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -23,8 +23,8 @@
 import * as Ajv from '@theia/core/shared/ajv';
 import debounce = require('p-debounce');
 import { postConstruct, injectable, inject } from '@theia/core/shared/inversify';
-import { JsonSchemaContribution, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
-import { InMemoryResources, deepClone, Emitter } from '@theia/core/lib/common';
+import { JsonSchemaContribution, JsonSchemaDataStore, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
+import { deepClone, Emitter } from '@theia/core/lib/common';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import { inputsSchema } from '@theia/variable-resolver/lib/browser/variable-input-schema';
 import URI from '@theia/core/lib/common/uri';
@@ -40,8 +40,8 @@ export const taskSchemaId = 'vscode://schemas/tasks';
 @injectable()
 export class TaskSchemaUpdater implements JsonSchemaContribution {
 
-    @inject(InMemoryResources)
-    protected readonly inmemoryResources: InMemoryResources;
+    @inject(JsonSchemaDataStore)
+    protected readonly jsonSchemaData: JsonSchemaDataStore;
 
     @inject(ProblemMatcherRegistry)
     protected readonly problemMatcherRegistry: ProblemMatcherRegistry;
@@ -62,12 +62,7 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
 
     @postConstruct()
     protected init(): void {
-        const resource = this.inmemoryResources.add(this.uri, '');
-        if (resource.onDidChangeContents) {
-            resource.onDidChangeContents(() => {
-                this.onDidChangeTaskSchemaEmitter.fire(undefined);
-            });
-        }
+        this.jsonSchemaData.setSchema(this.uri, '');
         this.updateProblemMatcherNames();
         this.updateSupportedTaskTypes();
         // update problem matcher names in the task schema every time a problem matcher is added or disposed
@@ -91,8 +86,8 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
 
         const schema = this.getTaskSchema();
         this.doValidate = new Ajv().compile(schema);
-        const schemaContent = JSON.stringify(schema);
-        this.inmemoryResources.update(this.uri, schemaContent);
+        this.jsonSchemaData.setSchema(this.uri, schema);
+        this.onDidChangeTaskSchemaEmitter.fire(undefined);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14765

Adds support for extension to read files from the `vscode` file system URI scheme. This enables the newest version of the JSON extension to give support for things like `launch.json` config files. See the linked issue for more info.

This also aligns our JSON schema handling closer to VS Code. Instead of using an `InMemoryResources`, we now have a dedicated service for this.

#### How to test

1. Ensure you have the newest version of the JSON language features extension installed
2. Open the `launch.json` file and place your cursor in the `configurations` array area.
3. Trigger the code completion. There should be a few snippets visible.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
