### PR TITLE
Refresh root when change notification hast no items

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -822,7 +822,7 @@ export interface TreeViewsMain {
     $registerTreeDataProvider(treeViewId: string, options?: RegisterTreeDataProviderOptions): void;
     $readDroppedFile(contentId: string): Promise<BinaryBuffer>;
     $unregisterTreeDataProvider(treeViewId: string): void;
-    $refresh(treeViewId: string, itemIds: string[]): Promise<void>;
+    $refresh(treeViewId: string, itemIds?: string[]): Promise<void>;
     $reveal(treeViewId: string, elementParentChain: string[], options: TreeViewRevealOptions): Promise<any>;
     $setMessage(treeViewId: string, message: string): void;
     $setTitle(treeViewId: string, title: string): void;

--- a/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-views-main.ts
@@ -110,7 +110,7 @@ export class TreeViewsMainImpl implements TreeViewsMain, Disposable {
         return BinaryBuffer.wrap(new Uint8Array(buffer));
     }
 
-    async $refresh(treeViewId: string, items: string[]): Promise<void> {
+    async $refresh(treeViewId: string, items?: string[]): Promise<void> {
         const viewPanel = await this.viewRegistry.getView(treeViewId);
         const widget = viewPanel && viewPanel.widgets[0];
         if (widget instanceof TreeViewWidget) {

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -253,21 +253,25 @@ class TreeViewExtImpl<T> implements Disposable {
         });
         this.toDispose.push(Disposable.create(() => this.proxy.$unregisterTreeDataProvider(treeViewId)));
         options.treeDataProvider.onDidChangeTreeData?.(elements => {
-            const ids = [];
-            elements = elements || [];
-            if (!Array.isArray(elements)) {
-                elements = [elements];
-            }
-            const set = new Set<T>();
-            for (const element of elements) {
-                set.add(element);
-            }
-            for (const node of this.nodes.values()) {
-                if (node.value && set.has(node.value)) {
-                    ids.push(node.id);
+            if (!elements) {
+                this.pendingRefresh = proxy.$refresh(treeViewId);
+            } else {
+                const ids = [];
+                elements = elements || [];
+                if (!Array.isArray(elements)) {
+                    elements = [elements];
                 }
+                const set = new Set<T>();
+                for (const element of elements) {
+                    set.add(element);
+                }
+                for (const node of this.nodes.values()) {
+                    if (node.value && set.has(node.value)) {
+                        ids.push(node.id);
+                    }
+                }
+                this.pendingRefresh = proxy.$refresh(treeViewId, ids);
             }
-            this.pendingRefresh = proxy.$refresh(treeViewId, ids);
         });
     }
 


### PR DESCRIPTION
#### What it does
This PR fixes a problem introduced in https://github.com/eclipse-theia/theia/pull/14697. When a plugin signals a refresh _without_ giving any items to refresh, it now does nothing. This PR makes sure the tree view is refreshed from the root.

Fixes #14851

#### How to test
Make sure the "Find All References" command works correctly. Also make sure the scenario from the PR above is still working.


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups



#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
