### PR TITLE
Refine system message settings

### DIFF
--- a/packages/ai-openai/README.md
+++ b/packages/ai-openai/README.md
@@ -51,7 +51,7 @@ Requests to an OpenAI model hosted on Azure need an `apiVersion`. To configure a
 Note that if you don't configure an `apiVersion`, the default `OpenAI` object is used for initialization and a connection to an Azure hosted OpenAI model will fail.
 
 An OpenAI model version deployed on Azure might not support the `developer` role. In that case it is possible to configure whether the `developer` role is supported or not via the 
-`supportsDeveloperMessage` option, which defaults to `true`.
+`developerMessageSettings` option, e.g. setting it to `system` or `user`.
 
 The following snippet shows a possible configuration to access an OpenAI model hosted on Azure. The `AZURE_OPENAI_API_BASE_URL` needs to be given without the `/chat/completions` 
 path and without the `api-version` parameter, e.g. _`https://<my_prefix>.openai.azure.com/openai/deployments/<my_deployment>`_
@@ -66,7 +66,7 @@ path and without the `api-version` parameter, e.g. _`https://<my_prefix>.openai.
       "id": "azure-deployment",
       "apiKey": "<AZURE_OPENAI_API_KEY>",
       "apiVersion": "<AZURE_OPENAI_API_VERSION>",
-      "developerMessageSettings": "skip"
+      "developerMessageSettings": "system"
     }
   ],
   "ai-features.agentSettings": {

--- a/packages/ai-openai/README.md
+++ b/packages/ai-openai/README.md
@@ -23,12 +23,12 @@ You can configure the end points via the `ai-features.openAiCustom.customOpenAiM
 
 ```ts
 {
-    model: string
-    url: string
-    id?: string
-    apiKey?: string | true
-    apiVersion?: string | true
-    supportsDeveloperMessage?: boolean
+    model: string,
+    url: string,
+    id?: string,
+    apiKey?: string | true,
+    apiVersion?: string | true,
+    developerMessageSettings?: 'user' | 'system' | 'developer' | 'mergeWithFollowingUserMessage' | 'skip',
     enableStreaming?: boolean
 }
 ```
@@ -37,7 +37,9 @@ You can configure the end points via the `ai-features.openAiCustom.customOpenAiM
 - `id` is an optional attribute which is used in the UI to refer to this configuration
 - `apiKey` is either the key to access the API served at the given URL or `true` to use the global OpenAI API key. If not given 'no-key' will be used.
 - `apiVersion` is either the api version to access the API served at the given URL in Azure or `true` to use the global OpenAI API version.
-- `supportsDeveloperMessage` is a flag that indicates whether the model supports the `developer` role or not. `true` by default.
+- `developerMessageSettings` Controls the handling of system messages: `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix the
+  following user message with the system message or convert the system message to user message if the next message is not a user message. `skip` will just remove the system message.
+  Defaulting to `developer`.
 - `enableStreaming` is a flag that indicates whether the streaming API shall be used or not. `true` by default.
 
 ### Azure OpenAI
