### PR TITLE
Support `fix-path` in non-bundled environments

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -37,12 +37,6 @@ export class BackendGenerator extends AbstractGenerator {
 
 require('@theia/core/shared/reflect-metadata');
 
-// Useful for Electron/NW.js apps as GUI apps on macOS doesn't inherit the \`$PATH\` define
-// in your dotfiles (.bashrc/.bash_profile/.zshrc/etc).
-// https://github.com/electron/electron/issues/550#issuecomment-162037357
-// https://github.com/eclipse-theia/theia/pull/3534#issuecomment-439689082
-require('@theia/core/electron-shared/fix-path').default();
-
 // Workaround for https://github.com/electron/electron/issues/9225. Chrome has an issue where
 // in certain locales (e.g. PL), image metrics are wrongly computed. We explicitly set the
 // LC_NUMERIC to prevent this from happening (selects the numeric formatting category of the
@@ -52,18 +46,24 @@ if (process.env.LC_ALL) {
 }
 process.env.LC_NUMERIC = 'C';
 
-const { resolve } = require('path');
-const theiaAppProjectPath = resolve(__dirname, '..', '..');
-process.env.THEIA_APP_PROJECT_PATH = theiaAppProjectPath;
-const { default: electronMainApplicationModule } = require('@theia/core/lib/electron-main/electron-main-application-module');
-const { ElectronMainApplication, ElectronMainApplicationGlobals } = require('@theia/core/lib/electron-main/electron-main-application');
-const { Container } = require('@theia/core/shared/inversify');
-const { app } = require('electron');
-
-const config = ${this.prettyStringify(this.pck.props.frontend.config)};
-const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};
-
 (async () => {
+    // Useful for Electron/NW.js apps as GUI apps on macOS doesn't inherit the \`$PATH\` define
+    // in your dotfiles (.bashrc/.bash_profile/.zshrc/etc).
+    // https://github.com/electron/electron/issues/550#issuecomment-162037357
+    // https://github.com/eclipse-theia/theia/pull/3534#issuecomment-439689082
+    (await require('@theia/core/electron-shared/fix-path')).default();
+
+    const { resolve } = require('path');
+    const theiaAppProjectPath = resolve(__dirname, '..', '..');
+    process.env.THEIA_APP_PROJECT_PATH = theiaAppProjectPath;
+    const { default: electronMainApplicationModule } = require('@theia/core/lib/electron-main/electron-main-application-module');
+    const { ElectronMainApplication, ElectronMainApplicationGlobals } = require('@theia/core/lib/electron-main/electron-main-application');
+    const { Container } = require('@theia/core/shared/inversify');
+    const { app } = require('electron');
+
+    const config = ${this.prettyStringify(this.pck.props.frontend.config)};
+    const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};
+
     if (isSingleInstance && !app.requestSingleInstanceLock()) {
         // There is another instance running, exit now. The other instance will request focus.
         app.quit();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -74,7 +74,6 @@ export class SomeClass {
   - `native-keymap` (from [`native-keymap@^2.2.1`](https://www.npmjs.com/package/native-keymap))
   - `electron` (from [`electron@30.1.2`](https://www.npmjs.com/package/electron/v/30.1.2))
   - `electron-store` (from [`electron-store@^8.0.0`](https://www.npmjs.com/package/electron-store))
-  - `fix-path` (from [`fix-path@^4.0.0`](https://www.npmjs.com/package/fix-path))
 - `@theia/core/shared/...`
   - `@phosphor/algorithm` (from [`@phosphor/algorithm@1`](https://www.npmjs.com/package/@phosphor/algorithm))
   - `@phosphor/commands` (from [`@phosphor/commands@1`](https://www.npmjs.com/package/@phosphor/commands))

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -20,7 +20,6 @@ The `@theia/electron` extension bundles all Electron-specific dependencies and c
   - `native-keymap` (from [`native-keymap@^2.2.1`](https://www.npmjs.com/package/native-keymap))
   - `electron` (from [`electron@30.1.2`](https://www.npmjs.com/package/electron/v/30.1.2))
   - `electron-store` (from [`electron-store@^8.0.0`](https://www.npmjs.com/package/electron-store))
-  - `fix-path` (from [`fix-path@^4.0.0`](https://www.npmjs.com/package/fix-path))
 
 ## Additional Information
 

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -21,15 +21,14 @@
       ],
       "export =": [
         "electron as Electron",
-        "electron-store as ElectronStore",
-        "fix-path as fixPath"
+        "electron-store as ElectronStore"
       ]
     }
   },
   "publishConfig": {
     "access": "public"
   },
-  "theiaExtensions": [ ],
+  "theiaExtensions": [],
   "keywords": [
     "theia-extension"
   ],

--- a/packages/electron/shared/fix-path/index.js
+++ b/packages/electron/shared/fix-path/index.js
@@ -1,1 +1,1 @@
-module.exports = require('fix-path');
+module.exports = import('fix-path');


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14804

Adjusts the import of `fix-path` to ensure that it also works in non-bundled environments.

#### How to test

1. Adjust the electron test app: Replace the `main` entry in the package.json with `"src-gen/backend/electron-main.js"`.
2. Run `npm run build:electron && npm run start:electron`
3. The app still doesn't start due to other ESM dependencies, but at least it gets to import them ¯\\\_(ツ)\_/¯

#### Follow-ups

We should switch to ESM modules in our app.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
