### PR TITLE
DevContainer: Added ability to use localEnv for containerEnv property

### DIFF
--- a/packages/dev-container/src/electron-node/dev-container-backend-module.ts
+++ b/packages/dev-container/src/electron-node/dev-container-backend-module.ts
@@ -28,11 +28,14 @@ import { RemoteCliContribution } from '@theia/core/lib/node/remote/remote-cli-co
 import { ProfileFileModificationContribution } from './devcontainer-contributions/profile-file-modification-contribution';
 import { DevContainerWorkspaceHandler } from './dev-container-workspace-handler';
 import { WorkspaceHandlerContribution } from '@theia/workspace/lib/node/default-workspace-server';
+import { registerVariableResolverContributions, VariableResolverContribution } from './devcontainer-contributions/variable-resolver-contribution';
 
 export const remoteConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService }) => {
     bindContributionProvider(bind, ContainerCreationContribution);
     registerContainerCreationContributions(bind);
     registerTheiaStartOptionsContributions(bind);
+    bindContributionProvider(bind, VariableResolverContribution);
+    registerVariableResolverContributions(bind);
     bind(ProfileFileModificationContribution).toSelf().inSingletonScope();
     bind(ContainerCreationContribution).toService(ProfileFileModificationContribution);
 

--- a/packages/dev-container/src/electron-node/devcontainer-contributions/variable-resolver-contribution.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/variable-resolver-contribution.ts
@@ -1,0 +1,54 @@
+// *****************************************************************************
+// Copyright (C) 2025 Typefox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, interfaces, LazyServiceIdentifier } from '@theia/core/shared/inversify';
+import { DockerContainerService } from '../docker-container-service';
+
+export const VariableResolverContribution = Symbol('VariableResolverContribution');
+export interface VariableResolverContribution {
+    canResolve(variable: string): boolean;
+    resolve(variable: string): string;
+}
+
+export function registerVariableResolverContributions(bind: interfaces.Bind): void {
+    bind(VariableResolverContribution).to(LocalEnvVariableResolver).inSingletonScope();
+    bind(VariableResolverContribution).to(ContainerIdResolver).inSingletonScope();
+}
+
+@injectable()
+export class LocalEnvVariableResolver implements VariableResolverContribution {
+    canResolve(type: string): boolean {
+        console.log(`Resolving localEnv variable: ${type}`);
+        return type === 'localEnv';
+    }
+
+    resolve(variable: string): string {
+        return process.env[variable] || '';
+    }
+}
+
+@injectable()
+export class ContainerIdResolver implements VariableResolverContribution {
+    @inject(new LazyServiceIdentifier(() => DockerContainerService))
+        protected readonly dockerContainerService: DockerContainerService;
+
+    canResolve(type: string): boolean {
+        return type === 'devcontainerId' && !!this.dockerContainerService.container;
+    }
+    resolve(variable: string): string {
+        return this.dockerContainerService.container?.id || variable;
+    }
+}

--- a/packages/dev-container/src/electron-node/docker-container-service.ts
+++ b/packages/dev-container/src/electron-node/docker-container-service.ts
@@ -60,6 +60,8 @@ export class DockerContainerService {
     @inject(DevContainerFileService)
     protected readonly devContainerFileService: DevContainerFileService;
 
+    container: Docker.Container | undefined;
+
     async getOrCreateContainer(docker: Docker, options: ContainerConnectionOptions, outputProvider?: ContainerOutputProvider): Promise<Docker.Container> {
         let container;
 
@@ -81,6 +83,7 @@ export class DockerContainerService {
         if (!container) {
             container = await this.buildContainer(docker, options.devcontainerFile, workspace, outputProvider);
         }
+        this.container = container;
         return container;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Adds the ability to use such a syntax in devcontainer.json: 
`"containerEnv": { "MY_VARIABLE": "${localEnv:MY_LOCAL_VARIABLE}" }`
So it references the value of the local environment variable MY_LOCAL_VARIABLE.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
 - Start theia via `Launch Electron Backend & Frontend`
 - Add `"containerEnv": {"FOO": "${localEnv:NODE_ENV}", "BAR": "BAZ"}` to the devcontainer.json of your choice
 - Start a devcontainer with that config
 - check that the environment variable FOO has `development` as a value and BAR (guess what)...
  
#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
