### PR TITLE
fix: `ContentHoverWidget` respects Theia styles

### DIFF
--- a/packages/monaco/src/browser/content-hover-widget-patcher.ts
+++ b/packages/monaco/src/browser/content-hover-widget-patcher.ts
@@ -1,0 +1,74 @@
+// *****************************************************************************
+// Copyright (C) 2025 and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { IPosition } from '@theia/monaco-editor-core/esm/vs/editor/common/core/position';
+import { ContentHoverWidget } from '@theia/monaco-editor-core/esm/vs/editor/contrib/hover/browser/contentHoverWidget';
+
+// https://github.com/microsoft/vscode/blob/1430e1845cbf5ec29a2fc265f12c7fb5c3d685c3/src/vs/editor/contrib/hover/browser/resizableContentWidget.ts#L13-L14
+const VSCODE_TOP_HEIGHT = 30;
+const VSCODE_BOTTOM_HEIGHT = 24;
+
+export interface SetActualHeightForContentHoverWidgetParams {
+    topHeight?: number;
+    bottomHeight?: number;
+}
+
+export interface ContentHoverWidgetPatcher {
+    setActualHeightForContentHoverWidget(params: SetActualHeightForContentHoverWidgetParams): void;
+}
+
+export function createContentWidgetPatcher(): ContentHoverWidgetPatcher {
+    let actualTopDiff: number | undefined;
+    let actualBottomDiff: number | undefined;
+
+    const originalAvailableVerticalSpaceAbove = ContentHoverWidget.prototype['_availableVerticalSpaceAbove'];
+    ContentHoverWidget.prototype['_availableVerticalSpaceAbove'] = function (position: IPosition): number | undefined {
+        const originalValue = originalAvailableVerticalSpaceAbove.call(this, position);
+        if (typeof originalValue !== 'number' || !actualTopDiff) {
+            return originalValue;
+        }
+        // The original implementation deducts the height of the top panel from the total available space.
+        // https://github.com/microsoft/vscode/blob/1430e1845cbf5ec29a2fc265f12c7fb5c3d685c3/src/vs/editor/contrib/hover/browser/resizableContentWidget.ts#L71
+        // However, in Theia, the top panel has generally different size (especially when the toolbar is visible).
+        // This additional height must be further subtracted from the computed height for accurate positioning.
+        return originalValue - actualTopDiff;
+    };
+
+    const originalAvailableVerticalSpaceBelow = ContentHoverWidget.prototype['_availableVerticalSpaceBelow'];
+    ContentHoverWidget.prototype['_availableVerticalSpaceBelow'] = function (position: IPosition): number | undefined {
+        const originalValue = originalAvailableVerticalSpaceBelow.call(this, position);
+        if (typeof originalValue !== 'number' || !actualBottomDiff) {
+            return originalValue;
+        }
+        // The original method subtracts the height of the bottom panel from the overall available height.
+        // https://github.com/microsoft/vscode/blob/1430e1845cbf5ec29a2fc265f12c7fb5c3d685c3/src/vs/editor/contrib/hover/browser/resizableContentWidget.ts#L83
+        // In Theia, the status bar has different height than in VS Code, which means this difference
+        // should be also removed to ensure the calculated available space is accurate.
+        // Note that removing negative value will increase the available space.
+        return originalValue - actualBottomDiff;
+    };
+
+    return {
+        setActualHeightForContentHoverWidget(params): void {
+            if (typeof params.topHeight === 'number') {
+                actualTopDiff = params.topHeight - VSCODE_TOP_HEIGHT;
+            }
+            if (typeof params.bottomHeight === 'number') {
+                actualBottomDiff = params.bottomHeight - VSCODE_BOTTOM_HEIGHT;
+            }
+        },
+    };
+}

--- a/packages/monaco/src/browser/content-hover-widget-patcher.ts
+++ b/packages/monaco/src/browser/content-hover-widget-patcher.ts
@@ -30,7 +30,7 @@ export interface ContentHoverWidgetPatcher {
     setActualHeightForContentHoverWidget(params: SetActualHeightForContentHoverWidgetParams): void;
 }
 
