### PR TITLE
[vscode] Support SourceControlResourceGroup optional contextValue

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1047,6 +1047,7 @@ export interface SourceControlProviderFeatures {
 
 export interface SourceControlGroupFeatures {
     hideWhenEmpty: boolean | undefined;
+    contextValue: string | undefined;
 }
 
 export interface ScmRawResource {

--- a/packages/plugin-ext/src/main/browser/scm-main.ts
+++ b/packages/plugin-ext/src/main/browser/scm-main.ts
@@ -53,6 +53,8 @@ export class PluginScmResourceGroup implements ScmResourceGroup {
 
     get hideWhenEmpty(): boolean { return !!this.features.hideWhenEmpty; }
 
+    get contextValue(): string | undefined { return this.features.contextValue; }
+
     private readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
 

--- a/packages/plugin-ext/src/plugin/scm.ts
+++ b/packages/plugin-ext/src/plugin/scm.ts
@@ -405,9 +405,17 @@ class ScmResourceGroupImpl implements theia.SourceControlResourceGroup {
         this.proxy.$updateGroup(this.sourceControlHandle, this.handle, this.features);
     }
 
+    private _contextValue: string | undefined = undefined;
+    get contextValue(): string | undefined { return this._contextValue; }
+    set contextValue(contextValue: string | undefined) {
+        this._contextValue = contextValue;
+        this.proxy.$updateGroup(this.sourceControlHandle, this.handle, this.features);
+    }
+
     get features(): SourceControlGroupFeatures {
         return {
-            hideWhenEmpty: this.hideWhenEmpty
+            hideWhenEmpty: this.hideWhenEmpty,
+            contextValue: this.contextValue
         };
     }
 
@@ -477,7 +485,7 @@ class ScmResourceGroupImpl implements theia.SourceControlResourceGroup {
                 // TODO remove the letter and colorId fields when the FileDecorationProvider is applied, see https://github.com/eclipse-theia/theia/pull/8911
                 const rawResource = {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    handle, sourceUri, letter: (r as any).letter, colorId: (r as any).color.id, icons,
+                    handle, sourceUri, letter: (r as any).letter, colorId: (r as any).color?.id, icons,
                     tooltip, strikeThrough, faded, contextValue, command
                 } as ScmRawResource;
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12244,6 +12244,26 @@ export module '@theia/plugin' {
         hideWhenEmpty?: boolean;
 
         /**
+         * Context value of the resource group. This can be used to contribute resource group specific actions.
+         * For example, if a resource group is given a context value of `exportable`, when contributing actions to `scm/resourceGroup/context`
+         * using `menus` extension point, you can specify context value for key `scmResourceGroupState` in `when` expressions, like `scmResourceGroupState == exportable`.
+         * ```json
+         * "contributes": {
+         *   "menus": {
+         *     "scm/resourceGroup/context": [
+         *       {
+         *         "command": "extension.export",
+         *         "when": "scmResourceGroupState == exportable"
+         *       }
+         *     ]
+         *   }
+         * }
+         * ```
+         * This will show action `extension.export` only for resource groups with `contextValue` equal to `exportable`.
+         */
+        contextValue?: string;
+
+        /**
          * This group's collection of
          * {@link SourceControlResourceState source control resource states}.
          */

--- a/packages/scm/src/browser/scm-context-key-service.ts
+++ b/packages/scm/src/browser/scm-context-key-service.ts
@@ -33,10 +33,16 @@ export class ScmContextKeyService {
         return this._scmResourceGroup;
     }
 
+    protected _scmResourceGroupState: ContextKey<string | undefined>;
+    get scmResourceGroupState(): ContextKey<string | undefined> {
+        return this._scmResourceGroupState;
+    }
+
     @postConstruct()
     protected init(): void {
         this._scmProvider = this.contextKeyService.createKey<string | undefined>('scmProvider', undefined);
         this._scmResourceGroup = this.contextKeyService.createKey<string | undefined>('scmResourceGroup', undefined);
+        this._scmResourceGroupState = this.contextKeyService.createKey<string | undefined>('scmResourceGroupState', undefined);
     }
 
     match(expression: string | undefined): boolean {

--- a/packages/scm/src/browser/scm-provider.ts
+++ b/packages/scm/src/browser/scm-provider.ts
@@ -44,6 +44,7 @@ export interface ScmResourceGroup extends Disposable {
     readonly label: string;
     readonly resources: ScmResource[];
     readonly hideWhenEmpty?: boolean;
+    readonly contextValue?: string;
 
     readonly provider: ScmProvider;
 }

--- a/packages/scm/src/browser/scm-tree-model.ts
+++ b/packages/scm/src/browser/scm-tree-model.ts
@@ -369,6 +369,7 @@ export abstract class ScmTreeModel extends TreeModelImpl {
 
         this.contextKeys.scmProvider.set(this.provider.id);
         this.contextKeys.scmResourceGroup.set(groupId);
+        this.contextKeys.scmResourceGroupState.set(this.findGroup(groupId)?.contextValue);
         try {
             callback();
         } finally {


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Introduces the support of the optional property contextValue in SourceControlResourceGroup API. This was introduced with VS Code 1.98 and is used to filter out some menus on the resource groups.

fix #15132

#### How to test

Install the following extension on a browser or electron theia example:
- src: [scm-resourcegroup-actions-0.0.1-src.zip](https://github.com/user-attachments/files/19316482/scm-resourcegroup-actions-0.0.1-src.zip)
- zip vsix: [scm-resourcegroup-actions-0.0.1.zip](https://github.com/user-attachments/files/19316487/scm-resourcegroup-actions-0.0.1.zip)

It contains a new Software Configuration Manager, based on file names in the workspace (files with name starting with "A_" are considered as added, files names starting with "M_" are modified and "D_" are deleted.

The extension provides also a set of menus to be opened or filtered on resource groups added / deleted / modified:
- one action should be always visible ("on any file")
- one specific action should be visible only on deleted or modified ("On Deleted" and "On Modified")
- the action "On Added" has the test "scmResourceGroupState == added", but the "added" resource group does not have a context value, so we can test the `undefined` case
- the action "Should not be displayed" should never be visible, as the state does not exist on any of the groups

https://github.com/user-attachments/assets/504e41c1-0cf7-4d7b-b2c4-450810e031cd

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
