### PR TITLE
chore: remove outline in the chat session settings editor

### DIFF
--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -701,3 +701,7 @@ details[open].collapsible-arguments .collapsible-arguments-summary {
   min-height: 1em;
   display: block;
 }
+
+.session-settings-container .monaco-editor {
+  outline-color: var(--theia-editor-background);
+}


### PR DESCRIPTION
#### What it does

Removes the focus-blueish outline at the bottom in the chat session settings editor.

![image](https://github.com/user-attachments/assets/31529402-a7d0-45ca-a3ee-e55da626b6f5)

#### How to test

Open the chat session settings editor and observe that the blueish outline border is gone in the bottom.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
