### PR TITLE
Introduce experimental generic LLM provider via Vercel AI

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -37,6 +37,7 @@
     "@theia/ai-openai": "1.61.0",
     "@theia/ai-scanoss": "1.61.0",
     "@theia/ai-terminal": "1.61.0",
+    "@theia/ai-vercel-ai": "1.61.0",
     "@theia/api-provider-sample": "1.61.0",
     "@theia/api-samples": "1.61.0",
     "@theia/bulk-edit": "1.61.0",

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -57,6 +57,9 @@
       "path": "../../packages/ai-terminal"
     },
     {
+      "path": "../../packages/ai-vercel-ai"
+    },
+    {
       "path": "../../packages/bulk-edit"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -468,6 +468,7 @@
         "@theia/ai-openai": "1.61.0",
         "@theia/ai-scanoss": "1.61.0",
         "@theia/ai-terminal": "1.61.0",
+        "@theia/ai-vercel-ai": "1.61.0",
         "@theia/api-provider-sample": "1.61.0",
         "@theia/api-samples": "1.61.0",
         "@theia/bulk-edit": "1.61.0",
@@ -703,6 +704,121 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.10.tgz",
+      "integrity": "sha512-PyE7EC2fPjs9DnzRAHDrPQmcnI2m2Eojr8pfhckOejOlDEh2w7NnSJr1W3qe5hUWzKr+6d7NG1ZKR9fhmpDdEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.7.tgz",
+      "integrity": "sha512-kM0xS3GWg3aMChh9zfeM+80vEZfXzR3JEUBdycZLtbRZ2TRT8xOj3WodGHPb06sUK5yD7pAXC/P7ctsi2fvUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.2.tgz",
+      "integrity": "sha512-ITdgNilJZwLKR7X5TnUr1BsQW6UTX5yFp0h66Nfx8XjBYkWD9W3yugr50GOz3CnE9m/U/Cd5OyEbTMI0rgi6ZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.6.tgz",
+      "integrity": "sha512-sUlZ7Gnq84DCGWMQRIK8XVbkzIBnvPR1diV4v6JwPgpn5armnLI/j+rqn62MpLrU5ZCQZlDKl/Lw6ed3ulYqaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.2",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-S2FzCSi4uTF0JuSN6zYMXyiAWVAzi/Hho8ISYgHpGZiICYLNCP2si4DuXQOsnWef3IXzQPLVoE11C63lILZIkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.6",
+        "@ai-sdk/ui-utils": "1.2.7",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.7.tgz",
+      "integrity": "sha512-OVRxa4SDj0wVsMZ8tGr/whT89oqNtNoXBKmqWC2BRv5ZG6azL2LYZ5ZK35u3lb4l1IE7cWGsLlmq0py0ttsL7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.2",
+        "@ai-sdk/provider-utils": "2.2.6",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4485,6 +4601,15 @@
         "@octokit/openapi-types": "^18.0.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
@@ -5608,6 +5733,10 @@
       "resolved": "packages/ai-terminal",
       "link": true
     },
+    "node_modules/@theia/ai-vercel-ai": {
+      "resolved": "packages/ai-vercel-ai",
+      "link": true
+    },
     "node_modules/@theia/api-provider-sample": {
       "resolved": "examples/api-provider-sample",
       "link": true
@@ -6059,6 +6188,12 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
       "integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
       "license": "MIT"
     },
     "node_modules/@types/docker-modem": {
@@ -9764,6 +9899,15 @@
         "devtools-protocol": "*"
       }
     },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -11507,7 +11651,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11579,6 +11722,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -17224,6 +17373,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -17286,6 +17441,35 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
       "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
       "license": "MIT"
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -25110,6 +25294,12 @@
       "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "license": "MIT"
     },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
@@ -26936,6 +27126,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -27251,6 +27454,18 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -28944,6 +29159,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -30263,12 +30487,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/zwitch": {
@@ -30561,15 +30794,6 @@
         "@theia/ext-scripts": "1.61.0"
       }
     },
-    "packages/ai-terminal/node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "packages/ai-terminal/node_modules/zod-to-json-schema": {
       "version": "3.24.5",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
