### PR TITLE
Support "Save As" for custom editors

### DIFF
--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -21,7 +21,7 @@ import { MaybePromise } from '../common/types';
 import { Key } from './keyboard/keys';
 import { AbstractDialog } from './dialogs';
 import { nls } from '../common/nls';
-import { Disposable, DisposableCollection, isObject } from '../common';
+import { Disposable, DisposableCollection, isObject, URI } from '../common';
 import { BinaryBuffer } from '../common/buffer';
 
 export type AutoSaveMode = 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowChange';
@@ -44,6 +44,10 @@ export interface Saveable {
      * Saves dirty changes.
      */
     save(options?: SaveOptions): MaybePromise<void>;
+    /**
+     * Performs the save operation with a new file name.
+     */
+    saveAs?(options: SaveAsOptions): MaybePromise<void>;
     /**
      * Reverts dirty changes.
      */
@@ -87,6 +91,7 @@ export class DelegatingSaveable implements Saveable {
     createSnapshot?(): Saveable.Snapshot;
     applySnapshot?(snapshot: object): void;
     serialize?(): Promise<BinaryBuffer>;
+    saveAs?(options: SaveAsOptions): MaybePromise<void>;
 
     protected _delegate?: Saveable;
     protected toDispose = new DisposableCollection();
@@ -110,6 +115,7 @@ export class DelegatingSaveable implements Saveable {
         this.createSnapshot = delegate.createSnapshot?.bind(delegate);
         this.applySnapshot = delegate.applySnapshot?.bind(delegate);
         this.serialize = delegate.serialize?.bind(delegate);
+        this.saveAs = delegate.saveAs?.bind(delegate);
     }
 
 }
@@ -339,6 +345,10 @@ export interface SaveOptions {
      * The reason for saving the resource.
      */
     readonly saveReason?: SaveReason;
+}
+
+export interface SaveAsOptions extends SaveOptions {
+    readonly target: URI;
 }
 
 /**

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1900,8 +1900,8 @@ export interface CustomEditorsExt {
     $redo(resource: UriComponents, viewType: string, editId: number, isDirty: boolean): Promise<void>;
     $revert(resource: UriComponents, viewType: string, cancellation: CancellationToken): Promise<void>;
     $disposeEdits(resourceComponents: UriComponents, viewType: string, editIds: number[]): void;
-    $onSave(resource: UriComponents, viewType: string, cancellation: CancellationToken): Promise<void>;
-    $onSaveAs(resource: UriComponents, viewType: string, targetResource: UriComponents, cancellation: CancellationToken): Promise<void>;
+    $save(resource: UriComponents, viewType: string, cancellation: CancellationToken): Promise<void>;
+    $saveAs(resource: UriComponents, viewType: string, targetResource: UriComponents, cancellation: CancellationToken): Promise<void>;
     // $backup(resource: UriComponents, viewType: string, cancellation: CancellationToken): Promise<string>;
     $onMoveCustomEditor(handle: string, newResource: UriComponents, viewType: string): Promise<void>;
 }

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { FileOperation } from '@theia/filesystem/lib/common/files';
-import { ApplicationShell, DelegatingSaveable, NavigatableWidget, Saveable, SaveableSource, SaveOptions } from '@theia/core/lib/browser';
+import { ApplicationShell, DelegatingSaveable, NavigatableWidget, Saveable, SaveableSource } from '@theia/core/lib/browser';
 import { SaveableService } from '@theia/core/lib/browser/saveable-service';
 import { Reference } from '@theia/core/lib/common/reference';
 import { WebviewWidget } from '../webview/webview';
@@ -72,18 +72,6 @@ export class CustomEditorWidget extends WebviewWidget implements CustomEditorWid
 
     redo(): void {
         this._modelRef.object?.redo();
-    }
-
-    async save(options?: SaveOptions): Promise<void> {
-        await this._modelRef.object?.saveCustomEditor(options);
-    }
-
-    async saveAs(source: URI, target: URI, options?: SaveOptions): Promise<void> {
-        if (this._modelRef.object) {
-            const result = await this._modelRef.object.saveCustomEditorAs(source, target, options);
-            this.doMove(target);
-            return result;
-        }
     }
 
     getResourceUri(): URI | undefined {

--- a/packages/plugin-ext/src/plugin/custom-editors.ts
+++ b/packages/plugin-ext/src/plugin/custom-editors.ts
@@ -184,12 +184,12 @@ export class CustomEditorsExtImpl implements CustomEditorsExt {
 
     async $undo(resourceComponents: UriComponents, viewType: string, editId: number, isDirty: boolean): Promise<void> {
         const entry = this.getCustomDocumentEntry(viewType, resourceComponents);
-        return entry.undo(editId, isDirty);
+        await entry.undo(editId, isDirty);
     }
 
     async $redo(resourceComponents: UriComponents, viewType: string, editId: number, isDirty: boolean): Promise<void> {
         const entry = this.getCustomDocumentEntry(viewType, resourceComponents);
-        return entry.redo(editId, isDirty);
+        await entry.redo(editId, isDirty);
     }
 
     async $revert(resourceComponents: UriComponents, viewType: string, cancellation: CancellationToken): Promise<void> {
@@ -198,16 +198,16 @@ export class CustomEditorsExtImpl implements CustomEditorsExt {
         await provider.revertCustomDocument(entry.document, cancellation);
     }
 
-    async $onSave(resourceComponents: UriComponents, viewType: string, cancellation: CancellationToken): Promise<void> {
+    async $save(resourceComponents: UriComponents, viewType: string, cancellation: CancellationToken): Promise<void> {
         const entry = this.getCustomDocumentEntry(viewType, resourceComponents);
         const provider = this.getCustomEditorProvider(viewType);
         await provider.saveCustomDocument(entry.document, cancellation);
     }
 
-    async $onSaveAs(resourceComponents: UriComponents, viewType: string, targetResource: UriComponents, cancellation: CancellationToken): Promise<void> {
+    async $saveAs(resourceComponents: UriComponents, viewType: string, targetResource: UriComponents, cancellation: CancellationToken): Promise<void> {
         const entry = this.getCustomDocumentEntry(viewType, resourceComponents);
         const provider = this.getCustomEditorProvider(viewType);
-        return provider.saveCustomDocumentAs(entry.document, URI.revive(targetResource), cancellation);
+        await provider.saveCustomDocumentAs(entry.document, URI.revive(targetResource), cancellation);
     }
 
     private getCustomEditorProvider(viewType: string): theia.CustomEditorProvider {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14966

Allows `Saveable` instances to implement their own `saveAs` routine. This is required to fix saving for custom editors. All other editors can continue to just serialize their contents to use the generic "Save As" function.

#### How to test

Follow the reproduction steps of https://github.com/eclipse-theia/theia/issues/14966 and ensure that the "Save As" functionality works for both the `.pawDraw` and `.cscratch` files.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
