### PR TITLE
fix: provide open handler for quick file open

### DIFF
--- a/packages/file-search/src/browser/quick-file-select-service.ts
+++ b/packages/file-search/src/browser/quick-file-select-service.ts
@@ -109,7 +109,7 @@ export class QuickFileSelectService {
                             label: nls.localizeByDefault('recently opened')
                         });
                     }
-                    const item = this.toItem(fileFilter, location.uri);
+                    const item = this.toItem(fileFilter, location.uri, options.onSelect);
                     recentlyUsedItems.push(item);
                     alreadyCollected.add(uriString);
                 }


### PR DESCRIPTION
#### What it does

Adds the open handler also for recent files when creating the quick pick item. This was an oversight in the refactoring that was part of #14787.

Fixes https://github.com/eclipse-theia/theia/issues/15002

#### How to test

Check if the steps reported in #15002 now work correctly.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