@@ -30577,6 +30801,103 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "packages/ai-vercel-ai": {
+      "name": "@theia/ai-vercel-ai",
+      "version": "1.61.0",
+      "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^1.2.10",
+        "@ai-sdk/openai": "^1.3.21",
+        "@ai-sdk/provider": "^1.1.3",
+        "@theia/ai-core": "1.61.0",
+        "@theia/core": "1.61.0",
+        "@theia/filesystem": "1.61.0",
+        "@theia/workspace": "1.61.0",
+        "ai": "^4.3.13",
+        "tslib": "^2.6.2"
+      },
+      "devDependencies": {
+        "@theia/ext-scripts": "1.61.0"
+      }
+    },
+    "packages/ai-vercel-ai/node_modules/@ai-sdk/openai": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.10.tgz",
+      "integrity": "sha512-XO0wF2lmAMWCYjkM5bLpWTKoXet61fBiIimTi+blqEGiLUjAvivt/1zZL1Lzhrv9+p19IC1rn9EWZI1dCelV8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.2",
+        "@ai-sdk/provider-utils": "2.2.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "packages/ai-vercel-ai/node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.2.tgz",
+      "integrity": "sha512-ITdgNilJZwLKR7X5TnUr1BsQW6UTX5yFp0h66Nfx8XjBYkWD9W3yugr50GOz3CnE9m/U/Cd5OyEbTMI0rgi6ZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ai-vercel-ai/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ai-vercel-ai/node_modules/ai": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.5.tgz",
+      "integrity": "sha512-hxJ+6YCdGOK1MVPGITmz1if+LXR/aW72w8TI8kiV+3R7lpK1hfpApR8EjqN2ag6cWa0R7OEI3gb/srWkQ3hT2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.2",
+        "@ai-sdk/provider-utils": "2.2.6",
+        "@ai-sdk/react": "1.2.8",
+        "@ai-sdk/ui-utils": "1.2.7",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-vercel-ai/node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.2.tgz",
+      "integrity": "sha512-ITdgNilJZwLKR7X5TnUr1BsQW6UTX5yFp0h66Nfx8XjBYkWD9W3yugr50GOz3CnE9m/U/Cd5OyEbTMI0rgi6ZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/bulk-edit": {

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -409,7 +409,7 @@ export abstract class AbstractStreamParsingChatAgent extends AbstractChatAgent {
                     request.response.response.addContent(newContent);
                 }
                 // And reset the marker index and the text buffer as we skip matching across non-text tokens
-                startIndex = request.response.response.content.length - 1;
+                startIndex = request.response.response.content.length;
                 completeTextBuffer = '';
             } else {
                 // parse the entire text so far (since beginning of the stream or last non-text token)

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -1516,6 +1516,8 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
         if (nextChatResponseContent.id === this.id) {
             this._finished = nextChatResponseContent.finished;
             this._result = nextChatResponseContent.result;
+            const args = nextChatResponseContent.arguments;
+            this._arguments = (args && args.length > 0) ? args : this._arguments;
             return true;
         }
         if (nextChatResponseContent.name !== undefined) {

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -74,7 +74,7 @@ export const isLanguageModelRequestMessage = (obj: unknown): obj is LanguageMode
     );
 
 export interface ToolRequestParameterProperty {
-    type?: string;
+    type?: | 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array' | 'null';
     anyOf?: ToolRequestParameterProperty[];
     [key: string]: unknown;
 }

--- a/packages/ai-vercel-ai/.eslintrc.js
+++ b/packages/ai-vercel-ai/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/packages/ai-vercel-ai/package.json
+++ b/packages/ai-vercel-ai/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@theia/ai-vercel-ai",
+  "version": "1.61.0",
+  "description": "Theia - Vercel AI SDK Integration",
+  "dependencies": {
+    "@theia/ai-core": "1.61.0",
+    "@theia/core": "1.61.0",
+    "@theia/filesystem": "1.61.0",
+    "@theia/workspace": "1.61.0",
+    "ai": "^4.3.13",
+    "@ai-sdk/provider": "^1.1.3",
+    "@ai-sdk/openai": "^1.3.21",
+    "@ai-sdk/anthropic": "^1.2.10",
+    "tslib": "^2.6.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/vercel-ai-frontend-module",
+      "backend": "lib/node/vercel-ai-backend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.61.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/ai-vercel-ai/src/browser/vercel-ai-frontend-application-contribution.ts
+++ b/packages/ai-vercel-ai/src/browser/vercel-ai-frontend-application-contribution.ts
@@ -1,0 +1,196 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution, PreferenceService, PreferenceChange } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { VercelAiLanguageModelsManager, VercelAiModelDescription, VercelAiProvider } from '../common';
+import { ANTHROPIC_API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF, OPENAI_API_KEY_PREF, VERCEL_AI_PROVIDER_ID } from './vercel-ai-preferences';
+
+interface ModelConfig {
+    id: string;
+    model: string;
+    provider: VercelAiProvider;
+}
+
+@injectable()
+export class VercelAiFrontendApplicationContribution implements FrontendApplicationContribution {
+
+    @inject(PreferenceService)
+    protected preferenceService: PreferenceService;
+
+    @inject(VercelAiLanguageModelsManager)
+    protected manager: VercelAiLanguageModelsManager;
+
+    onStart(): void {
+        this.preferenceService.ready.then(() => {
+            // Set up provider-specific API keys
+            const openaiApiKey = this.preferenceService.get<string>(OPENAI_API_KEY_PREF, undefined);
+            const anthropicApiKey = this.preferenceService.get<string>(ANTHROPIC_API_KEY_PREF, undefined);
+
+            // Set provider configs
+            if (openaiApiKey) {
+                this.manager.setProviderConfig('openai', { provider: 'openai', apiKey: openaiApiKey });
+            }
+
+            if (anthropicApiKey) {
+                this.manager.setProviderConfig('anthropic', { provider: 'anthropic', apiKey: anthropicApiKey });
+            }
+
+            // Initial setup of models
+            const models = this.preferenceService.get<ModelConfig[]>(MODELS_PREF, []);
+            this.manager.createOrUpdateLanguageModels(...models.map(model => this.createVercelAiModelDescription(model)));
+
+            const customModels = this.preferenceService.get<Partial<VercelAiModelDescription>[]>(CUSTOM_ENDPOINTS_PREF, []);
+            this.manager.createOrUpdateLanguageModels(...this.createCustomModelDescriptionsFromPreferences(customModels));
+
+            // Set up listeners for preference changes
+            this.preferenceService.onPreferenceChanged(this.handlePreferenceChange.bind(this));
+        });
+    }
+
+    protected handlePreferenceChange(event: PreferenceChange): void {
+        switch (event.preferenceName) {
+            case OPENAI_API_KEY_PREF:
+                this.manager.setProviderConfig('openai', { provider: 'openai', apiKey: event.newValue });
+                break;
+            case ANTHROPIC_API_KEY_PREF:
+                this.manager.setProviderConfig('anthropic', { provider: 'anthropic', apiKey: event.newValue });
+                break;
+            case MODELS_PREF:
+                this.handleModelChanges(event);
+                break;
+            case CUSTOM_ENDPOINTS_PREF:
+                this.handleCustomModelChanges(event);
+                break;
+        }
+    }
+
+    protected handleModelChanges(event: PreferenceChange): void {
+        const newModels = this.ensureModelConfigArray(event.newValue);
+        const oldModels = this.ensureModelConfigArray(event.oldValue);
+
+        const oldModelIds = new Set(oldModels.map(m => m.id));
+        const newModelIds = new Set(newModels.map(m => m.id));
+
+        const modelsToRemove = [...oldModelIds].filter(modelId => !newModelIds.has(modelId));
+        const modelsToAdd = newModels.filter(model => !oldModelIds.has(model.id));
+
+        this.manager.removeLanguageModels(...modelsToRemove);
+        this.manager.createOrUpdateLanguageModels(...modelsToAdd.map(model => this.createVercelAiModelDescription(model)));
+    }
+
+    protected handleCustomModelChanges(event: PreferenceChange): void {
+        const newCustomModels = this.ensureCustomModelArray(event.newValue);
+        const oldCustomModels = this.ensureCustomModelArray(event.oldValue);
+
+        const oldModels = this.createCustomModelDescriptionsFromPreferences(oldCustomModels);
+        const newModels = this.createCustomModelDescriptionsFromPreferences(newCustomModels);
+
+        const modelsToRemove = oldModels.filter(model => !newModels.some(newModel => newModel.id === model.id));
+        const modelsToAddOrUpdate = newModels.filter(newModel =>
+            !oldModels.some(model =>
+                model.id === newModel.id &&
+                model.model === newModel.model &&
+                model.url === newModel.url &&
+                model.apiKey === newModel.apiKey &&
+                model.supportsStructuredOutput === newModel.supportsStructuredOutput &&
+                model.enableStreaming === newModel.enableStreaming &&
+                model.provider === newModel.provider));
+
+        this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
+        this.manager.createOrUpdateLanguageModels(...modelsToAddOrUpdate);
+    }
+
+    protected ensureModelConfigArray(value: unknown): ModelConfig[] {
+        if (!value || !Array.isArray(value)) {
+            return [];
+        }
+
+        return value.filter(item =>
+            item &&
+            typeof item === 'object' &&
+            'id' in item &&
+            'model' in item &&
+            'provider' in item &&
+            typeof item.id === 'string' &&
+            typeof item.model === 'string' &&
+            (typeof item.provider === 'string' || item.provider === undefined)
+        ) as ModelConfig[];
+    }
+
+    protected ensureCustomModelArray(value: unknown): Partial<VercelAiModelDescription>[] {
+        if (!value || !Array.isArray(value)) {
+            return [];
+        }
+
+        return value.filter(item =>
+            item &&
+            typeof item === 'object'
+        ) as Partial<VercelAiModelDescription>[];
+    }
+
+    protected createVercelAiModelDescription(modelInfo: ModelConfig): VercelAiModelDescription {
+        // The model ID already includes the 'vercel' prefix from preferences
+        return {
+            id: modelInfo.id,
+            model: modelInfo.model,
+            provider: modelInfo.provider,
+            apiKey: true,
+            enableStreaming: true,
+            supportsStructuredOutput: modelsSupportingStructuredOutput.includes(modelInfo.model)
+        };
+    }
+
+    protected createCustomModelDescriptionsFromPreferences(
+        preferences: Partial<VercelAiModelDescription>[]
+    ): VercelAiModelDescription[] {
+        return preferences.reduce((acc, pref) => {
+            if (!pref.model || !pref.url || typeof pref.model !== 'string' || typeof pref.url !== 'string') {
+                return acc;
+            }
+
+            // Ensure custom model IDs have the 'vercel' prefix
+            const modelId = pref.id && typeof pref.id === 'string' ? pref.id : pref.model;
+            const prefixedId = modelId.startsWith('vercel/') ? modelId : `${VERCEL_AI_PROVIDER_ID}/${modelId}`;
+
+            return [
+                ...acc,
+                {
+                    id: prefixedId,
+                    model: pref.model,
+                    url: pref.url,
+                    provider: pref.provider || 'openai',
+                    apiKey: typeof pref.apiKey === 'string' || pref.apiKey === true ? pref.apiKey : undefined,
+                    supportsStructuredOutput: pref.supportsStructuredOutput ?? true,
+                    enableStreaming: pref.enableStreaming ?? true
+                }
+            ];
+        }, []);
+    }
+}
+
+// List of models that support structured output via JSON schema
+const modelsSupportingStructuredOutput = [
+    'gpt-4.1',
+    'gpt-4.1-mini',
+    'gpt-4.1-nano',
+    'gpt-4o',
+    'gpt-4o-mini',
+    'gpt-4-turbo',
+    'claude-3-7-sonnet-20250219',
+    'claude-3-5-haiku-20241022',
+    'claude-3-opus-20240229'
+];

--- a/packages/ai-vercel-ai/src/browser/vercel-ai-frontend-module.ts
+++ b/packages/ai-vercel-ai/src/browser/vercel-ai-frontend-module.ts
@@ -1,0 +1,31 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { VercelAiPreferencesSchema } from './vercel-ai-preferences';
+import { FrontendApplicationContribution, PreferenceContribution, RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
+import { VercelAiFrontendApplicationContribution } from './vercel-ai-frontend-application-contribution';
+import { VERCEL_AI_LANGUAGE_MODELS_MANAGER_PATH, VercelAiLanguageModelsManager } from '../common';
+
+export default new ContainerModule(bind => {
+    bind(PreferenceContribution).toConstantValue({ schema: VercelAiPreferencesSchema });
+    bind(VercelAiFrontendApplicationContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(VercelAiFrontendApplicationContribution);
+    bind(VercelAiLanguageModelsManager).toDynamicValue(ctx => {
+        const provider = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);
+        return provider.createProxy<VercelAiLanguageModelsManager>(VERCEL_AI_LANGUAGE_MODELS_MANAGER_PATH);
+    }).inSingletonScope();
+});

--- a/packages/ai-vercel-ai/src/browser/vercel-ai-preferences.ts
+++ b/packages/ai-vercel-ai/src/browser/vercel-ai-preferences.ts
@@ -1,0 +1,137 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceSchema } from '@theia/core/lib/browser/preferences/preference-contribution';
+import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/browser/ai-core-preferences';
+import { nls } from '@theia/core';
+
+export const OPENAI_API_KEY_PREF = 'ai-features.vercelAi.openaiApiKey';
+export const ANTHROPIC_API_KEY_PREF = 'ai-features.vercelAi.anthropicApiKey';
+export const MODELS_PREF = 'ai-features.vercelAi.officialModels';
+export const CUSTOM_ENDPOINTS_PREF = 'ai-features.vercelAi.customModels';
+
+export const VERCEL_AI_PROVIDER_ID = 'vercel-ai';
+
+export const VercelAiPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        [OPENAI_API_KEY_PREF]: {
+            type: 'string',
+            markdownDescription: nls.localize('theia/ai/vercelai/openaiApiKey/mdDescription',
+                'Enter an API Key for OpenAI models. **Please note:** By using this preference the API key will be stored in clear text \
+on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to set the key securely.'),
+            title: AI_CORE_PREFERENCES_TITLE,
+        },
+        [ANTHROPIC_API_KEY_PREF]: {
+            type: 'string',
+            markdownDescription: nls.localize('theia/ai/vercelai/anthropicApiKey/mdDescription',
+                'Enter an API Key for Anthropic models. **Please note:** By using this preference the API key will be stored in clear text \
+on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` to set the key securely.'),
+            title: AI_CORE_PREFERENCES_TITLE,
+        },
+        [MODELS_PREF]: {
+            type: 'array',
+            description: nls.localize('theia/ai/vercelai/models/description', 'Official models to use with Vercel AI SDK'),
+            title: AI_CORE_PREFERENCES_TITLE,
+            default: [
+                { id: 'vercel/openai/gpt-4.1', model: 'gpt-4.1', provider: 'openai' },
+                { id: 'vercel/openai/gpt-4.1-nano', model: 'gpt-4.1-nano', provider: 'openai' },
+                { id: 'vercel/openai/gpt-4.1-mini', model: 'gpt-4.1-mini', provider: 'openai' },
+                { id: 'vercel/openai/gpt-4-turbo', model: 'gpt-4-turbo', provider: 'openai' },
+                { id: 'vercel/openai/gpt-4o', model: 'gpt-4o', provider: 'openai' },
+                { id: 'vercel/openai/gpt-4o-mini', model: 'gpt-4o-mini', provider: 'openai' },
+                { id: 'vercel/anthropic/claude-3-7-sonnet-20250219', model: 'claude-3-7-sonnet-20250219', provider: 'anthropic' },
+                { id: 'vercel/anthropic/claude-3-5-haiku-20241022', model: 'claude-3-5-haiku-20241022', provider: 'anthropic' },
+                { id: 'vercel/anthropic/claude-3-opus-20240229', model: 'claude-3-opus-20240229', provider: 'anthropic' }
+            ],
+            items: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'string',
+                        title: nls.localize('theia/ai/vercelai/models/id/title', 'Model ID')
+                    },
+                    model: {
+                        type: 'string',
+                        title: nls.localize('theia/ai/vercelai/models/model/title', 'Model Name')
+                    },
+                    provider: {
+                        type: 'string',
+                        enum: ['openai', 'anthropic'],
+                        title: nls.localize('theia/ai/vercelai/models/provider/title', 'Provider')
+                    }
+                },
+                required: ['id', 'model', 'provider']
+            }
+        },
+        [CUSTOM_ENDPOINTS_PREF]: {
+            type: 'array',
+            title: AI_CORE_PREFERENCES_TITLE,
+            markdownDescription: nls.localize('theia/ai/vercelai/customEndpoints/mdDescription',
+                'Integrate custom models compatible with the Vercel AI SDK. The required attributes are `model` and `url`.\
+            \n\
+            Optionally, you can\
+            \n\
+            - specify a unique `id` to identify the custom model in the UI. If none is given `model` will be used as `id`.\
+            \n\
+            - provide an `apiKey` to access the API served at the given url. Use `true` to indicate the use of the global API key.\
+            \n\
+            - specify `supportsStructuredOutput: false` to indicate that structured output shall not be used.\
+            \n\
+            - specify `enableStreaming: false` to indicate that streaming shall not be used.\
+            \n\
+            - specify `provider` to indicate which provider the model is from (openai, anthropic).'),
+            default: [],
+            items: {
+                type: 'object',
+                properties: {
+                    model: {
+                        type: 'string',
+                        title: nls.localize('theia/ai/vercelai/customEndpoints/modelId/title', 'Model ID')
+                    },
+                    url: {
+                        type: 'string',
+                        title: nls.localize('theia/ai/vercelai/customEndpoints/url/title', 'The API endpoint where the model is hosted')
+                    },
+                    id: {
+                        type: 'string',
+                        title: nls.localize('theia/ai/vercelai/customEndpoints/id/title', 'A unique identifier which is used in the UI to identify the custom model'),
+                    },
+                    provider: {
+                        type: 'string',
+                        enum: ['openai', 'anthropic'],
+                        title: nls.localize('theia/ai/vercelai/customEndpoints/provider/title', 'Provider')
+                    },
+                    apiKey: {
+                        type: ['string', 'boolean'],
+                        title: nls.localize('theia/ai/vercelai/customEndpoints/apiKey/title',
+                            'Either the key to access the API served at the given url or `true` to use the global API key'),
+                    },
+                    supportsStructuredOutput: {
+                        type: 'boolean',
+                        title: nls.localize('theia/ai/vercelai/customEndpoints/supportsStructuredOutput/title',
+                            'Indicates whether the model supports structured output. `true` by default.'),
+                    },
+                    enableStreaming: {
+                        type: 'boolean',
+                        title: nls.localize('theia/ai/vercelai/customEndpoints/enableStreaming/title',
+                            'Indicates whether the streaming API shall be used. `true` by default.'),
+                    }
+                }
+            }
+        }
+    }
+};

