### PR TITLE
Add JSON schema to extensions package.json

### DIFF
--- a/packages/outline-view/package.json
+++ b/packages/outline-view/package.json
@@ -43,5 +43,6 @@
   },
   "nyc": {
     "extends": "../../configs/nyc.json"
-  }
+  },
+  "$schema": "../../schemas/theia-extension.schema.json"
 }

--- a/schemas/theia-extension.schema.json
+++ b/schemas/theia-extension.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Theia package.json Schema",
+  "type": "object",
+  "$ref": "https://json.schemastore.org/package.json",
+  "required": [
+    "keywords",
+    "theiaExtensions"
+  ],
+  "properties": {
+    "keywords": {
+      "description": "This helps people discover your package as it's listed in 'npm search'. Must include 'theia-extension'.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "contains": {
+        "const": "theia-extension"
+      },
+      "minItems": 1
+    },
+    "theiaExtensions": {
+      "type": "array",
+      "description": "Array of Theia extension configurations",
+      "items": {
+        "type": "object",
+        "description": "A Theia extension module configuration",
+        "properties": {
+          "frontend": {
+            "type": "string",
+            "description": "Path to the frontend module (used in browser and electron if frontendElectron is not provided)"
+          },
+          "frontendOnly": {
+            "type": "string",
+            "description": "Path to the frontend-only module"
+          },
+          "frontendElectron": {
+            "type": "string",
+            "description": "Path to the electron-specific frontend module"
+          },
+          "frontendPreload": {
+            "type": "string",
+            "description": "Path to the frontend preload module"
+          },
+          "frontendOnlyPreload": {
+            "type": "string",
+            "description": "Path to the frontend-only preload module"
+          },
+          "backend": {
+            "type": "string",
+            "description": "Path to the backend module (used in node and electron if backendElectron is not provided)"
+          },
+          "backendElectron": {
+            "type": "string",
+            "description": "Path to the electron-specific backend module"
+          },
+          "electronMain": {
+            "type": "string",
+            "description": "Path to the electron main process module"
+          },
+          "preload": {
+            "type": "string",
+            "description": "Path to the preload module"
+          },
+          "secondaryWindow": {
+            "type": "string",
+            "description": "Path to the secondary window module"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What it does

This PR introduces a custom JSON schema for Theia extension's `package.json` files. The schema extends the standard `package.json` schema while adding proper validation and IntelliSense support for Theia-specific properties such as  `theiaExtensions`

This enhancement improves the developer experience by providing:
- Auto-completion for Theia-specific properties
- Proper property descriptions and type validation
- Clear validation errors when required properties are missing
- Better discoverability of available configuration options

#### How to test

1. Open an existing Theia extension from the packages dir.
2. Add the schema reference to the extension's `package.json`:
   ```json
   {
     "$schema": "https://raw.githubusercontent.com/eclipse-theia/theia/master/schemas/theia-extension.schema.json",
     ...
   }
   ```
3. Open the `package.json` file in VS Code or Theia
4. Verify that you get:
   - IntelliSense suggestions for Theia-specific properties
   - Property descriptions when hovering over Theia-specific fields
5. Try removing required properties and verify validation errors appear
6. Test auto-completion for the `theiaExtensions` configuration

#### Follow-ups

- Add other properties to the schema
- Improve descriptions of properties
- Consider creating documentation about all available schema properties
- Adding this to the Teoman generator for generated extensions

#### Breaking changes

- [ ] No breaking changes introduced

#### Attribution

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)