### PR TITLE
[vsode] Support command workbench.extensions.command.installFromVSIX

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -375,7 +375,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.files.action.refreshFilesExplorer' }, {
             execute: () => commands.executeCommand(FileNavigatorCommands.REFRESH_NAVIGATOR.id)
         });
-        commands.registerCommand({ id: VscodeCommands.INSTALL_EXTENSION_FROM_ID_OR_URI.id }, {
+        commands.registerCommand(VscodeCommands.INSTALL_EXTENSION_FROM_ID_OR_URI, {
             execute: async (vsixUriOrExtensionId: TheiaURI | UriComponents | string) => {
                 if (typeof vsixUriOrExtensionId === 'string') {
                     await this.pluginServer.deploy(VSCodeExtensionUri.fromId(vsixUriOrExtensionId).toString());
@@ -384,10 +384,10 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                 }
             }
         });
-        commands.registerCommand({ id: VscodeCommands.INSTALL_EXTENSION_FROM_VSIX_COMMAND.id }, {
+        commands.registerCommand(VscodeCommands.INSTALL_EXTENSION_FROM_VSIX_COMMAND, {
             execute: async (uris: TheiaURI[] | UriComponents[] | TheiaURI | UriComponents) => {
                 if (isArray(uris)) {
-                    await Promise.all((uris as (TheiaURI | UriComponents)[]).map(async vsix => {
+                    await Promise.all(uris.map(async vsix => {
                         await this.deployPlugin(vsix);
                     }));
                 } else {

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -244,7 +244,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
     protected async installVsixFile(fileURI: URI): Promise<void> {
         const extensionName = this.labelProvider.getName(fileURI);
         try {
-            await this.commandRegistry.executeCommand(VscodeCommands.INSTALL_FROM_VSIX.id, fileURI);
+            await this.commandRegistry.executeCommand(VscodeCommands.INSTALL_EXTENSION_FROM_ID_OR_URI.id, fileURI);
             this.messageService.info(nls.localizeByDefault('Completed installing extension.', extensionName));
         } catch (e) {
             this.messageService.error(nls.localize('theia/vsx-registry/failedInstallingVSIX', 'Failed to install {0} from VSIX.', extensionName));


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Adds the support of a vscode command to install extension(s) from a URI. 
fixes #15169

#### How to test

Follow the steps described in the issue #15169. 
1. Run the browser example
2. Try to install CodeLLDB via the Extensions view (search for LLDB in the extension search area). The extension shall install properly with the patch.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
