### PR TITLE
chore(chat): minor chat style improvements

### DIFF
--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -453,7 +453,7 @@ div:last-child > .theia-ChatNode {
 .theia-ChatInputOptions {
   width: 100%;
   height: 25px;
-  padding-left: 6px;
+  padding-left: 3px;
   padding-right: 6px;
   display: flex;
   justify-content: space-between;
@@ -465,7 +465,7 @@ div:last-child > .theia-ChatNode {
 }
 
 .theia-ChatInputOptions .theia-ChatInputOptions-right {
-  margin-right: 12px;
+  margin-right: 8px;
 }
 
 .theia-ChatInputOptions .option {
@@ -506,6 +506,10 @@ div:last-child > .theia-ChatNode {
   gap: 2px;
   border: var(--theia-border-width) solid var(--theia-input-border);
   border-radius: 4px;
+}
+
+.theia-CodePartRenderer-root .monaco-editor {
+  outline-color: var(--theia-editor-background);
 }
 
 .theia-CodePartRenderer-left {


### PR DESCRIPTION
#### What it does

Removes the focus outline appearing at the bottom of Monaco editors of code parts in the chat response and fine-tunes the margins of the actions in the chat input.

#### How to test

Open the chat and ask e.g. `@Universal` to print some typescript code and ensure that there is no focus-colored outline at the bottom of the code blocks.

Also have a look at the chat input to check if the margins of the actions below the chat input look fine and even.

Before:
![image](https://github.com/user-attachments/assets/377b8c17-48ab-43a5-a444-204617dcea1b)

After:
![image](https://github.com/user-attachments/assets/6355b064-6cd6-4dcb-b50e-df2def546469)

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
