### PR TITLE
fix: no watch evaluation if no current stack frame

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -316,15 +316,16 @@ export class ExpressionItem extends ExpressionContainer {
 
     async evaluate(context: string = 'repl'): Promise<void> {
         const session = this.session;
-        if (session) {
-            try {
-                const body = await session.evaluate(this._expression, context);
-                this.setResult(body);
-            } catch (err) {
-                this.setResult(undefined, err.message);
-            }
-        } else {
-            this.setResult(undefined, 'Please start a debug session to evaluate');
+        if (!session?.currentFrame) {
+            this.setResult(undefined, ExpressionItem.notAvailable);
+            return;
+        }
+
+        try {
+            const body = await session.evaluate(this._expression, context);
+            this.setResult(body);
+        } catch (err) {
+            this.setResult(undefined, err.message);
         }
     }
 

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -218,6 +218,10 @@
   color: var(--theia-debugConsole-errorForeground);
 }
 
+.theia-debug-console-variable .watch-not-available {
+  font-style: italic;
+}
+
 .theia-debug-watch-expression {
   display: flex;
 }

--- a/packages/debug/src/browser/view/debug-view-model.ts
+++ b/packages/debug/src/browser/view/debug-view-model.ts
@@ -220,7 +220,7 @@ export class DebugViewModel implements Disposable {
         this.refreshWatchExpressionsQueue = this.refreshWatchExpressionsQueue.then(async () => {
             try {
                 for (const watchExpression of this.watchExpressions) {
-                    await Promise.all([
+                    await Promise.race([
                         watchExpression.evaluate(),
                         // For example vscode-js-debug does not error when evaluating watch expressions "too early".
                         // https://github.com/eclipse-theia/theia/issues/11955#issuecomment-2643161927

--- a/packages/debug/src/browser/view/debug-view-model.ts
+++ b/packages/debug/src/browser/view/debug-view-model.ts
@@ -27,6 +27,7 @@ import { DebugWatchExpression } from './debug-watch-expression';
 import { DebugWatchManager } from '../debug-watch-manager';
 import { DebugFunctionBreakpoint } from '../model/debug-function-breakpoint';
 import { DebugInstructionBreakpoint } from '../model/debug-instruction-breakpoint';
+import { timeoutReject } from '@theia/core/lib/common/promise-util';
 
 @injectable()
 export class DebugViewModel implements Disposable {
@@ -219,7 +220,12 @@ export class DebugViewModel implements Disposable {
         this.refreshWatchExpressionsQueue = this.refreshWatchExpressionsQueue.then(async () => {
             try {
                 for (const watchExpression of this.watchExpressions) {
-                    await watchExpression.evaluate();
+                    await Promise.all([
+                        watchExpression.evaluate(),
+                        // For example vscode-js-debug does not error when evaluating watch expressions "too early".
+                        // https://github.com/eclipse-theia/theia/issues/11955#issuecomment-2643161927
+                        timeoutReject(1_000, 'Failed to refresh watch expressions: timeout'),
+                    ]);
                 }
             } catch (e) {
                 console.error('Failed to refresh watch expressions: ', e);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The `vscode-js-debug` does not reject when the `evaluate` request arrives too early to the debug adapter and the evaluate handler is not yet registered. See the details at https://github.com/eclipse-theia/theia/issues/11955#issuecomment-2643161927.

Ref: https://github.com/microsoft/vscode-js-debug/blob/d7730405d64e81eb364f76ea38efb7c93a5f877d/src/dap/connection.ts#L172

If the first evaluate request is never rejected or resolved, none of the following evaluate requests will be, as they are queued, making the Theia UI never update.

This PR changes how Theia evaluates the expressions: no evaluation happens when there is no current stack frame.
_(I debugged into VS Code, and they do not evaluate when there is no current stack frame. I think this makes sense, though I might have overlooked something.)_

When there is no active debug session or there is no current stack frame, use <i>not available</i>, just like VS Code does.

Closes eclipse-theia/theia#11955

Theia:

https://github.com/user-attachments/assets/6df170aa-0783-4e0a-9292-1a74a3ec7b3a

VS Code:

https://github.com/user-attachments/assets/e98f0f60-f61b-40a1-85c3-dbbb421cc869


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

Follow the steps from #11955.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

~I wonder why the vscode-js-debug sends the initialized when it cannot yet accept requests?~
 - ~https://github.com/microsoft/vscode-js-debug/blob/d7730405d64e81eb364f76ea38efb7c93a5f877d/src/dap/connection.ts#L42-L48~
 - ~https://github.com/microsoft/vscode-js-debug/blob/d7730405d64e81eb364f76ea38efb7c93a5f877d/src/dap/connection.ts#L184-L187~

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
