### PR TITLE
fix: add missing `editor` dependency to `console`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30418,6 +30418,7 @@
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
         "@theia/core": "1.59.0",
+        "@theia/editor": "1.59.0",
         "@theia/monaco": "1.59.0",
         "@theia/monaco-editor-core": "1.96.302",
         "anser": "^2.0.1",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -4,6 +4,7 @@
   "description": "Theia - Console Extension",
   "dependencies": {
     "@theia/core": "1.59.0",
+    "@theia/editor": "1.59.0",
     "@theia/monaco": "1.59.0",
     "@theia/monaco-editor-core": "1.96.302",
     "anser": "^2.0.1",

--- a/packages/console/tsconfig.json
+++ b/packages/console/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../core"
     },
     {
+      "path": "../editor"
+    },
+    {
       "path": "../monaco"
     }
   ]


### PR DESCRIPTION
Closes eclipse-theia/theia#15353

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The PR adds the missing `editor` dependency to the `console`.

#### How to test

`npm run all` passes.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
