### PR TITLE
Prevent plugin localization errors

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-localization-service.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-localization-service.ts
@@ -379,11 +379,11 @@ function coerceLocalizations(translations: Record<string, string | LocalizeInfo>
 function localizePackage(value: unknown, translations: PackageTranslation, callback: (key: string, defaultValue: string) => string): unknown {
     if (typeof value === 'string') {
         let result = value;
-        if (value.startsWith('%') && value.endsWith('%')) {
+        if (value.length > 2 && value.startsWith('%') && value.endsWith('%')) {
             const key = value.slice(1, -1);
-            if (translations.translation) {
+            if (translations.translation && key in translations.translation) {
                 result = translations.translation[key];
-            } else if (translations.default) {
+            } else if (translations.default && key in translations.default) {
                 result = callback(key, translations.default[key]);
             }
         }


### PR DESCRIPTION
#### What it does

After https://github.com/eclipse-theia/theia/pull/15142, the backend became to eager trying to localize values in the package.json. This led to errors in the output console during the translation process. This PR fixes these errors.

#### How to test

1. Current Theia prints errors such as: `2025-03-24T21:59:06.485Z root ERROR Failed to localize plugin 'vscode.r'. TypeError: Cannot read properties of undefined (reading 'replace')`
2. After applying this patch, these errors should no longer appear.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