--- a/packages/ai-vercel-ai/src/common/index.ts
+++ b/packages/ai-vercel-ai/src/common/index.ts
@@ -1,0 +1,16 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+export * from './vercel-ai-language-models-manager';

--- a/packages/ai-vercel-ai/src/common/vercel-ai-language-models-manager.ts
+++ b/packages/ai-vercel-ai/src/common/vercel-ai-language-models-manager.ts
@@ -1,0 +1,63 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+export const VERCEL_AI_LANGUAGE_MODELS_MANAGER_PATH = '/services/vercel-ai/language-model-manager';
+
+export type VercelAiProvider = 'openai' | 'anthropic';
+
+export interface VercelAiProviderConfig {
+    provider: VercelAiProvider;
+    apiKey?: string;
+    baseURL?: string;
+}
+
+export interface VercelAiModelDescription {
+    /**
+     * The identifier of the model which will be shown in the UI.
+     */
+    id: string;
+    /**
+     * The model ID as used by the Vercel AI SDK.
+     */
+    model: string;
+    /**
+     * The provider of the model (openai, anthropic, etc.)
+     */
+    provider?: VercelAiProvider;
+    /**
+     * The API base URL where the model is hosted. If not provided the default provider endpoint will be used.
+     */
+    url?: string;
+    /**
+     * The key for the model. If 'true' is provided the global provider API key will be used.
+     */
+    apiKey: string | true | undefined;
+    /**
+     * Controls whether streaming is enabled for this model.
+     */
+    enableStreaming: boolean;
+    /**
+     * Flag to configure whether the model supports structured output. Default is `true`.
+     */
+    supportsStructuredOutput: boolean;
+}
+
+export const VercelAiLanguageModelsManager = Symbol('VercelAiLanguageModelsManager');
+export interface VercelAiLanguageModelsManager {
+    apiKey: string | undefined;
+    setProviderConfig(provider: VercelAiProvider, config: Partial<VercelAiProviderConfig>): void;
+    createOrUpdateLanguageModels(...models: VercelAiModelDescription[]): Promise<void>;
+    removeLanguageModels(...modelIds: string[]): void;
+}

