### PR TITLE
fix(chat): prevent duplicate context element entries

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -192,8 +192,7 @@ export class AIChatInputWidget extends ReactWidget {
     protected addContextElement(): void {
         this.contextVariablePicker.pickContextVariable().then(contextElement => {
             if (contextElement) {
-                this.context.push(contextElement);
-                this.update();
+                this.addContext(contextElement);
             }
         });
     }
@@ -211,8 +210,11 @@ export class AIChatInputWidget extends ReactWidget {
         event.preventDefault();
     }
 
-    addContext(variable: AIVariableResolutionRequest): void {
-        this.context.push(variable);
+    addContext(variableRequest: AIVariableResolutionRequest): void {
+        if (this.context.some(existing => existing.variable.id === variableRequest.variable.id && existing.arg === variableRequest.arg)) {
+            return;
+        }
+        this.context.push(variableRequest);
         this.update();
     }
 }


### PR DESCRIPTION
#### What it does

Prevents duplicate context variable requests in the AI chat input (filtering by variable and arguments).

#### How to test

Try adding files multiple times into the chat widget (by drag and drop, by auto-complete) and observe that it won't add it multiple times in the list.

Note that I kept adding it multiple times in the text, as users may want to use drag and drop to create the variable string for refering to it in their user request.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
