### PR TITLE
chore(chat): move chat window to the right by default

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -48,7 +48,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             widgetId: ChatViewWidget.ID,
             widgetName: ChatViewWidget.LABEL,
             defaultWidgetOptions: {
-                area: 'left',
+                area: 'right',
                 rank: 100
             },
             toggleCommandId: AI_CHAT_TOGGLE_COMMAND_ID,


### PR DESCRIPTION
#### What it does

As we now expect users to drag files into the chat window, we should move it to the right by default to make it easier to drag files into the chat window.

#### How to test

Open the chat window in a fresh environment without stored window layouts and test whether the chat window appears in the right area.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
