### PR TITLE
[vscode] introduction of the CommentingRange type

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -729,7 +729,7 @@ export interface CommentThread {
     extensionId?: string;
     threadId: string;
     resource: string | null;
-    range: Range;
+    range: Range | undefined;
     label: string | undefined;
     contextValue: string | undefined;
     comments: Comment[] | undefined;
@@ -738,7 +738,7 @@ export interface CommentThread {
     state?: CommentThreadState;
     input?: CommentInput;
     onDidChangeInput: TheiaEvent<CommentInput | undefined>;
-    onDidChangeRange: TheiaEvent<Range>;
+    onDidChangeRange: TheiaEvent<Range | undefined>;
     onDidChangeLabel: TheiaEvent<string | undefined>;
     onDidChangeState: TheiaEvent<CommentThreadState | undefined>;
     onDidChangeCollapsibleState: TheiaEvent<CommentThreadCollapsibleState | undefined>;
@@ -771,6 +771,7 @@ export interface CommentThreadChangedEvent {
 export interface CommentingRanges {
     readonly resource: URI;
     ranges: Range[];
+    fileComments: boolean;
 }
 
 export interface CommentInfo {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2069,10 +2069,10 @@ export interface ClipboardMain {
 }
 
 export interface CommentsExt {
-    $createCommentThreadTemplate(commentControllerHandle: number, uriComponents: UriComponents, range: Range): void;
+    $createCommentThreadTemplate(commentControllerHandle: number, uriComponents: UriComponents, range: Range | undefined): void;
     $updateCommentThreadTemplate(commentControllerHandle: number, threadHandle: number, range: Range): Promise<void>;
     $deleteCommentThread(commentControllerHandle: number, commentThreadHandle: number): Promise<void>;
-    $provideCommentingRanges(commentControllerHandle: number, uriComponents: UriComponents, token: CancellationToken): Promise<Range[] | undefined>;
+    $provideCommentingRanges(commentControllerHandle: number, uriComponents: UriComponents, token: CancellationToken): Promise<{ ranges: Range[]; fileComments: boolean } | undefined>;
 }
 
 export interface CommentProviderFeatures {
@@ -2093,7 +2093,7 @@ export interface CommentsMain {
     $registerCommentController(handle: number, id: string, label: string): void;
     $unregisterCommentController(handle: number): void;
     $updateCommentControllerFeatures(handle: number, features: CommentProviderFeatures): void;
-    $createCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: Range, extensionId: string): CommentThread | undefined;
+    $createCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: Range | undefined, extensionId: string): CommentThread | undefined;
     $updateCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, changes: CommentThreadChanges): void;
     $deleteCommentThread(handle: number, commentThreadHandle: number): void;
     $onDidCommentThreadsChange(handle: number, event: CommentThreadChangedEvent): void;

--- a/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
@@ -73,7 +73,7 @@ export class CommentThreadWidget extends BaseWidget {
         this.toDispose.push(this.commentGlyphWidget = new CommentGlyphWidget(editor));
         this.toDispose.push(this._commentThread.onDidChangeCollapsibleState(state => {
             if (state === CommentThreadCollapsibleState.Expanded && !this.isExpanded) {
-                const lineNumber = this._commentThread.range.startLineNumber;
+                const lineNumber = this._commentThread.range?.startLineNumber ?? 0;
 
                 this.display({ afterLineNumber: lineNumber, afterColumn: 1, heightInLines: 2 });
                 return;
@@ -256,8 +256,8 @@ export class CommentThreadWidget extends BaseWidget {
         const frameThickness = Math.round(lineHeight / 9) * 2;
         const body = this.zoneWidget.containerNode.getElementsByClassName('body')[0];
 
-        const computedLinesNumber = Math.ceil((headHeight + body.clientHeight + arrowHeight + frameThickness + 8 /** margin bottom to avoid margin collapse */) / lineHeight);
-        this.zoneWidget.show({ afterLineNumber: this._commentThread.range.startLineNumber, heightInLines: computedLinesNumber });
+        const computedLinesNumber = Math.ceil((headHeight + body?.clientHeight + arrowHeight + frameThickness + 8 /** margin bottom to avoid margin collapse */) / lineHeight);
+        this.zoneWidget.show({ afterLineNumber: this._commentThread.range?.startLineNumber ?? 0, heightInLines: computedLinesNumber });
     }
 
     protected render(): void {
@@ -588,7 +588,8 @@ export class CommentEditContainer extends React.Component<CommentEditContainer.P
                 {menus.getMenu(COMMENT_CONTEXT).children.map((node, index) => {
                     const onClick = () => {
                         commands.executeCommand(node.id, {
-                            thread: commentThread,
+                            commentControlHandle: commentThread.controllerHandle,
+                            commentThreadHandle: commentThread.commentThreadHandle,
                             commentUniqueId: comment.uniqueIdInThread,
                             text: this.inputRef.current ? this.inputRef.current.value : ''
                         });
@@ -623,7 +624,8 @@ export class CommentsInlineAction extends React.Component<CommentsInlineAction.P
                 title={node.label}
                 onClick={() => {
                     commands.executeCommand(node.id, {
-                        thread: commentThread,
+                        commentControlHandle: commentThread.controllerHandle,
+                        commentThreadHandle: commentThread.commentThreadHandle,
                         commentUniqueId
                     });
                 }} />
@@ -651,8 +653,10 @@ export class CommentActions extends React.Component<CommentActions.Props> {
                     commands={commands}
                     node={node}
                     onClick={() => {
+                        console.log('CommentActions.onClick: ' + commentThread);
                         commands.executeCommand(node.id, {
-                            thread: commentThread,
+                            commentControlHandle: commentThread.controllerHandle,
+                            commentThreadHandle: commentThread.commentThreadHandle,
                             text: getInput()
                         });
                         clearInput();

--- a/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
@@ -256,7 +256,8 @@ export class CommentThreadWidget extends BaseWidget {
         const frameThickness = Math.round(lineHeight / 9) * 2;
         const body = this.zoneWidget.containerNode.getElementsByClassName('body')[0];
 
-        const computedLinesNumber = Math.ceil((headHeight + body?.clientHeight + arrowHeight + frameThickness + 8 /** margin bottom to avoid margin collapse */) / lineHeight);
+        const computedLinesNumber = Math.ceil((headHeight + (body?.clientHeight ?? 0) + arrowHeight + frameThickness + 8 /** margin bottom to avoid margin collapse */)
+            / lineHeight);
         this.zoneWidget.show({ afterLineNumber: this._commentThread.range?.startLineNumber ?? 0, heightInLines: computedLinesNumber });
     }
 
@@ -653,7 +654,6 @@ export class CommentActions extends React.Component<CommentActions.Props> {
                     commands={commands}
                     node={node}
                     onClick={() => {
-                        console.log('CommentActions.onClick: ' + commentThread);
                         commands.executeCommand(node.id, {
                             commentControlHandle: commentThread.controllerHandle,
                             commentThreadHandle: commentThread.commentThreadHandle,

--- a/packages/plugin-ext/src/main/browser/comments/comments-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/comments/comments-contribution.ts
@@ -196,7 +196,7 @@ export class CommentsContribution {
                 this.commentsContextKeyService.commentController.set(provider.id);
             }
             const zoneWidget = new CommentThreadWidget(editor, owner, thread, this.commentService, this.menus, this.commentsContextKeyService, this.commands);
-            zoneWidget.display({ afterLineNumber: thread.range.startLineNumber, heightInLines: 5 });
+            zoneWidget.display({ afterLineNumber: thread.range?.startLineNumber ?? 0, heightInLines: 5 }); // messages with no range are put on top of the editor
             const currentEditor = this.getCurrentEditor();
             if (currentEditor) {
                 currentEditor.onDispose(() => zoneWidget.dispose());

--- a/packages/plugin-ext/src/main/browser/comments/comments-service.ts
+++ b/packages/plugin-ext/src/main/browser/comments/comments-service.ts
@@ -190,15 +190,17 @@ export class PluginCommentService implements CommentsService {
     }
 
     async getCommentingRanges(resource: URI): Promise<Range[]> {
-        const commentControlResult: Promise<Range[]>[] = [];
+        const commentControlResult: Promise<{ ranges: Range[]; fileComments: boolean } | undefined>[] = [];
 
         this.commentControls.forEach(control => {
             commentControlResult.push(control.getCommentingRanges(resource, CancellationToken.None));
         });
 
         const ret = await Promise.all(commentControlResult);
-        return ret.reduce((prev, curr) => {
-            prev.push(...curr);
+        return ret.reduce<Range[]>((prev, curr) => {
+            if (curr) {
+                prev.push(...curr.ranges);
+            }
             return prev;
         }, []);
     }

--- a/packages/plugin-ext/src/plugin/comments.ts
+++ b/packages/plugin-ext/src/plugin/comments.ts
@@ -177,15 +177,7 @@ export class CommentsExtImpl implements CommentsExt {
 
         const documentData = this._documents.getDocumentData(URI.revive(uriComponents));
         if (documentData) {
-            const commentingRanges:
-                | theia.Range[]
-                | theia.CommentingRanges
-                | undefined
-                | null =
-                await commentController.commentingRangeProvider!.provideCommentingRanges(
-                    documentData.document,
-                    token
-                );
+            const commentingRanges = await commentController.commentingRangeProvider!.provideCommentingRanges(documentData.document, token);
             if (isArray(commentingRanges)) {
                 return {
                     ranges: commentingRanges.map(x => fromRange(x)),
@@ -196,8 +188,6 @@ export class CommentsExtImpl implements CommentsExt {
                     ranges: commentingRanges.ranges?.map(x => fromRange(x)) || [],
                     fileComments: commentingRanges.enableFileComments
                 };
-            } else {
-                return commentingRanges ?? undefined;
             }
         }
         return undefined;
@@ -244,16 +234,16 @@ export class ExtHostCommentThread implements theia.CommentThread, theia.Disposab
     private readonly _onDidUpdateCommentThread = new Emitter<void>();
     readonly onDidUpdateCommentThread = this._onDidUpdateCommentThread.event;
 
-    set range(range: theia.Range) {
-        if ( ((range === undefined) !== (this._range === undefined))
-            || (range && !range.isEqual(this._range))) {
+    set range(range: theia.Range | undefined) {
+        if (((range === undefined) !== (this._range === undefined))
+            || (range && this._range && !range.isEqual(this._range))) {
             this._range = range;
             this.modifications.range = range;
             this._onDidUpdateCommentThread.fire();
         }
     }
 
-    get range(): theia.Range {
+    get range(): theia.Range | undefined {
         return this._range;
     }
 
@@ -345,7 +335,7 @@ export class ExtHostCommentThread implements theia.CommentThread, theia.Disposab
         private commentController: CommentController,
         private _id: string | undefined,
         private _uri: theia.Uri,
-        private _range: theia.Range,
+        private _range: theia.Range | undefined,
         private _comments: theia.Comment[],
         extensionId: string
     ) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -13744,9 +13744,10 @@ export module '@theia/plugin' {
 
         /**
          * The range the comment thread is located within the document. The thread icon will be shown
-         * at the first line of the range.
+         * at the last line of the range. When set to undefined, the comment will be associated with the
+         * file, and not a specific range.
          */
-        range: Range;
+        range: Range | undefined;
 
         /**
          * The ordered comments of the thread.
@@ -13922,13 +13923,28 @@ export module '@theia/plugin' {
     }
 
     /**
+     * The ranges a CommentingRangeProvider enables commenting on.
+     */
+    export interface CommentingRanges {
+        /**
+         * Enables comments to be added to a file without a specific range.
+         */
+        enableFileComments: boolean;
+
+        /**
+         * The ranges which allow new comment threads creation.
+         */
+        ranges?: Range[];
+    }
+
+    /**
      * Commenting range provider for a {@link CommentController comment controller}.
      */
     export interface CommentingRangeProvider {
         /**
          * Provide a list of ranges which allow new comment threads creation or null for a given document
          */
-        provideCommentingRanges(document: TextDocument, token: CancellationToken): ProviderResult<Range[]>;
+        provideCommentingRanges(document: TextDocument, token: CancellationToken): ProviderResult<Range[] | CommentingRanges>;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Introduce the support for Commenting Ranges and capability to create comments on file rather than on a specific range.

also it fixes the creation of comments, with arguments passed to the command being the one expected by argument processor

fix #14941

It is interesting to note that commenting range is supported, but the API do not let the extensions create Thread with not range (see https://github.com/microsoft/vscode/blob/c5549bc00e5f2e17773e9cffa694996fff318772/src/vscode-dts/vscode.d.ts#L17413). So this is hard to test and debug, even on vscode itself... For now, theia code support the ranges to be undefined, but it is not possible to test at runtime. Weird!

#### How to test

Steps to test:
1. Install this extension to test the feature on comparing markdown or typescript files (commenting ruler is available on Theia on diff comparator):
- src:[comment-sample-0.0.4-src.zip](https://github.com/user-attachments/files/18940465/comment-sample-0.0.4-src.zip)
- zip vsix: [vscode-comment-api-example-0.0.4.zip](https://github.com/user-attachments/files/18940456/vscode-comment-api-example-0.0.4.zip)
Using this extension, you get 2 comment providers: 
- the markdown (*.md files) comment controller provide 10 lines range every 20 lines and also allow file comments, 
- the typescript (*.ts files) allow commenting on every line. 

2. Open the comparison between 2 files (for example, 2 typescript files or 2 markdown files using **_compare with each other_** menu

3. You can see in the diff editor the comment gutter (grey bar) on the side of the text editors, you can create a comment while clicking on the gutter. Notice that the md files have a gutter that is starting every 20 lines for a length of 10 lines. ts files have a gutter for the whole file length.

![comment-sample-extension-ranges](https://github.com/user-attachments/assets/84b928d6-0ad8-4b59-a516-71565ef6c457)

The UI seems currently broken on comments, I commented on a followup issue for comments action and UI: https://github.com/eclipse-theia/theia/issues/12452.  (css are bad, actions do no support the 'when' condition, etc.). But this is not relevant for this API implementation

#### Follow-ups

Improvements on Comment support: 

Improvements on buttons and UI: #12452

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
