### PR TITLE
Rename workspace agent to architect

### DIFF
--- a/packages/ai-ide-agents/README.md
+++ b/packages/ai-ide-agents/README.md
@@ -26,7 +26,7 @@ The package includes the following agents:
 
 - **Command Chat Agent**: This agent helps users execute commands within the Theia IDE based on user requests. It identifies the correct command from Theia's command registry and facilitates its execution, providing users with a seamless command interaction experience.
 
-- **Workspace Agent**: The agent is able to inspect the current files of the workspace, including their content, to answer questions.
+- **Architect Agent**: The agent is able to inspect the current files of the workspace, including their content, to answer questions.
 
 ## Additional Information
 

--- a/packages/ai-ide-agents/src/browser/architect-agent.ts
+++ b/packages/ai-ide-agents/src/browser/architect-agent.ts
@@ -16,15 +16,15 @@
 import { AbstractStreamParsingChatAgent } from '@theia/ai-chat/lib/common';
 import { LanguageModelRequirement } from '@theia/ai-core';
 import { injectable } from '@theia/core/shared/inversify';
-import { workspacePromptTemplate } from '../common/workspace-prompt-template';
+import { architectPromptTemplate } from '../common/architect-prompt-template';
 import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID } from '../common/workspace-functions';
 import { nls } from '@theia/core';
 
 @injectable()
