### PR TITLE
Allow multiple replacements in Coder function

### DIFF
--- a/packages/ai-ide/src/browser/content-replacer.spec.ts
+++ b/packages/ai-ide/src/browser/content-replacer.spec.ts
@@ -53,7 +53,7 @@ describe('ContentReplacer', () => {
         ];
         const result = contentReplacer.applyReplacements(originalContent, replacements);
         expect(result.updatedContent).to.equal(originalContent);
-        expect(result.errors).to.include('Content to replace not found: "Nonexistent"');
+        expect(result.errors).to.include('Error: Content to replace not found: "Nonexistent"');
     });
 
     it('should return an error when oldContent has multiple occurrences', () => {
@@ -63,7 +63,7 @@ describe('ContentReplacer', () => {
         ];
         const result = contentReplacer.applyReplacements(originalContent, replacements);
         expect(result.updatedContent).to.equal(originalContent);
-        expect(result.errors).to.include('Multiple occurrences found for: "Repeat"');
+        expect(result.errors).to.include('Error: Multiple occurrences found for: "Repeat"');
     });
 
     it('should prepend newContent when oldContent is an empty string', () => {
@@ -88,5 +88,26 @@ describe('ContentReplacer', () => {
         const result = contentReplacer.applyReplacements(originalContent, replacements);
         expect(result.updatedContent).to.equal(expectedContent);
         expect(result.errors).to.be.empty;
+    });
+
+    it('should replace all occurrences when mutiple is true', () => {
+        const originalContent = 'Repeat Repeat Repeat';
+        const replacements: Replacement[] = [
+            { oldContent: 'Repeat', newContent: 'Once', multiple: true }
+        ];
+        const expectedContent = 'Once Once Once';
+        const result = contentReplacer.applyReplacements(originalContent, replacements);
+        expect(result.updatedContent).to.equal(expectedContent);
+        expect(result.errors).to.be.empty;
+    });
+
+    it('should return an error when mutiple is false and multiple occurrences are found', () => {
+        const originalContent = 'Repeat Repeat Repeat';
+        const replacements: Replacement[] = [
+            { oldContent: 'Repeat', newContent: 'Once', multiple: false }
+        ];
+        const result = contentReplacer.applyReplacements(originalContent, replacements);
+        expect(result.updatedContent).to.equal(originalContent);
+        expect(result.errors).to.include('Error: Multiple occurrences found for: "Repeat"');
     });
 });

--- a/packages/ai-ide/src/browser/content-replacer.spec.ts
+++ b/packages/ai-ide/src/browser/content-replacer.spec.ts
@@ -53,7 +53,7 @@ describe('ContentReplacer', () => {
         ];
         const result = contentReplacer.applyReplacements(originalContent, replacements);
         expect(result.updatedContent).to.equal(originalContent);
-        expect(result.errors).to.include('Error: Content to replace not found: "Nonexistent"');
+        expect(result.errors).to.include('Content to replace not found: "Nonexistent"');
     });
 
     it('should return an error when oldContent has multiple occurrences', () => {
@@ -63,7 +63,7 @@ describe('ContentReplacer', () => {
         ];
         const result = contentReplacer.applyReplacements(originalContent, replacements);
         expect(result.updatedContent).to.equal(originalContent);
-        expect(result.errors).to.include('Error: Multiple occurrences found for: "Repeat"');
+        expect(result.errors).to.include('Multiple occurrences found for: "Repeat"');
     });
 
     it('should prepend newContent when oldContent is an empty string', () => {
@@ -108,6 +108,17 @@ describe('ContentReplacer', () => {
         ];
         const result = contentReplacer.applyReplacements(originalContent, replacements);
         expect(result.updatedContent).to.equal(originalContent);
-        expect(result.errors).to.include('Error: Multiple occurrences found for: "Repeat"');
+        expect(result.errors).to.include('Multiple occurrences found for: "Repeat"');
+    });
+
+    it('should return an error when conflicting replacements for the same oldContent are provided', () => {
+        const originalContent = 'Conflict test content';
+        const replacements: Replacement[] = [
+            { oldContent: 'test', newContent: 'test1' },
+            { oldContent: 'test', newContent: 'test2' }
+        ];
+        const result = contentReplacer.applyReplacements(originalContent, replacements);
+        expect(result.updatedContent).to.equal(originalContent);
+        expect(result.errors).to.include('Conflicting replacement values for: "test"');
     });
 });

