### PR TITLE
Set o1 to stream by default

### DIFF
--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -168,6 +168,6 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
     }
 }
 
-const openAIModelsWithDisabledStreaming = ['o1'];
+const openAIModelsWithDisabledStreaming: string[] = [];
 const openAIModelsNotSupportingDeveloperMessages = ['o1-preview', 'o1-mini'];
 const openAIModelsWithoutStructuredOutput = ['o1-preview', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo', 'o1-mini', 'gpt-4o-2024-05-13'];


### PR DESCRIPTION
fixed #14946

#### What it does

Set streaming to true per default for o1 on official OpenAI.
The openAIModelsWithDisabledStreaming stays, as we might have models not supporting streaming again.

#### How to test

Talk to o1 and observe it streams.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
