### PR TITLE
Add schema for agent settings

### DIFF
--- a/packages/ai-core/src/browser/agent-preferences.ts
+++ b/packages/ai-core/src/browser/agent-preferences.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2024 EclipseSource GmbH.
+// Copyright (C) 2025 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-core/src/browser/agent-preferences.ts
+++ b/packages/ai-core/src/browser/agent-preferences.ts
@@ -1,0 +1,73 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { PreferenceSchema } from '@theia/core/lib/browser/preferences/preference-contribution';
+
+export const AGENT_SETTINGS_PREF = 'ai-features.agentSettings';
+
+export const AgentSettingsPreferenceSchema: PreferenceSchema = {
+  type: 'object',
+  properties: {
+    [AGENT_SETTINGS_PREF]: {
+      type: 'object',
+      title: nls.localize('theia/ai/agents/title', 'Agent Settings'),
+      markdownDescription: nls.localize('theia/ai/agents/mdDescription', 'Configure agent settings such as enabling or disabling specific agents, configuring prompts and \
+        selecting LLMs.'),
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          enable: {
+            type: 'boolean',
+            title: nls.localize('theia/ai/agents/enable/title', 'Enable Agent'),
+            markdownDescription: nls.localize('theia/ai/agents/enable/mdDescription', 'Specifies whether the agent should be enabled (true) or disabled (false).'),
+            default: true
+          },
+          languageModelRequirements: {
+            type: 'array',
+            title: nls.localize('theia/ai/agents/languageModelRequirements/title', 'Language Model Requirements'),
+            markdownDescription: nls.localize('theia/ai/agents/languageModelRequirements/mdDescription', 'Specifies the used language models for this agent.'),
+            items: {
+              type: 'object',
+              properties: {
+                purpose: {
+                  type: 'string',
+                  title: nls.localize('theia/ai/agents/languageModelRequirements/purpose/title', 'Purpose'),
+                  markdownDescription: nls.localize('theia/ai/agents/languageModelRequirements/purpose/mdDescription', 'The purpose for which this language model is used.')
+                },
+                identifier: {
+                  type: 'string',
+                  title: nls.localize('theia/ai/agents/languageModelRequirements/identifier/title', 'Identifier'),
+                  markdownDescription: nls.localize('theia/ai/agents/languageModelRequirements/identifier/mdDescription', 'The identifier of the language model to be used.')
+                }
+              },
+              required: ['purpose', 'identifier']
+            }
+          },
+          selectedVariants: {
+            type: 'object',
+            title: nls.localize('theia/ai/agents/selectedVariants/title', 'Selected Variants'),
+            markdownDescription: nls.localize('theia/ai/agents/selectedVariants/mdDescription', 'Specifies the currently selected prompt variants for this agent.'),
+            additionalProperties: {
+              type: 'string'
+            }
+          }
+        },
+        required: ['languageModelRequirements']
+      }
+    }
+  }
+};

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -42,12 +42,13 @@ import {
     LanguageModelDelegateClientImpl,
 } from './frontend-language-model-registry';
 
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, PreferenceContribution } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { LanguageGrammarDefinitionContribution } from '@theia/monaco/lib/browser/textmate';
 
 import { AICoreFrontendApplicationContribution } from './ai-core-frontend-application-contribution';
 import { bindAICorePreferences } from './ai-core-preferences';
+import { AgentSettingsPreferenceSchema } from './agent-preferences';
 import { AISettingsServiceImpl } from './ai-settings-service';
 import { FrontendPromptCustomizationServiceImpl } from './frontend-prompt-customization-service';
 import { DefaultFrontendVariableService, FrontendVariableService } from './frontend-variable-service';
@@ -88,6 +89,7 @@ export default new ContainerModule(bind => {
         .inSingletonScope();
 
     bindAICorePreferences(bind);
+    bind(PreferenceContribution).toConstantValue({ schema: AgentSettingsPreferenceSchema });
 
     bind(FrontendPromptCustomizationServiceImpl).toSelf().inSingletonScope();
     bind(PromptCustomizationService).toService(FrontendPromptCustomizationServiceImpl);


### PR DESCRIPTION
fixed #15174

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

registers a schema for the agent settings

#### How to test

Open the settings.json and see that agent settings do not show a warning anymore

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
