### PR TITLE
fix: getFileDiagnostics waits forever

### DIFF
--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -392,7 +392,7 @@ export class FileDiagonsticProvider implements ToolProvider {
                 await open(this.openerService, uri);
                 // Give some time to fetch problems in a newly opened editor.
                 await new Promise<void>(res => {
-                    setTimeout(() => res, 5000);
+                    setTimeout(res, 5000);
                     // Give another moment for additional markers to come in from different sources.
                     const listener = this.problemManager.onDidChangeMarkers(changed => changed.isEqual(uri) && setTimeout(res, 500));
                     toDispose.push(listener);


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Makes sure that 'getFileDiagnostics' internal promises are resolved.

In some code paths the 'getFileDiagnostics' tool function constructed a promise to wait between 500ms-5000ms for diagnostics. However this promise did never resolve, leading to an endless wait.

fixes #15299

#### How to test

Trigger a diagnostic lookup for a file without issue markers. For example via 

```
@Coder What is wrong with this file? packages/ai-history/src/common/communication-recording-service.ts
```

#### Follow-ups

We could install a general safety guideline for all tool functions to abort them if they don't return in X seconds.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
