### PR TITLE
Pass code action provider metadata to editor

### DIFF
--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -940,7 +940,11 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
             },
             resolveCodeAction: (codeAction, token) => this.resolveCodeAction(handle, codeAction, token)
         };
-        this.register(handle, (monaco.languages.registerCodeActionProvider as RegistrationFunction<monaco.languages.CodeActionProvider>)(languageSelector, quickFixProvider));
+        this.register(handle,
+            monaco.languages.registerCodeActionProvider(languageSelector, quickFixProvider, {
+                documentation: documentation,
+                providedCodeActionKinds
+            }));
     }
 
     protected async provideCodeActions(


### PR DESCRIPTION
#### What it does
This PR passes the `CodeActionProviderMetadata` information from plugins through to the monaco editor. This causes the context key for `supportedCodeAction` to be set correctly and thus enables the related commands like "Organize Imports".

Partial fix of #14955


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open a typescript file with a bunch of imports. 
2. Wait for the typescript extension to start up
3. Open the command palette and make sure "Organize Imports" is available as a command.
4. Hit "alt-shift-o" and observe the imports being reorganized

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
