### PR TITLE
Put all prompts under MIT license

### DIFF
--- a/LICENSE-MIT.txt
+++ b/LICENSE-MIT.txt
@@ -1,0 +1,34 @@
+
+This license covers code in the repository with the MIT license header:
+
+// *****************************************************************************
+// Copyright (C) {year, original author} and others.
+//
+// This file is licensed under the MIT License. 
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
+//
+// SPDX-License-Identifier: MIT
+// *****************************************************************************
+
+-----
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -22,6 +22,7 @@ import { generateUuid, ILogger, nls, ProgressService } from '@theia/core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { PREF_AI_INLINE_COMPLETION_MAX_CONTEXT_LINES } from './ai-code-completion-preference';
+import { codeCompletionPromptTemplates } from './code-completion-prompt-template';
 import { PreferenceService } from '@theia/core/lib/browser';
 import { CodeCompletionPostProcessor } from './code-completion-postprocessor';
 
@@ -185,36 +186,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
     name = 'Code Completion';
     description =
         nls.localize('theia/ai/completion/agent/description', 'This agent provides inline code completion in the code editor in the Theia IDE.');
-    promptTemplates: PromptTemplate[] = [
-        {
-            id: 'code-completion-prompt-previous',
-            variantOf: 'code-completion-prompt',
-            template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-You are a code completion agent. The current file you have to complete is named {{file}}.
-The language of the file is {{language}}. Return your result as plain text without markdown formatting.
-Finish the following code snippet.
-
-{{prefix}}[[MARKER]]{{suffix}}
-
-Only return the exact replacement for [[MARKER]] to complete the snippet.`
-        },
-        {
-            id: 'code-completion-prompt',
-            template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-## Code snippet
-\`\`\`
-{{ prefix }}[[MARKER]]{{ suffix }}
-\`\`\`
-
-## Meta Data
-- File: {{file}}
-- Language: {{language}}
-
-Replace [[MARKER]] with the exact code to complete the code snippet. Return only the replacement of [[MAKRER]] as plain text.`,
-        },
-    ];
+    promptTemplates: PromptTemplate[] = codeCompletionPromptTemplates;
     languageModelRequirements: LanguageModelRequirement[] = [
         {
             purpose: 'code-completion',

--- a/packages/ai-code-completion/src/browser/code-completion-prompt-template.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-prompt-template.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/tslint/config */
+// *****************************************************************************
+// Copyright (C) {year, original author} and others.
+//
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
+//
+// SPDX-License-Identifier: MIT
+// *****************************************************************************
+
+import { PromptTemplate } from '@theia/ai-core/lib/common';
+
+export const codeCompletionPromptTemplates: PromptTemplate[] = [
+    {
+        id: 'code-completion-prompt-previous',
+        variantOf: 'code-completion-prompt',
+        template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+You are a code completion agent. The current file you have to complete is named {{file}}.
+The language of the file is {{language}}. Return your result as plain text without markdown formatting.
+Finish the following code snippet.
+
+{{prefix}}[[MARKER]]{{suffix}}
+
+Only return the exact replacement for [[MARKER]] to complete the snippet.`
+    },
+    {
+        id: 'code-completion-prompt',
+        template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+## Code snippet
+\`\`\`
+{{ prefix }}[[MARKER]]{{ suffix }}
+\`\`\`
+
+## Meta Data
+- File: {{file}}
+- Language: {{language}}
+
+Replace [[MARKER]] with the exact code to complete the code snippet. Return only the replacement of [[MAKRER]] as plain text.`,
+    },
+];

--- a/packages/ai-code-completion/src/browser/code-completion-prompt-template.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-prompt-template.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) {year, original author} and others.
+// Copyright (C) 2025 EclipseSource GmbH and others.
 //
 // This file is licensed under the MIT License.
 // See LICENSE-MIT.txt in the project root for license information.

--- a/packages/ai-ide/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide/src/common/architect-prompt-template.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) {year, original author} and others.
+// Copyright (C) 2025 EclipseSource GmbH and others.
 //
 // This file is licensed under the MIT License.
 // See LICENSE-MIT.txt in the project root for license information.

