### PR TITLE
Fix recent workspace tracking for devcontainer workspaces

### DIFF
--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -82,7 +82,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
             throw new Error(`Devcontainer file at ${filePath} not found in workspace`);
         }
 
-        return this.doOpenInContainer(devcontainerFile, uri.toString());
+        return this.doOpenInContainer(devcontainerFile, uri.path.toString());
     }
 
     async getWorkspaceLabel(uri: URI): Promise<string | undefined> {
@@ -103,7 +103,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         this.doOpenInContainer(devcontainerFile);
     }
 
-    async doOpenInContainer(devcontainerFile: DevContainerFile, workspaceUri?: string): Promise<void> {
+    async doOpenInContainer(devcontainerFile: DevContainerFile, workspacePath?: string): Promise<void> {
         const lastContainerInfoKey = `${LAST_USED_CONTAINER}:${devcontainerFile.path}`;
         const lastContainerInfo = await this.workspaceStorageService.getData<LastContainerInfo | undefined>(lastContainerInfoKey);
 
@@ -113,7 +113,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
             nodeDownloadTemplate: this.remotePreferences['remote.nodeDownloadTemplate'],
             lastContainerInfo,
             devcontainerFile: devcontainerFile.path,
-            workspaceUri
+            workspacePath: workspacePath
         });
 
         this.workspaceStorageService.setData<LastContainerInfo>(lastContainerInfoKey, {
@@ -122,7 +122,7 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         });
 
         this.workspaceServer.setMostRecentlyUsedWorkspace(
-            `${DEV_CONTAINER_WORKSPACE_SCHEME}:${this.workspaceService.workspace?.resource.path}?${DEV_CONTAINER_PATH_QUERY}=${devcontainerFile.path}`);
+            `${DEV_CONTAINER_WORKSPACE_SCHEME}:${workspacePath ?? this.workspaceService.workspace?.resource.path}?${DEV_CONTAINER_PATH_QUERY}=${devcontainerFile.path}`);
 
         this.openRemote(connectionResult.port, false, connectionResult.workspacePath);
     }

--- a/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
@@ -26,7 +26,7 @@ export interface ContainerConnectionOptions {
     nodeDownloadTemplate?: string;
     lastContainerInfo?: LastContainerInfo
     devcontainerFile: string;
-    workspaceUri?: string;
+    workspacePath?: string;
 }
 
 export interface LastContainerInfo {

--- a/packages/dev-container/src/electron-node/docker-container-service.ts
+++ b/packages/dev-container/src/electron-node/docker-container-service.ts
@@ -65,7 +65,7 @@ export class DockerContainerService {
     async getOrCreateContainer(docker: Docker, options: ContainerConnectionOptions, outputProvider?: ContainerOutputProvider): Promise<Docker.Container> {
         let container;
 
-        const workspace = new URI(options.workspaceUri ?? await this.workspaceServer.getMostRecentlyUsedWorkspace());
+        const workspace = new URI(options.workspacePath ?? await this.workspaceServer.getMostRecentlyUsedWorkspace());
 
         if (options.lastContainerInfo && fs.statSync(options.devcontainerFile).mtimeMs < options.lastContainerInfo.lastUsed) {
             try {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Ensure devcontainer workspaces are correctly added to recentWorkspaces. 
Previously, incorrect URI handling caused invalid workspace entries. 
Now, the workspace path is passed instead of the full URI. 
Also the setMostRecentlyUsedWorkspace is now called with the correct workspace. 
Renamed the ContainerConnectionOptions.workspaceUri to workspacePath for consistency.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open a devcontainer from a workspace
2. Notice that is has been added to the recentWorkspaces
3. Open some other workspaces
4. Open the same devcontainer again
5. Observe that it is being opened and now at the top of the recentWorkspaces again

(Same steps for reproducing the issue on current master, except there the entry is not moved to the top and another weird entry is added)

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
