### PR TITLE
Do not create a model reference for inline editors

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -380,7 +380,7 @@ export class MonacoEditorProvider {
             }, this.m2p, this.p2m);
             toDispose.push(document);
             const model = (await document.load()).textEditorModel;
-            return await MonacoEditor.create(
+            return new MonacoEditor(
                 uri,
                 document,
                 node,

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -128,7 +128,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     protected model: monaco.editor.ITextModel | null;
     savedViewState: monaco.editor.ICodeEditorViewState | null;
 
-    protected constructor(
+    constructor(
         readonly uri: URI,
         readonly document: MonacoEditorModel,
         readonly node: HTMLElement,


### PR DESCRIPTION
#### What it does
Fixes #14924

#### How to test
Make sure all our uses of text editors (regular editors, notebook, output view, chat input) work as expected. Make sure the original problem (https://github.com/eclipse-theia/theia/issues/14880) stays fixed on Linux.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups
We should investigate the root causes both in the chat input widget layout as well as our text model management that caused this problem.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