--- a/packages/ai-vercel-ai/src/node/vercel-ai-backend-module.ts
+++ b/packages/ai-vercel-ai/src/node/vercel-ai-backend-module.ts
@@ -1,0 +1,35 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { VERCEL_AI_LANGUAGE_MODELS_MANAGER_PATH, VercelAiLanguageModelsManager } from '../common/vercel-ai-language-models-manager';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core';
+import { VercelAiLanguageModelsManagerImpl } from './vercel-ai-language-models-manager-impl';
+import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
+import { VercelAiLanguageModelFactory } from './vercel-ai-language-model-factory';
+
+const vercelAiConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService, bindFrontendService }) => {
+    bind(VercelAiLanguageModelsManagerImpl).toSelf().inSingletonScope();
+    bind(VercelAiLanguageModelsManager).toService(VercelAiLanguageModelsManagerImpl);
+    bind(VercelAiLanguageModelFactory).toSelf().inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler(VERCEL_AI_LANGUAGE_MODELS_MANAGER_PATH, () => ctx.container.get(VercelAiLanguageModelsManager))
+    ).inSingletonScope();
+});
+
+export default new ContainerModule(bind => {
+    bind(ConnectionContainerModule).toConstantValue(vercelAiConnectionModule);
+});

--- a/packages/ai-vercel-ai/src/node/vercel-ai-language-model-factory.ts
+++ b/packages/ai-vercel-ai/src/node/vercel-ai-language-model-factory.ts
@@ -1,0 +1,82 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { LanguageModelV1 } from '@ai-sdk/provider';
+import { injectable } from '@theia/core/shared/inversify';
+import { VercelAiModelDescription } from '../common';
+
+export type VercelAiProvider = 'openai' | 'anthropic';
+
+export interface VercelAiProviderConfig {
+    provider: VercelAiProvider;
+    apiKey?: string;
+    baseURL?: string;
+}
+
+@injectable()
+export class VercelAiLanguageModelFactory {
+
+    createLanguageModel(modelDescription: VercelAiModelDescription, providerConfig: VercelAiProviderConfig): LanguageModelV1 {
+        const apiKey = this.resolveApiKey(modelDescription, providerConfig);
+        if (!apiKey) {
+            throw new Error(`Please provide an API key for ${providerConfig.provider} in preferences or via environment variable`);
+        }
+
+        const baseURL = modelDescription.url || providerConfig.baseURL;
+
+        switch (providerConfig.provider) {
+            case 'openai':
+                return createOpenAI({
+                    apiKey,
+                    baseURL,
+                    compatibility: 'strict'
+                }).languageModel(modelDescription.model);
+            case 'anthropic':
+                return createAnthropic({
+                    apiKey,
+                    baseURL
+                }).languageModel(modelDescription.model);
+            default:
+                throw new Error(`Unsupported provider: ${providerConfig.provider}`);
+        }
+    }
+
+    private resolveApiKey(modelDescription: VercelAiModelDescription, providerConfig: VercelAiProviderConfig): string | undefined {
+        if (modelDescription.apiKey === true) {
+            return this.getApiKeyBasedOnProvider(providerConfig);
+        }
+        if (modelDescription.apiKey) {
+            return modelDescription.apiKey;
+        }
+        return this.getApiKeyBasedOnProvider(providerConfig);
+    }
+
+    private getApiKeyBasedOnProvider(providerConfig: VercelAiProviderConfig): string | undefined {
+        if (providerConfig.apiKey) {
+            return providerConfig.apiKey;
+        }
+        switch (providerConfig.provider) {
+            case 'openai':
+                return process.env.OPENAI_API_KEY;
+            case 'anthropic':
+                return process.env.ANTHROPIC_API_KEY;
+            default:
+                return undefined;
+        }
+    }
+}

