### PR TITLE
Use DiffEditor DiffNavigator to navigate diffs

### DIFF
--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -43,8 +43,9 @@ import { ScmCommand } from './scm-provider';
 import { ScmDecorationsService } from '../browser/decorations/scm-decorations-service';
 import { nls } from '@theia/core/lib/common/nls';
 import { isHighContrast } from '@theia/core/lib/common/theme';
-import { EditorMainMenu } from '@theia/editor/lib/browser';
+import { EditorMainMenu, EditorWidget } from '@theia/editor/lib/browser';
 import { DirtyDiffNavigator } from './dirty-diff/dirty-diff-navigator';
+import { MonacoDiffEditor } from '@theia/monaco/lib/browser/monaco-diff-editor';
 
 export const SCM_WIDGET_FACTORY_ID = ScmWidget.ID;
 export const SCM_VIEW_CONTAINER_ID = 'scm-view-container';
@@ -95,12 +96,14 @@ export namespace SCM_COMMANDS {
     export const GOTO_NEXT_CHANGE = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.editor.nextChange',
         category: 'Source Control',
-        label: 'Go to Next Change'
+        label: 'Go to Next Change',
+        iconClass: codicon('arrow-down')
     });
     export const GOTO_PREVIOUS_CHANGE = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.editor.previousChange',
         category: 'Source Control',
-        label: 'Go to Previous Change'
+        label: 'Go to Previous Change',
+        iconClass: codicon('arrow-up')
     });
     export const SHOW_NEXT_CHANGE = Command.toDefaultLocalizedCommand({
         id: 'editor.action.dirtydiff.next',
@@ -198,10 +201,34 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
         // This is consistent with behavior in VS Code, and also with other similar commands (such as `Next Problem/Previous Problem`) in Theia.
         // See https://github.com/eclipse-theia/theia/pull/13104#discussion_r1497316614 for a detailed discussion.
         commandRegistry.registerCommand(SCM_COMMANDS.GOTO_NEXT_CHANGE, {
-            execute: () => this.dirtyDiffNavigator.gotoNextChange()
+            execute: widget => {
+                if (widget instanceof EditorWidget && widget.editor instanceof MonacoDiffEditor) {
+                    widget.editor.diffNavigator.next();
+                } else {
+                    this.dirtyDiffNavigator.gotoNextChange();
+                }
+            },
+            isEnabled: widget => {
+                if (widget instanceof EditorWidget && widget.editor instanceof MonacoDiffEditor) {
+                    return widget.editor.diffNavigator.hasNext();
+                }
+                return true;
+            }
         });
         commandRegistry.registerCommand(SCM_COMMANDS.GOTO_PREVIOUS_CHANGE, {
-            execute: () => this.dirtyDiffNavigator.gotoPreviousChange()
+            execute: widget => {
+                if (widget instanceof EditorWidget && widget.editor instanceof MonacoDiffEditor) {
+                    widget.editor.diffNavigator.previous();
+                } else {
+                    this.dirtyDiffNavigator.gotoPreviousChange();
+                }
+            },
+            isEnabled: widget => {
+                if (widget instanceof EditorWidget && widget.editor instanceof MonacoDiffEditor) {
+                    return widget.editor.diffNavigator.hasPrevious();
+                }
+                return true;
+            }
         });
         commandRegistry.registerCommand(SCM_COMMANDS.SHOW_NEXT_CHANGE, {
             execute: () => this.dirtyDiffNavigator.showNextChange()
@@ -270,6 +297,18 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
                 }
                 return false;
             }
+        });
+
+        registry.registerItem({
+            id: SCM_COMMANDS.GOTO_PREVIOUS_CHANGE.id,
+            command: SCM_COMMANDS.GOTO_PREVIOUS_CHANGE.id,
+            isVisible: widget => widget instanceof EditorWidget && widget.editor instanceof MonacoDiffEditor,
+        });
+
+        registry.registerItem({
+            id: SCM_COMMANDS.GOTO_NEXT_CHANGE.id,
+            command: SCM_COMMANDS.GOTO_NEXT_CHANGE.id,
+            isVisible: widget => widget instanceof EditorWidget && widget.editor instanceof MonacoDiffEditor,
         });
 
         registry.registerItem({


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #14888 by adding diff navigation commands to the toolbar of diff editors and using the existing diff navigator tool in `MonacoDiffEditors` to navigate among changes.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open a diff editor with some changes.
> Common ways to do this: modify a file and then open it from the source control view; use the 'select for comparison...compare with selected' commands in the file tree; using the AI chat features, ask the `@Coder` agent to make modifications.
2. You should see up and down arrows on the toolbar, and clicking them should take to the next / previous change in the file, as appropriate.
3. If you open a diff editor with no differences, the arrows should appear, but they should be greyed out.

> @ reviewers, there was relevant work in #13104, but since that was mostly related to `@theia/git`, I'm not sure the machinery implemented there is relevant anymore. The code here just skips that machinery in the case that I believe I know how to handle better, but possibly it's just no longer necessary. In particular, I'm not sure how we would have a diff in an editor with a `file` scheme.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
