### PR TITLE
Respect editor associations when opening diff-editors

### DIFF
--- a/packages/core/src/browser/open-with-service.ts
+++ b/packages/core/src/browser/open-with-service.ts
@@ -49,7 +49,7 @@ export interface OpenWithHandler {
      */
     canHandle(uri: URI): number;
     /**
-     * Test whether this handler and open the given URI
+     * Test whether this handler can open the given URI
      * and return the order of this handler in the list.
      */
     getOrder?(uri: URI): number;

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -18,7 +18,7 @@ import { injectable, postConstruct, inject, named } from '@theia/core/shared/inv
 import URI from '@theia/core/lib/common/uri';
 import { RecursivePartial, Emitter, Event, MaybePromise, CommandService, nls, ContributionProvider, Prioritizeable, Disposable } from '@theia/core/lib/common';
 import {
-    WidgetOpenerOptions, NavigatableWidgetOpenHandler, NavigatableWidgetOptions, PreferenceService, CommonCommands, getDefaultHandler, defaultHandlerPriority
+    WidgetOpenerOptions, NavigatableWidgetOpenHandler, NavigatableWidgetOptions, PreferenceService, CommonCommands, getDefaultHandler, defaultHandlerPriority, DiffUris
 } from '@theia/core/lib/browser';
 import { EditorWidget } from './editor-widget';
 import { Range, Position, Location, TextEditor } from './editor';
@@ -209,6 +209,10 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     }
 
     canHandle(uri: URI, options?: WidgetOpenerOptions): number {
+        if (DiffUris.isDiffUri(uri)) {
+            const [/* left */, right] = DiffUris.decode(uri);
+            uri = right;
+        }
         if (getDefaultHandler(uri, this.preferenceService) === 'default') {
             return defaultHandlerPriority;
         }

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
@@ -54,7 +54,11 @@ export class CustomEditorOpener implements OpenHandler {
         if (DiffUris.isDiffUri(uri)) {
             const [left, right] = DiffUris.decode(uri);
             if (this.matches(selector, right) && this.matches(selector, left)) {
-                priority = this.getPriority();
+                if (getDefaultHandler(right, this.preferenceService) === this.editor.viewType) {
+                    priority = defaultHandlerPriority;
+                } else {
+                    priority = this.getPriority();
+                }
             }
         } else if (this.matches(selector, uri)) {
             if (getDefaultHandler(uri, this.preferenceService) === this.editor.viewType) {


### PR DESCRIPTION
#### What it does

Fixes #15401.

#### How to test

Verify that editor associations are now respected when opening both text compare editors and custom compare editors.

For example, using the [custom editor sample](https://github.com/microsoft/vscode-extension-samples/tree/main/custom-editor-sample):

0. Compile the custom editor sample and copy it to the Theia `plugins` directory. Launch Theia.

1. Open, modify, and save a `*.cscratch` file (e.g. `custom-editor-sample/exampleFiles/example.cscratch`) using the default custom editor.

2. Compare the changes made to the file. The custom compare editor should open by default.

3. Open the `*.cscratch` file with the text editor using `Open With... -> Configure default editor for '*.cscratch'... -> Text Editor`.

4. Compare the changes made to the file. Verify that the text compare editor is opened now instead of the custom compare editor.

5. Open the `*.cscratch` file with the custom editor using `Open With... -> Configure default editor for '*.cscratch'... -> Cat Scratch`.

6. Compare the changes made to the file. Verify that the custom compare editor is opened now instead of the text compare editor.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
