### PR TITLE
correctly set the systemPromptId in custom agents

### DIFF
--- a/packages/ai-chat/src/common/custom-chat-agent.ts
+++ b/packages/ai-chat/src/common/custom-chat-agent.ts
@@ -24,9 +24,10 @@ export class CustomChatAgent extends AbstractStreamParsingChatAgent {
     name: string = 'CustomChatAgent';
     languageModelRequirements: LanguageModelRequirement[] = [{ purpose: 'chat' }];
     protected defaultLanguageModelPurpose: string = 'chat';
-    protected override systemPromptId: string = `${this.name}_prompt`;
 
     set prompt(prompt: string) {
+        // the name is dynamic, so we set the propmptId here
+        this.systemPromptId = `${this.name}_prompt`;
         this.promptTemplates.push({ id: `${this.name}_prompt`, template: prompt });
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Fix the custom agent prompt handling. The system prompt was referencing a prompt which was never adapted.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Create a custom agent. Then change the prompt and make sure the agent changes its behavior.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
