### PR TITLE
Make parameters in ToolRequest mandatory

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -28,11 +28,6 @@ import { Anthropic } from '@anthropic-ai/sdk';
 import { MessageParam } from '@anthropic-ai/sdk/resources';
 
 export const DEFAULT_MAX_TOKENS = 4096;
-const EMPTY_INPUT_SCHEMA = {
-    type: 'object',
-    properties: {},
-    required: []
-} as const;
 
 interface ToolCallback {
     readonly name: string;
@@ -254,7 +249,7 @@ export class AnthropicModel implements LanguageModel {
         return request.tools?.map(tool => ({
             name: tool.name,
             description: tool.description,
-            input_schema: tool.parameters ?? EMPTY_INPUT_SCHEMA
+            input_schema: tool.parameters
         } as Anthropic.Messages.Tool));
     }
 

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -137,12 +137,20 @@ describe('ChatRequestParserImpl', () => {
         const testTool1: ToolRequest = {
             id: 'testTool1',
             name: 'Test Tool 1',
-            handler: async () => undefined
+            handler: async () => undefined,
+            parameters: {
+                type: 'object',
+                properties: {}
+            },
         };
         const testTool2: ToolRequest = {
             id: 'testTool2',
             name: 'Test Tool 2',
-            handler: async () => undefined
+            handler: async () => undefined,
+            parameters: {
+                type: 'object',
+                properties: {}
+            },
         };
         // Configure the tool registry to return our test tools
         toolInvocationRegistry.getFunction.withArgs(testTool1.id).returns(testTool1);

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -48,7 +48,7 @@ export interface ToolRequestParameters {
 export interface ToolRequest {
     id: string;
     name: string;
-    parameters?: ToolRequestParameters
+    parameters: ToolRequestParameters
     description?: string;
     handler: (arg_string: string, ctx?: unknown) => Promise<unknown>;
     providerName?: string;

--- a/packages/ai-ide/src/browser/context-functions.ts
+++ b/packages/ai-ide/src/browser/context-functions.ts
@@ -35,7 +35,11 @@ export class ListChatContext implements ToolProvider {
                     type: contextElement.variable.name
                 }));
                 return JSON.stringify(result, undefined, 2);
-            }
+            },
+            parameters: {
+                type: 'object',
+                properties: {}
+            },
         };
     }
 }

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -143,6 +143,10 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
             name: GetWorkspaceDirectoryStructure.ID,
             description: `Retrieve the complete directory structure of the workspace, listing only directories (no file contents). This structure excludes specific directories,
             such as node_modules and hidden files, ensuring paths are within workspace boundaries.`,
+            parameters: {
+                type: 'object',
+                properties: {}
+            },
             handler: () => this.getDirectoryStructure()
         };
     }

--- a/packages/ai-mcp/src/browser/mcp-frontend-service.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-service.ts
@@ -94,7 +94,10 @@ export class MCPFrontendService {
                 type: tool.inputSchema.type,
                 properties: tool.inputSchema.properties,
                 required: tool.inputSchema.required
-            } : undefined,
+            } : {
+                type: 'object',
+                properties: {}
+            },
             description: tool.description,
             handler: async (arg_string: string) => {
                 try {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Make the parameters property of ToolRequest interface mandatory.
Most LLMs expect the parameters section of a ToolRequest to be defined.
OpenAI is there a bit more flexible but Anthropic isn't.
An Anthropic specific workaround could be removed now.

Fixes #14663

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Test especially tools that do not have parameters, eg `getWorkspaceDirectoryStructure` in OpenAi and Anthropic.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
