### PR TITLE
Pass the original argv to the "second instance" handler

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -64,7 +64,7 @@ process.env.LC_NUMERIC = 'C';
     const config = ${this.prettyStringify(this.pck.props.frontend.config)};
     const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};
 
-    if (isSingleInstance && !app.requestSingleInstanceLock()) {
+    if (isSingleInstance && !app.requestSingleInstanceLock(process.argv)) {
         // There is another instance running, exit now. The other instance will request focus.
         app.quit();
         return;

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -753,7 +753,7 @@ export class ElectronMainApplication {
         if (originalArgv.includes('--open-url')) {
             this.openUrl(originalArgv[originalArgv.length - 1]);
         } else {
-            createYargs(this.processArgv.getProcessArgvWithoutBin(originalArgv), process.cwd())
+            createYargs(this.processArgv.getProcessArgvWithoutBin(originalArgv), cwd)
                 .help(false)
                 .command('$0 [file]', false,
                     cmd => cmd
@@ -761,7 +761,7 @@ export class ElectronMainApplication {
                     async args => {
                         await this.handleMainCommand({
                             file: args.file,
-                            cwd: process.cwd(),
+                            cwd: cwd,
                             secondInstance: true
                         });
                     },

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -746,11 +746,14 @@ export class ElectronMainApplication {
         this.stopContributions();
     }
 
-    protected async onSecondInstance(event: ElectronEvent, argv: string[], cwd: string): Promise<void> {
-        if (argv.includes('--open-url')) {
-            this.openUrl(argv[argv.length - 1]);
+    protected async onSecondInstance(event: ElectronEvent, _: string[], cwd: string, originalArgv: string[]): Promise<void> {
+        // the second instance passes it's original argument array as the fourth argument to this method
+        // The `argv` second parameter is not usable for us since it is mangled by electron before being passed here
+
+        if (originalArgv.includes('--open-url')) {
+            this.openUrl(originalArgv[originalArgv.length - 1]);
         } else {
-            createYargs(this.processArgv.getProcessArgvWithoutBin(argv), process.cwd())
+            createYargs(this.processArgv.getProcessArgvWithoutBin(originalArgv), process.cwd())
                 .help(false)
                 .command('$0 [file]', false,
                     cmd => cmd


### PR DESCRIPTION
#### What it does
Fixes #14747

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Make sure you can pass a workspace directory to both the first and second instance of Theia in
1. From source like `npm run start:electron <workspace dir>`
2. When built like `TheiaIDE.exe <workspace dir>`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
