### PR TITLE
Improve AI diff UX

### DIFF
--- a/examples/api-samples/src/browser/chat/change-set-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/change-set-chat-agent-contribution.ts
@@ -81,7 +81,8 @@ export class ChangeSetChatAgent extends AbstractStreamParsingChatAgent {
 
         const chatSessionId = request.session.id;
         const changeSet = new ChangeSetImpl('My Test Change Set');
-        changeSet.addElement(
+
+        changeSet.addElements(
             this.fileChangeFactory({
                 uri: fileToAdd,
                 type: 'add',
@@ -93,7 +94,7 @@ export class ChangeSetChatAgent extends AbstractStreamParsingChatAgent {
         );
 
         if (fileToChange && fileToChange.resource) {
-            changeSet.addElement(
+            changeSet.addElements(
                 this.fileChangeFactory({
                     uri: fileToChange.resource,
                     type: 'modify',
@@ -105,7 +106,7 @@ export class ChangeSetChatAgent extends AbstractStreamParsingChatAgent {
             );
         }
         if (fileToDelete && fileToDelete.resource) {
-            changeSet.addElement(
+            changeSet.addElements(
                 this.fileChangeFactory({
                     uri: fileToDelete.resource,
                     type: 'delete',
@@ -115,6 +116,7 @@ export class ChangeSetChatAgent extends AbstractStreamParsingChatAgent {
                 })
             );
         }
+
         request.session.setChangeSet(changeSet);
 
         request.response.response.addContent(new MarkdownChatResponseContentImpl(

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -426,8 +426,8 @@ const buildChangeSetUI = (changeSet: ChangeSet, labelProvider: LabelProvider, on
         name: element.name ?? labelProvider.getName(element.uri),
         additionalInfo: element.additionalInfo ?? labelProvider.getDetails(element.uri),
         openChange: element?.openChange?.bind(element),
-        accept: element.state !== 'applied' ? element?.accept?.bind(element) : undefined,
-        discard: element.state === 'applied' ? element?.discard?.bind(element) : undefined,
+        accept: element.state !== 'applied' ? element?.apply?.bind(element) : undefined,
+        discard: element.state === 'applied' ? element?.revert?.bind(element) : undefined,
         delete: () => onDeleteChangeSetElement(changeSet.getElements().indexOf(element))
     }))
 });
@@ -557,7 +557,7 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({ left
 );
 
 function acceptAllPendingElements(changeSet: ChangeSet): void {
-    acceptablePendingElements(changeSet).forEach(e => e.accept!());
+    acceptablePendingElements(changeSet).forEach(e => e.apply!());
 }
 
 function hasPendingElementsToAccept(changeSet: ChangeSet): boolean | undefined {
@@ -565,7 +565,7 @@ function hasPendingElementsToAccept(changeSet: ChangeSet): boolean | undefined {
 }
 
 function acceptablePendingElements(changeSet: ChangeSet): ChangeSetElement[] {
-    return changeSet.getElements().filter(e => e.accept && (e.state === undefined || e.state === 'pending'));
+    return changeSet.getElements().filter(e => e.apply && (e.state === undefined || e.state === 'pending'));
 }
 
 function getLatestRequest(chatModel: ChatModel): ChatRequestModel | undefined {

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -460,10 +460,10 @@ const ChangeSetBox: React.FunctionComponent<{ changeSet: ChangeSetUI }> = ({ cha
                 <button
                     className='theia-button'
                     disabled={changeSet.disabled}
-                    title={nls.localize('theia/ai/chat-ui/acceptAll', 'Apply all pending suggestions')}
+                    title={nls.localize('theia/ai/chat-ui/applyAllTitle', 'Apply all pending suggestions')}
                     onClick={() => changeSet.applyAllPendingElements()}
                 >
-                    {nls.localizeByDefault('Copy All')}
+                    {nls.localize('theia/ai/chat-ui/acceptAll', 'Apply All')}
                 </button>
                 <span className='codicon codicon-close action' title={nls.localize('theia/ai/chat-ui/deleteChangeSet', 'Delete Change Set')} onClick={() => changeSet.delete()} />
             </div>

--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -14,14 +14,17 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { MEMORY_TEXT, URI } from '@theia/core';
+import { DisposableCollection, Emitter, URI } from '@theia/core';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { ChangeSetElement, ChangeSetImpl } from '../common';
-import { createChangeSetFileUri } from './change-set-file-resource';
+import { ChangeSetFileResourceResolver, createChangeSetFileUri, UpdatableReferenceResource } from './change-set-file-resource';
 import { ChangeSetFileService } from './change-set-file-service';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { ConfirmDialog } from '@theia/core/lib/browser';
 
 export const ChangeSetFileElementFactory = Symbol('ChangeSetFileElementFactory');
 export type ChangeSetFileElementFactory = (elementProps: ChangeSetElementArgs) => ChangeSetFileElement;
+type ChangeSetElementState = ChangeSetElement['state'];
 
 export const ChangeSetElementArgs = Symbol('ChangeSetElementArgs');
 export interface ChangeSetElementArgs extends Partial<ChangeSetElement> {
@@ -41,23 +44,74 @@ export interface ChangeSetElementArgs extends Partial<ChangeSetElement> {
 @injectable()
 export class ChangeSetFileElement implements ChangeSetElement {
 
+    static toReadOnlyUri(baseUri: URI, sessionId: string): URI {
+        return baseUri.withScheme('change-set-immutable').withAuthority(sessionId);
+    }
+
     @inject(ChangeSetElementArgs)
     protected readonly elementProps: ChangeSetElementArgs;
 
     @inject(ChangeSetFileService)
     protected readonly changeSetFileService: ChangeSetFileService;
 
-    protected _state: 'pending' | 'applied' | undefined;
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(ChangeSetFileResourceResolver)
+    protected readonly resourceResolver: ChangeSetFileResourceResolver;
+
+    protected readonly toDispose = new DisposableCollection();
+    protected _state: ChangeSetElementState;
 
     protected originalContent: string | undefined;
 
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+    protected readOnlyResource: UpdatableReferenceResource;
+    protected changeResource: UpdatableReferenceResource;
+
     @postConstruct()
     init(): void {
+        this.getResources();
         this.obtainOriginalContent();
+        this.listenForOriginalFileChanges();
+        this.toDispose.push(this.onDidChangeEmitter);
     }
 
     protected async obtainOriginalContent(): Promise<void> {
         this.originalContent = await this.changeSetFileService.read(this.uri);
+        this.readOnlyResource.update({ contents: this.originalContent ?? '' });
+        if (this.state === 'applied') {
+
+        }
+    }
+
+    protected getResources(): void {
+        this.readOnlyResource = this.resourceResolver.tryGet(this.readOnlyUri) ?? this.resourceResolver.add(this.readOnlyUri, { autosaveable: false, readOnly: true });
+        let changed = this.resourceResolver.tryGet(this.changedUri);
+        if (changed) {
+            changed.update({ contents: this.targetState, onSave: content => this.writeChanges(content) });
+        } else {
+            changed = this.resourceResolver.add(this.changedUri, { contents: this.targetState, onSave: content => this.writeChanges(content), autosaveable: false });
+        }
+        this.changeResource = changed;
+        this.toDispose.pushAll([this.readOnlyResource, this.changeResource]);
+    }
+
+    protected listenForOriginalFileChanges(): void {
+        this.toDispose.push(this.fileService.onDidFilesChange(async event => {
+            if (!event.contains(this.uri)) { return; }
+            // If we are applied, the tricky thing becomes the question what to revert to; otherwise, what to apply.
+            const newContent = await this.changeSetFileService.read(this.uri).catch(() => '');
+            this.readOnlyResource.update({ contents: newContent });
+            if (newContent === this.originalContent) {
+                this.state = 'pending';
+            } else if (newContent === this.targetState) {
+                this.state = 'applied';
+            } else {
+                this.state = 'stale';
+            }
+        }));
     }
 
     get uri(): URI {
@@ -65,7 +119,7 @@ export class ChangeSetFileElement implements ChangeSetElement {
     }
 
     get readOnlyUri(): URI {
-        return this.elementProps.uri.withScheme(MEMORY_TEXT).withQuery(this.originalContent ?? '');
+        return ChangeSetFileElement.toReadOnlyUri(this.uri, this.elementProps.chatSessionId);
     }
 
     get changedUri(): URI {
@@ -84,13 +138,15 @@ export class ChangeSetFileElement implements ChangeSetElement {
         return this.changeSetFileService.getAdditionalInfo(this.uri);
     }
 
-    get state(): 'pending' | 'applied' | undefined {
+    get state(): ChangeSetElementState {
         return this._state ?? this.elementProps.state;
     }
 
-    protected set state(value: 'pending' | 'applied' | undefined) {
-        this._state = value;
-        this.elementProps.changeSet.notifyChange();
+    protected set state(value: ChangeSetElementState) {
+        if (this._state !== value) {
+            this._state = value;
+            this.onDidChangeEmitter.fire();
+        }
     }
 
     get type(): 'add' | 'modify' | 'delete' | undefined {
@@ -117,13 +173,16 @@ export class ChangeSetFileElement implements ChangeSetElement {
     }
 
     async apply(contents?: string): Promise<void> {
-        if (await this.changeSetFileService.trySave(this.changedUri)) { /** Continue */ } else if (this.type === 'delete') {
-            await this.changeSetFileService.delete(this.uri);
-            this.state = 'applied';
-        } else {
-            await this.writeChanges(contents);
+        if (!await this.confirm('Apply')) { return; }
+        if (!(await this.changeSetFileService.trySave(this.changedUri))) {
+            if (this.type === 'delete') {
+                await this.changeSetFileService.delete(this.uri);
+                this.state = 'applied';
+            } else {
+                await this.writeChanges(contents);
+            }
         }
-        this.changeSetFileService.closeDiffsFor(this.readOnlyUri);
+        this.changeSetFileService.closeDiff(this.readOnlyUri);
     }
 
     async writeChanges(contents?: string): Promise<void> {
@@ -132,6 +191,7 @@ export class ChangeSetFileElement implements ChangeSetElement {
     }
 
     async revert(): Promise<void> {
+        if (!await this.confirm('Revert')) { return; }
         this.state = 'pending';
         if (this.type === 'add') {
             await this.changeSetFileService.delete(this.uri);
@@ -140,7 +200,17 @@ export class ChangeSetFileElement implements ChangeSetElement {
         }
     }
 
+    async confirm(verb: string): Promise<boolean> {
+        if (this._state !== 'stale') { return true; }
+        await this.openChange();
+        const thing = await new ConfirmDialog({
+            title: `${verb} suggestion.`,
+            msg: `The file ${this.uri.path.toString()} has changed since this suggestion was created. Are you certain you wish to ${verb.toLowerCase()} the change?`
+        }).open(true);
+        return !!thing;
+    }
+
     dispose(): void {
-        this.changeSetFileService.closeDiffsFor(this.readOnlyUri);
+        this.toDispose.dispose();
     }
 }

--- a/packages/ai-chat/src/browser/change-set-file-resource.ts
+++ b/packages/ai-chat/src/browser/change-set-file-resource.ts
@@ -14,79 +14,147 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Resource, ResourceResolver, ResourceSaveOptions, URI } from '@theia/core';
-import { inject, injectable } from '@theia/core/shared/inversify';
-import { ChatService } from '../common';
-import { ChangeSetFileElement } from './change-set-file-element';
-import { ChangeSetFileService } from './change-set-file-service';
+import { MutableResource, Reference, ReferenceMutableResource, Resource, ResourceResolver, URI } from '@theia/core';
+import { injectable } from '@theia/core/shared/inversify';
 
 export const CHANGE_SET_FILE_RESOURCE_SCHEME = 'changeset-file';
-const QUERY = 'uri=';
+export type ResourceInitializationOptions = Pick<Resource, 'autosaveable' | 'initiallyDirty' | 'readOnly'> & { contents?: string, onSave?: Resource['saveContents'] };
+export type ResourceUpdateOptions = Pick<ResourceInitializationOptions, 'contents' | 'onSave'>;
 
 export function createChangeSetFileUri(chatSessionId: string, elementUri: URI): URI {
-    return new URI(CHANGE_SET_FILE_RESOURCE_SCHEME + '://' + chatSessionId + '/' + elementUri.path).withQuery(QUERY + encodeURIComponent(elementUri.path.toString()));
+    return elementUri.withScheme(CHANGE_SET_FILE_RESOURCE_SCHEME).withAuthority(chatSessionId);
 }
 
-/**
- * A file resource within a chat's change set can be resolved with the following URI:
- * changeset-file:/<chat-session-id>?uri=<element-uri-without-scheme>
- */
-@injectable()
-export class ChangeSetFileResourceResolver implements ResourceResolver {
-
-    @inject(ChatService)
-    protected readonly chatService: ChatService;
-
-    @inject(ChangeSetFileService)
-    protected readonly changeSetFileService: ChangeSetFileService;
-
-    async resolve(uri: URI): Promise<Resource> {
-        if (uri.scheme !== CHANGE_SET_FILE_RESOURCE_SCHEME) {
-            throw new Error('The given uri is not a change set file uri: ' + uri);
-        }
-
-        const chatSessionId = uri.authority;
-        const session = this.chatService.getSession(chatSessionId);
-        if (!session) {
-            throw new Error('Chat session not found: ' + chatSessionId);
-        }
-
-        const changeSet = session.model.changeSet;
-        if (!changeSet) {
-            throw new Error('Chat session has no change set: ' + chatSessionId);
-        }
-
-        const fileUri = decodeURIComponent(uri.query.toString().replace(QUERY, ''));
-        let current: ChangeSetFileElement | undefined = undefined;
-        const refreshElement = () => {
-            const element = changeSet.getElements().find(e => e.uri.path.toString() === fileUri);
-            if (element instanceof ChangeSetFileElement) {
-                current = element;
-            } else if (!current) {
-                throw new Error('Change set element not found: ' + fileUri);
-            }
-            return current;
-        };
-        refreshElement();
-
-        const changeListener = changeSet.onDidChange(() => {
-            try {
-                const activeElement = refreshElement();
-                this.changeSetFileService.updateEditorsWithNewSuggestion(activeElement.changedUri, activeElement.targetState);
-            } catch { /** No op - we should be closing any editors anyway. */ }
-        });
-
-        return {
-            uri,
-            readOnly: false,
-            initiallyDirty: true,
-            autosaveable: false,
-            readContents: async () => refreshElement().targetState ?? '',
-            saveContents: async (content: string, options?: ResourceSaveOptions): Promise<void> => refreshElement().writeChanges(),
-            dispose: () => {
-                changeListener.dispose();
-            }
-        };
+export class UpdatableReferenceResource extends ReferenceMutableResource {
+    static acquire(resource: UpdatableReferenceResource): UpdatableReferenceResource {
+        DisposableRefCounter.acquire(resource.reference);
+        return resource;
     }
 
+    constructor(protected override reference: DisposableRefCounter<DisposableMutableResource>) {
+        super(reference);
+    }
+
+    update(options: ResourceUpdateOptions): void {
+        this.reference.object.update(options);
+    }
+
+    get readOnly(): Resource['readOnly'] {
+        return this.reference.object.readOnly;
+    }
+
+    get initiallyDirty(): boolean {
+        return this.reference.object.initiallyDirty;
+    }
+
+    get autosaveable(): boolean {
+        return this.reference.object.autosaveable;
+    }
+}
+
+export class DisposableMutableResource extends MutableResource {
+    onSave: Resource['saveContents'] | undefined;
+    constructor(uri: URI, protected readonly options?: ResourceInitializationOptions) {
+        super(uri);
+        this.onSave = options?.onSave;
+        this.contents = options?.contents ?? '';
+    }
+
+    get readOnly(): Resource['readOnly'] {
+        return this.options?.readOnly || !this.onSave;
+    }
+
+    get autosaveable(): boolean {
+        return this.options?.autosaveable !== false;
+    }
+
+    get initiallyDirty(): boolean {
+        return !!this.options?.initiallyDirty;
+    }
+
+    override async saveContents(contents: string): Promise<void> {
+        if (this.options?.onSave) {
+            await this.options.onSave(contents);
+            this.update({ contents });
+        }
+    }
+
+    update(options: ResourceUpdateOptions): void {
+        if (options.contents !== undefined && options.contents !== this.contents) {
+            this.contents = options.contents;
+            this.fireDidChangeContents();
+        }
+        if ('onSave' in options && options.onSave !== this.onSave) {
+            this.onSave = options.onSave;
+        }
+    }
+
+    override dispose(): void {
+        this.onDidChangeContentsEmitter.dispose();
+    }
+}
+
+export class DisposableRefCounter<V = unknown> implements Reference<V> {
+    static acquire<V>(item: DisposableRefCounter<V>): DisposableRefCounter<V> {
+        item.refs++;
+        return item;
+    }
+    static create<V>(value: V, onDispose: () => void): DisposableRefCounter<V> {
+        return this.acquire(new this(value, onDispose));
+    }
+    readonly object: V;
+    protected refs = 0;
+    protected constructor(value: V, protected readonly onDispose: () => void) {
+        this.object = value;
+    }
+    dispose(): void {
+        this.refs--;
+        if (this.refs === 0) {
+            this.onDispose();
+        }
+    }
+}
+
+@injectable()
+export class ChangeSetFileResourceResolver implements ResourceResolver {
+    protected readonly cache = new Map<string, UpdatableReferenceResource>();
+
+    add(uri: URI, options?: ResourceInitializationOptions): UpdatableReferenceResource {
+        const key = uri.toString();
+        if (this.cache.has(key)) {
+            throw new Error(`Resource ${key} already exists.`);
+        }
+        const underlyingResource = new DisposableMutableResource(uri, options);
+        const ref = DisposableRefCounter.create(underlyingResource, () => {
+            underlyingResource.dispose();
+            this.cache.delete(key);
+        });
+        const refResource = new UpdatableReferenceResource(ref);
+        this.cache.set(key, refResource);
+        return refResource;
+    }
+
+    tryGet(uri: URI): UpdatableReferenceResource | undefined {
+        try {
+            return this.resolve(uri);
+        } catch {
+            return undefined;
+        }
+    }
+
+    update(uri: URI, contents: string): void {
+        const key = uri.toString();
+        const resource = this.cache.get(key);
+        if (!resource) {
+            throw new Error(`No resource for ${key}.`);
+        }
+        resource.update({ contents });
+    }
+
+    resolve(uri: URI): UpdatableReferenceResource {
+        const key = uri.toString();
+        const ref = this.cache.get(key);
+        if (!ref) { throw new Error(`No resource for ${key}.`); }
+        return UpdatableReferenceResource.acquire(ref);
+    }
 }

--- a/packages/ai-chat/src/browser/change-set-file-service.ts
+++ b/packages/ai-chat/src/browser/change-set-file-service.ts
@@ -143,14 +143,16 @@ export class ChangeSetFileService {
         }
     }
 
-    updateEditorsWithNewSuggestion(uri: URI, content: string): void {
-        const existingModel = this.monacoWorkspace.getTextDocument(uri.toString());
-        existingModel?.textEditorModel.setValue(content);
+    closeDiffsForSession(sessionId: string, except?: URI[]): void {
+        const openEditors = this.shell.widgets.filter(widget => {
+            const uri = NavigatableWidget.getUri(widget);
+            return uri && uri.authority === sessionId && !except?.some(candidate => candidate.path.toString() === uri.path.toString());
+        });
+        openEditors.forEach(editor => editor.close());
     }
 
-    closeDiffsFor(originalUri: URI): void {
-        // Diff editors return the URI of the left side as their URI.
-        const openEditors = this.shell.widgets.filter(widget => NavigatableWidget.getUri(widget)?.isEqual(originalUri));
+    closeDiff(uri: URI): void {
+        const openEditors = this.shell.widgets.filter(widget => NavigatableWidget.getUri(widget)?.isEqual(uri));
         openEditors.forEach(editor => editor.close());
     }
 }

--- a/packages/ai-chat/src/browser/change-set-file-service.ts
+++ b/packages/ai-chat/src/browser/change-set-file-service.ts
@@ -14,8 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ILogger, UNTITLED_SCHEME, URI } from '@theia/core';
-import { DiffUris, LabelProvider, OpenerService, open } from '@theia/core/lib/browser';
+import { ILogger, URI } from '@theia/core';
+import { ApplicationShell, DiffUris, LabelProvider, NavigatableWidget, OpenerService, open } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
@@ -39,6 +39,9 @@ export class ChangeSetFileService {
 
     @inject(EditorManager)
     protected readonly editorManager: EditorManager;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
 
     @inject(MonacoWorkspace)
     protected readonly monacoWorkspace: MonacoWorkspace;
@@ -95,15 +98,14 @@ export class ChangeSetFileService {
     }
 
     async openDiff(originalUri: URI, suggestedUri: URI): Promise<void> {
-        const exists = await this.fileService.exists(originalUri);
-        const openedUri = exists ? originalUri : originalUri.withScheme(UNTITLED_SCHEME);
-        // Currently we don't have a great way to show the suggestions in a diff editor with accept/reject buttons
-        // So we just use plain diffs with the suggestions as original and the current state as modified, so users can apply changes in their current state
-        // But this leads to wrong colors and wrong label (revert change instead of accept change)
-        const diffUri = DiffUris.encode(openedUri, suggestedUri,
+        const diffUri = this.getDiffUri(originalUri, suggestedUri);
+        open(this.openerService, diffUri);
+    }
+
+    protected getDiffUri(originalUri: URI, suggestedUri: URI): URI {
+        return DiffUris.encode(originalUri, suggestedUri,
             `AI Changes: ${this.labelProvider.getName(originalUri)}`,
         );
-        open(this.openerService, diffUri);
     }
 
     async delete(uri: URI): Promise<void> {
@@ -113,24 +115,42 @@ export class ChangeSetFileService {
         }
     }
 
-    async write(uri: URI, targetState: string): Promise<void> {
-        const exists = await this.fileService.exists(uri);
-        if (!exists) {
-            await this.fileService.create(uri, targetState);
+    /** Returns true if there was a document available to save for the specified URI. */
+    async trySave(suggestedUri: URI): Promise<boolean> {
+        const openModel = this.monacoWorkspace.getTextDocument(suggestedUri.toString());
+        if (openModel) {
+            await openModel.save();
+            return true;
+        } else {
+            return false;
         }
-        await this.doWrite(uri, targetState);
     }
 
-    protected async doWrite(uri: URI, text: string): Promise<void> {
+    async writeFrom(from: URI, to: URI, fallbackContent: string): Promise<void> {
+        const authoritativeContent = this.monacoWorkspace.getTextDocument(from.toString())?.getText() ?? fallbackContent;
+        await this.write(to, authoritativeContent);
+    }
+
+    async write(uri: URI, text: string): Promise<void> {
         const document = this.monacoWorkspace.getTextDocument(uri.toString());
         if (document) {
             await this.monacoWorkspace.applyBackgroundEdit(document, [{
                 range: document.textEditorModel.getFullModelRange(),
                 text
-            }], (editor, wasDirty) => editor === undefined || !wasDirty);
+            }], () => true);
         } else {
             await this.fileService.write(uri, text);
         }
     }
 
+    updateEditorsWithNewSuggestion(uri: URI, content: string): void {
+        const existingModel = this.monacoWorkspace.getTextDocument(uri.toString());
+        existingModel?.textEditorModel.setValue(content);
+    }
+
+    closeDiffsFor(originalUri: URI): void {
+        // Diff editors return the URI of the left side as their URI.
+        const openEditors = this.shell.widgets.filter(widget => NavigatableWidget.getUri(widget)?.isEqual(originalUri));
+        openEditors.forEach(editor => editor.close());
+    }
 }

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -95,6 +95,7 @@ export interface ChatModel {
 export interface ChangeSet {
     readonly title: string;
     getElements(): ChangeSetElement[];
+    onDidChange: Event<void>;
 }
 
 export interface ChangeSetElement {
@@ -104,14 +105,15 @@ export interface ChangeSetElement {
     readonly icon?: string;
     readonly additionalInfo?: string;
 
-    readonly state?: 'pending' | 'applied' | 'discarded';
+    readonly state?: 'pending' | 'applied';
     readonly type?: 'add' | 'modify' | 'delete';
     readonly data?: { [key: string]: unknown };
 
     open?(): Promise<void>;
     openChange?(): Promise<void>;
-    accept?(): Promise<void>;
-    discard?(): Promise<void>;
+    apply?(): Promise<void>;
+    revert?(): Promise<void>;
+    dispose?(): void;
 }
 
 export interface ChatRequest {
@@ -584,7 +586,8 @@ export class ChangeSetImpl implements ChangeSet {
     }
 
     removeElement(index: number): void {
-        this._elements.splice(index, 1);
+        const deletion = this._elements.splice(index, 1);
+        deletion.forEach(deleted => deleted.dispose?.());
         this.notifyChange();
     }
 

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -35,7 +35,6 @@ export type ChatChangeEvent =
     | ChatAddResponseEvent
     | ChatRemoveRequestEvent
     | ChatSetChangeSetEvent
-    | ChatSetChangeDeleteEvent
     | ChatUpdateChangeSetEvent
     | ChatRemoveChangeSetEvent;
 
@@ -52,10 +51,7 @@ export interface ChatAddResponseEvent {
 export interface ChatSetChangeSetEvent {
     kind: 'setChangeSet';
     changeSet: ChangeSet;
-}
-
-export interface ChatSetChangeDeleteEvent {
-    kind: 'deleteChangeSet';
+    oldChangeSet?: ChangeSet;
 }
 
 export interface ChatUpdateChangeSetEvent {
@@ -70,7 +66,7 @@ export interface ChatRemoveChangeSetEvent {
 
 export namespace ChatChangeEvent {
     export function isChangeSetEvent(event: ChatChangeEvent): event is ChatSetChangeSetEvent | ChatUpdateChangeSetEvent | ChatRemoveChangeSetEvent {
-        return event.kind === 'setChangeSet' || event.kind === 'deleteChangeSet' || event.kind === 'removeChangeSet' || event.kind === 'updateChangeSet';
+        return event.kind === 'setChangeSet' || event.kind === 'removeChangeSet' || event.kind === 'updateChangeSet';
     }
 }
 
@@ -93,19 +89,21 @@ export interface ChatModel {
 }
 
 export interface ChangeSet {
+    onDidChange: Event<ChangeSetChangeEvent>;
     readonly title: string;
     getElements(): ChangeSetElement[];
-    onDidChange: Event<void>;
+    dispose(): void;
 }
 
 export interface ChangeSetElement {
     readonly uri: URI;
 
+    onDidChange?: Event<void>
     readonly name?: string;
     readonly icon?: string;
     readonly additionalInfo?: string;
 
-    readonly state?: 'pending' | 'applied';
+    readonly state?: 'pending' | 'applied' | 'stale';
     readonly type?: 'add' | 'modify' | 'delete';
     readonly data?: { [key: string]: unknown };
 
@@ -468,13 +466,12 @@ export interface ChatResponseModel {
  * Implementations
  **********************/
 
-export class MutableChatModel implements ChatModel {
+export class MutableChatModel implements ChatModel, Disposable {
     protected readonly _onDidChangeEmitter = new Emitter<ChatChangeEvent>();
     onDidChange: Event<ChatChangeEvent> = this._onDidChangeEmitter.event;
 
     protected _requests: MutableChatRequestModel[];
     protected _id: string;
-    protected _changeSetListener?: Disposable;
     protected _changeSet?: ChangeSetImpl;
 
     constructor(public readonly location = ChatAgentLocation.Panel) {
@@ -500,22 +497,21 @@ export class MutableChatModel implements ChatModel {
     }
 
     setChangeSet(changeSet: ChangeSetImpl | undefined): void {
-        this._changeSet = changeSet;
-        if (this._changeSet === undefined) {
-            this._changeSetListener?.dispose();
-            this._onDidChangeEmitter.fire({
-                kind: 'deleteChangeSet',
-            });
-            return;
+        if (!changeSet) {
+            return this.removeChangeSet();
         }
+        const oldChangeSet = this._changeSet;
+        oldChangeSet?.dispose();
+        this._changeSet = changeSet;
         this._onDidChangeEmitter.fire({
             kind: 'setChangeSet',
-            changeSet: this._changeSet,
+            changeSet,
+            oldChangeSet,
         });
-        this._changeSetListener = this._changeSet.onDidChange(() => {
+        changeSet.onDidChange(() => {
             this._onDidChangeEmitter.fire({
                 kind: 'updateChangeSet',
-                changeSet: this._changeSet!,
+                changeSet,
             });
         });
     }
@@ -524,6 +520,7 @@ export class MutableChatModel implements ChatModel {
         if (this._changeSet) {
             const oldChangeSet = this._changeSet;
             this._changeSet = undefined;
+            oldChangeSet.dispose();
             this._onDidChangeEmitter.fire({
                 kind: 'removeChangeSet',
                 changeSet: oldChangeSet,
@@ -544,55 +541,72 @@ export class MutableChatModel implements ChatModel {
     isEmpty(): boolean {
         return this._requests.length === 0;
     }
+
+    dispose(): void {
+        this.removeChangeSet(); // Signal disposal of last change set.
+        this._onDidChangeEmitter.dispose();
+    }
+}
+
+interface ChangeSetChangeEvent {
+    added?: URI[],
+    removed?: URI[],
+    modified?: URI[],
+    /** Fired when only the state of a given element changes, not its contents */
+    state?: URI[],
 }
 
 export class ChangeSetImpl implements ChangeSet {
-    protected readonly _onDidChangeEmitter = new Emitter<void>();
-    onDidChange: Event<void> = this._onDidChangeEmitter.event;
+    protected readonly _onDidChangeEmitter = new Emitter<ChangeSetChangeEvent>();
+    onDidChange: Event<ChangeSetChangeEvent> = this._onDidChangeEmitter.event;
 
     protected _elements: ChangeSetElement[] = [];
 
     constructor(public readonly title: string, elements: ChangeSetElement[] = []) {
-        this.addElements(elements);
+        this.addElements(...elements);
     }
 
     getElements(): ChangeSetElement[] {
         return this._elements;
     }
 
-    addElement(element: ChangeSetElement): void {
-        this.addElements([element]);
+    /** Will replace any element that is already present, using URI as identity criterion. */
+    addElements(...elements: ChangeSetElement[]): void {
+        const added: URI[] = [];
+        const modified: URI[] = [];
+        const toDispose: ChangeSetElement[] = [];
+        const current = new Map(this.getElements().map((element, index) => [element.uri.toString(), index]));
+        elements.forEach(element => {
+            const existingIndex = current.get(element.uri.toString());
+            if (existingIndex !== undefined) {
+                modified.push(element.uri);
+                toDispose.push(this._elements[existingIndex]);
+                this._elements[existingIndex] = element;
+            } else {
+                added.push(element.uri);
+                this._elements.push(element);
+            }
+            element.onDidChange?.(() => this.notifyChange({ state: [element.uri] }));
+        });
+        toDispose.forEach(element => element.dispose?.());
+        this.notifyChange({ added, modified });
     }
 
-    addElements(elements: ChangeSetElement[]): void {
-        this._elements.push(...elements);
-        this.notifyChange();
+    removeElements(...indices: number[]): void {
+        // From highest to lowest so that we don't affect lower indices with our splicing.
+        const sorted = indices.slice().sort((left, right) => left - right);
+        const deletions = sorted.flatMap(index => this._elements.splice(index, 1));
+        deletions.forEach(deleted => deleted.dispose?.());
+        this.notifyChange({ removed: deletions.map(element => element.uri) });
     }
 
-    replaceElement(element: ChangeSetElement): boolean {
-        const index = this._elements.findIndex(e => e.uri.toString() === element.uri.toString());
-        if (index < 0) {
-            return false;
-        }
-        this._elements[index] = element;
-        this.notifyChange();
-        return true;
+    protected notifyChange(change: ChangeSetChangeEvent): void {
+        this._onDidChangeEmitter.fire(change);
     }
 
-    addOrReplaceElement(element: ChangeSetElement): void {
-        if (!this.replaceElement(element)) {
-            this.addElement(element);
-        }
-    }
-
-    removeElement(index: number): void {
-        const deletion = this._elements.splice(index, 1);
-        deletion.forEach(deleted => deleted.dispose?.());
-        this.notifyChange();
-    }
-
-    notifyChange(): void {
-        this._onDidChangeEmitter.fire();
+    dispose(): void {
+        this._elements.forEach(element => element.dispose?.());
+        this._onDidChangeEmitter.dispose();
     }
 }
 

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -162,11 +162,15 @@ export class ChatServiceImpl implements ChatService {
     }
 
     deleteSession(sessionId: string): void {
+        const sessionIndex = this._sessions.findIndex(candidate => candidate.id === sessionId);
+        if (~sessionIndex) { return; }
+        const session = this._sessions[sessionIndex];
         // If the removed session is the active one, set the newest one as active
-        if (this.getSession(sessionId)?.isActive) {
+        if (session.isActive) {
             this.setActiveSession(this._sessions[this._sessions.length - 1]?.id);
         }
-        this._sessions = this._sessions.filter(item => item.id !== sessionId);
+        session.model.dispose();
+        this._sessions.splice(sessionIndex, 1);
     }
 
     setActiveSession(sessionId: string | undefined, options?: SessionOptions): void {
@@ -291,6 +295,6 @@ export class ChatServiceImpl implements ChatService {
     }
 
     deleteChangeSetElement(sessionId: string, index: number): void {
-        this.getSession(sessionId)?.model.changeSet?.removeElement(index);
+        this.getSession(sessionId)?.model.changeSet?.removeElements(index);
     }
 }

--- a/packages/ai-ide-agents/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide-agents/src/browser/file-changeset-functions.ts
@@ -73,7 +73,7 @@ export class WriteChangeToFileProvider implements ToolProvider {
                 if (!await this.fileService.exists(uri)) {
                     type = 'add';
                 }
-                changeSet.addOrReplaceElement(
+                changeSet.addElements(
                     this.fileChangeFactory({
                         uri: uri,
                         type: type as 'modify' | 'add' | 'delete',
@@ -163,7 +163,7 @@ export class ReplaceContentInFileProvider implements ToolProvider {
                             ctx.session.setChangeSet(changeSet);
                         }
 
-                        changeSet.addOrReplaceElement(
+                        changeSet.addElements(
                             this.fileChangeFactory({
                                 uri: fileUri,
                                 type: 'modify',

--- a/packages/core/src/browser/saveable-service.ts
+++ b/packages/core/src/browser/saveable-service.ts
@@ -162,7 +162,7 @@ export class SaveableService implements FrontendApplicationContribution {
             // Never auto-save untitled documents
             return false;
         } else {
-            return saveable.dirty;
+            return saveable.autosaveable !== false && saveable.dirty;
         }
     }
 

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -28,6 +28,8 @@ export type AutoSaveMode = 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowCha
 
 export interface Saveable {
     readonly dirty: boolean;
+    /** If false, the saveable will not participate in autosaving. */
+    readonly autosaveable?: boolean;
     /**
      * This event is fired when the content of the `dirty` variable changes.
      */

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -225,7 +225,7 @@ export class DefaultResourceProvider {
 }
 
 export class MutableResource implements Resource {
-    private contents: string = '';
+    protected contents: string = '';
 
     constructor(readonly uri: URI) {
     }
@@ -290,7 +290,7 @@ export class InMemoryResources implements ResourceResolver {
         const resourceUri = uri.toString();
         const resource = this.resources.get(resourceUri);
         if (!resource) {
-            throw new Error(`Cannot update non-existed in-memory resource '${resourceUri}'`);
+            throw new Error(`Cannot update non-existent in-memory resource '${resourceUri}'`);
         }
         resource.saveContents(contents);
         return resource;

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -62,6 +62,8 @@ export interface Resource extends Disposable {
     readonly readOnly?: boolean | MarkdownString;
 
     readonly initiallyDirty?: boolean;
+    /** If false, the application should not attempt to auto-save this resource. */
+    readonly autosaveable?: boolean;
     /**
      * Reads latest content of this resource.
      *
@@ -390,7 +392,8 @@ export class UntitledResourceResolver implements ResourceResolver {
 export class UntitledResource implements Resource {
 
     protected readonly onDidChangeContentsEmitter = new Emitter<void>();
-    initiallyDirty: boolean;
+    readonly initiallyDirty: boolean;
+    readonly autosaveable = false;
     get onDidChangeContents(): Event<void> {
         return this.onDidChangeContentsEmitter.event;
     }

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -259,6 +259,10 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
         return this.resource.uri.toString();
     }
 
+    get autosaveable(): boolean | undefined {
+        return this.resource.autosaveable;
+    }
+
     protected _languageId: string | undefined;
     get languageId(): string {
         return this._languageId !== undefined ? this._languageId : this.model.getLanguageId();


### PR DESCRIPTION
 - Updates editors when new suggestions proposed
 - Separates accept and saving actions to avoid unnecessary prompts
 - Avoids use of untitled editors to avoid prompts for them

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes parts of #14768. In particular:
 - Eliminates autosaving for AI chat generated editors. Here, I chose to pipe a new `autosavable` field from the `Resource` interface to the `Saveable` interface and then not perform autosaves if the `Saveable` says it doesn't want to be autosaved. @msujew, you've recently worked on the autosaving infrastructure, so I'd be grateful to get your thoughts. Another alternative I considered was to pipe the `SaveReason` through to the `Resource`'s save options so that some resources could just reject automatic saves, but that feels less clean than having the `Saveable` declare itself exempt from that system.
 - Switches to using query-based in-memory resources for the left side of chat diffs. That makes them read-only, which I think makes sense: the user's focus is (or should be) on the right side, where the AI has suggested things. This avoids some synching issues, but arguably introduces others. `@Reviewers`, please see what you think of the way the diff behaves when you save the right side. It will still show the diff relative to original state, without showing that the underlying left-side file has actually been updated. I can fix that by using mutable in-memory resources, but then the lifecycle gets a little trickier.
 - Separates the save cycle of the resource from the `apply` cycle of the ChangeSetFileElement. This allows us to avoid hanging dirty state or prompts to save when the user believes they _have_ saved / applied the changes.
 - Changes the names of methods on `ChangeSetElements` from `accept` and `discard` to `apply` and `revert` and removes the `'discarded'` state option. The practical reason for doing so was that we were inconsistent in our handling of 'reverted' changes: we let them be reapplied on the element level, but we didn't reactivate the global `Activate` button on the ChangeSet level. Now if the user reverts a change, it returns to `'pending'` state: I don't think we should stand in the way of the user having third thoughts. Semantically, `discard` also sounded more like `delete` than it behaved. I'm open to discussion about this point.
 - Speaking of `delete`, I added optional `dispose` to the `ChangeSetElement` interface to be called when the element is deleted. This lets me do cleanup like closing diff editors when a change element is deleted. I have some misgivings about the lifecycle still: we currently replace elements in the change set, but we don't want everything associated with a given proposal (e.g. diff editors)  to die when it gets replaced.
 - And finally (I think), I adapted my code from https://github.com/eclipse-theia/theia/pull/14901 to update an editor when a new suggestion is made for the same file in the same session.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Fairly thorough testing of all the interactions you've gotten used to re: LLM suggestions.
2. Turn on autosave and observe that your AI editors aren't affected.
3. Open a diff editor and close it in a dirty state -> you should be prompted to save. I thought about getting rid of this if the user hasn't actually interacted with the editor, since then the state is saved as part of the LLM interaction. Let me know your thoughts.
4. Open a diff editor and save it. The corresponding node should be marked as accepted in the UI.
5. Open a diff and accept it in the chat UI. The diff should close without a prompt re: saving.
6. Have the LLM generate a new file. No matter what you do, you should never be prompted for the path at which to save something.
7. Open a diff editor and then delete the corresponding node. The editor should close. It should prompt you whether you want to save. Same question as re: (3).
8. Open a diff editor, then ask the agent to do something else in the same file (see instructions for https://github.com/eclipse-theia/theia/pull/14901, e.g.). The editor should be updated with the new content.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review.
- [ ]  If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated before merge.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
