### PR TITLE
Do not re-export the configuration folder as env variable

### DIFF
--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -55,19 +55,20 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
         const dataFolderPath = join(BackendApplicationPath, 'data');
         const userDataPath = join(dataFolderPath, 'user-data');
         const dataFolderExists = this.pathExistenceCache[dataFolderPath] ??= await pathExists(dataFolderPath);
+        let theiaConfigDir: string;
         if (dataFolderExists) {
             const userDataExists = this.pathExistenceCache[userDataPath] ??= await pathExists(userDataPath);
             if (userDataExists) {
-                process.env.THEIA_CONFIG_DIR = userDataPath;
+                theiaConfigDir = userDataPath;
             } else {
                 await mkdir(userDataPath);
-                process.env.THEIA_CONFIG_DIR = userDataPath;
+                theiaConfigDir = userDataPath;
                 this.pathExistenceCache[userDataPath] = true;
             }
         } else {
-            process.env.THEIA_CONFIG_DIR = join(homedir(), BackendApplicationConfigProvider.get().configurationFolder);
+            theiaConfigDir = join(homedir(), BackendApplicationConfigProvider.get().configurationFolder);
         }
-        return FileUri.create(process.env.THEIA_CONFIG_DIR).toString();
+        return FileUri.create(theiaConfigDir).toString();
     }
 
     async getExecPath(): Promise<string> {

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -58,13 +58,11 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
         let theiaConfigDir: string;
         if (dataFolderExists) {
             const userDataExists = this.pathExistenceCache[userDataPath] ??= await pathExists(userDataPath);
-            if (userDataExists) {
-                theiaConfigDir = userDataPath;
-            } else {
+            if (!userDataExists) {
                 await mkdir(userDataPath);
-                theiaConfigDir = userDataPath;
                 this.pathExistenceCache[userDataPath] = true;
             }
+            theiaConfigDir = userDataPath;
         } else {
             theiaConfigDir = join(homedir(), BackendApplicationConfigProvider.get().configurationFolder);
         }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Before this the configurationFolder (which includes the user settings for example) was exported as a env variable THEIA_CONFIG_DIR. This is problematic, as we also allow users to define a configurationFolder via this variable, and use it whenever provided for a new session.
Therefore, if you debug another application from a Theia tool (e.g. the Theia IDE) you will always get the tools configurationFolder, which is probably not intended. As this results in settings being changed in the started application to also be applied in the root too (e.g. colorTheme).
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Start the Theia example application from a Theia application (Theia IDE, example application)
2. Run `echo $THEIA_CONFIG_DIR`
3. Notice that before this change you would see the root applications directory and with these changes you will get no output.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
