### PR TITLE
Fix tool calling string in messages

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-view-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-contribution.ts
@@ -69,7 +69,7 @@ export class ChatViewMenuContribution implements MenuContribution, CommandContri
                     const parent = extractRequestOrResponseNodes(args).find(arg => arg.parent)?.parent;
                     const text = parent?.children
                         .filter(isRequestOrResponseNode)
-                        .map(child => this.getText(child))
+                        .map(child => this.getCopyText(child))
                         .join('\n\n---\n\n');
                     if (text) {
                         this.clipboardService.writeText(text);
@@ -93,19 +93,19 @@ export class ChatViewMenuContribution implements MenuContribution, CommandContri
     }
 
     protected copyMessage(args: (RequestNode | ResponseNode)[]): void {
-        const text = this.getTextAndJoin(args);
+        const text = this.getCopyTextAndJoin(args);
         this.clipboardService.writeText(text);
     }
 
-    protected getTextAndJoin(args: (RequestNode | ResponseNode)[] | undefined): string {
-        return args !== undefined ? args.map(arg => this.getText(arg)).join() : '';
+    protected getCopyTextAndJoin(args: (RequestNode | ResponseNode)[] | undefined): string {
+        return args !== undefined ? args.map(arg => this.getCopyText(arg)).join() : '';
     }
 
-    protected getText(arg: RequestNode | ResponseNode): string {
+    protected getCopyText(arg: RequestNode | ResponseNode): string {
         if (isRequestNode(arg)) {
             return arg.request.request.text;
         } else if (isResponseNode(arg)) {
-            return arg.response.response.asString();
+            return arg.response.response.asDisplayString();
         }
         return '';
     }

--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -25,6 +25,7 @@ import {
     ChatRequestParser,
     ChatRequestParserImpl,
     ChatService,
+    ToolCallChatResponseContentFactory,
 } from '../common';
 import { ChatAgentsVariableContribution } from '../common/chat-agents-variable-contribution';
 import { CustomChatAgent } from '../common/custom-chat-agent';
@@ -89,4 +90,5 @@ export default new ContainerModule(bind => {
     });
     bind(ChangeSetFileResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(ChangeSetFileResourceResolver);
+    bind(ToolCallChatResponseContentFactory).toSelf().inSingletonScope();
 });

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -28,6 +28,7 @@ import {
     LanguageModelStreamResponse,
     PromptService,
     ResolvedPromptTemplate,
+    ToolCall,
     ToolRequest,
 } from '@theia/ai-core';
 import {
@@ -312,8 +313,26 @@ export abstract class AbstractTextToModelParsingChatAgent<T> extends AbstractCha
     protected abstract createResponseContent(parsedModel: T, request: ChatRequestModelImpl): ChatResponseContent;
 }
 
+/**
+ * Factory for creating ToolCallChatResponseContent instances.
+ */
+@injectable()
+export class ToolCallChatResponseContentFactory {
+    create(toolCall: ToolCall): ChatResponseContent {
+        return new ToolCallChatResponseContentImpl(
+            toolCall.id,
+            toolCall.function?.name,
+            toolCall.function?.arguments,
+            toolCall.finished,
+            toolCall.result
+        );
+    }
+}
+
 @injectable()
 export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
+    @inject(ToolCallChatResponseContentFactory)
+    protected toolCallResponseContentFactory: ToolCallChatResponseContentFactory;
 
     protected override async addContentsToResponse(languageModelResponse: LanguageModelResponse, request: ChatRequestModelImpl): Promise<void> {
         if (isLanguageModelTextResponse(languageModelResponse)) {
@@ -371,10 +390,23 @@ export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
         const toolCalls = token.tool_calls;
         if (toolCalls !== undefined) {
             const toolCallContents = toolCalls.map(toolCall =>
-                new ToolCallChatResponseContentImpl(toolCall.id, toolCall.function?.name, toolCall.function?.arguments, toolCall.finished, toolCall.result));
+                this.createToolCallResponseContent(toolCall)
+            );
             return toolCallContents;
         }
         return this.defaultContentFactory.create('', request);
     }
 
+    /**
+     * Creates a ToolCallChatResponseContent instance from the provided tool call data.
+     *
+     * This method is called when parsing stream response tokens that contain tool call data.
+     * Subclasses can override this method to customize the creation of tool call response contents.
+     *
+     * @param toolCall The ToolCall.
+     * @returns A ChatResponseContent representing the tool call.
+     */
+    protected createToolCallResponseContent(toolCall: ToolCall): ChatResponseContent {
+        return this.toolCallResponseContentFactory.create(toolCall);
+    }
 }

