### PR TITLE
Do not clear the editor model when the editor is hidden

### DIFF
--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -43,9 +43,6 @@ export namespace MonacoDiffEditor {
 export class MonacoDiffEditor extends MonacoEditor {
     protected _diffEditor: IStandaloneDiffEditor;
     protected _diffNavigator: DiffNavigator;
-    protected savedDiffState: monaco.editor.IDiffEditorViewState | null;
-    protected originalTextModel: monaco.editor.ITextModel;
-    protected modifiedTextModel: monaco.editor.ITextModel;
 
     constructor(
         uri: URI,
@@ -59,8 +56,6 @@ export class MonacoDiffEditor extends MonacoEditor {
         parentEditor?: MonacoEditor
     ) {
         super(uri, modifiedModel, node, services, options, override, parentEditor);
-        this.originalTextModel = originalModel.textEditorModel;
-        this.modifiedTextModel = modifiedModel.textEditorModel;
         this.documents.add(originalModel);
         const original = originalModel.textEditorModel;
         const modified = modifiedModel.textEditorModel;
@@ -132,26 +127,6 @@ export class MonacoDiffEditor extends MonacoEditor {
 
     override shouldDisplayDirtyDiff(): boolean {
         return false;
-    }
-
-    override handleVisibilityChanged(nowVisible: boolean): void {
-        if (nowVisible) {
-            this.diffEditor.setModel({ original: this.originalTextModel, modified: this.modifiedTextModel });
-            this.diffEditor.restoreViewState(this.savedDiffState);
-            this.diffEditor.focus();
-        } else {
-            const originalModel = this.diffEditor.getOriginalEditor().getModel();
-            if (originalModel) {
-                this.originalTextModel = originalModel;
-            }
-            const modifiedModel = this.diffEditor.getModifiedEditor().getModel();
-            if (modifiedModel) {
-                this.modifiedTextModel = modifiedModel;
-            }
-            this.savedDiffState = this.diffEditor.saveViewState();
-            // eslint-disable-next-line no-null/no-null
-            this.diffEditor.setModel(null);
-        }
     }
 }
 

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -126,8 +126,6 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     readonly onDidResize = this.onResizeEmitter.event;
 
     readonly documents = new Set<MonacoEditorModel>();
-    protected model: monaco.editor.ITextModel | null;
-    savedViewState: monaco.editor.ICodeEditorViewState | null;
 
     protected constructor(
         readonly uri: URI,
@@ -259,19 +257,6 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     }
 
     handleVisibilityChanged(nowVisible: boolean): void {
-        if (nowVisible) {
-            if (this.model) {
-                this.editor.setModel(this.model);
-                this.editor.restoreViewState(this.savedViewState);
-                this.editor.focus();
-            }
-        } else {
-            this.model = this.editor.getModel();
-            this.savedViewState = this.editor.saveViewState();
-
-            // eslint-disable-next-line no-null/no-null
-            this.editor.setModel(null); // workaround for https://github.com/eclipse-theia/theia/issues/14880
-        }
     }
 
     getVisibleRanges(): Range[] {


### PR DESCRIPTION
#### What it does

TL;DR This PR proposes to reconsider the change introduced by #14909.

So, #14909 has caused regressions all around Theia and probably even outside Theia (in Theia extensions, as opposed to VS Code extensions) because it significantly changed the way that hidden text editors had been behaving in Theia for years. And, unfortunately, in its nature it is also the worst kind of a breaking change possible, one that the compiler would never tell you about.

Setting the editor model to `null` when the editor is hidden detaches the model from the editor, which has the following effects (the list is not exhaustive):

- All decorations owned by the editor are removed from the model;

- All view zones, overlay widgets, etc. are removed;

- The `monaco-editor` node is removed from the DOM.

While the editor is hidden, calling `TextEditor.deltaDecorations` API has no effect now, since the model is detached from the editor. (I have not checked it yet, but it seems likely that other editor-related APIs in Theia might also behave differently in this state now.)

When the editor becomes visible again and the model is reattached to the editor, the `monaco-editor` node hierarchy is recreated from scratch and some editor components (e.g. overlay widgets) are recreated from the data stored in the model, while others such as decorations owned by the editor and view zones are not automatically recreated and would need to recreated manually now.

Of course, such a drastic change in well-established behavior has a vast potential for regressions, which has already materialised in practice: after two months and a couple of releases, their list is still growing.

This PR proposes to reconsider the change introduced by #14909. It reverts the effect of #14909 in a non-disruptive way, making as few changes as possible. It fixes #15426, #15496, #15497, #15498, and any other known or potential issues caused by #14909. The fix should be safe to apply, since any code that have already been adapted to the change in #14909 is expected to keep working, while any code that have not been adapted, and is currently broken, will function normally again. Of course, it does mean that #14880, which was fixed by #14909, will need to be fixed in some other way.

#### How to test

Verify that all known regressions from #14909 are now fixed, including those that have already been fixed by adapting the code to the change in #14909. To the best of my knowledge, the list of currently known regressions is:

- #14924
- #15038
- #15057
- #15178
- #15426
- #15496
- #15497
- #15498

There are also #15201 and #15234, which may be related, but have not been confirmed as regressions.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
