### PR TITLE
Expand local variables by default

### DIFF
--- a/packages/core/src/browser/source-tree/source-tree.ts
+++ b/packages/core/src/browser/source-tree/source-tree.ts
@@ -49,9 +49,10 @@ export class SourceTree extends TreeImpl {
         const existing = this.getNode(id);
         const updated = existing && <TreeElementNode>Object.assign(existing, { element, parent });
         if (CompositeTreeElement.hasElements(element)) {
+            const expand = element.expandByDefault ? element.expandByDefault() : false;
             if (updated) {
                 if (!ExpandableTreeNode.is(updated)) {
-                    Object.assign(updated, { expanded: false });
+                    Object.assign(updated, { expanded: expand });
                 }
                 if (!CompositeTreeNode.is(updated)) {
                     Object.assign(updated, { children: [] });
@@ -64,7 +65,7 @@ export class SourceTree extends TreeImpl {
                 id,
                 name,
                 selected: false,
-                expanded: false,
+                expanded: expand,
                 children: []
             } as TreeElementNode;
         }

--- a/packages/core/src/browser/source-tree/tree-source.ts
+++ b/packages/core/src/browser/source-tree/tree-source.ts
@@ -34,6 +34,7 @@ export interface CompositeTreeElement extends TreeElement {
     /** default: true */
     readonly hasElements?: boolean
     getElements(): MaybePromise<IterableIterator<TreeElement>>
+    expandByDefault?(): boolean
 }
 export namespace CompositeTreeElement {
     export function is(element: unknown): element is CompositeTreeElement {

--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -386,4 +386,8 @@ export class DebugScope extends ExpressionContainer {
         return this.raw.name;
     }
 
+    expandByDefault(): boolean {
+        return this.raw.presentationHint === 'locals';
+    }
+
 }


### PR DESCRIPTION
#### What it does

Looking at the local variables is a very comon thing. In Theia, the local variables are not visible when starting to debug. This PR will expand the local variables, so they become visible when starting to debug.

Fixes #14738

#### How to test

* Open a Javascript/Python file in Theia
* Set a breakpoint and start debugging it
* When the execution stops at the breakpoint, the local variables should be visible in the debug activity bar without needing to expand them.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
