### PR TITLE
fix: store original handle of debug adapter config

### DIFF
--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-configuration-provider.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-configuration-provider.ts
@@ -23,6 +23,11 @@ import {
 import { DebugConfiguration } from '@theia/debug/lib/common/debug-configuration';
 
 export class PluginDebugConfigurationProvider implements DebugConfigurationProvider {
+    /**
+     * After https://github.com/eclipse-theia/theia/pull/13196, the debug config handles might change.
+     * Store the original handle to be able to call the extension host when getting by handle.
+     */
+    protected readonly originalHandle: number;
     public handle: number;
     public type: string;
     public triggerKind: DebugConfigurationProviderTriggerKind;
@@ -41,23 +46,24 @@ export class PluginDebugConfigurationProvider implements DebugConfigurationProvi
         protected readonly debugExt: DebugExt
     ) {
         this.handle = description.handle;
+        this.originalHandle = this.handle;
         this.type = description.type;
         this.triggerKind = description.trigger;
 
         if (description.provideDebugConfiguration) {
-            this.provideDebugConfigurations = async (folder: string | undefined) => this.debugExt.$provideDebugConfigurationsByHandle(this.handle, folder);
+            this.provideDebugConfigurations = async (folder: string | undefined) => this.debugExt.$provideDebugConfigurationsByHandle(this.originalHandle, folder);
         }
 
         if (description.resolveDebugConfigurations) {
             this.resolveDebugConfiguration =
                 async (folder: string | undefined, debugConfiguration: DebugConfiguration) =>
-                    this.debugExt.$resolveDebugConfigurationByHandle(this.handle, folder, debugConfiguration);
+                    this.debugExt.$resolveDebugConfigurationByHandle(this.originalHandle, folder, debugConfiguration);
         }
 
         if (description.resolveDebugConfigurationWithSubstitutedVariables) {
             this.resolveDebugConfigurationWithSubstitutedVariables =
                 async (folder: string | undefined, debugConfiguration: DebugConfiguration) =>
-                    this.debugExt.$resolveDebugConfigurationWithSubstitutedVariablesByHandle(this.handle, folder, debugConfiguration);
+                    this.debugExt.$resolveDebugConfigurationWithSubstitutedVariablesByHandle(this.originalHandle, folder, debugConfiguration);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

When frontend and main VS Code extensions load together, Theia creates two extension host instances to manage different kinds of extensions. Each will register the extensions' contributed debug adapter configuration providers with incremented handles.

In cases of handle collisions during the registration of debug configurations, Theia adjusts the handle of incoming providers. However, this adjustment causes issues as the extension host no longer associates the new handle with the original ID.

For instance, if the main VSIX contributes two debuggers assigned handles `0` and `1`, and the web VSIX contributes a debugger with a colliding handle `0`, Theia changes the web provider's handle to `2`. Subsequently, when starting a debug session, the main extension attempts to resolve handle `2`, but the frontend extension host only recognizes the initial configuration.

This commit addresses the issue by storing the original handle of the debug adapter configuration. During handle ID lookups, it will reference the originally assigned handle instead of the adjusted one, ensuring proper resolution and functionality across both extension host instances.

Ref: eclipse-theia/theia#13196

#### How to test

1. Extract the VSIX to the `plugins` folder:
[mock-debug-web-0.0.0.vsix.zip](https://github.com/user-attachments/files/19130011/mock-debug-web-0.0.0.vsix.zip)

2. Create `launch.json`:
```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "mock-debug-web",
      "name": "Web debug",
      "request": "launch",
      "foo": "yes!",
      "program": "hello",
    }
  ]
}
```
3. Launch `Web debug`. It works.
4. Put a breakpoint to 
https://github.com/eclipse-theia/theia/blob/afde78f081ef1725a6b48f08425548209f7fd609/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts#L73

    >👆 A cheap and easy way to let the main contributed debug config adapters get registered before the web. Here, it is important that the handle index exceeds the array. There are more main contributed plugins, and the web `0` handle will change to the main contributed debug config count.
5. Launch `Web debug`. See the handle error.

Errors:

```
root ERROR Error: No Debug configuration provider found with given handle number: 13
    at Proxy.getConfigurationProviderRecord (http://localhost:3000/packages_core_lib_common_markdown-rendering_index_js-packages_plugin-ext_lib_hosted_browser_w-8a6a3d.js:13576:19)
    at Proxy.$resolveDebugConfigurationByHandle (http://localhost:3000/packages_core_lib_common_markdown-rendering_index_js-packages_plugin-ext_lib_hosted_browser_w-8a6a3d.js:13592:35)
    at RPCProtocolImpl.handleRequest (http://localhost:3000/packages_plugin-ext_lib_common_plugin-api-rpc_js-packages_plugin-ext_lib_main_browser_hierarc-ea2111.js:855:31)
    at RpcProtocol.requestHandler (http://localhost:3000/packages_plugin-ext_lib_common_plugin-api-rpc_js-packages_plugin-ext_lib_main_browser_hierarc-ea2111.js:837:96)
    at RpcProtocol.handleRequest (http://localhost:3000/packages_core_lib_common_markdown-rendering_index_js-packages_plugin-ext_lib_hosted_browser_w-8a6a3d.js:5185:39)
    at RpcProtocol.handleMessage (http://localhost:3000/packages_core_lib_common_markdown-rendering_index_js-packages_plugin-ext_lib_hosted_browser_w-8a6a3d.js:5072:26)
    at http://localhost:3000/packages_core_lib_common_markdown-rendering_index_js-packages_plugin-ext_lib_hosted_browser_w-8a6a3d.js:5058:66
    at http://localhost:3000/packages_core_lib_common_markdown-rendering_index_js-packages_plugin-ext_lib_hosted_browser_w-8a6a3d.js:1943:69
    at CallbackList.invoke (http://localhost:3000/packages_core_lib_common_markdown-rendering_index_js-packages_plugin-ext_lib_hosted_browser_w-8a6a3d.js:1949:26)
    at Emitter.fire (http://localhost:3000/packages_core_lib_common_markdown-rendering_index_js-packages_plugin-ext_lib_hosted_browser_w-8a6a3d.js:2064:36)
```

```
 root ERROR Error: No Debug configuration provider found with given handle number: 16
    at DebugExtImpl.getConfigurationProviderRecord (/Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_core_shared_reflect-metadata_index_js-packages_plugin-ext_lib_hosted_node_plugin-hos-48197a.js:4777:19)
    at DebugExtImpl.$resolveDebugConfigurationWithSubstitutedVariablesByHandle (/Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_core_shared_reflect-metadata_index_js-packages_plugin-ext_lib_hosted_node_plugin-hos-48197a.js:4798:35)
    at RPCProtocolImpl.handleRequest (/Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_plugin-ext_lib_common_plugin-api-rpc_js.js:2090:31)
    at RpcProtocol.requestHandler (/Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_plugin-ext_lib_common_plugin-api-rpc_js.js:2072:96)
    at RpcProtocol.handleRequest (/Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_core_lib_common_index_js-node_modules_vscode-languageserver-types_lib_umd_sync_recursive.js:3728:39)
    at RpcProtocol.handleMessage (/Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_core_lib_common_index_js-node_modules_vscode-languageserver-types_lib_umd_sync_recursive.js:3615:26)
    at /Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_core_lib_common_index_js-node_modules_vscode-languageserver-types_lib_umd_sync_recursive.js:3601:66
    at /Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_core_lib_common_index_js-node_modules_vscode-languageserver-types_lib_umd_sync_recursive.js:1438:69
    at CallbackList.invoke (/Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_core_lib_common_index_js-node_modules_vscode-languageserver-types_lib_umd_sync_recursive.js:1444:26)
    at Emitter.fire (/Users/kittaakos/dev/git/theia/examples/browser/lib/backend/packages_core_lib_common_index_js-node_modules_vscode-languageserver-types_lib_umd_sync_recursive.js:1559:36)
```

It works by accident:

https://github.com/user-attachments/assets/4dbbfb31-ecf1-41f2-baa6-3550bbe127ee

Pause the worker thread for a second or two. It errors:

https://github.com/user-attachments/assets/5148f2e2-c641-4b42-a9b4-0e0049853ae9

Pause the worker thread. It works with the fix:

https://github.com/user-attachments/assets/d929307f-cc6d-4cec-a36e-fcf2cf19552e


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
