### PR TITLE
React to editor model changing.

### DIFF
--- a/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
@@ -161,8 +161,11 @@ export class DebugBreakpointWidget implements Disposable {
                 }
             }));
         this.toDispose.push(this.zone.onDidLayoutChange(dimension => this.layout(dimension)));
+        this.toDispose.push(this.editor.getControl().onDidChangeModel(() => {
+            this.zone.hide();
+        }));
         this.toDispose.push(input.getControl().onDidChangeModelContent(() => {
-            const heightInLines = input.getControl().getModel()?.getLineCount() || 0 + 1;
+            const heightInLines = (input.getControl().getModel()?.getLineCount() || 0) + 1;
             this.zone.layout(heightInLines);
             this.updatePlaceholder();
         }));

--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -132,6 +132,7 @@ export class DebugEditorModel implements Disposable {
         if (model) {
             this.toDisposeOnModelChange.push(model.onDidChangeDecorations(() => this.updateBreakpoints()));
         }
+        this.update();
         this.render();
     }
 


### PR DESCRIPTION
#### What it does
Makes sure the UI is properly updated when the model of the monaco editor underlying a theia editor is changed. Also fixes a layout problem with the breakpoint condition editor where the layout was sized to n lines instead of n+1 lines.

Fixes, #15498, #15497, #15496


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Run through the scenarios in the related issues.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
