### PR TITLE
Fix ssh terminals

### DIFF
--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -25,6 +25,7 @@ const REQUIRE_VSCODE_WINDOWS_CA_CERTS = '@vscode/windows-ca-certs';
 const REQUIRE_BINDINGS = 'bindings';
 const REQUIRE_KEYMAPPING = './build/Release/keymapping';
 const REQUIRE_PARCEL_WATCHER = './build/Release/watcher.node';
+const REQUIRE_NODE_PTY_CONPTY = '../build/Release/conpty.node';
 
 export interface NativeWebpackPluginOptions {
     out: string;
@@ -71,6 +72,11 @@ export class NativeWebpackPlugin {
                 [REQUIRE_VSCODE_WINDOWS_CA_CERTS]: windowsCaCertsFile,
                 [REQUIRE_PARCEL_WATCHER]: issuer => Promise.resolve(findNativeWatcherFile(issuer))
             };
+            if (process.platform !== 'win32') {
+                // The expected conpty.node file is not available on non-windows platforms during build.
+                // We need to provide a stub that will be replaced by the real file at runtime.
+                replacements[REQUIRE_NODE_PTY_CONPTY] = () => buildFile(directory, 'conpty.js', conhostWindowsReplacement());
+            }
         });
         compiler.hooks.normalModuleFactory.tap(
             NativeWebpackPlugin.name,
@@ -208,3 +214,7 @@ ${cases.join(os.EOL)}
     throw new Error(\`unhandled module: "\${jsModule}"\`);
 }`.trim();
 };
+
+const conhostWindowsReplacement = (nativePath: string = '.'): string => `
+module.exports = __non_webpack_require__('${nativePath}/native/conpty.node');
+`;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR addresses an [issue](https://github.com/eclipse-theia/theia/issues/14348#issuecomment-2500722794) where from a linux client connecting to a windows server with by ssh, you cannot open terminals. This is because the node-pty module that we rely on to create terminals is compiled in a platform specific way, so when the node backend is copied onto the server, an incorrect version of node-pty is provided. For some reason, this does not cause issues making the reverse connection, from a windows client to a linux server.

To fix this, we do a webpack exclude so that the node-pty module is resolved at run-time instead of at compile time, and as part of the server setup we install node-pty so a correct version will be available for the server's platform. We don't exclude node-pty when not connected to a server. Otherwise, additional care would need to be taken when creating a theia extension to ensure any generated appimages include the node-pty module, and that a remote, which would then have two copies of the module, resolve the correct one.

#### How to test

To reproduce the issue, connect from a linux client to a windows server, and attempt to open an ide terminal. Any other client-server combination should still work. I have tested linux-linux, linux-windows, windows-linux, and windows-windows, but have don't have access to any systems running macos. When connecting to a server twice with different builds, make sure to delete the `.theia-example-electron-1.60.0-remote` folder.

#### Follow-ups

The current implementation is somewhat complex. Suggestions would be appreciated, but at the moment I don't see a way to simplify it.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