@@ -64,7 +66,7 @@ path and without the `api-version` parameter, e.g. _`https://<my_prefix>.openai.
       "id": "azure-deployment",
       "apiKey": "<AZURE_OPENAI_API_KEY>",
       "apiVersion": "<AZURE_OPENAI_API_VERSION>",
-      "supportsDeveloperMessage": false
+      "developerMessageSettings": "skip"
     }
   ],
   "ai-features.agentSettings": {

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -92,7 +92,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                 model.url === newModel.url &&
                 model.apiKey === newModel.apiKey &&
                 model.apiVersion === newModel.apiVersion &&
-                model.supportsDeveloperMessage === newModel.supportsDeveloperMessage &&
+                model.developerMessageSettings === newModel.developerMessageSettings &&
                 model.supportsStructuredOutput === newModel.supportsStructuredOutput &&
                 model.enableStreaming === newModel.enableStreaming));
 
@@ -117,7 +117,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             model: modelId,
             apiKey: true,
             apiVersion: true,
-            supportsDeveloperMessage: !openAIModelsNotSupportingDeveloperMessages.includes(modelId),
+            developerMessageSettings: openAIModelsNotSupportingDeveloperMessages.includes(modelId) ? 'user' : 'developer',
             enableStreaming: !openAIModelsWithDisabledStreaming.includes(modelId),
             supportsStructuredOutput: !openAIModelsWithoutStructuredOutput.includes(modelId),
             defaultRequestSettings: modelRequestSetting?.requestSettings
@@ -143,7 +143,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     url: pref.url,
                     apiKey: typeof pref.apiKey === 'string' || pref.apiKey === true ? pref.apiKey : undefined,
                     apiVersion: typeof pref.apiVersion === 'string' || pref.apiVersion === true ? pref.apiVersion : undefined,
-                    supportsDeveloperMessage: pref.supportsDeveloperMessage ?? true,
+                    developerMessageSettings: pref.developerMessageSettings ?? 'developer',
                     supportsStructuredOutput: pref.supportsStructuredOutput ?? true,
                     enableStreaming: pref.enableStreaming ?? true,
                     defaultRequestSettings: modelRequestSetting?.requestSettings

--- a/packages/ai-openai/src/browser/openai-preferences.ts
+++ b/packages/ai-openai/src/browser/openai-preferences.ts
@@ -57,7 +57,7 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             \n\
             - set `developerMessageSettings` to one of `user`, `system`, `developer`, `mergeWithFollowingUserMessage`, or `skip` to control how the developer message is\
             included (where `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix the following user message with the system\
-            message or convert the system message to user mesage if the next message is not a user message. `skip` will just remove the system message).\
+            message or convert the system message to user message if the next message is not a user message. `skip` will just remove the system message).\
             Defaulting to `developer`.\
             \n\
             - specify `supportsStructuredOutput: false` to indicate that structured output shall not be used.\
