### PR TITLE
Use SimpleMonacoEditor for most inline editors

### DIFF
--- a/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
@@ -36,7 +36,7 @@ export function bindAskAndContinueChatAgentContribution(bind: interfaces.Bind): 
 const systemPrompt: PromptTemplate = {
     id: 'askAndContinue-system',
     template: `
-You are an agent demonstrating on how to generate questions and continuing the conversation based on the user's answers.
+You are an agent demonstrating how to generate questions and continue the conversation based on the user's answers.
 
 First answer the user's question or continue their story.
 Then come up with an interesting question and 2-3 answers which will be presented to the user as multiple choice.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "license:check": "node scripts/check_3pp_licenses.js",
     "license:check:review": "node scripts/check_3pp_licenses.js --review",
     "lint": "lerna run lint",
+    "lint:fix": "lerna run lint -- --fix",
     "lint:clean": "rimraf .eslintcache",
     "preinstall": "node-gyp install",
     "postinstall": "theia-patch && npm run -s compute-references && lerna run afterInstall",

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -20,7 +20,7 @@ import { Deferred } from '@theia/core/lib/common/promise-util';
 import { inject, injectable, optional, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { IMouseEvent } from '@theia/monaco-editor-core';
-import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
+import { SimpleMonacoEditor } from '@theia/monaco/lib/browser/simple-monaco-editor';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 import { CHAT_VIEW_LANGUAGE_EXTENSION } from './chat-view-language-contribution';
 import { AIVariableResolutionRequest } from '@theia/ai-core';
@@ -74,7 +74,7 @@ export class AIChatInputWidget extends ReactWidget {
     @inject(ChangeSetDecoratorService)
     protected readonly changeSetDecoratorService: ChangeSetDecoratorService;
 
-    protected editorRef: MonacoEditor | undefined = undefined;
+    protected editorRef: SimpleMonacoEditor | undefined = undefined;
     protected readonly editorReady = new Deferred<void>();
 
     protected isEnabled = false;
@@ -267,7 +267,7 @@ interface ChatInputProperties {
     resources: InMemoryResources;
     resourceUriProvider: () => URI;
     contextMenuCallback: (event: IMouseEvent) => void;
-    setEditorRef: (editor: MonacoEditor | undefined) => void;
+    setEditorRef: (editor: SimpleMonacoEditor | undefined) => void;
     showContext?: boolean;
     showPinnedAgent?: boolean;
     showChangeSet?: boolean;
@@ -300,7 +300,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     const editorContainerRef = React.useRef<HTMLDivElement | null>(null);
     // eslint-disable-next-line no-null/no-null
     const placeholderRef = React.useRef<HTMLDivElement | null>(null);
-    const editorRef = React.useRef<MonacoEditor | undefined>(undefined);
+    const editorRef = React.useRef<SimpleMonacoEditor | undefined>(undefined);
 
     React.useEffect(() => {
         const uri = props.resourceUriProvider();
@@ -309,7 +309,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
             const paddingTop = 6;
             const lineHeight = 20;
             const maxHeight = 240;
-            const editor = await props.editorProvider.createInline(uri, editorContainerRef.current!, {
+            const editor = await props.editorProvider.createSimpleInline(uri, editorContainerRef.current!, {
                 language: CHAT_VIEW_LANGUAGE_EXTENSION,
                 // Disable code lens, inlay hints and hover support to avoid console errors from other contributions
                 codeLens: false,

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -26,7 +26,7 @@ import { ReactNode } from '@theia/core/shared/react';
 import { nls } from '@theia/core/lib/common/nls';
 import { Position } from '@theia/core/shared/vscode-languageserver-protocol';
 import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
-import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
+import { SimpleMonacoEditor } from '@theia/monaco/lib/browser/simple-monaco-editor';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
 import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
@@ -206,11 +206,11 @@ export const CodeWrapper = (props: {
 }) => {
     // eslint-disable-next-line no-null/no-null
     const ref = React.useRef<HTMLDivElement | null>(null);
-    const editorRef = React.useRef<MonacoEditor | undefined>(undefined);
+    const editorRef = React.useRef<SimpleMonacoEditor | undefined>(undefined);
 
     const createInputElement = async () => {
         const resource = await props.untitledResourceResolver.createUntitledResource(undefined, props.language);
-        const editor = await props.editorProvider.createInline(resource.uri, ref.current!, {
+        const editor = await props.editorProvider.createSimpleInline(resource.uri, ref.current!, {
             readOnly: true,
             autoSizing: true,
             scrollBeyondLastLine: false,

--- a/packages/ai-chat-ui/src/browser/chat-view-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-contribution.ts
@@ -22,7 +22,6 @@ import {
     isResponseNode, RequestNode, ResponseNode, type EditableRequestNode
 } from './chat-tree-view/chat-view-tree-widget';
 import { AIChatInputWidget } from './chat-input-widget';
-import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 
 export namespace ChatViewCommands {
     export const COPY_MESSAGE = Command.toDefaultLocalizedCommand({
@@ -62,17 +61,6 @@ export class ChatViewMenuContribution implements MenuContribution, CommandContri
                 }
             },
             isEnabled: (...args: unknown[]) => containsRequestOrResponseNode(args)
-        });
-        commands.registerHandler(CommonCommands.PASTE.id, {
-            execute: async (...args) => {
-                if (hasEditorAsFirstArg(args)) {
-                    const editor = args[0];
-                    const range = editor.selection;
-                    const newText = await this.clipboardService.readText();
-                    editor.executeEdits([{ range, newText }]);
-                }
-            },
-            isEnabled: (...args) => hasEditorAsFirstArg(args)
         });
         commands.registerCommand(ChatViewCommands.COPY_MESSAGE, {
             execute: (...args: unknown[]) => {
@@ -160,10 +148,6 @@ export class ChatViewMenuContribution implements MenuContribution, CommandContri
         });
     }
 
-}
-
-function hasEditorAsFirstArg(args: unknown[]): args is [MonacoEditor, ...unknown[]] {
-    return hasAsFirstArg(args, (arg): arg is MonacoEditor => arg instanceof MonacoEditor);
 }
 
 function hasAsFirstArg<T>(args: unknown[], guard: (arg: unknown) => arg is T): args is [T, ...unknown[]] {

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -342,12 +342,8 @@ export class DebugConfigurationManager {
         if (!model) {
             return;
         }
-        const widget = await this.doOpen(model);
-        if (!(widget.editor instanceof MonacoEditor)) {
-            return;
-        }
-        const editor = widget.editor.getControl();
-        const editorModel = editor.getModel();
+        const editor = MonacoEditor.get(await this.doOpen(model))?.getControl();
+        const editorModel = editor && editor.getModel();
         if (!editorModel) {
             return;
         }

--- a/packages/debug/src/browser/editor/debug-editor-service.ts
+++ b/packages/debug/src/browser/editor/debug-editor-service.ts
@@ -53,8 +53,8 @@ export class DebugEditorService {
     }
 
     protected push(widget: EditorWidget): void {
-        const { editor } = widget;
-        if (!(editor instanceof MonacoEditor)) {
+        const editor = MonacoEditor.get(widget);
+        if (!editor) {
             return;
         }
         const uri = editor.getResourceUri().toString();

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -414,6 +414,10 @@
   margin-bottom: var(--theia-ui-padding);
 }
 
+.theia-debug-breakpoint-input .monaco-editor {
+  outline: none;
+}
+
 /* Status Bar */
 .theia-mod-debugging #theia-statusBar {
   background: var(--theia-statusBar-debuggingBackground);

--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -82,14 +82,10 @@ export class MonacoEditorService extends StandaloneCodeEditorService {
         const openerOptions = this.createEditorOpenerOptions(input, source, sideBySide);
         const widget = await open(this.openerService, uri, openerOptions);
         const editorWidget = await this.findEditorWidgetByUri(widget, uri.toString());
-        if (editorWidget && editorWidget.editor instanceof MonacoEditor) {
-            const candidate = editorWidget.editor.getControl();
-            // Since we extend a private super class, we have to check that the thing that matches the public interface also matches the private expectations the superclass.
-            // eslint-disable-next-line no-null/no-null
-            return candidate instanceof StandaloneCodeEditor ? candidate : null;
-        }
+        const candidate = MonacoEditor.get(editorWidget)?.getControl();
+        // Since we extend a private super class, we have to check that the thing that matches the public interface also matches the private expectations the superclass.
         // eslint-disable-next-line no-null/no-null
-        return null;
+        return candidate instanceof StandaloneCodeEditor ? candidate : null;
     }
 
     protected async findEditorWidgetByUri(widget: object | undefined, uriAsString: string): Promise<EditorWidget | undefined> {

--- a/packages/monaco/src/browser/monaco-editor-zone-widget.ts
+++ b/packages/monaco/src/browser/monaco-editor-zone-widget.ts
@@ -45,10 +45,10 @@ export class MonacoEditorZoneWidget implements Disposable {
         this.toHide
     );
 
-    editor: monaco.editor.IStandaloneCodeEditor;
+    editor: monaco.editor.ICodeEditor;
 
     constructor(
-        editorInstance: monaco.editor.IStandaloneCodeEditor, readonly showArrow: boolean = true
+        editorInstance: monaco.editor.ICodeEditor, readonly showArrow: boolean = true
     ) {
         this.editor = editorInstance;
         this.zoneNode.classList.add('zone-widget');

--- a/packages/monaco/src/browser/simple-monaco-editor.ts
+++ b/packages/monaco/src/browser/simple-monaco-editor.ts
@@ -39,13 +39,13 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
     protected readonly onDocumentContentChangedEmitter = new Emitter<TextDocumentChangeEvent>();
     readonly onDocumentContentChanged = this.onDocumentContentChangedEmitter.event;
     protected readonly onMouseDownEmitter = new Emitter<EditorMouseEvent>();
+    readonly onDidChangeReadOnly = this.document.onDidChangeReadOnly;
     protected readonly onLanguageChangedEmitter = new Emitter<string>();
     readonly onLanguageChanged = this.onLanguageChangedEmitter.event;
     protected readonly onScrollChangedEmitter = new Emitter<void>();
     readonly onEncodingChanged = this.document.onDidChangeEncoding;
     protected readonly onResizeEmitter = new Emitter<Dimension | null>();
     readonly onDidResize = this.onResizeEmitter.event;
-    readonly onDidChangeReadOnly = this.document.onDidChangeReadOnly;
 
     constructor(
         readonly uri: URI,
@@ -67,7 +67,8 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
         ]);
         this.toDispose.push(this.create({
             ...MonacoEditor.createReadOnlyOptions(document.readOnly),
-            ...options
+            ...options,
+            model: undefined,
         }, override, widgetOptions));
         this.addHandlers(this.editor);
         this.editor.setModel(document.textEditorModel);
@@ -154,7 +155,9 @@ export class SimpleMonacoEditor extends MonacoEditorServices implements Disposab
         const instantiator = StandaloneServices.get(IInstantiationService);
         if (override) {
             const overrideServices = new ServiceCollection(...override);
-            return instantiator.createChild(overrideServices);
+            const childService = instantiator.createChild(overrideServices);
+            this.toDispose.push(childService);
+            return childService;
         }
         return instantiator;
     }

--- a/packages/output/src/browser/output-widget.ts
+++ b/packages/output/src/browser/output-widget.ts
@@ -228,13 +228,7 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
     }
 
     private get editor(): MonacoEditor | undefined {
-        const widget = this.editorWidget;
-        if (widget instanceof EditorWidget) {
-            if (widget.editor instanceof MonacoEditor) {
-                return widget.editor;
-            }
-        }
-        return undefined;
+        return MonacoEditor.get(this.editorWidget);
     }
 
     getText(): string | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #15218

Adds a new function `createSimpleInline` to the `MonacoEditorProvider` that returns an instance of `SimpleMonacoEditor` that is more customizable than our standard `MonacoEditor`, allowing customization of both services, which the `MonacoEditor` also does, and editor contributions, which the `MonacoEditor` does not, and 'simplicity', which the `MonacoEditor` also doesn't. Control of contributions is the more direct way to control the presence or absence, rather than behavior, of certain features: remove the inlay hints contribution, and the editor won't have inlay hints, etc.

See discussion on issue re: current design.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Three current inline editor use cases have been replaced: breakpoint widgets, AI chat input, and AI chat code snippet rendering.
2. Confirm that each of the three behaves as expected:
  - breakpoint widgets should have code completion for the current context. (But NB that the code completion [isn't currently](https://github.com/eclipse-theia/theia/issues/15218#issuecomment-2775733958) as sophisticated as in the editor itself.
  - AI chat input should have code completion for chat variables, etc.
  - AI chat code snippets should still be colored according to the language in which they're written.

Note that currently, all three editors are instantiated with a full complement of both services and editor contributions - the primary difference in behavior is from setting `isSimpleWidget` to true; see discussion [here](https://github.com/eclipse-theia/theia/issues/15218#issuecomment-2773845226). 

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
