### PR TITLE
fix(chat): ensure we keep space after variables and agent label in place

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -434,7 +434,13 @@ const ChatRequestRender = (
                             />
                         );
                     } else {
-                        const ref = useMarkdownRendering(part.text.replace(/^[\r\n]+|[\r\n]+$/g, ''), openerService, true);
+                        const ref = useMarkdownRendering(
+                            part.text
+                                .replace(/^[\r\n]+|[\r\n]+$/g, '') // remove excessive new lines
+                                .replace(/(^ )/g, '&nbsp;'), // enforce keeping space before
+                            openerService,
+                            true
+                        );
                         return (
                             <span key={index} ref={ref}></span>
                         );


### PR DESCRIPTION
#### What it does

As a side-effect of https://github.com/eclipse-theia/theia/pull/15344 we seem to collapse space after labels (agents or variables) in the request text, as we are not replacing them with `nbsp;`. Note that this also breaks copy and paste of the selected text as we are losing the spaces.

With this change we replace the first space of text parts with a `nbsp;` to ensure we keep them visible and make them part of the selected text for copy and paste.

#### How to test

Before:
![image](https://github.com/user-attachments/assets/be8541bf-72e0-4f24-a780-8ac8482ca3bf)

After:
![image](https://github.com/user-attachments/assets/c8bb1b10-07ad-4c80-9952-db0dbe387eb9)


#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
