### PR TITLE
Basic ssh_config support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26458,6 +26458,12 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssh-config": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/ssh-config/-/ssh-config-5.0.3.tgz",
+      "integrity": "sha512-E+u2sZZVSOqH8uXvp/4LeXXWV4EIcfeni6eZKCGSu4uXdb5uUtpdTrSvUFpOVbC67a+Rzfl2uqlUVDbci1t/tA==",
+      "license": "MIT"
+    },
     "node_modules/ssh2": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
@@ -30537,6 +30543,8 @@
         "@theia/markers": "1.60.0",
         "@theia/monaco": "1.60.0",
         "@theia/navigator": "1.60.0",
+        "@theia/search-in-workspace": "1.60.0",
+        "@theia/task": "1.60.0",
         "@theia/terminal": "1.60.0",
         "@theia/workspace": "1.60.0",
         "date-fns": "^4.1.0",
@@ -31638,6 +31646,7 @@
         "glob": "^8.1.0",
         "socket.io": "^4.5.3",
         "socket.io-client": "^4.5.3",
+        "ssh-config": "^5.0.3",
         "ssh2": "^1.15.0",
         "ssh2-sftp-client": "^9.1.0",
         "tslib": "^2.6.2"

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -15,6 +15,7 @@
     "glob": "^8.1.0",
     "socket.io": "^4.5.3",
     "socket.io-client": "^4.5.3",
+    "ssh-config": "^5.0.3",
     "ssh2": "^1.15.0",
     "ssh2-sftp-client": "^9.1.0",
     "tslib": "^2.6.2"

--- a/packages/remote/src/electron-browser/remote-preferences.ts
+++ b/packages/remote/src/electron-browser/remote-preferences.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { OS } from '@theia/core';
 import { interfaces } from '@theia/core/shared/inversify';
 import {
     PreferenceProxy,
@@ -43,7 +44,7 @@ export const RemotePreferenceSchema: PreferenceSchema = {
         },
         'remote.ssh.configFile': {
             type: 'string',
-            default: '',
+            default: OS.backend.isWindows ? '${env:USERPROFILE}\\.ssh\\config' : '${env:HOME}/.ssh/config',
             markdownDescription: nls.localize(
                 'theia/remote/ssh/configFile',
                 'Remote SSH Config file'

--- a/packages/remote/src/electron-browser/remote-preferences.ts
+++ b/packages/remote/src/electron-browser/remote-preferences.ts
@@ -41,11 +41,20 @@ export const RemotePreferenceSchema: PreferenceSchema = {
                 'Controls the template used to download the node.js binaries for the remote backend. Points to the official node.js website by default. Uses multiple placeholders:'
             ) + '\n- ' + nodeDownloadTemplateParts.join('\n- ')
         },
+        'remote.ssh.configFile': {
+            type: 'string',
+            default: '',
+            markdownDescription: nls.localize(
+                'theia/remote/ssh/configFile',
+                'Remote SSH Config file'
+            )
+        },
     }
 };
 
 export interface RemoteConfiguration {
     'remote.nodeDownloadTemplate': string;
+    'remote.ssh.configFile': string;
 }
 
 export const RemotePreferenceContribution = Symbol('RemotePreferenceContribution');

--- a/packages/remote/src/electron-browser/remote-ssh-contribution.ts
+++ b/packages/remote/src/electron-browser/remote-ssh-contribution.ts
@@ -19,7 +19,7 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { RemoteSSHConnectionProvider } from '../electron-common/remote-ssh-connection-provider';
 import { AbstractRemoteRegistryContribution, RemoteRegistry } from './remote-registry-contribution';
 import { RemotePreferences } from './remote-preferences';
