### PR TITLE
Use default import of fix-path package

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -35,13 +35,13 @@ export class BackendGenerator extends AbstractGenerator {
     protected compileElectronMain(electronMainModules?: Map<string, string>): string {
         return `// @ts-check
 
-require('reflect-metadata');
+require('@theia/core/shared/reflect-metadata');
 
 // Useful for Electron/NW.js apps as GUI apps on macOS doesn't inherit the \`$PATH\` define
 // in your dotfiles (.bashrc/.bash_profile/.zshrc/etc).
 // https://github.com/electron/electron/issues/550#issuecomment-162037357
 // https://github.com/eclipse-theia/theia/pull/3534#issuecomment-439689082
-require('fix-path')();
+require('@theia/core/electron-shared/fix-path').default();
 
 // Workaround for https://github.com/electron/electron/issues/9225. Chrome has an issue where
 // in certain locales (e.g. PL), image metrics are wrongly computed. We explicitly set the
@@ -57,7 +57,7 @@ const theiaAppProjectPath = resolve(__dirname, '..', '..');
 process.env.THEIA_APP_PROJECT_PATH = theiaAppProjectPath;
 const { default: electronMainApplicationModule } = require('@theia/core/lib/electron-main/electron-main-application-module');
 const { ElectronMainApplication, ElectronMainApplicationGlobals } = require('@theia/core/lib/electron-main/electron-main-application');
-const { Container } = require('inversify');
+const { Container } = require('@theia/core/shared/inversify');
 const { app } = require('electron');
 
 const config = ${this.prettyStringify(this.pck.props.frontend.config)};
@@ -186,7 +186,7 @@ const main = require('@theia/core/lib/node/main');
 
 BackendApplicationConfigProvider.set(${this.prettyStringify(this.pck.props.backend.config)});
 
-globalThis.extensionInfo = ${this.prettyStringify(this.pck.extensionPackages.map(({ name, version }) => ({ name, version }))) };
+globalThis.extensionInfo = ${this.prettyStringify(this.pck.extensionPackages.map(({ name, version }) => ({ name, version })))};
 
 const serverModule = require('./server');
 const serverAddress = main.start(serverModule());

--- a/package-lock.json
+++ b/package-lock.json
@@ -11509,15 +11509,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/default-shell": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
-      "integrity": "sha512-/Os8tTMPSriNHCsVj3VLjMZblIl1sIg8EXz3qg7C5K+y9calfTA/qzlfPvCQ+LEgLWmtZ9wCnzE1w+S6TPPFyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -14240,21 +14231,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
-      }
-    },
-    "node_modules/fix-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fix-path/-/fix-path-3.0.0.tgz",
-      "integrity": "sha512-opGAl4+ip5jUikHR2C8Jo7czZ80pz8EK/0gMlAZu7xgDmBqIynlX8SMYg9KowYjAU6HT0nxsSJEWru0u+n+N2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "shell-path": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat": {
@@ -23299,12 +23275,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "license": "ISC"
-    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -25149,144 +25119,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/shell-env": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-0.3.0.tgz",
-      "integrity": "sha512-VrC6OSm5riGAFWvlYExA80Rrlfi4STsztNXjyet9Jf20hbiVeeKvJIesb92gJk7zlmpQjB0wOZpy8ClzVdPVWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "default-shell": "^1.0.0",
-        "execa": "^0.5.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/shell-env/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shell-env/node_modules/cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/shell-env/node_modules/execa": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-      "integrity": "sha512-R66dW/hW3I8yV77Wg4xn6zMguRPUgt59VLm5e85NrOF05ZdPn7YOfPBSw0E9epJDvuzwVWEG+HmEaQ4muYuWKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^4.0.0",
-        "get-stream": "^2.2.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/shell-env/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shell-env/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/shell-env/node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/shell-env/node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/shell-env/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shell-env/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/shell-env/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "license": "ISC"
-    },
     "node_modules/shell-escape": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
       "integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw==",
       "license": "MIT"
-    },
-    "node_modules/shell-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/shell-path/-/shell-path-2.1.0.tgz",
-      "integrity": "sha512-w+mbrnpA+r5jSFS4MgFfxZJ1Wx8qMKkR4gvQ+wgaZEoZCMMYZ6Yl/dcNjW/zLMfmx5a9IVIFwGAtUJcnDMmFrg==",
-      "license": "MIT",
-      "dependencies": {
-        "shell-env": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/shell-quote": {
       "version": "1.8.2",
@@ -26547,15 +26384,6 @@
       "license": "MIT",
       "dependencies": {
         "is-natural-number": "^4.0.1"
-      }
-    },
-    "node_modules/strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14804

Correctly uses the default import of the `fix-path` library. Since the 4.0.0 version is an ESM library, we need to call `default()` explicitly. Additionally adjusts the imports used in the generated code to ensure that non-hoisting of libraries does not result in errors.

#### How to test

1. Clean your Theia `node_modules`, ideally using something like `git clean -xfd`
2. Run `npm i && npm run build:electron && npm run start:electron`
3. Everything should work as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
