### PR TITLE
[TheiaAi] Support referencing prompt fragments via variable

### DIFF
--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -18,32 +18,42 @@ import * as sinon from 'sinon';
 import { ChatAgentServiceImpl } from './chat-agent-service';
 import { ChatRequestParserImpl } from './chat-request-parser';
 import { ChatAgentLocation } from './chat-agents';
-import { ChatRequest } from './chat-model';
+import { ChatContext, ChatRequest } from './chat-model';
 import { expect } from 'chai';
-import { DefaultAIVariableService, ToolInvocationRegistry, ToolInvocationRegistryImpl } from '@theia/ai-core';
+import { AIVariable, DefaultAIVariableService, ResolvedAIVariable, ToolInvocationRegistryImpl, ToolRequest } from '@theia/ai-core';
+import { ILogger, Logger } from '@theia/core';
+import { ParsedChatRequestTextPart, ParsedChatRequestVariablePart } from './parsed-chat-request';
 
 describe('ChatRequestParserImpl', () => {
     const chatAgentService = sinon.createStubInstance(ChatAgentServiceImpl);
     const variableService = sinon.createStubInstance(DefaultAIVariableService);
-    const toolInvocationRegistry: ToolInvocationRegistry = sinon.createStubInstance(ToolInvocationRegistryImpl);
-    const parser = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry);
+    const toolInvocationRegistry = sinon.createStubInstance(ToolInvocationRegistryImpl);
+    const logger: ILogger = sinon.createStubInstance(Logger);
+    const parser = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry, logger);
 
