### PR TITLE
chore(chat): pass pinned agent in frontend chat service

### DIFF
--- a/packages/ai-chat/src/browser/frontend-chat-service.ts
+++ b/packages/ai-chat/src/browser/frontend-chat-service.ts
@@ -65,8 +65,8 @@ export class FrontendChatServiceImpl extends ChatServiceImpl {
         return configuredDefaultChatAgent;
     }
 
-    override createSession(location?: ChatAgentLocation, options?: SessionOptions): ChatSession {
-        const session = super.createSession(location, options);
+    override createSession(location?: ChatAgentLocation, options?: SessionOptions, pinnedAgent?: ChatAgent): ChatSession {
+        const session = super.createSession(location, options, pinnedAgent);
         session.model.onDidChange(event => {
             const changeSet = (event as { changeSet?: ChangeSet }).changeSet;
             if (event.kind === 'removeChangeSet') {


### PR DESCRIPTION
#### What it does

Support setting a `pinnedAgent` also in the frontend service.

Reported in https://github.com/eclipse-theia/theia/discussions/15053#discussioncomment-12334912

#### How to test

Everything should work as before when creating new chats. However, now commands can also specify a pinned agent via the frontend service, e.g.

```ts
@injectable()
export class SampleCommandContribution implements CommandContribution {

    @inject(ChatService)
    protected readonly chatService: ChatService;


    @inject(ChatAgentService)
    protected chatAgentService: ChatAgentService;

    registerCommands(commands: CommandRegistry): void {
        commands.registerCommand(SampleCommand, {
            execute: async () => {
                 const agent = this.chatAgentService.getAgent('Coder');
                // creates a clean session
                const session = this.chatService.createSession(ChatAgentLocation.Panel, { focus: true }, agent);
                // submit a request
                await this.chatService.sendRequest(session.id, { text: 'Hello World!' });
            }
        });
    }
}
```

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
