### PR TITLE
fix(chat): fix context menu paste

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -216,7 +216,8 @@ export class AIChatInputWidget extends ReactWidget {
         this.contextMenuRenderer.render({
             menuPath: AIChatInputWidget.CONTEXT_MENU,
             anchor: { x: event.posx, y: event.posy },
-            context: event.target
+            context: event.target,
+            args: [this.editorRef]
         });
         event.preventDefault();
     }

--- a/packages/ai-chat-ui/src/browser/chat-view-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-contribution.ts
@@ -19,6 +19,7 @@ import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatViewTreeWidget, isRequestNode, isResponseNode, RequestNode, ResponseNode } from './chat-tree-view/chat-view-tree-widget';
 import { AIChatInputWidget } from './chat-input-widget';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 
 export namespace ChatViewCommands {
     export const COPY_MESSAGE = Command.toDefaultLocalizedCommand({
@@ -54,6 +55,17 @@ export class ChatViewMenuContribution implements MenuContribution, CommandContri
                 }
             },
             isEnabled: (...args: unknown[]) => containsRequestOrResponseNode(args)
+        });
+        commands.registerHandler(CommonCommands.PASTE.id, {
+            execute: async (...args) => {
+                if (hasEditorAsFirstArg(args)) {
+                    const editor = args[0];
+                    const range = editor.selection;
+                    const newText = await this.clipboardService.readText();
+                    editor.executeEdits([{ range, newText }]);
+                }
+            },
+            isEnabled: (...args) => hasEditorAsFirstArg(args)
         });
         commands.registerCommand(ChatViewCommands.COPY_MESSAGE, {
             execute: (...args: unknown[]) => {
@@ -131,6 +143,10 @@ export class ChatViewMenuContribution implements MenuContribution, CommandContri
         });
     }
 
+}
+
+function hasEditorAsFirstArg(args: unknown[]): args is [MonacoEditor, ...unknown[]] {
+    return args.length > 0 && args[0] instanceof MonacoEditor;
 }
 
 function extractRequestOrResponseNodes(args: unknown[]): (RequestNode | ResponseNode)[] {


### PR DESCRIPTION
#### What it does

It looks like the Monaco-specific paste handler is not enabled for editors that are not tracked in the CodeEditorService (see packages/monaco/src/browser/monaco-command.ts). Therefore, we register a specific paste handler for the AI chat input editor.

Fixes https://github.com/eclipse-theia/theia/issues/15054

#### How to test

Use copy and paste via the context menu in the AI chat input in all possible combinations.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
