### PR TITLE
Fix autocompletion for functions in chat input

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts
@@ -13,14 +13,14 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import * as monaco from '@theia/monaco-editor-core';
-import { ContributionProvider, MaybePromise } from '@theia/core';
+import { MaybePromise } from '@theia/core';
 import { ProviderResult } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
 import { ChatAgentService } from '@theia/ai-chat';
 import { AIVariableService } from '@theia/ai-core/lib/common';
-import { ToolProvider } from '@theia/ai-core/lib/common/tool-invocation-registry';
+import { ToolInvocationRegistry } from '@theia/ai-core/lib/common/tool-invocation-registry';
 
 export const CHAT_VIEW_LANGUAGE_ID = 'theia-ai-chat-view-language';
 export const CHAT_VIEW_LANGUAGE_EXTENSION = 'aichatviewlanguage';
@@ -34,9 +34,8 @@ export class ChatViewLanguageContribution implements FrontendApplicationContribu
     @inject(AIVariableService)
     protected readonly variableService: AIVariableService;
 
-    @inject(ContributionProvider)
-    @named(ToolProvider)
-    private providers: ContributionProvider<ToolProvider>;
+    @inject(ToolInvocationRegistry)
+    private readonly toolInvocationRegistry: ToolInvocationRegistry;
 
     onStart(_app: FrontendApplication): MaybePromise<void> {
         monaco.languages.register({ id: CHAT_VIEW_LANGUAGE_ID, extensions: [CHAT_VIEW_LANGUAGE_EXTENSION] });
@@ -130,7 +129,7 @@ export class ChatViewLanguageContribution implements FrontendApplicationContribu
             model,
             position,
             '~',
-            this.providers.getContributions().map(provider => provider.getTool()),
+            this.toolInvocationRegistry.getAllFunctions(),
             monaco.languages.CompletionItemKind.Function,
             tool => tool.id,
             tool => tool.name,

--- a/packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts
@@ -35,7 +35,7 @@ export class ChatViewLanguageContribution implements FrontendApplicationContribu
     protected readonly variableService: AIVariableService;
 
     @inject(ToolInvocationRegistry)
-    private readonly toolInvocationRegistry: ToolInvocationRegistry;
+    protected readonly toolInvocationRegistry: ToolInvocationRegistry;
 
     onStart(_app: FrontendApplication): MaybePromise<void> {
         monaco.languages.register({ id: CHAT_VIEW_LANGUAGE_ID, extensions: [CHAT_VIEW_LANGUAGE_EXTENSION] });


### PR DESCRIPTION
fixed #14837

#### What it does

use tool invocation registry for auto completing functions in chat input instead of contribution point.
See how it is done in packages/ai-core/src/browser/prompttemplate-contribution.ts

#### How to test

Auto complete functions in the chat and see that MCP functions are now also suggested.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