-export function createContentWidgetPatcher(): ContentHoverWidgetPatcher {
+export function createContentHoverWidgetPatcher(): ContentHoverWidgetPatcher {
     let actualTopDiff: number | undefined;
     let actualBottomDiff: number | undefined;
 

--- a/packages/monaco/src/browser/default-content-hover-widget-patcher.ts
+++ b/packages/monaco/src/browser/default-content-hover-widget-patcher.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2025 and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { ApplicationShell, FrontendApplication, FrontendApplicationContribution } from '@theia/core/src/browser';
+import { setActualHeightForContentHoverWidget } from './monaco-init';
+import { SetActualHeightForContentHoverWidgetParams } from './content-hover-widget-patcher';
+
+@injectable()
+export class DefaultContentHoverWidgetPatcher implements FrontendApplicationContribution {
+    onStart(app: FrontendApplication): void {
+        const shell = app.shell;
+
+        this.updateContentHoverWidgetHeight({
+            topHeight: this.getTopPanelHeight(shell),
+            bottomHeight: this.getStatusBarHeight(shell)
+        });
+
+        shell['statusBar'].onDidChangeVisibility(() => {
+            this.updateContentHoverWidgetHeight({
+                bottomHeight: this.getStatusBarHeight(shell)
+            });
+        });
+    }
+
+    protected updateContentHoverWidgetHeight(params: SetActualHeightForContentHoverWidgetParams): void {
+        setActualHeightForContentHoverWidget(params);
+    }
+
+    protected getTopPanelHeight(shell: ApplicationShell): number {
+        return shell.topPanel.node.getBoundingClientRect().height;
+    }
+
+    protected getStatusBarHeight(shell: ApplicationShell): number {
+        return shell['statusBar'].node.getBoundingClientRect().height;
+    }
+}

--- a/packages/monaco/src/browser/default-content-hover-widget-patcher.ts
+++ b/packages/monaco/src/browser/default-content-hover-widget-patcher.ts
@@ -16,8 +16,8 @@
 
 import { injectable } from '@theia/core/shared/inversify';
 import { ApplicationShell, FrontendApplication, FrontendApplicationContribution } from '@theia/core/src/browser';
-import { setActualHeightForContentHoverWidget } from './monaco-init';
 import { SetActualHeightForContentHoverWidgetParams } from './content-hover-widget-patcher';
+import { contentHoverWidgetPatcher } from './monaco-init';
 
 @injectable()
 export class DefaultContentHoverWidgetPatcher implements FrontendApplicationContribution {
@@ -37,7 +37,7 @@ export class DefaultContentHoverWidgetPatcher implements FrontendApplicationCont
     }
 
     protected updateContentHoverWidgetHeight(params: SetActualHeightForContentHoverWidgetParams): void {
-        setActualHeightForContentHoverWidget(params);
+        contentHoverWidgetPatcher.setActualHeightForContentHoverWidget(params);
     }
 
     protected getTopPanelHeight(shell: ApplicationShell): number {

--- a/packages/monaco/src/browser/default-content-hover-widget-patcher.ts
+++ b/packages/monaco/src/browser/default-content-hover-widget-patcher.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable } from '@theia/core/shared/inversify';
-import { ApplicationShell, FrontendApplication, FrontendApplicationContribution } from '@theia/core/src/browser';
+import { ApplicationShell, FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { SetActualHeightForContentHoverWidgetParams } from './content-hover-widget-patcher';
 import { contentHoverWidgetPatcher } from './monaco-init';
 

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -77,6 +77,7 @@ import { IContextKeyService } from '@theia/monaco-editor-core/esm/vs/platform/co
 import { IThemeService } from '@theia/monaco-editor-core/esm/vs/platform/theme/common/themeService.js';
 import { ActiveMonacoUndoRedoHandler, FocusedMonacoUndoRedoHandler } from './monaco-undo-redo-handler';
 import { ILogService } from '@theia/monaco-editor-core/esm/vs/platform/log/common/log';
+import { DefaultContentHoverWidgetPatcher } from './default-content-hover-widget-patcher';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MonacoThemingService).toSelf().inSingletonScope();
@@ -184,6 +185,9 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(ActiveMonacoUndoRedoHandler).toSelf().inSingletonScope();
     bind(UndoRedoHandler).toService(FocusedMonacoUndoRedoHandler);
     bind(UndoRedoHandler).toService(ActiveMonacoUndoRedoHandler);
+
+    bind(DefaultContentHoverWidgetPatcher).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(DefaultContentHoverWidgetPatcher);
 });
 
 export const MonacoConfigurationService = Symbol('MonacoConfigurationService');

