### PR TITLE
Fix handling of additionalEventTypes in TreeWidget.addKeyListener

### DIFF
--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -290,7 +290,7 @@ export function addKeyListener<K extends keyof HTMLElementEventMap>(
             return (actual: KeyCode) => KeysOrKeyCodes.toKeyCodes(keysOrKeyCodes).some(k => k.equals(actual));
         }
     })();
-    toDispose.push(addEventListener(element, 'keydown', e => {
+    const wrappedHandler = (e: KeyboardEvent) => {
         const kc = KeyCode.createKeyCode(e);
         if (keyCodePredicate(kc)) {
             const result = action(e);
@@ -299,17 +299,10 @@ export function addKeyListener<K extends keyof HTMLElementEventMap>(
                 e.preventDefault();
             }
         }
-    }));
+    };
+    toDispose.push(addEventListener(element, 'keydown', wrappedHandler));
     for (const type of additionalEventTypes) {
-        toDispose.push(addEventListener(element, type, e => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const event = (type as any)['keydown'];
-            const result = action(event);
-            if (typeof result !== 'boolean' || result) {
-                e.stopPropagation();
-                e.preventDefault();
-            }
-        }));
+        toDispose.push(addEventListener(element, type as 'keydown', wrappedHandler));
     }
     return toDispose;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #15209 by passing the original event to the handler and casting the event type as a keyboard event type rather than casting the type as any and reading a field off of it.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Pass additional event types to the `addKeyListener` method of the `TreeWidget`
2. In the handler, refer to a field of what is expected to be a `KeyboardEvent`
3. See that your handler behaves as you'd expect.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

⚠️  In my view, the current implementation is clearly buggy in two respects: ⚠️ 
 - For events other than `keydown`, it calls the handler with `undefined` rather than the original event. This breaks the type contract of the signature: the `action` is allowed to expect a `KeyboardEvent`.
 - For events other than `keydown`, it calls the handler even if the intended predicate re: keys pressed is not satisfied.

The latter behavior may be intentional, and could be relied on by downstream implementations, since for events other than `keydown`, the behavior of modifiers in particular may be less predictable, depending on order of release, etc. The branch I've pushed changes both behaviors, but we could focus on the former if we believe that changing the latter could disrupt downstream implementations.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
