### PR TITLE
15035: Missing I18N in UI

### DIFF
--- a/packages/ai-core/src/browser/prompttemplate-contribution.ts
+++ b/packages/ai-core/src/browser/prompttemplate-contribution.ts
@@ -30,19 +30,19 @@ const PROMPT_TEMPLATE_TEXTMATE_SCOPE = 'source.prompttemplate';
 
 export const PROMPT_TEMPLATE_EXTENSION = '.prompttemplate';
 
-export const DISCARD_PROMPT_TEMPLATE_CUSTOMIZATIONS: Command = {
+export const DISCARD_PROMPT_TEMPLATE_CUSTOMIZATIONS: Command = Command.toLocalizedCommand({
     id: 'theia-ai-prompt-template:discard',
     iconClass: codicon('discard'),
     category: 'Theia AI Prompt Templates'
-};
+}, '', 'theia/ai/core/prompts/category');
 
 // TODO this command is mainly for testing purposes
-export const SHOW_ALL_PROMPTS_COMMAND: Command = {
+export const SHOW_ALL_PROMPTS_COMMAND: Command = Command.toLocalizedCommand({
     id: 'theia-ai-prompt-template:show-prompts-command',
     label: 'Show all prompts',
     iconClass: codicon('beaker'),
     category: 'Theia AI Prompt Templates',
-};
+}, 'theia/ai/core/showAllPrompts/label', 'theia/ai/core/prompts/category');
 
 @injectable()
 export class PromptTemplateContribution implements LanguageGrammarDefinitionContribution, CommandContribution, TabBarToolbarContribution {

--- a/packages/core/src/browser/about-dialog.tsx
+++ b/packages/core/src/browser/about-dialog.tsx
@@ -94,8 +94,9 @@ export class AboutDialog extends ReactDialog<void> {
 
     protected renderExtensions(): React.ReactNode {
         const extensionsInfos = this.extensionsInfos;
+        const listOfExtensions = nls.localize('theia/core/about/listOfExtensions', 'List of extensions');
         return <>
-            <h3>List of extensions</h3>
+            <h3>{listOfExtensions}</h3>
             <ul className={ABOUT_EXTENSIONS_CLASS}>
                 {
                     extensionsInfos

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.ts
@@ -20,10 +20,10 @@ import { Command, CommandContribution, CommandRegistry, ContributionProvider } f
 import { VariableContribution, VariableRegistry } from './variable';
 import { VariableQuickOpenService } from './variable-quick-open-service';
 
-export const LIST_VARIABLES: Command = {
+export const LIST_VARIABLES: Command = Command.toLocalizedCommand({
     id: 'variable.list',
     label: 'Variable: List All'
-};
+}, 'theia/variableResolver/listAllVariables');
 
 @injectable()
 export class VariableResolverFrontendContribution implements FrontendApplicationContribution, CommandContribution {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Localize some commands and texts that were missing

Note: the original issue contains a long list of commands that were previously not localized. Localizations are generated quite late in the release cycle, so they have been introduced just yesterday morning. Only a few localize calls were actually missing from the code base; so I added them.

#### How to test

The PR only introduces nls.localize() calls, so it can't immediately be tested. I'm not sure what is the best way to test the changes, but what I did:

- Add (a subset of) the keys to your favorite language, in packages/core/i18n/nls.**.json

For example, in French:

```json
"theia": {
    "core": {
      "about": {
          "listOfExtensions": "Liste des extensions"
      }
    }
}
```
- Start Theia
- In the Command Palette, call Configure Display Language and select the modified language
- Restart Theia Frontend
- Check that the localized messages properly appear (For this example: open the "About" dialog)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- Wait until all keys are officially localized (Typically done just before release)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
