### PR TITLE
Align AI chat toggle keybinding with VS Code on macOS

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { CommandRegistry, QuickInputButton, QuickInputService, QuickPickItem } from '@theia/core';
+import { CommandRegistry, isOSX, QuickInputButton, QuickInputService, QuickPickItem } from '@theia/core';
 import { Widget } from '@theia/core/lib/browser';
 import { AI_CHAT_NEW_CHAT_WINDOW_COMMAND, AI_CHAT_SHOW_CHATS_COMMAND, ChatCommands } from './chat-view-commands';
 import { ChatAgentLocation, ChatService } from '@theia/ai-chat';
@@ -52,7 +52,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
                 rank: 100
             },
             toggleCommandId: AI_CHAT_TOGGLE_COMMAND_ID,
-            toggleKeybinding: 'ctrlcmd+alt+i'
+            toggleKeybinding: isOSX ? 'ctrl+cmd+i' : 'ctrl+alt+i'
         });
     }
 


### PR DESCRIPTION
#### What it does

On macOS, assign `Control+Command+I` keybinding and on other platforms `Control+Alternate+I` to align with VS Code on Mac and not clash with Chrome devtools on all platforms.

Fixes #14814

#### How to test

1. On macOS,
    1. Hit <kbd>⌃</kbd>+<kbd>⌘</kbd>+<kbd>I</kbd> repeatedly and see the AI Chat view toggle on and off.
    2. Hit <kbd>⌥</kbd>+<kbd>⌘</kbd>+<kbd>I</kbd> and see the Chrome devtools appear. 
3. On Linux and Windows,
    1. Hit <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd> repeatedly and see the AI Chat view toggle on and off.
    2. Hit whatever is the platform's keyboard shortcut for Chrome devtools and see them appear.

Review the keybinding editor. On macOS, you should see something like this (never mind that Theia shows the modifiers in the wrong order):

![CleanShot 2025-02-05 at 13 36 42](https://github.com/user-attachments/assets/471c5309-90ef-43d8-bafa-a9a71cb769be)

#### Follow-ups

None.

#### Breaking changes

None.

#### Attribution

None.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