--- a/packages/ai-ide/src/browser/content-replacer.ts
+++ b/packages/ai-ide/src/browser/content-replacer.ts
@@ -17,6 +17,7 @@
 export interface Replacement {
     oldContent: string;
     newContent: string;
+    multiple?: boolean;
 }
 
 export class ContentReplacer {
@@ -24,13 +25,14 @@ export class ContentReplacer {
      * Applies a list of replacements to the original content using a multi-step matching strategy.
      * @param originalContent The original file content.
      * @param replacements Array of Replacement objects.
+     * @param allowMultiple If true, all occurrences of each oldContent will be replaced. If false, an error is returned when multiple occurrences are found.
      * @returns An object containing the updated content and any error messages.
      */
     applyReplacements(originalContent: string, replacements: Replacement[]): { updatedContent: string, errors: string[] } {
         let updatedContent = originalContent;
         const errorMessages: string[] = [];
 
-        replacements.forEach(({ oldContent, newContent }) => {
+        replacements.forEach(({ oldContent, newContent, multiple }) => {
             // If the old content is empty, prepend the new content to the beginning of the file (e.g. in new file)
             if (oldContent === '') {
                 updatedContent = newContent + updatedContent;
@@ -44,9 +46,13 @@ export class ContentReplacer {
             }
 
             if (matchIndices.length === 0) {
-                errorMessages.push(`Content to replace not found: "${oldContent}"`);
+                errorMessages.push(`Error: Content to replace not found: "${oldContent}"`);
             } else if (matchIndices.length > 1) {
-                errorMessages.push(`Multiple occurrences found for: "${oldContent}"`);
+                if (multiple) {
+                    updatedContent = this.replaceContentAll(updatedContent, oldContent, newContent);
+                } else {
+                    errorMessages.push(`Error: Multiple occurrences found for: "${oldContent}"`);
+                }
             } else {
                 updatedContent = this.replaceContentOnce(updatedContent, oldContent, newContent);
             }
@@ -123,4 +129,14 @@ export class ContentReplacer {
         return content.substring(0, index) + newContent + content.substring(index + oldContent.length);
     }
 
+    /**
+     * Replaces all occurrences of oldContent with newContent in the content.
+     * @param content The original content.
+     * @param oldContent The content to be replaced.
+     * @param newContent The content to replace with.
+     * @returns The content after all replacements.
+     */
+    private replaceContentAll(content: string, oldContent: string, newContent: string): string {
+        return content.split(oldContent).join(newContent);
+    }
 }

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { ToolProvider, ToolRequest } from '@theia/ai-core';
+import { ToolProvider, ToolRequest, ToolRequestParameters, ToolRequestParametersProperties } from '@theia/ai-core';
 import { WorkspaceFunctionScope } from './workspace-functions';
 import { ChangeSetFileElementFactory } from '@theia/ai-chat/lib/browser/change-set-file-element';
 import { ChangeSetImpl, MutableChatRequestModel } from '@theia/ai-chat';
@@ -90,9 +90,7 @@ export class WriteChangeToFileProvider implements ToolProvider {
 }
 
 @injectable()
-export class ReplaceContentInFileProvider implements ToolProvider {
-    static ID = 'changeSet_replaceContentInFile';
-
+export class ReplaceContentInFileFunctionHelper {
     @inject(WorkspaceFunctionScope)
     protected readonly workspaceFunctionScope: WorkspaceFunctionScope;
 
@@ -108,78 +106,134 @@ export class ReplaceContentInFileProvider implements ToolProvider {
         this.replacer = new ContentReplacer();
     }
 
+    getToolMetadata(supportMutipleReplace: boolean = false): { description: string, parameters: ToolRequestParameters } {
+        const replacementProperties: ToolRequestParametersProperties = {
+            oldContent: {
+                type: 'string',
+                description: 'The exact content to be replaced. Must match exactly, including whitespace, comments, etc.'
+            },
+            newContent: {
+                type: 'string',
+                description: 'The new content to insert in place of matched old content.'
+            }
+        };
+
+        if (supportMutipleReplace) {
+            replacementProperties.multiple = {
+                type: 'boolean',
+                description: 'Set to true if multiple occurrences of the oldContent are expected to be replaced.'
+            };
+        }
+        const replacementParameters = {
+            type: 'object',
+            properties: {
+                path: {
+                    type: 'string',
+                    description: 'The path of the file where content will be replaced.'
+                },
+                replacements: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: replacementProperties,
+                        required: ['oldContent', 'newContent']
+                    },
+                    description: 'An array of replacement objects, each containing oldContent and newContent strings.'
+                }
+            },
+            required: ['path', 'replacements']
+        } as ToolRequestParameters;
+
+        const replacementSentence = supportMutipleReplace
+            ? 'By default, a single occurrence of each old content in the tuples is expected to be replaced. If the optional \'multiple\' flag is set to true, all occurrences will\
+             be replaced. In either case, if the number of occurrences in the file does not match the expectation the function will return an error, try a different approach then.'
+            : 'A single occurrence of each old content in the tuples is expected to be replaced. If the number of occurrences in the file does not match the expectation,\
+              the function will return an error, try a different approach then.';
+
+        const replacementDescription = `Request to replace sections of content in an existing file by providing a list of tuples with old content to be matched and replaced.
+            ${replacementSentence}. For deletions, use an empty new content in the tuple.\
+            Make sure you use the same line endings and whitespace as in the original file content. The proposed changes will be applied when the user accepts.\
+            If called again for the same file, it will override previously proposed changes.`;
+
+        return {
+            description: replacementDescription,
+            parameters: replacementParameters
+        };
+
+    }
+
+    async createChangesetFromToolCall(toolCallString: string, ctx: MutableChatRequestModel): Promise<string> {
+        try {
+            const { path, replacements } = JSON.parse(toolCallString) as { path: string, replacements: Replacement[] };
+            const fileUri = await this.workspaceFunctionScope.resolveRelativePath(path);
+            const fileContent = (await this.fileService.read(fileUri)).value.toString();
+
+            const { updatedContent, errors } = this.replacer.applyReplacements(fileContent, replacements);
+
+            if (errors.length > 0) {
+                return `Errors encountered: ${errors.join('; ')}`;
+            }
+
+            if (updatedContent !== fileContent) {
+                let changeSet = ctx.session.changeSet;
+                if (!changeSet) {
+                    changeSet = new ChangeSetImpl('Changes proposed by Coder');
+                    ctx.session.setChangeSet(changeSet);
+                }
+
+                changeSet.addElements(
+                    this.fileChangeFactory({
+                        uri: fileUri,
+                        type: 'modify',
+                        state: 'pending',
+                        targetState: updatedContent,
+                        changeSet,
+                        chatSessionId: ctx.session.id
+                    })
+                );
+            }
+            return `Proposed replacements in file ${path}. The user will review and potentially apply the changes.`;
+        } catch (error) {
+            console.info('Error processing replacements:', error.message);
+            return JSON.stringify({ error: error.message });
+        }
+    }
+}
+
+@injectable()
+export class SimpleReplaceContentInFileProvider implements ToolProvider {
+    static ID = 'changeSet_replaceContentInFilev1';
+    @inject(ReplaceContentInFileFunctionHelper)
+    protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
+
     getTool(): ToolRequest {
+        const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata();
+        return {
+            id: SimpleReplaceContentInFileProvider.ID,
+            name: SimpleReplaceContentInFileProvider.ID,
+            description: metadata.description,
+            parameters: metadata.parameters,
+            handler: async (args: string, ctx: MutableChatRequestModel): Promise<string> =>
+                this.replaceContentInFileFunctionHelper.createChangesetFromToolCall(args, ctx)
+        };
+    }
+}
+
+@injectable()
+export class ReplaceContentInFileProvider implements ToolProvider {
+    static ID = 'changeSet_replaceContentInFile';
+    @inject(ReplaceContentInFileFunctionHelper)
+    protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
+
+    getTool(): ToolRequest {
+        const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata(true);
         return {
             id: ReplaceContentInFileProvider.ID,
             name: ReplaceContentInFileProvider.ID,
-            description: `Request to replace sections of content in an existing file by providing a list of tuples with old content to be matched and replaced.
-            Only the first matched instance of each old content in the tuples will be replaced. For deletions, use an empty new content in the tuple.\n
-            Make sure you use the same line endings and whitespace as in the original file content. The proposed changes will be applied when the user accepts.\n
-            If called again for the same file, it will override previously proposed changes.`,
-            parameters: {
-                type: 'object',
-                properties: {
-                    path: {
-                        type: 'string',
-                        description: 'The path of the file where content will be replaced.'
-                    },
-                    replacements: {
-                        type: 'array',
-                        items: {
-                            type: 'object',
-                            properties: {
-                                oldContent: {
-                                    type: 'string',
-                                    description: 'The exact content to be replaced. Must match exactly, including whitespace, comments, etc.'
-                                },
-                                newContent: {
-                                    type: 'string',
-                                    description: 'The new content to insert in place of matched old content.'
-                                }
-                            },
-                            required: ['oldContent', 'newContent']
-                        },
-                        description: 'An array of replacement objects, each containing oldContent and newContent strings.'
-                    }
-                },
-                required: ['path', 'replacements']
-            },
-            handler: async (args: string, ctx: MutableChatRequestModel): Promise<string> => {
-                try {
-                    const { path, replacements } = JSON.parse(args) as { path: string, replacements: Replacement[] };
-                    const fileUri = await this.workspaceFunctionScope.resolveRelativePath(path);
-                    const fileContent = (await this.fileService.read(fileUri)).value.toString();
-
-                    const { updatedContent, errors } = this.replacer.applyReplacements(fileContent, replacements);
-
-                    if (errors.length > 0) {
-                        return `Errors encountered: ${errors.join('; ')}`;
-                    }
-
-                    if (updatedContent !== fileContent) {
-                        let changeSet = ctx.session.changeSet;
-                        if (!changeSet) {
-                            changeSet = new ChangeSetImpl('Changes proposed by Coder');
-                            ctx.session.setChangeSet(changeSet);
-                        }
-
-                        changeSet.addElements(
-                            this.fileChangeFactory({
-                                uri: fileUri,
-                                type: 'modify',
-                                state: 'pending',
-                                targetState: updatedContent,
-                                changeSet,
-                                chatSessionId: ctx.session.id
-                            })
-                        );
-                    }
-                    return `Proposed replacements in file ${path}. The user will review and potentially apply the changes.`;
-                } catch (error) {
-                    console.info('Error processing replacements:', error.message);
-                    return JSON.stringify({ error: error.message });
-                }
-            }
+            description: metadata.description,
+            parameters: metadata.parameters,
+            handler: async (args: string, ctx: MutableChatRequestModel): Promise<string> =>
+                this.replaceContentInFileFunctionHelper.createChangesetFromToolCall(args, ctx)
         };
     }
 }

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -146,9 +146,10 @@ export class ReplaceContentInFileFunctionHelper {
 
         const replacementSentence = supportMutipleReplace
             ? 'By default, a single occurrence of each old content in the tuples is expected to be replaced. If the optional \'multiple\' flag is set to true, all occurrences will\
-             be replaced. In either case, if the number of occurrences in the file does not match the expectation the function will return an error, try a different approach then.'
+             be replaced. In either case, if the number of occurrences in the file does not match the expectation the function will return an error. \
+             In that case try a different approach.'
             : 'A single occurrence of each old content in the tuples is expected to be replaced. If the number of occurrences in the file does not match the expectation,\
-              the function will return an error, try a different approach then.';
+              the function will return an error. In that case try a different approach.';
 
         const replacementDescription = `Request to replace sections of content in an existing file by providing a list of tuples with old content to be matched and replaced.
             ${replacementSentence}. For deletions, use an empty new content in the tuple.\
@@ -194,7 +195,7 @@ export class ReplaceContentInFileFunctionHelper {
             }
             return `Proposed replacements in file ${path}. The user will review and potentially apply the changes.`;
         } catch (error) {
-            console.info('Error processing replacements:', error.message);
+            console.debug('Error processing replacements:', error.message);
             return JSON.stringify({ error: error.message });
         }
     }

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -72,7 +72,6 @@ export default new ContainerModule(bind => {
     bind(ToolProvider).to(WriteChangeToFileProvider);
     bind(ReplaceContentInFileFunctionHelper).toSelf().inSingletonScope();
     bind(ToolProvider).to(ReplaceContentInFileProvider);
-
     bind(ToolProvider).to(ListChatContext);
     bind(ToolProvider).to(ResolveChatContext);
     bind(AIConfigurationSelectionService).toSelf().inSingletonScope();

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -23,7 +23,9 @@ import { FileContentFunction, GetWorkspaceDirectoryStructure, GetWorkspaceFileLi
 import { PreferenceContribution, WidgetFactory, bindViewContribution } from '@theia/core/lib/browser';
 import { WorkspacePreferencesSchema } from './workspace-preferences';
 import {
+    ReplaceContentInFileFunctionHelper,
     ReplaceContentInFileProvider,
+    SimpleReplaceContentInFileProvider,
     WriteChangeToFileProvider
 } from './file-changeset-functions';
 import { OrchestratorChatAgent, OrchestratorChatAgentId } from '../common/orchestrator-chat-agent';
@@ -68,6 +70,7 @@ export default new ContainerModule(bind => {
     bind(WorkspaceFunctionScope).toSelf().inSingletonScope();
 
     bind(ToolProvider).to(WriteChangeToFileProvider);
+    bind(ReplaceContentInFileFunctionHelper).toSelf().inSingletonScope();
     bind(ToolProvider).to(ReplaceContentInFileProvider);
 
     bind(ToolProvider).to(ListChatContext);
@@ -99,4 +102,5 @@ export default new ContainerModule(bind => {
         }))
         .inSingletonScope();
 
+    bind(ToolProvider).to(SimpleReplaceContentInFileProvider);
 });


### PR DESCRIPTION
fixed #14933

#### What it does

Adds a new optional boolean 'multiple' to the 'changeSet_replaceContentInFile' tool function. This allows the LLM to explicitly expect and replace multiple occurrences of a specific string.
The old version without the boolean is still there via 'changeSet_replaceContentInFilev1' (at runtime in the prompt editor) in case we find LLMs that are not capable of using the boolean correctly. This makes the code a bit more complicated, but for safety, I would leave it in for while.

- also slightly adapted the description of the function to clarify the multiple case and what to do in case of an error
- also prefixed the two errors that can occur with 'Error: '

#### How to test

I tested with 3.5-sonnet, 4o and o3-mini, all were able to use the new parameter only when it made sense.
My test prompts (the first one is the only one which should trigger the new option)

@Coder Rename the function toOpenAIMessage in packages/ai-openai/src/node/openai-language-model.ts to convertToOpenAIMessage

@Coder Add o13 and o14-mini to the default list of open ai models in the preferences of the openai package

@Coder Move the readme file to a sub direcotry called /readme

@Coder Implement the interface MCPServerManager in the same file (packages/ai-mcp/src/common/mcp-server-manager.ts). Don't ask me anything, jut do it.

@Coder Remove the prefix "MCP" from all user message in packages/ai-mcp/src/browser/mcp-command-contribution.ts

@Coder Allow the user to start already started MCP servers again in packages/ai-mcp/src/browser/mcp-command-contribution.ts

@Coder please translate all of the comments in packages/ai-chat/src/browser/change-set-file-element.ts into Swahili.

#### Follow-ups

Remove the old version completely.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
