### PR TITLE
AI Chat Context UI: Collapse label from right & no printed &nbsp;

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -719,12 +719,14 @@ const ChatContext: React.FunctionComponent<ChatContextUI> = ({ context }) => (
             {context.map((element, index) => (
                 <li key={index} className="theia-ChatInput-ChatContext-Element" title={element.details} onClick={() => element.open?.()}>
                     <div className={`theia-ChatInput-ChatContext-Icon ${element.iconClass}`} />
-                    <span className={`theia-ChatInput-ChatContext-title ${element.nameClass}`}>
-                        {element.name}
-                    </span>
-                    <span className='theia-ChatInput-ChatContext-additionalInfo'>
-                        {element.additionalInfo}
-                    </span>
+                    <div className="theia-ChatInput-ChatContext-labelParts">
+                        <span className={`theia-ChatInput-ChatContext-title ${element.nameClass}`}>
+                            {element.name}
+                        </span>
+                        <span className='theia-ChatInput-ChatContext-additionalInfo'>
+                            {element.additionalInfo}
+                        </span>
+                    </div>
                     <span className="codicon codicon-close action" title={nls.localizeByDefault('Delete')} onClick={() => element.delete()} />
                 </li>
             ))}

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -434,8 +434,7 @@ const ChatRequestRender = (
                             />
                         );
                     } else {
-                        // maintain the leading and trailing spaces with explicit `&nbsp;`, otherwise they would get trimmed by the markdown renderer
-                        const ref = useMarkdownRendering(part.text, openerService, true);
+                        const ref = useMarkdownRendering(part.text.replace(/^[\r\n]+|[\r\n]+$/g, ''), openerService, true);
                         return (
                             <span key={index} ref={ref}></span>
                         );

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -435,7 +435,7 @@ const ChatRequestRender = (
                         );
                     } else {
                         // maintain the leading and trailing spaces with explicit `&nbsp;`, otherwise they would get trimmed by the markdown renderer
-                        const ref = useMarkdownRendering(part.text.replace(/^\s|\s$/g, '&nbsp;'), openerService, true);
+                        const ref = useMarkdownRendering(part.text, openerService, true);
                         return (
                             <span key={index} ref={ref}></span>
                         );

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -183,9 +183,15 @@ div:last-child > .theia-ChatNode {
   min-width: 0;
 }
 
+.theia-ChatInput-ChatContext-labelParts {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .theia-ChatInput-ChatContext-title {
-  flex: 10 1 auto;
-  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -199,8 +205,6 @@ div:last-child > .theia-ChatNode {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1 10 auto;
-  min-width: 0;
 }
 
 .theia-ChatInput-ChatContext-Element .action {

--- a/packages/ai-chat/src/browser/context-file-variable-label-provider.ts
+++ b/packages/ai-chat/src/browser/context-file-variable-label-provider.ts
@@ -49,7 +49,7 @@ export class ContextFileVariableLabelProvider implements LabelProviderContributi
     }
 
     getDetails(element: object): string | undefined {
-        return this.changeSetFileService.getAdditionalInfo(this.getUri(element)!);
+        return this.labelProvider.getDetails(this.getUri(element)!);
     }
 
     protected getUri(element: object): URI | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR addresses three minor issues in the styling of chat items:
 - Delegates to the label provider system for the 'additional information' label on context files. The current implementation more or less recapitulates the existing `WorkspaceUriLabelProviderContribution` logic, but by delegating directly to the `ChangeSetFileService`, it makes it more difficult to override labeling for specific URI types.
 - Wraps the components of the context element label so that the 'additional information' is clipped before the 'name':

Before:  
![image](https://github.com/user-attachments/assets/a4d74452-2d4d-46d8-aa28-e0dee2f93b44)

Note that both additional info and the name are clipped, though the name less so.
 
 After:  
  
![image](https://github.com/user-attachments/assets/82b565d3-80ac-4a32-8a4c-2df2f645d370)

Note that the extra path is clipped with `...`, but the name is not. This is more consistent with the behavior of e.g. tree elements.

- Removes the replacement of leading and trailing whitespace with a non-breaking space. The code indicated a desire to retain such whitespace, but there was misbehavior:
  - Trailing whitespace was preserved, but a literal `&nbsp` was also printed.
  - Line-initial whitespace can be meaningful in markdown, e.g. it can be a substitute for triple ticks to start a code block. By substituting it, we were negating that interpretation.

Before:

![image](https://github.com/user-attachments/assets/4c3ce9bc-86b3-441e-97fe-aaa03cf3d13d)

After:

![image](https://github.com/user-attachments/assets/32e91a89-a6d8-422f-ac24-252a4c5a7652)

I'm open to discussion on both points, if any reviewer would like to make a case for the old behavior.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