--- a/packages/ai-chat/src/common/chat-history-entry.ts
+++ b/packages/ai-chat/src/common/chat-history-entry.ts
@@ -40,7 +40,7 @@ export namespace ChatHistoryEntry {
             agentId: agentId,
             sessionId: request.session.id,
             requestId: request.id,
-            response: request.response.response.asString(),
+            response: request.response.response.asDisplayString(),
             ...args,
         };
     }

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -964,14 +964,14 @@ class ChatResponseImpl implements ChatResponse {
     }
 
     protected _updateResponseRepresentation(): void {
-        this._responseRepresentation = this.responseRepresentationsToString(this._content, false);
-        this._responseRepresentationForDisplay = this.responseRepresentationsToString(this.content, true);
+        this._responseRepresentation = this.responseRepresentationsToString(this._content, 'asString');
+        this._responseRepresentationForDisplay = this.responseRepresentationsToString(this.content, 'asDisplayString');
     }
 
-    protected responseRepresentationsToString(content: ChatResponseContent[], forDisplay: boolean): string {
+    protected responseRepresentationsToString(content: ChatResponseContent[], collect: 'asString' | 'asDisplayString'): string {
         return content
             .map(responseContent => {
-                if (forDisplay) {
+                if (collect === 'asDisplayString') {
                     if (ChatResponseContent.hasDisplayString(responseContent)) {
                         return responseContent.asDisplayString();
                     }

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -171,6 +171,7 @@ export interface ChatResponseContent {
      * representation of the response.
      */
     asString?(): string | undefined;
+    asDisplayString?(): string | undefined;
     merge?(nextChatResponseContent: ChatResponseContent): boolean;
 }
 
@@ -187,6 +188,11 @@ export namespace ChatResponseContent {
         obj: ChatResponseContent
     ): obj is Required<Pick<ChatResponseContent, 'asString'>> & ChatResponseContent {
         return typeof obj.asString === 'function';
+    }
+    export function hasDisplayString(
+        obj: ChatResponseContent
+    ): obj is Required<Pick<ChatResponseContent, 'asDisplayString'>> & ChatResponseContent {
+        return typeof obj.asDisplayString === 'function';
     }
     export function hasMerge(
         obj: ChatResponseContent
@@ -398,6 +404,7 @@ export namespace QuestionResponseContent {
 export interface ChatResponse {
     readonly content: ChatResponseContent[];
     asString(): string;
+    asDisplayString(): string;
 }
 
 /**
@@ -674,6 +681,10 @@ export class TextChatResponseContentImpl implements TextChatResponseContent {
         return this._content;
     }
 
+    asDisplayString(): string | undefined {
+        return this.asString();
+    }
+
     merge(nextChatResponseContent: TextChatResponseContent): boolean {
         this._content += nextChatResponseContent.content;
         return true;
@@ -694,6 +705,10 @@ export class MarkdownChatResponseContentImpl implements MarkdownChatResponseCont
 
     asString(): string {
         return this._content.value;
+    }
+
+    asDisplayString(): string | undefined {
+        return this.asString();
     }
 
     merge(nextChatResponseContent: MarkdownChatResponseContent): boolean {
@@ -798,11 +813,7 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
     }
 
     asDisplayString(): string {
-        let description = `Tool call: ${this._name}(${this._arguments ?? ''})`;
-        if (this._result) {
-            description += ` => ${this._result}`;
-        }
-        return description;
+        return `Tool call: ${this._name}(${this._arguments ?? ''})`;
     }
     merge(nextChatResponseContent: ToolCallChatResponseContent): boolean {
         if (nextChatResponseContent.id === this.id) {
@@ -855,6 +866,10 @@ export class HorizontalLayoutChatResponseContentImpl implements HorizontalLayout
         return this._content.map(child => child.asString && child.asString()).join(' ');
     }
 
+    asDisplayString(): string | undefined {
+        return this.asString();
+    }
+
     merge(nextChatResponseContent: ChatResponseContent): boolean {
         if (HorizontalLayoutChatResponseContent.is(nextChatResponseContent)) {
             this._content.push(...nextChatResponseContent.content);
@@ -895,6 +910,7 @@ class ChatResponseImpl implements ChatResponse {
     onDidChange: Event<void> = this._onDidChangeEmitter.event;
     protected _content: ChatResponseContent[];
     protected _responseRepresentation: string;
+    protected _responseRepresentationForDisplay: string;
 
     constructor() {
         // TODO accept serialized data as a parameter to restore a previously saved ChatResponse
@@ -948,8 +964,18 @@ class ChatResponseImpl implements ChatResponse {
     }
 
     protected _updateResponseRepresentation(): void {
-        this._responseRepresentation = this._content
+        this._responseRepresentation = this.responseRepresentationsToString(this._content, false);
+        this._responseRepresentationForDisplay = this.responseRepresentationsToString(this.content, true);
+    }
+
+    protected responseRepresentationsToString(content: ChatResponseContent[], forDisplay: boolean): string {
+        return content
             .map(responseContent => {
+                if (forDisplay) {
+                    if (ChatResponseContent.hasDisplayString(responseContent)) {
+                        return responseContent.asDisplayString();
+                    }
+                }
                 if (ChatResponseContent.hasAsString(responseContent)) {
                     return responseContent.asString();
                 }
@@ -962,12 +988,16 @@ class ChatResponseImpl implements ChatResponse {
                 );
                 return undefined;
             })
-            .filter(text => text !== undefined)
+            .filter(text => (text !== undefined || text === ''))
             .join('\n\n');
     }
 
     asString(): string {
         return this._responseRepresentation;
+    }
+
+    asDisplayString(): string {
+        return this._responseRepresentationForDisplay;
     }
 }
 

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -988,7 +988,7 @@ class ChatResponseImpl implements ChatResponse {
                 );
                 return undefined;
             })
-            .filter(text => (text !== undefined || text === ''))
+            .filter(text => (text !== undefined && text !== ''))
             .join('\n\n');
     }
 

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -794,7 +794,15 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
     }
 
     asString(): string {
-        return `Tool call: ${this._name}(${this._arguments ?? ''})`;
+        return '';
+    }
+
+    asDisplayString(): string {
+        let description = `Tool call: ${this._name}(${this._arguments ?? ''})`;
+        if (this._result) {
+            description += ` => ${this._result}`;
+        }
+        return description;
     }
     merge(nextChatResponseContent: ToolCallChatResponseContent): boolean {
         if (nextChatResponseContent.id === this.id) {


### PR DESCRIPTION
fixed #14905

#### What it does

- Removes the string "Tool Call:..." from AI messages that were introduced by the ToolCallResponsContent.asString
- Make the Creation of ToolCallResponsContent adaptable by:
  - Moving it into an overridable method, so you can adapt it per agents
  - Retrieving the default in ChatAgent via DI, so you can globally override it
- Add a 'asDisplayString' (currently not yet used) to ToolCallResponsContent

#### How to test

Try the Coder agent in a longer conversation and see that it does not switch to attempting calling tools by outputting text like:
"Tool Call:"

see that copy still works in the chat and that the function call is mentioned in the history view.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
