### PR TITLE
Fix SiW height mismatch

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -16,17 +16,12 @@
 
 #search-in-workspace {
   height: 100%;
-  position: relative;
+  display: flex;
+  flex-flow: column nowrap;
 }
 
 #search-in-workspace .theia-TreeContainer.empty {
   overflow: hidden;
-}
-
-#search-in-workspace .theia-progress-bar-container {
-    position: absolute;
-    top: 0;
-    left: 0;
 }
 
 .t-siw-search-container {
@@ -35,6 +30,7 @@
   flex-direction: column;
   height: 100%;
   box-sizing: border-box;
+  flex: 1 1 auto;
 }
 
 .t-siw-search-container .theia-ExpansionToggle {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -16,10 +16,17 @@
 
 #search-in-workspace {
   height: 100%;
+  position: relative;
 }
 
 #search-in-workspace .theia-TreeContainer.empty {
   overflow: hidden;
+}
+
+#search-in-workspace .theia-progress-bar-container {
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 
 .t-siw-search-container {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #15271 by taking the SiW scrollbar out of the layout.
> Perhaps we should make this behavior the default, since in general, I don't think we want the progress bars affecting the layout of surrounding elements. But maybe there are better ways of handling the problem: we could just modify the height of the affected item to be 100% - 2px.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open the Search in Workspace widget.
2. There shouldn't be an extra scrollbar when the widget isn't populated.
3. Perform a search.
4. If the search takes some time, you should see a progress bar.
5. When results are populated, there should be a scrollbar for the results (if necessary), but not for the rest of the widget.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
