### PR TITLE
Fix issue where minimums of 0 for number preferences are ignored

### DIFF
--- a/packages/preferences/src/browser/views/components/preference-number-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-number-input.ts
@@ -147,6 +147,9 @@ export class PreferenceNumberInputRenderer extends PreferenceLeafNodeRenderer<nu
                 errorMessages.push(nls.localizeByDefault('Value must be strictly less than {0}.', data.exclusiveMaximum));
             }
         }
+        if (isNumber(data.multipleOf) && data.multipleOf !== 0 && !Number.isInteger(inputValue / data.multipleOf)) {
+            errorMessages.push(nls.localizeByDefault('Value must be a multiple of {0}.', data.multipleOf));
+        }
 
         return {
             value: errorMessages.length ? NaN : inputValue,

--- a/packages/preferences/src/browser/views/components/preference-number-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-number-input.ts
@@ -105,6 +105,9 @@ export class PreferenceNumberInputRenderer extends PreferenceLeafNodeRenderer<nu
         if (input === '' || isNaN(inputValue)) {
             return { value: NaN, message: nls.localizeByDefault('Value must be a number.') };
         }
+        if (data.type === 'integer' && !Number.isInteger(inputValue)) {
+            errorMessages.push(nls.localizeByDefault('Value must be an integer.'));
+        }
         if (data.minimum !== undefined && isFinite(data.minimum)) {
             // https://json-schema.org/understanding-json-schema/reference/numeric
             // "In JSON Schema Draft 4, exclusiveMinimum and exclusiveMaximum work differently.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

On a Theia based project we found that preferences with a minimum of 0 were not being validated as such.  This PR fixes this check to compare a Number Preference's minimum based on type.  This PR also implements exclusiveMinimum and exclusiveMaximum.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Have a number preference with a minimum of 0
2. Set minimum to less than 0
3. Validation does not fail on input being below minimum


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
