### PR TITLE
chore: use fileservice.exist instead of trying to read the file

### DIFF
--- a/packages/ai-workspace-agent/src/browser/file-changeset-functions.ts
+++ b/packages/ai-workspace-agent/src/browser/file-changeset-functions.ts
@@ -70,10 +70,7 @@ export class WriteChangeToFileProvider implements ToolProvider {
                 if (content === '') {
                     type = 'delete';
                 }
-                // In case the file does not exist and the content is empty, we consider that the AI wants to add an empty file.
-                try {
-                    await this.fileService.read(uri);
-                } catch (error) {
+                if (!await this.fileService.exists(uri)) {
                     type = 'add';
                 }
                 changeSet.addOrReplaceElement(


### PR DESCRIPTION
#### What it does

use fileservice.exist instead of trying to read the file in packages/ai-workspace-agent/src/browser/file-changeset-functions.ts

#### How to test

Prompt coder with
"@Coder Move the readme file to a sub direcotry called /readme"
=> one file delete, one addition

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
