### PR TITLE
fix cell editor and notebook output selection

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -23,7 +23,10 @@ import { CellEditType, CellKind, NotebookCommand } from '../../common';
 import { NotebookKernelQuickPickService } from '../service/notebook-kernel-quick-pick-service';
 import { NotebookExecutionService } from '../service/notebook-execution-service';
 import { NotebookEditorWidgetService } from '../service/notebook-editor-widget-service';
-import { NOTEBOOK_CELL_CURSOR_FIRST_LINE, NOTEBOOK_CELL_CURSOR_LAST_LINE, NOTEBOOK_CELL_FOCUSED, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_HAS_OUTPUTS, NOTEBOOK_OUTPUT_FOCUSED } from './notebook-context-keys';
+import {
+    NOTEBOOK_CELL_CURSOR_FIRST_LINE, NOTEBOOK_CELL_CURSOR_LAST_LINE,
+    NOTEBOOK_CELL_FOCUSED, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_HAS_OUTPUTS, NOTEBOOK_OUTPUT_FOCUSED
+} from './notebook-context-keys';
 import { NotebookClipboardService } from '../service/notebook-clipboard-service';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { NotebookEditorWidget } from '../notebook-editor-widget';

--- a/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-actions-contribution.ts
@@ -23,7 +23,7 @@ import { CellEditType, CellKind, NotebookCommand } from '../../common';
 import { NotebookKernelQuickPickService } from '../service/notebook-kernel-quick-pick-service';
 import { NotebookExecutionService } from '../service/notebook-execution-service';
 import { NotebookEditorWidgetService } from '../service/notebook-editor-widget-service';
-import { NOTEBOOK_CELL_CURSOR_FIRST_LINE, NOTEBOOK_CELL_CURSOR_LAST_LINE, NOTEBOOK_CELL_FOCUSED, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_HAS_OUTPUTS } from './notebook-context-keys';
+import { NOTEBOOK_CELL_CURSOR_FIRST_LINE, NOTEBOOK_CELL_CURSOR_LAST_LINE, NOTEBOOK_CELL_FOCUSED, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_HAS_OUTPUTS, NOTEBOOK_OUTPUT_FOCUSED } from './notebook-context-keys';
 import { NotebookClipboardService } from '../service/notebook-clipboard-service';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { NotebookEditorWidget } from '../notebook-editor-widget';
