### PR TITLE
[vscode] make DiagnosticCollection iterable

### DIFF
--- a/packages/plugin-ext/src/plugin/languages/diagnostics.ts
+++ b/packages/plugin-ext/src/plugin/languages/diagnostics.ts
@@ -135,9 +135,16 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
         });
     }
 
-    get(uri: URI): theia.Diagnostic[] | undefined {
+    *[Symbol.iterator](): IterableIterator<[uri: theia.Uri, diagnostics: readonly theia.Diagnostic[]]> {
         this.ensureNotDisposed();
-        return this.getDiagnosticsByUri(uri);
+        for (const [uriString, diag] of this.diagnostics.entries()) {
+            yield [URI.parse(uriString), diag instanceof Array ? Object.freeze(diag) : []];
+        }
+    }
+
+    get(uri: URI): theia.Diagnostic[] {
+        this.ensureNotDisposed();
+        return this.getDiagnosticsByUri(uri) || [];
     }
 
     has(uri: URI): boolean {


### PR DESCRIPTION
#### What it does

This PR makes the DiagnosticCollection implementation iterable. It is the case in vscode (see https://github.com/microsoft/vscode/blob/6609ac3d66f4eade5cf376d1cb76f13985724bcb/src/vs/workbench/api/common/extHostDiagnostics.ts#L195) and it is used by vscode spell checker (https://github.com/streetsidesoftware/vscode-spell-checker/blob/c2bf82250a98f90c1a6d08842a2edfdbceade0f5/packages/client/src/diags.mts#L139). 
This is the root cause of the extension logging issues. I do not have any other error messages after patch when using this extension with several ts files, opening, closing, editing them.

Note: The vscode API does not specify that the collection _should_ be iterable. We may create a follow-up issue on Spell checker extension that would require a code update (maybe using forEach() instead of iterating over the collection. In any case, having a type named collection being iterable seems reasonable.

fixes #15348

#### How to test

Install the extension https://open-vsx.org/extension/streetsidesoftware/code-spell-checker in theia example (browser or electron)
Edit any ts file, open several ts editors, etc. 
No errors shall be printed in the console.

Just in case, here is the build from today's master of the code spell checker, non minified: 
[code-spell-checker-4.0.42.zip](https://github.com/user-attachments/files/19554840/code-spell-checker-4.0.42.zip)
That is the one that I used to understand the root cause. 

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
