### PR TITLE
DevContainer: Added simple ContainerEnv contribution

### DIFF
--- a/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
@@ -30,6 +30,7 @@ export function registerContainerCreationContributions(bind: interfaces.Bind): v
     bind(ContainerCreationContribution).to(MountsContribution).inSingletonScope();
     bind(ContainerCreationContribution).to(RemoteUserContribution).inSingletonScope();
     bind(ContainerCreationContribution).to(PostCreateCommandContribution).inSingletonScope();
+    bind(ContainerCreationContribution).to(ContainerEnvContribution).inSingletonScope();
 }
 
 @injectable()
@@ -177,6 +178,18 @@ export class PostCreateCommandContribution implements ContainerCreationContribut
                 } catch (error) {
                     outputprovider.onRemoteOutput('could not execute postCreateCommand ' + JSON.stringify(command) + ' reason:' + error.message);
                 }
+            }
+        }
+    }
+}
+
+@injectable()
+export class ContainerEnvContribution implements ContainerCreationContribution {
+    async handleContainerCreation(createOptions: Docker.ContainerCreateOptions, containerConfig: DevContainerConfiguration): Promise<void> {
+        if (containerConfig.containerEnv) {
+            if(createOptions.Env === undefined) createOptions.Env = [];
+            for(const [key, value] of Object.entries(containerConfig.containerEnv)) {
+                createOptions.Env.push(`${key}=${value}`);
             }
         }
     }

--- a/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
@@ -187,8 +187,10 @@ export class PostCreateCommandContribution implements ContainerCreationContribut
 export class ContainerEnvContribution implements ContainerCreationContribution {
     async handleContainerCreation(createOptions: Docker.ContainerCreateOptions, containerConfig: DevContainerConfiguration): Promise<void> {
         if (containerConfig.containerEnv) {
-            if(createOptions.Env === undefined) createOptions.Env = [];
-            for(const [key, value] of Object.entries(containerConfig.containerEnv)) {
+            if (createOptions.Env === undefined) {
+                createOptions.Env = [];
+            }
+            for (const [key, value] of Object.entries(containerConfig.containerEnv)) {
                 createOptions.Env.push(`${key}=${value}`);
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
One can now set the `containerDev` property in the devcontainer.json. This is a very simple solution for now. 

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Add `"containerEnv": { "FOO": "BAR" }` to respective devcontainer.json. Start the devcontainer with it. Test env variable FOO. Should be BAR.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups
Add ability to use [variables](https://containers.dev/implementors/json_reference/#variables-in-devcontainerjson).

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
