### PR TITLE
Send plugin logs to the frontend

### DIFF
--- a/packages/debug/src/common/debug-adapter-session.ts
+++ b/packages/debug/src/common/debug-adapter-session.ts
@@ -43,7 +43,6 @@ export class DebugAdapterSessionImpl implements DebugAdapterSession {
         this.debugAdapter.onMessageReceived((message: string) => this.send(message));
         this.debugAdapter.onClose(() => this.onDebugAdapterExit());
         this.debugAdapter.onError(error => this.onDebugAdapterError(error));
-
     }
 
     async start(channel: DebugChannel): Promise<void> {

--- a/packages/notebook/src/browser/service/notebook-execution-service.ts
+++ b/packages/notebook/src/browser/service/notebook-execution-service.ts
@@ -18,13 +18,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { CellExecution, NotebookExecutionStateService } from '../service/notebook-execution-state-service';
 import { CellKind, NotebookCellExecutionState } from '../../common';
 import { NotebookCellModel } from '../view-model/notebook-cell-model';
 import { NotebookModel } from '../view-model/notebook-model';
 import { NotebookKernelService } from './notebook-kernel-service';
-import { CommandService, Disposable } from '@theia/core';
+import { CommandService, Disposable, ILogger } from '@theia/core';
 import { NotebookKernelQuickPickService } from './notebook-kernel-quick-pick-service';
 import { NotebookKernelHistoryService } from './notebook-kernel-history-service';
 
@@ -50,6 +50,9 @@ export class NotebookExecutionService {
     @inject(NotebookKernelQuickPickService)
     protected notebookKernelQuickPickService: NotebookKernelQuickPickService;
 
+    @inject(ILogger) @named('notebook')
+    protected readonly logger: ILogger;
+
     protected readonly cellExecutionParticipants = new Set<CellExecutionParticipant>();
 
     async executeNotebookCells(notebook: NotebookModel, cells: Iterable<NotebookCellModel>): Promise<void> {
@@ -58,6 +61,11 @@ export class NotebookExecutionService {
         if (!cellsArr.length) {
             return;
         }
+
+        this.logger.debug('Executing notebook cells', {
+            notebook: notebook.uri.toString(),
+            cells: cellsArr.map(c => c.handle)
+        });
 
         // create cell executions
         const cellExecutions: [NotebookCellModel, CellExecution][] = [];
@@ -71,6 +79,7 @@ export class NotebookExecutionService {
         const kernel = await this.notebookKernelHistoryService.resolveSelectedKernel(notebook);
 
         if (!kernel) {
+            this.logger.debug('Failed to resolve kernel for execution', notebook.uri.toString());
             // clear all pending cell executions
             cellExecutions.forEach(cellExe => cellExe[1].complete({}));
             return;
@@ -99,7 +108,16 @@ export class NotebookExecutionService {
             });
             await this.runExecutionParticipants(validCellExecutions);
 
+            this.logger.debug('Selecting kernel for cell execution', {
+                notebook: notebook.uri.toString(),
+                kernel: kernel.id
+            });
             this.notebookKernelService.selectKernelForNotebook(kernel, notebook);
+
+            this.logger.debug('Running cell execution request', {
+                notebook: notebook.uri.toString(),
+                cells: validCellExecutions.map(c => c.cellHandle)
+            });
             await kernel.executeNotebookCellsRequest(notebook.uri, validCellExecutions.map(c => c.cellHandle));
             // the connecting state can change before the kernel resolves executeNotebookCellsRequest
             const unconfirmed = validCellExecutions.filter(exe => exe.state === NotebookCellExecutionState.Unconfirmed);

--- a/packages/notebook/src/browser/service/notebook-execution-state-service.ts
+++ b/packages/notebook/src/browser/service/notebook-execution-state-service.ts
@@ -169,7 +169,6 @@ export class CellExecution implements Disposable {
         readonly cellHandle: number,
         protected readonly notebook: NotebookModel,
     ) {
-        console.debug(`CellExecution#ctor ${this.getCellLog()}`);
     }
 
     initialize(): void {
@@ -186,10 +185,6 @@ export class CellExecution implements Disposable {
             }
         };
         this.applyCellExecutionEditsToNotebook([startExecuteEdit]);
-    }
-
-    protected getCellLog(): string {
-        return `${this.notebookURI.toString()}, ${this.cellHandle}`;
     }
 
     confirm(): void {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2296,8 +2296,9 @@ export interface TestingMain {
 }
 
 export const PLUGIN_RPC_CONTEXT = {
-    AUTHENTICATION_MAIN: <ProxyIdentifier<AuthenticationMain>>createProxyIdentifier<AuthenticationMain>('AuthenticationMain'),
-    COMMAND_REGISTRY_MAIN: <ProxyIdentifier<CommandRegistryMain>>createProxyIdentifier<CommandRegistryMain>('CommandRegistryMain'),
+    LOGGER_MAIN: createProxyIdentifier<LoggerMain>('LoggerMain'),
+    AUTHENTICATION_MAIN: createProxyIdentifier<AuthenticationMain>('AuthenticationMain'),
+    COMMAND_REGISTRY_MAIN: createProxyIdentifier<CommandRegistryMain>('CommandRegistryMain'),
     QUICK_OPEN_MAIN: createProxyIdentifier<QuickOpenMain>('QuickOpenMain'),
     DIALOGS_MAIN: createProxyIdentifier<DialogsMain>('DialogsMain'),
     WORKSPACE_MAIN: createProxyIdentifier<WorkspaceMain>('WorkspaceMain'),
@@ -2330,14 +2331,14 @@ export const PLUGIN_RPC_CONTEXT = {
     SECRETS_MAIN: createProxyIdentifier<SecretsMain>('SecretsMain'),
     DECORATIONS_MAIN: createProxyIdentifier<DecorationsMain>('DecorationsMain'),
     WINDOW_MAIN: createProxyIdentifier<WindowMain>('WindowMain'),
-    CLIPBOARD_MAIN: <ProxyIdentifier<ClipboardMain>>createProxyIdentifier<ClipboardMain>('ClipboardMain'),
-    LABEL_SERVICE_MAIN: <ProxyIdentifier<LabelServiceMain>>createProxyIdentifier<LabelServiceMain>('LabelServiceMain'),
-    TIMELINE_MAIN: <ProxyIdentifier<TimelineMain>>createProxyIdentifier<TimelineMain>('TimelineMain'),
-    THEMING_MAIN: <ProxyIdentifier<ThemingMain>>createProxyIdentifier<ThemingMain>('ThemingMain'),
-    COMMENTS_MAIN: <ProxyIdentifier<CommentsMain>>createProxyIdentifier<CommentsMain>('CommentsMain'),
-    TABS_MAIN: <ProxyIdentifier<TabsMain>>createProxyIdentifier<TabsMain>('TabsMain'),
-    TELEMETRY_MAIN: <ProxyIdentifier<TelemetryMain>>createProxyIdentifier<TelemetryMain>('TelemetryMain'),
-    LOCALIZATION_MAIN: <ProxyIdentifier<LocalizationMain>>createProxyIdentifier<LocalizationMain>('LocalizationMain'),
+    CLIPBOARD_MAIN: createProxyIdentifier<ClipboardMain>('ClipboardMain'),
+    LABEL_SERVICE_MAIN: createProxyIdentifier<LabelServiceMain>('LabelServiceMain'),
+    TIMELINE_MAIN: createProxyIdentifier<TimelineMain>('TimelineMain'),
+    THEMING_MAIN: createProxyIdentifier<ThemingMain>('ThemingMain'),
+    COMMENTS_MAIN: createProxyIdentifier<CommentsMain>('CommentsMain'),
+    TABS_MAIN: createProxyIdentifier<TabsMain>('TabsMain'),
+    TELEMETRY_MAIN: createProxyIdentifier<TelemetryMain>('TelemetryMain'),
+    LOCALIZATION_MAIN: createProxyIdentifier<LocalizationMain>('LocalizationMain'),
     TESTING_MAIN: createProxyIdentifier<TestingMain>('TestingMain'),
     URI_MAIN: createProxyIdentifier<UriMain>('UriMain')
 };
@@ -2758,4 +2759,16 @@ export interface StringDetails {
 
 export interface LocalizationMain {
     $fetchBundle(id: string): Promise<LanguagePackBundle | undefined>;
+}
+
+export enum LogLevel {
+    Trace = 1,
+    Debug = 2,
+    Info = 3,
+    Warn = 4,
+    Error = 5
+}
+
+export interface LoggerMain {
+    $log(level: LogLevel, name: string | undefined, message: string, params: any[]): void;
 }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -192,8 +192,7 @@ export class HostedPluginProcess implements ServerPluginRunner {
             // 5th element MUST be 'overlapped' for it to work properly on Windows.
             // 'overlapped' works just like 'pipe' on non-Windows platforms.
             // See: https://nodejs.org/docs/latest-v14.x/api/child_process.html#child_process_options_stdio
-            // Note: For some reason `@types/node` does not know about 'overlapped'.
-            stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'overlapped' as 'pipe']
+            stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'overlapped']
         };
         const inspectArgPrefix = `--${options.serverName}-inspect`;
         const inspectArg = process.argv.find(v => v.startsWith(inspectArgPrefix));

--- a/packages/plugin-ext/src/hosted/node/plugin-host-logger.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-logger.ts
@@ -1,0 +1,39 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { LogLevel } from '../../common/plugin-api-rpc';
+import { RPCProtocol } from '../../common/rpc-protocol';
+import { PluginLogger } from '../../plugin/logger';
+import { format } from 'util';
+
+export function setupPluginHostLogger(rpc: RPCProtocol): void {
+    const logger = new PluginLogger(rpc, 'plugin-host');
+
+    function createLog(level: LogLevel): typeof console.log {
+        return (message, ...params) => {
+            // Format the messages beforehand
+            // This ensures that we don't accidentally send objects that are not serializable
+            const formatted = format(message, ...params);
+            logger.log(level, formatted);
+        };
+    }
+
+    console.log = console.info = createLog(LogLevel.Info);
+    console.debug = createLog(LogLevel.Debug);
+    console.warn = createLog(LogLevel.Warn);
+    console.error = createLog(LogLevel.Error);
+    console.trace = createLog(LogLevel.Trace);
+}

--- a/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
@@ -13,6 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
+
 import '@theia/core/shared/reflect-metadata';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { RPCProtocol, RPCProtocolImpl } from '../../common/rpc-protocol';
@@ -34,10 +35,13 @@ import { KeyValueStorageProxy, InternalStorageExt } from '../../plugin/plugin-st
 import { WebviewsExtImpl } from '../../plugin/webviews';
 import { TerminalServiceExtImpl } from '../../plugin/terminal-ext';
 import { InternalSecretsExt, SecretsExtImpl } from '../../plugin/secrets-ext';
+import { setupPluginHostLogger } from './plugin-host-logger';
 
 export default new ContainerModule(bind => {
     const channel = new IPCChannel();
-    bind(RPCProtocol).toConstantValue(new RPCProtocolImpl(channel));
+    const rpc = new RPCProtocolImpl(channel);
+    setupPluginHostLogger(rpc);
+    bind(RPCProtocol).toConstantValue(rpc);
 
     bind(PluginContainerModuleLoader).toDynamicValue(({ container }) =>
         (module: ContainerModule) => {

--- a/packages/plugin-ext/src/main/browser/logger-main.ts
+++ b/packages/plugin-ext/src/main/browser/logger-main.ts
@@ -1,0 +1,53 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { interfaces } from '@theia/core/shared/inversify';
+import { LoggerMain, LogLevel } from '../../common';
+import { ILogger } from '@theia/core';
+
+export class LoggerMainImpl implements LoggerMain {
+
+    constructor(private readonly container: interfaces.Container) {
+    }
+
+    $log(level: LogLevel, name: string | undefined, message: string, params: any[]): void {
+        let logger: ILogger;
+        if (name) {
+            logger = this.container.getNamed<ILogger>(ILogger, name);
+        } else {
+            logger = this.container.get<ILogger>(ILogger);
+        }
+        switch (level) {
+            case LogLevel.Trace:
+                logger.trace(message, ...params);
+                break;
+            case LogLevel.Debug:
+                logger.debug(message, ...params);
+                break;
+            case LogLevel.Info:
+                logger.info(message, ...params);
+                break;
+            case LogLevel.Warn:
+                logger.warn(message, ...params);
+                break;
+            case LogLevel.Error:
+                logger.error(message, ...params);
+                break;
+        }
+    }
+}

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -65,8 +65,12 @@ import { NotebookKernelsMainImpl } from './notebooks/notebook-kernels-main';
 import { NotebooksAndEditorsMain } from './notebooks/notebook-documents-and-editors-main';
 import { TestingMainImpl } from './test-main';
 import { UriMainImpl } from './uri-main';
+import { LoggerMainImpl } from './logger-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
+    const loggerMain = new LoggerMainImpl(container);
+    rpc.set(PLUGIN_RPC_CONTEXT.LOGGER_MAIN, loggerMain);
+
     const authenticationMain = new AuthenticationMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.AUTHENTICATION_MAIN, authenticationMain);
 

--- a/packages/plugin-ext/src/plugin/debug/debug-ext.ts
+++ b/packages/plugin-ext/src/plugin/debug/debug-ext.ts
@@ -35,6 +35,7 @@ import { NodeDebugAdapterCreator } from '../node/debug/plugin-node-debug-adapter
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { DebugConfiguration, DebugSessionOptions } from '@theia/debug/lib/common/debug-configuration';
 import { checkTestRunInstance } from '../tests';
+import { PluginLogger } from '../logger';
 
 interface ConfigurationProviderRecord {
     handle: number;
@@ -69,6 +70,7 @@ export class DebugExtImpl implements DebugExt {
     private commandRegistryExt: CommandRegistryImpl;
 
     private proxy: DebugMain;
+    private logger: PluginLogger;
 
     private readonly onDidChangeBreakpointsEmitter = new Emitter<theia.BreakpointsChangeEvent>();
     private readonly onDidChangeActiveDebugSessionEmitter = new Emitter<theia.DebugSession | undefined>();
@@ -104,6 +106,7 @@ export class DebugExtImpl implements DebugExt {
     @postConstruct()
     initialize(): void {
         this.proxy = this.rpc.getProxy(Ext.DEBUG_MAIN);
+        this.logger = new PluginLogger(this.rpc, 'debug');
     }
 
     /**
@@ -129,7 +132,7 @@ export class DebugExtImpl implements DebugExt {
                 type: contribution.type,
                 label: contribution.label || contribution.type
             });
-            console.log(`Debugger contribution has been registered: ${contribution.type}`);
+            this.logger.debug(`Debugger contribution has been registered: ${contribution.type}`);
         });
     }
 
@@ -259,7 +262,7 @@ export class DebugExtImpl implements DebugExt {
     }
 
     registerDebugConfigurationProvider(debugType: string, provider: theia.DebugConfigurationProvider, trigger: DebugConfigurationProviderTriggerKind): Disposable {
-        console.log(`Debug configuration provider has been registered: ${debugType}, trigger: ${trigger}`);
+        this.logger.info(`Debug configuration provider has been registered: ${debugType}, trigger: ${trigger}`);
 
         const handle = this.configurationProviderHandleGenerator++;
         this.configurationProviders.push({ handle, type: debugType, trigger, provider });

--- a/packages/plugin-ext/src/plugin/decorations.ts
+++ b/packages/plugin-ext/src/plugin/decorations.ts
@@ -27,6 +27,7 @@ import { RPCProtocol } from '../common/rpc-protocol';
 import { Disposable, FileDecoration, URI } from './types-impl';
 import { CancellationToken } from '@theia/core/lib/common';
 import { dirname } from 'path';
+import { PluginLogger } from './logger';
 
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -45,9 +46,11 @@ export class DecorationsExtImpl implements DecorationsExt {
 
     private readonly providersMap: Map<number, ProviderData>;
     private readonly proxy: DecorationsMain;
+    private readonly logger: PluginLogger;
 
     constructor(readonly rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.DECORATIONS_MAIN);
+        this.logger = new PluginLogger(rpc, 'decorations-plugin');
         this.providersMap = new Map();
     }
 
@@ -128,10 +131,10 @@ export class DecorationsExtImpl implements DecorationsExt {
                     FileDecoration.validate(data);
                     result[id] = <DecorationData>[data.propagate, data.tooltip, data.badge, data.color];
                 } catch (e) {
-                    console.warn(`INVALID decoration from extension '${pluginInfo.name}': ${e}`);
+                    this.logger.warn(`INVALID decoration from extension '${pluginInfo.name}': ${e}`);
                 }
             } catch (err) {
-                console.error(err);
+                this.logger.error(err);
             }
         }));
 

--- a/packages/plugin-ext/src/plugin/localization-ext.ts
+++ b/packages/plugin-ext/src/plugin/localization-ext.ts
@@ -23,6 +23,7 @@ import { LocalizationExt, LocalizationMain, Plugin, PLUGIN_RPC_CONTEXT, StringDe
 import { LanguagePackBundle } from '../common/language-pack-service';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { URI } from './types-impl';
+import { PluginLogger } from './logger';
 
 @injectable()
 export class LocalizationExtImpl implements LocalizationExt {
@@ -30,6 +31,7 @@ export class LocalizationExtImpl implements LocalizationExt {
     protected readonly rpc: RPCProtocol;
 
     private _proxy: LocalizationMain;
+    private logger: PluginLogger;
     private currentLanguage?: string;
     private isDefaultLanguage = true;
     private readonly bundleCache = new Map<string, LanguagePackBundle | undefined>();
@@ -37,6 +39,7 @@ export class LocalizationExtImpl implements LocalizationExt {
     @postConstruct()
     initialize(): void {
         this._proxy = this.rpc.getProxy(PLUGIN_RPC_CONTEXT.LOCALIZATION_MAIN);
+        this.logger = new PluginLogger(this.rpc, 'nls');
     }
 
     translateMessage(pluginId: string, details: StringDetails): string {
@@ -79,7 +82,7 @@ export class LocalizationExtImpl implements LocalizationExt {
         try {
             bundle = await this._proxy.$fetchBundle(plugin.model.id);
         } catch (e) {
-            console.error(`Failed to load translations for ${plugin.model.id}: ${e.message}`);
+            this.logger.error(`Failed to load translations for ${plugin.model.id}: ${e.message}`);
             return;
         }
 

--- a/packages/plugin-ext/src/plugin/logger.ts
+++ b/packages/plugin-ext/src/plugin/logger.ts
@@ -1,0 +1,66 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { LoggerMain, LogLevel, PLUGIN_RPC_CONTEXT } from '../common';
+import { RPCProtocol } from '../common/rpc-protocol';
+
+export class PluginLogger {
+
+    private readonly logger: LoggerMain;
+    private readonly name?: string;
+
+    constructor(rpc: RPCProtocol, name?: string) {
+        this.name = name;
+        this.logger = rpc.getProxy(PLUGIN_RPC_CONTEXT.LOGGER_MAIN);
+    }
+
+    trace(message: string, ...params: any[]): void {
+        this.sendLog(LogLevel.Trace, message, params);
+    }
+
+    debug(message: string, ...params: any[]): void {
+        this.sendLog(LogLevel.Debug, message, params);
+    }
+
+    log(logLevel: LogLevel, message: string, ...params: any[]): void {
+        this.sendLog(logLevel, message, params);
+    }
+
+    info(message: string, ...params: any[]): void {
+        this.sendLog(LogLevel.Info, message, params);
+    }
+
+    warn(message: string, ...params: any[]): void {
+        this.sendLog(LogLevel.Warn, message, params);
+    }
+
+    error(message: string, ...params: any[]): void {
+        this.sendLog(LogLevel.Error, message, params);
+    }
+
+    private sendLog(level: LogLevel, message: string, params: any[]): void {
+        this.logger.$log(level, this.name, this.toLog(message), params.map(e => this.toLog(e)));
+    }
+
+    private toLog(value: any): any {
+        if (value instanceof Error) {
+            return value.stack ?? value.message ?? value.toString();
+        }
+        return value;
+    }
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -287,6 +287,7 @@ import { NotebookEditorsExtImpl } from './notebook/notebook-editors';
 import { TestingExtImpl } from './tests';
 import { UriExtImpl } from './uri-ext';
 import { isObject } from '@theia/core';
+import { PluginLogger } from './logger';
 
 export function createAPIObject<T extends Object>(rawObject: T): T {
     return new Proxy(rawObject, {
@@ -353,6 +354,8 @@ export function createAPIFactory(
     const uriExt = rpc.set(MAIN_RPC_CONTEXT.URI_EXT, new UriExtImpl(rpc));
     rpc.set(MAIN_RPC_CONTEXT.DEBUG_EXT, debugExt);
 
+    const commandLogger = new PluginLogger(rpc, 'commands-plugin');
+
     return function (plugin: InternalPlugin): typeof theia {
         const authentication: typeof theia.authentication = {
             registerAuthenticationProvider(id: string, label: string, provider: theia.AuthenticationProvider, options?: theia.AuthenticationProviderOptions): theia.Disposable {
@@ -393,7 +396,7 @@ export function createAPIFactory(
                 const internalHandler = (...args: any[]): any => {
                     const activeTextEditor = editors.getActiveEditor();
                     if (!activeTextEditor) {
-                        console.warn('Cannot execute ' + command + ' because there is no active text editor.');
+                        commandLogger.warn('Cannot execute ' + command + ' because there is no active text editor.');
                         return undefined;
                     }
 
@@ -402,10 +405,10 @@ export function createAPIFactory(
                         handler.apply(thisArg, args);
                     }).then(result => {
                         if (!result) {
-                            console.warn('Edits from command ' + command + ' were not applied.');
+                            commandLogger.warn('Edits from command ' + command + ' were not applied.');
                         }
                     }, err => {
-                        console.warn('An error occurred while running command ' + command, err);
+                        commandLogger.warn('An error occurred while running command ' + command, err);
                     });
                 };
                 return commandIsDeclaredInPackage(command, plugin.rawModel)

--- a/packages/plugin-ext/src/plugin/uri-ext.ts
+++ b/packages/plugin-ext/src/plugin/uri-ext.ts
@@ -31,7 +31,6 @@ export class UriExtImpl implements UriExt {
 
     constructor(readonly rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.URI_MAIN);
-        console.log(this.proxy);
     }
 
     registerUriHandler(handler: theia.UriHandler, plugin: PluginInfo): theia.Disposable {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12234

Adds a new `LoggerMain` plugin browser service that is in charge of sending all data logged in the plugin host (either explicitly via the new `PluginLogger` or simply via the `console` functions) to the frontend where it will be logged under its respective logger. This allows to configure the logging level of individual parts of the plugin host logging.

#### How to test

1. Set a logger config via the `--log-config` argument that sets the `"notebook": "debug"` level.
2. Open and a notebook and execute some code within.
3. The respective debug level logging will be performed for the notebook logger.
4. Changing the level back to `info` will print less information to the console.

#### Follow-ups

We could send the information to an output log in the frontend instead of the console log of the browser tools. That's how VS Code does it. However, I would implement this in a separate PR.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
