### PR TITLE
feat(hover-service) make hover-service use platform showPopover()

### DIFF
--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -92,6 +92,7 @@ export class HoverService {
             this._hoverHost = document.createElement('div');
             this._hoverHost.classList.add(HoverService.hostClassName);
             this._hoverHost.style.position = 'absolute';
+            this._hoverHost.setAttribute('popover', 'hint');
         }
         return this._hoverHost;
     }
@@ -138,6 +139,9 @@ export class HoverService {
         host.style.left = '0px';
         host.style.top = '0px';
         document.body.append(host);
+        if (!host.matches(':popover-open')) {
+            host.showPopover();
+        }
 
         if (request.visualPreview) {
             // If just a string is being rendered use the size of the outer box
@@ -219,6 +223,9 @@ export class HoverService {
     }
 
     protected unRenderHover(): void {
+        if (this.hoverHost.matches(':popover-open')) {
+            this.hoverHost.hidePopover();
+        }
         this.hoverHost.remove();
         this.hoverHost.replaceChildren();
     }

--- a/packages/core/src/browser/style/hover-service.css
+++ b/packages/core/src/browser/style/hover-service.css
@@ -31,7 +31,7 @@
   max-width: var(--theia-hover-max-width);
 }
 
-/* user agent style-sheet has overflow:hidden, so pointer is not visible but scroll is */
+/* overwrite potentially different default user agent styles */
 .theia-hover[popover] {
   inset: unset;
   overflow: visible;

--- a/packages/core/src/browser/style/hover-service.css
+++ b/packages/core/src/browser/style/hover-service.css
@@ -29,7 +29,12 @@
   border: 1px solid var(--theia-editorHoverWidget-border);
   padding: var(--theia-ui-padding);
   max-width: var(--theia-hover-max-width);
-  z-index: 1000;
+}
+
+/* user agent style-sheet has overflow:hidden, so pointer is not visible but scroll is */
+.theia-hover[popover] {
+  inset: unset;
+  overflow: visible;
 }
 
 .theia-hover .hover-row:not(:first-child):not(:empty) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Prevents any z-index problems for hovers/

It makes HoverService use web platform `[popover='hint']`.
Which it turn puts them on "top-layer"
Popover API is baseline available now and some of us use it.
https://developer.mozilla.org/en-US/docs/Web/API/Popover_API

HoverService popovers had no chance of being on top of "true" popovers.
This PR addresses just that.
Screenshot of browser-only example with this change in place:

![image](https://github.com/user-attachments/assets/33a37ed1-3088-4052-b53d-b238fc7baa64)


Bonus: It also allows to close such popovers with "Escape"

#### How to test

HoverService popovers should be visible and on top of everything else.


#### Follow-ups

Someday when options for showPopover() will be baseline available it would be possible to position them declaratively to target. So code that calculates position could be thrown away.
It is available in chromium based browsers already.
![image](https://github.com/user-attachments/assets/26fb12ed-b76e-4b68-b16e-0557e535e730)

#### Attribution

on behalf of web standards and performance 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
