### PR TITLE
Fix error handling in OPFSFileSystemProvider

### DIFF
--- a/packages/filesystem/src/browser-only/opfs-filesystem-provider.ts
+++ b/packages/filesystem/src/browser-only/opfs-filesystem-provider.ts
@@ -103,9 +103,8 @@ export class OPFSFileSystemProvider implements FileSystemProviderWithFileReadWri
             }
 
             throw createFileSystemProviderError('Unknown file handle error', FileSystemProviderErrorCode.Unknown);
-
         } catch (error) {
-            throw createFileSystemProviderError(`Error while accessing resource ${resource.toString()}`, FileSystemProviderErrorCode.Unknown);
+            throw toFileSystemProviderError(error);
         }
     }
 
@@ -262,7 +261,7 @@ async function recursiveFileSystemHandle(handle: FileSystemHandle, pathParts: st
     }
     // If there are parts left, the handle must be a directory
     if (handle.kind !== 'directory') {
-        throw FileSystemProviderErrorCode.FileNotADirectory;
+        throw createFileSystemProviderError('Not a directory', FileSystemProviderErrorCode.FileNotADirectory);
     }
     const dirHandle = handle as FileSystemDirectoryHandle;
     // We need to create it and thus we need to stop early to create the file or directory
@@ -289,7 +288,7 @@ async function recursiveFileSystemHandle(handle: FileSystemHandle, pathParts: st
         return recursiveFileSystemHandle(newHandle, pathParts, options);
     }
 
-    throw FileSystemProviderErrorCode.FileNotFound;
+    throw createFileSystemProviderError('File not found', FileSystemProviderErrorCode.FileNotFound);
 }
 
 // Function to copy directory contents recursively


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
There was a mistake in the error handling/throwing in the OPFS file system provider which prevented it from creating directories.

#### How to test
Run the browser-only variant and try to create a directory. This should work now as expected

#### Follow-ups
None
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
