### PR TITLE
Consolidate the variables we provide in the chat

### DIFF
--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -24,6 +24,9 @@ import { AIVariableContribution, AIVariableResolver, AIVariableService, AIVariab
  */
 @injectable()
 export class TheiaVariableContribution implements AIVariableContribution, AIVariableResolver {
+
+    private static readonly THEIA_PREFIX = 'theia-';
+
     @inject(VariableResolverService)
     protected readonly variableResolverService: VariableResolverService;
 
@@ -77,7 +80,7 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
                         : nls.localize('theia/ai/core/variable-contribution/builtInVariable', 'Theia Built-in Variable'));
 
                 service.registerResolver({
-                    id: `theia-${variable.name}`,
+                    id: `${TheiaVariableContribution.THEIA_PREFIX}${variable.name}`,
                     name: newName,
                     description: newDescription
                 }, this);
@@ -86,13 +89,14 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
     }
 
     protected toTheiaVariable(request: AIVariableResolutionRequest): string {
-        // Remove the 'theia-' prefix if present before constructing the variable string
-        const variableId = request.variable.id.startsWith('theia-') ? request.variable.id.slice(6) : request.variable.id;
+        // Remove the THEIA_PREFIX if present before constructing the variable string
+        const variableId = request.variable.id.startsWith(TheiaVariableContribution.THEIA_PREFIX) ? request.variable.id.slice(TheiaVariableContribution.THEIA_PREFIX.length) :
+            request.variable.id;
         return `\${${variableId}${request.arg ? ':' + request.arg : ''}}`;
     }
 
     async canResolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<number> {
-        if (!request.variable.id.startsWith('theia-')) {
+        if (!request.variable.id.startsWith(TheiaVariableContribution.THEIA_PREFIX)) {
             return 0;
         }
         // some variables are not resolvable without providing a specific context

--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -41,7 +41,7 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
             currently opened file. Please note that most agents will expect a relative file path (relative to the current workspace).')
         }],
         ['selectedText', {
-            name: 'currentSelectedText', description: nls.localize('theia/ai/core/variable-contribution/currentSelectedText', 'The plain text that is currently selected in the \
+            description: nls.localize('theia/ai/core/variable-contribution/currentSelectedText', 'The plain text that is currently selected in the \
             opened file. This excludes the information where the content is coming from. Please note that most agents will work better with a relative file path \
             (relative to the current workspace).')
         }],


### PR DESCRIPTION
fixed #15019

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Removed the following variables contributed by Theia:
- command
- config
- cwd
- env
- execPath
- fileBasename
- fileBasenameNoExtension
- fileDirname
- fileExtname
- input
- pathSeparator
- workspaceFolderBasename
- workspaceRoot
- workspaceRootFolderName

Named remaning variables more consistently and added better descriptions
Only resolve Theia variables, if the start with "theia-" => This might have led to issues before

#### How to test

Resolved all remaining variables, e.g. by mentioning them in the chat and watching the output. Also check prompt variable usage.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
