### PR TITLE
Add MCP Server config view to AI Configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30205,6 +30205,7 @@
         "@theia/ai-chat": "1.59.0",
         "@theia/ai-chat-ui": "1.59.0",
         "@theia/ai-core": "1.59.0",
+        "@theia/ai-mcp": "1.59.0",
         "@theia/core": "1.59.0",
         "@theia/filesystem": "1.59.0",
         "@theia/markers": "1.59.0",

--- a/packages/ai-ide/package.json
+++ b/packages/ai-ide/package.json
@@ -25,6 +25,7 @@
     "@theia/navigator": "1.59.0",
     "@theia/terminal": "1.59.0",
     "@theia/workspace": "1.59.0",
+    "@theia/ai-mcp": "1.59.0",
     "ignore": "^6.0.0",
     "minimatch": "^9.0.0"
   },

--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-widget.tsx
@@ -22,6 +22,7 @@ import { AIAgentConfigurationWidget } from './agent-configuration-widget';
 import { AIVariableConfigurationWidget } from './variable-configuration-widget';
 import { AIConfigurationSelectionService } from './ai-configuration-service';
 import { nls } from '@theia/core';
+import { AIMCPConfigurationWidget } from './mcp-configuration-widget';
 
 @injectable()
 export class AIConfigurationContainerWidget extends BaseWidget {
@@ -39,6 +40,7 @@ export class AIConfigurationContainerWidget extends BaseWidget {
 
     protected agentsWidget: AIAgentConfigurationWidget;
     protected variablesWidget: AIVariableConfigurationWidget;
+    protected mcpWidget: AIMCPConfigurationWidget;
 
     @postConstruct()
     protected init(): void {
@@ -63,8 +65,10 @@ export class AIConfigurationContainerWidget extends BaseWidget {
 
         this.agentsWidget = await this.widgetManager.getOrCreateWidget(AIAgentConfigurationWidget.ID);
         this.variablesWidget = await this.widgetManager.getOrCreateWidget(AIVariableConfigurationWidget.ID);
+        this.mcpWidget = await this.widgetManager.getOrCreateWidget(AIMCPConfigurationWidget.ID);
         this.dockpanel.addWidget(this.agentsWidget);
         this.dockpanel.addWidget(this.variablesWidget);
+        this.dockpanel.addWidget(this.mcpWidget);
 
         this.update();
     }
@@ -75,6 +79,8 @@ export class AIConfigurationContainerWidget extends BaseWidget {
                 this.dockpanel.activateWidget(this.agentsWidget);
             } else if (widgetId === AIVariableConfigurationWidget.ID) {
                 this.dockpanel.activateWidget(this.variablesWidget);
+            } else if (widgetId === AIMCPConfigurationWidget.ID) {
+                this.dockpanel.activateWidget(this.mcpWidget);
             }
         });
     }

