### PR TITLE
feat(chat): enhance streaming content parsing for incomplete response content matches

### DIFF
--- a/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
@@ -21,7 +21,8 @@ import {
     MutableChatRequestModel,
     lastProgressMessage,
     QuestionResponseContentImpl,
-    unansweredQuestions
+    unansweredQuestions,
+    ProgressChatResponseContentImpl
 } from '@theia/ai-chat';
 import { Agent, LanguageModelMessage, PromptTemplate } from '@theia/ai-core';
 import { injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
@@ -129,10 +130,14 @@ export class AskAndContinueChatAgent extends AbstractStreamParsingChatAgent {
             contentFactory: (content: string, request: MutableChatRequestModel) => {
                 const question = content.replace(/^<question>\n|<\/question>$/g, '');
                 const parsedQuestion = JSON.parse(question);
+
                 return new QuestionResponseContentImpl(parsedQuestion.question, parsedQuestion.options, request, selectedOption => {
                     this.handleAnswer(selectedOption, request);
                 });
-            }
+            },
+            incompleteContentFactory: (content: string, request: MutableChatRequestModel) =>
+                // Display a progress indicator while the question is being parsed
+                new ProgressChatResponseContentImpl('Preparing question...')
         });
     }
 

--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -35,6 +35,7 @@ import {
     MarkdownPartRenderer,
     ToolCallPartRenderer,
     ThinkingPartRenderer,
+    ProgressPartRenderer,
 } from './chat-response-renderer';
 import {
     GitHubSelectionResolver,
@@ -89,6 +90,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(ChatResponsePartRenderer).to(ErrorPartRenderer).inSingletonScope();
     bind(ChatResponsePartRenderer).to(ThinkingPartRenderer).inSingletonScope();
     bind(ChatResponsePartRenderer).to(QuestionPartRenderer).inSingletonScope();
+    bind(ChatResponsePartRenderer).to(ProgressPartRenderer).inSingletonScope();
     [CommandContribution, MenuContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).to(ChatViewMenuContribution).inSingletonScope()
     );

--- a/packages/ai-chat-ui/src/browser/chat-progress-message.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-progress-message.tsx
@@ -1,0 +1,40 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatProgressMessage } from '@theia/ai-chat';
+import * as React from '@theia/core/shared/react';
+
+export type ProgressMessageProps = Omit<ChatProgressMessage, 'kind' | 'id' | 'show'>;
+
+export const ProgressMessage = (c: ProgressMessageProps) => (
+    <div className='theia-ResponseNode-ProgressMessage'>
+        <Indicator {...c} /> {c.content}
+    </div>
+);
+
+export const Indicator = (progressMessage: ProgressMessageProps) => (
+    <span className='theia-ResponseNode-ProgressMessage-Indicator'>
+        {progressMessage.status === 'inProgress' &&
+            <i className={'fa fa-spinner fa-spin ' + progressMessage.status}></i>
+        }
+        {progressMessage.status === 'completed' &&
+            <i className={'fa fa-check ' + progressMessage.status}></i>
+        }
+        {progressMessage.status === 'failed' &&
+            <i className={'fa fa-warning ' + progressMessage.status}></i>
+        }
+    </span>
+);

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/index.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/index.ts
@@ -22,3 +22,4 @@ export * from './markdown-part-renderer';
 export * from './text-part-renderer';
 export * from './toolcall-part-renderer';
 export * from './thinking-part-renderer';
