### PR TITLE
Improve error handling on optional dependencies

### DIFF
--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -315,12 +315,10 @@ export class ApplicationPackage {
      */
     get resolveModule(): ApplicationModuleResolver {
         if (!this._moduleResolver) {
-
             this._moduleResolver = (parentPackagePath, modulePath) => {
                 const resolved = resolvePackagePath(modulePath, parentPackagePath);
                 if (!resolved) {
-                    console.error(`cannot resolve ${modulePath} relative to ${parentPackagePath}`);
-                    throw new Error('Could not resolve module: ' + modulePath);
+                    throw new Error(`Cannot resolve package ${modulePath} relative to ${parentPackagePath}`);
                 }
                 return resolved;
             };

--- a/dev-packages/application-package/src/npm-registry.ts
+++ b/dev-packages/application-package/src/npm-registry.ts
@@ -39,6 +39,10 @@ export interface Dependencies {
     [name: string]: string | undefined;
 }
 
+export interface PeerDependenciesMeta {
+    [name: string]: { optional: boolean } | undefined;
+}
+
 export interface NodePackage {
     name?: string;
     version?: string;
@@ -49,6 +53,7 @@ export interface NodePackage {
     keywords?: string[];
     dependencies?: Dependencies;
     peerDependencies?: Dependencies;
+    peerDependenciesMeta?: PeerDependenciesMeta;
     [property: string]: any;
 }
 


### PR DESCRIPTION
#### What it does

Currently, whenever adopters build a Theia app that exclusively uses the Theia browser build, the `@theia/application-package` package prints an error about `@theia/electron` missing due to it being declared as an optional peer dependency. However, the current implementation does not take this optionality into account and prints an error even though it is not strictly required.

This change takes the `peerDependenciesMeta` property into account to print a better message for unresolved peer dependencies.

Note that this error message has confused **a lot of adopters** in the past.

#### How to test

Cannot be properly tested in this repo. In theory you will need to build a Theia browser app and then simply build the app. It should not log an error about being unable to find `@theia/electron`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
