### PR TITLE
Override change elements on additional changes

### DIFF
--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -571,13 +571,10 @@ export class ChangeSetImpl implements ChangeSet {
     }
 
     addOrReplaceElement(element: ChangeSetElement): void {
-        const index = this._elements.findIndex(e => e.uri.toString() === element.uri.toString());
-        if (index >= 0) {
-            this._elements[index] = element;
-        } else {
-            this._elements.push(element);
+        if (!this.replaceElement(element)) {
+            this.addElement(element);
+            this.notifyChange();
         }
-        this.notifyChange();
     }
 
     removeElement(index: number): void {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -570,6 +570,16 @@ export class ChangeSetImpl implements ChangeSet {
         return true;
     }
 
+    addOrReplaceElement(element: ChangeSetElement): void {
+        const index = this._elements.findIndex(e => e.uri.toString() === element.uri.toString());
+        if (index >= 0) {
+            this._elements[index] = element;
+        } else {
+            this._elements.push(element);
+        }
+        this.notifyChange();
+    }
+
     removeElement(index: number): void {
         this._elements.splice(index, 1);
         this.notifyChange();

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -573,7 +573,6 @@ export class ChangeSetImpl implements ChangeSet {
     addOrReplaceElement(element: ChangeSetElement): void {
         if (!this.replaceElement(element)) {
             this.addElement(element);
-            this.notifyChange();
         }
     }
 

--- a/packages/ai-workspace-agent/src/browser/file-changeset-functions.ts
+++ b/packages/ai-workspace-agent/src/browser/file-changeset-functions.ts
@@ -41,7 +41,7 @@ export class WriteChangeToFileProvider implements ToolProvider {
             description: `Proposes writing content to a file. If the file exists, it will be overwritten with the provided content.\n
              If the file does not exist, it will be created. This tool will automatically create any directories needed to write the file.\n
              If the new content is empty, the file will be deleted. To move a file, delete it and re-create it at the new location.\n
-             The proposed changes will be applied when the user accepts.`,
+             The proposed changes will be applied when the user accepts. If called again for the same file, previously proposed changes will be overridden.`,
             parameters: {
                 type: 'object',
                 properties: {
@@ -76,7 +76,7 @@ export class WriteChangeToFileProvider implements ToolProvider {
                 } catch (error) {
                     type = 'add';
                 }
-                changeSet.addElement(
+                changeSet.addOrReplaceElement(
                     this.fileChangeFactory({
                         uri: uri,
                         type: type as 'modify' | 'add' | 'delete',
@@ -117,7 +117,8 @@ export class ReplaceContentInFileProvider implements ToolProvider {
             name: ReplaceContentInFileProvider.ID,
             description: `Request to replace sections of content in an existing file by providing a list of tuples with old content to be matched and replaced.
             Only the first matched instance of each old content in the tuples will be replaced. For deletions, use an empty new content in the tuple.\n
-            Make sure you use the same line endings and whitespace as in the original file content. The proposed changes will be applied when the user accepts.`,
+            Make sure you use the same line endings and whitespace as in the original file content. The proposed changes will be applied when the user accepts.\n
+            If called again for the same file, it will override previously proposed changes.`,
             parameters: {
                 type: 'object',
                 properties: {
@@ -165,7 +166,7 @@ export class ReplaceContentInFileProvider implements ToolProvider {
                             ctx.session.setChangeSet(changeSet);
                         }
 
-                        changeSet.addElement(
+                        changeSet.addOrReplaceElement(
                             this.fileChangeFactory({
                                 uri: fileUri,
                                 type: 'modify',


### PR DESCRIPTION
fixed #14791

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Coder functions use new addOrReplace function in changeset to override existing changes for a file.

#### How to test

generate two changes for a file and check that only the second change is applied e.g.:

1. '@Coder Remove the prefix "MCP" from all user message in packages/ai-mcp/src/browser/mcp-command-contribution.ts'
2. '@Coder Sorry I meant replace "MCP" with "PCM"'

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
