### PR TITLE
Handle the case where the editor model is set to null

### DIFF
--- a/packages/console/src/browser/console-widget.ts
+++ b/packages/console/src/browser/console-widget.ts
@@ -175,6 +175,10 @@ export class ConsoleWidget extends BaseWidget implements StatefulWidget {
 
     get consoleNavigationForwardEnabled(): boolean {
         const editor = this.input.getControl();
+        const model = editor.getModel();
+        if (!model) {
+            return false;
+        }
         const lineNumber = editor.getModel()!.getLineCount();
         const column = editor.getModel()!.getLineMaxColumn(lineNumber);
         return !!editor.getPosition()!.equals({ lineNumber, column });

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -347,6 +347,10 @@ export class DebugConfigurationManager {
             return;
         }
         const editor = widget.editor.getControl();
+        const editorModel = editor.getModel();
+        if (!editorModel) {
+            return;
+        }
         const commandService = StandaloneServices.get(ICommandService);
         let position: monaco.Position | undefined;
         let depthInArray = 0;
@@ -357,7 +361,7 @@ export class DebugConfigurationManager {
             },
             onArrayBegin: offset => {
                 if (lastProperty === 'configurations' && depthInArray === 0) {
-                    position = editor.getModel()!.getPositionAt(offset + 1);
+                    position = editorModel!.getPositionAt(offset + 1);
                 }
                 depthInArray++;
             },
@@ -369,12 +373,12 @@ export class DebugConfigurationManager {
             return;
         }
         // Check if there are more characters on a line after a "configurations": [, if yes enter a newline
-        if (editor.getModel()!.getLineLastNonWhitespaceColumn(position.lineNumber) > position.column) {
+        if (editorModel.getLineLastNonWhitespaceColumn(position.lineNumber) > position.column) {
             editor.setPosition(position);
             editor.trigger('debug', 'lineBreakInsert', undefined);
         }
         // Check if there is already an empty line to insert suggest, if yes just place the cursor
-        if (editor.getModel()!.getLineLastNonWhitespaceColumn(position.lineNumber + 1) === 0) {
+        if (editorModel!.getLineLastNonWhitespaceColumn(position.lineNumber + 1) === 0) {
             editor.setPosition({ lineNumber: position.lineNumber + 1, column: 1 << 30 });
             await commandService.executeCommand('editor.action.deleteLines');
         }

--- a/packages/debug/src/browser/editor/debug-editor-service.ts
+++ b/packages/debug/src/browser/editor/debug-editor-service.ts
@@ -57,7 +57,7 @@ export class DebugEditorService {
         if (!(editor instanceof MonacoEditor)) {
             return;
         }
-        const uri = editor.getControl().getModel()!.uri.toString();
+        const uri = editor.getResourceUri().toString();
         const debugModel = this.factory(editor);
         this.models.set(uri, debugModel);
         editor.getControl().onDidDispose(() => {
@@ -134,7 +134,7 @@ export class DebugEditorService {
         const { model } = this;
         if (model) {
             const selection = model.editor.getControl().getSelection()!;
-            return !!model.editor.getControl().getModel()!.getWordAtPosition(selection.getStartPosition());
+            return !!model.editor.getControl().getModel()?.getWordAtPosition(selection.getStartPosition());
         }
         return false;
     }

--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -196,24 +196,25 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
                 }
             }
         } else { // use fallback if no provider was registered
-            matchingExpression = this.expressionProvider.get(this.editor.getControl().getModel()!, options.selection);
-            if (matchingExpression) {
-                const expressionLineContent = this.editor
-                    .getControl()
-                    .getModel()!
-                    .getLineContent(this.options.selection.startLineNumber);
-                const startColumn =
-                    expressionLineContent.indexOf(
-                        matchingExpression,
-                        this.options.selection.startColumn - matchingExpression.length
-                    ) + 1;
-                const endColumn = startColumn + matchingExpression.length;
-                this.options.selection = new monaco.Range(
-                    this.options.selection.startLineNumber,
-                    startColumn,
-                    this.options.selection.startLineNumber,
-                    endColumn
-                );
+            const model = this.editor.getControl().getModel();
+            if (model) {
+
+                matchingExpression = this.expressionProvider.get(model, options.selection);
+                if (matchingExpression) {
+                    const expressionLineContent = model.getLineContent(this.options.selection.startLineNumber);
+                    const startColumn =
+                        expressionLineContent.indexOf(
+                            matchingExpression,
+                            this.options.selection.startColumn - matchingExpression.length
+                        ) + 1;
+                    const endColumn = startColumn + matchingExpression.length;
+                    this.options.selection = new monaco.Range(
+                        this.options.selection.startLineNumber,
+                        startColumn,
+                        this.options.selection.startLineNumber,
+                        endColumn
+                    );
+                }
             }
         }
 
@@ -263,7 +264,7 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
     }
 
     protected isEditorFrame(): boolean {
-        return this.sessions.isCurrentEditorFrame(this.editor.getControl().getModel()!.uri);
+        return this.sessions.isCurrentEditorFrame(this.editor.getResourceUri());
     }
 
     getPosition(): monaco.editor.IContentWidgetPosition {

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -559,10 +559,8 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
         const toPosition = (line: number): monaco.Position => this.p2m.asPosition({ line, character: 0 });
         const start = toPosition(startLineNumber).lineNumber;
         const end = toPosition(endLineNumber).lineNumber;
-        return this.editor
-            .getModel()!
-            .getLinesDecorations(start, end)
-            .map(this.toEditorDecoration.bind(this));
+        return this.editor.getModel()?.getLinesDecorations(start, end)
+            .map(this.toEditorDecoration.bind(this)) || [];
     }
 
     protected toEditorDecoration(decoration: monaco.editor.IModelDecoration): EditorDecoration & Readonly<{ id: string }> {


### PR DESCRIPTION
#### What it does
Because the monaco editor does not work correctly when hidden with `display: none` we are removing the editor model from the editor when hidden. Unfortunately, some of our code relied on the model being non-null, despite the API saying otherwise. This PR introduces code handling the case.

Fixes #14996

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Makes sure the changed code still works, mostly the cases are in the debugger like breakpoints or editing launch configurations.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
