### PR TITLE
style: inputselect of memory inspector ui enhanced

### DIFF
--- a/packages/memory-inspector/src/browser/style/index.css
+++ b/packages/memory-inspector/src/browser/style/index.css
@@ -25,13 +25,13 @@
 }
 
 .memory-view-icon {
-  -webkit-mask: url("memory-view.svg");
-  mask: url("memory-view.svg");
+  -webkit-mask: url('memory-view.svg');
+  mask: url('memory-view.svg');
 }
 
 .register-view-icon {
-  -webkit-mask: url("register-view.svg");
-  mask: url("register-view.svg");
+  -webkit-mask: url('register-view.svg');
+  mask: url('register-view.svg');
 }
 
 .memory-view-icon.toolbar,
@@ -50,13 +50,13 @@
 }
 
 .memory-lock-icon {
-  -webkit-mask: url("memory-lock.svg");
-  mask: url("memory-lock.svg");
+  -webkit-mask: url('memory-lock.svg');
+  mask: url('memory-lock.svg');
 }
 
 .register-lock-icon {
-  -webkit-mask: url("register-lock.svg");
-  mask: url("register-lock.svg");
+  -webkit-mask: url('register-lock.svg');
+  mask: url('register-lock.svg');
 }
 
 .t-mv-container {
@@ -382,7 +382,7 @@ table.t-mv-view .t-mv-view-address {
 }
 
 .t-mv-variable-label:not(:last-of-type)::after {
-  content: ",";
+  content: ',';
   margin-right: var(--theia-ui-padding);
   color: var(--theia-editor-foreground);
 }
@@ -394,8 +394,11 @@ table.t-mv-view .t-mv-view-address {
 
 .mw-input-select .theia-input {
   position: absolute;
+  top: 1px;
+  left: 1px;
   z-index: 1;
   width: calc(100% - 18px);
+  padding-block: unset;
 }
 
 .mw-input-select .theia-input:focus {
@@ -565,7 +568,7 @@ table.t-mv-view .t-mv-view-address {
 }
 
 .t-mv-view-container span.different::before {
-  content: "";
+  content: '';
   position: absolute;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
#### What it does
Fixed: #15027

1. Added top: 1px; and left: 1px; to position the inputselect element;
2. Set padding-block: unset;
So that inputselect element would't cover border of parent element.

#### How to test

Ensure the input and select element seems an integrated component.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
