### PR TITLE
fix: fix response content in language model utility

### DIFF
--- a/packages/ai-core/src/common/language-model-util.ts
+++ b/packages/ai-core/src/common/language-model-util.ts
@@ -39,7 +39,7 @@ export const getTextOfResponse = async (response: LanguageModelResponse): Promis
     } else if (isLanguageModelStreamResponse(response)) {
         let result = '';
         for await (const chunk of response.stream) {
-            result += (isTextResponsePart(chunk) && chunk.content) ?? '';
+            result += (isTextResponsePart(chunk) && chunk.content) ? chunk.content : '';
         }
         return result;
     } else if (isLanguageModelParsedResponse(response)) {


### PR DESCRIPTION
#### What it does

I ran into cases where the `getTextOfResponse()` appended `false` to the returned string.
It happens for instance with the chat session naming agent:

![image](https://github.com/user-attachments/assets/3b2b56e2-8b0e-4db4-b0d4-06abcfd9faf3)

#### How to test

Ensure `getTextOfResponse()` doesn't append the result of the boolean `isTextResponsePart(chunk) && chunk.content` check. For instance, with the chat session naming agent.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
