### PR TITLE
Fix structured output dispatch and settings

### DIFF
--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -93,6 +93,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                 model.apiKey === newModel.apiKey &&
                 model.apiVersion === newModel.apiVersion &&
                 model.supportsDeveloperMessage === newModel.supportsDeveloperMessage &&
+                model.supportsStructuredOutput === newModel.supportsStructuredOutput &&
                 model.enableStreaming === newModel.enableStreaming));
 
         this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
@@ -118,6 +119,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             apiVersion: true,
             supportsDeveloperMessage: !openAIModelsSupportingDeveloperMessages.includes(modelId),
             enableStreaming: !openAIModelsWithDisabledStreaming.includes(modelId),
+            supportsStructuredOutput: !openAIModelsWithoutStructuredOutput.includes(modelId),
             defaultRequestSettings: modelRequestSetting?.requestSettings
         };
     }
@@ -142,6 +144,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     apiKey: typeof pref.apiKey === 'string' || pref.apiKey === true ? pref.apiKey : undefined,
                     apiVersion: typeof pref.apiVersion === 'string' || pref.apiVersion === true ? pref.apiVersion : undefined,
                     supportsDeveloperMessage: pref.supportsDeveloperMessage ?? true,
+                    supportsStructuredOutput: pref.supportsStructuredOutput ?? true,
                     enableStreaming: pref.enableStreaming ?? true,
                     defaultRequestSettings: modelRequestSetting?.requestSettings
                 }
@@ -167,3 +170,4 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
 
 const openAIModelsWithDisabledStreaming = ['o1-preview', 'o1-mini'];
 const openAIModelsSupportingDeveloperMessages = ['o1-preview', 'o1-mini'];
+const openAIModelsWithoutStructuredOutput = ['o1-preview', 'gpt-4-turbo', 'gtp-4', 'gpt-3.5-turbo'];

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -170,4 +170,4 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
 
 const openAIModelsWithDisabledStreaming = ['o1-preview', 'o1-mini'];
 const openAIModelsSupportingDeveloperMessages = ['o1-preview', 'o1-mini'];
-const openAIModelsWithoutStructuredOutput = ['o1-preview', 'gpt-4-turbo', 'gtp-4', 'gpt-3.5-turbo'];
+const openAIModelsWithoutStructuredOutput = ['o1-preview', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo', 'o1-mini', 'gpt-4o-2024-05-13'];

--- a/packages/ai-openai/src/browser/openai-preferences.ts
+++ b/packages/ai-openai/src/browser/openai-preferences.ts
@@ -54,6 +54,8 @@ export const OpenAiPreferencesSchema: PreferenceSchema = {
             \n\
             - specify `supportsDeveloperMessage: false` to indicate that the developer role shall not be used.\
             \n\
+            - specify `supportsStructuredOutput: false` to indicate that structured output shall not be used.\
+            \n\
             - specify `enableStreaming: false` to indicate that streaming shall not be used.\
             \n\
             Refer to [our documentation](https://theia-ide.org/docs/user_ai/#openai-compatible-models-eg-via-vllm) for more information.',
@@ -84,6 +86,10 @@ export const OpenAiPreferencesSchema: PreferenceSchema = {
                     supportsDeveloperMessage: {
                         type: 'boolean',
                         title: 'Indicates whether the model supports the `developer` role. `true` by default.',
+                    },
+                    supportsStructuredOutput: {
+                        type: 'boolean',
+                        title: 'Indicates whether the model supports structured output. `true` by default.',
                     },
                     enableStreaming: {
                         type: 'boolean',

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -45,6 +45,10 @@ export interface OpenAiModelDescription {
      */
     supportsDeveloperMessage: boolean;
     /**
+     * Flag to configure whether the OpenAPI model supports structured output. Default is `true`.
+     */
+    supportsStructuredOutput: boolean;
+    /**
      * Default request settings for the OpenAI model.
      */
     defaultRequestSettings?: { [key: string]: unknown };

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -71,6 +71,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                 model.apiKey = apiKeyProvider;
                 model.apiVersion = apiVersionProvider;
                 model.supportsDeveloperMessage = modelDescription.supportsDeveloperMessage;
+                model.supportsStructuredOutput = modelDescription.supportsStructuredOutput;
                 model.defaultRequestSettings = modelDescription.defaultRequestSettings;
             } else {
                 this.languageModelRegistry.addLanguageModels([
@@ -81,6 +82,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                         apiKeyProvider,
                         apiVersionProvider,
                         modelDescription.supportsDeveloperMessage,
+                        modelDescription.supportsStructuredOutput,
                         modelDescription.url,
                         modelDescription.defaultRequestSettings
                     )


### PR DESCRIPTION
fixed #14810

#### What it does

- Move call to structured output variant before handling non streaming requests in openAI language model, otherwise, it is never used
- Introduce a parameter to model descriptions whether an opneAI model supports structured output
- Add default values in the frontend contribution where other defaults are specified
- Make the new parameter configurable for custom openAI models

#### How to test

Use the terminal agent with 4o and o1-preview and verify with a debugger that structured output is used only for 4o

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
