### PR TITLE
Added an error for when a notebook editor is opened with a non existing file

### DIFF
--- a/packages/notebook/src/browser/notebook-editor-widget.tsx
+++ b/packages/notebook/src/browser/notebook-editor-widget.tsx
@@ -15,8 +15,8 @@
 // *****************************************************************************
 
 import * as React from '@theia/core/shared/react';
-import { CommandRegistry, MenuModelRegistry, URI } from '@theia/core';
-import { ReactWidget, Navigatable, SaveableSource, Message, DelegatingSaveable, lock, unlock, animationFrame } from '@theia/core/lib/browser';
+import { CommandRegistry, MenuModelRegistry, URI, nls } from '@theia/core';
+import { ReactWidget, Navigatable, SaveableSource, Message, DelegatingSaveable, lock, unlock, animationFrame, codicon } from '@theia/core/lib/browser';
 import { ReactNode } from '@theia/core/shared/react';
 import { CellKind, NotebookCellsChangeType } from '../common';
 import { CellRenderer as CellRenderer, NotebookCellListView } from './view/notebook-cell-list-view';
@@ -72,6 +72,7 @@ export interface NotebookEditorProps {
     uri: URI,
     readonly notebookType: string,
     notebookData: Promise<NotebookModel>
+    error?: Promise<string>
 }
 export const NOTEBOOK_EDITOR_ID_PREFIX = 'notebook:';
 
@@ -135,6 +136,7 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
 
     protected readonly renderers = new Map<CellKind, CellRenderer>();
     protected _model?: NotebookModel;
+    protected error?: string;
     protected _ready: Deferred<NotebookModel> = new Deferred();
     protected _findWidgetVisible = false;
     protected _findWidgetRef = React.createRef<NotebookFindWidget>();
@@ -187,6 +189,10 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
                     this.cellOutputWebview.cellsChanged(cellEvent);
                 }
             });
+        });
+        this.props.error?.then(error => {
+            this.error = error;
+            this.update();
         });
     }
 
@@ -287,6 +293,11 @@ export class NotebookEditorWidget extends ReactWidget implements Navigatable, Sa
                         </div>
                     </PerfectScrollbar>
                 </div>
+            </div>;
+        } else if (this.error) {
+            return <div className='theia-notebook-main-container error-message' tabIndex={-1}>
+                <span className={codicon('error')}></span>
+                <h3>{nls.localizeByDefault('The editor could not be opened because the file was not found.')}</h3>
             </div>;
         } else {
             return <div className='theia-notebook-main-container' tabIndex={-1}>

--- a/packages/notebook/src/browser/service/notebook-model-resolver-service.ts
+++ b/packages/notebook/src/browser/service/notebook-model-resolver-service.ts
@@ -65,14 +65,21 @@ export class NotebookModelResolverService {
             throw new Error(`Missing viewType for '${resource}'`);
         }
 
-        const actualResource = await this.resourceProvider(resource);
-        const notebookData = await this.resolveExistingNotebookData(actualResource, viewType!);
-        const notebookModel = await this.notebookService.createNotebookModel(notebookData, viewType, actualResource);
+        try {
 
-        notebookModel.onDirtyChanged(() => this.onDidChangeDirtyEmitter.fire(notebookModel));
-        notebookModel.onDidSaveNotebook(() => this.onDidSaveNotebookEmitter.fire(notebookModel.uri.toComponents()));
+            const actualResource = await this.resourceProvider(resource);
+            const notebookData = await this.resolveExistingNotebookData(actualResource, viewType!);
+            const notebookModel = await this.notebookService.createNotebookModel(notebookData, viewType, actualResource);
 
-        return notebookModel;
+            notebookModel.onDirtyChanged(() => this.onDidChangeDirtyEmitter.fire(notebookModel));
+            notebookModel.onDidSaveNotebook(() => this.onDidSaveNotebookEmitter.fire(notebookModel.uri.toComponents()));
+
+            return notebookModel;
+        } catch (e) {
+            const message = `Error resolving notebook model for: \n ${resource.path.fsPath()} \n with view type ${viewType}. \n ${e}`;
+            console.error(message);
+            throw new Error(message);
+        }
     }
 
     async resolveUntitledResource(arg: UntitledResource, viewType: string): Promise<NotebookModel> {

--- a/packages/notebook/src/browser/style/index.css
+++ b/packages/notebook/src/browser/style/index.css
@@ -257,6 +257,17 @@
   height: 2px;
 }
 
+.error-message {
+  justify-content: center;
+  margin: 0 50px;
+  text-align: center;
+}
+
+.error-message > span {
+  color: var(--theia-errorForeground);
+  font-size: 40px !important;
+}
+
 .theia-notebook-viewport {
   display: flex;
   overflow: hidden;


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14834

This adds an Error screen to the notebook editor when it's trying to open a non existing file
![grafik](https://github.com/user-attachments/assets/8b9cd8fb-e614-4cfe-a37b-5de925c4aad0)

#### How to test

1. Open a Notebook
2. Delete the notebook file in you local file explorer
3. Reload theia and see the error message

#### Follow-ups

One could try and parse the server error to display different error messages.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
