### PR TITLE
Consider TerminalLinkProvider contributions recursively

### DIFF
--- a/packages/terminal/src/browser/terminal-link-provider.ts
+++ b/packages/terminal/src/browser/terminal-link-provider.ts
@@ -72,7 +72,7 @@ export class TerminalLinkProviderContribution implements TerminalContribution {
         const context = getLinkContext(terminal.getTerminal(), line);
 
         const linkProviderPromises: Promise<TerminalLink[]>[] = [];
-        for (const provider of this.terminalLinkContributionProvider.getContributions()) {
+        for (const provider of this.terminalLinkContributionProvider.getContributions(true)) {
             linkProviderPromises.push(provider.provideLinks(context.text, terminal));
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #15050 by considering the TerminalLinkProvider contributions also recursively (i.e., consider TerminalLinkProvider contributions bound in the root container). 

For a thorough analysis of the issue see https://github.com/eclipse-theia/theia/issues/15050#issuecomment-2718141068

#### How to test

See #15050 description.
In short:

* npm run build:browser
* npm run download:plugins
* npm run start:browser
* Start frontend and make sure a folder is opened
* Command Palette: Terminal: Create new Terminal
* In the terminal, execute `ls -l`
* Try to hover over a file (e.g., package.json)

Without the fix, there is no link provided, with the fix, the link is there and clicking leads to the file being opened in an editor.

Notes:
1. I am not 100% sure whether this is the correct fix. It could also be a bug that plugin-ext binds the TerminalServiceMainImpl in the child container, not the parent (root) container. So, maybe someone with knowledge in this area should have a second look. (Again, see the linked comment in the issue for details)
2. I tried to write a unit test but failed because importing the `terminal-link-provider` from the test results in a phosphor error (`ReferenceError: navigator is not defined`). So I am not sure how to mock the UI dependencies correctly and I haven't found a similar example/test case in the code base...

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
