### PR TITLE
More legible history entries

### DIFF
--- a/packages/ai-history/src/browser/ai-history-communication-card.tsx
+++ b/packages/ai-history/src/browser/ai-history-communication-card.tsx
@@ -20,31 +20,28 @@ import * as React from '@theia/core/shared/react';
 export interface CommunicationCardProps {
     entry: CommunicationHistoryEntry;
 }
+// Format JSON with error handling
+const formatJson = (data: unknown): React.ReactNode => {
+    try {
+        return JSON.stringify(data, undefined, 2).split(/(?:\\r)?\\n/).flatMap((stringChunk, i) => [stringChunk, <br key={stringChunk + i}/>]);
+    } catch (error) {
+        console.error('Error formatting JSON:', error);
+        return 'Error formatting data';
+    }
+};
 
-export const CommunicationCard: React.FC<CommunicationCardProps> = ({ entry }) => {
-    // Format JSON with error handling
-    const formatJson = (data: unknown): string => {
-        try {
-            return JSON.stringify(data, undefined, 2);
-        } catch (error) {
-            console.error('Error formatting JSON:', error);
-            return 'Error formatting data';
-        }
-    };
+// Format the timestamp for better readability
+const formatTimestamp = (timestamp: number): string =>
+    new Date(timestamp).toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+    });
 
-    // Format the timestamp for better readability
-    const formatTimestamp = (timestamp: number): string =>
-        new Date(timestamp).toLocaleString(undefined, {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit'
-        });
-    ;
-
-    return (
+export const CommunicationCard: React.FC<CommunicationCardProps> = ({ entry }) => (
         <div className='theia-card' role="article" aria-label={`Communication log for request ${entry.requestId}`}>
             <div className='theia-card-meta'>
                 <span className='theia-card-request-id'>{nls.localize('theia/ai/history/communication-card/requestId', 'Request ID')}: {entry.requestId}</span>
@@ -104,4 +101,3 @@ export const CommunicationCard: React.FC<CommunicationCardProps> = ({ entry }) =
             </div>
         </div>
     );
-};

--- a/packages/ai-history/src/browser/style/ai-history.css
+++ b/packages/ai-history/src/browser/style/ai-history.css
@@ -110,6 +110,7 @@
 .theia-card-request pre,
 .theia-card-response pre {
   background-color: var(--theia-editor-background);
+  text-wrap: wrap;
 }
 
 .theia-card-request,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

From #15092, history entries were wrapped in `pre` elements with no word wrap, leading to very long horizontal scrollbars.
This PR attempts to make the history entries more readable by:
 - Adding wordwrap for the `pre` elements.
 - Restoring line breaks as `br` tags.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Chat with an agent.
2. Check the history of that chat in the 'AI Agent History' view.
3. Observe that the entries wrap when the lines are long, and that line breaks are restored in the `text` field (or other fields containing line breaks).

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
