### PR TITLE
Notebook: fixed small race condition for outputs

### DIFF
--- a/packages/notebook/src/browser/renderers/cell-output-webview.ts
+++ b/packages/notebook/src/browser/renderers/cell-output-webview.ts
@@ -45,7 +45,5 @@ export interface CellOutputWebview extends Disposable {
     onDidRenderOutput: Event<OutputRenderEvent>
 
     requestOutputPresentationUpdate(cellHandle: number, output: NotebookCellOutputModel): void;
-
-    attachWebview(): void;
     isAttached(): boolean
 }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -42,6 +42,7 @@ import { NotebookOptionsService, NotebookOutputOptions } from '@theia/notebook/l
 import { NotebookCellModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-model';
 import { CellOutput, NotebookCellsChangeType } from '@theia/notebook/lib/common';
 import { NotebookCellOutputModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-output-model';
+import { Deferred } from '@theia/core/lib/common/promise-util';
 
 export const AdditionalNotebookCellOutputCss = Symbol('AdditionalNotebookCellOutputCss');
 
@@ -242,6 +243,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     protected element?: HTMLDivElement; // React.createRef<HTMLDivElement>();
 
     protected webviewWidget: WebviewWidget;
+    protected webiviewWidgetInitialized = new Deferred();
 
     protected toDispose = new DisposableCollection();
 
@@ -257,6 +259,9 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
         }));
 
         this.webviewWidget = await this.widgetManager.getOrCreateWidget(WebviewWidget.FACTORY_ID, { id: this.id });
+
+        this.webiviewWidgetInitialized.resolve();
+
         // this.webviewWidget.parent = this.editor ?? null;
         this.webviewWidget.setContentOptions({
             allowScripts: true,
@@ -331,15 +336,16 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     }
 
     render(): React.JSX.Element {
-        return <div className='theia-notebook-cell-output-webview' ref={element => {
+        return <div className='theia-notebook-cell-output-webview' ref={async element => {
             if (element) {
                 this.element = element;
+                await this.webiviewWidgetInitialized.promise;
                 this.attachWebview();
             }
         }}></div>;
     }
 
-    attachWebview(): void {
+    protected attachWebview(): void {
         if (this.element) {
             this.webviewWidget.processMessage(new Message('before-attach'));
             this.element.appendChild(this.webviewWidget.node);

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -243,7 +243,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
     protected element?: HTMLDivElement; // React.createRef<HTMLDivElement>();
 
     protected webviewWidget: WebviewWidget;
-    protected webiviewWidgetInitialized = new Deferred();
+    protected webviewWidgetInitialized = new Deferred();
 
     protected toDispose = new DisposableCollection();
 
@@ -260,7 +260,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
         this.webviewWidget = await this.widgetManager.getOrCreateWidget(WebviewWidget.FACTORY_ID, { id: this.id });
 
-        this.webiviewWidgetInitialized.resolve();
+        this.webviewWidgetInitialized.resolve();
 
         // this.webviewWidget.parent = this.editor ?? null;
         this.webviewWidget.setContentOptions({
@@ -339,7 +339,7 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
         return <div className='theia-notebook-cell-output-webview' ref={async element => {
             if (element) {
                 this.element = element;
-                await this.webiviewWidgetInitialized.promise;
+                await this.webviewWidgetInitialized.promise;
                 this.attachWebview();
             }
         }}></div>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes a small race condition that could happen when the rendering of the outputs widget was triggered before the `WebviewWidget`. This led to the outputs not being rendered at all

#### How to test

The only way i was able to reproduce this once was when i had an notebook with outputs open and then did a window reload.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
