### PR TITLE
fix(chat): prevent focus outline color of AI chat

### DIFF
--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -405,6 +405,10 @@ div:last-child > .theia-ChatNode {
   border-color: var(--theia-focusBorder);
 }
 
+.theia-ChatInput-Editor-Box .monaco-editor {
+  outline-color: var(--theia-editor-background);
+}
+
 .theia-ChatInput-Editor {
   width: 100%;
   height: auto;
@@ -493,7 +497,7 @@ div:last-child > .theia-ChatNode {
 }
 
 .theia-ChatInputOptions .reverse {
-    flex-direction: row-reverse;
+  flex-direction: row-reverse;
 }
 
 .theia-CodePartRenderer-root {


### PR DESCRIPTION
#### What it does

In some focus scenarios, the Monaco editor in the chat got a focus-colored outline, which we want to avoid, as we are putting the focus color outline on the overall widget containing the Monaco editor.

#### How to test

Focus the AI chat and ensure the editor never recieves an own outline color (which was sometimes visible below the Monaco editor).


#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