--- a/packages/ai-vercel-ai/src/node/vercel-ai-language-model.ts
+++ b/packages/ai-vercel-ai/src/node/vercel-ai-language-model.ts
@@ -1,0 +1,408 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { LanguageModelV1 } from '@ai-sdk/provider';
+import {
+    LanguageModel,
+    LanguageModelMessage,
+    LanguageModelParsedResponse,
+    LanguageModelRequest,
+    LanguageModelResponse,
+    LanguageModelStreamResponse,
+    LanguageModelStreamResponsePart,
+    LanguageModelTextResponse,
+    TokenUsageService,
+    ToolCall,
+    UserRequest,
+} from '@theia/ai-core';
+import { CancellationToken, Disposable, ILogger } from '@theia/core';
+import {
+    CoreMessage,
+    generateObject,
+    GenerateObjectResult,
+    generateText,
+    GenerateTextResult,
+    jsonSchema,
+    StepResult,
+    streamText,
+    TextStreamPart,
+    tool,
+    ToolExecutionOptions,
+    ToolResultPart,
+    ToolSet
+} from 'ai';
+import { VercelAiLanguageModelFactory, VercelAiProviderConfig } from './vercel-ai-language-model-factory';
+
+interface VercelCancellationToken extends Disposable {
+    signal: AbortSignal;
+    cancellationToken: CancellationToken;
+    isCancellationRequested: boolean;
+}
+
+type StreamPart = ToolResultPart | {
+    type: string;
+    textDelta?: string;
+    toolCallId?: string;
+    toolName?: string;
+    args?: object | string;
+    argsTextDelta?: string;
+    usage?: { promptTokens: number; completionTokens: number };
+    signature?: string;
+};
+
+interface VercelAiStream extends AsyncIterable<TextStreamPart<ToolSet>> {
+    cancel: () => void;
+}
+
+interface StreamContext {
+    logger: ILogger;
+    cancellationToken?: VercelCancellationToken;
+}
+
+export class VercelAiStreamTransformer {
+    private toolCallsMap = new Map<string, ToolCall>();
+
+    constructor(
+        protected readonly fullStream: VercelAiStream,
+        protected readonly context: StreamContext
+    ) { }
+
+    async *transform(): AsyncGenerator<LanguageModelStreamResponsePart> {
+        this.toolCallsMap.clear();
+        try {
+            for await (const part of this.fullStream) {
+                this.context.logger.trace('Received stream part:', part);
+                if (this.context.cancellationToken?.isCancellationRequested) {
+                    this.context.logger.debug('Cancellation requested, stopping stream');
+                    this.fullStream.cancel();
+                    break;
+                }
+
+                let toolCallUpdated = false;
+
+                switch (part.type) {
+                    case 'text-delta':
+                        if (part.textDelta) {
+                            yield { content: part.textDelta };
+                        }
+                        break;
+
+                    case 'tool-call':
+                        if (part.toolCallId && part.toolName) {
+                            const args = typeof part.args === 'object' ? JSON.stringify(part.args) : (part.args || '');
+                            toolCallUpdated = this.updateToolCall(part.toolCallId, part.toolName, args);
+                        }
+                        break;
+
+                    case 'tool-call-streaming-start':
+                        if (part.toolCallId && part.toolName) {
+                            toolCallUpdated = this.updateToolCall(part.toolCallId, part.toolName);
+                        }
+                        break;
+
+                    case 'tool-call-delta':
+                        if (part.toolCallId && part.argsTextDelta) {
+                            toolCallUpdated = this.appendToToolCallArgs(part.toolCallId, part.argsTextDelta);
+                        }
+                        break;
+
+                    default:
+                        if (this.isToolResultPart(part)) {
+                            toolCallUpdated = this.processToolResult(part);
+                        }
+                        break;
+                }
+
+                if (toolCallUpdated && this.toolCallsMap.size > 0) {
+                    yield { tool_calls: Array.from(this.toolCallsMap.values()) };
+                }
+            }
+        } catch (error) {
+            this.context.logger.error('Error in AI SDK stream:', error);
+        }
+    }
+
+    private isToolResultPart(part: StreamPart): part is ToolResultPart {
+        return part.type === 'tool-result';
+    }
+
+    private updateToolCall(id: string, name: string, args?: string): boolean {
+        const toolCall: ToolCall = {
+            id,
+            function: { name, arguments: args ? args : '' },
+            finished: false
+        };
+        this.toolCallsMap.set(id, toolCall);
+        return true;
+    }
+
+    private appendToToolCallArgs(id: string, argsTextDelta: string): boolean {
+        const existingCall = this.toolCallsMap.get(id);
+        if (existingCall?.function) {
+            existingCall.function.arguments = (existingCall.function.arguments || '') + argsTextDelta;
+            return true;
+        }
+        return false;
+    }
+
+    private processToolResult(part: ToolResultPart): boolean {
+        if (!part.toolCallId) {
+            return false;
+        }
+
+        const completedCall = this.toolCallsMap.get(part.toolCallId);
+        if (!completedCall) {
+            return false;
+        }
+
+        completedCall.result = part.result as string;
+        completedCall.finished = true;
+        return true;
+    }
+
+}
+
+export class VercelAiModel implements LanguageModel {
+
+    constructor(
+        public readonly id: string,
+        public model: string,
+        public enableStreaming: boolean,
+        public supportsStructuredOutput: boolean,
+        public url: string | undefined,
+        protected readonly logger: ILogger,
+        protected readonly languageModelFactory: VercelAiLanguageModelFactory,
+        protected providerConfig: () => VercelAiProviderConfig,
+        protected readonly tokenUsageService?: TokenUsageService
+    ) { }
+
+    protected getSettings(request: LanguageModelRequest): Record<string, unknown> {
+        return request.settings ?? {};
+    }
+
+    async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {
+        const settings = this.getSettings(request);
+        const model = this.languageModelFactory.createLanguageModel(
+            {
+                id: this.id,
+                model: this.model,
+                url: this.url,
+                apiKey: true, // We'll use the provider's API key
+                enableStreaming: this.enableStreaming,
+                supportsStructuredOutput: this.supportsStructuredOutput
+            },
+            this.providerConfig()
+        );
+        const cancel = this.createCancellationToken(cancellationToken);
+
+        try {
+            if (request.response_format?.type === 'json_schema' && this.supportsStructuredOutput) {
+                return this.handleStructuredOutputRequest(model, request, cancel);
+            }
+            if (!this.enableStreaming || (typeof settings.stream === 'boolean' && !settings.stream)) {
+                return this.handleNonStreamingRequest(model, request, cancel);
+            }
+            return this.handleStreamingRequest(model, request, cancel);
+        } catch (error) {
+            this.logger.error('Error in Vercel AI model request:', error);
+            throw error;
+        } finally {
+            cancel.dispose();
+        }
+    }
+
+    protected createCancellationToken(cancellationToken?: CancellationToken): VercelCancellationToken {
+        const abortController = new AbortController();
+        const abortSignal = abortController.signal;
+        if (cancellationToken?.isCancellationRequested) {
+            abortController.abort();
+        }
+        const cancellationListener = cancellationToken ?
+            cancellationToken.onCancellationRequested(() => {
+                abortController.abort();
+            }) : undefined;
+        return {
+            signal: abortSignal,
+            cancellationToken: cancellationToken ?? CancellationToken.None,
+            get isCancellationRequested(): boolean {
+                return cancellationToken?.isCancellationRequested ?? abortSignal.aborted;
+            },
+            dispose: () => cancellationListener?.dispose()
+        };
+    }
+
+    protected async handleNonStreamingRequest(
+        model: LanguageModelV1,
+        request: UserRequest,
+        cancellationToken?: VercelCancellationToken
+    ): Promise<LanguageModelTextResponse> {
+        const settings = this.getSettings(request);
+        const messages = this.processMessages(request.messages);
+        const tools = this.createTools(request);
+        const abortSignal = cancellationToken?.signal;
+
+        const response = await generateText({
+            model,
+            messages,
+            tools,
+            toolChoice: 'auto',
+            abortSignal,
+            ...settings
+        });
+
+        await this.recordTokenUsage(response, request);
+
+        return { text: response.text };
+    }
+
+    protected createTools(request: UserRequest): ToolSet | undefined {
+        if (!request.tools) {
+            return undefined;
+        }
+
+        const toolSet: ToolSet = {};
+        for (const toolRequest of request.tools) {
+            toolSet[toolRequest.name] = tool({
+                description: toolRequest.description,
+                parameters: jsonSchema(toolRequest.parameters),
+                execute: async (args: object, options: ToolExecutionOptions) => {
+                    try {
+                        const result = await toolRequest.handler(JSON.stringify(args), options);
+                        return JSON.stringify(result);
+                    } catch (error) {
+                        this.logger.error(`Error executing tool (${toolRequest.name}):`, error);
+                        return { status: 'error', error: 'Tool execution failed', details: error };
+                    }
+                }
+            });
+        }
+        return toolSet;
+    }
+
+    protected async handleStructuredOutputRequest(
+        model: LanguageModelV1,
+        request: UserRequest,
+        cancellationToken?: VercelCancellationToken
+    ): Promise<LanguageModelParsedResponse | LanguageModelStreamResponse> {
+        if (request.response_format?.type !== 'json_schema' || !request.response_format.json_schema.schema) {
+            throw Error('Invalid response format for structured output request');
+        }
+
+        const schema = jsonSchema(request.response_format.json_schema.schema);
+        if (!schema) {
+            throw new Error('Schema extraction failed.');
+        }
+
+        const settings = this.getSettings(request);
+        const messages = this.processMessages(request.messages);
+        const abortSignal = cancellationToken?.signal;
+
+        const response = await generateObject<unknown>({
+            model,
+            output: 'object',
+            messages,
+            schema,
+            abortSignal,
+            ...settings
+        });
+
+        await this.recordTokenUsage(response, request);
+
+        return {
+            content: JSON.stringify(response.object),
+            parsed: response.object
+        };
+    }
+
+    private async recordTokenUsage(
+        result: GenerateObjectResult<unknown> | GenerateTextResult<ToolSet, unknown>,
+        request: UserRequest
+    ): Promise<void> {
+        if (this.tokenUsageService && !isNaN(result.usage.completionTokens) && !isNaN(result.usage.promptTokens)) {
+            await this.tokenUsageService.recordTokenUsage(
+                this.id,
+                {
+                    inputTokens: result.usage.promptTokens,
+                    outputTokens: result.usage.completionTokens,
+                    requestId: request.requestId
+                }
+            );
+        }
+    }
+
+    protected async handleStreamingRequest(
+        model: LanguageModelV1,
+        request: UserRequest,
+        cancellationToken?: VercelCancellationToken
+    ): Promise<LanguageModelStreamResponse> {
+        const settings = this.getSettings(request);
+        const messages = this.processMessages(request.messages);
+        const tools = this.createTools(request);
+        const abortSignal = cancellationToken?.signal;
+
+        const { fullStream } = streamText({
+            model,
+            messages,
+            tools,
+            toolChoice: 'auto',
+            maxSteps: 100,
+            toolCallStreaming: true,
+            abortSignal,
+            onStepFinish: (stepResult: StepResult<ToolSet>) => {
+                if (!isNaN(stepResult.usage.completionTokens) && !isNaN(stepResult.usage.promptTokens)) {
+                    this.tokenUsageService?.recordTokenUsage(this.id, {
+                        inputTokens: stepResult.usage.promptTokens,
+                        outputTokens: stepResult.usage.completionTokens,
+                        requestId: request.requestId
+                    });
+                }
+            },
+            ...settings
+        });
+
+        const transformer = new VercelAiStreamTransformer(
+            fullStream, { cancellationToken, logger: this.logger }
+        );
+
+        return {
+            stream: transformer.transform()
+        };
+    }
+
+    protected processMessages(messages: LanguageModelMessage[]): Array<CoreMessage> {
+        return messages.map(message => {
+            const content = LanguageModelMessage.isTextMessage(message) ? message.text : '';
+            let role: 'user' | 'assistant' | 'system';
+            switch (message.actor) {
+                case 'user':
+                    role = 'user';
+                    break;
+                case 'ai':
+                    role = 'assistant';
+                    break;
+                case 'system':
+                    role = 'system';
+                    break;
+                default:
+                    role = 'user';
+            }
+            return {
+                role,
+                content,
+            };
+        });
+    }
+}

