### PR TITLE
fix: autocomplete content in chat view

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -221,6 +221,8 @@ blockquote {
 
 .lm-Widget {
     font-size: var(--theia-ui-font-size1);
+    /** We override the contain of lm-Widget to make sure Monaco autocomplete etc. is correctly applied */
+    contain: none !important;
 }
 
 .lm-Widget.lm-mod-hidden {

--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -77,7 +77,7 @@ export class MonacoDiffEditor extends MonacoEditor {
     }
 
     protected override create(options?: IDiffEditorConstructionOptions, override?: EditorServiceOverrides): Disposable {
-        options = { ...options, fixedOverflowWidgets: false };
+        options = { ...options, fixedOverflowWidgets: true };
         const instantiator = this.getInstantiatorWithOverrides(override);
         /**
          *  @monaco-uplift. Should be guaranteed to work.
@@ -101,7 +101,7 @@ export class MonacoDiffEditor extends MonacoEditor {
             const hasReachedSideBySideBreakpoint = leftEditor.contextKeyService
                 .getContextKeyValue(EditorContextKeys.diffEditorRenderSideBySideInlineBreakpointReached.key);
             if (hasReachedSideBySideBreakpoint !== this.lastReachedSideBySideBreakpoint) {
-                leftEditor.updateOptions({ wordWrapOverride2: this.wordWrapOverride ?? hasReachedSideBySideBreakpoint ?  'off' : 'inherit' });
+                leftEditor.updateOptions({ wordWrapOverride2: this.wordWrapOverride ?? hasReachedSideBySideBreakpoint ? 'off' : 'inherit' });
             }
             this.lastReachedSideBySideBreakpoint = !!hasReachedSideBySideBreakpoint;
         }
@@ -131,7 +131,7 @@ export class MonacoDiffEditor extends MonacoEditor {
 
     override handleVisibilityChanged(nowVisible: boolean): void {
         if (nowVisible) {
-            this.diffEditor.setModel({original: this.originalTextModel, modified: this.modifiedTextModel});
+            this.diffEditor.setModel({ original: this.originalTextModel, modified: this.modifiedTextModel });
             this.diffEditor.restoreViewState(this.savedDiffState);
             this.diffEditor.focus();
         } else {

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -409,7 +409,7 @@ export class MonacoEditorProvider {
         overviewRulerBorder: false,
         scrollBeyondLastLine: false,
         renderLineHighlight: 'none',
-        fixedOverflowWidgets: false,
+        fixedOverflowWidgets: true,
         acceptSuggestionOnEnter: 'smart',
         minimap: {
             enabled: false
@@ -421,7 +421,7 @@ export class MonacoEditorProvider {
         options = {
             scrollBeyondLastLine: true,
             overviewRulerLanes: 2,
-            fixedOverflowWidgets: false,
+            fixedOverflowWidgets: true,
             minimap: { enabled: false },
             renderSideBySide: false,
             readOnly: true,

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -174,7 +174,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
         const combinedOptions = {
             ...options,
             lightbulb: { enabled: ShowLightbulbIconMode.On },
-            fixedOverflowWidgets: false,
+            fixedOverflowWidgets: true,
             scrollbar: {
                 useShadows: false,
                 verticalHasArrows: false,

--- a/packages/monaco/src/browser/simple-monaco-editor.ts
+++ b/packages/monaco/src/browser/simple-monaco-editor.ts
@@ -89,7 +89,7 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
         const combinedOptions = {
             ...options,
             lightbulb: { enabled: ShowLightbulbIconMode.On },
-            fixedOverflowWidgets: false,
+            fixedOverflowWidgets: true,
             automaticLayout: true,
             scrollbar: {
                 useShadows: false,

--- a/packages/output/src/browser/output-editor-factory.ts
+++ b/packages/output/src/browser/output-editor-factory.ts
@@ -47,7 +47,7 @@ export class OutputEditorFactory implements MonacoEditorFactory {
             ...defaultOptions,
             overviewRulerLanes: 3,
             lineNumbersMinChars: 3,
-            fixedOverflowWidgets: false,
+            fixedOverflowWidgets: true,
             wordWrap: 'off',
             lineNumbers: 'off',
             glyphMargin: false,


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes autocomplete content not showing up in inline editors like the ChatInput.

With the Lumino migration we disabled 'fixedOverflowWidgets' in our Monaco editors, as Lumino widget styles leverages 'contain', influencing the position of autocomplete content.

This is now reverted, and instead the 'contain' of Lumino widgets is forcefully disabled, fixing the autocomplete issue.

fixes #15237

#### How to test

- Trigger autocomplete in the Chat Input, e.g by entering `@`. Observe that the content shows up.
- Smoke test all of Theia UI to make sure that this does not bring in new regressions

#### Follow-ups

- Discuss with Lumino community on how to better solve this issue

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