@@ -344,17 +344,17 @@ export class NotebookActionsContribution implements CommandContribution, MenuCon
             {
                 command: NotebookCommands.CUT_SELECTED_CELL.id,
                 keybinding: 'ctrlcmd+x',
-                when: `${NOTEBOOK_EDITOR_FOCUSED} && !inputFocus`
+                when: `${NOTEBOOK_EDITOR_FOCUSED} && !inputFocus && !${NOTEBOOK_OUTPUT_FOCUSED}`
             },
             {
                 command: NotebookCommands.COPY_SELECTED_CELL.id,
                 keybinding: 'ctrlcmd+c',
-                when: `${NOTEBOOK_EDITOR_FOCUSED} && !inputFocus`
+                when: `${NOTEBOOK_EDITOR_FOCUSED} && !inputFocus && !${NOTEBOOK_OUTPUT_FOCUSED}`
             },
             {
                 command: NotebookCommands.PASTE_CELL.id,
                 keybinding: 'ctrlcmd+v',
-                when: `${NOTEBOOK_EDITOR_FOCUSED} && !inputFocus`
+                when: `${NOTEBOOK_EDITOR_FOCUSED} && !inputFocus && !${NOTEBOOK_OUTPUT_FOCUSED}`
             },
             {
                 command: NotebookCommands.NOTEBOOK_FIND.id,

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -197,6 +197,8 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
                 this.props.notebookCellEditorService.editorFocusChanged(this.editor);
             }));
             this.toDispose.push(this.editor.getControl().onDidBlurEditorText(() => {
+                // extra blur to really also loose widget focus. Otherwise actions like copy can still be handled by monaco even thogh it does not have focus.
+                this.blurEditor();
                 if (this.props.notebookCellEditorService.getActiveCell()?.uri.toString() === this.props.cell.uri.toString()) {
                     this.props.notebookCellEditorService.editorFocusChanged(undefined);
                 }

--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -197,8 +197,6 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
                 this.props.notebookCellEditorService.editorFocusChanged(this.editor);
             }));
             this.toDispose.push(this.editor.getControl().onDidBlurEditorText(() => {
-                // extra blur to really also loose widget focus. Otherwise actions like copy can still be handled by monaco even thogh it does not have focus.
-                this.blurEditor();
                 if (this.props.notebookCellEditorService.getActiveCell()?.uri.toString() === this.props.cell.uri.toString()) {
                     this.props.notebookCellEditorService.editorFocusChanged(undefined);
                 }

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -530,7 +530,9 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 }
                 break;
             case 'webviewFocusChanged':
-                console.log('webviewFocusChanged', message.focused);
+                if (message.focused) {
+                    window.getSelection()?.empty();
+                }
                 this.contextKeyService.setContext(NOTEBOOK_OUTPUT_FOCUSED, message.focused);
                 break;
             case 'cellHeightRequest':

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/cell-output-webview.tsx
@@ -43,6 +43,8 @@ import { NotebookCellModel } from '@theia/notebook/lib/browser/view-model/notebo
 import { CellOutput, NotebookCellsChangeType } from '@theia/notebook/lib/common';
 import { NotebookCellOutputModel } from '@theia/notebook/lib/browser/view-model/notebook-cell-output-model';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { NOTEBOOK_OUTPUT_FOCUSED } from '@theia/notebook/lib/browser/contributions/notebook-context-keys';
 
 export const AdditionalNotebookCellOutputCss = Symbol('AdditionalNotebookCellOutputCss');
 
@@ -227,6 +229,9 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
 
     @inject(NotebookOptionsService)
     protected readonly notebookOptionsService: NotebookOptionsService;
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
 
     // returns the output Height
     protected readonly onDidRenderOutputEmitter = new Emitter<OutputRenderEvent>();
@@ -523,6 +528,10 @@ export class CellOutputWebviewImpl implements CellOutputWebview, Disposable {
                 if (selectedCell) {
                     this.notebook.setSelectedCell(selectedCell);
                 }
+                break;
+            case 'webviewFocusChanged':
+                console.log('webviewFocusChanged', message.focused);
+                this.contextKeyService.setContext(NOTEBOOK_OUTPUT_FOCUSED, message.focused);
                 break;
             case 'cellHeightRequest':
                 const cellHeight = this.notebook.getCellByHandle(message.cellHandle)?.cellHeight ?? 0;

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/output-webview-internal.ts
@@ -801,10 +801,14 @@ export async function outputWebviewPreload(ctx: PreloadContext): Promise<void> {
             theia.postMessage({ type: 'inputFocusChanged', focused: focus } as webviewCommunication.InputFocusChange);
         }
     };
-
     window.addEventListener('focusin', (event: FocusEvent) => focusChange(event, true));
-
     window.addEventListener('focusout', (event: FocusEvent) => focusChange(event, false));
+
+    const webviewFocuseChange = (focus: boolean) => {
+        theia.postMessage({ type: 'webviewFocusChanged', focused: focus } as webviewCommunication.WebviewFocusChange);
+    };
+    window.addEventListener('focus', () => webviewFocuseChange(true));
+    window.addEventListener('blur', () => webviewFocuseChange(false));
 
     new ResizeObserver(() => {
         theia.postMessage({

--- a/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
+++ b/packages/plugin-ext/src/main/browser/notebooks/renderers/webview-communication.ts
@@ -150,6 +150,11 @@ export interface CellOuputFocus {
     readonly cellHandle: number;
 }
 
+export interface WebviewFocusChange {
+    readonly type: 'webviewFocusChanged';
+    readonly focused: boolean;
+}
+
 export interface CellHeightRequest {
     readonly type: 'cellHeightRequest';
     readonly cellHandle: number;
@@ -167,6 +172,7 @@ export type FromWebviewMessage = WebviewInitialized
     | KernelMessage
     | InputFocusChange
     | CellOuputFocus
+    | WebviewFocusChange
     | CellHeightRequest
     | BodyHeightChange;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This fixes two issue with doing copy,paste,cut inside of outputs.
1. it fixes the selection when a output is focused, so that copy,paste,cut events will not be stolen by monaco
2. fixes cell copy,paste,cut actions to not happen when an output is selected, so that a user can copy,paste,cut in the output without modifying the notebook.

#### How to test

1. Open a notebook with outputs
2. copy,paste,cut inside output, editor, when cell is selected

#### Follow-ups

Maybe it might be better to allow copy, paste, cut for cells as long as there is no text selection or an input is selected in the output 

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