@@ -96,7 +96,7 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
                         enum: ['user', 'system', 'developer', 'mergeWithFollowingUserMessage', 'skip'],
                         default: 'developer',
                         title: nls.localize('theia/ai/openai/customEndpoints/developerMessageSettings/title',
-                            'Controls the first system message: `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix\
+                            'Controls the handling of system messages: `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix\
                          the following user message with the system message or convert the system message to user message if the next message is not a user message.\
                          `skip` will just remove the system message), defaulting to `developer`.')
                     },

--- a/packages/ai-openai/src/browser/openai-preferences.ts
+++ b/packages/ai-openai/src/browser/openai-preferences.ts
@@ -56,8 +56,9 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             - provide an `apiVersion` to access the API served at the given url in Azure. Use `true` to indicate the use of the global OpenAI API version.\
             \n\
             - set `developerMessageSettings` to one of `user`, `system`, `developer`, `mergeWithFollowingUserMessage`, or `skip` to control how the developer message is\
-            included (where `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix the first user message with the system message,\
-            or convert the system message to user mesage if the next message is not a user message. `skip` will just remove the system message). Defaulting to `developer`.\
+            included (where `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix the following user message with the system\
+            message or convert the system message to user mesage if the next message is not a user message. `skip` will just remove the system message).\
+            Defaulting to `developer`.\
             \n\
             - specify `supportsStructuredOutput: false` to indicate that structured output shall not be used.\
             \n\

--- a/packages/ai-openai/src/browser/openai-preferences.ts
+++ b/packages/ai-openai/src/browser/openai-preferences.ts
@@ -45,23 +45,25 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             type: 'array',
             title: AI_CORE_PREFERENCES_TITLE,
             markdownDescription: nls.localize('theia/ai/openai/customEndpoints/mdDescription',
-                'Integrate custom models compatible with the OpenAI API, for example via `vllm`. The required attributes are `model` and `url`.\n\
-\n\
-Optionally, you can\
-\n\
-- specify a unique `id` to identify the custom model in the UI. If none is given `model` will be used as `id`.\
-\n\
-- provide an `apiKey` to access the API served at the given url. Use `true` to indicate the use of the global OpenAI API key.\
-\n\
-- provide an `apiVersion` to access the API served at the given url in Azure. Use `true` to indicate the use of the global OpenAI API version.\
-\n\
-- specify `supportsDeveloperMessage: false` to indicate that the developer role shall not be used.\
-\n\
-- specify `supportsStructuredOutput: false` to indicate that structured output shall not be used.\
-\n\
-- specify `enableStreaming: false` to indicate that streaming shall not be used.\n\
-\n\
-Refer to [our documentation](https://theia-ide.org/docs/user_ai/#openai-compatible-models-eg-via-vllm) for more information.'),
+                'Integrate custom models compatible with the OpenAI API, for example via `vllm`. The required attributes are `model` and `url`.\
+            \n\
+            Optionally, you can\
+            \n\
+            - specify a unique `id` to identify the custom model in the UI. If none is given `model` will be used as `id`.\
+            \n\
+            - provide an `apiKey` to access the API served at the given url. Use `true` to indicate the use of the global OpenAI API key.\
+            \n\
+            - provide an `apiVersion` to access the API served at the given url in Azure. Use `true` to indicate the use of the global OpenAI API version.\
+            \n\
+            - set `developerMessageSettings` to one of `user`, `system`, `developer`, `mergeWithFirstUserMessage`, or `skip` to control how the developer message is\
+            included (where `user`, `system`, and `developer` will be used as a role, `mergeWithFirstUserMessage` will prefix the first user message with the system message,\
+            and `skip` will just remove the system message), defaulting to `developer`.\
+            \n\
+            - specify `supportsStructuredOutput: false` to indicate that structured output shall not be used.\
+            \n\
+            - specify `enableStreaming: false` to indicate that streaming shall not be used.\
+            \n\
+            Refer to [our documentation](https://theia-ide.org/docs/user_ai/#openai-compatible-models-eg-via-vllm) for more information.'),
             default: [],
             items: {
                 type: 'object',
@@ -88,10 +90,13 @@ Refer to [our documentation](https://theia-ide.org/docs/user_ai/#openai-compatib
                         title: nls.localize('theia/ai/openai/customEndpoints/apiVersion/title',
                             'Either the version to access the API served at the given url in Azure or `true` to use the global OpenAI API version'),
                     },
-                    supportsDeveloperMessage: {
-                        type: 'boolean',
-                        title: nls.localize('theia/ai/openai/customEndpoints/supportsDevMessage/title',
-                            'Indicates whether the model supports the `developer` role. `true` by default.'),
+                    developerMessageSettings: {
+                        type: 'string',
+                        enum: ['user', 'system', 'developer', 'mergeWithFirstUserMessage', 'skip'],
+                        default: 'developer',
+                        title: nls.localize('theia/ai/openai/customEndpoints/developerMessageSettings/title',
+                            'Controls the first system message: `user`, `system`, and `developer` will be used as a role, `mergeWithFirstUserMessage` will prefix\
+                         the first user message with the system message, and `skip` will just remove the system message), defaulting to `developer`.')
                     },
                     supportsStructuredOutput: {
                         type: 'boolean',

--- a/packages/ai-openai/src/browser/openai-preferences.ts
+++ b/packages/ai-openai/src/browser/openai-preferences.ts
@@ -55,9 +55,9 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             \n\
             - provide an `apiVersion` to access the API served at the given url in Azure. Use `true` to indicate the use of the global OpenAI API version.\
             \n\
-            - set `developerMessageSettings` to one of `user`, `system`, `developer`, `mergeWithFirstUserMessage`, or `skip` to control how the developer message is\
-            included (where `user`, `system`, and `developer` will be used as a role, `mergeWithFirstUserMessage` will prefix the first user message with the system message,\
-            and `skip` will just remove the system message), defaulting to `developer`.\
+            - set `developerMessageSettings` to one of `user`, `system`, `developer`, `mergeWithFollowingUserMessage`, or `skip` to control how the developer message is\
+            included (where `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix the first user message with the system message,\
+            or convert the system message to user mesage if the next message is not a user message. `skip` will just remove the system message). Defaulting to `developer`.\
             \n\
             - specify `supportsStructuredOutput: false` to indicate that structured output shall not be used.\
             \n\