-    it('parses simple text', () => {
+    beforeEach(() => {
+        // Reset our stubs before each test
+        sinon.reset();
+    });
+
+    it('parses simple text', async () => {
         const req: ChatRequest = {
             text: 'What is the best pizza topping?'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result.parts).to.deep.contain({
             text: 'What is the best pizza topping?',
             range: { start: 0, endExclusive: 31 }
         });
     });
 
-    it('parses text with variable name', () => {
+    it('parses text with variable name', async () => {
         const req: ChatRequest = {
             text: 'What is the #best pizza topping?'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result).to.deep.contain({
             parts: [{
                 text: 'What is the ',
@@ -59,11 +69,12 @@ describe('ChatRequestParserImpl', () => {
         });
     });
 
-    it('parses text with variable name with argument', () => {
+    it('parses text with variable name with argument', async () => {
         const req: ChatRequest = {
             text: 'What is the #best:by-poll pizza topping?'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result).to.deep.contain({
             parts: [{
                 text: 'What is the ',
@@ -79,11 +90,12 @@ describe('ChatRequestParserImpl', () => {
         });
     });
 
-    it('parses text with variable name with numeric argument', () => {
+    it('parses text with variable name with numeric argument', async () => {
         const req: ChatRequest = {
             text: '#size-class:2'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result.parts[0]).to.contain(
             {
                 variableName: 'size-class',
@@ -92,11 +104,12 @@ describe('ChatRequestParserImpl', () => {
         );
     });
 
-    it('parses text with variable name with POSIX path argument', () => {
+    it('parses text with variable name with POSIX path argument', async () => {
         const req: ChatRequest = {
             text: '#file:/path/to/file.ext'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result.parts[0]).to.contain(
             {
                 variableName: 'file',
@@ -105,16 +118,81 @@ describe('ChatRequestParserImpl', () => {
         );
     });
 
-    it('parses text with variable name with Win32 path argument', () => {
+    it('parses text with variable name with Win32 path argument', async () => {
         const req: ChatRequest = {
             text: '#file:c:\\path\\to\\file.ext'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result.parts[0]).to.contain(
             {
                 variableName: 'file',
                 variableArg: 'c:\\path\\to\\file.ext'
             }
         );
+    });
+
+    it('resolves variable and extracts tool functions from resolved variable', async () => {
+        // Set up two test tool requests that will be referenced in the variable content
+        const testTool1: ToolRequest = {
+            id: 'testTool1',
+            name: 'Test Tool 1',
+            handler: async () => undefined
+        };
+        const testTool2: ToolRequest = {
+            id: 'testTool2',
+            name: 'Test Tool 2',
+            handler: async () => undefined
+        };
+        // Configure the tool registry to return our test tools
+        toolInvocationRegistry.getFunction.withArgs(testTool1.id).returns(testTool1);
+        toolInvocationRegistry.getFunction.withArgs(testTool2.id).returns(testTool2);
+
+        // Set up the test variable to include in the request
+        const testVariable: AIVariable = {
+            id: 'testVariable',
+            name: 'testVariable',
+            description: 'A test variable',
+        };
+        // Configure the variable service to return our test variable
+        variableService.getVariable.withArgs(testVariable.name).returns(testVariable);
+        variableService.resolveVariable.withArgs(
+            { variable: testVariable.name, arg: 'myarg' },
+            sinon.match.any
+        ).resolves({
+            variable: testVariable,
+            arg: 'myarg',
+            value: 'This is a test with ~testTool1 and ~testTool2',
+        });
+
+        // Create a request with the test variable
+        const req: ChatRequest = {
+            text: 'Test with #testVariable:myarg'
+        };
+        const context: ChatContext = { variables: [] };
+
+        // Parse the request
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
+
+        // Verify the variable part contains the correct properties
+        expect(result.parts.length).to.equal(2);
+        expect(result.parts[0] instanceof ParsedChatRequestTextPart).to.be.true;
+        expect(result.parts[1] instanceof ParsedChatRequestVariablePart).to.be.true;
+        const variablePart = result.parts[1] as ParsedChatRequestVariablePart;
+        expect(variablePart).to.have.property('resolution');
+        expect(variablePart.resolution).to.deep.equal({
+            variable: testVariable,
+            arg: 'myarg',
+            value: 'This is a test with ~testTool1 and ~testTool2',
+        } satisfies ResolvedAIVariable);
+
+        // Verify both tool functions were extracted from the variable content
+        expect(result.toolRequests.size).to.equal(2);
+        expect(result.toolRequests.has(testTool1.id)).to.be.true;
+        expect(result.toolRequests.has(testTool2.id)).to.be.true;
+
+        // Verify the result contains the tool requests returned by the registry
+        expect(result.toolRequests.get(testTool1.id)).to.deep.equal(testTool1);
+        expect(result.toolRequests.get(testTool2.id)).to.deep.equal(testTool2);
     });
 });

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -35,7 +35,7 @@ import {
     ParsedChatRequest,
     ParsedChatRequestPart,
 } from './parsed-chat-request';
-import { AIVariable, AIVariableService, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
+import { AIVariable, AIVariableService, PROMPT_FUNCTION_REGEX, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
 
 const agentReg = /^@([\w_\-\.]+)(?=(\s|$|\b))/i; // An @-agent
 const functionReg = /^~([\w_\-\.]+)(?=(\s|$|\b))/i; // A ~ tool function
@@ -202,7 +202,8 @@ export class ChatRequestParserImpl {
     }
 
     private tryParseFunction(message: string, offset: number): ParsedChatRequestFunctionPart | undefined {
-        const nextFunctionMatch = message.match(functionReg);
+        // Support both the and chat and prompt formats for functions
+        const nextFunctionMatch = message.match(functionReg) || message.match(PROMPT_FUNCTION_REGEX);
         if (!nextFunctionMatch) {
             return;
         }

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -22,7 +22,7 @@
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatAgentService } from './chat-agent-service';
 import { ChatAgentLocation } from './chat-agents';
-import { ChatRequest } from './chat-model';
+import { ChatContext, ChatRequest } from './chat-model';
 import {
     chatAgentLeader,
     chatFunctionLeader,
@@ -36,6 +36,7 @@ import {
     ParsedChatRequestPart,
 } from './parsed-chat-request';
 import { AIVariable, AIVariableService, PROMPT_FUNCTION_REGEX, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
+import { ILogger } from '@theia/core';
 
 const agentReg = /^@([\w_\-\.]+)(?=(\s|$|\b))/i; // An @-agent
 const functionReg = /^~([\w_\-\.]+)(?=(\s|$|\b))/i; // A ~ tool function
@@ -43,7 +44,7 @@ const variableReg = /^#([\w_\-]+)(?::([\w_\-_\/\\.:]+))?(?=(\s|$|\b))/i; // A #-
 
 export const ChatRequestParser = Symbol('ChatRequestParser');
 export interface ChatRequestParser {
-    parseChatRequest(request: ChatRequest, location: ChatAgentLocation): ParsedChatRequest;
+    parseChatRequest(request: ChatRequest, location: ChatAgentLocation, context: ChatContext): Promise<ParsedChatRequest>;
 }
 
 function offsetRange(start: number, endExclusive: number): OffsetRange {
@@ -57,10 +58,43 @@ export class ChatRequestParserImpl {
     constructor(
         @inject(ChatAgentService) private readonly agentService: ChatAgentService,
         @inject(AIVariableService) private readonly variableService: AIVariableService,
-        @inject(ToolInvocationRegistry) private readonly toolInvocationRegistry: ToolInvocationRegistry
+        @inject(ToolInvocationRegistry) private readonly toolInvocationRegistry: ToolInvocationRegistry,
+        @inject(ILogger) private readonly logger: ILogger
     ) { }
 
-    parseChatRequest(request: ChatRequest, location: ChatAgentLocation): ParsedChatRequest {
+    async parseChatRequest(request: ChatRequest, location: ChatAgentLocation, context: ChatContext): Promise<ParsedChatRequest> {
+        // Parse the request into parts
+        const { parts, toolRequests, variables } = this.parseParts(request, location);
+
+        // Resolve all variables and add them to the variable parts.
+        // Parse resolved variable texts again for tool requests.
+        // These are not added to parts as they are not visible in the initial chat message.
+        // However, add they need to be added to the result to be considered by the executing agent.
+        // TODO [recursive variable resolution] collect recursively resolved variables for result
+        for (const part of parts) {
+            if (part instanceof ParsedChatRequestVariablePart) {
+                const resolvedVariable = await this.variableService.resolveVariable(
+                    { variable: part.variableName, arg: part.variableArg },
+                    context
+                );
+                if (resolvedVariable) {
+                    part.resolution = resolvedVariable;
+                    // Resolve tool requests in resolved variables
+                    this.parseFunctionsFromText(resolvedVariable.value, toolRequests);
+                } else {
+                    this.logger.warn(`Failed to resolve variable ${part.variableName} for ${location}`);
+                }
+            }
+        }
+
+        return { request, parts, toolRequests, variables };
+    }
+
+    protected parseParts(request: ChatRequest, location: ChatAgentLocation): {
+        parts: ParsedChatRequestPart[];
+        toolRequests: Map<string, ToolRequest>;
+        variables: Map<string, AIVariable>;
+    } {
         const parts: ParsedChatRequestPart[] = [];
         const variables = new Map<string, AIVariable>();
         const toolRequests = new Map<string, ToolRequest>();
@@ -72,7 +106,7 @@ export class ChatRequestParserImpl {
 
             if (previousChar.match(/\s/) || i === 0) {
                 if (char === chatFunctionLeader) {
-                    const functionPart = this.tryParseFunction(
+                    const functionPart = this.tryToParseFunction(
                         message.slice(i),
                         i
                     );
@@ -107,8 +141,7 @@ export class ChatRequestParserImpl {
                 if (i !== 0) {
                     // Insert a part for all the text we passed over, then insert the new parsed part
                     const previousPart = parts.at(-1);
-                    const previousPartEnd =
-                        previousPart?.range.endExclusive ?? 0;
+                    const previousPartEnd = previousPart?.range.endExclusive ?? 0;
                     parts.push(
                         new ParsedChatRequestTextPart(
                             offsetRange(previousPartEnd, i),
@@ -131,8 +164,26 @@ export class ChatRequestParserImpl {
                 )
             );
         }
+        return { parts, toolRequests, variables };
+    }
 
-        return { request, parts, toolRequests, variables };
+    /**
+     * Parse text for tool requests and add them to the given map
+     */
+    private parseFunctionsFromText(text: string, toolRequests: Map<string, ToolRequest>): void {
+        for (let i = 0; i < text.length; i++) {
+            const previousChar = i === 0 ? ' ' : text.charAt(i - 1);
+            const char = text.charAt(i);
+
+            // Check for function markers at start of words
+            if ((previousChar.match(/\s/) || i === 0) && char === chatFunctionLeader) {
+                const functionPart = this.tryToParseFunction(text.slice(i), i);
+                if (functionPart) {
+                    // Add the found tool request to the given map
+                    toolRequests.set(functionPart.toolRequest.id, functionPart.toolRequest);
+                }
+            }
+        }
     }
 
     private tryToParseAgent(
@@ -201,7 +252,7 @@ export class ChatRequestParserImpl {
         return new ParsedChatRequestVariablePart(varRange, name, variableArg);
     }
 
-    private tryParseFunction(message: string, offset: number): ParsedChatRequestFunctionPart | undefined {
+    private tryToParseFunction(message: string, offset: number): ParsedChatRequestFunctionPart | undefined {
         // Support both the and chat and prompt formats for functions
         const nextFunctionMatch = message.match(functionReg) || message.match(PROMPT_FUNCTION_REGEX);
         if (!nextFunctionMatch) {

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -245,6 +245,7 @@ export class ChatServiceImpl implements ChatService {
         resolutionRequests: readonly AIVariableResolutionRequest[],
         context: ChatSessionContext,
     ): Promise<ChatContext> {
+        // TODO use a common cache to resolve variables and return recursively resolved variables?
         const resolvedVariables = await Promise.all(
             resolutionRequests.map(async contextVariable => {
                 const resolvedVariable = await this.variableService.resolveVariable(contextVariable, context);

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -35,7 +35,7 @@ import {
     ChatContext,
 } from './chat-model';
 import { ChatRequestParser } from './chat-request-parser';
-import { ParsedChatRequest, ParsedChatRequestAgentPart, ParsedChatRequestVariablePart } from './parsed-chat-request';
+import { ParsedChatRequest, ParsedChatRequestAgentPart } from './parsed-chat-request';
 
 export interface ChatRequestInvocation {
     /**
@@ -191,7 +191,9 @@ export class ChatServiceImpl implements ChatService {
         }
         session.title = request.text;
 
-        const parsedRequest = this.chatRequestParser.parseChatRequest(request, session.model.location);
+        const resolutionContext: ChatSessionContext = { model: session.model };
+        const resolvedContext = await this.resolveChatContext(session.model.context.getVariables(), resolutionContext);
+        const parsedRequest = await this.chatRequestParser.parseChatRequest(request, session.model.location, resolvedContext);
         const agent = this.getAgent(parsedRequest, session);
 
         if (agent === undefined) {
@@ -205,24 +207,8 @@ export class ChatServiceImpl implements ChatService {
             };
         }
 
-        const resolutionContext: ChatSessionContext = { model: session.model };
-        const resolvedContext = await this.resolveChatContext(session.model.context.getVariables(), resolutionContext);
         const requestModel = session.model.addRequest(parsedRequest, agent?.id, resolvedContext);
         resolutionContext.request = requestModel;
-
-        for (const part of parsedRequest.parts) {
-            if (part instanceof ParsedChatRequestVariablePart) {
-                const resolvedVariable = await this.variableService.resolveVariable(
-                    { variable: part.variableName, arg: part.variableArg },
-                    resolutionContext
-                );
-                if (resolvedVariable) {
-                    part.resolution = resolvedVariable;
-                } else {
-                    this.logger.warn(`Failed to resolve variable ${part.variableName} for ${session.model.location}`);
-                }
-            }
-        }
 
         let resolveResponseCreated: (responseModel: ChatResponseModel) => void;
         let resolveResponseCompleted: (responseModel: ChatResponseModel) => void;

--- a/packages/ai-chat/src/common/parsed-chat-request.ts
+++ b/packages/ai-chat/src/common/parsed-chat-request.ts
@@ -20,7 +20,7 @@
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/editor/common/core/offsetRange.ts
 
-import { AIVariable, ResolvedAIVariable, ToolRequest, toolRequestToPromptText } from '@theia/ai-core';
+import { ResolvedAIVariable, ToolRequest, toolRequestToPromptText } from '@theia/ai-core';
 import { ChatRequest } from './chat-model';
 
 export const chatVariableLeader = '#';
@@ -41,7 +41,7 @@ export interface ParsedChatRequest {
     readonly request: ChatRequest;
     readonly parts: ParsedChatRequestPart[];
     readonly toolRequests: Map<string, ToolRequest>;
-    readonly variables: Map<string, AIVariable>;
+    readonly variables: ResolvedAIVariable[];
 }
 
 export interface ParsedChatRequestPart {

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -60,6 +60,7 @@ import { AIActivationService } from './ai-activation-service';
 import { AgentService, AgentServiceImpl } from '../common/agent-service';
 import { AICommandHandlerFactory } from './ai-command-handler-factory';
 import { AISettingsService } from '../common/settings-service';
+import { PromptVariableContribution } from '../common/prompt-variable-contribution';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, LanguageModelProvider);
@@ -109,6 +110,7 @@ export default new ContainerModule(bind => {
     bind(TheiaVariableContribution).toSelf().inSingletonScope();
     bind(AIVariableContribution).toService(TheiaVariableContribution);
 
+    bind(AIVariableContribution).to(PromptVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(TodayVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(FileVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(AgentsVariableContribution).inSingletonScope();

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -265,7 +265,7 @@ export class PromptServiceImpl implements PromptService {
 
         // First resolve variables and arguments
         let resolvedTemplate = prompt.template;
-        const variableAndArgReplacements = await this.getVariableAndArgReplacements(prompt.template, args);
+        const variableAndArgReplacements = await this.getVariableAndArgReplacements(prompt.template, args, context);
         variableAndArgReplacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
 
         // Then resolve function references with already resolved variables and arguments
@@ -315,7 +315,11 @@ export class PromptServiceImpl implements PromptService {
      * @param template the unresolved template text
      * @param args the object with placeholders, mapping the placeholder key to the value
      */
-    protected async getVariableAndArgReplacements(template: string, args?: { [key: string]: unknown }): Promise<{ placeholder: string; value: string }[]> {
+    protected async getVariableAndArgReplacements(
+        template: string,
+        args?: { [key: string]: unknown },
+        context?: AIVariableContext
+    ): Promise<{ placeholder: string; value: string }[]> {
         const matches = matchVariablesRegEx(template);
         const variableAndArgReplacements = await Promise.all(matches.map(async match => {
             const completeText = match[0];

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -68,6 +68,19 @@ export interface PromptService {
      * @param args the object with placeholders, mapping the placeholder key to the value
      */
     getPrompt(id: string, args?: { [key: string]: unknown }, context?: AIVariableContext): Promise<ResolvedPromptTemplate | undefined>;
+
+    /**
+     * Allows to directly replace placeholders in the prompt. The supported format is 'Hi {{name}}!'.
+     * The placeholder is then searched inside the args object and replaced.
+     *
+     * In contrast to {@link getPrompt}, this method does not resolve function references but leaves them as is.
+     * This allows resolving them later as part of the prompt or chat message containing the fragment.
+     *
+     * @param id the id of the prompt
+     * @param @param args the object with placeholders, mapping the placeholder key to the value
+     */
+    getPromptFragment(id: string, args?: { [key: string]: unknown }): Promise<Omit<ResolvedPromptTemplate, 'functionDescriptions'> | undefined>;
+
     /**
      * Adds a {@link PromptTemplate} to the list of prompts.
      * @param promptTemplate the prompt template to store
@@ -246,25 +259,7 @@ export class PromptServiceImpl implements PromptService {
             return undefined;
         }
 
-        const matches = matchVariablesRegEx(prompt.template);
-        const variableAndArgReplacements = await Promise.all(matches.map(async match => {
-            const completeText = match[0];
-            const variableAndArg = match[1];
-            let variableName = variableAndArg;
-            let argument: string | undefined;
-            const parts = variableAndArg.split(':', 2);
-            if (parts.length > 1) {
-                variableName = parts[0];
-                argument = parts[1];
-            }
-            return {
-                placeholder: completeText,
-                value: String(args?.[variableAndArg] ?? (await this.variableService?.resolveVariable({
-                    variable: variableName,
-                    arg: argument
-                }, context ?? {}))?.value ?? completeText)
-            };
-        }));
+        const variableAndArgReplacements = await this.getVariableAndArgReplacements(prompt.template, args);
 
         const functionMatches = matchFunctionsRegEx(prompt.template);
         const functions = new Map<string, ToolRequest>();
@@ -290,6 +285,52 @@ export class PromptServiceImpl implements PromptService {
             functionDescriptions: functions.size > 0 ? functions : undefined
         };
     }
+
+    async getPromptFragment(id: string, args?: { [key: string]: unknown }): Promise<Omit<ResolvedPromptTemplate, 'functionDescriptions'> | undefined> {
+        const variantId = await this.getVariantId(id);
+        const prompt = this.getUnresolvedPrompt(variantId);
+        if (prompt === undefined) {
+            return undefined;
+        }
+
+        const replacements = await this.getVariableAndArgReplacements(prompt.template, args);
+        let resolvedTemplate = prompt.template;
+        replacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
+        return {
+            id,
+            text: resolvedTemplate,
+        };
+    }
+
+    /**
+     * Calculates all variable and argument replacements for an unresolved template.
+     *
+     * @param template the unresolved template text
+     * @param args the object with placeholders, mapping the placeholder key to the value
+     */
+    protected async getVariableAndArgReplacements(template: string, args?: { [key: string]: unknown }): Promise<{ placeholder: string; value: string }[]> {
+        const matches = matchVariablesRegEx(template);
+        const variableAndArgReplacements = await Promise.all(matches.map(async match => {
+            const completeText = match[0];
+            const variableAndArg = match[1];
+            let variableName = variableAndArg;
+            let argument: string | undefined;
+            const parts = variableAndArg.split(':', 2);
+            if (parts.length > 1) {
+                variableName = parts[0];
+                argument = parts[1];
+            }
+            return {
+                placeholder: completeText,
+                value: String(args?.[variableAndArg] ?? (await this.variableService?.resolveVariable({
+                    variable: variableName,
+                    arg: argument
+                }, context ?? {}))?.value ?? completeText)
+            };
+        }));
+        return variableAndArgReplacements;
+    }
+
     getAllPrompts(): PromptMap {
         if (this.customizationService !== undefined) {
             const myCustomization = this.customizationService;

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -16,7 +16,7 @@
 
 import { URI, Event } from '@theia/core';
 import { inject, injectable, optional } from '@theia/core/shared/inversify';
-import { AIVariableContext, AIVariableService } from './variable-service';
+import { AIVariableContext, AIVariableResolutionRequest, AIVariableService, createAIResolveVariableCache, ResolvedAIVariable } from './variable-service';
 import { ToolInvocationRegistry } from './tool-invocation-registry';
 import { toolRequestToPromptText } from './language-model-util';
 import { ToolRequest } from './language-model';
@@ -41,6 +41,8 @@ export interface ResolvedPromptTemplate {
     text: string;
     /** All functions referenced in the prompt template. */
     functionDescriptions?: Map<string, ToolRequest>;
+    /** All variables resolved in the prompt template */
+    variables?: ResolvedAIVariable[];
 }
 
 export const PromptService = Symbol('PromptService');
@@ -81,9 +83,16 @@ export interface PromptService {
      * This allows resolving them later as part of the prompt or chat message containing the fragment.
      *
      * @param id the id of the prompt
-     * @param @param args the object with placeholders, mapping the placeholder key to the value
+     * @param args the object with placeholders, mapping the placeholder key to the value
+     * @param context the {@link AIVariableContext} to use during variable resolvement
+     * @param resolveVariable the variable resolving method. Fall back to using the {@link AIVariableService} if not given.
      */
-    getPromptFragment(id: string, args?: { [key: string]: unknown }): Promise<Omit<ResolvedPromptTemplate, 'functionDescriptions'> | undefined>;
+    getPromptFragment(
+        id: string,
+        args?: { [key: string]: unknown },
+        context?: AIVariableContext,
+        resolveVariable?: (req: AIVariableResolutionRequest) => Promise<ResolvedAIVariable | undefined>
+    ): Promise<Omit<ResolvedPromptTemplate, 'functionDescriptions'> | undefined>;
 
     /**
      * Adds a {@link PromptTemplate} to the list of prompts.
@@ -266,7 +275,7 @@ export class PromptServiceImpl implements PromptService {
         // First resolve variables and arguments
         let resolvedTemplate = prompt.template;
         const variableAndArgReplacements = await this.getVariableAndArgReplacements(prompt.template, args, context);
-        variableAndArgReplacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
+        variableAndArgReplacements.replacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
 
         // Then resolve function references with already resolved variables and arguments
         // This allows to resolve function references contained in resolved variables (e.g. prompt fragments)
@@ -289,23 +298,31 @@ export class PromptServiceImpl implements PromptService {
         return {
             id,
             text: resolvedTemplate,
-            functionDescriptions: functions.size > 0 ? functions : undefined
+            functionDescriptions: functions.size > 0 ? functions : undefined,
+            variables: variableAndArgReplacements.resolvedVariables
         };
     }
 
-    async getPromptFragment(id: string, args?: { [key: string]: unknown }): Promise<Omit<ResolvedPromptTemplate, 'functionDescriptions'> | undefined> {
+    async getPromptFragment(
+        id: string,
+        args?: { [key: string]: unknown },
+        context?: AIVariableContext,
+        resolveVariable?: (req: AIVariableResolutionRequest) => Promise<ResolvedAIVariable | undefined>
+    ): Promise<Omit<ResolvedPromptTemplate, 'functionDescriptions'> | undefined> {
         const variantId = await this.getVariantId(id);
         const prompt = this.getUnresolvedPrompt(variantId);
         if (prompt === undefined) {
             return undefined;
         }
 
-        const replacements = await this.getVariableAndArgReplacements(prompt.template, args);
+        const replacements = await this.getVariableAndArgReplacements(prompt.template, args, context, resolveVariable);
         let resolvedTemplate = prompt.template;
-        replacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
+        replacements.replacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
+
         return {
             id,
             text: resolvedTemplate,
+            variables: replacements.resolvedVariables
         };
     }
 
@@ -314,14 +331,20 @@ export class PromptServiceImpl implements PromptService {
      *
      * @param template the unresolved template text
      * @param args the object with placeholders, mapping the placeholder key to the value
+     * @param context the {@link AIVariableContext} to use during variable resolvement
+     * @param resolveVariable the variable resolving method. Fall back to using the {@link AIVariableService} if not given.
      */
     protected async getVariableAndArgReplacements(
         template: string,
         args?: { [key: string]: unknown },
-        context?: AIVariableContext
-    ): Promise<{ placeholder: string; value: string }[]> {
+        context?: AIVariableContext,
+        resolveVariable?: (req: AIVariableResolutionRequest) => Promise<ResolvedAIVariable | undefined>
+    ): Promise<{ replacements: { placeholder: string; value: string }[], resolvedVariables: ResolvedAIVariable[] }> {
         const matches = matchVariablesRegEx(template);
-        const variableAndArgReplacements = await Promise.all(matches.map(async match => {
+        const variableCache = createAIResolveVariableCache();
+        const variableAndArgReplacements: { placeholder: string; value: string }[] = [];
+        const resolvedVariables: Set<ResolvedAIVariable> = new Set();
+        for (const match of matches) {
             const completeText = match[0];
             const variableAndArg = match[1];
             let variableName = variableAndArg;
@@ -331,15 +354,33 @@ export class PromptServiceImpl implements PromptService {
                 variableName = parts[0];
                 argument = parts[1];
             }
-            return {
-                placeholder: completeText,
-                value: String(args?.[variableAndArg] ?? (await this.variableService?.resolveVariable({
-                    variable: variableName,
-                    arg: argument
-                }, context ?? {}))?.value ?? completeText)
-            };
-        }));
-        return variableAndArgReplacements;
+            let value: string;
+            if (args && args[variableAndArg] !== undefined) {
+                value = String(args[variableAndArg]);
+            } else {
+                let resolved: ResolvedAIVariable | undefined;
+                if (resolveVariable) {
+                    const variable = this.variableService?.getVariable(variableName);
+                    if (variable) {
+                        resolved = await resolveVariable({ variable, arg: argument });
+                    }
+                } else {
+                    resolved = await this.variableService?.resolveVariable({
+                        variable: variableName,
+                        arg: argument
+                    }, context ?? {}, variableCache);
+                }
+                // Track resolved variable and its dependencies in all resolved variables
+                if (resolved) {
+                    resolvedVariables.add(resolved);
+                    resolved.allResolvedDependencies?.forEach(v => resolvedVariables.add(v));
+                }
+                value = String(resolved?.value ?? completeText);
+            }
+            variableAndArgReplacements.push({ placeholder: completeText, value });
+        }
+
+        return { replacements: variableAndArgReplacements, resolvedVariables: Array.from(resolvedVariables) };
     }
 
     getAllPrompts(): PromptMap {

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -63,7 +63,7 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
         if (request.variable.name === PROMPT_VARIABLE.name) {
             const promptId = request.arg?.trim();
             if (promptId) {
-                const resolvedPrompt = await this.promptService.getPrompt(promptId);
+                const resolvedPrompt = await this.promptService.getPromptFragment(promptId);
                 if (resolvedPrompt) {
                     return { variable: request.variable, value: resolvedPrompt.text, contextValue: resolvedPrompt.text };
                 }

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -18,12 +18,12 @@ import { injectable, inject, optional } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import {
     AIVariable,
-    ResolvedAIVariable,
     AIVariableContribution,
     AIVariableResolver,
     AIVariableService,
     AIVariableResolutionRequest,
-    AIVariableContext
+    AIVariableContext,
+    ResolvedAIContextVariable
 } from './variable-service';
 import { PromptCustomizationService, PromptService } from './prompt-service';
 import { PromptText } from './prompt-text';
@@ -35,6 +35,7 @@ export const PROMPT_VARIABLE: AIVariable = {
     args: [
         { name: 'id', description: nls.localize('theia/ai/core/promptVariable/argDescription', 'The prompt template id to resolve') }
     ],
+    isContextVariable: true
 };
 
 @injectable()
@@ -58,19 +59,14 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
         return -1;
     }
 
-    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
+    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIContextVariable | undefined> {
         if (request.variable.name === PROMPT_VARIABLE.name) {
-            return this.resolvePromptVariable(request);
-        }
-        return undefined;
-    }
-
-    private async resolvePromptVariable(request: AIVariableResolutionRequest): Promise<ResolvedAIVariable | undefined> {
-        const promptId = request.arg?.trim();
-        if (promptId) {
-            const resolvedPrompt = await this.promptService.getPrompt(promptId);
-            if (resolvedPrompt) {
-                return { variable: request.variable, value: resolvedPrompt.text };
+            const promptId = request.arg?.trim();
+            if (promptId) {
+                const resolvedPrompt = await this.promptService.getPrompt(promptId);
+                if (resolvedPrompt) {
+                    return { variable: request.variable, value: resolvedPrompt.text, contextValue: resolvedPrompt.text };
+                }
             }
         }
         return undefined;

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -19,11 +19,11 @@ import * as monaco from '@theia/monaco-editor-core';
 import {
     AIVariable,
     AIVariableContribution,
-    AIVariableResolver,
     AIVariableService,
     AIVariableResolutionRequest,
     AIVariableContext,
-    ResolvedAIVariable
+    ResolvedAIVariable,
+    AIVariableResolverWithVariableDependencies
 } from './variable-service';
 import { PromptCustomizationService, PromptService } from './prompt-service';
 import { PromptText } from './prompt-text';
@@ -38,7 +38,7 @@ export const PROMPT_VARIABLE: AIVariable = {
 };
 
 @injectable()
-export class PromptVariableContribution implements AIVariableContribution, AIVariableResolver {
+export class PromptVariableContribution implements AIVariableContribution, AIVariableResolverWithVariableDependencies {
 
     @inject(PromptService)
     protected readonly promptService: PromptService;
@@ -58,13 +58,21 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
         return -1;
     }
 
-    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
+    async resolve(
+        request: AIVariableResolutionRequest,
+        context: AIVariableContext,
+        resolveDependency?: (req: AIVariableResolutionRequest) => Promise<ResolvedAIVariable | undefined>
+    ): Promise<ResolvedAIVariable | undefined> {
         if (request.variable.name === PROMPT_VARIABLE.name) {
             const promptId = request.arg?.trim();
             if (promptId) {
-                const resolvedPrompt = await this.promptService.getPromptFragment(promptId);
+                const resolvedPrompt = await this.promptService.getPromptFragment(promptId, undefined, context, resolveDependency);
                 if (resolvedPrompt) {
-                    return { variable: request.variable, value: resolvedPrompt.text };
+                    return {
+                        variable: request.variable,
+                        value: resolvedPrompt.text,
+                        allResolvedDependencies: resolvedPrompt.variables
+                    };
                 }
             }
         }

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -1,0 +1,115 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { injectable, inject, optional } from '@theia/core/shared/inversify';
+import * as monaco from '@theia/monaco-editor-core';
+import {
+    AIVariable,
+    ResolvedAIVariable,
+    AIVariableContribution,
+    AIVariableResolver,
+    AIVariableService,
+    AIVariableResolutionRequest,
+    AIVariableContext
+} from './variable-service';
+import { PromptCustomizationService, PromptService } from './prompt-service';
+import { PromptText } from './prompt-text';
+
+export const PROMPT_VARIABLE: AIVariable = {
+    id: 'prompt-provider',
+    description: 'Resolves prompt templates via the prompt service',
+    name: 'prompt',
+    args: [
+        { name: 'id', description: 'The prompt template id to resolve' }
+    ],
+};
+
+@injectable()
+export class PromptVariableContribution implements AIVariableContribution, AIVariableResolver {
+
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
+
+    @inject(PromptCustomizationService) @optional()
+    protected readonly promptCustomizationService: PromptCustomizationService;
+
+    registerVariables(service: AIVariableService): void {
+        service.registerResolver(PROMPT_VARIABLE, this);
+        service.registerArgumentCompletionProvider(PROMPT_VARIABLE, this.provideArgumentCompletionItems.bind(this));
+    }
+
+    canResolve(request: AIVariableResolutionRequest, context: AIVariableContext): number {
+        if (request.variable.name === PROMPT_VARIABLE.name) {
+            return 1;
+        }
+        return -1;
+    }
+
+    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
+        if (request.variable.name === PROMPT_VARIABLE.name) {
+            return this.resolvePromptVariable(request);
+        }
+        return undefined;
+    }
+
+    private async resolvePromptVariable(request: AIVariableResolutionRequest): Promise<ResolvedAIVariable | undefined> {
+        const promptId = request.arg?.trim();
+        if (promptId) {
+            const resolvedPrompt = await this.promptService.getPrompt(promptId);
+            if (resolvedPrompt) {
+                return { variable: request.variable, value: resolvedPrompt.text };
+            }
+        }
+        return undefined;
+    }
+
+    protected async provideArgumentCompletionItems(
+        model: monaco.editor.ITextModel,
+        position: monaco.Position
+    ): Promise<monaco.languages.CompletionItem[] | undefined> {
+        const lineContent = model.getLineContent(position.lineNumber);
+
+        // Only provide completions once the variable argument separator is typed
+        const triggerCharIndex = lineContent.lastIndexOf(PromptText.VARIABLE_ARG_SEPARATOR, position.column - 1);
+        if (triggerCharIndex === -1) {
+            return undefined;
+        }
+
+        // Check if the text immediately before the trigger is the prompt variable, i.e #prompt
+        const requiredVariable = `${PromptText.VARIABLE_CHAR}${PROMPT_VARIABLE.name}`;
+        if (triggerCharIndex < requiredVariable.length ||
+            lineContent.substring(triggerCharIndex - requiredVariable.length, triggerCharIndex) !== requiredVariable) {
+            return undefined;
+        }
+
+        const range = new monaco.Range(position.lineNumber, triggerCharIndex + 2, position.lineNumber, position.column);
+
+        // TODO consider all prompts or only custom prompts? If only custom, we might also consider this during variable resolution.
+        const prompts = this.promptService.getAllPrompts();
+        if (this.promptCustomizationService) {
+            this.promptCustomizationService.getCustomPromptTemplateIDs();
+        }
+        const allPromptIds = [...Object.keys(prompts), ...(this.promptCustomizationService?.getCustomPromptTemplateIDs() || [])];
+        allPromptIds.sort();
+
+        return allPromptIds.map(promptId => ({
+            filterText: PromptText.VARIABLE_ARG_SEPARATOR,
+            label: promptId,
+            kind: monaco.languages.CompletionItemKind.Variable,
+            insertText: promptId,
+            range
+        }));
+    }
+}

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -13,6 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
+import { nls } from '@theia/core';
 import { injectable, inject, optional } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import {
@@ -29,10 +30,10 @@ import { PromptText } from './prompt-text';
 
 export const PROMPT_VARIABLE: AIVariable = {
     id: 'prompt-provider',
-    description: 'Resolves prompt templates via the prompt service',
+    description: nls.localize('theia/ai/core/promptVariable/description', 'Resolves prompt templates via the prompt service'),
     name: 'prompt',
     args: [
-        { name: 'id', description: 'The prompt template id to resolve' }
+        { name: 'id', description: nls.localize('theia/ai/core/promptVariable/argDescription', 'The prompt template id to resolve') }
     ],
 };
 
@@ -82,7 +83,7 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
         const lineContent = model.getLineContent(position.lineNumber);
 
         // Only provide completions once the variable argument separator is typed
-        const triggerCharIndex = lineContent.lastIndexOf(PromptText.VARIABLE_ARG_SEPARATOR, position.column - 1);
+        const triggerCharIndex = lineContent.lastIndexOf(PromptText.VARIABLE_SEPARATOR_CHAR, position.column - 1);
         if (triggerCharIndex === -1) {
             return undefined;
         }
@@ -96,20 +97,26 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
 
         const range = new monaco.Range(position.lineNumber, triggerCharIndex + 2, position.lineNumber, position.column);
 
-        // TODO consider all prompts or only custom prompts? If only custom, we might also consider this during variable resolution.
-        const prompts = this.promptService.getAllPrompts();
-        if (this.promptCustomizationService) {
-            this.promptCustomizationService.getCustomPromptTemplateIDs();
-        }
-        const allPromptIds = [...Object.keys(prompts), ...(this.promptCustomizationService?.getCustomPromptTemplateIDs() || [])];
-        allPromptIds.sort();
+        const customPromptIds = this.promptCustomizationService?.getCustomPromptTemplateIDs() ?? [];
+        const builtinPromptIds = Object.keys(this.promptService.getAllPrompts());
 
-        return allPromptIds.map(promptId => ({
-            filterText: PromptText.VARIABLE_ARG_SEPARATOR,
+        const customPromptCompletions = customPromptIds.map(promptId => ({
+            label: promptId,
+            kind: monaco.languages.CompletionItemKind.Enum,
+            insertText: promptId,
+            range,
+            detail: nls.localize('theia/ai/core/promptVariable/completions/detail/custom', 'Custom prompt template'),
+            sortText: `AAA${promptId}` // Sort before everything else including all built-in prompts
+        }));
+        const builtinPromptCompletions = builtinPromptIds.map(promptId => ({
             label: promptId,
             kind: monaco.languages.CompletionItemKind.Variable,
             insertText: promptId,
-            range
+            range,
+            detail: nls.localize('theia/ai/core/promptVariable/completions/detail/builtin', 'Built-in prompt template'),
+            sortText: `AAB${promptId}` // Sort after all custom prompts but before others
         }));
+
+        return [...customPromptCompletions, ...builtinPromptCompletions];
     }
 }

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -23,7 +23,7 @@ import {
     AIVariableService,
     AIVariableResolutionRequest,
     AIVariableContext,
-    ResolvedAIContextVariable
+    ResolvedAIVariable
 } from './variable-service';
 import { PromptCustomizationService, PromptService } from './prompt-service';
 import { PromptText } from './prompt-text';
@@ -34,8 +34,7 @@ export const PROMPT_VARIABLE: AIVariable = {
     name: 'prompt',
     args: [
         { name: 'id', description: nls.localize('theia/ai/core/promptVariable/argDescription', 'The prompt template id to resolve') }
-    ],
-    isContextVariable: true
+    ]
 };
 
 @injectable()
@@ -59,13 +58,13 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
         return -1;
     }
 
-    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIContextVariable | undefined> {
+    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
         if (request.variable.name === PROMPT_VARIABLE.name) {
             const promptId = request.arg?.trim();
             if (promptId) {
                 const resolvedPrompt = await this.promptService.getPromptFragment(promptId);
                 if (resolvedPrompt) {
-                    return { variable: request.variable, value: resolvedPrompt.text, contextValue: resolvedPrompt.text };
+                    return { variable: request.variable, value: resolvedPrompt.text };
                 }
             }
         }

--- a/packages/ai-core/src/common/variable-service.ts
+++ b/packages/ai-core/src/common/variable-service.ts
@@ -137,6 +137,11 @@ export interface AIVariableResolver {
 
 export interface AIVariableResolverWithVariableDependencies extends AIVariableResolver {
     resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined>;
+    /**
+     * Resolve the given AI variable resolution request. When resolving dependencies with `resolveDependency`,
+     * add the resolved dependencies to the result's `allResolvedDependencies` list
+     * to enable consumers of the resolved variable to inspect dependencies.
+     */
     resolve(
         request: AIVariableResolutionRequest,
         context: AIVariableContext,
@@ -146,11 +151,6 @@ export interface AIVariableResolverWithVariableDependencies extends AIVariableRe
 
 function isResolverWithDependencies(resolver: AIVariableResolver | undefined): resolver is AIVariableResolverWithVariableDependencies {
     return resolver !== undefined && resolver.resolve.length >= 3;
-}
-
-interface CacheEntry {
-    promise: Promise<ResolvedAIVariable | undefined>;
-    inProgress: boolean;
 }
 
 export const AIVariableService = Symbol('AIVariableService');
@@ -174,13 +174,40 @@ export interface AIVariableService {
     unregisterArgumentCompletionProvider(variable: AIVariable, argPicker: AIVariableArgCompletionProvider): void;
     getArgumentCompletionProvider(name: string): Promise<AIVariableArgCompletionProvider | undefined>;
 
-    resolveVariable(variable: AIVariableArg, context: AIVariableContext, cache?: Map<string, CacheEntry>): Promise<ResolvedAIVariable | undefined>;
+    resolveVariable(variable: AIVariableArg, context: AIVariableContext, cache?: Map<string, ResolveAIVariableCacheEntry>): Promise<ResolvedAIVariable | undefined>;
 }
 
 /** Contributions on the frontend can optionally implement `FrontendVariableContribution`. */
 export const AIVariableContribution = Symbol('AIVariableContribution');
 export interface AIVariableContribution {
     registerVariables(service: AIVariableService): void;
+}
+
+export interface ResolveAIVariableCacheEntry {
+    promise: Promise<ResolvedAIVariable | undefined>;
+    inProgress: boolean;
+}
+
+export type ResolveAIVariableCache = Map<string, ResolveAIVariableCacheEntry>;
+/**
+ * Creates a new, empty cache for AI variable resolvement to hand into `AIVariableService.resolveVariable`.
+ */
+export function createAIResolveVariableCache(): Map<string, ResolveAIVariableCacheEntry> {
+    return new Map();
+}
+
+/** Utility function to get all resolved AI variables from a {@link ResolveAIVariableCache}  */
+export async function getAllResolvedAIVariables(cache: ResolveAIVariableCache): Promise<ResolvedAIVariable[]> {
+    const resolvedVariables: ResolvedAIVariable[] = [];
+    for (const cacheEntry of cache.values()) {
+        if (!cacheEntry.inProgress) {
+            const resolvedVariable = await cacheEntry.promise;
+            if (resolvedVariable) {
+                resolvedVariables.push(resolvedVariable);
+            }
+        }
+    }
+    return resolvedVariables;
 }
 
 @injectable()
@@ -315,7 +342,7 @@ export class DefaultAIVariableService implements AIVariableService {
     async resolveVariable(
         request: AIVariableArg,
         context: AIVariableContext,
-        cache: Map<string, CacheEntry> = new Map()
+        cache: ResolveAIVariableCache = createAIResolveVariableCache()
     ): Promise<ResolvedAIVariable | undefined> {
         // Calculate unique variable cache key from variable name and argument
         const variableName = typeof request === 'string'
@@ -337,11 +364,11 @@ export class DefaultAIVariableService implements AIVariableService {
             return existingEntry.promise;
         }
 
-        const entry: CacheEntry = { promise: Promise.resolve(undefined), inProgress: true };
+        const entry: ResolveAIVariableCacheEntry = { promise: Promise.resolve(undefined), inProgress: true };
         cache.set(cacheKey, entry);
 
-        // TODO track all resolved dependencies of resolved variables.
-        // Does this need to be done here or in resolver implementations? If here: derive from cache?
+        // Asynchronously resolves a variable, handling its dependencies while preventing cyclical resolution.
+        // Selects the appropriate resolver and resolution strategy based on whether nested dependency resolution is supported.
         const promise = (async () => {
             const variable = this.getVariable(variableName);
             if (!variable) {
@@ -358,6 +385,7 @@ export class DefaultAIVariableService implements AIVariableService {
                         this.resolveVariable(depRequest, context, cache)
                 );
             } else if (resolver) {
+                // Explicit cast needed because Typescript does not consider the method parameter length of the type guard at compile time
                 resolved = await (resolver as AIVariableResolver).resolve({ variable, arg }, context);
             } else {
                 resolved = undefined;


### PR DESCRIPTION
#### What it does

Prompt fragments allow to define parts of prompts in a reusable way. You can embed these prompts then via a variable in the chat or in our prompt templates. This also allows to have a set of prompts available in the chat without always defining a custom agent.

This PR defines a Theia Ai variable `prompt` with an argument containing the prompt fragment's id. The variable is fully resolved including variables and function calls in the fragment.

This also adds auto completion for available custom and builtin prompt fragments to the chat UI.

The variable is defined as a context variable meaning it is added to the chat context similar to referenced files. This was discussed here: https://github.com/eclipse-theia/theia/issues/14899#issuecomment-2655942388

Note that agents need to be adapted to use this from the context as explained here: https://github.com/eclipse-theia/theia/pull/14787#issuecomment-2663510081
This is not part of this PR.

[prompt-template-autocomplete.webm](https://github.com/user-attachments/assets/58ccaa80-2d27-4d11-a3ce-b03319f6096c)

Part of #14899 

#### How to test

- Configure setting `Ai-features › Prompt Templates: Prompt Templates Folder` to point to a folder of your choosing
- Create a `.prompttemplate` file in the specified folder.
- Define a prompt in the file. Ideally, it uses a variable to test that this is resolved. E.g.
  ```
  Convert the timestamp to a human readable date: {{today:inUnixSeconds}}.
  ```
- Open the AI Chat and verify that the autocompletion works (see video in `What id does`)
- Send the request and make sure that your prompt fragment is used. You can use the AI Agent History to see what was sent to the LLM

#### Follow-ups

Step 2 of #14899 implementing settings UI and editing for prompt fragments

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
