### PR TITLE
Add shortcut for adding the current file to the AI chat context

### DIFF
--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -20,6 +20,14 @@ import { VariableRegistry, VariableResolverService } from '@theia/variable-resol
 import { AIVariableContribution, AIVariableResolver, AIVariableService, AIVariableResolutionRequest, AIVariableContext, ResolvedAIVariable } from '../common';
 
 /**
+ * Mapping configuration for a Theia variable to one or more AI variables
+ */
+interface VariableMapping {
+    name?: string;
+    description?: string;
+}
+
+/**
  * Integrates the Theia VariableRegistry with the Theia AI VariableService
  */
 @injectable()
@@ -36,33 +44,52 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
     @inject(FrontendApplicationStateService)
     protected readonly stateService: FrontendApplicationStateService;
 
-    // Map original variable name to new name and description. If a mapped value is not present then the original will be kept.
+    // Map original variable name to one or more mappings with new name and description.
     // Only variables present in this map are registered.
-    protected variableRenameMap: Map<string, { name?: string, description?: string }> = new Map([
-        ['file', {
-            name: 'currentAbsoluteFilePath', description: nls.localize('theia/ai/core/variable-contribution/currentAbsoluteFilePath', 'The absolute path of the \
-            currently opened file. Please note that most agents will expect a relative file path (relative to the current workspace).')
-        }],
-        ['selectedText', {
-            description: nls.localize('theia/ai/core/variable-contribution/currentSelectedText', 'The plain text that is currently selected in the \
-            opened file. This excludes the information where the content is coming from. Please note that most agents will work better with a relative file path \
-            (relative to the current workspace).')
-        }],
-        ['currentText', {
-            name: 'currentFileContent', description: nls.localize('theia/ai/core/variable-contribution/currentFileContent', 'The plain content of the \
-            currently opened file. This excludes the information where the content is coming from. Please note that most agents will work better with a relative file path \
-            (relative to the current workspace).')
-        }],
-        ['relativeFile', {
-            name: 'currentRelativeFilePath', description: nls.localize('theia/ai/core/variable-contribution/currentRelativeFilePath', 'The relative path of the \
-            currently opened file.')
-        }],
-        ['relativeFileDirname', {
-            name: 'currentRelativeDirPath', description: nls.localize('theia/ai/core/variable-contribution/currentRelativeDirPath', 'The relative path of the directory \
-            containing the currently opened file.')
-        }],
-        ['lineNumber', {}],
-        ['workspaceFolder', {}]
+    protected variableRenameMap: Map<string, VariableMapping[]> = new Map([
+        ['file', [
+            {
+                name: 'currentAbsoluteFilePath',
+                description: nls.localize('theia/ai/core/variable-contribution/currentAbsoluteFilePath', 'The absolute path of the \
+                currently opened file. Please note that most agents will expect a relative file path (relative to the current workspace).')
+            }
+        ]],
+        ['selectedText', [
+            {
+                description: nls.localize('theia/ai/core/variable-contribution/currentSelectedText', 'The plain text that is currently selected in the \
+                opened file. This excludes the information where the content is coming from. Please note that most agents will work better with a relative file path \
+                (relative to the current workspace).')
+            }
+        ]],
+        ['currentText', [
+            {
+                name: 'currentFileContent',
+                description: nls.localize('theia/ai/core/variable-contribution/currentFileContent', 'The plain content of the \
+                currently opened file. This excludes the information where the content is coming from. Please note that most agents will work better with a relative file path \
+                (relative to the current workspace).')
+            }
+        ]],
+        ['relativeFile', [
+            {
+                name: 'currentRelativeFilePath',
+                description: nls.localize('theia/ai/core/variable-contribution/currentRelativeFilePath', 'The relative path of the \
+                currently opened file.')
+            },
+            {
+                name: '_f',
+                description: nls.localize('theia/ai/core/variable-contribution/dotRelativePath', 'Short reference to the relative path of the \
+                currently opened file (\'currentRelativeFilePath\').')
+            }
+        ]],
+        ['relativeFileDirname', [
+            {
+                name: 'currentRelativeDirPath',
+                description: nls.localize('theia/ai/core/variable-contribution/currentRelativeDirPath', 'The relative path of the directory \
+                containing the currently opened file.')
+            }
+        ]],
+        ['lineNumber', [{}]],
+        ['workspaceFolder', [{}]]
     ]);
 
     registerVariables(service: AIVariableService): void {
@@ -73,25 +100,39 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
                 if (!this.variableRenameMap.has(variable.name)) {
                     return; // Do not register variables not part of the map
                 }
-                const mapping = this.variableRenameMap.get(variable.name)!;
-                const newName = (mapping.name && mapping.name.trim() !== '') ? mapping.name : variable.name;
-                const newDescription = (mapping.description && mapping.description.trim() !== '') ? mapping.description
-                    : (variable.description && variable.description.trim() !== '' ? variable.description
-                        : nls.localize('theia/ai/core/variable-contribution/builtInVariable', 'Theia Built-in Variable'));
 
-                service.registerResolver({
-                    id: `${TheiaVariableContribution.THEIA_PREFIX}${variable.name}`,
-                    name: newName,
-                    description: newDescription
-                }, this);
+                const mappings = this.variableRenameMap.get(variable.name)!;
+
+                // Register each mapping for this variable
+                mappings.forEach((mapping, index) => {
+                    const newName = (mapping.name && mapping.name.trim() !== '') ? mapping.name : variable.name;
+                    const newDescription = (mapping.description && mapping.description.trim() !== '') ? mapping.description
+                        : (variable.description && variable.description.trim() !== '' ? variable.description
+                            : nls.localize('theia/ai/core/variable-contribution/builtInVariable', 'Theia Built-in Variable'));
+
+                    // For multiple mappings of the same variable, add a suffix to the ID to make it unique
+                    const idSuffix = mappings.length > 1 ? `-${index}` : '';
+                    const id = `${TheiaVariableContribution.THEIA_PREFIX}${variable.name}${idSuffix}`;
+
+                    service.registerResolver({
+                        id,
+                        name: newName,
+                        description: newDescription
+                    }, this);
+                });
             });
         });
     }
 
     protected toTheiaVariable(request: AIVariableResolutionRequest): string {
-        // Remove the THEIA_PREFIX if present before constructing the variable string
-        const variableId = request.variable.id.startsWith(TheiaVariableContribution.THEIA_PREFIX) ? request.variable.id.slice(TheiaVariableContribution.THEIA_PREFIX.length) :
-            request.variable.id;
+        // Extract the base variable name by removing the THEIA_PREFIX and any potential index suffix
+        let variableId = request.variable.id;
+        if (variableId.startsWith(TheiaVariableContribution.THEIA_PREFIX)) {
+            variableId = variableId.slice(TheiaVariableContribution.THEIA_PREFIX.length);
+            // Remove any potential index suffix (e.g., -0, -1)
+            variableId = variableId.replace(/-\d+$/, '');
+        }
+
         return `\${${variableId}${request.arg ? ':' + request.arg : ''}}`;
     }
 


### PR DESCRIPTION
#### What it does

Adds a shortcut "_f" to the variable currentRelativeFilePath

#### How to test

Use #_f in the AI chat and see that it behaves the same as #currentRelativeFilePath

I am open to debate on the format, but I researched a bit and this was the best option I could come up with.
I think a prefix for shortcuts makes sense and things like "%" or "$" or "." are either not allowed in variable names or look really weird in combination with "#"

#### Follow-ups

we might want to create other shortcuts, e.g. for the selection?

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
