### PR TITLE
Support prompt fragments and variable dependencies with recursive resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - [core] fixed version `@types/express` to `^4.17.21` and `@types/express-serve-static-core` to `5.0.4`. This might be required for adopters as well if they run into typing issues. [#15147](https://github.com/eclipse-theia/theia/pull/15147)
 
+<a name="breaking_changes_1.60.0">[Breaking Changes:](#breaking_changes_1.60.0)</a>
+
+- [ai-chat] `ParsedChatRequest.variables` is now `ResolvedAIVariable[]` instead of a `Map<string, AIVariable>` [#15196](https://github.com/eclipse-theia/theia/pull/15196)
+- [ai-chat] `ChatRequestParser.parseChatRequest` is now asynchronous and expects an additional `ChatContext` parameter [#15196](https://github.com/eclipse-theia/theia/pull/15196)
+
 ## 1.59.0 - 02/27/2025
 
 - [ai] added claude sonnet 3.7 to default models [#15023](https://github.com/eclipse-theia/theia/pull/15023)

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -18,32 +18,42 @@ import * as sinon from 'sinon';
 import { ChatAgentServiceImpl } from './chat-agent-service';
 import { ChatRequestParserImpl } from './chat-request-parser';
 import { ChatAgentLocation } from './chat-agents';
-import { ChatRequest } from './chat-model';
+import { ChatContext, ChatRequest } from './chat-model';
 import { expect } from 'chai';
-import { DefaultAIVariableService, ToolInvocationRegistry, ToolInvocationRegistryImpl } from '@theia/ai-core';
+import { AIVariable, DefaultAIVariableService, ResolvedAIVariable, ToolInvocationRegistryImpl, ToolRequest } from '@theia/ai-core';
+import { ILogger, Logger } from '@theia/core';
+import { ParsedChatRequestTextPart, ParsedChatRequestVariablePart } from './parsed-chat-request';
 
 describe('ChatRequestParserImpl', () => {
     const chatAgentService = sinon.createStubInstance(ChatAgentServiceImpl);
     const variableService = sinon.createStubInstance(DefaultAIVariableService);
-    const toolInvocationRegistry: ToolInvocationRegistry = sinon.createStubInstance(ToolInvocationRegistryImpl);
-    const parser = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry);
+    const toolInvocationRegistry = sinon.createStubInstance(ToolInvocationRegistryImpl);
+    const logger: ILogger = sinon.createStubInstance(Logger);
+    const parser = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry, logger);
 
-    it('parses simple text', () => {
+    beforeEach(() => {
+        // Reset our stubs before each test
+        sinon.reset();
+    });
+
+    it('parses simple text', async () => {
         const req: ChatRequest = {
             text: 'What is the best pizza topping?'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result.parts).to.deep.contain({
             text: 'What is the best pizza topping?',
             range: { start: 0, endExclusive: 31 }
         });
     });
 
-    it('parses text with variable name', () => {
+    it('parses text with variable name', async () => {
         const req: ChatRequest = {
             text: 'What is the #best pizza topping?'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result).to.deep.contain({
             parts: [{
                 text: 'What is the ',
@@ -59,11 +69,12 @@ describe('ChatRequestParserImpl', () => {
         });
     });
 
-    it('parses text with variable name with argument', () => {
+    it('parses text with variable name with argument', async () => {
         const req: ChatRequest = {
             text: 'What is the #best:by-poll pizza topping?'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result).to.deep.contain({
             parts: [{
                 text: 'What is the ',
@@ -79,11 +90,12 @@ describe('ChatRequestParserImpl', () => {
         });
     });
 
-    it('parses text with variable name with numeric argument', () => {
+    it('parses text with variable name with numeric argument', async () => {
         const req: ChatRequest = {
             text: '#size-class:2'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result.parts[0]).to.contain(
             {
                 variableName: 'size-class',
@@ -92,11 +104,12 @@ describe('ChatRequestParserImpl', () => {
         );
     });
 
-    it('parses text with variable name with POSIX path argument', () => {
+    it('parses text with variable name with POSIX path argument', async () => {
         const req: ChatRequest = {
             text: '#file:/path/to/file.ext'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result.parts[0]).to.contain(
             {
                 variableName: 'file',
@@ -105,16 +118,82 @@ describe('ChatRequestParserImpl', () => {
         );
     });
 
-    it('parses text with variable name with Win32 path argument', () => {
+    it('parses text with variable name with Win32 path argument', async () => {
         const req: ChatRequest = {
             text: '#file:c:\\path\\to\\file.ext'
         };
-        const result = parser.parseChatRequest(req, ChatAgentLocation.Panel);
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
         expect(result.parts[0]).to.contain(
             {
                 variableName: 'file',
                 variableArg: 'c:\\path\\to\\file.ext'
             }
         );
+    });
+
+    it('resolves variable and extracts tool functions from resolved variable', async () => {
+        // Set up two test tool requests that will be referenced in the variable content
+        const testTool1: ToolRequest = {
+            id: 'testTool1',
+            name: 'Test Tool 1',
+            handler: async () => undefined
+        };
+        const testTool2: ToolRequest = {
+            id: 'testTool2',
+            name: 'Test Tool 2',
+            handler: async () => undefined
+        };
+        // Configure the tool registry to return our test tools
+        toolInvocationRegistry.getFunction.withArgs(testTool1.id).returns(testTool1);
+        toolInvocationRegistry.getFunction.withArgs(testTool2.id).returns(testTool2);
+
+        // Set up the test variable to include in the request
+        const testVariable: AIVariable = {
+            id: 'testVariable',
+            name: 'testVariable',
+            description: 'A test variable',
+        };
+        // Configure the variable service to return our test variable
+        // One tool reference uses chat format and one uses prompt format because the parser needs to handle both.
+        variableService.getVariable.withArgs(testVariable.name).returns(testVariable);
+        variableService.resolveVariable.withArgs(
+            { variable: testVariable.name, arg: 'myarg' },
+            sinon.match.any
+        ).resolves({
+            variable: testVariable,
+            arg: 'myarg',
+            value: 'This is a test with ~testTool1 and **~{testTool2}** and more text.',
+        });
+
+        // Create a request with the test variable
+        const req: ChatRequest = {
+            text: 'Test with #testVariable:myarg'
+        };
+        const context: ChatContext = { variables: [] };
+
+        // Parse the request
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
+
+        // Verify the variable part contains the correct properties
+        expect(result.parts.length).to.equal(2);
+        expect(result.parts[0] instanceof ParsedChatRequestTextPart).to.be.true;
+        expect(result.parts[1] instanceof ParsedChatRequestVariablePart).to.be.true;
+        const variablePart = result.parts[1] as ParsedChatRequestVariablePart;
+        expect(variablePart).to.have.property('resolution');
+        expect(variablePart.resolution).to.deep.equal({
+            variable: testVariable,
+            arg: 'myarg',
+            value: 'This is a test with ~testTool1 and **~{testTool2}** and more text.',
+        } satisfies ResolvedAIVariable);
+
+        // Verify both tool functions were extracted from the variable content
+        expect(result.toolRequests.size).to.equal(2);
+        expect(result.toolRequests.has(testTool1.id)).to.be.true;
+        expect(result.toolRequests.has(testTool2.id)).to.be.true;
+
+        // Verify the result contains the tool requests returned by the registry
+        expect(result.toolRequests.get(testTool1.id)).to.deep.equal(testTool1);
+        expect(result.toolRequests.get(testTool2.id)).to.deep.equal(testTool2);
     });
 });

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -35,7 +35,7 @@ import {
     ParsedChatRequest,
     ParsedChatRequestPart,
 } from './parsed-chat-request';
-import { AIVariable, AIVariableService, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
+import { AIVariable, AIVariableService, PROMPT_FUNCTION_REGEX, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
 
 const agentReg = /^@([\w_\-\.]+)(?=(\s|$|\b))/i; // An @-agent
 const functionReg = /^~([\w_\-\.]+)(?=(\s|$|\b))/i; // A ~ tool function
@@ -202,7 +202,8 @@ export class ChatRequestParserImpl {
     }
 
     private tryParseFunction(message: string, offset: number): ParsedChatRequestFunctionPart | undefined {
-        const nextFunctionMatch = message.match(functionReg);
+        // Support both the and chat and prompt formats for functions
+        const nextFunctionMatch = message.match(functionReg) || message.match(PROMPT_FUNCTION_REGEX);
         if (!nextFunctionMatch) {
             return;
         }

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -70,7 +70,7 @@ export class ChatRequestParserImpl {
         // Resolve all variables and add them to the variable parts.
         // Parse resolved variable texts again for tool requests.
         // These are not added to parts as they are not visible in the initial chat message.
-        // However, add they need to be added to the result to be considered by the executing agent.
+        // However, they need to be added to the result to be considered by the executing agent.
         const variableCache = createAIResolveVariableCache();
         for (const part of parts) {
             if (part instanceof ParsedChatRequestVariablePart) {

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -65,18 +65,19 @@ export class ChatRequestParserImpl {
 
     async parseChatRequest(request: ChatRequest, location: ChatAgentLocation, context: ChatContext): Promise<ParsedChatRequest> {
         // Parse the request into parts
-        const { parts, toolRequests, variables } = this.parseParts(request, location);
+        const { parts, toolRequests } = this.parseParts(request, location);
 
         // Resolve all variables and add them to the variable parts.
         // Parse resolved variable texts again for tool requests.
         // These are not added to parts as they are not visible in the initial chat message.
         // However, add they need to be added to the result to be considered by the executing agent.
-        // TODO [recursive variable resolution] collect recursively resolved variables for result
+        const variableCache = createAIResolveVariableCache();
         for (const part of parts) {
             if (part instanceof ParsedChatRequestVariablePart) {
                 const resolvedVariable = await this.variableService.resolveVariable(
                     { variable: part.variableName, arg: part.variableArg },
-                    context
+                    context,
+                    variableCache
                 );
                 if (resolvedVariable) {
                     part.resolution = resolvedVariable;
@@ -88,7 +89,11 @@ export class ChatRequestParserImpl {
             }
         }
 
-        return { request, parts, toolRequests, variables };
+        // Get resolved variables from variable cache after all variables have been resolved.
+        // We want to return all recursilvely resolved variables, thus use the whole cache.
+        const resolvedVariables = await getAllResolvedAIVariables(variableCache);
+
+        return { request, parts, toolRequests, variables: resolvedVariables };
     }
 
     protected parseParts(request: ChatRequest, location: ChatAgentLocation): {

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -245,6 +245,7 @@ export class ChatServiceImpl implements ChatService {
         resolutionRequests: readonly AIVariableResolutionRequest[],
         context: ChatSessionContext,
     ): Promise<ChatContext> {
+        // TODO use a common cache to resolve variables and return recursively resolved variables?
         const resolvedVariables = await Promise.all(
             resolutionRequests.map(async contextVariable => {
                 const resolvedVariable = await this.variableService.resolveVariable(contextVariable, context);

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -35,7 +35,7 @@ import {
     ChatContext,
 } from './chat-model';
 import { ChatRequestParser } from './chat-request-parser';
-import { ParsedChatRequest, ParsedChatRequestAgentPart, ParsedChatRequestVariablePart } from './parsed-chat-request';
+import { ParsedChatRequest, ParsedChatRequestAgentPart } from './parsed-chat-request';
 
 export interface ChatRequestInvocation {
     /**
@@ -191,7 +191,9 @@ export class ChatServiceImpl implements ChatService {
         }
         session.title = request.text;
 
-        const parsedRequest = this.chatRequestParser.parseChatRequest(request, session.model.location);
+        const resolutionContext: ChatSessionContext = { model: session.model };
+        const resolvedContext = await this.resolveChatContext(session.model.context.getVariables(), resolutionContext);
+        const parsedRequest = await this.chatRequestParser.parseChatRequest(request, session.model.location, resolvedContext);
         const agent = this.getAgent(parsedRequest, session);
 
         if (agent === undefined) {
@@ -205,24 +207,8 @@ export class ChatServiceImpl implements ChatService {
             };
         }
 
-        const resolutionContext: ChatSessionContext = { model: session.model };
-        const resolvedContext = await this.resolveChatContext(session.model.context.getVariables(), resolutionContext);
         const requestModel = session.model.addRequest(parsedRequest, agent?.id, resolvedContext);
         resolutionContext.request = requestModel;
-
-        for (const part of parsedRequest.parts) {
-            if (part instanceof ParsedChatRequestVariablePart) {
-                const resolvedVariable = await this.variableService.resolveVariable(
-                    { variable: part.variableName, arg: part.variableArg },
-                    resolutionContext
-                );
-                if (resolvedVariable) {
-                    part.resolution = resolvedVariable;
-                } else {
-                    this.logger.warn(`Failed to resolve variable ${part.variableName} for ${session.model.location}`);
-                }
-            }
-        }
 
         let resolveResponseCreated: (responseModel: ChatResponseModel) => void;
         let resolveResponseCompleted: (responseModel: ChatResponseModel) => void;

--- a/packages/ai-chat/src/common/parsed-chat-request.ts
+++ b/packages/ai-chat/src/common/parsed-chat-request.ts
@@ -20,7 +20,7 @@
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/editor/common/core/offsetRange.ts
 
-import { AIVariable, ResolvedAIVariable, ToolRequest, toolRequestToPromptText } from '@theia/ai-core';
+import { ResolvedAIVariable, ToolRequest, toolRequestToPromptText } from '@theia/ai-core';
 import { ChatRequest } from './chat-model';
 
 export const chatVariableLeader = '#';
@@ -41,7 +41,7 @@ export interface ParsedChatRequest {
     readonly request: ChatRequest;
     readonly parts: ParsedChatRequestPart[];
     readonly toolRequests: Map<string, ToolRequest>;
-    readonly variables: Map<string, AIVariable>;
+    readonly variables: ResolvedAIVariable[];
 }
 
 export interface ParsedChatRequestPart {

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -61,6 +61,7 @@ import { AIActivationService } from './ai-activation-service';
 import { AgentService, AgentServiceImpl } from '../common/agent-service';
 import { AICommandHandlerFactory } from './ai-command-handler-factory';
 import { AISettingsService } from '../common/settings-service';
+import { PromptVariableContribution } from '../common/prompt-variable-contribution';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, LanguageModelProvider);
@@ -111,6 +112,7 @@ export default new ContainerModule(bind => {
     bind(TheiaVariableContribution).toSelf().inSingletonScope();
     bind(AIVariableContribution).toService(TheiaVariableContribution);
 
+    bind(AIVariableContribution).to(PromptVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(TodayVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(FileVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(AgentsVariableContribution).inSingletonScope();

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -22,6 +22,8 @@ import { PromptService, PromptServiceImpl } from './prompt-service';
 import { DefaultAIVariableService, AIVariableService } from './variable-service';
 import { ToolInvocationRegistry } from './tool-invocation-registry';
 import { ToolRequest } from './language-model';
+import { Logger } from '@theia/core';
+import * as sinon from 'sinon';
 
 describe('PromptService', () => {
     let promptService: PromptService;
@@ -29,8 +31,9 @@ describe('PromptService', () => {
     beforeEach(() => {
         const container = new Container();
         container.bind<PromptService>(PromptService).to(PromptServiceImpl).inSingletonScope();
+        const logger = sinon.createStubInstance(Logger);
 
-        const variableService = new DefaultAIVariableService({ getContributions: () => [] });
+        const variableService = new DefaultAIVariableService({ getContributions: () => [] }, logger);
         const nameVariable = { id: 'test', name: 'name', description: 'Test name ' };
         variableService.registerResolver(nameVariable, {
             canResolve: () => 100,

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -20,6 +20,8 @@ import { expect } from 'chai';
 import { Container } from 'inversify';
 import { PromptService, PromptServiceImpl } from './prompt-service';
 import { DefaultAIVariableService, AIVariableService } from './variable-service';
+import { ToolInvocationRegistry } from './tool-invocation-registry';
+import { ToolRequest } from './language-model';
 
 describe('PromptService', () => {
     let promptService: PromptService;
@@ -297,5 +299,67 @@ describe('PromptService', () => {
 
         expect(variantsForMainWithVariants).to.deep.equal(['variant1', 'variant2']);
         expect(variantsForMainWithoutVariants).to.deep.equal([]);
+    });
+
+    it('should resolve function references within resolved variable replacements', async () => {
+        // Mock the tool invocation registry
+        const toolInvocationRegistry = {
+            getFunction: sinon.stub()
+        };
+
+        // Create a test tool request that will be returned by the registry
+        const testFunction: ToolRequest = {
+            id: 'testFunction',
+            name: 'Test Function',
+            description: 'A test function',
+            parameters: {
+                type: 'object',
+                properties: {
+                    param1: {
+                        type: 'string',
+                        description: 'Test parameter'
+                    }
+                }
+            },
+            providerName: 'test-provider',
+            handler: sinon.stub()
+        };
+        toolInvocationRegistry.getFunction.withArgs('testFunction').returns(testFunction);
+
+        // Create a container with our mocked registry
+        const container = new Container();
+        container.bind<PromptService>(PromptService).to(PromptServiceImpl).inSingletonScope();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        container.bind<ToolInvocationRegistry>(ToolInvocationRegistry).toConstantValue(toolInvocationRegistry as any);
+
+        // Set up a variable service that returns a fragment with a function reference
+        const variableService = new DefaultAIVariableService({ getContributions: () => [] }, sinon.createStubInstance(Logger));
+        const fragmentVariable = { id: 'test', name: 'fragment', description: 'Test fragment with function' };
+        variableService.registerResolver(fragmentVariable, {
+            canResolve: () => 100,
+            resolve: async () => ({
+                variable: fragmentVariable,
+                value: 'This fragment contains a function reference: ~{testFunction}'
+            })
+        });
+        container.bind<AIVariableService>(AIVariableService).toConstantValue(variableService);
+
+        const testPromptService = container.get<PromptService>(PromptService);
+        testPromptService.storePromptTemplate({ id: 'testPrompt', template: 'Template with fragment: {{fragment}}' });
+
+        // Get the resolved prompt
+        const resolvedPrompt = await testPromptService.getPrompt('testPrompt');
+
+        // Verify that the function was resolved
+        expect(resolvedPrompt).to.not.be.undefined;
+        expect(resolvedPrompt?.text).to.include('This fragment contains a function reference:');
+        expect(resolvedPrompt?.text).to.not.include('~{testFunction}');
+
+        // Verify that the function description was added to functionDescriptions
+        expect(resolvedPrompt?.functionDescriptions?.size).to.equal(1);
+        expect(resolvedPrompt?.functionDescriptions?.get('testFunction')).to.deep.equal(testFunction);
+
+        // Verify that the tool invocation registry was called
+        expect(toolInvocationRegistry.getFunction.calledWith('testFunction')).to.be.true;
     });
 });

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -1,0 +1,110 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { injectable, inject, optional } from '@theia/core/shared/inversify';
+import * as monaco from '@theia/monaco-editor-core';
+import {
+    AIVariable,
+    AIVariableContribution,
+    AIVariableResolver,
+    AIVariableService,
+    AIVariableResolutionRequest,
+    AIVariableContext,
+    ResolvedAIVariable
+} from './variable-service';
+import { PromptCustomizationService, PromptService } from './prompt-service';
+import { PromptText } from './prompt-text';
+
+export const PROMPT_VARIABLE: AIVariable = {
+    id: 'prompt-provider',
+    description: 'Resolves prompt templates via the prompt service',
+    name: 'prompt',
+    args: [
+        { name: 'id', description: 'The prompt template id to resolve' }
+    ]
+};
+
+@injectable()
+export class PromptVariableContribution implements AIVariableContribution, AIVariableResolver {
+
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
+
+    @inject(PromptCustomizationService) @optional()
+    protected readonly promptCustomizationService: PromptCustomizationService;
+
+    registerVariables(service: AIVariableService): void {
+        service.registerResolver(PROMPT_VARIABLE, this);
+        service.registerArgumentCompletionProvider(PROMPT_VARIABLE, this.provideArgumentCompletionItems.bind(this));
+    }
+
+    canResolve(request: AIVariableResolutionRequest, context: AIVariableContext): number {
+        if (request.variable.name === PROMPT_VARIABLE.name) {
+            return 1;
+        }
+        return -1;
+    }
+
+    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
+        if (request.variable.name === PROMPT_VARIABLE.name) {
+            const promptId = request.arg?.trim();
+            if (promptId) {
+                const resolvedPrompt = await this.promptService.getPrompt(promptId);
+                if (resolvedPrompt) {
+                    return { variable: request.variable, value: resolvedPrompt.text };
+                }
+            }
+        }
+        return undefined;
+    }
+
+    protected async provideArgumentCompletionItems(
+        model: monaco.editor.ITextModel,
+        position: monaco.Position
+    ): Promise<monaco.languages.CompletionItem[] | undefined> {
+        const lineContent = model.getLineContent(position.lineNumber);
+
+        // Only provide completions once the variable argument separator is typed
+        const triggerCharIndex = lineContent.lastIndexOf(PromptText.VARIABLE_ARG_SEPARATOR, position.column - 1);
+        if (triggerCharIndex === -1) {
+            return undefined;
+        }
+
+        // Check if the text immediately before the trigger is the prompt variable, i.e #prompt
+        const requiredVariable = `${PromptText.VARIABLE_CHAR}${PROMPT_VARIABLE.name}`;
+        if (triggerCharIndex < requiredVariable.length ||
+            lineContent.substring(triggerCharIndex - requiredVariable.length, triggerCharIndex) !== requiredVariable) {
+            return undefined;
+        }
+
+        const range = new monaco.Range(position.lineNumber, triggerCharIndex + 2, position.lineNumber, position.column);
+
+        // TODO consider all prompts or only custom prompts? If only custom, we might also consider this during variable resolution.
+        const prompts = this.promptService.getAllPrompts();
+        if (this.promptCustomizationService) {
+            this.promptCustomizationService.getCustomPromptTemplateIDs();
+        }
+        const allPromptIds = [...Object.keys(prompts), ...(this.promptCustomizationService?.getCustomPromptTemplateIDs() || [])];
+        allPromptIds.sort();
+
+        return allPromptIds.map(promptId => ({
+            filterText: PromptText.VARIABLE_ARG_SEPARATOR,
+            label: promptId,
+            kind: monaco.languages.CompletionItemKind.Variable,
+            insertText: promptId,
+            range
+        }));
+    }
+}

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { nls } from '@theia/core';
+import { CommandService, nls } from '@theia/core';
 import { injectable, inject, optional } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import {
@@ -41,6 +41,9 @@ export const PROMPT_VARIABLE: AIVariable = {
 @injectable()
 export class PromptVariableContribution implements AIVariableContribution, AIVariableResolverWithVariableDependencies {
 
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
     @inject(PromptService)
     protected readonly promptService: PromptService;
 
@@ -49,6 +52,7 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
 
     registerVariables(service: AIVariableService): void {
         service.registerResolver(PROMPT_VARIABLE, this);
+        service.registerArgumentPicker(PROMPT_VARIABLE, this.triggerArgumentPicker.bind(this));
         service.registerArgumentCompletionProvider(PROMPT_VARIABLE, this.provideArgumentCompletionItems.bind(this));
     }
 
@@ -77,6 +81,14 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
                 }
             }
         }
+        return undefined;
+    }
+
+    protected async triggerArgumentPicker(): Promise<string | undefined> {
+        // Trigger the suggestion command to show argument completions
+        this.commandService.executeCommand('editor.action.triggerSuggest');
+        // Return undefined because we don't actually pick the argument here.
+        // The argument is selected and inserted by the monaco editor's completion mechanism.
         return undefined;
     }
 

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -62,7 +62,7 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
         if (request.variable.name === PROMPT_VARIABLE.name) {
             const promptId = request.arg?.trim();
             if (promptId) {
-                const resolvedPrompt = await this.promptService.getPrompt(promptId);
+                const resolvedPrompt = await this.promptService.getPromptFragment(promptId);
                 if (resolvedPrompt) {
                     return { variable: request.variable, value: resolvedPrompt.text };
                 }

--- a/packages/ai-core/src/common/variable-service.spec.ts
+++ b/packages/ai-core/src/common/variable-service.spec.ts
@@ -1,0 +1,289 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as sinon from 'sinon';
+import { ContributionProvider, Logger } from '@theia/core';
+import { expect } from 'chai';
+import {
+    DefaultAIVariableService,
+    AIVariable,
+    AIVariableContribution,
+    AIVariableResolverWithVariableDependencies,
+    ResolvedAIVariable,
+    createAIResolveVariableCache,
+    AIVariableArg
+} from './variable-service';
+
+describe('DefaultAIVariableService', () => {
+    let variableService: DefaultAIVariableService;
+    let contributionProvider: sinon.SinonStubbedInstance<ContributionProvider<AIVariableContribution>>;
+    let logger: sinon.SinonStubbedInstance<Logger>;
+
+    const varA: AIVariable = {
+        id: 'provider.a',
+        name: 'a',
+        description: 'Variable A'
+    };
+
+    const varB: AIVariable = {
+        id: 'provider.b',
+        name: 'b',
+        description: 'Variable B'
+    };
+
+    const varC: AIVariable = {
+        id: 'provider.c',
+        name: 'c',
+        description: 'Variable C'
+    };
+
+    const varD: AIVariable = {
+        id: 'provider.d',
+        name: 'd',
+        description: 'Variable D'
+    };
+
+    // Create resolvers for our variables
+    const resolverA: AIVariableResolverWithVariableDependencies = {
+        canResolve: sinon.stub().returns(1),
+        resolve: async (_request, _context, resolveDependency?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>) => {
+            if (resolveDependency) {
+                // Variable A depends on both B and C
+                const dependencyB = await resolveDependency({ variable: varB });
+                const dependencyC = await resolveDependency({ variable: varC });
+
+                return {
+                    variable: varA,
+                    value: `A resolved with B: ${dependencyB?.value ?? 'undefined'} and C: ${dependencyC?.value ?? 'undefined'}`,
+                    allResolvedDependencies: [
+                        ...(dependencyB ? [dependencyB] : []),
+                        ...(dependencyC ? [dependencyC] : [])
+                    ]
+                };
+            }
+            return { variable: varA, value: 'A value' };
+        }
+    };
+
+    const resolverB: AIVariableResolverWithVariableDependencies = {
+        canResolve: sinon.stub().returns(1),
+        resolve: async (_request, _context, resolveDependency?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>) => {
+            if (resolveDependency) {
+                // Variable B depends on A, creating a cycle
+                const dependencyA = await resolveDependency({ variable: varA });
+
+                return {
+                    variable: varB,
+                    value: `B resolved with A: ${dependencyA?.value ?? 'undefined (cycle detected)'}`,
+                    allResolvedDependencies: dependencyA ? [dependencyA] : []
+                };
+            }
+            return { variable: varB, value: 'B value' };
+        }
+    };
+
+    const resolverC: AIVariableResolverWithVariableDependencies = {
+        canResolve: sinon.stub().returns(1),
+        resolve: async (_request, _context, resolveDependency?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>) => {
+            if (resolveDependency) {
+                // Variable C depends on D with two different arguments
+                const dependencyD1 = await resolveDependency({ variable: varD, arg: 'arg1' });
+                const dependencyD2 = await resolveDependency({ variable: varD, arg: 'arg2' });
+
+                return {
+                    variable: varC,
+                    value: `C resolved with D(arg1): ${dependencyD1?.value ?? 'undefined'} and D(arg2): ${dependencyD2?.value ?? 'undefined'}`,
+                    allResolvedDependencies: [
+                        ...(dependencyD1 ? [dependencyD1] : []),
+                        ...(dependencyD2 ? [dependencyD2] : [])
+                    ]
+                };
+            }
+            return { variable: varC, value: 'C value' };
+        }
+    };
+
+    const resolverD: AIVariableResolverWithVariableDependencies = {
+        canResolve: sinon.stub().returns(1),
+        resolve: async request => {
+            const arg = request.arg;
+            return {
+                variable: varD,
+                value: arg ? `D value with ${arg}` : 'D value'
+            };
+        }
+    };
+
+    beforeEach(() => {
+        // Create stub for the contribution provider
+        contributionProvider = {
+            getContributions: sinon.stub().returns([])
+        } as sinon.SinonStubbedInstance<ContributionProvider<AIVariableContribution>>;
+
+        // Create stub for logger
+        logger = sinon.createStubInstance(Logger);
+
+        // Create the service under test
+        variableService = new DefaultAIVariableService(
+            contributionProvider,
+            logger
+        );
+
+        // Register the variables and resolvers
+        variableService.registerResolver(varA, resolverA);
+        variableService.registerResolver(varB, resolverB);
+        variableService.registerResolver(varC, resolverC);
+        variableService.registerResolver(varD, resolverD);
+    });
+
+    describe('resolveVariable', () => {
+        it('should handle recursive variable resolution and detect cycles', async () => {
+            // Try to resolve variable A, which has a cycle with B and also depends on C which depends on D
+            const result = await variableService.resolveVariable('a', {});
+
+            // Verify the result
+            expect(result).to.not.be.undefined;
+            expect(result!.variable).to.deep.equal(varA);
+
+            // The value should contain B's value (with a cycle detection) and C's value
+            expect(result!.value).to.include('B resolved with A: undefined (cycle detected)');
+            expect(result!.value).to.include('C resolved with D(arg1): D value with arg1 and D(arg2): D value with arg2');
+
+            // Verify that we logged a warning about the cycle
+            expect(logger.warn.calledOnce).to.be.true;
+            expect(logger.warn.firstCall.args[0]).to.include('Cycle detected for variable: a');
+
+            // Verify dependencies are tracked
+            expect(result!.allResolvedDependencies).to.have.lengthOf(2);
+
+            // Find the B dependency and verify it doesn't have A in its dependencies (due to cycle detection)
+            const bDependency = result!.allResolvedDependencies!.find(d => d.variable.name === 'b');
+            expect(bDependency).to.not.be.undefined;
+            expect(bDependency!.allResolvedDependencies).to.be.empty;
+
+            // Find the C dependency and its D dependencies
+            const cDependency = result!.allResolvedDependencies!.find(d => d.variable.name === 'c');
+            expect(cDependency).to.not.be.undefined;
+            expect(cDependency!.value).to.equal('C resolved with D(arg1): D value with arg1 and D(arg2): D value with arg2');
+            expect(cDependency!.allResolvedDependencies).to.have.lengthOf(2);
+
+            const dDependency1 = cDependency!.allResolvedDependencies![0];
+            expect(dDependency1.variable.name).to.equal('d');
+            expect(dDependency1.value).to.equal('D value with arg1');
+
+            const dDependency2 = cDependency!.allResolvedDependencies![1];
+            expect(dDependency2.variable.name).to.equal('d');
+            expect(dDependency2.value).to.equal('D value with arg2');
+        });
+
+        it('should handle variables with a simple chain of dependencies', async () => {
+            // Variable C depends on D with two different arguments
+            const result = await variableService.resolveVariable('c', {});
+
+            expect(result).to.not.be.undefined;
+            expect(result!.variable).to.deep.equal(varC);
+            expect(result!.value).to.equal('C resolved with D(arg1): D value with arg1 and D(arg2): D value with arg2');
+
+            // Verify dependency chain
+            expect(result!.allResolvedDependencies).to.have.lengthOf(2);
+
+            const dDependency1 = result!.allResolvedDependencies![0];
+            expect(dDependency1.variable.name).to.equal('d');
+            expect(dDependency1.value).to.equal('D value with arg1');
+
+            const dDependency2 = result!.allResolvedDependencies![1];
+            expect(dDependency2.variable.name).to.equal('d');
+            expect(dDependency2.value).to.equal('D value with arg2');
+        });
+
+        it('should handle variables without dependencies', async () => {
+            // D has no dependencies
+            const result = await variableService.resolveVariable('d', {});
+
+            expect(result).to.not.be.undefined;
+            expect(result!.variable).to.deep.equal(varD);
+            expect(result!.value).to.equal('D value');
+            expect(result!.allResolvedDependencies).to.be.undefined;
+        });
+
+        it('should handle variables with arguments', async () => {
+            // Test D with an argument
+            const result = await variableService.resolveVariable({ variable: 'd', arg: 'test-arg' }, {}, undefined);
+
+            expect(result).to.not.be.undefined;
+            expect(result!.variable).to.deep.equal(varD);
+            expect(result!.value).to.equal('D value with test-arg');
+            expect(result!.allResolvedDependencies).to.be.undefined;
+        });
+
+        it('should return undefined for non-existent variables', async () => {
+            const result = await variableService.resolveVariable('nonexistent', {});
+            expect(result).to.be.undefined;
+        });
+
+        it('should properly populate cache when resolving variables with dependencies', async () => {
+            // Create a cache to pass into the resolver
+            const cache = createAIResolveVariableCache();
+
+            // Resolve variable A, which depends on B and C, and C depends on D with two arguments
+            const result = await variableService.resolveVariable('a', {}, cache);
+
+            // Verify that the result is correct
+            expect(result).to.not.be.undefined;
+            expect(result!.variable).to.deep.equal(varA);
+
+            // Verify that the cache has entries for all variables
+            expect(cache.size).to.equal(5); // A, B, C, D(arg1), and D(arg2)
+
+            // Verify that all variables have entries in the cache
+            expect(cache.has('a:')).to.be.true; // 'a:' key format is variableName + separator + arg (empty in this case)
+            expect(cache.has('b:')).to.be.true;
+            expect(cache.has('c:')).to.be.true;
+            expect(cache.has('d:arg1')).to.be.true;
+            expect(cache.has('d:arg2')).to.be.true;
+
+            // Verify that all promises in the cache are resolved
+            for (const entry of cache.values()) {
+                const resolvedVar = await entry.promise;
+                expect(resolvedVar).to.not.be.undefined;
+                expect(entry.inProgress).to.be.false;
+            }
+
+            // Check specific variable results from cache
+            const aEntry = cache.get('a:');
+            const aResult = await aEntry!.promise;
+            expect(aResult!.variable.name).to.equal('a');
+
+            const bEntry = cache.get('b:');
+            const bResult = await bEntry!.promise;
+            expect(bResult!.variable.name).to.equal('b');
+
+            const cEntry = cache.get('c:');
+            const cResult = await cEntry!.promise;
+            expect(cResult!.variable.name).to.equal('c');
+
+            const dEntry1 = cache.get('d:arg1');
+            const dResult1 = await dEntry1!.promise;
+            expect(dResult1!.variable.name).to.equal('d');
+            expect(dResult1!.value).to.equal('D value with arg1');
+
+            const dEntry2 = cache.get('d:arg2');
+            const dResult2 = await dEntry2!.promise;
+            expect(dResult2!.variable.name).to.equal('d');
+            expect(dResult2!.value).to.equal('D value with arg2');
+        });
+    });
+});


### PR DESCRIPTION
#### What it does

fixes #14899
fixes #15000 
supersedes #14985

Summary: Support custom prompt fragments via variable `prompt` with prompt id as argument. Prompt fragments may reference each other recursively while the variable service ensures safe cycle handling.

---

Prompt fragments allow to define parts of prompts in a reusable way. You can embed these prompts then via a variable in the chat or in our prompt templates. This also allows to have a set of prompts available in the chat without always defining a custom agent.

This PR defines a Theia Ai variable `prompt` with an argument containing the prompt fragment's id. Corresponding auto completion for available custom and builtin prompt fragments to the chat UI is implemented, too.

Proper usage of prompt fragments - which can reference other variables and prompt fragments - requires two additional features implemented in this PR:

1. Resolving of tool functions in resolved variable text in the prompt service and the chat request parser. Both have been extended to provide this.
2. Recursive resolving of variables including cycle detection. Prompt fragments may compose other prompt fragments. Thus, they need to be resolved recursively. Furthermore, cycles are detected and resolving aborted for the cycle to a void crashing Theia in an endless loop in case users configure a cycle.

[prompt-template-autocomplete.webm](https://github.com/user-attachments/assets/a9829115-567d-4ac1-aeb2-97a5813403c3)

#### How to test

- Configure setting `Ai-features › Prompt Templates: Prompt Templates Folder` to point to a folder of your choosing
- Create one or multiple `.prompttemplate` files in the specified folder.
  - For recursion testing, you need at least two referencing each other
  - Find example prompt templates here: [prompttemplates.zip](https://github.com/user-attachments/files/19251429/prompttemplates.zip). Add them to you prompt templates folder
- Open the AI chat and test using templates there (see video above)
  - for instance use `#prompt:golang` and tell it to generate mergesort. You'll see it generates it in go
  - Use agent `@Universal` which usually does not have access to the workspace. Ask it to explain the contents of a file (use relative path) and use `#prompt:workspace-functions`. Now the agent should read the file. Try again without the variable and see that it will not read the file
- Edit the prompt editor for an agent (e.g. Universal again). Reference prompt templates there via `{{prompt:workspace-functions}}`. Observe that you Universal agent now can access files even when you don't specify the variable in the chat


#### Follow-ups

- https://github.com/eclipse-theia/theia/issues/15202
- https://github.com/eclipse-theia/theia/issues/15226

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
