### PR TITLE
Clarify error for multiple occurences during replace

### DIFF
--- a/packages/core/src/common/content-replacer.spec.ts
+++ b/packages/core/src/common/content-replacer.spec.ts
@@ -63,7 +63,7 @@ describe('ContentReplacer', () => {
         ];
         const result = contentReplacer.applyReplacements(originalContent, replacements);
         expect(result.updatedContent).to.equal(originalContent);
-        expect(result.errors).to.include('Multiple occurrences found for: "Repeat"');
+        expect(result.errors.some(candidate => candidate.startsWith('Multiple occurrences found for: "Repeat"'))).to.be.true;
     });
 
     it('should prepend newContent when oldContent is an empty string', () => {
@@ -108,7 +108,7 @@ describe('ContentReplacer', () => {
         ];
         const result = contentReplacer.applyReplacements(originalContent, replacements);
         expect(result.updatedContent).to.equal(originalContent);
-        expect(result.errors).to.include('Multiple occurrences found for: "Repeat"');
+        expect(result.errors.some(candidate => candidate.startsWith('Multiple occurrences found for: "Repeat"'))).to.be.true;
     });
 
     it('should return an error when conflicting replacements for the same oldContent are provided', () => {

--- a/packages/core/src/common/content-replacer.ts
+++ b/packages/core/src/common/content-replacer.ts
@@ -60,7 +60,8 @@ export class ContentReplacer {
                 if (multiple) {
                     updatedContent = this.replaceContentAll(updatedContent, oldContent, newContent);
                 } else {
-                    errorMessages.push(`Multiple occurrences found for: "${oldContent}"`);
+                    errorMessages.push(`Multiple occurrences found for: "${oldContent}". Set 'multiple' to true if multiple occurrences of the oldContent are expected to be\
+                         replaced at once.`);
                 }
             } else {
                 updatedContent = this.replaceContentOnce(updatedContent, oldContent, newContent);


### PR DESCRIPTION
#### What it does

Clarifies the error message when multiple occurrences are found, but the flag "multiple" is not set

#### How to test

The following prompt should work with replace (typically it tries it without mutliple first)

@Coder Rename the function toOpenAIMessage in packages/ai-openai/src/node/openai-language-model.ts to convertToOpenAIMessage

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
