### PR TITLE
feat(chat): add customizable welcome message

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -27,7 +27,6 @@ import {
 import { CommandRegistry, ContributionProvider } from '@theia/core';
 import {
     codicon,
-    CommonCommands,
     CompositeTreeNode,
     ContextMenuRenderer,
     HoverService,
@@ -44,6 +43,7 @@ import {
     inject,
     injectable,
     named,
+    optional,
     postConstruct
 } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
@@ -66,8 +66,14 @@ export interface ResponseNode extends TreeNode {
 }
 export const isResponseNode = (node: TreeNode): node is ResponseNode => 'response' in node;
 
-function isEnterKey(e: React.KeyboardEvent): boolean {
+export function isEnterKey(e: React.KeyboardEvent): boolean {
     return Key.ENTER.keyCode === KeyCode.createKeyCode(e.nativeEvent).key?.keyCode;
+}
+
+export const ChatWelcomeMessageProvider = Symbol('ChatWelcomeMessageProvider');
+export interface ChatWelcomeMessageProvider {
+    renderWelcomeMessage?(): React.ReactNode;
+    renderDisabledMessage?(): React.ReactNode;
 }
 
 @injectable()
@@ -95,6 +101,9 @@ export class ChatViewTreeWidget extends TreeWidget {
 
     @inject(HoverService)
     protected hoverService: HoverService;
+
+    @inject(ChatWelcomeMessageProvider) @optional()
+    protected welcomeMessageProvider?: ChatWelcomeMessageProvider;
 
     protected _shouldScrollToEnd = true;
 
@@ -142,77 +151,21 @@ export class ChatViewTreeWidget extends TreeWidget {
     }
 
     protected override renderTree(model: TreeModel): React.ReactNode {
-        if (this.isEnabled) {
+        if (!this.isEnabled) {
+            return this.renderDisabledMessage();
+        }
+        if (CompositeTreeNode.is(model.root) && model.root.children?.length > 0) {
             return super.renderTree(model);
         }
-        return this.renderDisabledMessage();
+        return this.renderWelcomeMessage();
     }
 
     protected renderDisabledMessage(): React.ReactNode {
-        return <div className={'theia-ResponseNode'}>
-            <div className='theia-ResponseNode-Content' key={'disabled-message'}>
-                <div className="disable-message">
-                    <span className="section-header">{
-                        nls.localize('theia/ai/chat-ui/chat-view-tree-widget/aiFeatureHeader', '🚀 AI Features Available (Alpha Version)!')}
-                    </span>
-                    <div className="section-title">
-                        <p><code>{nls.localize('theia/ai/chat-ui/chat-view-tree-widget/featuresDisabled', 'Currently, all AI Features are disabled!')}</code></p>
-                    </div>
-                    <div className="section-title">
-                        <p>{nls.localize('theia/ai/chat-ui/chat-view-tree-widget/howToEnable', 'How to Enable the AI Features:')}</p>
-                    </div>
-                    <div className="section-content">
-                        <p>To enable the AI features, please go to &nbsp;
-                            {this.renderLinkButton(nls.localize('theia/ai/chat-ui/chat-view-tree-widget/settingsMenu', 'the settings menu'), CommonCommands.OPEN_PREFERENCES.id)}
-                            &nbsp;and locate the <strong>AI Features</strong> section.</p>
-                        <ol>
-                            <li>Toggle the switch for <strong>{nls.localize('theia/ai/chat-ui/chat-view-tree-widget/aiFeaturesEnable', 'Ai-features: Enable')}</strong>.</li>
-                            <li>Provide at least one LLM provider (e.g. OpenAI), also see <a href="https://theia-ide.org/docs/user_ai/" target="_blank">the documentation</a>
-                                for more information.</li>
-                        </ol>
-                        <p>This will activate the AI capabilities in the app. Please remember, these features are <strong>in an alpha state</strong>,
-                            so they may change and we are working on improving them 🚧.<br></br>
-                            Please support us by <a href="https://github.com/eclipse-theia/theia">providing feedback
-                            </a>!</p>
-                    </div>
-
-                    <div className="section-title">
-                        <p>Currently Supported Views and Features:</p>
-                    </div>
-                    <div className="section-content">
-                        <p>Once the AI features are enabled, you can access the following views and features:</p>
-                        <ul>
-                            <li>Code Completion</li>
-                            <li>Terminal Assistance (via CTRL+I in a terminal)</li>
-                            <li>This Chat View (features the following agents):
-                                <ul>
-                                    <li>Universal Chat Agent</li>
-                                    <li>Coder Chat Agent</li>
-                                    <li>Architect Chat Agent</li>
-                                    <li>Command Chat Agent</li>
-                                    <li>Orchestrator Chat Agent</li>
-                                </ul>
-                            </li>
-                            <li>{this.renderLinkButton(nls.localize('theia/ai/chat-ui/chat-view-tree-widget/aiHistoryView', 'AI History View'), 'aiHistory:open')}</li>
-                            <li>{this.renderLinkButton(
-                                nls.localize('theia/ai/chat-ui/chat-view-tree-widget/aiConfigurationView', 'AI Configuration View'), 'aiConfiguration:open')}
-                            </li>
-                        </ul>
-                        <p>See <a href="https://theia-ide.org/docs/user_ai/" target="_blank">the documentation</a> for more information.</p>
-                    </div>
-                </div>
-            </div>
-        </div >;
+        return this.welcomeMessageProvider?.renderDisabledMessage?.() ?? <></>;
     }
 
-    protected renderLinkButton(title: string, openCommandId: string): React.ReactNode {
-        return <a
-            role={'button'}
-            tabIndex={0}
-            onClick={() => this.commandRegistry.executeCommand(openCommandId)}
-            onKeyDown={e => isEnterKey(e) && this.commandRegistry.executeCommand(openCommandId)}>
-            {title}
-        </a>;
+    protected renderWelcomeMessage(): React.ReactNode {
+        return this.welcomeMessageProvider?.renderWelcomeMessage?.() ?? <></>;
     }
 
     protected mapRequestToNode(request: ChatRequestModel): RequestNode {

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -574,7 +574,8 @@ div:last-child > .theia-ChatNode {
   background-color: var(--theia-button-secondaryBackground);
 }
 
-.theia-toolCall, .theia-thinking {
+.theia-toolCall,
+.theia-thinking {
   font-weight: normal;
   color: var(--theia-descriptionForeground);
   line-height: 20px;
@@ -670,12 +671,6 @@ details[open].collapsible-arguments .collapsible-arguments-summary {
   margin: 20px 0px;
 }
 
-.disable-message {
-  font-size: 12px;
-  line-height: 1.6;
-  padding: 15px;
-}
-
 .section-content p {
   margin: 10px 0;
 }
@@ -689,17 +684,17 @@ details[open].collapsible-arguments .collapsible-arguments-summary {
 }
 
 .session-settings-container {
-    margin-bottom: 10px;
-    height: calc(100% - 50px);
+  margin-bottom: 10px;
+  height: calc(100% - 50px);
 }
 .monaco-session-settings-dialog {
-    flex: 1;
-    min-height: 350px;
-    min-width: 500px;
-    height: 25vh;
-    width: 30vh;
-    border: 1px solid var(--theia-editorWidget-border);
-    margin-bottom: 10px;
+  flex: 1;
+  min-height: 350px;
+  min-width: 500px;
+  height: 25vh;
+  width: 30vh;
+  border: 1px solid var(--theia-editorWidget-border);
+  margin-bottom: 10px;
 }
 .session-settings-error {
   color: var(--theia-errorForeground);

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -41,6 +41,8 @@ import { ContextFilesVariableContribution } from '../common/context-files-variab
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { AiConfigurationPreferences } from './ai-configuration/ai-configuration-preferences';
 import { AIMCPConfigurationWidget } from './ai-configuration/mcp-configuration-widget';
+import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
+import { IdeChatWelcomeMessageProvider } from './ide-chat-welcome-message-provider';
 
 export default new ContainerModule(bind => {
     bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
@@ -67,6 +69,8 @@ export default new ContainerModule(bind => {
 
     bind(DefaultChatAgentId).toConstantValue({ id: OrchestratorChatAgentId });
     bind(FallbackChatAgentId).toConstantValue({ id: UniversalChatAgentId });
+
+    bind(ChatWelcomeMessageProvider).to(IdeChatWelcomeMessageProvider);
 
     bind(ToolProvider).to(GetWorkspaceFileList);
     bind(ToolProvider).to(FileContentFunction);

--- a/packages/ai-ide/src/browser/ide-chat-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/ide-chat-welcome-message-provider.tsx
@@ -66,10 +66,15 @@ export class IdeChatWelcomeMessageProvider implements ChatWelcomeMessageProvider
             <div className="theia-WelcomeMessage-Content">
                 <h1>Ask the Theia IDE AI</h1>
                 <p>
-                    Chat with agents specialized for specific tasks or questions, such as <em>@Coder</em> or <em>@Architect</em>.
+                    To talk to a specialized agent, simply start your message with <em>@</em> followed by the agent's name:{' '}
+                    <em>@Coder</em>, <em>@Architect</em>, <em>@Universal</em>, and more.
                 </p>
                 <p>
-                    Attach context: click <span className="codicon codicon-add" /> or use variables, like <em>#selectedText</em>, <em>#currentFileContent</em>, or <em>#file</em>.
+                    Attach context:  use variables, like <em>#file</em>, <em>#_f</em> (current file), <em>#selectedText</em>{' '}
+                    or click <span className="codicon codicon-add" />.
+                </p>
+                <p>
+                    Lean more in the <a target='_blank' href="https://theia-ide.org/docs/user_ai/#chat">documentation</a>.
                 </p>
             </div>
         </div>;

--- a/packages/ai-ide/src/browser/ide-chat-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/ide-chat-welcome-message-provider.tsx
@@ -1,0 +1,145 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatWelcomeMessageProvider, isEnterKey } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core/lib/common/nls';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { CommandRegistry } from '@theia/core';
+import { CommonCommands } from '@theia/core/lib/browser';
+
+const TheiaIdeAiLogo = ({ width = 200, height = 200, className = '' }) =>
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 200 200"
+        width={width}
+        height={height}
+        className={className}
+    >
+        <rect x="55" y="45" width="90" height="85" rx="30" fill="var(--theia-disabledForeground)" />
+
+        <line x1="100" y1="45" x2="100" y2="30" stroke="var(--theia-foreground)" stroke-width="4" />
+        <circle cx="100" cy="25" r="6" fill="var(--theia-foreground)" />
+
+        <rect x="40" y="75" width="15" height="30" rx="5" fill="var(--theia-foreground)" />
+        <rect x="145" y="75" width="15" height="30" rx="5" fill="var(--theia-foreground)" />
+
+        <circle cx="80" cy="80" r="10" fill="var(--theia-editor-background)" />
+        <circle cx="120" cy="80" r="10" fill="var(--theia-editor-background)" />
+
+        <path d="M85 105 Q100 120 115 105" fill="none" stroke="var(--theia-editor-background)" stroke-width="4" stroke-linecap="round" />
+
+        <rect x="55" y="135" width="90" height="30" rx="5" fill="var(--theia-foreground)" />
+
+        <rect x="60" y="140" width="10" height="8" rx="2" fill="var(--theia-editor-background)" />
+        <rect x="75" y="140" width="10" height="8" rx="2" fill="var(--theia-editor-background)" />
+        <rect x="90" y="140" width="10" height="8" rx="2" fill="var(--theia-editor-background)" />
+        <rect x="105" y="140" width="10" height="8" rx="2" fill="var(--theia-editor-background)" />
+        <rect x="120" y="140" width="10" height="8" rx="2" fill="var(--theia-editor-background)" />
+
+        <rect x="65" y="152" width="50" height="8" rx="2" fill="var(--theia-editor-background)" />
+        <rect x="120" y="152" width="10" height="8" rx="2" fill="var(--theia-editor-background)" />
+    </svg>;
+
+@injectable()
+export class IdeChatWelcomeMessageProvider implements ChatWelcomeMessageProvider {
+
+    @inject(CommandRegistry)
+    protected commandRegistry: CommandRegistry;
+
+    renderWelcomeMessage?(): React.ReactNode {
+        return <div className={'theia-WelcomeMessage'}>
+            <TheiaIdeAiLogo width={200} height={200} className="theia-WelcomeMessage-Logo" />
+            <div className="theia-WelcomeMessage-Content">
+                <h1>Ask the Theia IDE AI</h1>
+                <p>
+                    Chat with agents specialized for specific tasks or questions, such as <em>@Coder</em> or <em>@Architect</em>.
+                </p>
+                <p>
+                    Attach context: click <span className="codicon codicon-add" /> or use variables, like <em>#selectedText</em>, <em>#currentFileContent</em>, or <em>#file</em>.
+                </p>
+            </div>
+        </div>;
+    }
+
+    renderDisabledMessage?(): React.ReactNode {
+        return <div className={'theia-ResponseNode'}>
+            <div className='theia-ResponseNode-Content' key={'disabled-message'}>
+                <div className="disable-message">
+                    <span className="section-header">{
+                        nls.localize('theia/ai/chat-ui/chat-view-tree-widget/aiFeatureHeader', '🚀 AI Features Available (Alpha Version)!')}
+                    </span>
+                    <div className="section-title">
+                        <p><code>{nls.localize('theia/ai/chat-ui/chat-view-tree-widget/featuresDisabled', 'Currently, all AI Features are disabled!')}</code></p>
+                    </div>
+                    <div className="section-title">
+                        <p>{nls.localize('theia/ai/chat-ui/chat-view-tree-widget/howToEnable', 'How to Enable the AI Features:')}</p>
+                    </div>
+                    <div className="section-content">
+                        <p>To enable the AI features, please go to &nbsp;
+                            {this.renderLinkButton(nls.localize('theia/ai/chat-ui/chat-view-tree-widget/settingsMenu', 'the settings menu'), CommonCommands.OPEN_PREFERENCES.id)}
+                            &nbsp;and locate the <strong>AI Features</strong> section.</p>
+                        <ol>
+                            <li>Toggle the switch for <strong>{nls.localize('theia/ai/chat-ui/chat-view-tree-widget/aiFeaturesEnable', 'Ai-features: Enable')}</strong>.</li>
+                            <li>Provide at least one LLM provider (e.g. OpenAI), also see <a href="https://theia-ide.org/docs/user_ai/" target="_blank">the documentation</a>
+                                for more information.</li>
+                        </ol>
+                        <p>This will activate the AI capabilities in the app. Please remember, these features are <strong>in an alpha state</strong>,
+                            so they may change and we are working on improving them 🚧.<br></br>
+                            Please support us by <a href="https://github.com/eclipse-theia/theia">providing feedback
+                            </a>!</p>
+                    </div>
+
+                    <div className="section-title">
+                        <p>Currently Supported Views and Features:</p>
+                    </div>
+                    <div className="section-content">
+                        <p>Once the AI features are enabled, you can access the following views and features:</p>
+                        <ul>
+                            <li>Code Completion</li>
+                            <li>Terminal Assistance (via CTRL+I in a terminal)</li>
+                            <li>This Chat View (features the following agents):
+                                <ul>
+                                    <li>Universal Chat Agent</li>
+                                    <li>Coder Chat Agent</li>
+                                    <li>Architect Chat Agent</li>
+                                    <li>Command Chat Agent</li>
+                                    <li>Orchestrator Chat Agent</li>
+                                </ul>
+                            </li>
+                            <li>{this.renderLinkButton(nls.localize('theia/ai/chat-ui/chat-view-tree-widget/aiHistoryView', 'AI History View'), 'aiHistory:open')}</li>
+                            <li>{this.renderLinkButton(
+                                nls.localize('theia/ai/chat-ui/chat-view-tree-widget/aiConfigurationView', 'AI Configuration View'), 'aiConfiguration:open')}
+                            </li>
+                        </ul>
+                        <p>See <a href="https://theia-ide.org/docs/user_ai/" target="_blank">the documentation</a> for more information.</p>
+                    </div>
+                </div>
+            </div>
+        </div >;
+    }
+
+    protected renderLinkButton(title: string, openCommandId: string): React.ReactNode {
+        return <a
+            role={'button'}
+            tabIndex={0}
+            onClick={() => this.commandRegistry.executeCommand(openCommandId)}
+            onKeyDown={e => isEnterKey(e) && this.commandRegistry.executeCommand(openCommandId)}>
+            {title}
+        </a>;
+    }
+
+}

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -14,7 +14,8 @@
   margin-left: var(--theia-ui-padding);
 }
 
-.theia-settings-container .settings-section-subcategory-title.ai-settings-section-subcategory-title {
+.theia-settings-container
+  .settings-section-subcategory-title.ai-settings-section-subcategory-title {
   padding-left: 0;
 }
 
@@ -308,4 +309,42 @@
   font-size: 12px;
   color: var(--theia-descriptionForeground);
   white-space: nowrap;
+}
+
+.theia-ResponseNode-Content .disable-message {
+  font-size: 12px;
+  line-height: 1.6;
+  padding: 15px;
+}
+
+.theia-WelcomeMessage {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.theia-WelcomeMessage-Content {
+  text-align: center;
+  padding: 0 18px;
+  max-width: 350px;
+}
+
+.theia-WelcomeMessage-Content h1 {
+  margin-top: 0;
+}
+
+.theia-WelcomeMessage-Content p {
+  font-size: var(--theia-ui-font-size2);
+  line-height: 18px;
+}
+
+.theia-WelcomeMessage-Content p .codicon {
+  vertical-align: sub;
+}
+
+.theia-WelcomeMessage-Content em {
+  font-weight: bolder;
+  font-style: normal;
 }


### PR DESCRIPTION
#### What it does

Extracts the disabled AI message and adds a welcome messages for the chat view. Both messages are provided by a customizable DI binding. The current messages are moved into the `ai-ide` package.

#### How to test

Open the chat view without a conversation with and without enabled AI support in the preferences.

![image](https://github.com/user-attachments/assets/05289978-5c73-4fe3-8ff3-c36fd2c244bb)

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
