### PR TITLE
Deprioritize file resource resolver to avoid resolution delays

### DIFF
--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -334,6 +334,8 @@ export class FileResource implements Resource {
 
 @injectable()
 export class FileResourceResolver implements ResourceResolver {
+    /** This resolver interacts with the VSCode plugin system in a way that can cause delays. Most other resource resolvers fail immediately, so this one should be tried late. */
+    readonly priority = -10;
 
     @inject(FileService)
     protected readonly fileService: FileService;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #14916 by deprioritizing the `FileResourceResolver`. See discussion on the issue - this seems like the least intrusive solution.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Reload the window (if you previously had an AI chat diff open, the application will attempt to resolve its URI at startup to restore the layout; it will fail and the editor won't be restored, but the attempt will mean you wouldn't have seen the slow diff load)
2. Open a diff from an AI chat.
3. Observe that the diff comes up quickly without a ca. 3 delay.
4. Open regular files / editors of other kinds.
5. Observe that they open without undue delay, as well.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

Although it's used in a few places, the system of trying various options to find the one that doesn't throw an error is a bit fragile, especially in an asynch context.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
