### PR TITLE
Add missing VS Code json schemas

### DIFF
--- a/packages/keymaps/src/browser/keybinding-schema-updater.ts
+++ b/packages/keymaps/src/browser/keybinding-schema-updater.ts
@@ -14,20 +14,20 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { nls, CommandRegistry, InMemoryResources, deepClone } from '@theia/core/lib/common';
-import { JsonSchemaContribution, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
+import { nls, CommandRegistry, deepClone } from '@theia/core/lib/common';
+import { JsonSchemaContribution, JsonSchemaDataStore, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
+import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 
 @injectable()
 export class KeybindingSchemaUpdater implements JsonSchemaContribution {
     protected readonly uri = new URI(keybindingSchemaId);
     @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry;
-    @inject(InMemoryResources) protected readonly inMemoryResources: InMemoryResources;
+    @inject(JsonSchemaDataStore) protected readonly schemaStore: JsonSchemaDataStore;
 
     @postConstruct()
     protected init(): void {
-        this.inMemoryResources.add(new URI(keybindingSchemaId), '');
         this.updateSchema();
         this.commandRegistry.onCommandsChanged(() => this.updateSchema());
     }
@@ -49,7 +49,7 @@ export class KeybindingSchemaUpdater implements JsonSchemaContribution {
                 enumDescriptions.push(command.label ?? '');
             }
         }
-        this.inMemoryResources.update(this.uri, JSON.stringify(schema));
+        this.schemaStore.setSchema(this.uri, schema);
     }
 }
 
@@ -91,5 +91,4 @@ export const keybindingSchema = {
     },
     allowComments: true,
     allowTrailingCommas: true,
-};
-
+} as const satisfies IJSONSchema;

--- a/packages/toolbar/src/browser/toolbar-command-contribution.ts
+++ b/packages/toolbar/src/browser/toolbar-command-contribution.ts
@@ -19,7 +19,6 @@ import {
     CommandContribution,
     CommandRegistry,
     CommandService,
-    InMemoryResources,
     MenuContribution,
     MenuModelRegistry,
 } from '@theia/core';
@@ -52,7 +51,7 @@ import { ToolbarController } from './toolbar-controller';
 import { ToolbarPreferencesSchema, ToolbarPreferences, TOOLBAR_ENABLE_PREFERENCE_ID } from './toolbar-preference-contribution';
 import { ToolbarDefaults, ToolbarDefaultsFactory } from './toolbar-defaults';
 import { ToolbarCommands, ToolbarMenus, UserToolbarURI, USER_TOOLBAR_URI } from './toolbar-constants';
-import { JsonSchemaContribution, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
+import { JsonSchemaContribution, JsonSchemaDataStore, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
 import { toolbarConfigurationSchema, toolbarSchemaId } from './toolbar-preference-schema';
 import URI from '@theia/core/lib/common/uri';
 
@@ -65,11 +64,11 @@ export class ToolbarCommandContribution implements CommandContribution, Keybindi
     @inject(EditorManager) protected readonly editorManager: EditorManager;
     @inject(PreferenceService) protected readonly preferenceService: PreferenceService;
     @inject(ToolbarController) protected readonly toolbarModel: ToolbarController;
-    @inject(InMemoryResources) protected readonly inMemoryResources: InMemoryResources;
+    @inject(JsonSchemaDataStore) protected readonly schemaStore: JsonSchemaDataStore;
     protected readonly schemaURI = new URI(toolbarSchemaId);
 
     registerSchemas(context: JsonSchemaRegisterContext): void {
-        this.inMemoryResources.add(this.schemaURI, JSON.stringify(toolbarConfigurationSchema));
+        this.schemaStore.setSchema(this.schemaURI, toolbarConfigurationSchema);
         context.registerSchema({
             fileMatch: ['toolbar.json'],
             url: this.schemaURI.toString(),

--- a/packages/vsx-registry/src/browser/recommended-extensions/recommended-extensions-json-schema.ts
+++ b/packages/vsx-registry/src/browser/recommended-extensions/recommended-extensions-json-schema.ts
@@ -15,8 +15,7 @@
 // *****************************************************************************
 
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { InMemoryResources } from '@theia/core';
-import { JsonSchemaContribution, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
+import { JsonSchemaContribution, JsonSchemaDataStore, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -56,12 +55,12 @@ export const extensionsConfigurationSchema: IJSONSchema = {
 @injectable()
 export class ExtensionSchemaContribution implements JsonSchemaContribution {
     protected readonly uri = new URI(extensionsSchemaID);
-    @inject(InMemoryResources) protected readonly inmemoryResources: InMemoryResources;
+    @inject(JsonSchemaDataStore) protected readonly schemaStore: JsonSchemaDataStore;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
 
     @postConstruct()
     protected init(): void {
-        this.inmemoryResources.add(this.uri, JSON.stringify(extensionsConfigurationSchema));
+        this.schemaStore.setSchema(this.uri, extensionsConfigurationSchema);
     }
 
     registerSchemas(context: JsonSchemaRegisterContext): void {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14863

Adds the missing few JSON schemas to the storage. I don't know how I didn't see them in the first place. I searched for all instances of `InMemoryResources`, but VS Code refused to show me those instances...

#### How to test

Assert that the reproduction steps from https://github.com/eclipse-theia/theia/issues/14863 are now working as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
