### PR TITLE
Only call resolve() on tasks that have no execution

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1621,7 +1621,7 @@ export interface CommandProperties {
 export type TaskGroupKind = 'build' | 'test' | 'rebuild' | 'clean';
 export interface TaskDto {
     type: string;
-    taskType?: 'shell' | 'process' | 'customExecution'; // the task execution type
+    executionType?: 'shell' | 'process' | 'customExecution'; // the task execution type
     executionId?: string,
     label: string;
     source?: string;

--- a/packages/plugin-ext/src/plugin/tasks/task-provider.ts
+++ b/packages/plugin-ext/src/plugin/tasks/task-provider.ts
@@ -46,7 +46,7 @@ export class TaskProviderAdapter {
         }
 
         const item = Converter.toTask(task);
-        if (!item) {
+        if (!item || item.execution) {
             return task;
         }
 

--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -163,7 +163,7 @@ export class TasksExtImpl implements TasksExt {
         if (adapter) {
             return adapter.provideTasks(CancellationToken.None).then(tasks => {
                 for (const task of tasks) {
-                    if (task.taskType === 'customExecution') {
+                    if (task.executionType === 'customExecution') {
                         this.applyCustomExecution(task);
                     }
                 }
@@ -179,8 +179,8 @@ export class TasksExtImpl implements TasksExt {
         if (adapter) {
             return adapter.resolveTask(task, token).then(resolvedTask => {
                 // ensure we do not lose task type and execution id during resolution as we need it for custom execution
-                resolvedTask.taskType = resolvedTask.taskType ?? task.taskType;
-                if (resolvedTask.taskType === 'customExecution') {
+                resolvedTask.executionType = resolvedTask.executionType ?? task.executionType;
+                if (resolvedTask.executionType === 'customExecution') {
                     this.applyCustomExecution(resolvedTask);
                 }
                 return resolvedTask;

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -188,7 +188,7 @@ describe('Type converters:', () => {
 
         const shellTaskDto: TaskDto = {
             type: shellType,
-            taskType: shellType,
+            executionType: shellType,
             label,
             source,
             scope: 1,
@@ -211,7 +211,7 @@ describe('Type converters:', () => {
 
         const shellTaskDtoWithCommandLine: TaskDto = {
             type: shellType,
-            taskType: shellType,
+            executionType: shellType,
             label,
             source,
             scope: 2,

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -983,7 +983,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
         throw new Error('Task should be provided for converting');
     }
 
-    const { type, taskType, label, source, scope, problemMatcher, detail, command, args, options, group, presentation, runOptions, ...properties } = taskDto;
+    const { type, executionType, label, source, scope, problemMatcher, detail, command, args, options, group, presentation, runOptions, ...properties } = taskDto;
     const result = {} as theia.Task;
     result.name = label;
     result.source = source;
@@ -1008,16 +1008,16 @@ export function toTask(taskDto: TaskDto): theia.Task {
 
     result.definition = taskDefinition;
 
-    if (taskType === 'process') {
+    if (executionType === 'process') {
         result.execution = getProcessExecution(taskDto);
     }
 
     const execution = { command, args, options };
-    if (taskType === 'shell' || types.ShellExecution.is(execution)) {
+    if (executionType === 'shell' || types.ShellExecution.is(execution)) {
         result.execution = getShellExecution(taskDto);
     }
 
-    if (taskType === 'customExecution' || types.CustomExecution.is(execution)) {
+    if (executionType === 'customExecution' || types.CustomExecution.is(execution)) {
         result.execution = getCustomExecution(taskDto);
         // if taskType is customExecution, we need to put all the information into taskDefinition,
         // because some parameters may be in taskDefinition.
@@ -1053,7 +1053,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
 }
 
 export function fromProcessExecution(execution: theia.ProcessExecution, taskDto: TaskDto): TaskDto {
-    taskDto.taskType = 'process';
+    taskDto.executionType = 'process';
     taskDto.command = execution.process;
     taskDto.args = execution.args;
 
@@ -1065,7 +1065,7 @@ export function fromProcessExecution(execution: theia.ProcessExecution, taskDto:
 }
 
 export function fromShellExecution(execution: theia.ShellExecution, taskDto: TaskDto): TaskDto {
-    taskDto.taskType = 'shell';
+    taskDto.executionType = 'shell';
     const options = execution.options;
     if (options) {
         taskDto.options = getShellExecutionOptions(options);
@@ -1087,7 +1087,7 @@ export function fromShellExecution(execution: theia.ShellExecution, taskDto: Tas
 }
 
 export function fromCustomExecution(execution: types.CustomExecution, taskDto: TaskDto): TaskDto {
-    taskDto.taskType = 'customExecution';
+    taskDto.executionType = 'customExecution';
     const callback = execution.callback;
     if (callback) {
         taskDto.callback = callback;

--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -42,7 +42,7 @@ export class ProcessTaskResolver implements TaskResolver {
      * sane default values. Also, resolve all known variables, e.g. `${workspaceFolder}`.
      */
     async resolveTask(taskConfig: TaskConfiguration): Promise<TaskConfiguration> {
-        const type = taskConfig.taskType || taskConfig.type;
+        const type = taskConfig.executionType || taskConfig.type;
         if (type !== 'process' && type !== 'shell') {
             throw new Error('Unsupported task configuration type.');
         }

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -753,7 +753,7 @@ export class TaskService implements TaskConfigurationClient {
         try {
             // resolve problemMatchers
             if (!option && task.problemMatcher) {
-                const customizationObject: TaskCustomization = { type: task.taskType, problemMatcher: task.problemMatcher, runOptions: task.runOptions };
+                const customizationObject: TaskCustomization = { type: task.type, problemMatcher: task.problemMatcher, runOptions: task.runOptions };
                 const resolvedMatchers = await this.resolveProblemMatchers(task, customizationObject);
                 option = {
                     customization: { ...customizationObject, ...{ problemMatcher: resolvedMatchers } }
@@ -840,7 +840,7 @@ export class TaskService implements TaskConfigurationClient {
         try {
             const resolver = await this.taskResolverRegistry.getTaskResolver(task.type);
             const resolvedTask = resolver ? await resolver.resolveTask(task) : task;
-            const executionResolver = this.taskResolverRegistry.getExecutionResolver(resolvedTask.taskType || resolvedTask.type);
+            const executionResolver = this.taskResolverRegistry.getExecutionResolver(resolvedTask.executionType || resolvedTask.type);
             overridePropertiesFunction(resolvedTask);
             const taskToRun = executionResolver ? await executionResolver.resolveTask(resolvedTask) : resolvedTask;
 

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -178,6 +178,7 @@ export interface TaskConfiguration extends TaskCustomization {
     /** A label that uniquely identifies a task configuration per source */
     readonly label: string;
     readonly _scope: TaskConfigurationScope;
+    readonly executionType?: 'shell' | 'process' | 'customExecution';
 }
 
 export interface ContributedTaskConfiguration extends TaskConfiguration {

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -95,7 +95,7 @@ export class ProcessTaskRunner implements TaskRunner {
                 });
             });
 
-            const processType = (taskConfig.taskType || taskConfig.type) as 'process' | 'shell';
+            const processType = (taskConfig.executionType || taskConfig.type) as 'process' | 'shell';
             return this.taskFactory({
                 label: taskConfig.label,
                 process: terminal,
@@ -135,7 +135,7 @@ export class ProcessTaskRunner implements TaskRunner {
          */
         let commandLine: string | undefined;
 
-        if ((taskConfig.taskType || taskConfig.type) === 'shell') {
+        if ((taskConfig.executionType || taskConfig.type) === 'shell') {
             // When running a shell task, we have to spawn a shell process somehow,
             // and tell it to run the command the user wants to run inside of it.
             //

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -90,7 +90,9 @@ export class TaskServerImpl implements TaskServer, Disposable {
     }
 
     async run(taskConfiguration: TaskConfiguration, ctx?: string, option?: RunTaskOption): Promise<TaskInfo> {
-        const runner = this.runnerRegistry.getRunner(taskConfiguration.type, taskConfiguration.taskType);
+        const runner = taskConfiguration.executionType ?
+            this.runnerRegistry.getRunner(taskConfiguration.type, taskConfiguration.executionType) :
+            this.runnerRegistry.getRunner(taskConfiguration.type);
         const task = await runner.run(taskConfiguration, ctx);
 
         if (!this.toDispose.has(task.id)) {


### PR DESCRIPTION
#### What it does
Do not call resolve on tasks that already have an execution set. Also renames the field `taskType` to `executionType` because it's less confusing. 

Fixes #15171


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Make sure the scenario from the related issue works. Also check that tasks like npm or custom tasks ("shell") still work as before.


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
