### PR TITLE
Streamline logging API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## 1.59.0
+
+<a name="breaking_changes_1.59.0">[Breaking Changes:](#breaking_changes_1.59.0)</a>
+
+- [core] Adjusted the binding of named `ILogger` injections. These no longer have to be bound explicitly.
+  If you encounter errors such as `Error: Ambiguous match found for serviceIdentifier: Symbol(ILogger)`, remove your bindings for the `ILogger` symbol.
+
 ## 1.58.0 - 01/30/2025
 
 - [ai] added 'required' property to tool call parameters [#14673](https://github.com/eclipse-theia/theia/pull/14673)
@@ -33,7 +40,7 @@
 - [core] added support for dragging files in browser [#14756](https://github.com/eclipse-theia/theia/pull/14756)
 - [core] fixed dragging file from outside the workspace [#14746](https://github.com/eclipse-theia/theia/pull/14746)
 - [core] fixed override of default key bindings [#14668](https://github.com/eclipse-theia/theia/pull/14668)
-- [core] fixed workbench.action.files.newUntitledFile [#0](https://github.com/eclipse-theia/theia/pull/0)
+- [core] fixed `workbench.action.files.newUntitledFile` command [#14754](https://github.com/eclipse-theia/theia/pull/14754)
 - [core] fixed z-index overlay issue in dock panels [#14695](https://github.com/eclipse-theia/theia/pull/14695)
 - [core] updated build scripts to use npm instead of yarn to build Theia [#14481](https://github.com/eclipse-theia/theia/pull/14481) - Contributed on behalf of STMicroelectronics
 - [core] updated keytar and drivelist [#14306](https://github.com/eclipse-theia/theia/pull/14306)

--- a/packages/ai-code-completion/src/browser/ai-code-completion-frontend-module.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-frontend-module.ts
@@ -14,7 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ILogger } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { CodeCompletionAgent, CodeCompletionAgentImpl } from './code-completion-agent';
 import { AIFrontendApplicationContribution } from './ai-code-frontend-application-contribution';
@@ -25,10 +24,6 @@ import { AICodeInlineCompletionsProvider } from './ai-code-inline-completion-pro
 import { CodeCompletionPostProcessor, DefaultCodeCompletionPostProcessor } from './code-completion-postprocessor';
 
 export default new ContainerModule(bind => {
-    bind(ILogger).toDynamicValue(ctx => {
-        const parentLogger = ctx.container.get<ILogger>(ILogger);
-        return parentLogger.child('code-completion-agent');
-    }).inSingletonScope().whenTargetNamed('code-completion-agent');
     bind(CodeCompletionAgentImpl).toSelf().inSingletonScope();
     bind(CodeCompletionAgent).toService(CodeCompletionAgentImpl);
     bind(Agent).toService(CodeCompletionAgentImpl);

--- a/packages/ai-history/src/browser/ai-history-frontend-module.ts
+++ b/packages/ai-history/src/browser/ai-history-frontend-module.ts
@@ -17,7 +17,6 @@ import { CommunicationRecordingService } from '@theia/ai-core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { DefaultCommunicationRecordingService } from '../common/communication-recording-service';
 import { bindViewContribution, WidgetFactory } from '@theia/core/lib/browser';
-import { ILogger } from '@theia/core';
 import { AIHistoryViewContribution } from './ai-history-contribution';
 import { AIHistoryView } from './ai-history-widget';
 import '../../src/browser/style/ai-history.css';
@@ -26,11 +25,6 @@ import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar
 export default new ContainerModule(bind => {
     bind(DefaultCommunicationRecordingService).toSelf().inSingletonScope();
     bind(CommunicationRecordingService).toService(DefaultCommunicationRecordingService);
-
-    bind(ILogger).toDynamicValue(ctx => {
-        const parentLogger = ctx.container.get<ILogger>(ILogger);
-        return parentLogger.child('llm-communication-recorder');
-    }).inSingletonScope().whenTargetNamed('llm-communication-recorder');
 
     bindViewContribution(bind, AIHistoryViewContribution);
 

--- a/packages/core/src/browser/logger-frontend-module.ts
+++ b/packages/core/src/browser/logger-frontend-module.ts
@@ -16,11 +16,12 @@
 
 import { ContainerModule, Container } from 'inversify';
 import { ILoggerServer, loggerPath, ConsoleLogger } from '../common/logger-protocol';
-import { ILogger, Logger, LoggerFactory, setRootLogger, LoggerName, rootLoggerName } from '../common/logger';
+import { ILogger, Logger, LoggerFactory, setRootLogger, LoggerName } from '../common/logger';
 import { LoggerWatcher } from '../common/logger-watcher';
 import { WebSocketConnectionProvider } from './messaging';
 import { FrontendApplicationContribution } from './frontend-application-contribution';
 import { EncodingError } from '../common/message-rpc/rpc-message-encoder';
+import { bindCommonLogger } from '../common/logger-binding';
 
 export const loggerFrontendModule = new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toDynamicValue(ctx => ({
@@ -29,9 +30,7 @@ export const loggerFrontendModule = new ContainerModule(bind => {
         }
     }));
 
-    bind(LoggerName).toConstantValue(rootLoggerName);
-    bind(ILogger).to(Logger).inSingletonScope().whenTargetIsDefault();
-    bind(LoggerWatcher).toSelf().inSingletonScope();
+    bindCommonLogger(bind);
     bind(ILoggerServer).toDynamicValue(ctx => {
         const loggerWatcher = ctx.container.get(LoggerWatcher);
         const connection = ctx.container.get(WebSocketConnectionProvider);

--- a/packages/core/src/common/logger-protocol.ts
+++ b/packages/core/src/common/logger-protocol.ts
@@ -110,10 +110,12 @@ export namespace ConsoleLogger {
         console.trace = consoles.get(LogLevel.TRACE)!;
         console.log = originalConsoleLog;
     }
-    export function log(name: string, logLevel: number, message: string, params: any[]): void {
+    export function log(name: string, logLevel: number, message: string, params: any[]): string {
         const console = consoles.get(logLevel) || originalConsoleLog;
         const severity = (LogLevel.strings.get(logLevel) || 'unknown').toUpperCase();
         const now = new Date();
-        console(`${now.toISOString()} ${name} ${severity} ${message}`, ...params);
+        const formattedMessage = `${now.toISOString()} ${name} ${severity} ${message}`;
+        console(formattedMessage, ...params);
+        return formattedMessage;
     }
 }

--- a/packages/core/src/common/logger.ts
+++ b/packages/core/src/common/logger.ts
@@ -240,6 +240,8 @@ export class Logger implements ILogger {
     @inject(LoggerFactory) protected readonly factory: LoggerFactory;
     @inject(LoggerName) protected name: string;
 
+    protected cache = new Map<string, ILogger>();
+
     @postConstruct()
     protected init(): void {
         if (this.name !== rootLoggerName) {
@@ -384,6 +386,13 @@ export class Logger implements ILogger {
     }
 
     child(name: string): ILogger {
-        return this.factory(name);
+        const existing = this.cache.get(name);
+        if (existing) {
+            return existing;
+        } else {
+            const child = this.factory(name);
+            this.cache.set(name, child);
+            return child;
+        }
     }
 }

--- a/packages/core/src/node/logger-backend-module.ts
+++ b/packages/core/src/node/logger-backend-module.ts
@@ -16,20 +16,19 @@
 
 import { ContainerModule, Container, interfaces } from 'inversify';
 import { ConnectionHandler, RpcConnectionHandler } from '../common/messaging';
-import { ILogger, LoggerFactory, Logger, setRootLogger, LoggerName, rootLoggerName } from '../common/logger';
+import { ILogger, LoggerFactory, Logger, setRootLogger, LoggerName } from '../common/logger';
 import { ILoggerServer, ILoggerClient, loggerPath, DispatchingLoggerClient } from '../common/logger-protocol';
 import { ConsoleLoggerServer } from './console-logger-server';
 import { LoggerWatcher } from '../common/logger-watcher';
 import { BackendApplicationContribution } from './backend-application';
 import { CliContribution } from './cli';
 import { LogLevelCliContribution } from './logger-cli-contribution';
+import { bindCommonLogger } from '../common/logger-binding';
 
 export function bindLogger(bind: interfaces.Bind, props?: {
     onLoggerServerActivation?: (context: interfaces.Context, server: ILoggerServer) => void
 }): void {
-    bind(LoggerName).toConstantValue(rootLoggerName);
-    bind(ILogger).to(Logger).inSingletonScope().whenTargetIsDefault();
-    bind(LoggerWatcher).toSelf().inSingletonScope();
+    bindCommonLogger(bind);
     bind<ILoggerServer>(ILoggerServer).to(ConsoleLoggerServer).inSingletonScope().onActivation((context, server) => {
         if (props && props.onLoggerServerActivation) {
             props.onLoggerServerActivation(context, server);

--- a/packages/core/src/node/logger-cli-contribution.ts
+++ b/packages/core/src/node/logger-cli-contribution.ts
@@ -43,6 +43,8 @@ export class LogLevelCliContribution implements CliContribution {
      */
     protected _defaultLogLevel: LogLevel = LogLevel.INFO;
 
+    protected _logFile?: string;
+
     protected logConfigChangedEvent: Emitter<void> = new Emitter<void>();
 
     get defaultLogLevel(): LogLevel {
@@ -51,6 +53,10 @@ export class LogLevelCliContribution implements CliContribution {
 
     get logLevels(): LogLevels {
         return this._logLevels;
+    }
+
+    get logFile(): string | undefined {
+        return this._logFile;
     }
 
     configure(conf: yargs.Argv): void {
@@ -64,6 +70,12 @@ export class LogLevelCliContribution implements CliContribution {
             description: 'Path to the JSON file specifying the configuration of various loggers',
             type: 'string',
             nargs: 1,
+        });
+
+        conf.option('log-file', {
+            description: 'Path to the log file',
+            type: 'string',
+            nargs: 1
         });
     }
 
@@ -87,22 +99,36 @@ export class LogLevelCliContribution implements CliContribution {
                 console.error(`Error reading log config file ${filename}: ${e}`);
             }
         }
+
+        if (args['log-file'] !== undefined) {
+            let filename: string = args['log-file'] as string;
+            try {
+                filename = path.resolve(filename);
+                await fs.writeFile(filename, '');
+                this._logFile = filename;
+            } catch (e) {
+                console.error(`Error creating log file ${filename}: ${e}`);
+            }
+        }
     }
 
     protected async watchLogConfigFile(filename: string): Promise<void> {
-        await subscribe(filename, async (err, events) => {
+        const dir = path.dirname(filename);
+        await subscribe(dir, async (err, events) => {
             if (err) {
                 console.log(`Error during log file watching ${filename}: ${err}`);
                 return;
             }
             try {
                 for (const event of events) {
-                    switch (event.type) {
-                        case 'create':
-                        case 'update':
-                            await this.slurpLogConfigFile(filename);
-                            this.logConfigChangedEvent.fire(undefined);
-                            break;
+                    if (event.path === filename) {
+                        switch (event.type) {
+                            case 'create':
+                            case 'update':
+                                await this.slurpLogConfigFile(filename);
+                                this.logConfigChangedEvent.fire(undefined);
+                                break;
+                        }
                     }
                 }
             } catch (e) {

--- a/packages/core/src/node/logger-cli-contribution.ts
+++ b/packages/core/src/node/logger-cli-contribution.ts
@@ -101,7 +101,7 @@ export class LogLevelCliContribution implements CliContribution {
         }
 
         if (args['log-file'] !== undefined) {
-            let filename: string = args['log-file'] as string;
+            let filename = args['log-file'] as string;
             try {
                 filename = path.resolve(filename);
                 try {
@@ -111,7 +111,7 @@ export class LogLevelCliContribution implements CliContribution {
                         const oldFilename = `${filename}.${stat.ctime.toISOString().replace(/:/g, '-')}.old`;
                         await fs.rename(filename, oldFilename);
                     }
-                } catch (err) {
+                } catch {
                     // File does not exist, just continue to create it
                 }
                 await fs.writeFile(filename, '');

--- a/packages/core/src/node/logger-cli-contribution.ts
+++ b/packages/core/src/node/logger-cli-contribution.ts
@@ -104,6 +104,16 @@ export class LogLevelCliContribution implements CliContribution {
             let filename: string = args['log-file'] as string;
             try {
                 filename = path.resolve(filename);
+                try {
+                    const stat = await fs.stat(filename);
+                    if (stat && stat.isFile()) {
+                        // Rename the previous log file to avoid overwriting it
+                        const oldFilename = `${filename}.${stat.ctime.toISOString().replace(/:/g, '-')}.old`;
+                        await fs.rename(filename, oldFilename);
+                    }
+                } catch (err) {
+                    // File does not exist, just continue to create it
+                }
                 await fs.writeFile(filename, '');
                 this._logFile = filename;
             } catch (e) {

--- a/packages/debug/src/node/debug-backend-module.ts
+++ b/packages/debug/src/node/debug-backend-module.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { bindContributionProvider, ILogger } from '@theia/core/lib/common';
+import { bindContributionProvider } from '@theia/core/lib/common';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import {
     DebugPath,
@@ -50,8 +50,4 @@ export default new ContainerModule(bind => {
     bind(DebugAdapterFactory).to(LaunchBasedDebugAdapterFactory).inSingletonScope();
     bind(DebugAdapterSessionManager).toSelf().inSingletonScope();
     bind(MessagingService.Contribution).toService(DebugAdapterSessionManager);
-
-    bind(ILogger).toDynamicValue(({ container }) =>
-        container.get<ILogger>(ILogger).child('debug')
-    ).inSingletonScope().whenTargetNamed('debug');
 });

--- a/packages/process/src/node/process-backend-module.ts
+++ b/packages/process/src/node/process-backend-module.ts
@@ -20,17 +20,12 @@ import { TerminalProcess, TerminalProcessOptions, TerminalProcessFactory } from 
 import { TaskTerminalProcess, TaskTerminalProcessFactory } from './task-terminal-process';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { ProcessManager } from './process-manager';
-import { ILogger } from '@theia/core/lib/common';
 import { MultiRingBuffer, MultiRingBufferOptions } from './multi-ring-buffer';
 
 export default new ContainerModule(bind => {
     bind(RawProcess).toSelf().inTransientScope();
     bind(ProcessManager).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(ProcessManager);
-    bind(ILogger).toDynamicValue(ctx => {
-        const parentLogger = ctx.container.get<ILogger>(ILogger);
-        return parentLogger.child('process');
-    }).inSingletonScope().whenTargetNamed('process');
     bind(RawProcessFactory).toFactory(ctx =>
         (options: RawProcessOptions | RawForkOptions) => {
             const child = new Container({ defaultScope: 'Singleton' });

--- a/packages/task/src/common/task-common-module.ts
+++ b/packages/task/src/common/task-common-module.ts
@@ -15,7 +15,6 @@
 // *****************************************************************************
 
 import { interfaces } from '@theia/core/shared/inversify';
-import { ILogger } from '@theia/core';
 import { TaskWatcher } from './task-watcher';
 
 /**
@@ -24,11 +23,5 @@ import { TaskWatcher } from './task-watcher';
  * @param bind The bind function from inversify.
  */
 export function createCommonBindings(bind: interfaces.Bind): void {
-
-    bind(ILogger).toDynamicValue(ctx => {
-        const logger = ctx.container.get<ILogger>(ILogger);
-        return logger.child('task');
-    }).inSingletonScope().whenTargetNamed('task');
-
     bind(TaskWatcher).toSelf().inSingletonScope();
 }

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -28,7 +28,6 @@ import { TerminalWidget, TerminalWidgetOptions } from './base/terminal-widget';
 import { ITerminalServer, terminalPath } from '../common/terminal-protocol';
 import { TerminalWatcher } from '../common/terminal-watcher';
 import { IShellTerminalServer, shellTerminalPath, ShellTerminalServerProxy } from '../common/shell-terminal-protocol';
-import { createCommonBindings } from '../common/terminal-common-module';
 import { TerminalService } from './base/terminal-service';
 import { bindTerminalPreferences } from './terminal-preferences';
 import { TerminalContribution } from './terminal-contribution';
@@ -103,8 +102,6 @@ export default new ContainerModule(bind => {
         return connection.createProxy<IShellTerminalServer>(shellTerminalPath, terminalWatcher.getTerminalClient());
     }).inSingletonScope();
     bind(IShellTerminalServer).toService(ShellTerminalServerProxy);
-
-    createCommonBindings(bind);
 
     bindContributionProvider(bind, TerminalContribution);
 

--- a/packages/terminal/src/node/terminal-backend-module.ts
+++ b/packages/terminal/src/node/terminal-backend-module.ts
@@ -24,7 +24,6 @@ import { TerminalServer } from './terminal-server';
 import { IShellTerminalServer, shellTerminalPath } from '../common/shell-terminal-protocol';
 import { ShellTerminalServer } from '../node/shell-terminal-server';
 import { TerminalWatcher } from '../common/terminal-watcher';
-import { createCommonBindings } from '../common/terminal-common-module';
 import { MessagingService } from '@theia/core/lib/node/messaging/messaging-service';
 
 export function bindTerminalServer(bind: interfaces.Bind, { path, identifier, constructor }: {
@@ -77,6 +76,4 @@ export default new ContainerModule(bind => {
         identifier: IShellTerminalServer,
         constructor: ShellTerminalServer
     });
-
-    createCommonBindings(bind);
 });


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/14858

This change fixes a bunch of issues that have been bugging me about the logging API. Due to the previous way of how the binding was done for the `@named` decorator, creating a dedicated logger was quite a lot of work (at least compared to the new binding logic). Now, named loggers are simply created on the fly.

Also adds a new `log-file` argument to the CLI. This isn't strictly necessary, as operating systems offer ways of streaming the output of a executable into files, but I find this to be pretty useful anyways, even if just for discoverability.

#### How to test

1. Ensure that named loggers still work as expected and they are correctly generated on the fly.
2. Use the new `log-file` CLI argument to see whether this works as expected.
3. Ensure that https://github.com/eclipse-theia/theia/issues/14858 has been fixed by following the repro instructions.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