--- a/packages/monaco/src/browser/monaco-init.ts
+++ b/packages/monaco/src/browser/monaco-init.ts
@@ -50,9 +50,9 @@ import { MonacoQuickInputImplementation } from './monaco-quick-input-service';
 import { IQuickInputService } from '@theia/monaco-editor-core/esm/vs/platform/quickinput/common/quickInput';
 import { IStandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
 import { MonacoStandaloneThemeService } from './monaco-standalone-theme-service';
-import { createContentWidgetPatcher } from './content-hover-widget-patcher';
+import { createContentHoverWidgetPatcher } from './content-hover-widget-patcher';
 
-export const { setActualHeightForContentHoverWidget } = createContentWidgetPatcher();
+export const contentHoverWidgetPatcher = createContentHoverWidgetPatcher();
 
 class MonacoEditorServiceConstructor {
     /**

--- a/packages/monaco/src/browser/monaco-init.ts
+++ b/packages/monaco/src/browser/monaco-init.ts
@@ -58,7 +58,7 @@ import { IPosition } from '@theia/monaco-editor-core/esm/vs/editor/common/core/p
 // https://github.com/eclipse-theia/theia/blob/b752ea690bdc4e7c5d9ab98a138504ead05be0d1/packages/core/src/browser/style/menus.css#L22
 // https://github.com/eclipse-theia/theia/blob/b752ea690bdc4e7c5d9ab98a138504ead05be0d1/packages/core/src/browser/style/status-bar.css#L18
 // https://github.com/eclipse-theia/theia/issues/14826
-function patchContentHoverWidget(actualTopHeight = 32): { setActualTopHeightForContentHoverWidget: (value: number) => void } {
+function patchContentHoverWidget(actualTopHeight = 32): { adjustActualTopHeightForContentHoverWidget: (value: number) => void } {
     const vscodeTopHeight = 30;
     let _actualTopHeight = actualTopHeight;
     function topHeightDiff(): number {
@@ -78,13 +78,13 @@ function patchContentHoverWidget(actualTopHeight = 32): { setActualTopHeightForC
     };
 
     return {
-        setActualTopHeightForContentHoverWidget: (value: number) => {
-            _actualTopHeight = value;
+        adjustActualTopHeightForContentHoverWidget: (pixelsToAdjustWith: number) => {
+            _actualTopHeight += pixelsToAdjustWith;
         }
     };
 }
 
-export const { setActualTopHeightForContentHoverWidget } = patchContentHoverWidget();
+export const { adjustActualTopHeightForContentHoverWidget } = patchContentHoverWidget();
 
 class MonacoEditorServiceConstructor {
     /**

--- a/packages/monaco/src/browser/monaco-init.ts
+++ b/packages/monaco/src/browser/monaco-init.ts
@@ -68,12 +68,20 @@ function patchContentHoverWidget(actualTopHeight = 32): { adjustActualTopHeightF
     const originalAvailableVerticalSpaceAbove = ContentHoverWidget.prototype['_availableVerticalSpaceAbove'];
     ContentHoverWidget.prototype['_availableVerticalSpaceAbove'] = function (position: IPosition): number | undefined {
         const value = originalAvailableVerticalSpaceAbove.call(this, position);
+        // The original implementation deducts the height of the top panel from the total available space.
+        // https://github.com/microsoft/vscode/blob/1430e1845cbf5ec29a2fc265f12c7fb5c3d685c3/src/vs/editor/contrib/hover/browser/resizableContentWidget.ts#L71
+        // However, in Theia, the top panel is generally 2 pixels taller (or more, depending on the visibility of the toolbar).
+        // This additional height must be further subtracted from the computed height for accurate positioning.
         return typeof value === 'number' ? value - topHeightDiff() : undefined;
     };
 
     const originalAvailableVerticalSpaceBelow = ContentHoverWidget.prototype['_availableVerticalSpaceBelow'];
     ContentHoverWidget.prototype['_availableVerticalSpaceBelow'] = function (position: IPosition): number | undefined {
         const value = originalAvailableVerticalSpaceBelow.call(this, position);
+        // The original method subtracts the height of the bottom panel from the overall available height.
+        // https://github.com/microsoft/vscode/blob/1430e1845cbf5ec29a2fc265f12c7fb5c3d685c3/src/vs/editor/contrib/hover/browser/resizableContentWidget.ts#L83
+        // In Theia, the status bar is 2 pixels shorter than in VS Code, which means this difference
+        // should be added back to ensure the calculated available space is accurate.
         return typeof value === 'number' ? value + 2 : undefined;
     };
 

--- a/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
+++ b/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
@@ -26,7 +26,6 @@ import { setActualTopHeightForContentHoverWidget } from '@theia/monaco/lib/brows
 import { Toolbar, ToolbarFactory } from './toolbar-interfaces';
 import { ToolbarPreferences, TOOLBAR_ENABLE_PREFERENCE_ID } from './toolbar-preference-contribution';
 
-
 @injectable()
 export class ApplicationShellWithToolbarOverride extends ApplicationShell {
     @inject(ToolbarPreferences) protected toolbarPreferences: ToolbarPreferences;

--- a/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
+++ b/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
@@ -22,6 +22,7 @@ import {
 } from '@theia/core/lib/browser';
 import { inject, injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
 import { MAXIMIZED_CLASS } from '@theia/core/lib/browser/shell/theia-dock-panel';
+import { setActualTopHeightForContentHoverWidget } from '@theia/monaco/lib/browser/monaco-init';
 import { Toolbar, ToolbarFactory } from './toolbar-interfaces';
 import { ToolbarPreferences, TOOLBAR_ENABLE_PREFERENCE_ID } from './toolbar-preference-contribution';
 
@@ -60,12 +61,14 @@ export class ApplicationShellWithToolbarOverride extends ApplicationShell {
     protected tryShowToolbar(): boolean {
         const doShowToolbarFromPreference = this.toolbarPreferences[TOOLBAR_ENABLE_PREFERENCE_ID];
         const isShellMaximized = this.mainPanel.hasClass(MAXIMIZED_CLASS) || this.bottomPanel.hasClass(MAXIMIZED_CLASS);
-        if (doShowToolbarFromPreference && !isShellMaximized) {
+        const show = doShowToolbarFromPreference && !isShellMaximized;
+        if (show) {
             this.toolbar.show();
-            return true;
+        } else {
+            this.toolbar.hide();
         }
-        this.toolbar.hide();
-        return false;
+        setActualTopHeightForContentHoverWidget(show ? 32 * 2 : 32);
+        return show;
     }
 
     protected override createLayout(): Layout {

--- a/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
+++ b/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
@@ -26,9 +26,6 @@ import { adjustActualTopHeightForContentHoverWidget } from '@theia/monaco/lib/br
 import { Toolbar, ToolbarFactory } from './toolbar-interfaces';
 import { ToolbarPreferences, TOOLBAR_ENABLE_PREFERENCE_ID } from './toolbar-preference-contribution';
 
-// The toolbar is 2px shorter than the height of the top panel.
-// https://github.com/eclipse-theia/theia/blob/451464e6ea3d4aaf9cdbffd3d17dbb117787fc4e/packages/toolbar/src/browser/style/toolbar.css#L18
-const TOOLBAR_HEIGHT_PX = 30;
 
 @injectable()
 export class ApplicationShellWithToolbarOverride extends ApplicationShell {
@@ -71,7 +68,8 @@ export class ApplicationShellWithToolbarOverride extends ApplicationShell {
         } else {
             this.toolbar.hide();
         }
-        adjustActualTopHeightForContentHoverWidget(show ? TOOLBAR_HEIGHT_PX : -TOOLBAR_HEIGHT_PX);
+        const toolbarHeight = this.toolbar.node.getBoundingClientRect().height;
+        adjustActualTopHeightForContentHoverWidget(show ? toolbarHeight : -toolbarHeight);
         return show;
     }
 

--- a/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
+++ b/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
@@ -22,7 +22,6 @@ import {
 } from '@theia/core/lib/browser';
 import { inject, injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
 import { MAXIMIZED_CLASS } from '@theia/core/lib/browser/shell/theia-dock-panel';
-import { setActualTopHeightForContentHoverWidget } from '@theia/monaco/lib/browser/monaco-init';
 import { Toolbar, ToolbarFactory } from './toolbar-interfaces';
 import { ToolbarPreferences, TOOLBAR_ENABLE_PREFERENCE_ID } from './toolbar-preference-contribution';
 
@@ -61,16 +60,12 @@ export class ApplicationShellWithToolbarOverride extends ApplicationShell {
     protected tryShowToolbar(): boolean {
         const doShowToolbarFromPreference = this.toolbarPreferences[TOOLBAR_ENABLE_PREFERENCE_ID];
         const isShellMaximized = this.mainPanel.hasClass(MAXIMIZED_CLASS) || this.bottomPanel.hasClass(MAXIMIZED_CLASS);
-        const show = doShowToolbarFromPreference && !isShellMaximized;
-        if (show) {
+        if (doShowToolbarFromPreference && !isShellMaximized) {
             this.toolbar.show();
-        } else {
-            this.toolbar.hide();
+            return true
         }
-        const topPanelHeight = this.topPanel.node.getBoundingClientRect().height;
-        const toolbarHeight = this.toolbar.node.getBoundingClientRect().height; // 0 if hidden
-        setActualTopHeightForContentHoverWidget(topPanelHeight + toolbarHeight);
-        return show;
+        this.toolbar.hide();
+        return false
     }
 
     protected override createLayout(): Layout {

--- a/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
+++ b/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
@@ -62,10 +62,10 @@ export class ApplicationShellWithToolbarOverride extends ApplicationShell {
         const isShellMaximized = this.mainPanel.hasClass(MAXIMIZED_CLASS) || this.bottomPanel.hasClass(MAXIMIZED_CLASS);
         if (doShowToolbarFromPreference && !isShellMaximized) {
             this.toolbar.show();
-            return true
+            return true;
         }
         this.toolbar.hide();
-        return false
+        return false;
     }
 
     protected override createLayout(): Layout {

--- a/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
+++ b/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
@@ -22,9 +22,13 @@ import {
 } from '@theia/core/lib/browser';
 import { inject, injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
 import { MAXIMIZED_CLASS } from '@theia/core/lib/browser/shell/theia-dock-panel';
-import { setActualTopHeightForContentHoverWidget } from '@theia/monaco/lib/browser/monaco-init';
+import { adjustActualTopHeightForContentHoverWidget } from '@theia/monaco/lib/browser/monaco-init';
 import { Toolbar, ToolbarFactory } from './toolbar-interfaces';
 import { ToolbarPreferences, TOOLBAR_ENABLE_PREFERENCE_ID } from './toolbar-preference-contribution';
+
+// The toolbar is 2px shorter than the height of the top panel.
+// https://github.com/eclipse-theia/theia/blob/451464e6ea3d4aaf9cdbffd3d17dbb117787fc4e/packages/toolbar/src/browser/style/toolbar.css#L18
+const TOOLBAR_HEIGHT_PX = 30;
 
 @injectable()
 export class ApplicationShellWithToolbarOverride extends ApplicationShell {
@@ -67,7 +71,7 @@ export class ApplicationShellWithToolbarOverride extends ApplicationShell {
         } else {
             this.toolbar.hide();
         }
-        setActualTopHeightForContentHoverWidget(show ? 32 * 2 : 32);
+        adjustActualTopHeightForContentHoverWidget(show ? TOOLBAR_HEIGHT_PX : -TOOLBAR_HEIGHT_PX);
         return show;
     }
 

--- a/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
+++ b/packages/toolbar/src/browser/application-shell-with-toolbar-override.ts
@@ -22,7 +22,7 @@ import {
 } from '@theia/core/lib/browser';
 import { inject, injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
 import { MAXIMIZED_CLASS } from '@theia/core/lib/browser/shell/theia-dock-panel';
-import { adjustActualTopHeightForContentHoverWidget } from '@theia/monaco/lib/browser/monaco-init';
+import { setActualTopHeightForContentHoverWidget } from '@theia/monaco/lib/browser/monaco-init';
 import { Toolbar, ToolbarFactory } from './toolbar-interfaces';
 import { ToolbarPreferences, TOOLBAR_ENABLE_PREFERENCE_ID } from './toolbar-preference-contribution';
 
@@ -68,8 +68,9 @@ export class ApplicationShellWithToolbarOverride extends ApplicationShell {
         } else {
             this.toolbar.hide();
         }
-        const toolbarHeight = this.toolbar.node.getBoundingClientRect().height;
-        adjustActualTopHeightForContentHoverWidget(show ? toolbarHeight : -toolbarHeight);
+        const topPanelHeight = this.topPanel.node.getBoundingClientRect().height;
+        const toolbarHeight = this.toolbar.node.getBoundingClientRect().height; // 0 if hidden
+        setActualTopHeightForContentHoverWidget(topPanelHeight + toolbarHeight);
         return show;
     }
 

--- a/packages/toolbar/src/browser/toolbar-content-hover-widget-patcher.ts
+++ b/packages/toolbar/src/browser/toolbar-content-hover-widget-patcher.ts
@@ -1,0 +1,51 @@
+// *****************************************************************************
+// Copyright (C) 2025 and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ApplicationShell, FrontendApplication } from '@theia/core/lib/browser';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { DefaultContentHoverWidgetPatcher } from '@theia/monaco/lib/browser/default-content-hover-widget-patcher';
+import { ApplicationShellWithToolbarOverride } from './application-shell-with-toolbar-override';
+
+@injectable()
+export class ToolbarContentHoverWidgetPatcher extends DefaultContentHoverWidgetPatcher {
+
+    override onStart(app: FrontendApplication): void {
+        super.onStart(app);
+        const shell = app.shell;
+        if (shell instanceof ApplicationShellWithToolbarOverride) {
+            shell['toolbar'].onDidChangeVisibility(() => {
+                this.updateContentHoverWidgetHeight({
+                    topHeight: this.getTopPanelHeight(shell)
+                });
+            });
+        }
+    }
+
+    protected override getTopPanelHeight(shell: ApplicationShell): number {
+        const defaultHeight = shell.topPanel.node.getBoundingClientRect().height;
+        if (shell instanceof ApplicationShellWithToolbarOverride) {
+            const toolbarHeight = shell['toolbar'].node.getBoundingClientRect().height;
+            return defaultHeight + toolbarHeight;
+        }
+        return defaultHeight;
+    }
+}
+
+export const bindToolbarContentHoverWidgetPatcher = (bind: interfaces.Bind, rebind: interfaces.Rebind, unbind: interfaces.Unbind): void => {
+    bind(ToolbarContentHoverWidgetPatcher).toSelf().inSingletonScope();
+    rebind(DefaultContentHoverWidgetPatcher).toService(ToolbarContentHoverWidgetPatcher);
+};
+

--- a/packages/toolbar/src/browser/toolbar-frontend-module.ts
+++ b/packages/toolbar/src/browser/toolbar-frontend-module.ts
@@ -18,6 +18,7 @@ import '../../src/browser/style/toolbar.css';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { bindToolbarApplicationShell } from './application-shell-with-toolbar-override';
 import { bindToolbar } from './toolbar-command-contribution';
+import { bindToolbarContentHoverWidgetPatcher } from './toolbar-content-hover-widget-patcher';
 
 export default new ContainerModule((
     bind: interfaces.Bind,
@@ -27,4 +28,5 @@ export default new ContainerModule((
 ) => {
     bindToolbarApplicationShell(bind, rebind, unbind);
     bindToolbar(bind);
+    bindToolbarContentHoverWidgetPatcher(bind, rebind, unbind);
 });


### PR DESCRIPTION





<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Customize the default `ContentHoverWidget` behavior to ensure it uses Theia styles when calculating available space for the hover widget.

VS Code uses 30 pixels for the top height and 24 pixels for the bottom height, but Theia uses 32 pixels for the top and 22 for the bottom.

Closes eclipse-theia/theia#14826

This PR fixes the available space calculation for the content hover widget in the monaco editor. As described in #14826, the Theia top and bottom height (menu + status bar) are different in VS Code. In some cases, the popup either was on the menu or was hidden under the Theia toolbar. This PR fixes both cases.

#### How to test

Please, as shown in the issue, try to make the editor hover either overlay the menu or hide below the toolbar when active. Let me know if you still find glitches.

In-action:

https://github.com/user-attachments/assets/e5cd92a0-b3ad-4893-a68a-dac444d52ed2

https://github.com/user-attachments/assets/e9b117ef-8ff1-4548-a4cd-18fd67c42dc7




<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
