### PR TITLE
Empty hidden editors

### DIFF
--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -225,14 +225,18 @@ export class BaseWidget extends Widget implements PreviewableWidget {
     override setFlag(flag: Widget.Flag): void {
         super.setFlag(flag);
         if (flag === Widget.Flag.IsVisible) {
-            this.onDidChangeVisibilityEmitter.fire(this.isVisible);
+            this.handleVisiblityChanged(this.isVisible)
         }
+    }
+
+    protected handleVisiblityChanged(isNowVisible: boolean): void {
+        this.onDidChangeVisibilityEmitter.fire(isNowVisible);
     }
 
     override clearFlag(flag: Widget.Flag): void {
         super.clearFlag(flag);
         if (flag === Widget.Flag.IsVisible) {
-            this.onDidChangeVisibilityEmitter.fire(this.isVisible);
+            this.handleVisiblityChanged(this.isVisible);
         }
     }
 }

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -225,7 +225,7 @@ export class BaseWidget extends Widget implements PreviewableWidget {
     override setFlag(flag: Widget.Flag): void {
         super.setFlag(flag);
         if (flag === Widget.Flag.IsVisible) {
-            this.handleVisiblityChanged(this.isVisible)
+            this.handleVisiblityChanged(this.isVisible);
         }
     }
 

--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -60,6 +60,11 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
         }
     }
 
+    protected override handleVisiblityChanged(isNowVisible: boolean): void {
+        this.editor.handleVisibilityChanged(isNowVisible);
+        super.handleVisiblityChanged(isNowVisible);
+    }
+
     get saveable(): Saveable {
         return this.editor.document;
     }

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -295,6 +295,8 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
     readonly onEncodingChanged: Event<string>;
 
     shouldDisplayDirtyDiff(): boolean;
+
+    handleVisibilityChanged(nowVisible: boolean): void;
 }
 
 export interface Selection extends Range {

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -48,7 +48,7 @@ import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 export const MonacoEditorFactory = Symbol('MonacoEditorFactory');
 export interface MonacoEditorFactory {
     readonly scheme: string;
-    create(model: MonacoEditorModel, defaultOptions: MonacoEditor.IOptions, defaultOverrides: EditorServiceOverrides): MonacoEditor;
+    create(model: MonacoEditorModel, defaultOptions: MonacoEditor.IOptions, defaultOverrides: EditorServiceOverrides): Promise<MonacoEditor>;
 }
 
 @injectable()
@@ -198,8 +198,8 @@ export class MonacoEditorProvider {
         const options = this.createMonacoEditorOptions(model);
         const factory = this.factories.getContributions().find(({ scheme }) => uri.scheme === scheme);
         const editor = factory
-            ? factory.create(model, options, override)
-            : new MonacoEditor(uri, model, document.createElement('div'), this.services, options, override);
+            ? await factory.create(model, options, override)
+            : await MonacoEditor.create(uri, model, document.createElement('div'), this.services, options, override);
         toDispose.push(this.editorPreferences.onPreferenceChanged(event => {
             if (event.affects(uri.toString(), model.languageId)) {
                 this.updateMonacoEditorOptions(editor, event);
@@ -380,7 +380,7 @@ export class MonacoEditorProvider {
             }, this.m2p, this.p2m);
             toDispose.push(document);
             const model = (await document.load()).textEditorModel;
-            return new MonacoEditor(
+            return await MonacoEditor.create(
                 uri,
                 document,
                 node,

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -109,6 +109,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     readonly onDidResize = this.onResizeEmitter.event;
 
     readonly documents = new Set<MonacoEditorModel>();
+    protected model: monaco.editor.ITextModel | null;
 
     constructor(
         readonly uri: URI,
@@ -226,6 +227,18 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
         this.toDispose.push(this.onDidChangeReadOnly(readOnly => {
             codeEditor.updateOptions(MonacoEditor.createReadOnlyOptions(readOnly));
         }));
+    }
+
+    handleVisibilityChanged(nowVisible: boolean): void {
+        if (nowVisible) {
+            if (this.model) {
+                this.editor.setModel(this.model);
+            }
+        } else {
+            this.model = this.editor.getModel();
+            // eslint-disable-next-line no-null/no-null
+            this.editor.setModel(null); // workaround for https://github.com/eclipse-theia/theia/issues/14880
+        }
     }
 
     getVisibleRanges(): Range[] {

--- a/packages/monaco/src/browser/monaco-to-protocol-converter.ts
+++ b/packages/monaco/src/browser/monaco-to-protocol-converter.ts
@@ -69,7 +69,14 @@ export class MonacoToProtocolConverter {
         }
     }
 
-    asSelection(selection: monaco.Selection): Selection {
+    asSelection(selection: monaco.Selection | null): Selection {
+        if (!selection) {
+            return {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 0 },
+                direction: 'ltr'
+            };
+        }
         const start = this.asPosition(selection.selectionStartLineNumber, selection.selectionStartColumn);
         const end = this.asPosition(selection.positionLineNumber, selection.positionColumn);
         return {

--- a/packages/output/src/browser/output-editor-factory.ts
+++ b/packages/output/src/browser/output-editor-factory.ts
@@ -35,11 +35,11 @@ export class OutputEditorFactory implements MonacoEditorFactory {
 
     readonly scheme: string = OutputUri.SCHEME;
 
-    create(model: MonacoEditorModel, defaultsOptions: MonacoEditor.IOptions): MonacoEditor {
+    create(model: MonacoEditorModel, defaultsOptions: MonacoEditor.IOptions): Promise<MonacoEditor> {
         const uri = new URI(model.uri);
         const options = this.createOptions(model, defaultsOptions);
         const overrides = this.createOverrides(model);
-        return new MonacoEditor(uri, model, document.createElement('div'), this.services, options, overrides);
+        return MonacoEditor.create(uri, model, document.createElement('div'), this.services, options, overrides);
     }
 
     protected createOptions(model: MonacoEditorModel, defaultOptions: MonacoEditor.IOptions): MonacoEditor.IOptions {


### PR DESCRIPTION
#### What it does
Monaco editors don't work correctly when they are hidden by setting `display: none`. This PR unsets the editor model from the editor when it is hidden and restores it when the editor is revealed again.

Fixes #14880

#### How to test
Test the scenario from the related issue. Have an eye out for an missing state in the editor or focus issues. This needs to be tested on Linux to make sure the issue is fixed as it did not happen on Windows.

#### Follow-ups


#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
