### PR TITLE
Make new code completion prompt default and turn on inline by default

### DIFF
--- a/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
@@ -31,7 +31,7 @@ export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
             description: 'Automatically trigger AI completions inline within any (Monaco) editor while editing.\
             \n\
             Alternatively, you can manually trigger the code via the command "Trigger Inline Suggestion" or the default shortcut "Ctrl+Alt+Space".',
-            default: false
+            default: true
         },
         [PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS]: {
             title: 'Excluded File Extensions',

--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -187,7 +187,8 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
         'This agent provides inline code completion in the code editor in the Theia IDE.';
     promptTemplates: PromptTemplate[] = [
         {
-            id: 'code-completion-prompt',
+            id: 'code-completion-prompt-previous',
+            variantOf: 'code-completion-prompt',
             template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 You are a code completion agent. The current file you have to complete is named {{file}}.
@@ -199,8 +200,7 @@ Finish the following code snippet.
 Only return the exact replacement for [[MARKER]] to complete the snippet.`
         },
         {
-            id: 'code-completion-prompt-next',
-            variantOf: 'code-completion-prompt',
+            id: 'code-completion-prompt',
             template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 ## Code snippet


### PR DESCRIPTION
fixed #14460

#### What it does

- Makes the new code completion prompt the default
- Activate inline completion by default

#### How to test

1. reset all code completion prompts and set code completion agents to default
2. Remove the setting "Automatic Code Completion" from the settings json (if it was set)
3. Inline code completion should work well now

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
