### PR TITLE
Support anyOf in function parameters

### DIFF
--- a/packages/ai-core/src/node/tool-request-parameters.spec.ts
+++ b/packages/ai-core/src/node/tool-request-parameters.spec.ts
@@ -1,0 +1,121 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { expect } from 'chai';
+import { ToolRequest } from '../common/language-model';
+
+describe('isToolRequestParameters', () => {
+    it('should return true for valid ToolRequestParameters', () => {
+        const validParams = {
+            type: 'object',
+            properties: {
+                param1: {
+                    type: 'string'
+                },
+                param2: {
+                    type: 'number'
+                }
+            },
+            required: ['param1']
+        };
+        expect(ToolRequest.isToolRequestParameters(validParams)).to.be.true;
+    });
+
+    it('should return false for ToolRequestParameters without type or anyOf', () => {
+        const paramsWithoutType = {
+            properties: {
+                param1: {
+                    description: 'string'
+                }
+            },
+            required: ['param1']
+        };
+        expect(ToolRequest.isToolRequestParameters(paramsWithoutType)).to.be.false;
+    });
+
+    it('should return false for invalid ToolRequestParameters with wrong property type', () => {
+        const invalidParams = {
+            type: 'object',
+            properties: {
+                param1: {
+                    type: 123
+                }
+            }
+        };
+        expect(ToolRequest.isToolRequestParameters(invalidParams)).to.be.false;
+    });
+
+    it('should return false if properties is not an object', () => {
+        const invalidParams = {
+            type: 'object',
+            properties: 'not-an-object',
+        };
+        expect(ToolRequest.isToolRequestParameters(invalidParams)).to.be.false;
+    });
+
+    it('should return true if required is missing', () => {
+        const missingRequiredParams = {
+            type: 'object',
+            properties: {
+                param1: {
+                    type: 'string'
+                }
+            }
+        };
+        expect(ToolRequest.isToolRequestParameters(missingRequiredParams)).to.be.true;
+    });
+
+    it('should return false if required is not an array', () => {
+        const invalidRequiredParams = {
+            type: 'object',
+            properties: {
+                param1: {
+                    type: 'string'
+                }
+            },
+            required: 'param1'
+        };
+        expect(ToolRequest.isToolRequestParameters(invalidRequiredParams)).to.be.false;
+    });
+
+    it('should return false if a required field is not a string', () => {
+        const invalidRequiredParams = {
+            type: 'object',
+            properties: {
+                param1: {
+                    type: 'string'
+                }
+            },
+            required: [123]
+        };
+        expect(ToolRequest.isToolRequestParameters(invalidRequiredParams)).to.be.false;
+    });
+
+    it('should validate properties with anyOf correctly', () => {
+        const paramsWithAnyOf = {
+            type: 'object',
+            properties: {
+                param1: {
+                    anyOf: [
+                        { type: 'string' },
+                        { type: 'number' }
+                    ]
+                }
+            },
+            required: ['param1']
+        };
+        expect(ToolRequest.isToolRequestParameters(paramsWithAnyOf)).to.be.true;
+    });
+});

--- a/packages/ai-ollama/src/node/ollama-language-model.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.ts
@@ -23,7 +23,8 @@ import {
     LanguageModelStreamResponse,
     LanguageModelStreamResponsePart,
     ToolCall,
-    ToolRequest
+    ToolRequest,
+    ToolRequestParametersProperties
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { ChatRequest, ChatResponse, Message, Ollama, Options, Tool } from 'ollama';
@@ -200,16 +201,21 @@ export class OllamaModel implements LanguageModel {
     }
 
     protected toOllamaTool(tool: ToolRequest): ToolWithHandler {
-        const transform = (props: Record<string, { [key: string]: unknown; type: string; }> | undefined) => {
+        const transform = (props: ToolRequestParametersProperties | undefined) => {
             if (!props) {
                 return undefined;
             }
             const result: Record<string, { type: string, description: string }> = {};
             for (const key in props) {
                 if (Object.prototype.hasOwnProperty.call(props, key)) {
-                    result[key] = {
-                        type: props[key].type,
-                        description: key
+                    const type = props[key].type;
+                    if (!type) {
+                        // Todo: Should handle anyOf, but this is not supported by the Ollama type yet
+                    } else {
+                        result[key] = {
+                            type: type,
+                            description: key
+                        };
                     };
                 }
             }


### PR DESCRIPTION
Fixed #15011

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Added support for `anyOf` types in function parameters.
- Added new test cases for validation.
- Ignore anyOf properties in Ollama, as they are not supported by their Schema

#### How to test

- Use functions in general
- Use the "createBranch" function of the [MCP Git server](https://github.com/modelcontextprotocol/servers/blob/main/src/git/README.md)

#### Follow-ups

We might consider to switch the property type to JSONSchema, as define by openAI, but we already have compatibility issues with Ollama now.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
