### PR TITLE
Set correct defaults for max tokens for anthropic models

### DIFF
--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -22,6 +22,14 @@ import { PREFERENCE_NAME_REQUEST_SETTINGS, RequestSetting } from '@theia/ai-core
 
 const ANTHROPIC_PROVIDER_ID = 'anthropic';
 
+// Model-specific maxTokens values
+const DEFAULT_MODEL_MAX_TOKENS: Record<string, number> = {
+    'claude-3-opus-latest': 4096,
+    'claude-3-5-haiku-latest': 8192,
+    'claude-3-5-sonnet-latest': 8192,
+    'claude-3-7-sonnet-latest': 64000
+};
+
 @injectable()
 export class AnthropicFrontendApplicationContribution implements FrontendApplicationContribution {
 
@@ -80,13 +88,21 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
     protected createAnthropicModelDescription(modelId: string, requestSettings: RequestSetting[]): AnthropicModelDescription {
         const id = `${ANTHROPIC_PROVIDER_ID}/${modelId}`;
         const modelRequestSetting = this.getMatchingRequestSetting(modelId, ANTHROPIC_PROVIDER_ID, requestSettings);
-        return {
+        const maxTokens = DEFAULT_MODEL_MAX_TOKENS[modelId];
+
+        const description: AnthropicModelDescription = {
             id: id,
             model: modelId,
             apiKey: true,
             enableStreaming: true,
             defaultRequestSettings: modelRequestSetting?.requestSettings
         };
+
+        if (maxTokens !== undefined) {
+            description.maxTokens = maxTokens;
+        }
+
+        return description;
     }
 
     protected getMatchingRequestSetting(

--- a/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
+++ b/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
@@ -33,6 +33,10 @@ export interface AnthropicModelDescription {
      */
     enableStreaming: boolean;
     /**
+     * Maximum number of tokens to generate. Default is 4096.
+     */
+    maxTokens?: number;
+    /**
      * Default request settings for the Anthropic model.
      */
     defaultRequestSettings?: { [key: string]: unknown };

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -27,8 +27,7 @@ import { CancellationToken, isArray } from '@theia/core';
 import { Anthropic } from '@anthropic-ai/sdk';
 import { MessageParam } from '@anthropic-ai/sdk/resources';
 
-const DEFAULT_MAX_TOKENS_STREAMING = 4096;
-const DEFAULT_MAX_TOKENS_NON_STREAMING = 2048;
+export const DEFAULT_MAX_TOKENS = 4096;
 const EMPTY_INPUT_SCHEMA = {
     type: 'object',
     properties: {},
@@ -93,7 +92,8 @@ export class AnthropicModel implements LanguageModel {
         public model: string,
         public enableStreaming: boolean,
         public apiKey: () => string | undefined,
-        public defaultRequestSettings?: Readonly<Record<string, unknown>>
+        public defaultRequestSettings?: Readonly<Record<string, unknown>>,
+        public maxTokens: number = DEFAULT_MAX_TOKENS
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {
@@ -144,8 +144,9 @@ export class AnthropicModel implements LanguageModel {
         const settings = this.getSettings(request);
         const { messages, systemMessage } = transformToAnthropicParams(request.messages);
         const tools = this.createTools(request);
+        console.log(this.maxTokens);
         const params: Anthropic.MessageCreateParams = {
-            max_tokens: DEFAULT_MAX_TOKENS_STREAMING,
+            max_tokens: this.maxTokens,
             messages: [...messages, ...(toolMessages ?? [])],
             tools,
             model: this.model,
@@ -267,7 +268,7 @@ export class AnthropicModel implements LanguageModel {
         const { messages, systemMessage } = transformToAnthropicParams(request.messages);
 
         const params: Anthropic.MessageCreateParams = {
-            max_tokens: DEFAULT_MAX_TOKENS_NON_STREAMING,
+            max_tokens: this.maxTokens,
             messages,
             model: this.model,
             ...(systemMessage && { system: systemMessage }),

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -144,7 +144,6 @@ export class AnthropicModel implements LanguageModel {
         const settings = this.getSettings(request);
         const { messages, systemMessage } = transformToAnthropicParams(request.messages);
         const tools = this.createTools(request);
-        console.log(this.maxTokens);
         const params: Anthropic.MessageCreateParams = {
             max_tokens: this.maxTokens,
             messages: [...messages, ...(toolMessages ?? [])],

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -16,7 +16,7 @@
 
 import { LanguageModelRegistry } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { AnthropicModel } from './anthropic-language-model';
+import { AnthropicModel, DEFAULT_MAX_TOKENS } from './anthropic-language-model';
 import { AnthropicLanguageModelsManager, AnthropicModelDescription } from '../common';
 
 @injectable()
@@ -53,6 +53,11 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                 model.enableStreaming = modelDescription.enableStreaming;
                 model.apiKey = apiKeyProvider;
                 model.defaultRequestSettings = modelDescription.defaultRequestSettings;
+                if (modelDescription.maxTokens !== undefined) {
+                    model.maxTokens = modelDescription.maxTokens;
+                } else {
+                    model.maxTokens = DEFAULT_MAX_TOKENS;
+                }
             } else {
                 this.languageModelRegistry.addLanguageModels([
                     new AnthropicModel(
@@ -60,7 +65,8 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                         modelDescription.model,
                         modelDescription.enableStreaming,
                         apiKeyProvider,
-                        modelDescription.defaultRequestSettings
+                        modelDescription.defaultRequestSettings,
+                        modelDescription.maxTokens
                     )
                 ]);
             }


### PR DESCRIPTION
fixed #15195


#### What it does

- Set max token to the correct default per known anthropic model (see https://docs.anthropic.com/en/docs/about-claude/models/all-models)
- Use 4096 as a default (This is the minimum of all know models and assumed to be OK for future models as well)

#### How to test

Test all existing Anthropic models, set a break point in /packages/ai-anthropic/src/node/anthropic-language-model.ts to check the corretc values are used. There must also be not error. An error occurs if a value is set that is higher than possible for the model.

Check that you can override the  settings with customr equest settings, e.g. the following settings should lead to an error:

    {
        "modelId": "claude-3-7-sonnet-latest",
        "requestSettings": {
            "max_tokens": 64001
        },
        "providerId": "anthropic"
    },


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
