### PR TITLE
improve integration between VariableRegistry and AI VariableService

### DIFF
--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -118,7 +118,10 @@ export default new ContainerModule(bind => {
     bind(FrontendVariableService).toSelf().inSingletonScope();
     bind(AIVariableService).toService(FrontendVariableService);
     bind(FrontendApplicationContribution).toService(FrontendVariableService);
-    bind(AIVariableContribution).to(TheiaVariableContribution).inSingletonScope();
+
+    bind(TheiaVariableContribution).toSelf().inSingletonScope();
+    bind(AIVariableContribution).toService(TheiaVariableContribution);
+
     bind(AIVariableContribution).to(TodayVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(TomorrowVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(AgentsVariableContribution).inSingletonScope();

--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -18,6 +18,9 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { VariableRegistry, VariableResolverService } from '@theia/variable-resolver/lib/browser';
 import { AIVariableContribution, AIVariableResolver, AIVariableService, AIVariableResolutionRequest, AIVariableContext, ResolvedAIVariable } from '../common';
 
+/**
+ * Integrates the Theia VariableRegistry with the Theia AI VariableService when running in the browser.
+ */
 @injectable()
 export class TheiaVariableContribution implements AIVariableContribution, AIVariableResolver {
     @inject(VariableResolverService)

--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -19,7 +19,7 @@ import { VariableRegistry, VariableResolverService } from '@theia/variable-resol
 import { AIVariableContribution, AIVariableResolver, AIVariableService, AIVariableResolutionRequest, AIVariableContext, ResolvedAIVariable } from '../common';
 
 /**
- * Integrates the Theia VariableRegistry with the Theia AI VariableService when running in the browser.
+ * Integrates the Theia VariableRegistry with the Theia AI VariableService
  */
 @injectable()
 export class TheiaVariableContribution implements AIVariableContribution, AIVariableResolver {


### PR DESCRIPTION
- make TheiaVariableContribution more easily to customize/override

fixes #14817

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Bind TheiaVariableContribution to self, to make it easier to override

Note: the ticket was about integrating the AI Variable Service with the Theia VariableRegistry (ideally reusing the VariableRegistry directly for AI). However, there are some key differences between the two:

- AI Variable Service is part of Common, whereas VariableRegistry only exists in the Frontend
- AI Variable Service is slightly more customizable, as Variable Resolvers are separate from the Variable Definition, and can be overridden more easily
- VariableRegistry supports more types (including structured arrays/objects); AI Variable Service only supports strings

Moreover, the AI Variable Service already includes a Contribution that delegates to the VariableRegistry in the browser, so no additional work is required here. I made the TheiaVariableContribution a bit easier to replaced (by binding it to self), but actual use cases for customization are unclear at this point, so I don't know how relevant this is.

#### How to test

- Start Theia with AI Chat view, and check that Theia Variables still work as expected (e.g. #lineNumber should appear in auto-completion)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