-import SshConfig = require('ssh-config');
+import * as SshConfig from 'ssh-config';
 
 export namespace RemoteSSHCommands {
     export const CONNECT: Command = Command.toLocalizedCommand({

--- a/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
+++ b/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
@@ -22,8 +22,11 @@ export interface RemoteSSHConnectionProviderOptions {
     user: string;
     host: string;
     nodeDownloadTemplate?: string;
+    customConfigFile?: string;
 }
 
 export interface RemoteSSHConnectionProvider {
     establishConnection(options: RemoteSSHConnectionProviderOptions): Promise<string>;
+    getSSHConfig(customConfigFile?: string): Promise<Array<Record<string, string[]>>>;
+    matchSSHConfigHost(host: string, user?: string, customConfigFile?: string): Promise<Record<string, string[]> | undefined>;
 }

--- a/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
+++ b/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
@@ -14,6 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import SshConfig = require('ssh-config');
+
 export const RemoteSSHConnectionProviderPath = '/remote/ssh';
 
 export const RemoteSSHConnectionProvider = Symbol('RemoteSSHConnectionProvider');
@@ -25,8 +27,12 @@ export interface RemoteSSHConnectionProviderOptions {
     customConfigFile?: string;
 }
 
+export interface SSHConfig extends Array<SshConfig.Line> {
+    compute(opts: string | SshConfig.MatchOptions): Record<string, string | string[]>;
+}
+
 export interface RemoteSSHConnectionProvider {
     establishConnection(options: RemoteSSHConnectionProviderOptions): Promise<string>;
-    getSSHConfig(customConfigFile?: string): Promise<Array<Record<string, string[]>>>;
-    matchSSHConfigHost(host: string, user?: string, customConfigFile?: string): Promise<Record<string, string[]> | undefined>;
+    getSSHConfig(customConfigFile?: string): Promise<SSHConfig>;
+    matchSSHConfigHost(host: string, user?: string, customConfigFile?: string): Promise<Record<string, string | string[]> | undefined>;
 }

--- a/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
+++ b/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import SshConfig = require('ssh-config');
+import * as SshConfig from 'ssh-config';
 
 export const RemoteSSHConnectionProviderPath = '/remote/ssh';
 

--- a/packages/remote/src/electron-node/ssh/remote-ssh-connection-provider.ts
+++ b/packages/remote/src/electron-node/ssh/remote-ssh-connection-provider.ts
@@ -18,7 +18,7 @@ import * as ssh2 from 'ssh2';
 import * as net from 'net';
 import * as fs from '@theia/core/shared/fs-extra';
 import SftpClient = require('ssh2-sftp-client');
-import SshConfig = require('ssh-config');
+import * as SshConfig from 'ssh-config';
 import { Emitter, Event, MessageService, QuickInputService } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { RemoteSSHConnectionProvider, RemoteSSHConnectionProviderOptions, SSHConfig } from '../../electron-common/remote-ssh-connection-provider';

--- a/packages/remote/src/electron-node/ssh/ssh-identity-file-collector.ts
+++ b/packages/remote/src/electron-node/ssh/ssh-identity-file-collector.ts
@@ -54,8 +54,8 @@ export class SSHIdentityFileCollector {
         ];
     }
 
-    async gatherIdentityFiles(sshAgentSock?: string): Promise<SSHKey[]> {
-        const identityFiles = this.getDefaultIdentityFiles();
+    async gatherIdentityFiles(sshAgentSock?: string, overrideIdentityFiles?: string[]): Promise<SSHKey[]> {
+        const identityFiles = overrideIdentityFiles || this.getDefaultIdentityFiles();
 
         const identityFileContentsResult = await Promise.allSettled(identityFiles.map(async keyPath => {
             keyPath = await fs.pathExists(keyPath + '.pub') ? keyPath + '.pub' : keyPath;


### PR DESCRIPTION
#### What it does

Very basic support for ssh_config files and quick access to ssh_config hosts.

Currently only Host, Hostname, Port, User, and IdentityFile is supported. With Host allowing some wildcards which can be accessed through %h

#### How to test

## Step 1: 

Create an sh file with the following and run it, it will generate  a ssh_config file and docker files and ssh keys to test with:

```
#!/bin/bash

# create docker-compose file
cat > ./docker-compose.yml << EOF
version: '3.8'
services:
    theia_ssh1:
        build:
            context: .
            args:
                SSH_PORT: "2221"
        ports:
            - 2221:2221
EOF

# create docker file with ssh server
cat > ./Dockerfile << \EOF
FROM ubuntu:latest
ARG SSH_PORT
RUN  mkdir ~/.ssh && apt-get update && apt-get install -y openssh-server xz-utils


COPY ./id_rsa.pub /root/.ssh/authorized_keys
RUN mkdir /var/run/sshd
RUN echo 'root:password' | chpasswd


RUN echo "PORT=${SSH_PORT}" \
    && sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
    && sed -i "s/#Port 22/Port ${SSH_PORT}/" /etc/ssh/sshd_config

    
CMD ["/usr/sbin/sshd", "-D"]
EOF

# create ssh_config file file
cat > ./ssh_config << EOF
Host localhost
    Port 2221
    User root
Host test1
    Hostname 127.0.0.1
    Port 2221
Host test2_*
    Hostname %h.0.0.1
    Port 2221
Host test3_?
    Hostname 127.0.0.%h
    User root
    Compression yes
    Port 2221
Host test4
    Hostname 127.0.0.1
    Port 2221
    IdentityFile ${PWD}/id_rsa 

EOF

#generate key
ssh-keygen -t rsa -f "${PWD}/id_rsa" -q -P ""
```
## Step 2:

set `remote.ssh.configFile` setting to point to config file generated

## Step 3:

docker-compuse up

## Step 4:

When connecting to remote host, you can either access them via typing like `test1` or pick it in the quick access menu(Connect Current Window to Host in Config File). You can also do things like `root@test1`, default password is `password`. You can also test wildcard via `root@test2_127` ,  `test3_1` shows single character wildcard and `test4` is key login without password 

#### Follow-ups

Partly fixes #14102 and #14289

@jonah-iden 

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
