### PR TITLE
Option to put close icons at the start of the tab label on macOS

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -121,6 +121,18 @@ export const corePreferenceSchema: PreferenceSchema = {
             scope: 'application',
             markdownDescription: nls.localizeByDefault('Separator used by {0}.', '`#window.title#`')
         },
+        'window.tabCloseIconPlacement': {
+            type: 'string',
+            enum: ['end', 'start'],
+            enumDescriptions: [
+                nls.localize('theia/core/window/tabCloseIconPlacement/end', 'Place the close icon at the end of the label. In left-to-right languages, this is the right side of the tab.'),
+                nls.localize('theia/core/window/tabCloseIconPlacement/start', 'Place the close icon at the start of the label. In left-to-right languages, this is the left side of the tab.'),
+            ],
+            default: 'end',
+            scope: 'application',
+            description: nls.localize('theia/core/window/tabCloseIconPlacement/description', 'Place the close icons on tab titles at the start or end of the tab. The default is end on all platforms.'),
+            included: isOSX
+        },
         'window.secondaryWindowPlacement': {
             type: 'string',
             enum: ['originalSize', 'halfWidth', 'fullSize'],
@@ -305,6 +317,7 @@ export interface CoreConfiguration {
     'window.menuBarVisibility': 'classic' | 'visible' | 'hidden' | 'compact';
     'window.title': string;
     'window.titleSeparator': string;
+    'window.tabCloseIconPlacement': 'end' | 'start';
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
     'workbench.editor.highlightModifiedTabs': boolean;

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -237,6 +237,12 @@
   -ms-user-select: none;
 }
 
+.lm-TabBar.theia-app-centers .lm-TabBar-tab.lm-mod-closable.closeIcon-start > .lm-TabBar-tabCloseIcon,
+.lm-TabBar.theia-app-centers .lm-TabBar-tab.theia-mod-pinned.closeIcon-start > .lm-TabBar-tabCloseIcon {
+  margin-left: inherit;
+  margin-right: 4px;
+}
+
 .lm-TabBar.theia-app-centers.dynamic-tabs .lm-TabBar-tab.lm-mod-closable>.lm-TabBar-tabCloseIcon,
 .lm-TabBar.theia-app-centers.dynamic-tabs .lm-TabBar-tab.theia-mod-pinned>.lm-TabBar-tabCloseIcon {
   /* hide close icon for dynamic tabs strategy*/
@@ -254,9 +260,14 @@
   background-color: rgba(50%, 50%, 50%, 0.2);
 }
 
-.lm-TabBar.theia-app-centers .lm-TabBar-tab.lm-mod-closable,
-.lm-TabBar.theia-app-centers .lm-TabBar-tab.theia-mod-pinned {
+.lm-TabBar.theia-app-centers .lm-TabBar-tab.lm-mod-closable:not(.closeIcon-start),
+.lm-TabBar.theia-app-centers .lm-TabBar-tab.theia-mod-pinned:not(.closeIcon-start) {
   padding-right: 4px;
+}
+
+.lm-TabBar.theia-app-centers .lm-TabBar-tab.lm-mod-closable.closeIcon-start,
+.lm-TabBar.theia-app-centers .lm-TabBar-tab.theia-mod-pinned.closeIcon-start {
+  padding-left: 4px;
 }
 
 .lm-TabBar.theia-app-centers .lm-TabBar-tab.lm-mod-closable:not(.theia-mod-dirty):hover>.lm-TabBar-tabCloseIcon:before,


### PR DESCRIPTION
#### What it does

Adds a new `window.tabCloseIconPlacement` preference for whether to present the Close (X) icon in tab titles on the left or the right of the tab.
~Defaults to the left on macOS platform in conformity with the OS's native tab controls.~
The tab bar rendering is updated to take the preference into account.

The preference is suppressed in the Settings view on non-Mac platforms as being largely irrelevant on those systems.

Fixes eclipse-theia/theia-ide#460

#### How to test

On a macOS system, build and launch the Theia example app. See that tabs in the main editor area are on the left side where they belong.

Open Settings and change the "Tab close icon placement" preference to "end". See the close icons move back to where they are presented on Linux and Windows platforms. Restore the default setting. See the close icons restored to the left side.

On Linux and Windows systems, verify that the "Tab close icon placement" preference does not appear in the Settings UI and that tab titles look as they ever did.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

> [!NOTE]
> My testing is only on macOS platform as that is the platform that my system runs and the feature is meant to be disabled on other platforms. I'm depending on buddy tests from the Theia community to check for regressions on other platforms.

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


----

#### Update 17 June 2025

Changed the default close icon placement to the end on all platforms, including macOS, to maintain current behaviour.

----

![CleanShot 2025-03-03 at 16 36 06](https://github.com/user-attachments/assets/8270cf9a-be2e-451e-b4fb-dbed33c1d900)
