### PR TITLE
Improve displaying inline frame decorator

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -67,7 +67,6 @@ export class DebugEditorModel implements Disposable {
     protected currentBreakpointDecorations: string[] = [];
 
     protected editorDecorations: string[] = [];
-    protected topFrameRange: monaco.Range | undefined;
 
     protected updatingDecorations = false;
     protected toDisposeOnModelChange = new DisposableCollection();
@@ -223,14 +222,13 @@ export class DebugEditorModel implements Disposable {
                 options: DebugEditorModel.TOP_STACK_FRAME_DECORATION,
                 range: columnUntilEOLRange
             });
-            const { topFrameRange } = this;
-            if (topFrameRange && topFrameRange.startLineNumber === currentFrame.raw.line && topFrameRange.startColumn !== currentFrame.raw.column) {
+            const firstNonWhitespaceColumn = this.editor.document.textEditorModel.getLineFirstNonWhitespaceColumn(currentFrame.raw.line);
+            if (currentFrame.raw.column > firstNonWhitespaceColumn) {
                 decorations.push({
                     options: DebugEditorModel.TOP_STACK_FRAME_INLINE_DECORATION,
                     range: columnUntilEOLRange
                 });
             }
-            this.topFrameRange = columnUntilEOLRange;
         } else {
             decorations.push({
                 options: DebugEditorModel.FOCUSED_STACK_FRAME_MARGIN,


### PR DESCRIPTION
#### What it does

Improve logic when to show inline frame decorator.
Currently, the displaying inline frame decorator depends on local state, that is where the frame decorator previously pointed to. However, this has inconsistent results, when reaching a line from different locations.
Now, the inline frame decorator always is shown, when the column points behind the beginning of a line (excluding white space). I think, this best reflects the objective to show the inline decoration only when it's needed.

Fixes #15095

#### How to test

Test with any program, which contains lines with multiple statements.
Note: The python debug adapter seems to always set the column to 1, so this cannot be reproduced in python.
However, the javascript debug adapter provides column information.

See #15095 how to reproduce the bug.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
