### PR TITLE
Explicitly set scrolling element to avoid document scroll

### DIFF
--- a/packages/preferences/src/browser/views/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/views/preference-editor-widget.ts
@@ -242,7 +242,7 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
                 const { id, collection } = this.analyzeIDAndGetRendererGroup(nodeIDToScrollTo);
                 const renderer = collection.get(id);
                 if (renderer?.visible) {
-                    renderer.node.scrollIntoView();
+                    this.scrollContainer.scrollTo(0, renderer.node.offsetHeight);
                     return;
                 }
             }

--- a/packages/preferences/src/browser/views/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/views/preference-editor-widget.ts
@@ -333,7 +333,7 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
     protected scrollWithoutModelUpdate(node?: HTMLElement): void {
         if (!node) { return; }
         this.shouldUpdateModelSelection = false;
-        node.scrollIntoView();
+        this.scrollContainer.scrollTo(0, node.offsetTop);
         requestAnimationFrame(() => this.shouldUpdateModelSelection = true);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #15248

Calling `scrollIntoView()` on a node in the preference view caused the `document` to scroll part of the way. This PR explicitly instructs the proference widget's scroll container to execute the scroll, instead, preventing any leakage to the `document` element.

> NB: I do not know why this behavior changed, although it seems reasonable to guess that it is related to the Lumino migration. Previously, the `scrollIntoView` call affected only the preferences widget, and the document was not scrolled. It may be worth investigating if Lumino is explicitly making the `document` element scrollable in a way that older Phosphor did not, or if it handles scrolling within widgets differently so that we can find a solution that would protect adopters.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open the browser app (or Electron app - it showed the same behavior)
2. Open the setting panel
3. Expand the extensions category
4. The extensions section should be scrolled into view, but the application apart from the scroll

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
