### PR TITLE
Fix resolve from root

### DIFF
--- a/packages/core/src/common/path.spec.ts
+++ b/packages/core/src/common/path.spec.ts
@@ -271,6 +271,10 @@ describe('Path', () => {
         });
     });
 
+    it('Should not produce joined paths with double initial //', () => {
+        expect(new Path('/').join('/something/absolute').toString()).eq('/something/absolute');
+    });
+
     const linuxHome = '/home/test-user';
     const windowsHome = '/C:/Users/test-user';
 

--- a/packages/core/src/common/path.ts
+++ b/packages/core/src/common/path.ts
@@ -215,10 +215,7 @@ export class Path {
         if (!relativePath) {
             return this;
         }
-        if (this.raw.endsWith(Path.separator)) {
-            return new Path(this.raw + relativePath);
-        }
-        return new Path(this.raw + Path.separator + relativePath);
+        return new Path(this.raw + Path.separator + relativePath).normalize();
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Currently, calling something like `URI.fromFilePath('/').resolve('/path/with/initial/separator')` fails with [an error](https://github.com/microsoft/vscode-uri/blob/edfdccd976efaf4bb8fdeca87e97c47257721729/src/uri.ts#L39) `If a URI does not contain an authority component, then the path cannot begin with two slash characters ("//")`. (Note that `URI.resolve` behaves like Node's `path.join`, not Node's `path.resolve`, which is `URI.resolveToAbsolute`). This PR prevents that error by normalizing the result of `Path.join` to prevent it from returning `//path/with/initial/separator` with a doubled initial path separator.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Tests should pass.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
