### PR TITLE
Add `commandsToSkipShell` preference for plugin support

### DIFF
--- a/dev-packages/private-eslint-plugin/rules/localization-check.js
+++ b/dev-packages/private-eslint-plugin/rules/localization-check.js
@@ -17,6 +17,7 @@
 
 const levenshtein = require('js-levenshtein');
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 const metadata = require('@theia/core/src/common/i18n/nls.metadata.json');
 const messages = new Set(Object.values(metadata.messages)
     .reduceRight((prev, curr) => prev.concat(curr), [])
@@ -39,7 +40,7 @@ module.exports = {
                     return;
                 }
                 const { value, byDefault, node: localizeNode } = evaluateLocalize(node);
-                if (value !== undefined) {
+                if (value !== undefined && localizeNode) {
                     if (byDefault && !messages.has(value)) {
                         let lowestDistance = Number.MAX_VALUE;
                         let lowestMessage = '';
@@ -51,12 +52,12 @@ module.exports = {
                             }
                         }
                         if (lowestMessage) {
+                            const replacementValue = `'${lowestMessage.replace(/'/g, "\\'").replace(/\n/g, '\\n')}'`;
                             context.report({
                                 node: localizeNode,
-                                message: `'${value}' is not a valid default value. Did you mean '${lowestMessage}'?`,
+                                message: `'${value}' is not a valid default value. Did you mean ${replacementValue}?`,
                                 fix: function (fixer) {
-                                    const updatedCall = `'${lowestMessage.replace(/'/g, "\\'")}'`;
-                                    return fixer.replaceText(localizeNode, updatedCall);
+                                    return fixer.replaceText(localizeNode, replacementValue);
                                 }
                             });
                         } else {

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -196,6 +196,15 @@ export const TerminalConfigSchema: PreferenceSchema = {
             default: [],
             deprecationMessage: shellArgsDeprecatedMessage(OS.Type.Linux),
         },
+        // TODO: This preference currently features no implementation but is only available for plugins to use.
+        'terminal.integrated.commandsToSkipShell': {
+            type: 'array',
+            markdownDescription: nls.localizeByDefault('A set of command IDs whose keybindings will not be sent to the shell but instead always be handled by VS Code. This allows keybindings that would normally be consumed by the shell to act instead the same as when the terminal is not focused, for example `Ctrl+P` to launch Quick Open.\n\n&nbsp;\n\nMany commands are skipped by default. To override a default and pass that command\'s keybinding to the shell instead, add the command prefixed with the `-` character. For example add `-workbench.action.quickOpen` to allow `Ctrl+P` to reach the shell.\n\n&nbsp;\n\nThe following list of default skipped commands is truncated when viewed in Settings Editor. To see the full list, {1} and search for the first command from the list below.\n\n&nbsp;\n\nDefault Skipped Commands:\n\n{0}'),
+            items: {
+                type: 'string'
+            },
+            default: []
+        },
         'terminal.integrated.confirmOnExit': {
             type: 'string',
             description: nls.localizeByDefault('Controls whether to confirm when the window closes if there are active terminal sessions.'),


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/14759

Adds the required preference for the Julia plugin to work as expected. This doesn't feature the full implementation (see todo) as I don't have time to do the full implementation right now :)

#### How to test

See https://github.com/eclipse-theia/theia/issues/14759 for reproduction steps. The plugin should startup as expected.

#### Follow-ups

Someone should do the actual implementation of the preference.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
