### PR TITLE
Ensure valid editor constructed before attempting to use editor services

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-peek-view-widget.ts
+++ b/packages/monaco/src/browser/monaco-editor-peek-view-widget.ts
@@ -90,6 +90,14 @@ export class MonacoEditorPeekViewWidget {
                 return this._actionbarWidget;
             }
 
+            fillContainer(container: HTMLElement): void {
+                super._fillContainer(container);
+            }
+
+            protected override _fillContainer(container: HTMLElement): void {
+                that.fillContainer(container);
+            }
+
             fillHead(container: HTMLElement, noCloseAction?: boolean): void {
                 super._fillHead(container, noCloseAction);
             }
@@ -136,6 +144,26 @@ export class MonacoEditorPeekViewWidget {
 
             protected override revealRange(range: monaco.Range, isLastLine: boolean): void {
                 that.doRevealRange(that.editor['m2p'].asRange(range), isLastLine);
+            }
+
+            getBodyElement(): HTMLDivElement | undefined {
+                return this._bodyElement;
+            }
+
+            setBodyElement(element: HTMLDivElement | undefined): void {
+                this._bodyElement = element;
+            }
+
+            getHeadElement(): HTMLDivElement | undefined {
+                return this._headElement;
+            }
+
+            setHeadElement(element: HTMLDivElement | undefined): void {
+                this._headElement = element;
+            }
+
+            override setCssClass(className: string, classToReplace?: string | undefined): void {
+                super.setCssClass(className, classToReplace);
             }
         }(
             editor.getControl() as unknown as ICodeEditor,
@@ -185,6 +213,10 @@ export class MonacoEditorPeekViewWidget {
         return action;
     }
 
+    protected fillContainer(container: HTMLElement): void {
+        this.delegate.fillContainer(container)
+    }
+
     protected fillHead(container: HTMLElement, noCloseAction?: boolean): void {
         this.delegate.fillHead(container, noCloseAction);
     }
@@ -207,6 +239,26 @@ export class MonacoEditorPeekViewWidget {
 
     protected doRevealRange(range: Range, isLastLine: boolean): void {
         this.delegate.doRevealRange(this.editor['p2m'].asRange(range), isLastLine);
+    }
+
+    protected get bodyElement(): HTMLDivElement | undefined {
+        return this.delegate.getBodyElement();
+    }
+
+    protected set bodyElement(element: HTMLDivElement | undefined) {
+        this.delegate.setBodyElement(element);
+    }
+
+    protected get headElement(): HTMLDivElement | undefined {
+        return this.delegate.getHeadElement();
+    }
+
+    protected set headElement(element: HTMLDivElement | undefined) {
+        this.delegate.setHeadElement(element);
+    }
+
+    protected setCssClass(className: string, classToReplace?: string | undefined): void {
+        this.delegate.setCssClass(className, classToReplace);
     }
 
     private convertStyles(styles: MonacoEditorPeekViewWidget.Styles): IPeekViewStyles {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #15102.

The bug is a bit of an odd one. Basically, when a `StandaloneCodeEditor` is constructed, it [sets](https://github.com/microsoft/vscode/blob/9f4e94e38442c0ca13b8ab4a94cd1e9948c44180/src/vs/editor/standalone/browser/standaloneCodeEditor.ts#L296) a [global value](https://github.com/microsoft/vscode/blob/9f4e94e38442c0ca13b8ab4a94cd1e9948c44180/src/vs/base/browser/ui/hover/hoverDelegateFactory.ts#L19-L22) for a hover delegate factory. That is then used ([indirectly](https://github.com/microsoft/vscode/blob/9f4e94e38442c0ca13b8ab4a94cd1e9948c44180/src/vs/base/browser/ui/hover/hoverDelegateFactory.ts#L33-L38)) by the [action bar](https://github.com/microsoft/vscode/blob/9f4e94e38442c0ca13b8ab4a94cd1e9948c44180/src/vs/base/browser/ui/actionbar/actionbar.ts#L121) in  [peek widgets](https://github.com/microsoft/vscode/blob/9f4e94e38442c0ca13b8ab4a94cd1e9948c44180/src/vs/editor/contrib/peekView/browser/peekView.ts#L199) if no hover delegate is specified in the options.

In the code for the `DirtyDiffPeekView`, the header for the view was getting constructed before the editor for a given view had been constructed, meaning that if the last thing to happen was the disposal of an editor with its local instantiation service, the attempt to create a hover delegate used the global value that referred to a now defunct instantiation service.

This PR therefore adjusts the lifecycle of the peek view to construct the editor before the rest of the code to build the view is run, ensuring that there is a valid instantiation service available to construct the hover delegate.

#### How to test

1. Make uncommitted changes to a file.
2. Open that file and scroll to your changes.
3. Click the marginal marker indicating the changed lines.
4. A diff peek view should appear.
5. Close it.
6. Open another by clicking again.
7. It should also open, you should see no errors in the console, and other Monaco services (quick picks, etc.) should also still work.

> In addition to the original issue reported in #15102, I occasionally observed issues with other Monaco services, but they were much less consistently reproducible than the reported issue.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
