### PR TITLE
Add variable completion for {{}} syntax in prompttemplate

### DIFF
--- a/packages/ai-chat/src/browser/file-chat-variable-contribution.ts
+++ b/packages/ai-chat/src/browser/file-chat-variable-contribution.ts
@@ -69,10 +69,11 @@ export class FileChatVariableContribution implements FrontendVariableContributio
 
     protected async provideArgumentCompletionItems(
         model: monaco.editor.ITextModel,
-        position: monaco.Position
+        position: monaco.Position,
+        matchString?: string
     ): Promise<monaco.languages.CompletionItem[] | undefined> {
         const lineContent = model.getLineContent(position.lineNumber);
-        const indexOfVariableTrigger = lineContent.lastIndexOf(PromptText.VARIABLE_CHAR, position.column - 1);
+        const indexOfVariableTrigger = lineContent.lastIndexOf(matchString ?? PromptText.VARIABLE_CHAR, position.column - 1);
 
         // check if there is a variable trigger and no space typed between the variable trigger and the cursor
         if (indexOfVariableTrigger === -1 || lineContent.substring(indexOfVariableTrigger).includes(' ')) {
@@ -86,7 +87,8 @@ export class FileChatVariableContribution implements FrontendVariableContributio
         const typedWord = lineContent.substring(triggerCharIndex + 1, position.column - 1);
         const range = new monaco.Range(position.lineNumber, triggerCharIndex + 2, position.lineNumber, position.column);
         const picks = await this.quickFileSelectService.getPicks(typedWord, CancellationToken.None);
-        const prefix = lineContent[triggerCharIndex] === PromptText.VARIABLE_CHAR ? FILE_VARIABLE.name + PromptText.VARIABLE_SEPARATOR_CHAR : '';
+        const matchVariableChar = lineContent[triggerCharIndex] === matchString ? matchString : PromptText.VARIABLE_CHAR;
+        const prefix = matchVariableChar ? FILE_VARIABLE.name + PromptText.VARIABLE_SEPARATOR_CHAR : '';
 
         return Promise.all(
             picks

--- a/packages/ai-chat/src/browser/file-chat-variable-contribution.ts
+++ b/packages/ai-chat/src/browser/file-chat-variable-contribution.ts
@@ -87,7 +87,7 @@ export class FileChatVariableContribution implements FrontendVariableContributio
         const typedWord = lineContent.substring(triggerCharIndex + 1, position.column - 1);
         const range = new monaco.Range(position.lineNumber, triggerCharIndex + 2, position.lineNumber, position.column);
         const picks = await this.quickFileSelectService.getPicks(typedWord, CancellationToken.None);
-        const matchVariableChar = lineContent[triggerCharIndex] === matchString ? matchString : PromptText.VARIABLE_CHAR;
+        const matchVariableChar = lineContent[triggerCharIndex] === (matchString ? matchString : PromptText.VARIABLE_CHAR);
         const prefix = matchVariableChar ? FILE_VARIABLE.name + PromptText.VARIABLE_SEPARATOR_CHAR : '';
 
         return Promise.all(

--- a/packages/ai-core/src/common/variable-service.ts
+++ b/packages/ai-core/src/common/variable-service.ts
@@ -128,7 +128,8 @@ export interface AIVariableContext {
 export type AIVariableArg = string | { variable: string, arg?: string } | AIVariableResolutionRequest;
 
 export type AIVariableArgPicker = (context: AIVariableContext) => MaybePromise<string | undefined>;
-export type AIVariableArgCompletionProvider = (model: monaco.editor.ITextModel, position: monaco.Position) => MaybePromise<monaco.languages.CompletionItem[] | undefined>;
+export type AIVariableArgCompletionProvider =
+    (model: monaco.editor.ITextModel, position: monaco.Position, matchString?: string) => MaybePromise<monaco.languages.CompletionItem[] | undefined>;
 
 export interface AIVariableResolver {
     canResolve(request: AIVariableResolutionRequest, context: AIVariableContext): MaybePromise<number>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Add variable autocomplete support for `{{}}` and `{{{}}}` syntax in prompttemplate

fixes: #15202

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Open the prompt template editor, eg for custom editors and try to use a variable. Using `#{` you get an autocompletion.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