--- a/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
@@ -1,0 +1,328 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ReactWidget } from '@theia/core/lib/browser';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import * as React from '@theia/core/shared/react';
+import { HoverService } from '@theia/core/lib/browser/hover-service';
+import { MCPFrontendNotificationService, MCPFrontendService, MCPServerDescription, MCPServerStatus } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { MessageService } from '@theia/core';
+
+@injectable()
+export class AIMCPConfigurationWidget extends ReactWidget {
+
+    static readonly ID = 'ai-mcp-configuration-container-widget';
+    static readonly LABEL = 'MCP Servers';
+
+    servers: MCPServerDescription[] = [];
+    expandedTools: Record<string, boolean> = {};
+
+    @inject(MCPFrontendService)
+    protected readonly mcpFrontendService: MCPFrontendService;
+
+    @inject(MCPFrontendNotificationService)
+    protected readonly mcpFrontendNotificationService: MCPFrontendNotificationService;
+
+    @inject(HoverService)
+    protected readonly hoverService: HoverService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @postConstruct()
+    protected init(): void {
+        this.id = AIMCPConfigurationWidget.ID;
+        this.title.label = AIMCPConfigurationWidget.LABEL;
+        this.title.closable = false;
+        this.toDispose.push(this.mcpFrontendNotificationService.onDidUpdateMCPServers(async () => {
+            this.loadServers();
+        }));
+        this.loadServers();
+    }
+
+    protected async loadServers(): Promise<void> {
+        const serverNames = await this.mcpFrontendService.getServerNames();
+        const promises = serverNames.map(name => this.mcpFrontendService.getServerDescription(name));
+        const descriptions = await Promise.all(promises);
+        this.servers = descriptions.filter((desc): desc is MCPServerDescription => desc !== undefined);
+        this.update();
+    }
+
+    protected getStatusColor(status?: MCPServerStatus): { bg: string, fg: string } {
+        if (!status) {
+            return { bg: 'var(--theia-descriptionForeground)', fg: 'white' };
+        }
+        switch (status) {
+            case MCPServerStatus.Running:
+                return { bg: 'var(--theia-successBackground)', fg: 'var(--theia-successForeground)' };
+            case MCPServerStatus.Starting:
+                return { bg: 'var(--theia-warningBackground)', fg: 'var(--theia-warningForeground)' };
+            case MCPServerStatus.Errored:
+                return { bg: 'var(--theia-errorBackground)', fg: 'var(--theia-errorForeground)' };
+            case MCPServerStatus.NotRunning:
+            default:
+                return { bg: 'var(--theia-inputValidation-infoBackground)', fg: 'var(--theia-inputValidation-infoForeground)' };
+        }
+    }
+
+    protected showErrorHover(spanRef: React.RefObject<HTMLSpanElement>, error: string): void {
+        this.hoverService.requestHover({ content: error, target: spanRef.current!, position: 'left' });
+    }
+
+    protected hideErrorHover(): void {
+        this.hoverService.cancelHover();
+    }
+
+    protected async handleStartServer(serverName: string): Promise<void> {
+        await this.mcpFrontendService.startServer(serverName);
+    }
+
+    protected async handleStopServer(serverName: string): Promise<void> {
+        await this.mcpFrontendService.stopServer(serverName);
+    }
+
+    protected renderButton(text: React.ReactNode,
+        title: string,
+        onClick: React.MouseEventHandler<HTMLButtonElement>,
+        className?: string,
+        style?: React.CSSProperties): React.ReactNode {
+        return (
+            <button className={className} title={title} onClick={onClick} style={style}>
+                {text}
+            </button>
+        );
+    }
+
+    protected renderStatusBadge(status?: MCPServerStatus, error?: string): React.ReactNode {
+        const colors = this.getStatusColor(status);
+        const displayStatus = status || MCPServerStatus.NotRunning;
+        const spanRef = React.createRef<HTMLSpanElement>();
+        return (
+            <div className="mcp-status-container">
+                <span className="mcp-status-badge" style={{
+                    backgroundColor: colors.bg,
+                    color: colors.fg
+                }}>
+                    {displayStatus}
+                </span>
+                {error && (
+                    <span
+                        onMouseEnter={() => this.showErrorHover(spanRef, error)}
+                        onMouseLeave={() => this.hideErrorHover()}
+                        ref={spanRef}
+                        className="mcp-error-indicator"
+                    >
+                        ?
+                    </span>
+                )}
+            </div>
+        );
+    }
+
+    protected renderServerHeader(server: MCPServerDescription): React.ReactNode {
+        return (
+            <div className="mcp-server-header">
+                <div className="mcp-server-name">{server.name}</div>
+                {this.renderStatusBadge(server.status, server.error)}
+            </div>
+        );
+    }
+
+    protected renderCommandSection(server: MCPServerDescription): React.ReactNode {
+        return (
+            <div className="mcp-server-section">
+                <span className="mcp-section-label">Command: </span>
+                <code className="mcp-code-block">{server.command}</code>
+            </div>
+        );
+    }
+
+    protected renderArgumentsSection(server: MCPServerDescription): React.ReactNode {
+        if (!server.args || server.args.length === 0) {
+            return;
+        }
+        return (
+            <div className="mcp-server-section">
+                <span className="mcp-section-label">Arguments: </span>
+                <code className="mcp-code-block">{server.args.join(' ')}</code>
+            </div>
+        );
+    }
+
+    protected renderEnvironmentSection(server: MCPServerDescription): React.ReactNode {
+        if (!server.env || Object.keys(server.env).length === 0) {
+            return;
+        }
+        return (
+            <div className="mcp-server-section">
+                <span className="mcp-section-label">Environment Variables: </span>
+                <div className="mcp-env-block">
+                    {Object.entries(server.env).map(([key, value]) => (
+                        <div key={key}>
+                            {key}={key.toLowerCase().includes('token') ? '******' : value}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    protected renderAutostartSection(server: MCPServerDescription): React.ReactNode {
+        return (
+            <div className="mcp-server-section">
+                <span className="mcp-section-label">Autostart: </span>
+                <span className="mcp-autostart-badge" style={{
+                    backgroundColor: server.autostart ? 'var(--theia-successBackground)' : 'var(--theia-errorBackground)',
+                    color: server.autostart ? 'var(--theia-successForeground)' : 'var(--theia-errorForeground)',
+                }}>
+                    {server.autostart ? 'Enabled' : 'Disabled'}
+                </span>
+            </div>
+        );
+    }
+
+    protected renderToolsSection(server: MCPServerDescription): React.ReactNode {
+        if (!server.tools || server.tools.length === 0) {
+            return;
+        }
+        const isToolsExpanded = this.expandedTools[server.name] || false;
+        return (
+            <div className="mcp-tools-section">
+                <div style={{ display: 'flex', alignItems: 'center' }} onClick={() => this.toggleTools(server.name)}>
+                    <div className="mcp-toggle-indicator" style={{ display: 'flex' }}>
+                        <span style={{
+                            display: 'inline-block',
+                            transition: 'transform 0.2s ease',
+                            fontSize: '12px'
+                        }}>
+                            {isToolsExpanded ? '▼' : '►'}
+                        </span>
+                    </div>
+                    <div style={{ flexGrow: 1 }}>
+                        <span className="mcp-section-label">Tools: </span>
+                    </div>
+                    <div style={{ display: 'flex' }}>
+                        {this.renderButton(
+                            <i className="codicon codicon-copy"></i>,
+                            'Copy all (for prompttemplate)',
+                            e => {
+                                e.stopPropagation();
+                                if (server.tools) {
+                                    const toolNames = server.tools.map(tool => `~{mcp_${server.name}_${tool.name}}`).join('\n');
+                                    navigator.clipboard.writeText(toolNames);
+                                    this.messageService.info('Copied all tools to clipboard (for prompttemplate)');
+                                }
+                            },
+                            'mcp-copy-tool-button'
+                        )}
+                    </div>
+                </div>
+                {isToolsExpanded && (
+                    <div className="mcp-tools-list">
+                        {server.tools.map(tool => (
+                            <div key={tool.name} style={{ display: 'flex', alignItems: 'center' }}>
+                                <div style={{ flexGrow: 1 }}>
+                                    <strong>{tool.name}:</strong> {tool.description}
+                                </div>
+                                <div style={{ display: 'flex', gap: '4px' }}>
+                                    {this.renderButton(
+                                        <i className="codicon codicon-comment"></i>,
+                                        'Copy (for Chat)',
+                                        e => {
+                                            e.stopPropagation();
+                                            const copied = `~mcp_${server.name}_${tool.name}`;
+                                            navigator.clipboard.writeText(copied);
+                                            this.messageService.info(`Copied ${copied} to clipboard (for chat)`);
+                                        },
+                                        'mcp-copy-tool-button'
+                                    )}
+                                    {this.renderButton(
+                                        <i className="codicon codicon-copy"></i>,
+                                        'Copy (for prompttemplate)',
+                                        e => {
+                                            e.stopPropagation();
+                                            const copied = `~{mcp_${server.name}_${tool.name}}`;
+                                            navigator.clipboard.writeText(copied);
+                                            this.messageService.info(`Copied ${copied} to clipboard (for prompttemplate)`);
+                                        },
+                                        'mcp-copy-tool-button'
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    protected toggleTools(serverName: string): void {
+        this.expandedTools[serverName] = !this.expandedTools[serverName];
+        this.update();
+    }
+
+    protected renderServerControls(server: MCPServerDescription): React.ReactNode {
+        const isStoppable = server.status === MCPServerStatus.Running || server.status === MCPServerStatus.Starting;
+        const isStartable = server.status === MCPServerStatus.NotRunning || server.status === MCPServerStatus.Errored;
+        return (
+            <div className="mcp-server-controls">
+                {isStartable && this.renderButton(
+                    <><i className="codicon codicon-play"></i> Start Server</>,
+                    'Start Server',
+                    () => this.handleStartServer(server.name),
+                    'mcp-server-button play-button'
+                )}
+                {isStoppable && this.renderButton(
+                    <><i className="codicon codicon-debug-stop"></i> Stop Server</>,
+                    'Stop Server',
+                    () => this.handleStopServer(server.name),
+                    'mcp-server-button stop-button'
+                )}
+            </div>
+        );
+    }
+
+    protected renderServerCard(server: MCPServerDescription): React.ReactNode {
+        return (
+            <div key={server.name} className="mcp-server-card">
+                {this.renderServerHeader(server)}
+                {this.renderCommandSection(server)}
+                {this.renderArgumentsSection(server)}
+                {this.renderEnvironmentSection(server)}
+                {this.renderAutostartSection(server)}
+                {this.renderToolsSection(server)}
+                {this.renderServerControls(server)}
+            </div>
+        );
+    }
+
+    protected render(): React.ReactNode {
+        if (this.servers.length === 0) {
+            return (
+                <div className="mcp-no-servers">
+                    No MCP servers configured
+                </div>
+            );
+        }
+
+        return (
+            <div className="mcp-configuration-container">
+                <h2 className="mcp-configuration-title">MCP Server Configurations</h2>
+                {this.servers.map(server => this.renderServerCard(server))}
+            </div>
+        );
+    }
+}

--- a/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
@@ -213,21 +213,31 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                     <div style={{ flexGrow: 1 }}>
                         <span className="mcp-section-label">Tools: </span>
                     </div>
-                    <div style={{ display: 'flex' }}>
+                    <div style={{ display: 'flex', gap: '4px' }}>
                         {this.renderButton(
-                            <i className="codicon codicon-copy"></i>,
-                            'Copy all (for prompttemplate)',
+                            <i className="codicon codicon-versions"></i>,
+                            'Copy all (multiple lines prompttemplate)',
                             e => {
                                 e.stopPropagation();
                                 if (server.tools) {
                                     const toolNames = server.tools.map(tool => `~{mcp_${server.name}_${tool.name}}`).join('\n');
                                     navigator.clipboard.writeText(toolNames);
-                                    this.messageService.info('Copied all tools to clipboard (for prompttemplate)');
+                                    this.messageService.info('Copied all tools to clipboard (multiple lines prompttemplate)');
                                 }
                             },
                             'mcp-copy-tool-button'
                         )}
-                                            </div>
+                        {this.renderButton(
+                            <i className="codicon codicon-copy"></i>,
+                            'Copy all (single line prompttemplate)',
+                            e => {
+                                e.stopPropagation();
+                                navigator.clipboard.writeText(`~{${this.mcpFrontendService.getPromptTemplateId(server.name)}}`);
+                                this.messageService.info('Copied all tools to clipboard (single line prompttemplate)');
+                            },
+                            'mcp-copy-tool-button'
+                        )}
+                    </div>
                 </div>
                 {isToolsExpanded && (
                     <div className="mcp-tools-list">

--- a/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2024 EclipseSource GmbH.
+// Copyright (C) 2025 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,8 +27,8 @@ export class AIMCPConfigurationWidget extends ReactWidget {
     static readonly ID = 'ai-mcp-configuration-container-widget';
     static readonly LABEL = 'MCP Servers';
 
-    servers: MCPServerDescription[] = [];
-    expandedTools: Record<string, boolean> = {};
+    protected servers: MCPServerDescription[] = [];
+    protected expandedTools: Record<string, boolean> = {};
 
     @inject(MCPFrontendService)
     protected readonly mcpFrontendService: MCPFrontendService;
@@ -55,8 +55,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
 
     protected async loadServers(): Promise<void> {
         const serverNames = await this.mcpFrontendService.getServerNames();
-        const promises = serverNames.map(name => this.mcpFrontendService.getServerDescription(name));
-        const descriptions = await Promise.all(promises);
+        const descriptions = await Promise.all(serverNames.map(name => this.mcpFrontendService.getServerDescription(name)));
         this.servers = descriptions.filter((desc): desc is MCPServerDescription => desc !== undefined);
         this.update();
     }
@@ -228,7 +227,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                             },
                             'mcp-copy-tool-button'
                         )}
-                    </div>
+                                            </div>
                 </div>
                 {isToolsExpanded && (
                     <div className="mcp-tools-list">
@@ -286,7 +285,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                     'mcp-server-button play-button'
                 )}
                 {isStoppable && this.renderButton(
-                    <><i className="codicon codicon-debug-stop"></i> Stop Server</>,
+                    <><i className="codicon codicon-close"></i> Stop Server</>,
                     'Stop Server',
                     () => this.handleStopServer(server.name),
                     'mcp-server-button stop-button'

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -39,7 +39,8 @@ import { AIConfigurationContainerWidget } from './ai-configuration/ai-configurat
 import { AIVariableConfigurationWidget } from './ai-configuration/variable-configuration-widget';
 import { ContextFilesVariableContribution } from '../common/context-files-variable';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
-import {AiConfigurationPreferences} from './ai-configuration/ai-configuration-preferences';
+import { AiConfigurationPreferences } from './ai-configuration/ai-configuration-preferences';
+import { AIMCPConfigurationWidget } from './ai-configuration/mcp-configuration-widget';
 
 export default new ContainerModule(bind => {
     bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
@@ -109,5 +110,13 @@ export default new ContainerModule(bind => {
     bind(ToolProvider).to(SimpleReplaceContentInFileProvider);
     bind(ToolProvider).to(AddFileToChatContext);
     bind(AIVariableContribution).to(ContextFilesVariableContribution).inSingletonScope();
-    bind(PreferenceContribution).toConstantValue({schema: AiConfigurationPreferences});
+    bind(PreferenceContribution).toConstantValue({ schema: AiConfigurationPreferences });
+    bind(AIMCPConfigurationWidget).toSelf();
+    bind(WidgetFactory)
+        .toDynamicValue(ctx => ({
+            id: AIMCPConfigurationWidget.ID,
+            createWidget: () => ctx.container.get(AIMCPConfigurationWidget)
+        }))
+        .inSingletonScope();
+
 });

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -125,3 +125,187 @@
   margin-top: 3em;
   margin-left: 0;
 }
+
+/* MCP Configuration Styles */
+.mcp-configuration-container {
+  padding: 16px;
+}
+
+.mcp-configuration-title {
+  margin: 0 0 16px 0;
+  border-bottom: 1px solid var(--theia-panelTitle-activeBorder);
+  padding-bottom: 8px;
+}
+
+.mcp-server-card {
+  border: 1px solid var(--theia-panelTitle-activeBorder);
+  border-radius: 6px;
+  padding: 12px;
+  margin-bottom: 16px;
+  background-color: var(--theia-editorWidget-background);
+}
+
+.mcp-server-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.mcp-server-name {
+  font-weight: bold;
+  font-size: var(--theia-ui-font-size3);
+}
+
+.mcp-status-badge {
+  padding: 3px 8px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: bold;
+  display: inline-block;
+}
+
+.mcp-error-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: var(--theia-errorBackground);
+  color: var(--theia-errorForeground);
+  font-size: 12px;
+  font-weight: bold;
+  cursor: pointer;
+  margin-left: 8px;
+}
+
+.mcp-server-section {
+  margin-bottom: 6px;
+}
+
+.mcp-section-label {
+  font-weight: bold;
+  color: var(--theia-descriptionForeground);
+}
+
+.mcp-code-block {
+  background-color: var(--theia-editor-background);
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-family: monospace;
+}
+
+.mcp-env-block {
+  margin-left: 10px;
+  background-color: var(--theia-editor-background);
+  padding: 4px 8px;
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.mcp-toggle-indicator {
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px;
+  transition: transform 0.2s ease;
+}
+
+.mcp-tools-section {
+  margin-top: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.mcp-tools-list {
+  margin-left: 24px;
+  margin-top: 4px;
+  background-color: var(--theia-editor-background);
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.mcp-autostart-badge {
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.mcp-no-servers {
+  padding: 20px;
+  text-align: center;
+  color: var(--theia-descriptionForeground);
+}
+
+.mcp-status-container {
+  display: flex;
+  align-items: center;
+}
+
+.mcp-server-controls {
+  display: flex;
+  align-items: center;
+  margin-top: 12px;
+  border-top: 1px solid var(--theia-panelTitle-inactiveForeground);
+  padding-top: 12px;
+}
+
+.mcp-server-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--theia-button-background);
+  color: var(--theia-button-foreground);
+  border: none;
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  margin-right: 10px;
+}
+
+.mcp-server-button:hover {
+  background-color: var(--theia-button-hoverBackground);
+}
+
+.mcp-server-button.play-button {
+  background-color: var(--theia-successBackground);
+  color: var(--theia-successForeground);
+}
+
+.mcp-server-button.play-button:hover {
+  background-color: var(--theia-successBackground);
+  filter: brightness(1.1);
+}
+
+.mcp-server-button.stop-button {
+  background-color: var(--theia-errorBackground);
+  color: var(--theia-errorForeground);
+}
+
+.mcp-server-button.stop-button:hover {
+  background-color: var(--theia-errorBackground);
+  filter: brightness(1.1);
+}
+
+.mcp-server-button-icon {
+  margin-right: 6px;
+  font-size: 14px;
+}
+
+.mcp-copy-tool-button {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--theia-descriptionForeground);
+  white-space: nowrap;
+}

--- a/packages/ai-ide/tsconfig.json
+++ b/packages/ai-ide/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../ai-core"
     },
     {
+      "path": "../ai-mcp"
+    },
+    {
       "path": "../core"
     },
     {

--- a/packages/ai-mcp/src/browser/mcp-command-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-command-contribution.ts
@@ -17,7 +17,7 @@ import { AICommandHandlerFactory } from '@theia/ai-core/lib/browser/ai-command-h
 import { CommandContribution, CommandRegistry, MessageService, nls } from '@theia/core';
 import { QuickInputService } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { MCPFrontendService } from './mcp-frontend-service';
+import { MCPFrontendService } from '../common/mcp-server-manager';
 
 export const StartMCPServer = {
     id: 'mcp.startserver',

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
@@ -19,7 +19,7 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { MCPServerDescription, MCPServerManager } from '../common';
 import { MCP_SERVERS_PREF } from './mcp-preferences';
 import { JSONObject } from '@theia/core/shared/@lumino/coreutils';
-import { MCPFrontendService } from './mcp-frontend-service';
+import { MCPFrontendService } from '../common/mcp-server-manager';
 
 interface MCPServersPreferenceValue {
     command: string;

--- a/packages/ai-mcp/src/browser/mcp-frontend-module.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-module.ts
@@ -18,18 +18,21 @@ import { CommandContribution } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { MCPCommandContribution } from './mcp-command-contribution';
 import { FrontendApplicationContribution, PreferenceContribution, RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
-import { MCPServerManager, MCPServerManagerPath } from '../common/mcp-server-manager';
+import { MCPFrontendService, MCPServerManager, MCPServerManagerPath, MCPFrontendNotificationService } from '../common/mcp-server-manager';
 import { McpServersPreferenceSchema } from './mcp-preferences';
 import { McpFrontendApplicationContribution } from './mcp-frontend-application-contribution';
-import { MCPFrontendService } from './mcp-frontend-service';
+import { MCPFrontendServiceImpl } from './mcp-frontend-service';
+import { MCPFrontendNotificationServiceImpl } from './mcp-frontend-notification-service';
 
 export default new ContainerModule(bind => {
     bind(PreferenceContribution).toConstantValue({ schema: McpServersPreferenceSchema });
     bind(FrontendApplicationContribution).to(McpFrontendApplicationContribution).inSingletonScope();
     bind(CommandContribution).to(MCPCommandContribution);
+    bind(MCPFrontendService).to(MCPFrontendServiceImpl).inSingletonScope();
+    bind(MCPFrontendNotificationService).to(MCPFrontendNotificationServiceImpl).inSingletonScope();
     bind(MCPServerManager).toDynamicValue(ctx => {
         const connection = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);
-        return connection.createProxy<MCPServerManager>(MCPServerManagerPath);
+        const client = ctx.container.get<MCPFrontendNotificationService>(MCPFrontendNotificationService);
+        return connection.createProxy<MCPServerManager>(MCPServerManagerPath, client);
     }).inSingletonScope();
-    bind(MCPFrontendService).toSelf().inSingletonScope();
 });

--- a/packages/ai-mcp/src/browser/mcp-frontend-notification-service.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-notification-service.ts
@@ -1,0 +1,29 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { MCPFrontendNotificationService } from '../common';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+
+@injectable()
+export class MCPFrontendNotificationServiceImpl implements MCPFrontendNotificationService {
+    protected readonly onDidUpdateMCPServersEmitter = new Emitter<void>();
+    public readonly onDidUpdateMCPServers: Event<void> = this.onDidUpdateMCPServersEmitter.event;
+
+    didUpdateMCPServers(): void {
+        this.onDidUpdateMCPServersEmitter.fire();
+    }
+}

--- a/packages/ai-mcp/src/browser/mcp-frontend-service.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-service.ts
@@ -53,7 +53,7 @@ export class MCPFrontendServiceImpl implements MCPFrontendService {
         }
     }
 
-    private getPromptTemplateId(serverName: string): string {
+    getPromptTemplateId(serverName: string): string {
         return `mcp_${serverName}_tools`;
     }
 

--- a/packages/ai-mcp/src/browser/mcp-frontend-service.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-service.ts
@@ -14,11 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { MCPServer, MCPServerManager } from '../common/mcp-server-manager';
+import { MCPFrontendService, MCPServer, MCPServerDescription, MCPServerManager } from '../common/mcp-server-manager';
 import { ToolInvocationRegistry, ToolRequest, PromptService } from '@theia/ai-core';
 
 @injectable()
-export class MCPFrontendService {
+export class MCPFrontendServiceImpl implements MCPFrontendService {
 
     @inject(MCPServerManager)
     protected readonly mcpServerManager: MCPServerManager;
@@ -31,7 +31,7 @@ export class MCPFrontendService {
 
     async startServer(serverName: string): Promise<void> {
         await this.mcpServerManager.startServer(serverName);
-        this.registerTools(serverName);
+        await this.registerTools(serverName);
     }
 
     async registerToolsForAllStartedServers(): Promise<void> {
@@ -73,11 +73,15 @@ export class MCPFrontendService {
     }
 
     getStartedServers(): Promise<string[]> {
-        return this.mcpServerManager.getStartedServers();
+        return this.mcpServerManager.getRunningServers();
     }
 
     getServerNames(): Promise<string[]> {
         return this.mcpServerManager.getServerNames();
+    }
+
+    async getServerDescription(name: string): Promise<MCPServerDescription | undefined> {
+        return this.mcpServerManager.getServerDescription(name);
     }
 
     getTools(serverName: string): ReturnType<MCPServer['getTools']> {

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -25,7 +25,7 @@ export interface MCPFrontendService {
     getStartedServers(): Promise<string[]>;
     getServerNames(): Promise<string[]>;
     getServerDescription(name: string): Promise<MCPServerDescription | undefined>;
-    getTools(serverName: string): ReturnType<MCPServer['getTools']>;
+    getTools(serverName: string): Promise<ReturnType<MCPServer['getTools']> | undefined>;
 }
 
 export const MCPFrontendNotificationService = Symbol('MCPFrontendNotificationService');
@@ -44,7 +44,7 @@ export interface MCPServerManager {
     callTool(serverName: string, toolName: string, arg_string: string): ReturnType<MCPServer['callTool']>;
     removeServer(name: string): void;
     addOrUpdateServer(description: MCPServerDescription): void;
-    getTools(serverName: string): ReturnType<MCPServer['getTools']>
+    getTools(serverName: string): ReturnType<MCPServer['getTools']>;
     getServerNames(): Promise<string[]>;
     getServerDescription(name: string): Promise<MCPServerDescription | undefined>;
     startServer(serverName: string): Promise<void>;

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -26,6 +26,7 @@ export interface MCPFrontendService {
     getServerNames(): Promise<string[]>;
     getServerDescription(name: string): Promise<MCPServerDescription | undefined>;
     getTools(serverName: string): Promise<ReturnType<MCPServer['getTools']> | undefined>;
+    getPromptTemplateId(serverName: string): string;
 }
 
 export const MCPFrontendNotificationService = Symbol('MCPFrontendNotificationService');

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -15,10 +15,29 @@
 // *****************************************************************************
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index';
+import { Event } from '@theia/core/lib/common/event';
+
+export const MCPFrontendService = Symbol('MCPFrontendService');
+export interface MCPFrontendService {
+    startServer(serverName: string): Promise<void>;
+    registerToolsForAllStartedServers(): Promise<void>;
+    stopServer(serverName: string): Promise<void>;
+    getStartedServers(): Promise<string[]>;
+    getServerNames(): Promise<string[]>;
+    getServerDescription(name: string): Promise<MCPServerDescription | undefined>;
+    getTools(serverName: string): ReturnType<MCPServer['getTools']>;
+}
+
+export const MCPFrontendNotificationService = Symbol('MCPFrontendNotificationService');
+export interface MCPFrontendNotificationService {
+    readonly onDidUpdateMCPServers: Event<void>;
+    didUpdateMCPServers(): void;
+}
 
 export interface MCPServer {
     callTool(toolName: string, arg_string: string): ReturnType<Client['callTool']>;
     getTools(): ReturnType<Client['listTools']>;
+    description: MCPServerDescription;
 }
 
 export interface MCPServerManager {
@@ -27,9 +46,24 @@ export interface MCPServerManager {
     addOrUpdateServer(description: MCPServerDescription): void;
     getTools(serverName: string): ReturnType<MCPServer['getTools']>
     getServerNames(): Promise<string[]>;
+    getServerDescription(name: string): Promise<MCPServerDescription | undefined>;
     startServer(serverName: string): Promise<void>;
     stopServer(serverName: string): Promise<void>;
-    getStartedServers(): Promise<string[]>;
+    getRunningServers(): Promise<string[]>;
+    setClient(client: MCPFrontendNotificationService): void;
+    disconnectClient(client: MCPFrontendNotificationService): void;
+}
+
+export interface ToolInformation {
+    name: string;
+    description?: string;
+}
+
+export enum MCPServerStatus {
+    NotRunning = 'Not Running',
+    Starting = 'Starting',
+    Running = 'Running',
+    Errored = 'Errored'
 }
 
 export interface MCPServerDescription {
@@ -57,6 +91,21 @@ export interface MCPServerDescription {
      * Flag indicating whether the server should automatically start when the application starts.
      */
     autostart?: boolean;
+
+    /**
+     * The current status of the server. Optional because only set by the server.
+     */
+    status?: MCPServerStatus;
+
+    /**
+     * Last error message that the server has returned.
+     */
+    error?: string;
+
+    /**
+     * List of available tools for the server. Returns the name and description if available.
+     */
+    tools?: ToolInformation[];
 }
 
 export const MCPServerManager = Symbol('MCPServerManager');

--- a/packages/ai-mcp/src/node/mcp-backend-module.ts
+++ b/packages/ai-mcp/src/node/mcp-backend-module.ts
@@ -17,17 +17,18 @@
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { ConnectionHandler, RpcConnectionHandler } from '@theia/core';
 import { MCPServerManagerImpl } from './mcp-server-manager-impl';
-import { MCPServerManager, MCPServerManagerPath } from '../common/mcp-server-manager';
+import { MCPFrontendNotificationService, MCPServerManager, MCPServerManagerPath } from '../common/mcp-server-manager';
 import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 
 // We use a connection module to handle AI services separately for each frontend.
 const mcpConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService, bindFrontendService }) => {
     bind(MCPServerManager).to(MCPServerManagerImpl).inSingletonScope();
-    bind(ConnectionHandler).toDynamicValue(ctx => new RpcConnectionHandler(
-        MCPServerManagerPath,
-        () => {
-            const service = ctx.container.get<MCPServerManager>(MCPServerManager);
-            return service;
+    bind(ConnectionHandler).toDynamicValue(ctx => new RpcConnectionHandler<MCPFrontendNotificationService>(
+        MCPServerManagerPath, client => {
+            const server = ctx.container.get<MCPServerManager>(MCPServerManager);
+            server.setClient(client);
+            client.onDidCloseConnection(() => server.disconnectClient(client));
+            return server;
         }
     )).inSingletonScope();
 });

--- a/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
+++ b/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
@@ -14,13 +14,16 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { injectable } from '@theia/core/shared/inversify';
-import { MCPServerDescription, MCPServerManager } from '../common/mcp-server-manager';
+import { MCPServerDescription, MCPServerManager, MCPFrontendNotificationService } from '../common/mcp-server-manager';
 import { MCPServer } from './mcp-server';
+import { Disposable } from '@theia/core/lib/common/disposable';
 
 @injectable()
 export class MCPServerManagerImpl implements MCPServerManager {
 
     protected servers: Map<string, MCPServer> = new Map();
+    protected clients: Array<MCPFrontendNotificationService> = [];
+    protected serverListeners: Map<string, Disposable> = new Map();
 
     async stopServer(serverName: string): Promise<void> {
         const server = this.servers.get(serverName);
@@ -29,16 +32,17 @@ export class MCPServerManagerImpl implements MCPServerManager {
         }
         server.stop();
         console.log(`MCP server "${serverName}" stopped.`);
+        this.notifyClients();
     }
 
-    async getStartedServers(): Promise<string[]> {
-        const startedServers: string[] = [];
+    async getRunningServers(): Promise<string[]> {
+        const runningServers: string[] = [];
         for (const [name, server] of this.servers.entries()) {
-            if (server.isStarted()) {
-                startedServers.push(name);
+            if (server.isRunnning()) {
+                runningServers.push(name);
             }
         }
-        return startedServers;
+        return runningServers;
     }
 
     callTool(serverName: string, toolName: string, arg_string: string): ReturnType<MCPServer['callTool']> {
@@ -55,9 +59,16 @@ export class MCPServerManagerImpl implements MCPServerManager {
             throw new Error(`MCP server "${serverName}" not found.`);
         }
         await server.start();
+        this.notifyClients();
     }
+
     async getServerNames(): Promise<string[]> {
         return Array.from(this.servers.keys());
+    }
+
+    async getServerDescription(name: string): Promise<MCPServerDescription | undefined> {
+        const server = this.servers.get(name);
+        return server ? server.getDescription() : undefined;
     }
 
     public async getTools(serverName: string): ReturnType<MCPServer['getTools']> {
@@ -66,19 +77,26 @@ export class MCPServerManagerImpl implements MCPServerManager {
             throw new Error(`MCP server "${serverName}" not found.`);
         }
         return server.getTools();
-
     }
 
     addOrUpdateServer(description: MCPServerDescription): void {
-        const { name, command, args, env } = description;
-        const existingServer = this.servers.get(name);
+        const existingServer = this.servers.get(description.name);
 
         if (existingServer) {
-            existingServer.update(command, args, env);
+            existingServer.update(description);
         } else {
-            const newServer = new MCPServer(name, command, args, env);
-            this.servers.set(name, newServer);
+            const newServer = new MCPServer(description);
+            this.servers.set(description.name, newServer);
+
+            // Subscribe to status updates from the new server
+            const listener = newServer.onDidUpdateStatus(() => {
+                this.notifyClients();
+            });
+
+            // Store the listener for later disposal
+            this.serverListeners.set(description.name, listener);
         }
+        this.notifyClients();
     }
 
     removeServer(name: string): void {
@@ -86,8 +104,31 @@ export class MCPServerManagerImpl implements MCPServerManager {
         if (server) {
             server.stop();
             this.servers.delete(name);
+
+            // Clean up the status listener
+            const listener = this.serverListeners.get(name);
+            if (listener) {
+                listener.dispose();
+                this.serverListeners.delete(name);
+            }
         } else {
             console.warn(`MCP server "${name}" not found.`);
         }
+        this.notifyClients();
+    }
+
+    setClient(client: MCPFrontendNotificationService): void {
+        this.clients.push(client);
+    }
+
+    disconnectClient(client: MCPFrontendNotificationService): void {
+        const index = this.clients.indexOf(client);
+        if (index !== -1) {
+            this.clients.splice(index, 1);
+        }
+    }
+
+    private notifyClients(): void {
+        this.clients.forEach(client => client.didUpdateMCPServers());
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
[Improve MCP services](https://github.com/eclipse-theia/theia/commit/cd6b55ba5775c8317559c2f20d3e64e3855f1565) 

Introduce notification mechanism to listen to MCP server changes.
Created common interface for MCPFrontendService.
Rename getStartedServers() to getRunningServers().
Added status handling to MCPServer (NotRunning, Starting, Running, Errored):
Add getServerDescription endpoint to retrieve information about the server.
Add status, error message and tool information to MCPServerDescription.

[Add MCP Config view to AI Configuration](https://github.com/eclipse-theia/theia/commit/d94c53acc7cad15e1efe20dfda0eb3879df54b85) 

This view helps to see the state of MCP servers.
Displays all the created settings. Obfuscates tokens (very basic support).
Shows the status of a server (Running, Starting, Errored, Not Running).
Shows all tools available. Let's the user easily copy the tools for chat and prompttemplate use.
Offers a button to start/stop the view.

[Fix autostart stopping for following servers if one fails](https://github.com/eclipse-theia/theia/commit/82651a6d4d24d35545ade80bd6ab68fdc193fad3) 

Before this the autostart would stop for all following servers if one failed.
This was due to uncatched errors when trying to resolve the tools.
To prevent this in the future, improved the handling of the getTools() on client side.
Also adapted the Start Command to use the new status reporting instead of calling getTools() again.
#### How to test
Check out the code and play around with the view and MCP servers.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
https://github.com/eclipse-theia/theia/issues/15306
#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