--- a/packages/ai-ide/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide/src/common/architect-prompt-template.ts
@@ -1,17 +1,12 @@
+/* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) 2024 EclipseSource GmbH.
+// Copyright (C) {year, original author} and others.
 //
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License v. 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0.
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
 //
-// This Source Code may also be made available under the following Secondary
-// Licenses when the conditions for such availability set forth in the Eclipse
-// Public License v. 2.0 are satisfied: GNU General Public License, version 2
-// with the GNU Classpath Exception which is available at
-// https://www.gnu.org/software/classpath/license.html.
-//
-// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// SPDX-License-Identifier: MIT
 // *****************************************************************************
 import { PromptTemplate } from '@theia/ai-core/lib/common';
 import { GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from './workspace-functions';
@@ -19,7 +14,8 @@ import { CONTEXT_FILES_VARIABLE_ID } from './context-variables';
 
 export const architectPromptTemplate = <PromptTemplate>{
    id: 'architect-system',
-   template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+   template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 # Instructions
 

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -1,19 +1,12 @@
+/* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-/*
- * Copyright (C) 2024 EclipseSource GmbH.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
- */
+// Copyright (C) {year, original author} and others.
+//
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
+//
+// SPDX-License-Identifier: MIT
 // *****************************************************************************
 
 import { PromptTemplate } from '@theia/ai-core/lib/common';
