### PR TITLE
Fix tool call prompt text replacement

### DIFF
--- a/packages/ai-core/src/common/language-model-util.ts
+++ b/packages/ai-core/src/common/language-model-util.ts
@@ -64,21 +64,4 @@ export const getJsonOfText = (text: string): unknown => {
     throw new Error('Invalid response format');
 };
 
-export const toolRequestToPromptText = (toolRequest: ToolRequest): string => {
-    const parameters = toolRequest.parameters;
-    let paramsText = '';
-    // parameters are supposed to be as a JSON schema. Thus, derive the parameters from its properties definition
-    if (parameters) {
-        const properties = parameters.properties;
-        paramsText = Object.keys(properties)
-            .map(key => {
-                const param = properties[key];
-                return `${key}: ${param.type}`;
-            })
-            .join(', ');
-    }
-    const descriptionText = toolRequest.description
-        ? `: ${toolRequest.description}`
-        : '';
-    return `You can call function: ${toolRequest.id}(${paramsText})${descriptionText}`;
-};
+export const toolRequestToPromptText = (toolRequest: ToolRequest): string => `${toolRequest.id}`;


### PR DESCRIPTION
fixed #14829

#### What it does

Tool functions in chats and prompts are no longer replaced with a full description, but only with the id of the function.
I left the replace function in there, as we might universally change this behavior in the future (see follow up)
see #14829 

#### How to test

Use tool functions in the chat and prompts and set a break point in the request function of the used LLM to check the correct prompt text.

#### Follow-ups

We might also offer ~{-functioName} in the future, which will add the function to the request, but not at al to the prompt.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
