### PR TITLE
fix: remove files in editor tab when deleted

### DIFF
--- a/packages/core/src/browser/navigatable-types.ts
+++ b/packages/core/src/browser/navigatable-types.ts
@@ -42,7 +42,7 @@ export namespace NavigatableWidget {
     export function is(arg: unknown): arg is NavigatableWidget {
         return arg instanceof BaseWidget && Navigatable.is(arg);
     }
-    export function* getAffected<T extends Widget>(
+    export function getAffected<T extends Widget>(
         widgets: Iterable<T>,
         context: MaybeArray<URI>
     ): IterableIterator<[URI, T & NavigatableWidget]> {


### PR DESCRIPTION
#### What it does
This PR solves the following issue where the editor tab of deleted files can not be closed. 
Closes https://github.com/eclipse-theia/theia/issues/13525

#### How to test

You can create a new file, open it in the editor and  delete it. Then the editor tab of this file should be closed autimatically instead of staying in the same place with "deleted" labeled. This should work for deleting several files too.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
