### PR TITLE
Use same autosave heuristic when closing widget

### DIFF
--- a/packages/core/src/browser/saveable-service.ts
+++ b/packages/core/src/browser/saveable-service.ts
@@ -222,7 +222,8 @@ export class SaveableService implements FrontendApplicationContribution {
         if (!Saveable.isDirty(widget)) {
             return false;
         }
-        if (this.autoSave !== 'off') {
+        const saveable = Saveable.get(widget);
+        if (this.autoSave !== 'off' && (!saveable || this.shouldAutoSave(widget, saveable))) {
             return true;
         }
         const notLastWithDocument = !Saveable.closingWidgetWouldLoseSaveable(widget, Array.from(this.saveThrottles.keys()));

--- a/packages/core/src/browser/saveable-service.ts
+++ b/packages/core/src/browser/saveable-service.ts
@@ -223,6 +223,10 @@ export class SaveableService implements FrontendApplicationContribution {
             return false;
         }
         const saveable = Saveable.get(widget);
+        if (!saveable) {
+            console.warn('Saveable.get returned undefined on a known saveable widget. This is unexpected.');
+        }
+        // Enter branch if saveable absent since we cannot check autosaveability more definitely.
         if (this.autoSave !== 'off' && (!saveable || this.shouldAutoSave(widget, saveable))) {
             return true;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #15501 by using the same heuristic for autosaveability when closing a widget as when deciding whether to apply autosaving.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Set your autosave preference to something other than `off`
2. Create an untitled editor and populate it.
3. Attempt to close it.
4. You should be offered the 'Change will be lost' dialog (not straight to the save location dialog).
5. Choose any of the options, and you should get the expected behavior.
> [!Note]
> If you choose to save, the newly saved version will be opened, rather than both being closed. Perhaps that should be otherwise?

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
