### PR TITLE
Improve handling of logging with proxies

### DIFF
--- a/packages/core/src/common/messaging/proxy-factory.ts
+++ b/packages/core/src/common/messaging/proxy-factory.ts
@@ -237,6 +237,10 @@ export class RpcProxyFactory<T extends object> implements ProxyHandler<T> {
             // Prevent inversify from identifying this proxy as a promise object.
             return undefined;
         }
+        if (p === 'toJSON') {
+            // Prevent packr from attempting to serialize proxies with `toJSON`.
+            return undefined;
+        }
         const isNotify = this.isNotification(p);
         return (...args: any[]) => {
             const method = p.toString();
@@ -333,4 +337,3 @@ export class JsonRpcProxyFactory<T extends object> extends RpcProxyFactory<T> {
 decorate(injectable(), JsonRpcProxyFactory);
 // eslint-disable-next-line deprecation/deprecation
 decorate(unmanaged(), JsonRpcProxyFactory, 0);
-


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

`packr` will attempt to use `toJSON` to serialize an object if sees that `toJSON` is defined. That means that if an object is logged that includes a reference to an RPC proxy, `packr` will attempt to call `toJSON`, and a type error will be logged if the remote target does not implement `toJSON` (even if it does, `packr` isn't expecting a `Promise`!). This PR returns `undefined` when `toJSON` is requested from a proxy to prevent `packr` from attempting to use that method to serialize the object.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Attempt to log an object with a reference to a proxy (e.g. the `FileService`)
2. Observe that the log appears successfully on the frontend.
3. Observe that no error is thrown indicating that `this.target[method] is not a function`
> The log won't appear on the backend because the object couldn't be serialized, but that is the usual behavior when logging anything that doesn't serialize cleanly.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

> [!NOTE]
> Since `toJSON` is JS API, proxies generally shouldn't implement it, and I don't see any cases where it is included in an interface in the repo. But an adopter could have defined that method in something they proxy, and it would now fail.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
