### PR TITLE
Fix notebook widget disposal

### DIFF
--- a/packages/notebook/src/browser/view/notebook-viewport-service.ts
+++ b/packages/notebook/src/browser/view/notebook-viewport-service.ts
@@ -30,7 +30,7 @@ export class NotebookViewportService implements Disposable {
 
     protected _viewportElement: HTMLDivElement | undefined;
 
-    protected resizeObserver: ResizeObserver;
+    protected resizeObserver?: ResizeObserver;
 
     set viewportElement(element: HTMLDivElement | undefined) {
         this._viewportElement = element;
@@ -56,6 +56,6 @@ export class NotebookViewportService implements Disposable {
     }
 
     dispose(): void {
-        this.resizeObserver.disconnect();
+        this.resizeObserver?.disconnect();
     }
 }


### PR DESCRIPTION
#### What it does

In case the notebook loading fails, disposing the notebook widget also failed (due to calling `disconnect` on `undefined`), which led to a cascade of other issues related to that widget.

#### How to test

1. Open a notebook file (I created a copy of an existing notebook
2. Close Theia and delete the notebook file
3. Open Theia again, the notebook error marker should be visible on the widget
4. Recreate the original notebook file
5. Close and reopen the widget. It should load the recreated notebook as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
