### PR TITLE
Planger/fix-terminal-assistant-styling

### DIFF
--- a/packages/ai-terminal/src/browser/style/ai-terminal.css
+++ b/packages/ai-terminal/src/browser/style/ai-terminal.css
@@ -13,7 +13,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  border: 1px solid var(--theia-menu-border);
+  border: var(--theia-border-width) solid var(--theia-dropdown-border);
+  border-radius: 4px;
 }
 
 .ai-terminal-chat-container .closeButton {
@@ -38,16 +39,22 @@
   align-items: center;
 }
 
-.ai-terminal-chat-input-container textarea {
+#theia-bottom-content-panel .theia-ChatInput {
+  border: var(--theia-border-width) solid var(--theia-dropdown-border);
+}
+
+.ai-terminal-chat-input-container .theia-ChatInput {
   flex-grow: 1;
   height: 36px;
   background-color: var(--theia-input-background);
+  border: var(--theia-border-width) solid var(--theia-dropdown-border);
   border-radius: 4px;
   box-sizing: border-box;
   padding: 8px;
   resize: none;
   overflow: hidden;
   line-height: 1.3rem;
+  margin-top: 0;
   margin-right: 10px; /* Add some space between textarea and button */
 }
 


### PR DESCRIPTION
#### What it does

The terminal assistant styling was broken, especially in light theme. This PR fixes the styling.

#### How to test

Open a terminal and open the AI assistant (Ctrl-I or context menu).
Check a few themes to make sure it looks fine on the most important ones.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
