### PR TITLE
Support snippet file edits

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -457,7 +457,7 @@ export interface WorkspaceEditMetadata {
     needsConfirmation: boolean;
     label: string;
     description?: string;
-    iconPath?: {
+    iconPath?: UriComponents | {
         id: string;
     } | {
         light: UriComponents;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1529,7 +1529,7 @@ export interface WorkspaceEditEntryMetadataDto {
     needsConfirmation: boolean;
     label: string;
     description?: string;
-    iconPath?: ThemeIcon | {
+    iconPath?: UriComponents | ThemeIcon | {
         light: UriComponents;
         dark: UriComponents;
     };

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -616,17 +616,24 @@ export function fromWorkspaceEdit(value: theia.WorkspaceEdit, documents?: any): 
     };
     for (const entry of (value as types.WorkspaceEdit)._allEntries()) {
         if (entry?._type === types.FileEditType.Text) {
-            // text edits
             const doc = documents ? documents.getDocument(entry.uri.toString()) : undefined;
             const workspaceTextEditDto: WorkspaceTextEditDto = {
                 resource: entry.uri,
                 modelVersionId: doc?.version,
-                textEdit: (entry.edit instanceof types.TextEdit) ? fromTextEdit(entry.edit) : fromSnippetTextEdit(entry.edit),
+                textEdit: fromTextEdit(entry.edit),
+                metadata: entry.metadata
+            };
+            result.edits.push(workspaceTextEditDto);
+        } else if (entry?._type === types.FileEditType.Snippet) {
+            const doc = documents ? documents.getDocument(entry.uri.toString()) : undefined;
+            const workspaceTextEditDto: WorkspaceTextEditDto = {
+                resource: entry.uri,
+                modelVersionId: doc?.version,
+                textEdit: fromSnippetTextEdit(entry.edit),
                 metadata: entry.metadata
             };
             result.edits.push(workspaceTextEditDto);
         } else if (entry?._type === types.FileEditType.File) {
-            // resource edits
             const workspaceFileEditDto: WorkspaceFileEditDto = {
                 oldResource: entry.from,
                 newResource: entry.to,
@@ -635,7 +642,6 @@ export function fromWorkspaceEdit(value: theia.WorkspaceEdit, documents?: any): 
             };
             result.edits.push(workspaceFileEditDto);
         } else if (entry?._type === types.FileEditType.Cell) {
-            // cell edit
             if (entry.edit) {
                 result.edits.push({
                     metadata: entry.metadata,
@@ -644,7 +650,6 @@ export function fromWorkspaceEdit(value: theia.WorkspaceEdit, documents?: any): 
                 });
             }
         } else if (entry?._type === types.FileEditType.CellReplace) {
-            // cell replace
             result.edits.push({
                 metadata: entry.metadata,
                 resource: entry.uri,

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1796,8 +1796,6 @@ export interface WorkspaceEditMetadata {
     label: string;
     description?: string;
     iconPath?: {
-        id: string;
-    } | {
         light: URI;
         dark: URI;
     } | ThemeIcon;


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13922

Adds proper support for the `FileEditType.Snippet` enum value. Previously, this was seemingly support via the `FileEditType.Text` enum value, but has since moved to a proper new structure.

#### How to test

See reproduction steps of https://github.com/eclipse-theia/theia/issues/13922.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
