### PR TITLE
Fix monaco model reference creation

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { ChangeSet, ChangeSetElement, ChatAgent, ChatChangeEvent, ChatModel, ChatRequestModel } from '@theia/ai-chat';
-import { Disposable, nls, UntitledResourceResolver } from '@theia/core';
+import { Disposable, InMemoryResources, URI, nls } from '@theia/core';
 import { ContextMenuRenderer, LabelProvider, Message, ReactWidget } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { inject, injectable, optional, postConstruct } from '@theia/core/shared/inversify';
@@ -44,8 +44,8 @@ export class AIChatInputWidget extends ReactWidget {
     @inject(MonacoEditorProvider)
     protected readonly editorProvider: MonacoEditorProvider;
 
-    @inject(UntitledResourceResolver)
-    protected readonly untitledResourceResolver: UntitledResourceResolver;
+    @inject(InMemoryResources)
+    protected readonly resources: InMemoryResources;
 
     @inject(ContextMenuRenderer)
     protected readonly contextMenuRenderer: ContextMenuRenderer;
@@ -119,7 +119,7 @@ export class AIChatInputWidget extends ReactWidget {
                 chatModel={this._chatModel}
                 pinnedAgent={this._pinnedAgent}
                 editorProvider={this.editorProvider}
-                untitledResourceResolver={this.untitledResourceResolver}
+                resources={this.resources}
                 contextMenuCallback={this.handleContextMenu.bind(this)}
                 isEnabled={this.isEnabled}
                 setEditorRef={editor => {
@@ -158,7 +158,7 @@ interface ChatInputProperties {
     chatModel: ChatModel;
     pinnedAgent?: ChatAgent;
     editorProvider: MonacoEditorProvider;
-    untitledResourceResolver: UntitledResourceResolver;
+    resources: InMemoryResources;
     contextMenuCallback: (event: IMouseEvent) => void;
     setEditorRef: (editor: MonacoEditor | undefined) => void;
     showContext?: boolean;
@@ -183,12 +183,13 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     const editorRef = React.useRef<MonacoEditor | undefined>(undefined);
 
     React.useEffect(() => {
+        const uri = new URI(`ai-chat:/input.${CHAT_VIEW_LANGUAGE_EXTENSION}`);
+        const resource = props.resources.add(uri, '');
         const createInputElement = async () => {
             const paddingTop = 6;
             const lineHeight = 20;
             const maxHeight = 240;
-            const resource = await props.untitledResourceResolver.createUntitledResource('', CHAT_VIEW_LANGUAGE_EXTENSION);
-            const editor = await props.editorProvider.createInline(resource.uri, editorContainerRef.current!, {
+            const editor = await props.editorProvider.createInline(uri, editorContainerRef.current!, {
                 language: CHAT_VIEW_LANGUAGE_EXTENSION,
                 // Disable code lens, inlay hints and hover support to avoid console errors from other contributions
                 codeLens: false,
@@ -252,6 +253,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
         };
         createInputElement();
         return () => {
+            resource.dispose();
             props.setEditorRef(undefined);
             if (editorRef.current) {
                 editorRef.current.dispose();

--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -28,6 +28,7 @@ import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/s
 import { DebugSession } from '../debug-session';
 import { DebugSessionManager, DidChangeActiveDebugSession } from '../debug-session-manager';
 import { DebugConsoleSession, DebugConsoleSessionFactory } from './debug-console-session';
+import { InMemoryResources } from '@theia/core';
 
 export type InDebugReplContextKey = ContextKey<boolean>;
 export const InDebugReplContextKey = Symbol('inDebugReplContextKey');
@@ -56,6 +57,9 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
     @inject(DebugSessionManager)
     protected debugSessionManager: DebugSessionManager;
 
+    @inject(InMemoryResources)
+    protected readonly resources: InMemoryResources;
+
     constructor() {
         super({
             widgetId: DebugConsoleContribution.options.id,
@@ -70,6 +74,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
 
     @postConstruct()
     protected init(): void {
+        this.resources.add(DebugConsoleSession.uri, '');
         this.debugSessionManager.onDidCreateDebugSession(session => {
             const consoleParent = session.findConsoleParent();
             if (consoleParent) {

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -373,14 +373,10 @@ export class MonacoEditorProvider {
         return this.doCreateEditor(uri, async (override, toDispose) => {
             const overrides = override ? Array.from(override) : [];
             overrides.push([IContextMenuService, { showContextMenu: () => {/** no op! */ } }]);
-            const document = new MonacoEditorModel({
-                uri,
-                readContents: async () => '',
-                dispose: () => { }
-            }, this.m2p, this.p2m);
-            toDispose.push(document);
+            const document = await this.getModel(uri, toDispose);
+            document.suppressOpenEditorWhenDirty = true;
             const model = (await document.load()).textEditorModel;
-            return new MonacoEditor(
+            return await MonacoEditor.create(
                 uri,
                 document,
                 node,

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -128,7 +128,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     protected model: monaco.editor.ITextModel | null;
     savedViewState: monaco.editor.ICodeEditorViewState | null;
 
-    constructor(
+    protected constructor(
         readonly uri: URI,
         readonly document: MonacoEditorModel,
         readonly node: HTMLElement,

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -32,7 +32,7 @@ import { MonacoKeybindingContribution } from './monaco-keybinding';
 import { MonacoLanguages } from './monaco-languages';
 import { MonacoWorkspace } from './monaco-workspace';
 import { MonacoEditorService, MonacoEditorServiceFactory, VSCodeContextKeyService, VSCodeThemeService } from './monaco-editor-service';
-import { MonacoTextModelService, MonacoEditorModelFactory } from './monaco-text-model-service';
+import { MonacoTextModelService, MonacoEditorModelFactory, MonacoEditorModelFilter } from './monaco-text-model-service';
 import { MonacoContextMenuService } from './monaco-context-menu';
 import { MonacoOutlineContribution } from './monaco-outline-contribution';
 import { MonacoStatusBarContribution } from './monaco-status-bar-contribution';
@@ -118,6 +118,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MonacoEditorProvider).toSelf().inSingletonScope();
     bindContributionProvider(bind, MonacoEditorFactory);
     bindContributionProvider(bind, MonacoEditorModelFactory);
+    bindContributionProvider(bind, MonacoEditorModelFilter);
     bind(MonacoCommandService).toSelf().inTransientScope();
 
     bind(TextEditorProvider).toProvider(context =>

--- a/packages/notebook/src/browser/notebook-frontend-module.ts
+++ b/packages/notebook/src/browser/notebook-frontend-module.ts
@@ -41,7 +41,7 @@ import { NotebookKernelHistoryService } from './service/notebook-kernel-history-
 import { NotebookEditorWidgetService } from './service/notebook-editor-widget-service';
 import { NotebookRendererMessagingService } from './service/notebook-renderer-messaging-service';
 import { NotebookColorContribution } from './contributions/notebook-color-contribution';
-import { NotebookMonacoTextModelService } from './service/notebook-monaco-text-model-service';
+import { NotebookMonacoEditorModelFilter, NotebookMonacoTextModelService } from './service/notebook-monaco-text-model-service';
 import { NotebookOutlineContribution } from './contributions/notebook-outline-contribution';
 import { NotebookLabelProviderContribution } from './contributions/notebook-label-provider-contribution';
 import { NotebookOutputActionContribution } from './contributions/notebook-output-action-contribution';
@@ -52,8 +52,9 @@ import { NotebookUndoRedoHandler } from './contributions/notebook-undo-redo-hand
 import { NotebookStatusBarContribution } from './contributions/notebook-status-bar-contribution';
 import { NotebookCellEditorService } from './service/notebook-cell-editor-service';
 import { NotebookCellStatusBarService } from './service/notebook-cell-status-bar-service';
+import { MonacoEditorModelFilter } from '@theia/monaco/lib/browser/monaco-text-model-service';
 
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
+export default new ContainerModule(bind => {
     bind(NotebookColorContribution).toSelf().inSingletonScope();
     bind(ColorContribution).toService(NotebookColorContribution);
 
@@ -108,6 +109,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     );
 
     bind(NotebookMonacoTextModelService).toSelf().inSingletonScope();
+    bind(NotebookMonacoEditorModelFilter).toSelf().inSingletonScope();
+    bind(MonacoEditorModelFilter).toService(NotebookMonacoEditorModelFilter);
 
     bind(NotebookOutlineContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(NotebookOutlineContribution);

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -80,7 +80,7 @@ import * as monaco from '@theia/monaco-editor-core';
 import { VSCodeExtensionUri } from '../common/plugin-vscode-uri';
 import { CodeEditorWidgetUtil } from '@theia/plugin-ext/lib/main/browser/menus/vscode-theia-menu-mappings';
 import { OutlineViewContribution } from '@theia/outline-view/lib/browser/outline-view-contribution';
-import { Range } from '@theia/plugin';
+import { CompletionList, Range, Position as PluginPosition } from '@theia/plugin';
 import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
 
 export namespace VscodeCommands {
@@ -675,6 +675,22 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
             {
                 execute: ((resource: URI, range: Range, kind?: string, itemResolveCount?: number) =>
                     commands.executeCommand<TextEdit[]>('_executeCodeActionProvider', monaco.Uri.from(resource), range, kind, itemResolveCount))
+            }
+        );
+        commands.registerCommand(
+            {
+                id: 'vscode.executeCompletionItemProvider'
+            },
+            {
+                execute: ((resource: URI, position: PluginPosition, triggerCharacter?: string, itemResolveCount?: number) =>
+                    commands.executeCommand<CompletionList[]>(
+                        '_executeCompletionItemProvider',
+                        monaco.Uri.from(resource),
+                        { lineNumber: position.line, column: position.character },
+                        triggerCharacter,
+                        itemResolveCount
+                    )
+                )
             }
         );
         commands.registerCommand(

--- a/packages/plugin-ext/src/plugin/notebook/notebook-document.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebook-document.ts
@@ -57,7 +57,7 @@ export class Cell {
             uri: cell.uri,
             isDirty: false,
             versionId: 1,
-            modeId: ''
+            modeId: cell.language
         };
     }
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/7671
Closes https://github.com/eclipse-theia/theia/issues/14842

As outlined in https://github.com/eclipse-theia/theia/issues/14842, the culprit for a lot of these issues seem to be that we don't actually create real `MonacoEditorModel` references for our inline editors. These models weren't synced with the plugin host and so we encountered a ton of errors within the plugin host which were then simply propagated and logged in the frontend.

This fixes the issue by ensuring that we actually create a `Resource` for each `MonacoEditorModel` that we attempt to create. This ensures that the models are correctly send to the plugin host.

Additionally adjusts how we create editor models for the notebook to ensure that they are all placed in one single reference list. Previously we had 2 lists, which then led to clashes inside of monaco.

Also fixes a very minor issue related to completion and language support in notebook editors.

#### How to test

1. Open a JS file and add a conditional breakpoint.
2. Open the AI chat widget and type something.
3. Ensure that no errors about unknown models/files is being logged
4. Open a notebook (`.ipynb`) file and scroll through it.
5. Ensure that no errors about duplicate monaco models are being logged.

Please also ensure that https://github.com/eclipse-theia/theia/issues/14924 remains fixed. I couldn't reproduce it (but I also only tested on Windows)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
