### PR TITLE
Don't stop watching folder because of dropped events.

### DIFF
--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
@@ -242,7 +242,7 @@ export class ParcelWatcher {
         }
         return subscribe(fsPath, (err, events) => {
             if (err) {
-                if (err.message && err.message.indexOf('File system must be re-scanned') !== -1) {
+                if (err.message && err.message.includes('File system must be re-scanned')) {
                     console.log(`FS Events were dropped on watcher ${fsp}`);
                 } else {
                     console.error(`Watcher service error on "${fsPath}":`, err);

--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
@@ -242,12 +242,18 @@ export class ParcelWatcher {
         }
         return subscribe(fsPath, (err, events) => {
             if (err) {
-                console.error(`Watcher service error on "${fsPath}":`, err);
-                this._dispose();
-                this.fireError();
-                return;
+                if (err.message && err.message.indexOf('File system must be re-scanned') !== -1) {
+                    console.log(`FS Events were dropped on watcher ${fsp}`);
+                } else {
+                    console.error(`Watcher service error on "${fsPath}":`, err);
+                    this._dispose();
+                    this.fireError();
+                    return;
+                }
             }
-            this.handleWatcherEvents(events);
+            if (events) {
+                this.handleWatcherEvents(events);
+            }
         }, {
             ...this.parcelFileSystemWatchServerOptions.parcelOptions
         });


### PR DESCRIPTION
Theia stops watching directories when an error is passed to the event handling function. This includes the case where the watcher has dropped some events due to performance reasons. This PR does not stop watching the directory anymore in this case.

Mitigates #15110

I call this a mitigation, becuase on Arm Macs, it is not expected that we run into a performance issue for the scenarios mentioned in the issue.


#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Follow the development scenarios mentioned in the issue on a Arm Mac.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
