### PR TITLE
Allow workspace specific custom agents

### DIFF
--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -202,9 +202,19 @@ export interface PromptCustomizationService {
     readonly onDidChangeCustomAgents: Event<void>;
 
     /**
-     * Open the custom agent yaml file.
+     * Returns all locations of existing customAgents.yml files and potential locations where
+     * new customAgents.yml files could be created.
+     *
+     * @returns An array of objects containing the URI and whether the file exists
      */
-    openCustomAgentYaml(): void;
+    getCustomAgentsLocations(): Promise<{ uri: URI, exists: boolean }[]>;
+
+    /**
+     * Opens an existing customAgents.yml file at the given URI, or creates a new one if it doesn't exist.
+     *
+     * @param uri The URI of the customAgents.yml file to open or create
+     */
+    openCustomAgentYaml(uri: URI): Promise<void>;
 }
 
 @injectable()


### PR DESCRIPTION
fixed #15456

#### What it does

Allows workspace specific agents.
If workspace specific prompt locations are configured, the user can choose now whether to use the global prompt directory or a workspace directory for adding a custom agent. Workspace specific custom agents win. Within workspace locations, the first one loaded wins.

#### How to test

Add a project specific prompt directory (settings prompt templates)
Click on "Add custom agent" in the AI configuration view
Choose where you want to add the agent, it should show two locations now
Check that workspace specific custom agents "win"
Check updates when modifying, deleting and adding files.

#### Follow-ups

@sgraband Do you consider custom agents in your new view already?

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