@@ -32,7 +25,10 @@ export const CODER_REPLACE_PROMPT_TEMPLATE_ID = 'coder-search-replace';
 export function getCoderReplacePromptTemplate(withSearchAndReplace: boolean = false): PromptTemplate {
   return {
     id: withSearchAndReplace ? CODER_REPLACE_PROMPT_TEMPLATE_ID : CODER_REWRITE_PROMPT_TEMPLATE_ID,
-    template: `You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes.
+    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes.
 
 ## Context Retrieval
 Use the following functions to interact with the workspace files if you require context:

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) {year, original author} and others.
+// Copyright (C) 2025 EclipseSource GmbH and others.
 //
 // This file is licensed under the MIT License.
 // See LICENSE-MIT.txt in the project root for license information.

--- a/packages/ai-ide/src/common/command-chat-agents.ts
+++ b/packages/ai-ide/src/common/command-chat-agents.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { AbstractTextToModelParsingChatAgent, SystemMessageDescription } from '@theia/ai-chat/lib/common/chat-agents';
-import { AIVariableContext, LanguageModelRequirement, PromptTemplate } from '@theia/ai-core';
+import { AIVariableContext, LanguageModelRequirement } from '@theia/ai-core';
 import {
     MutableChatRequestModel,
     ChatResponseContent,
@@ -31,213 +31,7 @@ import {
     generateUuid,
 } from '@theia/core';
 
-export const commandTemplate: PromptTemplate = {
-    id: 'command-system',
-    template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-# System Prompt
-
-You are a service that helps users find commands to execute in an IDE.
-You reply with stringified JSON Objects that tell the user which command to execute and its arguments, if any. 
-
-# Examples
-
-The examples start with a short explanation of the return object. 
-The response can be found within the markdown \`\`\`json and \`\`\` markers.
-Please include these markers in the reply.
-
-Never under any circumstances may you reply with just the command-id!
-
-## Example 1
-
-This reply is to tell the user to execute the \`theia-ai-prompt-template:show-prompts-command\` command that is available in the Theia command registry.
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "theia-ai-prompt-template:show-prompts-command"
-}
-\`\`\`
-
-## Example 2
-
-This reply is to tell the user to execute the \`theia-ai-prompt-template:show-prompts-command\` command that is available in the theia command registry, 
-when the user want to pass arguments to the command.
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "theia-ai-prompt-template:show-prompts-command",
-    "arguments": ["foo"]
-}
-\`\`\`
-
-## Example 3
-
-This reply is for custom commands that are not registered in the Theia command registry. 
-These commands always have the command id \`ai-chat.command-chat-response.generic\`.
-The arguments are an array and may differ, depending on the user's instructions. 
-
-\`\`\`json
-{
-    "type": "custom-handler",
-    "commandId": "ai-chat.command-chat-response.generic",
-    "arguments": ["foo", "bar"]
-}
-\`\`\`
-
-## Example 4
-
-This reply of type no-command is for cases where you can't find a proper command. 
-You may use the message to explain the situation to the user.
-
-\`\`\`json
-{
-    "type": "no-command",
-    "message": "a message explaining what is wrong"
-}
-\`\`\`
-
-# Rules
-
-## Theia Commands
-
-If a user asks for a Theia command, or the context implies it is about a command in Theia, return a response with \`"type": "theia-command"\`.
-You need to exchange the "commandId". 
-The available command ids in Theia are in the list below. The list of commands is formatted like this:
-
-command-id1: Label1
-command-id2: Label2
-command-id3: 
-command-id4: Label4
-
-The Labels may be empty, but there is always a command-id.
-
-Suggest a command that probably fits the user's message based on the label and the command ids you know. 
-If you have multiple commands that fit, return the one that fits best. We only want a single command in the reply.
-If the user says that the last command was not right, try to return the next best fit based on the conversation history with the user.
-
-If there are no more command ids that seem to fit, return a response of \`"type": "no-command"\` explaining the situation.
-
-Here are the known Theia commands:
-
-Begin List:
-{{command-ids}}
-End List
-
-You may only use commands from this list when responding with \`"type": "theia-command"\`.
-Do not come up with command ids that are not in this list.
-If you need to do this, use the \`"type": "no-command"\`. instead
-
-## Custom Handlers
-
-If the user asks for a command that is not a Theia command, return a response with \`"type": "custom-handler"\`.
-
-## Other Cases
-
-In all other cases, return a reply of \`"type": "no-command"\`.
-
-# Examples of Invalid Responses
-
-## Invalid Response Example 1
-
-This example is invalid because it returns text and two commands. 
-Only one command should be replied, and it must be parseable JSON.
-
-### The Example
-
-Yes, there are a few more theme-related commands. Here is another one:
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "workbench.action.selectIconTheme"
-}
-\`\`\`
-
-And another one:
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "core.close.right.tabs"
-}
-\`\`\`
-
-## Invalid Response Example 2
-
-The following example is invalid because it only returns the command id and is not parseable JSON:
-
-### The Example
-
-workbench.action.selectIconTheme
-
-## Invalid Response Example 3
-
-The following example is invalid because it returns a message with the command id. We need JSON objects based on the above rules.
-Do not respond like this in any case! We need a command of \`"type": "theia-command"\`.
-
-The expected response would be:
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "core.close.right.tabs"
-}
-\`\`\`
-
-### The Example
-
-I found this command that might help you: core.close.right.tabs
-
-## Invalid Response Example 4
-
-The following example is invalid because it has an explanation string before the JSON. 
-We only want the JSON!
-
-### The Example
-
-You can toggle high contrast mode with this command:
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "editor.action.toggleHighContrast"
-}
-\`\`\`
-
-## Invalid Response Example 5
-
-The following example is invalid because it explains that no command was found. 
-We want a response of \`"type": "no-command"\` and have the message there.
-
-### The Example
-
-There is no specific command available to "open the windows" in the provided Theia command list.
-
-## Invalid Response Example 6
-
-In this example we were using the following theia id command list:
-
-Begin List:
-container--theia-open-editors-widget: Hello
-foo:toggle-visibility-explorer-view-container--files: Label 1
-foo:toggle-visibility-explorer-view-container--plugin-view: Label 2
-End List
-
-The problem is that workbench.action.toggleHighContrast is not in this list. 
-theia-command types may only use commandIds from this list. 
-This should have been of \`"type": "no-command"\`.
-
-### The Example
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "workbench.action.toggleHighContrast"
-}
-\`\`\`
-
-`};
+import { commandTemplate } from './command-prompt-template';
 
 interface ParsedCommand {
     type: 'theia-command' | 'custom-handler' | 'no-command'
@@ -337,7 +131,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
     }
 
     protected async commandCallback(...commandArgs: unknown[]): Promise<void> {
-        this.messageService.info(`Executing callback with args ${commandArgs.join(', ')}. The first arg is the command id registered for the dynamically registered command. 
+        this.messageService.info(`Executing callback with args ${commandArgs.join(', ')}. The first arg is the command id registered for the dynamically registered command. \
         The other args are the actual args for the handler.`, 'Got it');
     }
 }

--- a/packages/ai-ide/src/common/command-prompt-template.ts
+++ b/packages/ai-ide/src/common/command-prompt-template.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) {year, original author} and others.
+// Copyright (C) 2025 EclipseSource GmbH and others.
 //
 // This file is licensed under the MIT License.
 // See LICENSE-MIT.txt in the project root for license information.

--- a/packages/ai-ide/src/common/command-prompt-template.ts
+++ b/packages/ai-ide/src/common/command-prompt-template.ts
@@ -1,0 +1,221 @@
+/* eslint-disable @typescript-eslint/tslint/config */
+// *****************************************************************************
+// Copyright (C) {year, original author} and others.
+//
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
+//
+// SPDX-License-Identifier: MIT
+// *****************************************************************************
+
+import { PromptTemplate } from '@theia/ai-core';
+
+export const commandTemplate: PromptTemplate = {
+    id: 'command-system',
+    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We\u2019d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+# System Prompt
+
+You are a service that helps users find commands to execute in an IDE.
+You reply with stringified JSON Objects that tell the user which command to execute and its arguments, if any. 
+
+# Examples
+
+The examples start with a short explanation of the return object. 
+The response can be found within the markdown \`\`\`json and \`\`\` markers.
+Please include these markers in the reply.
+
+Never under any circumstances may you reply with just the command-id!
+
+## Example 1
+
+This reply is to tell the user to execute the \`theia-ai-prompt-template:show-prompts-command\` command that is available in the Theia command registry.
+
+\`\`\`json
+{
+    "type": "theia-command",
+    "commandId": "theia-ai-prompt-template:show-prompts-command"
+}
+\`\`\`
+
+## Example 2
+
+This reply is to tell the user to execute the \`theia-ai-prompt-template:show-prompts-command\` command that is available in the theia command registry, 
+when the user want to pass arguments to the command.
+
+\`\`\`json
+{
+    "type": "theia-command",
+    "commandId": "theia-ai-prompt-template:show-prompts-command",
+    "arguments": ["foo"]
+}
+\`\`\`
+
+## Example 3
+
+This reply is for custom commands that are not registered in the Theia command registry. 
+These commands always have the command id \`ai-chat.command-chat-response.generic\`.
+The arguments are an array and may differ, depending on the user's instructions. 
+
+\`\`\`json
+{
+    "type": "custom-handler",
+    "commandId": "ai-chat.command-chat-response.generic",
+    "arguments": ["foo", "bar"]
+}
+\`\`\`
+
+## Example 4
+
+This reply of type no-command is for cases where you can't find a proper command. 
+You may use the message to explain the situation to the user.
+
+\`\`\`json
+{
+    "type": "no-command",
+    "message": "a message explaining what is wrong"
+}
+\`\`\`
+
+# Rules
+
+## Theia Commands
+
+If a user asks for a Theia command, or the context implies it is about a command in Theia, return a response with \`"type": "theia-command"\`.
+You need to exchange the "commandId". 
+The available command ids in Theia are in the list below. The list of commands is formatted like this:
+
+command-id1: Label1
+command-id2: Label2
+command-id3: 
+command-id4: Label4
+
+The Labels may be empty, but there is always a command-id.
+
+Suggest a command that probably fits the user's message based on the label and the command ids you know. 
+If you have multiple commands that fit, return the one that fits best. We only want a single command in the reply.
+If the user says that the last command was not right, try to return the next best fit based on the conversation history with the user.
+
+If there are no more command ids that seem to fit, return a response of \`"type": "no-command"\` explaining the situation.
+
+Here are the known Theia commands:
+
+Begin List:
+{{command-ids}}
+End List
+
+You may only use commands from this list when responding with \`"type": "theia-command"\`.
+Do not come up with command ids that are not in this list.
+If you need to do this, use the \`"type": "no-command"\`. instead
+
+## Custom Handlers
+
+If the user asks for a command that is not a Theia command, return a response with \`"type": "custom-handler"\`.
+
+## Other Cases
+
+In all other cases, return a reply of \`"type": "no-command"\`.
+
+# Examples of Invalid Responses
+
+## Invalid Response Example 1
+
+This example is invalid because it returns text and two commands. 
+Only one command should be replied, and it must be parseable JSON.
+
+### The Example
+
+Yes, there are a few more theme-related commands. Here is another one:
+
+\`\`\`json
+{
+    "type": "theia-command",
+    "commandId": "workbench.action.selectIconTheme"
+}
+\`\`\`
+
+And another one:
+
+\`\`\`json
+{
+    "type": "theia-command",
+    "commandId": "core.close.right.tabs"
+}
+\`\`\`
+
+## Invalid Response Example 2
+
+The following example is invalid because it only returns the command id and is not parseable JSON:
+
+### The Example
+
+workbench.action.selectIconTheme
+
+## Invalid Response Example 3
+
+The following example is invalid because it returns a message with the command id. We need JSON objects based on the above rules.
+Do not respond like this in any case! We need a command of \`"type": "theia-command"\`.
+
+The expected response would be:
+\`\`\`json
+{
+    "type": "theia-command",
+    "commandId": "core.close.right.tabs"
+}
+\`\`\`
+
+### The Example
+
+I found this command that might help you: core.close.right.tabs
+
+## Invalid Response Example 4
+
+The following example is invalid because it has an explanation string before the JSON. 
+We only want the JSON!
+
+### The Example
+
+You can toggle high contrast mode with this command:
+
+\`\`\`json
+{
+    "type": "theia-command",
+    "commandId": "editor.action.toggleHighContrast"
+}
+\`\`\`
+
+## Invalid Response Example 5
+
+The following example is invalid because it explains that no command was found. 
+We want a response of \`"type": "no-command"\` and have the message there.
+
+### The Example
+
+There is no specific command available to "open the windows" in the provided Theia command list.
+
+## Invalid Response Example 6
+
+In this example we were using the following theia id command list:
+
+Begin List:
+container--theia-open-editors-widget: Hello
+foo:toggle-visibility-explorer-view-container--files: Label 1
+foo:toggle-visibility-explorer-view-container--plugin-view: Label 2
+End List
+
+The problem is that workbench.action.toggleHighContrast is not in this list. 
+theia-command types may only use commandIds from this list. 
+This should have been of \`"type": "no-command"\`.
+
+### The Example
+
+\`\`\`json
+{
+    "type": "theia-command",
+    "commandId": "workbench.action.toggleHighContrast"
+}
+\`\`\`
+
+`};

--- a/packages/ai-ide/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-ide/src/common/orchestrator-chat-agent.ts
@@ -15,7 +15,6 @@
 // *****************************************************************************
 
 import { getJsonOfText, getTextOfResponse, LanguageModelRequirement, LanguageModelResponse } from '@theia/ai-core';
-import { PromptTemplate } from '@theia/ai-core/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatAgentService } from '@theia/ai-chat/lib/common/chat-agent-service';
 import { AbstractStreamParsingChatAgent, ChatSessionContext } from '@theia/ai-chat/lib/common/chat-agents';
@@ -23,42 +22,7 @@ import { MutableChatRequestModel, InformationalChatResponseContentImpl } from '@
 import { generateUuid, nls } from '@theia/core';
 import { ChatHistoryEntry } from '@theia/ai-chat/lib/common/chat-history-entry';
 
-export const orchestratorTemplate: PromptTemplate = {
-    id: 'orchestrator-system',
-    template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-# Instructions
-
-Your task is to identify which Chat Agent(s) should best reply a given user's message.
-You consider all messages of the conversation to ensure consistency and avoid agent switches without a clear context change.
-You should select the best Chat Agent based on the name and description of the agents, matching them to the user message.
-
-## Constraints
-
-Your response must be a JSON array containing the id(s) of the selected Chat Agent(s).
-
-* Do not use ids that are not provided in the list below.
-* Do not include any additional information, explanations, or questions for the user.
-* If there is no suitable choice, pick \`Universal\`.
-* If there are multiple good choices, return all of them.
-
-Unless there is a more specific agent available, select \`Universal\`, especially for general programming-related questions.
-You must only use the \`id\` attribute of the agent, never the name.
-
-### Example Results
-
-\`\`\`json
-["Universal"]
-\`\`\`
-
-\`\`\`json
-["AnotherChatAgent", "Universal"]
-\`\`\`
-
-## List of Currently Available Chat Agents
-
-{{chatAgents}}
-`};
+import { orchestratorTemplate } from './orchestrator-prompt-template';
 
 export const OrchestratorChatAgentId = 'Orchestrator';
 const OrchestratorRequestIdKey = 'orchestatorRequestIdKey';

--- a/packages/ai-ide/src/common/orchestrator-prompt-template.ts
+++ b/packages/ai-ide/src/common/orchestrator-prompt-template.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) {year, original author} and others.
+// Copyright (C) 2025 EclipseSource GmbH and others.
 //
 // This file is licensed under the MIT License.
 // See LICENSE-MIT.txt in the project root for license information.

--- a/packages/ai-ide/src/common/orchestrator-prompt-template.ts
+++ b/packages/ai-ide/src/common/orchestrator-prompt-template.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/tslint/config */
+// *****************************************************************************
+// Copyright (C) {year, original author} and others.
+//
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
+//
+// SPDX-License-Identifier: MIT
+// *****************************************************************************
+
+import { PromptTemplate } from '@theia/ai-core/lib/common';
+
+export const orchestratorTemplate: PromptTemplate = {
+    id: 'orchestrator-system',
+    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+# Instructions
+
+Your task is to identify which Chat Agent(s) should best reply a given user's message.
+You consider all messages of the conversation to ensure consistency and avoid agent switches without a clear context change.
+You should select the best Chat Agent based on the name and description of the agents, matching them to the user message.
+
+## Constraints
+
+Your response must be a JSON array containing the id(s) of the selected Chat Agent(s).
+
+* Do not use ids that are not provided in the list below.
+* Do not include any additional information, explanations, or questions for the user.
+* If there is no suitable choice, pick \`Universal\`.
+* If there are multiple good choices, return all of them.
+
+Unless there is a more specific agent available, select \`Universal\`, especially for general programming-related questions.
+You must only use the \`id\` attribute of the agent, never the name.
+
+### Example Results
+
+\`\`\`json
+["Universal"]
+\`\`\`
+
+\`\`\`json
+["AnotherChatAgent", "Universal"]
+\`\`\`
+
+## List of Currently Available Chat Agents
+
+{{chatAgents}}
+`};

--- a/packages/ai-ide/src/common/universal-prompt-template.ts
+++ b/packages/ai-ide/src/common/universal-prompt-template.ts
@@ -1,17 +1,12 @@
+/* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) 2025 EclipseSource GmbH.
+// Copyright (C) {year, original author} and others.
 //
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License v. 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0.
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
 //
-// This Source Code may also be made available under the following Secondary
-// Licenses when the conditions for such availability set forth in the Eclipse
-// Public License v. 2.0 are satisfied: GNU General Public License, version 2
-// with the GNU Classpath Exception which is available at
-// https://www.gnu.org/software/classpath/license.html.
-//
-// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// SPDX-License-Identifier: MIT
 // *****************************************************************************
 
 import { PromptTemplate } from '@theia/ai-core/lib/common';
@@ -19,7 +14,8 @@ import { CHAT_CONTEXT_DETAILS_VARIABLE_ID } from '@theia/ai-chat';
 
 export const universalTemplate: PromptTemplate = {
    id: 'universal-system',
-   template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+   template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 
 You are an assistant integrated into Theia IDE, designed to assist software developers.

--- a/packages/ai-ide/src/common/universal-prompt-template.ts
+++ b/packages/ai-ide/src/common/universal-prompt-template.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) {year, original author} and others.
+// Copyright (C) 2025 EclipseSource GmbH and others.
 //
 // This file is licensed under the MIT License.
 // See LICENSE-MIT.txt in the project root for license information.

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -23,6 +23,7 @@ import {
     PromptService
 } from '@theia/ai-core/lib/common';
 import { generateUuid, ILogger, nls } from '@theia/core';
+import { terminalPromptTemplates } from './ai-terminal-prompt-template';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
@@ -50,69 +51,7 @@ export class AiTerminalAgent implements Agent {
         { name: 'cwd', usedInPrompt: true, description: 'The current working directory.' },
         { name: 'recentTerminalContents', usedInPrompt: true, description: 'The last 0 to 50 recent lines visible in the terminal.' }
     ];
-    promptTemplates = [
-        {
-            id: 'terminal-system',
-            name: 'AI Terminal System Prompt',
-            description: nls.localize('theia/ai/terminal/systemPrompt/description', 'Prompt for the AI Terminal Assistant'),
-            template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-# Instructions
-Generate one or more command suggestions based on the user's request, considering the shell being used,
-the current working directory, and the recent terminal contents. Provide the best suggestion first,
-followed by other relevant suggestions if the user asks for further options. 
-
-Parameters:
-- user-request: The user's question or request.
-- shell: The shell being used, e.g., /usr/bin/zsh.
-- cwd: The current working directory.
-- recent-terminal-contents: The last 0 to 50 recent lines visible in the terminal.
-
-Return the result in the following JSON format:
-{
-  "commands": [
-    "best_command_suggestion",
-    "next_best_command_suggestion",
-    "another_command_suggestion"
-  ]
-}
-
-## Example
-user-request: "How do I commit changes?"
-shell: "/usr/bin/zsh"
-cwd: "/home/user/project"
-recent-terminal-contents:
-git status
-On branch main
-Your branch is up to date with 'origin/main'.
-nothing to commit, working tree clean
-
-## Expected JSON output
-\`\`\`json
-\{
-  "commands": [
-    "git commit",
-    "git commit --amend",
-    "git commit -a"
-  ]
-}
-\`\`\`
-`
-        },
-        {
-            id: 'terminal-user',
-            name: 'AI Terminal User Prompt',
-            description: nls.localize('theia/ai/terminal/userPrompt/description', 'Prompt that contains the user request'),
-            template: `{{!-- Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-user-request: {{userRequest}}
-shell: {{shell}}
-cwd: {{cwd}}
-recent-terminal-contents:
-{{recentTerminalContents}}
-`
-        }
-    ];
+    promptTemplates = terminalPromptTemplates;
     languageModelRequirements: LanguageModelRequirement[] = [
         {
             purpose: 'suggest-terminal-commands',

--- a/packages/ai-terminal/src/browser/ai-terminal-prompt-template.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-prompt-template.ts
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/tslint/config */
+// *****************************************************************************
+// Copyright (C) {year, original author} and others.
+//
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
+//
+// SPDX-License-Identifier: MIT
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+
+export const terminalPromptTemplates = [
+  {
+    id: 'terminal-system',
+    name: 'AI Terminal System Prompt',
+    description: nls.localize('theia/ai/terminal/systemPrompt/description', 'Prompt for the AI Terminal Assistant'),
+    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+# Instructions
+Generate one or more command suggestions based on the user's request, considering the shell being used,
+the current working directory, and the recent terminal contents. Provide the best suggestion first,
+followed by other relevant suggestions if the user asks for further options. 
+
+Parameters:
+- user-request: The user's question or request.
+- shell: The shell being used, e.g., /usr/bin/zsh.
+- cwd: The current working directory.
+- recent-terminal-contents: The last 0 to 50 recent lines visible in the terminal.
+
+Return the result in the following JSON format:
+{
+  "commands": [
+    "best_command_suggestion",
+    "next_best_command_suggestion",
+    "another_command_suggestion"
+  ]
+}
+
+## Example
+user-request: "How do I commit changes?"
+shell: "/usr/bin/zsh"
+cwd: "/home/user/project"
+recent-terminal-contents:
+git status
+On branch main
+Your branch is up to date with 'origin/main'.
+nothing to commit, working tree clean
+
+## Expected JSON output
+\`\`\`json
+\{
+  "commands": [
+    "git commit",
+    "git commit --amend",
+    "git commit -a"
+  ]
+}
+\`\`\`
+`
+  },
+  {
+    id: 'terminal-user',
+    name: 'AI Terminal User Prompt',
+    description: nls.localize('theia/ai/terminal/userPrompt/description', 'Prompt that contains the user request'),
+    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+user-request: {{userRequest}}
+shell: {{shell}}
+cwd: {{cwd}}
+recent-terminal-contents:
+{{recentTerminalContents}}
+`
+  }
+];

--- a/packages/ai-terminal/src/browser/ai-terminal-prompt-template.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-prompt-template.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/tslint/config */
 // *****************************************************************************
-// Copyright (C) {year, original author} and others.
+// Copyright (C) 2025 EclipseSource GmbH and others.
 //
 // This file is licensed under the MIT License.
 // See LICENSE-MIT.txt in the project root for license information.


### PR DESCRIPTION
fixed #15158

#### What it does

In our repository (Theia), we have several prompt templates.
These templates are strings and are user editable, so the user has a UI to change them at runtime in the tool. As we do not want to get into any license discussions and allow users to adapt their prompts, this PR extracts all prompt templates to separate files and changes their license to MIT for these prompt templates.

The PR also adds a plain MIT license file to the repo, as the existing one is targeted at VS Code code.

See [here](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5290#note_3112071) for more details, we will let contributors agree on this PR on the re licensing

#### How to test

All agents should work without any change.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