-export class WorkspaceAgent extends AbstractStreamParsingChatAgent {
+export class ArchitectAgent extends AbstractStreamParsingChatAgent {
 
-    name = 'Workspace';
-    id = 'Workspace';
+    name = 'Architect';
+    id = 'Architect';
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat',
         identifier: 'openai/gpt-4o',
@@ -32,10 +32,10 @@ export class WorkspaceAgent extends AbstractStreamParsingChatAgent {
     protected defaultLanguageModelPurpose: string = 'chat';
 
     override description = nls.localize('theia/ai/workspace/workspaceAgent/description',
-        'This agent can access the users workspace, it can get a list of all available files and retrieve their content. \
-    It can therefore answer questions about the current project, project files and source code in the workspace, such as how to build the project, \
-    where to put source code, where to find specific code or configurations, etc.');
-    override promptTemplates = [workspacePromptTemplate];
+        'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \
+         and folders and retrieve their content. It cannot modify files. It can therefore answer questions about the current project, project files and source code in the \
+         workspace, such as how to build the project, where to put source code, where to find specific code or configurations, etc.');
+    override promptTemplates = [architectPromptTemplate];
     override functions = [GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID];
-    protected override systemPromptId: string | undefined = workspacePromptTemplate.id;
+    protected override systemPromptId: string | undefined = architectPromptTemplate.id;
 }

--- a/packages/ai-ide-agents/src/browser/coder-agent.ts
+++ b/packages/ai-ide-agents/src/browser/coder-agent.ts
@@ -32,7 +32,9 @@ export class CoderAgent extends AbstractStreamParsingChatAgent {
     protected defaultLanguageModelPurpose: string = 'chat';
 
     override description = nls.localize('theia/ai/workspace/coderAgent/description',
-        'An AI assistant integrated into Theia IDE, designed to assist software developers with code tasks.');
+        'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \
+        and folders and retrieve their content. Futhermore, it can suggest modifications of files to the user. It can therefore assist the user with coding tasks or other \
+        tasks involving file changes.');
     override promptTemplates = [getCoderReplacePromptTemplate(true), getCoderReplacePromptTemplate(false)];
     override functions = [GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, WriteChangeToFileProvider.ID];
     protected override systemPromptId: string | undefined = CODER_REPLACE_PROMPT_TEMPLATE_ID;

--- a/packages/ai-ide-agents/src/browser/frontend-module.ts
+++ b/packages/ai-ide-agents/src/browser/frontend-module.ts
@@ -17,7 +17,7 @@
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { ChatAgent, DefaultChatAgentId, FallbackChatAgentId } from '@theia/ai-chat/lib/common';
 import { Agent, ToolProvider } from '@theia/ai-core/lib/common';
-import { WorkspaceAgent } from './workspace-agent';
+import { ArchitectAgent } from './architect-agent';
 import { CoderAgent } from './coder-agent';
 import { FileContentFunction, GetWorkspaceDirectoryStructure, GetWorkspaceFileList, WorkspaceFunctionScope } from './workspace-functions';
 import { PreferenceContribution } from '@theia/core/lib/browser';
@@ -33,9 +33,9 @@ import { CommandChatAgent } from '../common/command-chat-agents';
 export default new ContainerModule(bind => {
     bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
 
-    bind(WorkspaceAgent).toSelf().inSingletonScope();
-    bind(Agent).toService(WorkspaceAgent);
-    bind(ChatAgent).toService(WorkspaceAgent);
+    bind(ArchitectAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(ArchitectAgent);
+    bind(ChatAgent).toService(ArchitectAgent);
 
     bind(CoderAgent).toSelf().inSingletonScope();
     bind(Agent).toService(CoderAgent);

--- a/packages/ai-ide-agents/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide-agents/src/common/architect-prompt-template.ts
@@ -16,14 +16,16 @@
 import { PromptTemplate } from '@theia/ai-core/lib/common';
 import { GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from './workspace-functions';
 
-export const workspacePromptTemplate = <PromptTemplate>{
-   id: 'workspace-system',
+export const architectPromptTemplate = <PromptTemplate>{
+   id: 'architect-system',
    template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 # Instructions
 
-You are an AI assistant integrated into Theia IDE, designed to assist software developers with concise answers to programming-related questions. Your goal is to enhance
-productivity with quick, relevant solutions, explanations, and best practices. Keep responses short, delivering valuable insights and direct solutions.
+You are an AI assistant integrated into Theia IDE, designed to assist software developers. You can not change any files, but you can navigate the users workspace read-only using \
+the provided functions. Therefore describe and explain the details or procedures necessary to achieve the desired outcome. If file changes are necessary to help the user, be \
+aware that there is another agent called 'Coder' that can suggest file changes. In this case you can create a description on what to do and tell the user to ask '@Coder' to \
+implement the change plan. If you refer to files, always mention the relative path.\
 
 Use the following functions to interact with the workspace files as needed:
 - **~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}}**: Returns the complete directory structure.
@@ -36,12 +38,5 @@ Use the following functions to interact with the workspace files as needed:
 2. **Confirm Paths**: Always verify paths by listing directories or files as you navigate. Avoid assumptions based on user input alone.
 3. **Navigate Step-by-Step**: Move into subdirectories only as needed, confirming each directory level.
 
-### Response Guidelines
-
-1. **Contextual Focus**: Provide answers relevant to the workspace, avoiding general advice. Use provided functions without assuming file structure or content.
-2. **Clear Solutions**: Offer direct answers and concise explanations. Link to official documentation as needed.
-3. **Tool & Language Adaptability**: Adjust guidance based on the programming language, framework, or tool specified by the developer.
-4. **Supportive Tone**: Maintain a friendly, professional tone with clear, accurate technical language.
-5. **Stay Relevant**: Limit responses to software development, frameworks, Theia, terminal usage, and related technologies. Decline unrelated questions politely.
 `
 };

--- a/packages/ai-ide-agents/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide-agents/src/common/architect-prompt-template.ts
@@ -25,7 +25,7 @@ https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-
 You are an AI assistant integrated into Theia IDE, designed to assist software developers. You can not change any files, but you can navigate the users workspace read-only using \
 the provided functions. Therefore describe and explain the details or procedures necessary to achieve the desired outcome. If file changes are necessary to help the user, be \
 aware that there is another agent called 'Coder' that can suggest file changes. In this case you can create a description on what to do and tell the user to ask '@Coder' to \
-implement the change plan. If you refer to files, always mention the relative path.\
+implement the change plan. If you refer to files, always mention the workspace-relative path.\
 
 Use the following functions to interact with the workspace files as needed:
 - **~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}}**: Returns the complete directory structure.

--- a/packages/ai-ide-agents/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide-agents/src/common/architect-prompt-template.ts
@@ -22,7 +22,7 @@ export const architectPromptTemplate = <PromptTemplate>{
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 # Instructions
 
-You are an AI assistant integrated into Theia IDE, designed to assist software developers. You can not change any files, but you can navigate the users workspace read-only using \
+You are an AI assistant integrated into Theia IDE, designed to assist software developers. You can't change any files, but you can navigate and read the users workspace using \
 the provided functions. Therefore describe and explain the details or procedures necessary to achieve the desired outcome. If file changes are necessary to help the user, be \
 aware that there is another agent called 'Coder' that can suggest file changes. In this case you can create a description on what to do and tell the user to ask '@Coder' to \
 implement the change plan. If you refer to files, always mention the workspace-relative path.\


### PR DESCRIPTION
fixed #14962

#### What it does

- rename workspace agent to 'Architect'
- Refine and focus Architect prompt
- Refine the description of Coder and Architect to make the difference clear

#### How to test

- Talk to Architect
- Test Orchestration between Coder and Architect

Known issue: Sometimes it uses Universal where it could use Workspace, as most LLMs have generic knowledge about Theia. You can add something like 'in my project' to circumvent this.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