@@ -92,11 +92,12 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
                     },
                     developerMessageSettings: {
                         type: 'string',
-                        enum: ['user', 'system', 'developer', 'mergeWithFirstUserMessage', 'skip'],
+                        enum: ['user', 'system', 'developer', 'mergeWithFollowingUserMessage', 'skip'],
                         default: 'developer',
                         title: nls.localize('theia/ai/openai/customEndpoints/developerMessageSettings/title',
-                            'Controls the first system message: `user`, `system`, and `developer` will be used as a role, `mergeWithFirstUserMessage` will prefix\
-                         the first user message with the system message, and `skip` will just remove the system message), defaulting to `developer`.')
+                            'Controls the first system message: `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix\
+                         the following user message with the system message or convert the system message to user message if the next message is not a user message.\
+                         `skip` will just remove the system message), defaulting to `developer`.')
                     },
                     supportsStructuredOutput: {
                         type: 'boolean',

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 export const OPENAI_LANGUAGE_MODELS_MANAGER_PATH = '/services/open-ai/language-model-manager';
 export const OpenAiLanguageModelsManager = Symbol('OpenAiLanguageModelsManager');
+
 export interface OpenAiModelDescription {
     /**
      * The identifier of the model which will be shown in the UI.
@@ -41,9 +42,11 @@ export interface OpenAiModelDescription {
      */
     enableStreaming: boolean;
     /**
-     * Flag to configure whether the OpenAPI model supports the `developer` role. Default is `true`.
+     * Property to configure the developer message of the model. Setting this property to 'user', 'system', or 'developer' will use that string as the role for the system message.
+     * Setting it to 'mergeWithFirstUserMessage' will prefix the first user message with the system message, while 'skip' will remove the system message altogether.
+     * Defaults to 'developer'.
      */
-    supportsDeveloperMessage: boolean;
+    developerMessageSettings?: 'user' | 'system' | 'developer' | 'mergeWithFirstUserMessage' | 'skip';
     /**
      * Flag to configure whether the OpenAPI model supports structured output. Default is `true`.
      */

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -43,8 +43,8 @@ export interface OpenAiModelDescription {
     enableStreaming: boolean;
     /**
      * Property to configure the developer message of the model. Setting this property to 'user', 'system', or 'developer' will use that string as the role for the system message.
-     * Setting it to 'mergeWithFollowingUserMessage' will prefix the following user message with the system message or convert the system message to user if the next message is
-     * not a user message. 'skip' will remove the system message altogether.
+     * Setting it to 'mergeWithFollowingUserMessage' will prefix the following user message with the system message or convert the system message to user if the following message
+     * is not a user message. 'skip' will remove the system message altogether.
      * Defaults to 'developer'.
      */
     developerMessageSettings?: 'user' | 'system' | 'developer' | 'mergeWithFollowingUserMessage' | 'skip';

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -43,10 +43,11 @@ export interface OpenAiModelDescription {
     enableStreaming: boolean;
     /**
      * Property to configure the developer message of the model. Setting this property to 'user', 'system', or 'developer' will use that string as the role for the system message.
-     * Setting it to 'mergeWithFirstUserMessage' will prefix the first user message with the system message, while 'skip' will remove the system message altogether.
+     * Setting it to 'mergeWithFollowingUserMessage' will prefix the following user message with the system message or convert the system message to user if the next message is
+     * not a user message. 'skip' will remove the system message altogether.
      * Defaults to 'developer'.
      */
-    developerMessageSettings?: 'user' | 'system' | 'developer' | 'mergeWithFirstUserMessage' | 'skip';
+    developerMessageSettings?: 'user' | 'system' | 'developer' | 'mergeWithFollowingUserMessage' | 'skip';
     /**
      * Flag to configure whether the OpenAPI model supports structured output. Default is `true`.
      */

--- a/packages/ai-openai/src/node/openai-backend-module.ts
+++ b/packages/ai-openai/src/node/openai-backend-module.ts
@@ -19,6 +19,7 @@ import { OPENAI_LANGUAGE_MODELS_MANAGER_PATH, OpenAiLanguageModelsManager } from
 import { ConnectionHandler, RpcConnectionHandler } from '@theia/core';
 import { OpenAiLanguageModelsManagerImpl } from './openai-language-models-manager-impl';
 import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
+import { OpenAiModelUtils } from './openai-language-model';
 
 export const OpenAiModelFactory = Symbol('OpenAiModelFactory');
 
@@ -32,5 +33,6 @@ const openAiConnectionModule = ConnectionContainerModule.create(({ bind, bindBac
 });
 
 export default new ContainerModule(bind => {
+    bind(OpenAiModelUtils).toSelf().inSingletonScope();
     bind(ConnectionContainerModule).toConstantValue(openAiConnectionModule);
 });

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -23,6 +23,7 @@ import {
     LanguageModelTextResponse
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
+import { injectable } from '@theia/core/shared/inversify';
 import { OpenAI, AzureOpenAI } from 'openai';
 import { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
 import { RunnableToolFunctionWithoutParse } from 'openai/lib/RunnableFunction';
@@ -30,6 +31,8 @@ import { ChatCompletionMessageParam } from 'openai/resources';
 import { StreamingAsyncIterator } from './openai-streaming-iterator';
 
 export const OpenAiModelIdentifier = Symbol('OpenAiModelIdentifier');
+
+export type DeveloperMessageSettings = 'user' | 'system' | 'developer' | 'mergeWithFirstUserMessage' | 'skip';
 
 export class OpenAiModel implements LanguageModel {
 
@@ -49,10 +52,11 @@ export class OpenAiModel implements LanguageModel {
         public enableStreaming: boolean,
         public apiKey: () => string | undefined,
         public apiVersion: () => string | undefined,
-        public supportsDeveloperMessage: boolean,
         public supportsStructuredOutput: boolean,
         public url: string | undefined,
-        public defaultRequestSettings?: { [key: string]: unknown }
+        public openAiModelUtils: OpenAiModelUtils,
+        public developerMessageSettings: DeveloperMessageSettings = 'developer',
+        public defaultRequestSettings?: { [key: string]: unknown },
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Record<string, unknown> {
@@ -84,7 +88,7 @@ export class OpenAiModel implements LanguageModel {
         if (tools) {
             runner = openai.beta.chat.completions.runTools({
                 model: this.model,
-                messages: request.messages.map(this.toOpenAIMessage.bind(this)),
+                messages: this.processMessages(request.messages),
                 stream: true,
                 tools: tools,
                 tool_choice: 'auto',
@@ -93,7 +97,7 @@ export class OpenAiModel implements LanguageModel {
         } else {
             runner = openai.beta.chat.completions.stream({
                 model: this.model,
-                messages: request.messages.map(this.toOpenAIMessage.bind(this)),
+                messages: this.processMessages(request.messages),
                 stream: true,
                 ...settings
             });
@@ -106,7 +110,7 @@ export class OpenAiModel implements LanguageModel {
         const settings = this.getSettings(request);
         const response = await openai.chat.completions.create({
             model: this.model,
-            messages: request.messages.map(this.toOpenAIMessage.bind(this)),
+            messages: this.processMessages(request.messages),
             ...settings
         });
 
@@ -115,24 +119,6 @@ export class OpenAiModel implements LanguageModel {
         return {
             text: message.content ?? ''
         };
-    }
-
-    protected toOpenAIMessage(message: LanguageModelRequestMessage): ChatCompletionMessageParam {
-        return {
-            role: this.toOpenAiRole(message),
-            content: message.query || ''
-        };
-    }
-
-    protected toOpenAiRole(message: LanguageModelRequestMessage): 'developer' | 'user' | 'assistant' {
-        switch (message.actor) {
-            case 'system':
-                return this.supportsDeveloperMessage ? 'developer' : 'user';
-            case 'ai':
-                return 'assistant';
-            default:
-                return 'user';
-        }
     }
 
     protected isNonStreamingModel(_model: string): boolean {
@@ -144,7 +130,7 @@ export class OpenAiModel implements LanguageModel {
         // TODO implement tool support for structured output (parse() seems to require different tool format)
         const result = await openai.beta.chat.completions.parse({
             model: this.model,
-            messages: request.messages.map(this.toOpenAIMessage.bind(this)),
+            messages: this.processMessages(request.messages),
             response_format: request.response_format,
             ...settings
         });
@@ -184,5 +170,93 @@ export class OpenAiModel implements LanguageModel {
             // We need to hand over "some" key, even if a custom url is not key protected as otherwise the OpenAI client will throw an error
             return new OpenAI({ apiKey: apiKey ?? 'no-key', baseURL: this.url });
         }
+    }
+
+    protected processMessages(messages: LanguageModelRequestMessage[]): ChatCompletionMessageParam[] {
+        return this.openAiModelUtils.processMessages(messages, this.developerMessageSettings, this.model);
+    }
+}
+
+/**
+ * Utility class for processing messages for the OpenAI language model.
+ *
+ * Adopters can rebind this class to implement custom message processing behavior.
+ */
+@injectable()
+export class OpenAiModelUtils {
+
+    protected processSystemMessages(
+        messages: LanguageModelRequestMessage[],
+        developerMessageSettings: DeveloperMessageSettings
+    ): LanguageModelRequestMessage[] {
+        if (messages.length > 0 && messages[0].actor === 'system') {
+            if (developerMessageSettings === 'skip') {
+                return messages.slice(1);
+            } else if (developerMessageSettings === 'mergeWithFirstUserMessage') {
+                const systemMsg = messages[0];
+                const updatedMessages = messages.slice();
+                const userIndex = updatedMessages.findIndex((m, index) => index > 0 && m.actor === 'user');
+                if (userIndex !== -1) {
+                    updatedMessages[userIndex] = {
+                        ...updatedMessages[userIndex],
+                        query: systemMsg.query + '\n' + updatedMessages[userIndex].query
+                    };
+                    // Remove the first system message
+                    updatedMessages.shift();
+                    return updatedMessages;
+                } else {
+                    // No user message exists, so create one with the system message content
+                    updatedMessages[0] = { actor: 'user', type: 'text', query: systemMsg.query };
+                    return updatedMessages;
+                }
+            }
+        }
+        return messages;
+    }
+
+    protected toOpenAiRole(
+        message: LanguageModelRequestMessage,
+        developerMessageSettings: DeveloperMessageSettings
+    ): 'developer' | 'user' | 'assistant' | 'system' {
+        if (message.actor === 'system') {
+            if (developerMessageSettings === 'user' || developerMessageSettings === 'system' || developerMessageSettings === 'developer') {
+                return developerMessageSettings;
+            } else {
+                return 'developer';
+            }
+        } else if (message.actor === 'ai') {
+            return 'assistant';
+        }
+        return 'user';
+    }
+
+    protected toOpenAIMessage(
+        message: LanguageModelRequestMessage,
+        developerMessageSettings: DeveloperMessageSettings
+    ): ChatCompletionMessageParam {
+        return {
+            role: this.toOpenAiRole(message, developerMessageSettings),
+            content: message.query || ''
+        };
+    }
+
+    /**
+     * Processes the provided list of messages by applying system message adjustments and converting
+     * them to the format expected by the OpenAI API.
+     *
+     * Adopters can rebind this processing to implement custom behavior.
+     *
+     * @param messages the list of messages to process.
+     * @param developerMessageSettings how system and developer messages are handled during processing.
+     * @param model the OpenAI model identifier. Currently not used, but allows subclasses to implement model-specific behavior.
+     * @returns an array of messages formatted for the OpenAI API.
+     */
+    public processMessages(
+        messages: LanguageModelRequestMessage[],
+        developerMessageSettings: DeveloperMessageSettings,
+        model: string
+    ): ChatCompletionMessageParam[] {
+        const processed = this.processSystemMessages(messages, developerMessageSettings);
+        return processed.map(m => this.toOpenAIMessage(m, developerMessageSettings));
     }
 }

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -42,7 +42,7 @@ export class OpenAiModel implements LanguageModel {
      * @param enableStreaming whether the streaming API shall be used
      * @param apiKey a function that returns the API key to use for this model, called on each request
      * @param apiVersion a function that returns the OpenAPI version to use for this model, called on each request
-     * @param supportsDeveloperMessage whether the model supports the `developer` role
+     * @param developerMessageSettings how to handle system messages
      * @param url the OpenAI API compatible endpoint where the model is hosted. If not provided the default OpenAI endpoint will be used.
      * @param defaultRequestSettings optional default settings for requests made using this model.
      */

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -82,8 +82,6 @@ export class OpenAiModel implements LanguageModel {
         if (cancellationToken?.isCancellationRequested) {
             return { text: '' };
         }
-        const check = this.processMessages(request.messages);
-        console.log(JSON.stringify(check, undefined, 2));
         let runner: ChatCompletionStream;
         const tools = this.createTools(request);
         if (tools) {

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -16,11 +16,14 @@
 
 import { LanguageModelRegistry } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { OpenAiModel } from './openai-language-model';
+import { OpenAiModel, OpenAiModelUtils } from './openai-language-model';
 import { OpenAiLanguageModelsManager, OpenAiModelDescription } from '../common';
 
 @injectable()
 export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsManager {
+
+    @inject(OpenAiModelUtils)
+    protected readonly openAiModelUtils: OpenAiModelUtils;
 
     protected _apiKey: string | undefined;
     protected _apiVersion: string | undefined;
@@ -70,7 +73,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                 model.url = modelDescription.url;
                 model.apiKey = apiKeyProvider;
                 model.apiVersion = apiVersionProvider;
-                model.supportsDeveloperMessage = modelDescription.supportsDeveloperMessage;
+                model.developerMessageSettings = modelDescription.developerMessageSettings || 'developer';
                 model.supportsStructuredOutput = modelDescription.supportsStructuredOutput;
                 model.defaultRequestSettings = modelDescription.defaultRequestSettings;
             } else {
@@ -81,9 +84,10 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                         modelDescription.enableStreaming,
                         apiKeyProvider,
                         apiVersionProvider,
-                        modelDescription.supportsDeveloperMessage,
                         modelDescription.supportsStructuredOutput,
                         modelDescription.url,
+                        this.openAiModelUtils,
+                        modelDescription.developerMessageSettings,
                         modelDescription.defaultRequestSettings
                     )
                 ]);

--- a/packages/ai-openai/src/node/openai-model-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-model-utils.spec.ts
@@ -88,7 +88,7 @@ describe('OpenAiModelUtils - processMessages', () => {
             ]);
         });
 
-        it('should create a new user message from several system mesages if the next message is not a user message', () => {
+        it('should create a new user message from several system messages if the next message is not a user message', () => {
             const messages = [
                 { actor: 'user', type: 'text', query: 'user message' },
                 { actor: 'system', type: 'text', query: 'system message' },

--- a/packages/ai-openai/src/node/openai-model-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-model-utils.spec.ts
@@ -1,0 +1,148 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+const { expect } = require('chai');
+const { OpenAiModelUtils } = require('./openai-language-model');
+const utils = new OpenAiModelUtils();
+
+describe('OpenAiModelUtils - processMessages', () => {
+    describe("when developerMessageSettings is 'skip'", () => {
+        it('should remove the first system message and assign roles correctly', () => {
+            const messages = [
+                { actor: 'system', type: 'text', query: 'system message' },
+                { actor: 'user', type: 'text', query: 'user message' },
+                { actor: 'system', type: 'text', query: 'another system message' },
+            ];
+            const result = utils.processMessages(messages, 'skip');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'user message' },
+                { role: 'developer', content: 'another system message' }
+            ]);
+        });
+
+        it('should do nothing if the first message is not system', () => {
+            const messages = [
+                { actor: 'user', type: 'text', query: 'user message' },
+                { actor: 'user', type: 'text', query: 'another user message' },
+                { actor: 'ai', type: 'text', query: 'ai message' }
+            ];
+            const result = utils.processMessages(messages, 'skip');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'user message' },
+                { role: 'user', content: 'another user message' },
+                { role: 'assistant', content: 'ai message' }
+            ]);
+        });
+    });
+
+    describe("when developerMessageSettings is 'mergeWithFirstUserMessage'", () => {
+        it('should merge the first system message with the first user message, assign role user, and remove the system message', () => {
+            const messages = [
+                { actor: 'system', type: 'text', query: 'system msg' },
+                { actor: 'user', type: 'text', query: 'user msg' },
+                { actor: 'ai', type: 'text', query: 'ai message' }
+            ];
+            const result = utils.processMessages(messages, 'mergeWithFirstUserMessage');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'system msg\nuser msg' },
+                { role: 'assistant', content: 'ai message' }
+            ]);
+        });
+
+        it('should create a new user message if no user message exists, and remove the system message', () => {
+            const messages = [
+                { actor: 'system', type: 'text', query: 'system only msg' },
+                { actor: 'ai', type: 'text', query: 'ai message' }
+            ];
+            const result = utils.processMessages(messages, 'mergeWithFirstUserMessage');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'system only msg' },
+                { role: 'assistant', content: 'ai message' }
+            ]);
+        });
+
+        it('should do nothing if the first message is not system', () => {
+            const messages = [
+                { actor: 'user', type: 'text', query: 'user message' },
+                { actor: 'system', type: 'text', query: 'system message' },
+                { actor: 'ai', type: 'text', query: 'ai message' }
+            ];
+            const result = utils.processMessages(messages, 'mergeWithFirstUserMessage');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'user message' },
+                { role: 'developer', content: 'system message' },
+                { role: 'assistant', content: 'ai message' }
+            ]);
+        });
+    });
+
+    describe('when no special merging or skipping is needed', () => {
+        it('should leave messages unchanged in ordering and assign roles based on developerMessageSettings if first message is not system', () => {
+            const messages = [
+                { actor: 'user', type: 'text', query: 'user message' },
+                { actor: 'system', type: 'text', query: 'system message' },
+                { actor: 'ai', type: 'text', query: 'ai message' }
+            ];
+            // Using a developerMessageSettings that is not merge/skip, e.g., 'developer'
+            const result = utils.processMessages(messages, 'developer');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'user message' },
+                { role: 'developer', content: 'system message' },
+                { role: 'assistant', content: 'ai message' }
+            ]);
+        });
+    });
+
+    describe('role assignment for system messages when developerMessageSettings is one of the role strings', () => {
+        it('should assign role as specified for a system message when developerMessageSettings is "user"', () => {
+            const messages = [
+                { actor: 'system', type: 'text', query: 'system msg' },
+                { actor: 'ai', type: 'text', query: 'ai msg' }
+            ];
+            // Since the first message is system and developerMessageSettings is not merge/skip, ordering is not adjusted
+            const result = utils.processMessages(messages, 'user');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'system msg' },
+                { role: 'assistant', content: 'ai msg' }
+            ]);
+        });
+
+        it('should assign role as specified for a system message when developerMessageSettings is "system"', () => {
+            const messages = [
+                { actor: 'system', type: 'text', query: 'system msg' },
+                { actor: 'ai', type: 'text', query: 'ai msg' }
+            ];
+            const result = utils.processMessages(messages, 'system');
+            expect(result).to.deep.equal([
+                { role: 'system', content: 'system msg' },
+                { role: 'assistant', content: 'ai msg' }
+            ]);
+        });
+
+        it('should assign role as specified for a system message when developerMessageSettings is "developer"', () => {
+            const messages = [
+                { actor: 'system', type: 'text', query: 'system msg' },
+                { actor: 'user', type: 'text', query: 'user msg' },
+                { actor: 'ai', type: 'text', query: 'ai msg' }
+            ];
+            const result = utils.processMessages(messages, 'developer');
+            expect(result).to.deep.equal([
+                { role: 'developer', content: 'system msg' },
+                { role: 'user', content: 'user msg' },
+                { role: 'assistant', content: 'ai msg' }
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
fixed #14867

#### What it does

- replaces the supportsDeveloperMessage with developerMessageSettings (enum: ['user', 'system', 'developer', 'mergeWithFollowingUserMessage', 'skip'])

Controls the first system message: `user`, `system`, and `developer` will be used as a role, `mergeWithFollowingUserMessage` will prefix  the following user message with the system message or convert the system message to user message if the next message is not a user message.  `skip` will just remove the system message), defaulting to `developer`.

- Extract message processing into a rebindable OpenAiModelUtils so that future special cases can be handled by adopters
- Add test case for message handling

#### How to test

Test official and custom OpenAI models. Specifically check official: ['o1-preview', 'o1-mini'] that the system message is converted to a user message. All other official openAI models should use 'developer'

To test custom models, you can use:

{
        "model": "gpt-4o",
        "url": "https://api.openai.com/v1",
        "id": "openaicustom",
        "apiKey": true,
        "enableStreaming": true,
        "developerMessageSettings": "valueToTest"
    },

DeepSeek reasoner now works with these settings:
    {
        "model": "deepseek-reasoner",
        "url": "https://api.deepseek.com",
        "id": "deepseek-resoner",
        "apiKey": "YourKey",
        "enableStreaming": true,
        "developerMessageSettings": "mergeWithFollowingUserMessage"
    },

To test, set a break point to where the messages are converted (the requests are sent)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