+export * from './progress-part-renderer';

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/progress-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/progress-part-renderer.tsx
@@ -1,0 +1,40 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
+import { injectable } from '@theia/core/shared/inversify';
+import { ChatResponseContent, ProgressChatResponseContent } from '@theia/ai-chat/lib/common';
+import { ReactNode } from '@theia/core/shared/react';
+import * as React from '@theia/core/shared/react';
+import { ProgressMessage } from '../chat-progress-message';
+
+@injectable()
+export class ProgressPartRenderer implements ChatResponsePartRenderer<ProgressChatResponseContent> {
+
+    canHandle(response: ChatResponseContent): number {
+        if (ProgressChatResponseContent.is(response)) {
+            return 10;
+        }
+        return -1;
+    }
+
+    render(response: ProgressChatResponseContent): ReactNode {
+        return (
+            <ProgressMessage content={response.message} status='inProgress' />
+        );
+    }
+
+}

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -17,7 +17,6 @@ import {
     ChatAgent,
     ChatAgentService,
     ChatModel,
-    ChatProgressMessage,
     ChatRequestModel,
     ChatResponseContent,
     ChatResponseModel,
@@ -53,6 +52,7 @@ import { ChatNodeToolbarActionContribution } from '../chat-node-toolbar-action-c
 import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
 import { useMarkdownRendering } from '../chat-response-renderer/markdown-part-renderer';
 import { AIVariableService } from '@theia/ai-core';
+import { ProgressMessage } from '../chat-progress-message';
 
 // TODO Instead of directly operating on the ChatRequestModel we could use an intermediate view model
 export interface RequestNode extends TreeNode {
@@ -474,23 +474,3 @@ const HoverableLabel = (
         </span>
     );
 };
-
-const ProgressMessage = (c: ChatProgressMessage) => (
-    <div className='theia-ResponseNode-ProgressMessage'>
-        <Indicator {...c} /> {c.content}
-    </div>
-);
-
-const Indicator = (progressMessage: ChatProgressMessage) => (
-    <span className='theia-ResponseNode-ProgressMessage-Indicator'>
-        {progressMessage.status === 'inProgress' &&
-            <i className={'fa fa-spinner fa-spin ' + progressMessage.status}></i>
-        }
-        {progressMessage.status === 'completed' &&
-            <i className={'fa fa-check ' + progressMessage.status}></i>
-        }
-        {progressMessage.status === 'failed' &&
-            <i className={'fa fa-warning ' + progressMessage.status}></i>
-        }
-    </span>
-);

--- a/packages/ai-chat/src/common/parse-contents-with-incomplete-parts.spec.ts
+++ b/packages/ai-chat/src/common/parse-contents-with-incomplete-parts.spec.ts
@@ -1,0 +1,114 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { MutableChatRequestModel, CodeChatResponseContentImpl, MarkdownChatResponseContentImpl } from './chat-model';
+import { parseContents } from './parse-contents';
+import { ResponseContentMatcher } from './response-content-matcher';
+
+const fakeRequest = {} as MutableChatRequestModel;
+
+// Custom matchers with incompleteContentFactory for testing
+const TestCodeContentMatcher: ResponseContentMatcher = {
+    start: /^```.*?$/m,
+    end: /^```$/m,
+    contentFactory: (content: string) => {
+        const language = content.match(/^```(\w+)/)?.[1] || '';
+        const code = content.replace(/^```(\w+)\n|```$/g, '');
+        return new CodeChatResponseContentImpl(code.trim(), language);
+    },
+    incompleteContentFactory: (content: string) => {
+        const language = content.match(/^```(\w+)/)?.[1] || '';
+        // Remove only the start delimiter, since we don't have an end delimiter yet
+        const code = content.replace(/^```(\w+)\n?/g, '');
+        return new CodeChatResponseContentImpl(code.trim(), language);
+    }
+};
+
+describe('parseContents with incomplete parts', () => {
+    it('should handle incomplete code blocks with incompleteContentFactory', () => {
+        // Only the start of a code block without an end
+        const text = '```typescript\nconsole.log("Hello World");';
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
+
+        expect(result.length).to.equal(1);
+        expect(result[0]).to.be.instanceOf(CodeChatResponseContentImpl);
+        const codeContent = result[0] as CodeChatResponseContentImpl;
+        expect(codeContent.code).to.equal('console.log("Hello World");');
+        expect(codeContent.language).to.equal('typescript');
+    });
+
+    it('should handle complete code blocks with contentFactory', () => {
+        const text = '```typescript\nconsole.log("Hello World");\n```';
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
+
+        expect(result.length).to.equal(1);
+        expect(result[0]).to.be.instanceOf(CodeChatResponseContentImpl);
+        const codeContent = result[0] as CodeChatResponseContentImpl;
+        expect(codeContent.code).to.equal('console.log("Hello World");');
+        expect(codeContent.language).to.equal('typescript');
+    });
+
+    it('should handle mixed content with incomplete and complete blocks', () => {
+        const text = 'Some text\n```typescript\nconsole.log("Hello");\n```\nMore text\n```python\nprint("World")';
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
+
+        expect(result.length).to.equal(4);
+        expect(result[0]).to.be.instanceOf(MarkdownChatResponseContentImpl);
+        expect(result[1]).to.be.instanceOf(CodeChatResponseContentImpl);
+        const completeContent = result[1] as CodeChatResponseContentImpl;
+        expect(completeContent.language).to.equal('typescript');
+        expect(result[2]).to.be.instanceOf(MarkdownChatResponseContentImpl);
+        expect(result[3]).to.be.instanceOf(CodeChatResponseContentImpl);
+        const incompleteContent = result[3] as CodeChatResponseContentImpl;
+        expect(incompleteContent.language).to.equal('python');
+    });
+
+    it('should use default content factory if no incompleteContentFactory provided', () => {
+        // Create a matcher without incompleteContentFactory
+        const matcherWithoutIncomplete: ResponseContentMatcher = {
+            start: /^<test>$/m,
+            end: /^<\/test>$/m,
+            contentFactory: (content: string) => new MarkdownChatResponseContentImpl('complete: ' + content)
+        };
+
+        // Text with only the start delimiter
+        const text = '<test>\ntest content';
+        const result = parseContents(text, fakeRequest, [matcherWithoutIncomplete]);
+
+        expect(result.length).to.equal(1);
+        expect(result[0]).to.be.instanceOf(MarkdownChatResponseContentImpl);
+        expect((result[0] as MarkdownChatResponseContentImpl).content.value).to.equal('<test>\ntest content');
+    });
+
+    it('should prefer complete matches over incomplete ones', () => {
+        // Text with both a complete and incomplete match at same position
+        const text = '```typescript\nconsole.log();\n```\n<test>\ntest content';
+        const matcherWithoutIncomplete: ResponseContentMatcher = {
+            start: /^<test>$/m,
+            end: /^<\/test>$/m,
+            contentFactory: (content: string) => new MarkdownChatResponseContentImpl('complete: ' + content)
+        };
+
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher, matcherWithoutIncomplete]);
+
+        expect(result.length).to.equal(2);
+        expect(result[0]).to.be.instanceOf(CodeChatResponseContentImpl);
+        expect((result[0] as CodeChatResponseContentImpl).language).to.equal('typescript');
+        expect(result[1]).to.be.instanceOf(MarkdownChatResponseContentImpl);
+        expect((result[1] as MarkdownChatResponseContentImpl).content.value).to.contain('test content');
+    });
+});

