### PR TITLE
[vscode] Support keepWhitespace in SnippetTextEdit and insertSnippet

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1241,6 +1241,10 @@ export interface ApplyEditsOptions extends UndoStopOptions {
     setEndOfLine: EndOfLine | undefined;
 }
 
+export interface SnippetEditOptions extends UndoStopOptions {
+    keepWhitespace?: boolean;
+}
+
 export interface ThemeColor {
     id: string;
 }
@@ -1345,7 +1349,7 @@ export interface TextEditorsMain {
     $trySetSelections(id: string, selections: Selection[]): Promise<void>;
     $tryApplyEdits(id: string, modelVersionId: number, edits: SingleEditOperation[], opts: ApplyEditsOptions): Promise<boolean>;
     $tryApplyWorkspaceEdit(workspaceEditDto: WorkspaceEditDto, metadata?: WorkspaceEditMetadataDto): Promise<boolean>;
-    $tryInsertSnippet(id: string, template: string, selections: Range[], opts: UndoStopOptions): Promise<boolean>;
+    $tryInsertSnippet(id: string, template: string, selections: Range[], opts: SnippetEditOptions): Promise<boolean>;
     $save(uri: UriComponents): PromiseLike<UriComponents | undefined>;
     $saveAs(uri: UriComponents): PromiseLike<UriComponents | undefined>;
     $saveAll(includeUntitled?: boolean): Promise<boolean>;
@@ -1545,7 +1549,7 @@ export interface WorkspaceFileEditDto {
 export interface WorkspaceTextEditDto {
     resource: UriComponents;
     modelVersionId?: number;
-    textEdit: TextEdit & { insertAsSnippet?: boolean };
+    textEdit: TextEdit & { insertAsSnippet?: boolean, keepWhitespace?: boolean };
     metadata?: WorkspaceEditEntryMetadataDto;
 }
 export namespace WorkspaceTextEditDto {

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -23,7 +23,6 @@ import {
     TextEditorRevealType,
     SingleEditOperation,
     ApplyEditsOptions,
-    UndoStopOptions,
     DecorationRenderOptions,
     ThemeDecorationInstanceRenderOptions,
     DecorationOptions,
@@ -31,6 +30,7 @@ import {
     WorkspaceNotebookCellEditDto,
     DocumentsMain,
     WorkspaceEditMetadataDto,
+    SnippetEditOptions,
 } from '../../common/plugin-api-rpc';
 import { Range, TextDocumentShowOptions } from '../../common/plugin-api-rpc-model';
 import { EditorsAndDocumentsMain } from './editors-and-documents-main';
@@ -157,7 +157,7 @@ export class TextEditorsMainImpl implements TextEditorsMain, Disposable {
         }
     }
 
-    $tryInsertSnippet(id: string, template: string, ranges: Range[], opts: UndoStopOptions): Promise<boolean> {
+    $tryInsertSnippet(id: string, template: string, ranges: Range[], opts: SnippetEditOptions): Promise<boolean> {
         if (!this.editorsAndDocuments.getEditor(id)) {
             return Promise.reject(disposed(`TextEditor(${id})`));
         }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -342,11 +342,12 @@ export function fromTextEdit(edit: theia.TextEdit): model.TextEdit {
     };
 }
 
-function fromSnippetTextEdit(edit: theia.SnippetTextEdit): model.TextEdit & { insertAsSnippet?: boolean } {
+function fromSnippetTextEdit(edit: theia.SnippetTextEdit): model.TextEdit & { insertAsSnippet?: boolean, keepWhitespace?: boolean } {
     return {
         text: edit.snippet.value,
         range: fromRange(edit.range),
-        insertAsSnippet: true
+        insertAsSnippet: true,
+        keepWhitespace: edit.keepWhitespace
     };
 }
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1341,6 +1341,7 @@ export class NotebookRange implements theia.NotebookRange {
 export class SnippetTextEdit implements theia.SnippetTextEdit {
     range: Range;
     snippet: SnippetString;
+    keepWhitespace?: boolean;
 
     static isSnippetTextEdit(thing: unknown): thing is SnippetTextEdit {
         return thing instanceof SnippetTextEdit || isObject<SnippetTextEdit>(thing)

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1146,7 +1146,20 @@ export module '@theia/plugin' {
          * @return A promise that resolves with a value indicating if the snippet could be inserted. Note that the promise does not signal
          * that the snippet is completely filled-in or accepted.
          */
-        insertSnippet(snippet: SnippetString, location?: Position | Range | Position[] | Range[], options?: { undoStopBefore: boolean; undoStopAfter: boolean; }): Thenable<boolean>;
+        insertSnippet(snippet: SnippetString, location?: Position | Range | Position[] | Range[], options?: {
+            /**
+             * Add undo stop before making the edits.
+             */
+            readonly undoStopBefore: boolean;
+            /**
+             * Add undo stop after making the edits.
+             */
+            readonly undoStopAfter: boolean;
+            /**
+             * Keep whitespace of the {@link SnippetString.value} as is.
+             */
+            readonly keepWhitespace?: boolean;
+        }): Thenable<boolean>;
 
         /**
          * Adds a set of decorations to the text editor. If a set of decorations already exists with
@@ -16298,6 +16311,11 @@ export module '@theia/plugin' {
          * The {@link SnippetString snippet} this edit will perform.
          */
         snippet: SnippetString;
+
+        /**
+         * Whether the snippet edit should be applied with existing whitespace preserved.
+         */
+        keepWhitespace?: boolean;
 
         /**
          * Create a new snippet edit.


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This introduces the support of the keepWhitespace optional value added in the TextEditor.insertSnippet API and SnippetTextEdit. 

fixes #15131

#### How to test

1. install the following exension in the browser or electron example: 
- src: [snippet-sample-0.0.1-src.zip](https://github.com/user-attachments/files/19213103/snippet-sample-0.0.1-src.zip)
- zip vsix: [snippet-sample-0.0.1.zip](https://github.com/user-attachments/files/19213104/snippet-sample-0.0.1.zip)

2. in a text file, insert text edits using the 3 following commands from the command palette on lines with different indentations: 
- "Insert Snippet - keepWhitespace True", 
- "Insert Snippet - keepWhitespace False"
- "Insert Snippet - keepWhitespace Undefined". 
These 3 commands will add 2 lines of text with 2 spaces at the beginning of each line. The keep whitespace parameter keeps or not the indentation at the beginning of the line. If you insert the text on an already indented line, 4 in video example, the insert with keepwhitespace parameter being true or false will behave differently. The second line will have a different indentation based on the parameter. If keepWhitespace is true, the second line will only have the spaces has defined in the snippet (2 in the extension case). If false or undefined, it will have snippet indentation (2) + current line indentation (4 in the video example) . The behavior is similar with the one on vscode.

Note: this only tests the insertSnippet() parameter addition. 
The SnippetTextEdit keepWhiteSpace property is simply passed from the extension to the main, and transformed directly to equivalent monaco type. 
When looking at https://github.com/eclipse-theia/theia/blob/5e851cd1a042555577537b51039d5af6ef3593b8/packages/plugin-ext/src/main/browser/languages-main.ts#L1415, in the case of a WorkspaceTextEditDto, the returned Monaco type [IWorkspaceTextEdit](https://github.com/microsoft/vscode/blob/6609ac3d66f4eade5cf376d1cb76f13985724bcb/src/vs/monaco.d.ts#L8021) also supports this keepWhitespace parameter.

Sample video:

https://github.com/user-attachments/assets/f7876315-f1d8-407b-a030-f3f6590ad622

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
