### PR TITLE
Instruct Coder to use replace when search and replace fails

### DIFF
--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -47,7 +47,8 @@ To propose code changes or any file changes to the user, never print code or new
 Instead, for each file you want to propose changes for:
 - **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the latest content of the target file.
 - **Change Content**: Use ~{changeSet_writeChangeToFile}${withSearchAndReplace ? ' or ~{changeSet_replaceContentInFile}' : ''} to propose file changes to the user.\
-  ${withSearchAndReplace ? 'Only select and call one function per file.' : ''}
+  ${withSearchAndReplace ? 'If ~{changeSet_replaceContentInFile} continously fails use ~{changeSet_writeChangeToFile}. Calling a function on a file will override previous function\
+  calls on the same files, so you need one successful call per changed file.' : ''}
   
 ## Additional Context
 


### PR DESCRIPTION
fixed #15060

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Add instructions to the coder prompt to fall back to full file rewrite if replace fails continously (this is already mentioned in the function description, but sometimes does not work)
- Clarify more precisely that only one successful function call per file is allowed (previous description might imply you are only allow to call one function even if it fails)

#### How to test

- Was tested in pre-test already
- Play around with prompts and LLMs
Expected behavior: It uses replace when "it make sense" and rewrite when "it makes sense". It switches to rewrite if replaces fails.

Some example prompts:

@Coder Rename the function toOpenAIMessage in packages/ai-openai/src/node/openai-language-model.ts to convertToOpenAIMessage

@Coder Add o13 and o14-mini to the default list of open ai models in the preferences of the openai package

@Coder Move the readme file to a sub direcotry called /readme

@Coder Implement the interface MCPServerManager in the same file (packages/ai-mcp/src/common/mcp-server-manager.ts). Don't ask me anything, jut do it.

@Coder Remove the prefix "MCP" from all user message in packages/ai-mcp/src/browser/mcp-command-contribution.ts

@Coder Do not display a message to the user anymore about the tools in packages/ai-mcp/src/browser/mcp-command-contribution.ts

@Coder Allow the user to start already started MCP servers again in packages/ai-mcp/src/browser/mcp-command-contribution.ts

@Coder please translate all of the comments in packages/ai-chat/src/browser/change-set-file-element.ts into Swahili.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