--- a/packages/ai-chat/src/common/parse-contents.spec.ts
+++ b/packages/ai-chat/src/common/parse-contents.spec.ts
@@ -19,6 +19,16 @@ import { MutableChatRequestModel, ChatResponseContent, CodeChatResponseContentIm
 import { parseContents } from './parse-contents';
 import { CodeContentMatcher, ResponseContentMatcher } from './response-content-matcher';
 
+export const TestCodeContentMatcher: ResponseContentMatcher = {
+    start: /^```.*?$/m,
+    end: /^```$/m,
+    contentFactory: (content: string) => {
+        const language = content.match(/^```(\w+)/)?.[1] || '';
+        const code = content.replace(/^```(\w+)\n|```$/g, '');
+        return new CodeChatResponseContentImpl(code.trim(), language);
+    }
+};
+
 export class CommandChatResponseContentImpl implements ChatResponseContent {
     constructor(public readonly command: string) { }
     kind = 'command';
@@ -38,19 +48,19 @@ const fakeRequest = {} as MutableChatRequestModel;
 describe('parseContents', () => {
     it('should parse code content', () => {
         const text = '```typescript\nconsole.log("Hello World");\n```';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript')]);
     });
 
     it('should parse markdown content', () => {
         const text = 'Hello **World**';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([new MarkdownChatResponseContentImpl('Hello **World**')]);
     });
 
     it('should parse multiple content blocks', () => {
         const text = '```typescript\nconsole.log("Hello World");\n```\nHello **World**';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([
             new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
             new MarkdownChatResponseContentImpl('\nHello **World**')
@@ -59,7 +69,7 @@ describe('parseContents', () => {
 
     it('should parse multiple content blocks with different languages', () => {
         const text = '```typescript\nconsole.log("Hello World");\n```\n```python\nprint("Hello World")\n```';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([
             new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
             new CodeChatResponseContentImpl('print("Hello World")', 'python')
@@ -68,7 +78,7 @@ describe('parseContents', () => {
 
     it('should parse multiple content blocks with different languages and markdown', () => {
         const text = '```typescript\nconsole.log("Hello World");\n```\nHello **World**\n```python\nprint("Hello World")\n```';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([
             new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
             new MarkdownChatResponseContentImpl('\nHello **World**\n'),
@@ -78,7 +88,7 @@ describe('parseContents', () => {
 
     it('should parse content blocks with empty content', () => {
         const text = '```typescript\n```\nHello **World**\n```python\nprint("Hello World")\n```';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([
             new CodeChatResponseContentImpl('', 'typescript'),
             new MarkdownChatResponseContentImpl('\nHello **World**\n'),
@@ -88,7 +98,7 @@ describe('parseContents', () => {
 
     it('should parse content with markdown, code, and markdown', () => {
         const text = 'Hello **World**\n```typescript\nconsole.log("Hello World");\n```\nGoodbye **World**';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([
             new MarkdownChatResponseContentImpl('Hello **World**\n'),
             new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
@@ -98,34 +108,36 @@ describe('parseContents', () => {
 
     it('should handle text with no special content', () => {
         const text = 'Just some plain text.';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([new MarkdownChatResponseContentImpl('Just some plain text.')]);
     });
 
     it('should handle text with only start code block', () => {
         const text = '```typescript\nconsole.log("Hello World");';
+        // We're using the standard CodeContentMatcher which has incompleteContentFactory 
         const result = parseContents(text, fakeRequest);
-        expect(result).to.deep.equal([new MarkdownChatResponseContentImpl('```typescript\nconsole.log("Hello World");')]);
+        expect(result).to.deep.equal([new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript')]);
     });
 
     it('should handle text with only end code block', () => {
         const text = 'console.log("Hello World");\n```';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([new MarkdownChatResponseContentImpl('console.log("Hello World");\n```')]);
     });
 
     it('should handle text with unmatched code block', () => {
         const text = '```typescript\nconsole.log("Hello World");\n```\n```python\nprint("Hello World")';
+        // We're using the standard CodeContentMatcher which has incompleteContentFactory
         const result = parseContents(text, fakeRequest);
         expect(result).to.deep.equal([
             new CodeChatResponseContentImpl('console.log("Hello World");', 'typescript'),
-            new MarkdownChatResponseContentImpl('\n```python\nprint("Hello World")')
+            new CodeChatResponseContentImpl('print("Hello World")', 'python')
         ]);
     });
 
     it('should parse code block without newline after language', () => {
         const text = '```typescript console.log("Hello World");```';
-        const result = parseContents(text, fakeRequest);
+        const result = parseContents(text, fakeRequest, [TestCodeContentMatcher]);
         expect(result).to.deep.equal([
             new MarkdownChatResponseContentImpl('```typescript console.log("Hello World");```')
         ]);

--- a/packages/ai-chat/src/common/response-content-matcher.ts
+++ b/packages/ai-chat/src/common/response-content-matcher.ts
@@ -23,7 +23,7 @@ import { injectable } from '@theia/core/shared/inversify';
 
 export type ResponseContentFactory = (content: string, request: MutableChatRequestModel) => ChatResponseContent;
 
-export const MarkdownContentFactory: ResponseContentFactory = (content: string) =>
+export const MarkdownContentFactory: ResponseContentFactory = (content: string, request: MutableChatRequestModel) =>
     new MarkdownChatResponseContentImpl(content);
 
 /**
@@ -53,14 +53,32 @@ export interface ResponseContentMatcher {
      * from start index to end index of the match (including delimiters).
      */
     contentFactory: ResponseContentFactory;
+    /**
+     * Optional factory for creating a response content when only the start delimiter has been matched,
+     * but not yet the end delimiter. Used during streaming to provide better visual feedback.
+     * If not provided, the default content factory will be used until the end delimiter is matched.
+     */
+    incompleteContentFactory?: ResponseContentFactory;
 }
 
 export const CodeContentMatcher: ResponseContentMatcher = {
-    start: /^```.*?$/m,
+    // Only match when we have the complete first line ending with a newline
+    // This ensures we have the full language specification before creating the editor
+    start: /^```.*\n/m,
     end: /^```$/m,
-    contentFactory: (content: string) => {
+    contentFactory: (content: string, request: MutableChatRequestModel) => {
         const language = content.match(/^```(\w+)/)?.[1] || '';
         const code = content.replace(/^```(\w+)\n|```$/g, '');
+        return new CodeChatResponseContentImpl(code.trim(), language);
+    },
+    incompleteContentFactory: (content: string, request: MutableChatRequestModel) => {
+        // By this point, we know we have at least the complete first line with ```
+        const firstLine = content.split('\n')[0];
+        const language = firstLine.match(/^```(\w+)/)?.[1] || '';
+
+        // Remove the first line to get just the code content
+        const code = content.substring(content.indexOf('\n') + 1);
+
         return new CodeChatResponseContentImpl(code.trim(), language);
     }
 };


### PR DESCRIPTION
#### What it does

- Enables `ResponseContentMatcher` to provide a `incompleteContentFactory` which will be used if the start delimiter matches, but no end delimiter hasn't been matched yet.
- Refactors `addStreamResponse` method to maintain a complete text buffer for streamed responses, enabling the handling of incomplete matches.
- Updated `parseContents` function to differentiate between complete and incomplete matches, allowing for better content management during streaming.
- Added unit tests for new functionality in `parse-contents-stream.spec.ts` and updated existing tests to utilize custom matchers for code content parsing.
- Introduces `ProgressChatResponseContent` interface and its implementation to support progress updates in chat responses via incomplete matches

There is some downside to using this approach:
As we eagerly match now, the `start` regex has to be pretty strict as we otherwise will show the content part where we shouldn't. So if the start delimiter is somewhat ambiguous it might be better to not use this approach for those cases. This is why this is optional and controlled by the specific response content matcher -- it can choose to provide an `incompleteContentFactory` or not.

Fixes https://github.com/eclipse-theia/theia/issues/15386

#### How to test

See how code content parts are now immediately matched and rendered:

https://github.com/user-attachments/assets/ffa022ce-7515-4ab6-abc9-ab37d53ecc2b

See how the `AskAndContinue` agent now shows a progress part instead of surfacing the structured `<question>` response to the user:

https://github.com/user-attachments/assets/cd9d8915-28c0-4a48-8d4b-e4d5ed9d619b

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
