### PR TITLE
[vscode] Selection properties are now readonly

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -357,19 +357,21 @@ export module '@theia/plugin' {
     export class Selection extends Range {
 
         /**
-         * Position where selection starts.
+         * The position at which the selection starts.
+         * This position might be before or after {@link Selection.active active}.
          */
-        anchor: Position;
+        readonly anchor: Position;
 
         /**
-         * Position of the cursor
+         * The position of the cursor.
+         * This position might be before or after {@link Selection.anchor anchor}.
          */
-        active: Position;
+        readonly active: Position;
 
         /**
-         * A selection is reversed if `active.isBefore(anchor)`
+         * A selection is reversed if its {@link Selection.anchor anchor} is the {@link Selection.end end} position.
          */
-        isReversed: boolean;
+        readonly isReversed: boolean;
 
         /**
          * Create a selection from two positions.


### PR DESCRIPTION
#### What it does

All properties from Selection are readonly since release 1.98. 

By implementation (see https://github.com/eclipse-theia/theia/blob/e213473b0bc5502ebd8487a3c7ac4e0ea677305c/packages/plugin-ext/src/plugin/types-impl.ts#L571), the selection properties were already readonly. 
This is then only an API description change. 
Comment change also reflects the current behavior

fixes #15130

#### How to test

This is only a documentation change. 

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
