### PR TITLE
Add dummy preference descriptions to open AI config widget

### DIFF
--- a/packages/ai-core/src/browser/agent-preferences.ts
+++ b/packages/ai-core/src/browser/agent-preferences.ts
@@ -25,6 +25,7 @@ export const AgentSettingsPreferenceSchema: PreferenceSchema = {
     [AGENT_SETTINGS_PREF]: {
       type: 'object',
       title: nls.localize('theia/ai/agents/title', 'Agent Settings'),
+      hidden: true,
       markdownDescription: nls.localize('theia/ai/agents/mdDescription', 'Configure agent settings such as enabling or disabling specific agents, configuring prompts and \
         selecting LLMs.'),
       additionalProperties: {

--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-preferences.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-preferences.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { PreferenceSchema } from '@theia/core/lib/browser/preferences/preference-contribution';
+
+/**
+ * These preferences are not intended to reflect real settings.
+ * They are placeholders to redirect users to the appropriate widget
+ * in case the user looks in the preferences editor UI to find the configuration.
+ */
+export const AiConfigurationPreferences: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'ai-features.agentSettings.details': {
+            type: 'null',
+            markdownDescription: nls.localize('theia/ai/ide/agent-description',
+                'Additional settings for AI agents can be configured using the [AI Configuration View]({0}).',
+                'command:aiConfiguration:open'
+            )
+        },
+        'ai-features.promptTemplates.details': {
+            type: 'null',
+            markdownDescription: nls.localize('theia/ai/ide/prompt-template-description',
+                'Additional AI prompt template settings can be configured using the [AI Configuration View]({0}).',
+                'command:aiConfiguration:open'
+            )
+        },
+        'ai-features.models.details': {
+            type: 'null',
+            markdownDescription: nls.localize('theia/ai/ide/prompt-template-description',
+                'Additional settings for AI models can be configured using the [AI Configuration View]({0}).',
+                'command:aiConfiguration:open'
+            )
+        }
+    }
+};

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -38,6 +38,7 @@ import { AIAgentConfigurationViewContribution } from './ai-configuration/ai-conf
 import { AIConfigurationContainerWidget } from './ai-configuration/ai-configuration-widget';
 import { AIVariableConfigurationWidget } from './ai-configuration/variable-configuration-widget';
 import { ContextFilesVariableContribution } from '../common/context-files-variable';
+import {AiConfigurationPreferences} from './ai-configuration/ai-configuration-preferences';
 
 export default new ContainerModule(bind => {
     bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
@@ -106,4 +107,5 @@ export default new ContainerModule(bind => {
     bind(ToolProvider).to(SimpleReplaceContentInFileProvider);
     bind(ToolProvider).to(AddFileToChatContext);
     bind(AIVariableContribution).to(ContextFilesVariableContribution).inSingletonScope();
+    bind(PreferenceContribution).toConstantValue({schema: AiConfigurationPreferences});
 });

--- a/packages/core/src/common/preferences/preference-schema.ts
+++ b/packages/core/src/common/preferences/preference-schema.ts
@@ -73,7 +73,10 @@ export interface PreferenceItem extends IJSONSchema {
      */
     defaultValue?: JSONValue;
     overridable?: boolean;
+    /** If false, the preference will not be included in the schema or the UI. */
     included?: boolean;
+    /** If true, this item will registered as part of the preference schema, but hidden in the preference editor UI. */
+    hidden?: boolean;
     [key: string]: any;
 }
 export interface PreferenceSchemaProperty extends PreferenceItem {

--- a/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
+++ b/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
@@ -103,7 +103,7 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
 
     handleSocketDisconnect(socket: Socket, channel: ReconnectableSocketChannel, frontEndId: string): void {
         socket.on('disconnect', evt => {
-            console.info('socked closed');
+            console.info('socket closed');
             channel.disconnect();
 
             const timeout = this.frontendConnectionTimeout();
@@ -183,4 +183,3 @@ class ReconnectableSocketChannel extends AbstractChannel {
         return writeBuffer;
     }
 }
-

--- a/packages/preferences/src/browser/util/preference-layout.ts
+++ b/packages/preferences/src/browser/util/preference-layout.ts
@@ -305,8 +305,80 @@ export const DEFAULT_LAYOUT: PreferenceLayout[] = [
     },
     {
         id: 'ai-features',
-        label: 'AI Features', // TODO localize
-        settings: ['ai-features.*']
+        label: nls.localize('theia/preferences/ai-features', 'AI Features'),
+        children: [
+            {
+                id: 'ai-features.aiEnablement',
+                label: nls.localize('theia/preferences/ai-features/ai-enable', 'AI Enablement'),
+                settings: ['ai-features.AiEnable.*']
+            },
+            {
+                id: 'ai-features.anthropic',
+                label: 'Anthropic',
+                settings: ['ai-features.anthropic.*']
+            },
+            {
+                id: 'ai-features.chat',
+                label: nls.localizeByDefault('Chat'),
+                settings: ['ai-features.chat.*']
+            },
+            {
+                id: 'ai-features.codeCompletion',
+                label: nls.localize('theia/preferences/ai-features/code-completion', 'Code Completion'),
+                settings: ['ai-features.codeCompletion.*']
+            },
+            {
+                id: 'ai-features.huggingFace',
+                label: 'Hugging Face',
+                settings: ['ai-features.huggingFace.*']
+            },
+            {
+                id: 'ai-features.mcp',
+                label: nls.localize('theia/preferences/ai-features/MCP', 'MCP'),
+                settings: ['ai-features.mcp.*']
+            },
+            {
+                id: 'ai-features.modelSettings',
+                label: nls.localize('theia/preferences/ai-features/model-settings', 'Model Settings'),
+                settings: ['ai-features.modelSettings.*']
+            },
+            {
+                id: 'ai-features.ollama',
+                label: 'Ollama',
+                settings: ['ai-features.ollama']
+            },
+            {
+                id: 'ai-features.llamafile',
+                label: 'Llamafile',
+                settings: ['ai-features.llamafile.*']
+            },
+            {
+                id: 'ai-features.openAiCustom',
+                label: nls.localize('theia/preferences/ai-features/open-ai-custom', '{0} Custom Models', 'Open AI'),
+                settings: ['ai-features.openAiCustom.*']
+            },
+            {
+                id: 'ai-features.openAiOfficial',
+                label: nls.localize('theia/preferences/ai-features/open-ai-official', '{0} Official Models', 'Open AI'),
+                settings: ['ai-features.openAiOfficial.*']
+            },
+            {
+                id: 'ai-features.promptTemplates',
+                label: nls.localize('theia/preferences/ai-features/promptTemplates', 'Prompt Templates'),
+                settings: ['ai-features.promptTemplates.*']
+            },
+            {
+                id: 'ai-features.SCANOSS',
+                label: 'SCAN OSS',
+                settings: ['ai-features.SCANOSS.*']
+            },
+            {
+                id: 'ai-features.workspaceFunctions',
+                label: nls.localize('theia/preferences/ai-features/workspace-functions', 'Workspace Functions'),
+                settings: ['ai-features.workspaceFunctions.*']
+            }
+        ]
+
     },
     {
         id: 'extensions',

--- a/packages/preferences/src/browser/util/preference-layout.ts
+++ b/packages/preferences/src/browser/util/preference-layout.ts
@@ -306,6 +306,7 @@ export const DEFAULT_LAYOUT: PreferenceLayout[] = [
     {
         id: 'ai-features',
         label: 'AI Features', // TODO localize
+        settings: ['ai-features.*']
     },
     {
         id: 'extensions',

--- a/packages/preferences/src/browser/util/preference-layout.ts
+++ b/packages/preferences/src/browser/util/preference-layout.ts
@@ -369,7 +369,7 @@ export const DEFAULT_LAYOUT: PreferenceLayout[] = [
             },
             {
                 id: 'ai-features.SCANOSS',
-                label: 'SCAN OSS',
+                label: 'SCANOSS',
                 settings: ['ai-features.SCANOSS.*']
             },
             {

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -92,7 +92,7 @@ export class PreferenceTreeGenerator {
         }
         for (const propertyName of propertyNames) {
             const property = preferencesSchema.properties[propertyName];
-            if (!this.preferenceConfigs.isSectionName(propertyName) && !OVERRIDE_PROPERTY_PATTERN.test(propertyName) && !property.deprecationMessage) {
+            if (!property.hidden && !property.deprecationMessage && !this.preferenceConfigs.isSectionName(propertyName) && !OVERRIDE_PROPERTY_PATTERN.test(propertyName)) {
                 if (property.owner) {
                     this.createPluginLeafNode(propertyName, property, root, groups);
                 } else {

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -207,6 +207,16 @@ export class PreferenceTreeGenerator {
         return this.defaultTopLevelCategory;
     }
 
+    protected getSubgroupName(labels: string[], computedGroupName: string): string | undefined {
+        if (computedGroupName !== labels[0]) {
+            return labels[0];
+        } else if (labels.length > 1) {
+            return labels[1];
+        } else {
+            return undefined;
+        }
+    }
+
     protected generateName(id: string): string {
         return this.labelProvider.formatString(id);
     }

--- a/packages/preferences/src/browser/util/preference-tree-label-provider.ts
+++ b/packages/preferences/src/browser/util/preference-tree-label-provider.ts
@@ -55,7 +55,7 @@ export class PreferenceTreeLabelProvider implements LabelProviderContribution {
         }
     }
 
-    protected formatString(string: string): string {
+    formatString(string: string): string {
         let formattedString = string[0].toLocaleUpperCase();
         for (let i = 1; i < string.length; i++) {
             if (this.isUpperCase(string[i]) && !/\s/.test(string[i - 1]) && !this.isUpperCase(string[i - 1])) {

--- a/packages/preferences/src/browser/views/components/preference-null-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-null-input.ts
@@ -1,0 +1,52 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
+import { Preference } from '../../util/preference-types';
+import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
+
+@injectable()
+/** For rendering preference items for which the only interesting feature is the description */
+export class PreferenceNullInputRenderer extends PreferenceLeafNodeRenderer<null, HTMLElement> {
+    protected override createInteractable(container: HTMLElement): void {
+        const span = document.createElement('span');
+        this.interactable = span;
+        container.appendChild(span);
+    }
+
+    protected override getFallbackValue(): null {
+        // eslint-disable-next-line no-null/no-null
+        return null;
+    }
+
+    protected override doHandleValueChange(): void { }
+}
+
+@injectable()
+export class PreferenceNullRendererContribution extends PreferenceLeafNodeRendererContribution {
+    static ID = 'preference-null-renderer';
+    id = PreferenceNullRendererContribution.ID;
+
+    canHandleLeafNode(node: Preference.LeafNode): number {
+        const isOnlyNull = node.preference.data.type === 'null' || Array.isArray(node.preference.data.type) && node.preference.data.type.every(candidate => candidate === 'null');
+        return isOnlyNull ? 5 : 0;
+    }
+
+    createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer {
+        return container.get(PreferenceNullInputRenderer);
+    }
+}

--- a/packages/preferences/src/browser/views/preference-widget-bindings.ts
+++ b/packages/preferences/src/browser/views/preference-widget-bindings.ts
@@ -36,6 +36,7 @@ import { PreferencesScopeTabBar } from './preference-scope-tabbar-widget';
 import { PreferencesSearchbarWidget } from './preference-searchbar-widget';
 import { PreferencesTreeWidget } from './preference-tree-widget';
 import { PreferencesWidget } from './preference-widget';
+import { PreferenceNullInputRenderer, PreferenceNullRendererContribution } from './components/preference-null-input';
 
 export function bindPreferencesWidgets(bind: interfaces.Bind): void {
     bind(PreferenceTreeLabelProvider).toSelf().inSingletonScope();
@@ -58,6 +59,8 @@ export function bindPreferencesWidgets(bind: interfaces.Bind): void {
 
     bind(PreferenceStringInputRenderer).toSelf();
     bind(PreferenceNodeRendererContribution).to(PreferenceStringInputRendererContribution).inSingletonScope();
+    bind(PreferenceNullInputRenderer).toSelf();
+    bind(PreferenceNodeRendererContribution).to(PreferenceNullRendererContribution).inSingletonScope();
 
     bind(PreferenceBooleanInputRenderer).toSelf();
     bind(PreferenceNodeRendererContribution).to(PreferenceBooleanInputRendererContribution).inSingletonScope();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #15160 by adding preferences whose descriptions redirect users to the config widget to enable them to perform more advanced AI configuration.

Fixes https://github.com/eclipse-theia/theia/issues/15165 by generating section names differently depending on presence or absence of layout item and by using the preference tree label provider's logic for label generation.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open the settings and look for settings under 'AI Features ... Agents', 'AI Features ... Models', and 'AI Features ... Prompt Templates'
2. You will find a dummy preference with a link to open the configuration widget.
3. Click the link, and the config widget should open.

The third segment (`details`) is to work around https://github.com/eclipse-theia/theia/issues/15165

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
