### PR TITLE
[vscode] Remove duplicate declaration for DocumentDropEdit

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -14528,6 +14528,7 @@ export module '@theia/plugin' {
          *
          * @returns The resolved edit or a thenable that resolves to such. It is OK to return the given
          * `edit`. If no result is returned, the given `edit` is used.
+         * @stubbed
          */
         resolveDocumentDropEdit?(edit: T, token: CancellationToken): ProviderResult<T>;
     }
@@ -14727,48 +14728,6 @@ export module '@theia/plugin' {
      * opening and closing brackets.
      */
     export type CharacterPair = [string, string];
-
-    /**
-     * An edit operation applied {@link DocumentDropEditProvider on drop}.
-     */
-    export class DocumentDropEdit {
-        /**
-         * The text or snippet to insert at the drop location.
-         */
-        insertText: string | SnippetString;
-
-        /**
-         * An optional additional edit to apply on drop.
-         */
-        additionalEdit?: WorkspaceEdit;
-
-        /**
-         * @param insertText The text or snippet to insert at the drop location.
-         */
-        constructor(insertText: string | SnippetString);
-    }
-
-    /**
-     * Provider which handles dropping of resources into a text editor.
-     *
-     * This allows users to drag and drop resources (including resources from external apps) into the editor. While dragging
-     * and dropping files, users can hold down `shift` to drop the file into the editor instead of opening it.
-     * Requires `editor.dropIntoEditor.enabled` to be on.
-     */
-    export interface DocumentDropEditProvider {
-        /**
-         * Provide edits which inserts the content being dragged and dropped into the document.
-         *
-         * @param document The document in which the drop occurred.
-         * @param position The position in the document where the drop occurred.
-         * @param dataTransfer A {@link DataTransfer} object that holds data about what is being dragged and dropped.
-         * @param token A cancellation token.
-         *
-         * @return A {@link DocumentDropEdit} or a thenable that resolves to such. The lack of a result can be
-         * signaled by returning `undefined` or `null`.
-         */
-        provideDocumentDropEdits(document: TextDocument, position: Position, dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentDropEdit>;
-    }
 
     /**
      * Represents a session of a currently logged in user.


### PR DESCRIPTION
#### What it does

Removes a duplicate in theia.d.ts file. DocumentDropEdit was improved when a proposed API was made public, but a duplicate was introduced in Theia rather than updating the existing one. This PR removes the duplicate. This fixes the status report for Theia VScode compatibility (https://eclipse-theia.github.io/vscode-theia-comparator/status.html)

It also mark the DocumentDropEditProvider#resolveDocumentDropEdit as stubbed as there is currently no implementation backing this optional field.

Also, as a note, the DocumentDropEditProviders do not behave as they are supposed to do. The upgrade to monaco editor did remove some functional code. see language-main changes in https://github.com/eclipse-theia/theia/pull/14737/files#diff-c3f11c10237ecdc571f7990062c887b7a1ab822927da02db28fedfe1e69fc4a9 

#### How to test

Nothing to test, as code was working or only documentation update. Only the report is now fixed.

Original
![image](https://github.com/user-attachments/assets/3b4f3be4-0fb0-472e-897c-12b9f6c8cc57)

After patch
![image](https://github.com/user-attachments/assets/fb37c321-89da-454e-9e6e-877bbf7c844a)

#### Follow-ups

Implementation / restore DocumentDropEditProvider (see #15058)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