--- a/packages/ai-vercel-ai/src/node/vercel-ai-language-models-manager-impl.ts
+++ b/packages/ai-vercel-ai/src/node/vercel-ai-language-models-manager-impl.ts
@@ -1,0 +1,101 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { LanguageModelRegistry, TokenUsageService } from '@theia/ai-core';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { VercelAiModel } from './vercel-ai-language-model';
+import { VercelAiLanguageModelsManager, VercelAiModelDescription } from '../common';
+import { ILogger } from '@theia/core';
+import { VercelAiLanguageModelFactory, VercelAiProvider, VercelAiProviderConfig } from './vercel-ai-language-model-factory';
+
+@injectable()
+export class VercelAiLanguageModelsManagerImpl implements VercelAiLanguageModelsManager {
+
+    apiKey: string | undefined;
+    protected providerConfigs: Map<VercelAiProvider, VercelAiProviderConfig> = new Map();
+
+    @inject(LanguageModelRegistry)
+    protected readonly languageModelRegistry: LanguageModelRegistry;
+
+    @inject(TokenUsageService)
+    protected readonly tokenUsageService: TokenUsageService;
+
+    @inject(ILogger) @named('vercel-ai')
+    protected readonly logger: ILogger;
+
+    @inject(VercelAiLanguageModelFactory)
+    protected readonly languageModelFactory: VercelAiLanguageModelFactory;
+
+    // Triggered from frontend. In case you want to use the models on the backend
+    // without a frontend then call this yourself
+    async createOrUpdateLanguageModels(...modelDescriptions: VercelAiModelDescription[]): Promise<void> {
+        for (const modelDescription of modelDescriptions) {
+            this.logger.info(`Vercel AI: Creating or updating model ${modelDescription.id}`);
+            const model = await this.languageModelRegistry.getLanguageModel(modelDescription.id);
+            const provider = this.determineProvider(modelDescription);
+            const providerConfig = this.getProviderConfig(provider);
+
+            if (model) {
+                if (!(model instanceof VercelAiModel)) {
+                    this.logger.warn(`Vercel AI: model ${modelDescription.id} is not a Vercel AI model`);
+                    continue;
+                }
+                model.model = modelDescription.model;
+                model.enableStreaming = modelDescription.enableStreaming;
+                model.url = modelDescription.url;
+                model.supportsStructuredOutput = modelDescription.supportsStructuredOutput;
+                this.providerConfigs.set(provider, providerConfig);
+            } else {
+                this.languageModelRegistry.addLanguageModels([
+                    new VercelAiModel(
+                        modelDescription.id,
+                        modelDescription.model,
+                        modelDescription.enableStreaming,
+                        modelDescription.supportsStructuredOutput,
+                        modelDescription.url,
+                        this.logger,
+                        this.languageModelFactory,
+                        () => this.getProviderConfig(provider),
+                        this.tokenUsageService
+                    )
+                ]);
+            }
+        }
+    }
+
+    removeLanguageModels(...modelIds: string[]): void {
+        this.languageModelRegistry.removeLanguageModels(modelIds);
+    }
+
+    setProviderConfig(provider: VercelAiProvider, config: Partial<VercelAiProviderConfig>): void {
+        const existingConfig = this.providerConfigs.get(provider) || { provider };
+        this.providerConfigs.set(provider, { ...existingConfig, ...config });
+    }
+
+    private determineProvider(modelDescription: VercelAiModelDescription): VercelAiProvider {
+        // Use the provider from the model description or default to OpenAI
+        return modelDescription.provider || 'openai';
+    }
+
+    private getProviderConfig(provider: VercelAiProvider): VercelAiProviderConfig {
+        let config = this.providerConfigs.get(provider);
+        if (!config) {
+            config = { provider, apiKey: this.apiKey };
+            this.providerConfigs.set(provider, config);
+        }
+        return config;
+    }
+}

