### PR TITLE
Avoid double registration of sticky scroll toggle

### DIFF
--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -46,6 +46,7 @@ export namespace MonacoCommands {
 
     export const EXCLUDE_ACTIONS = new Set([
         'editor.action.quickCommand',
+        'editor.action.toggleStickyScroll', // Handled by `editor` package.
         'undo',
         'redo'
     ]);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

At the moment, both the `editor` and the `monaco` packages register the command `editor.action.toggleStickyScroll` leading to a warning in the console upon the second registration.

This PR favors the `editor` package's implementation and suppresses the `monaco` package's registration. That seems reasonable in this case because the primary action in both the `editor` package and in [VSCode's implementation](https://github.com/microsoft/vscode/blob/0e333c267aa2ea042aa3128cbdaaf930dce66326/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts#L44-L52) is to update the preferences, which can be done without direct access to a given editor.

Alternatively, we could register the command and the `View` menu item in the `editor` package and then defer to Monaco to register the handler. 

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. The command should be accessible from the `View` menu and from the command palette, and it should work in both locations.
2. There should be no warnings about double registration of the command.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
