### PR TITLE
Update editors when ChangeElement added or replaced

### DIFF
--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -19,6 +19,7 @@ import { inject, injectable, postConstruct } from '@theia/core/shared/inversify'
 import { ChangeSetElement, ChangeSetImpl } from '../common';
 import { createChangeSetFileUri } from './change-set-file-resource';
 import { ChangeSetFileService } from './change-set-file-service';
+import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 
 export const ChangeSetFileElementFactory = Symbol('ChangeSetFileElementFactory');
 export type ChangeSetFileElementFactory = (elementProps: ChangeSetElementArgs) => ChangeSetFileElement;
@@ -46,6 +47,9 @@ export class ChangeSetFileElement implements ChangeSetElement {
 
     @inject(ChangeSetFileService)
     protected readonly changeSetFileService: ChangeSetFileService;
+
+    @inject(MonacoWorkspace)
+    protected readonly monacoWorkspace: MonacoWorkspace;
 
     protected _state: 'pending' | 'applied' | 'discarded' | undefined;
 
@@ -110,6 +114,12 @@ export class ChangeSetFileElement implements ChangeSetElement {
             this.uri,
             this.changedUri
         );
+    }
+
+    updateEditors(): void {
+        const existingModel = this.monacoWorkspace.getTextDocument(this.changedUri.toString());
+        if (!existingModel) { return; }
+        existingModel.textEditorModel.setValue(this.targetState);
     }
 
     async accept(contents?: string): Promise<void> {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -110,6 +110,7 @@ export interface ChangeSetElement {
 
     open?(): Promise<void>;
     openChange?(): Promise<void>;
+    updateEditors?(): void;
     accept?(): Promise<void>;
     discard?(): Promise<void>;
 }
@@ -574,6 +575,7 @@ export class ChangeSetImpl implements ChangeSet {
         if (!this.replaceElement(element)) {
             this.addElement(element);
         }
+        element.updateEditors?.();
     }
 
     removeElement(index: number): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #14900 by updating any open editors referring to a given change proposal when the change proposal is updated.

> I've put some thoughts together re: this problem [here](https://github.com/eclipse-theia/theia/issues/14768#issuecomment-2651484965). This PR implements the Monaco editor update solution proposed there. I have a branch that uses the resource-based approach, but that has the problem that we consider the editor 'dirty.' Would be happy to discuss implementing any of the solutions proposed there, or any others. This one isn't my favorite, because it feels like a weird place to assign responsibility for updating the editors, but it does get around the issue of dirty editors most directly.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a chat and use a prompt like
> `@Coder` Remove the prefix "MCP" from all user message in packages/ai-mcp/src/browser/mcp-command-contribution.ts
2. The agent should propose a change set. Open a diff for the file affected.
3. Prompt the agent again with something like.
> `@Coder` Actually, let's change the original MCP to CMP instead.
4. The agent should suggest a new set of changes, and the content of the right side of the diff should be updated accordingly.

> As I mention over on the issue, this means that any changes the user had made get wiped out. That's probably ok in a case like this, because the user chose to go back to the chat rather than use what had been proposed. On the other hand, if we chose to go with a solution like the Cline extension's, then the file would have been modified in place, and any changes the user made to the suggestions would be picked up by the agent in its second go around. On the other hand, it wouldn't see any MCP's to change to CMP, so it would fail on that count in this case. Lots of tradeoffs when trying to work intelligently with multiple potential versions of the same text 🤷 .

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