--- a/packages/ai-vercel-ai/src/package.spec.ts
+++ b/packages/ai-vercel-ai/src/package.spec.ts
@@ -1,0 +1,27 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, without having any actual unit tests in it.
+   This way a coverage report will be generated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe('ai-vercel-ai package', () => {
+    it('support code coverage statistics', () => true);
+});

--- a/packages/ai-vercel-ai/tsconfig.json
+++ b/packages/ai-vercel-ai/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../ai-core"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../filesystem"
+    },
+    {
+      "path": "../workspace"
+    }
+  ]
+}


### PR DESCRIPTION
#### What it does

Adds a generic model provider via [Vercel AI](https://github.com/vercel/ai) to explore the opportunity of saving maintenance effort for all the different model providers we currently and maybe plan to support in the future.

What already works:
* Tested with OpenAI and Anthropic models
* Tool calling
* Token usage tracking
* Streaming
* Structured output

#### How to test

Set your API key in:
*  `ai-features.vercelAi.openaiApiKey`
*  `ai-features.vercelAi.anthropicApiKey`

By default, we specify the following models in the preference `ai-features.vercelAi.officialModels`:
```
{ id: 'vercel/openai/gpt-4.1', model: 'gpt-4.1', provider: 'openai' },
{ id: 'vercel/openai/gpt-4.1-nano', model: 'gpt-4.1-nano', provider: 'openai' },
{ id: 'vercel/openai/gpt-4.1-mini', model: 'gpt-4.1-mini', provider: 'openai' },
{ id: 'vercel/openai/gpt-4-turbo', model: 'gpt-4-turbo', provider: 'openai' },
{ id: 'vercel/openai/gpt-4o', model: 'gpt-4o', provider: 'openai' },
{ id: 'vercel/openai/gpt-4o-mini', model: 'gpt-4o-mini', provider: 'openai' },
{ id: 'vercel/anthropic/claude-3-7-sonnet-20250219', model: 'claude-3-7-sonnet-20250219', provider: 'anthropic' },
{ id: 'vercel/anthropic/claude-3-5-haiku-20241022', model: 'claude-3-5-haiku-20241022', provider: 'anthropic' },
{ id: 'vercel/anthropic/claude-3-opus-20240229', model: 'claude-3-opus-20240229', provider: 'anthropic' }
```

Select them for arbitrary agents and test them. You can add others too for OpenAI and Anthropic. See the supported models by Vercel:
* [OpenAI](https://sdk.vercel.ai/providers/ai-sdk-providers/openai)
* [Anthropic](https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic)

What still needs testing:
* Custom OpenAI compatible models
* Azure-hosted OpenAI models

#### Follow-ups

* Split LLM providers (OpenAI, Anthropic, etc.)  into external packages to allow consuming them one by one

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)