### PR TITLE
white label prompt templates

### DIFF
--- a/packages/ai-core/src/browser/prompttemplate-contribution.ts
+++ b/packages/ai-core/src/browser/prompttemplate-contribution.ts
@@ -17,7 +17,7 @@
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { GrammarDefinition, GrammarDefinitionProvider, LanguageGrammarDefinitionContribution, TextmateRegistry } from '@theia/monaco/lib/browser/textmate';
 import * as monaco from '@theia/monaco-editor-core';
-import { Command, CommandContribution, CommandRegistry, MessageService, nls } from '@theia/core';
+import { Command, CommandContribution, CommandRegistry, nls } from '@theia/core';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 import { codicon, Widget } from '@theia/core/lib/browser';
@@ -33,26 +33,16 @@ export const PROMPT_TEMPLATE_EXTENSION = '.prompttemplate';
 
 export const DISCARD_PROMPT_TEMPLATE_CUSTOMIZATIONS: Command = Command.toLocalizedCommand({
     id: 'theia-ai-prompt-template:discard',
+    label: 'Discard AI Prompt Templates',
     iconClass: codicon('discard'),
     category: 'AI Prompt Templates'
 }, '', 'theia/ai/core/prompts/category');
-
-// TODO this command is mainly for testing purposes
-export const SHOW_ALL_PROMPTS_COMMAND: Command = Command.toLocalizedCommand({
-    id: 'theia-ai-prompt-template:show-prompts-command',
-    label: 'Show all prompts',
-    iconClass: codicon('beaker'),
-    category: 'AI Prompt Templates',
-}, 'theia/ai/core/showAllPrompts/label', 'theia/ai/core/prompts/category');
 
 @injectable()
 export class PromptTemplateContribution implements LanguageGrammarDefinitionContribution, CommandContribution, TabBarToolbarContribution {
 
     @inject(PromptService)
     private readonly promptService: PromptService;
-
-    @inject(MessageService)
-    private readonly messageService: MessageService;
 
     @inject(PromptCustomizationService)
     protected readonly customizationService: PromptCustomizationService;
@@ -253,10 +243,6 @@ export class PromptTemplateContribution implements LanguageGrammarDefinitionCont
             isEnabled: (widget: EditorWidget) => this.canDiscard(widget),
             execute: (widget: EditorWidget) => this.discard(widget)
         });
-
-        commands.registerCommand(SHOW_ALL_PROMPTS_COMMAND, {
-            execute: () => this.showAllPrompts()
-        });
     }
 
     protected isPromptTemplateWidget(widget: Widget): boolean {
@@ -308,13 +294,6 @@ export class PromptTemplateContribution implements LanguageGrammarDefinitionCont
         await widget.editor.replaceText({
             source,
             replaceOperations: [replaceOperation]
-        });
-    }
-
-    private showAllPrompts(): void {
-        const allPrompts = this.promptService.getAllPrompts();
-        Object.keys(allPrompts).forEach(id => {
-            this.messageService.info(`Prompt Template ID: ${id}\n${allPrompts[id].template}`, 'Got it');
         });
     }
 

--- a/packages/ai-core/src/browser/prompttemplate-contribution.ts
+++ b/packages/ai-core/src/browser/prompttemplate-contribution.ts
@@ -33,10 +33,10 @@ export const PROMPT_TEMPLATE_EXTENSION = '.prompttemplate';
 
 export const DISCARD_PROMPT_TEMPLATE_CUSTOMIZATIONS: Command = Command.toLocalizedCommand({
     id: 'theia-ai-prompt-template:discard',
-    label: 'Discard AI Prompt Templates',
+    label: 'Discard AI Prompt Template',
     iconClass: codicon('discard'),
     category: 'AI Prompt Templates'
-}, '', 'theia/ai/core/prompts/category');
+}, 'theia/ai/core/discard/label', 'theia/ai/core/prompts/category');
 
 @injectable()
 export class PromptTemplateContribution implements LanguageGrammarDefinitionContribution, CommandContribution, TabBarToolbarContribution {

--- a/packages/ai-core/src/browser/prompttemplate-contribution.ts
+++ b/packages/ai-core/src/browser/prompttemplate-contribution.ts
@@ -34,7 +34,7 @@ export const PROMPT_TEMPLATE_EXTENSION = '.prompttemplate';
 export const DISCARD_PROMPT_TEMPLATE_CUSTOMIZATIONS: Command = Command.toLocalizedCommand({
     id: 'theia-ai-prompt-template:discard',
     iconClass: codicon('discard'),
-    category: 'Theia AI Prompt Templates'
+    category: 'AI Prompt Templates'
 }, '', 'theia/ai/core/prompts/category');
 
 // TODO this command is mainly for testing purposes
@@ -42,7 +42,7 @@ export const SHOW_ALL_PROMPTS_COMMAND: Command = Command.toLocalizedCommand({
     id: 'theia-ai-prompt-template:show-prompts-command',
     label: 'Show all prompts',
     iconClass: codicon('beaker'),
-    category: 'Theia AI Prompt Templates',
+    category: 'AI Prompt Templates',
 }, 'theia/ai/core/showAllPrompts/label', 'theia/ai/core/prompts/category');
 
 @injectable()
@@ -89,7 +89,7 @@ export class PromptTemplateContribution implements LanguageGrammarDefinitionCont
         monaco.languages.register({
             id: PROMPT_TEMPLATE_LANGUAGE_ID,
             'aliases': [
-                'Theia AI Prompt Templates'
+                'AI Prompt Template'
             ],
             'extensions': [
                 PROMPT_TEMPLATE_EXTENSION,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

White labels the AI prompt templates by removing Theia-specific branding. Renames "Theia AI Prompt Templates" to generic "AI Prompt Template(s)" for adopters who want to customize the naming and branding of AI-related features.
Is this ok for you or is there a strategy behind labeling it with Theia?

#### How to test

Verify all references to "Theia AI Prompt Templates" have been replaced with "AI Prompt Template(s)"

#### Follow-ups

Review other potential areas where Theia-specific branding might limit adopter customization

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
