### PR TITLE
Implement "code actions on save"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 <a name="breaking_changes_1.62.0">[Breaking Changes:](#breaking_changes_1.62.0)</a>
 
 - [monaco] Implement "code actions on save" [#15555](https://github.com/eclipse-theia/theia/pull/15555)
+  Replaced `MonacoEditorModel.onWillSave` "wait until event" event with `registerWillSaveModelListener` for simpler semantics. Also removed the `EditorModelService.onWillSave`
+  as it's pure convenience and unused in framework code.
 
 ## 1.61.0 - 4/29/2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## History
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
+## 1.62.0 - 
+
+<a name="breaking_changes_1.62.0">[Breaking Changes:](#breaking_changes_1.62.0)</a>
+
+- [monaco] Implement "code actions on save" [#15555](https://github.com/eclipse-theia/theia/pull/15555)
 
 ## 1.61.0 - 4/29/2025
 

--- a/packages/monaco/src/browser/monaco-code-action-save-participant.ts
+++ b/packages/monaco/src/browser/monaco-code-action-save-participant.ts
@@ -56,13 +56,11 @@ export class MonacoCodeActionSaveParticipant implements SaveParticipant {
             return undefined;
         }
 
-
         const settingItems: string[] = Array.isArray(setting)
             ? setting
             : Object.keys(setting).filter(x => setting[x]);
 
         const codeActionsOnSave = this.createCodeActionsOnSave(settingItems);
-
 
         if (!codeActionsOnSave.length) {
             return undefined;

--- a/packages/monaco/src/browser/monaco-code-action-save-participant.ts
+++ b/packages/monaco/src/browser/monaco-code-action-save-participant.ts
@@ -1,0 +1,139 @@
+// *****************************************************************************
+// Copyright (C) 2025 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { CancellationToken } from '@theia/core';
+import { SaveOptions, SaveReason } from '@theia/core/lib/browser';
+import { MonacoEditor } from './monaco-editor';
+import { SaveParticipant, SAVE_PARTICIPANT_DEFAULT_ORDER } from './monaco-editor-provider';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
+import { ILanguageFeaturesService } from '@theia/monaco-editor-core/esm/vs/editor/common/services/languageFeatures';
+import { CodeActionKind, CodeActionSet, CodeActionTriggerSource } from '@theia/monaco-editor-core/esm/vs/editor/contrib/codeAction/common/types';
+import { applyCodeAction, ApplyCodeActionReason, getCodeActions } from '@theia/monaco-editor-core/esm/vs/editor/contrib/codeAction/browser/codeAction';
+
+import { HierarchicalKind } from '@theia/monaco-editor-core/esm/vs/base/common/hierarchicalKind';
+import { EditorPreferences } from '@theia/editor/lib/browser';
+import { ITextModel } from '@theia/monaco-editor-core/esm/vs/editor/common/model';
+import { CodeActionProvider, CodeActionTriggerType } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
+import { IProgress } from '@theia/monaco-editor-core/esm/vs/platform/progress/common/progress';
+import { IInstantiationService } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/instantiation';
+
+@injectable()
+export class MonacoCodeActionSaveParticipant implements SaveParticipant {
+    @inject(EditorPreferences)
+    protected readonly editorPreferences: EditorPreferences;
+
+    readonly order = SAVE_PARTICIPANT_DEFAULT_ORDER;
+
+    async applyChangesOnSave(editor: MonacoEditor, cancellationToken: CancellationToken, options?: SaveOptions): Promise<void> {
+        // Convert boolean values to strings
+        const setting = this.editorPreferences.get({
+            preferenceName: 'editor.codeActionsOnSave',
+            overrideIdentifier: editor.document.textEditorModel.getLanguageId()
+        }, undefined, editor.document.textEditorModel.uri.toString());
+
+        if (!setting) {
+            return undefined;
+        }
+
+        if (options?.saveReason !== SaveReason.Manual) {
+            return undefined;
+        }
+
+        const settingItems: string[] = Array.isArray(setting)
+            ? setting
+            : Object.keys(setting).filter(x => setting[x] && setting[x]);
+
+        const codeActionsOnSave = this.createCodeActionsOnSave(settingItems);
+
+        if (!Array.isArray(setting)) {
+            codeActionsOnSave.sort((a, b) => {
+                if (CodeActionKind.SourceFixAll.contains(a)) {
+                    if (CodeActionKind.SourceFixAll.contains(b)) {
+                        return 0;
+                    }
+                    return -1;
+                }
+                if (CodeActionKind.SourceFixAll.contains(b)) {
+                    return 1;
+                }
+                return 0;
+            });
+        }
+
+        if (!codeActionsOnSave.length) {
+            return undefined;
+        }
+        const excludedActions = Array.isArray(setting)
+            ? []
+            : Object.keys(setting)
+                .filter(x => setting[x] === false)
+                .map(x => new HierarchicalKind(x));
+
+        await this.applyOnSaveActions(editor.document.textEditorModel, codeActionsOnSave, excludedActions, cancellationToken);
+    }
+
+    private createCodeActionsOnSave(settingItems: readonly string[]): HierarchicalKind[] {
+        const kinds = settingItems.map(x => new HierarchicalKind(x));
+
+        // Remove subsets
+        return kinds.filter(kind => kinds.every(otherKind => otherKind.equals(kind) || !otherKind.contains(kind)));
+    }
+
+    private async applyOnSaveActions(model: ITextModel, codeActionsOnSave: readonly HierarchicalKind[],
+        excludes: readonly HierarchicalKind[], token: CancellationToken): Promise<void> {
+
+        const instantiationService = StandaloneServices.get(IInstantiationService);
+
+        for (const codeActionKind of codeActionsOnSave) {
+            const actionsToRun = await this.getActionsToRun(model, codeActionKind, excludes, token);
+
+            if (token.isCancellationRequested) {
+                actionsToRun.dispose();
+                return;
+            }
+
+            try {
+                for (const action of actionsToRun.validActions) {
+                    instantiationService.invokeFunction(applyCodeAction, action, ApplyCodeActionReason.OnSave, {}, token);
+                    if (token.isCancellationRequested) {
+                        return;
+                    }
+                }
+            } catch {
+                // Failure to apply a code action should not block other on save actions
+            } finally {
+                actionsToRun.dispose();
+            }
+        }
+    }
+
+    private getActionsToRun(model: ITextModel, codeActionKind: HierarchicalKind, excludes: readonly HierarchicalKind[], token: CancellationToken): Promise<CodeActionSet> {
+        const { codeActionProvider } = StandaloneServices.get(ILanguageFeaturesService);
+
+        const progress: IProgress<CodeActionProvider> = {
+            report(item): void {
+                // empty
+            },
+        };
+
+        return getCodeActions(codeActionProvider, model, model.getFullModelRange(), {
+            type: CodeActionTriggerType.Auto,
+            triggerAction: CodeActionTriggerSource.OnSave,
+            filter: { include: codeActionKind, excludes: excludes, includeSourceActions: true },
+        }, progress, token);
+    }
+}

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -224,7 +224,7 @@ export class MonacoEditorProvider {
         }));
         toDispose.push(editor.onLanguageChanged(() => this.updateMonacoEditorOptions(editor)));
         toDispose.push(editor.onDidChangeReadOnly(() => this.updateReadOnlyMessage(options, model.readOnly)));
-        editor.document.registerWillSaveModelListener((_, token, o) => this.runSaveParticipants(editor, token, o));
+        toDispose.push(editor.document.registerWillSaveModelListener((_, token, o) => this.runSaveParticipants(editor, token, o)));
         return editor;
     }
 
@@ -501,12 +501,10 @@ export class MonacoEditorProvider {
         if (options.saveReason !== TextDocumentSaveReason.Manual) {
             return false;
         }
-        if (options.formatType) {
-            switch (options.formatType) {
-                case FormatType.ON: return true;
-                case FormatType.OFF: return false;
-                case FormatType.DIRTY: return model.dirty;
-            }
+        switch (options.formatType) {
+            case FormatType.ON: return true;
+            case FormatType.OFF: return false;
+            case FormatType.DIRTY: return model.dirty;
         }
         return true;
     }

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -25,7 +25,7 @@ import {
     WidgetStatusBarContribution
 } from '@theia/core/lib/browser';
 import { TextEditorProvider, DiffNavigatorProvider, TextEditor } from '@theia/editor/lib/browser';
-import { MonacoEditorProvider, MonacoEditorFactory } from './monaco-editor-provider';
+import { MonacoEditorProvider, MonacoEditorFactory, SaveParticipant } from './monaco-editor-provider';
 import { MonacoEditorMenuContribution } from './monaco-menu';
 import { MonacoEditorCommandHandlers } from './monaco-command';
 import { MonacoKeybindingContribution } from './monaco-keybinding';
@@ -79,6 +79,7 @@ import { ActiveMonacoUndoRedoHandler, FocusedMonacoUndoRedoHandler } from './mon
 import { ILogService } from '@theia/monaco-editor-core/esm/vs/platform/log/common/log';
 import { DefaultContentHoverWidgetPatcher } from './default-content-hover-widget-patcher';
 import { MonacoWorkspaceContextService } from './monaco-workspace-context-service';
+import { MonacoCodeActionSaveParticipant } from './monaco-code-action-save-participant';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MonacoThemingService).toSelf().inSingletonScope();
@@ -90,6 +91,9 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MonacoFrontendApplicationContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(MonacoFrontendApplicationContribution);
     bind(StylingParticipant).toService(MonacoFrontendApplicationContribution);
+
+    bind(MonacoCodeActionSaveParticipant).toSelf().inSingletonScope();
+    bind(SaveParticipant).toService(MonacoCodeActionSaveParticipant);
 
     bind(MonacoToProtocolConverter).toSelf().inSingletonScope();
     bind(ProtocolToMonacoConverter).toSelf().inSingletonScope();
@@ -121,6 +125,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindContributionProvider(bind, MonacoEditorFactory);
     bindContributionProvider(bind, MonacoEditorModelFactory);
     bindContributionProvider(bind, MonacoEditorModelFilter);
+    bindContributionProvider(bind, SaveParticipant);
     bind(MonacoCommandService).toSelf().inTransientScope();
 
     bind(TextEditorProvider).toProvider(context =>

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -23,7 +23,7 @@ import { Emitter } from '@theia/core/lib/common/event';
 import { FileSystemPreferences } from '@theia/filesystem/lib/browser';
 import { EditorManager, EditorPreferences } from '@theia/editor/lib/browser';
 import { MonacoTextModelService } from './monaco-text-model-service';
-import { WillSaveMonacoModelEvent, MonacoEditorModel, MonacoModelContentChangedEvent } from './monaco-editor-model';
+import { MonacoEditorModel, MonacoModelContentChangedEvent } from './monaco-editor-model';
 import { MonacoEditor } from './monaco-editor';
 import { ProblemManager } from '@theia/markers/lib/browser';
 import { ArrayUtils } from '@theia/core/lib/common/types';
@@ -101,9 +101,6 @@ export class MonacoWorkspace {
     protected readonly onDidChangeTextDocumentEmitter = new Emitter<MonacoModelContentChangedEvent>();
     readonly onDidChangeTextDocument = this.onDidChangeTextDocumentEmitter.event;
 
-    protected readonly onWillSaveTextDocumentEmitter = new Emitter<WillSaveMonacoModelEvent>();
-    readonly onWillSaveTextDocument = this.onWillSaveTextDocumentEmitter.event;
-
     protected readonly onDidSaveTextDocumentEmitter = new Emitter<MonacoEditorModel>();
     readonly onDidSaveTextDocument = this.onDidSaveTextDocumentEmitter.event;
 
@@ -160,7 +157,6 @@ export class MonacoWorkspace {
         });
         model.onDidChangeContent(event => this.fireDidChangeContent(event));
         model.onDidSaveModel(() => this.fireDidSave(model));
-        model.onWillSaveModel(event => this.fireWillSave(event));
         model.onDirtyChanged(() => this.openEditorIfDirty(model));
         model.onDispose(() => this.fireDidClose(model));
     }
@@ -175,10 +171,6 @@ export class MonacoWorkspace {
 
     protected fireDidChangeContent(event: MonacoModelContentChangedEvent): void {
         this.onDidChangeTextDocumentEmitter.fire(event);
-    }
-
-    protected fireWillSave(event: WillSaveMonacoModelEvent): void {
-        this.onWillSaveTextDocumentEmitter.fire(event);
     }
 
     protected fireDidSave(model: MonacoEditorModel): void {

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -16,14 +16,14 @@
 import { DocumentsMain, MAIN_RPC_CONTEXT, DocumentsExt } from '../../common/plugin-api-rpc';
 import { UriComponents } from '../../common/uri-components';
 import { EditorsAndDocumentsMain } from './editors-and-documents-main';
-import { DisposableCollection, Disposable, UntitledResourceResolver } from '@theia/core';
+import { DisposableCollection, Disposable, UntitledResourceResolver, CancellationToken } from '@theia/core';
 import { MonacoEditorModel } from '@theia/monaco/lib/browser/monaco-editor-model';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { EditorModelService } from './text-editor-model-service';
 import { EditorOpenerOptions } from '@theia/editor/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { URI as CodeURI } from '@theia/core/shared/vscode-uri';
-import { ApplicationShell } from '@theia/core/lib/browser';
+import { ApplicationShell, SaveOptions, SaveReason } from '@theia/core/lib/browser';
 import { TextDocumentShowOptions } from '../../common/plugin-api-rpc-model';
 import { Range } from '@theia/core/shared/vscode-languageserver-protocol';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
@@ -33,6 +33,8 @@ import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
 import * as monaco from '@theia/monaco-editor-core';
 import { TextDocumentChangeReason } from '../../plugin/types-impl';
 import { NotebookDocumentsMainImpl } from './notebooks/notebook-documents-main';
+import { MonacoEditorProvider, SAVE_PARTICIPANT_DEFAULT_ORDER } from '@theia/monaco/lib/browser/monaco-editor-provider';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -98,6 +100,7 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
         private shell: ApplicationShell,
         private untitledResourceResolver: UntitledResourceResolver,
         private languageService: MonacoLanguages,
+        monacoEditorProvider: MonacoEditorProvider
     ) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.DOCUMENTS_EXT);
 
@@ -111,10 +114,16 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
         this.toDispose.push(modelService.onModelSaved(m => {
             this.proxy.$acceptModelSaved(m.textEditorModel.uri);
         }));
-        this.toDispose.push(modelService.onModelWillSave(onWillSaveModelEvent => {
-            onWillSaveModelEvent.waitUntil(new Promise<monaco.editor.IIdentifiedSingleEditOperation[]>(async (resolve, reject) => {
-                setTimeout(() => reject(new Error(`Aborted onWillSaveTextDocument-event after ${this.saveTimeout}ms`)), this.saveTimeout);
-                const edits = await this.proxy.$acceptModelWillSave(onWillSaveModelEvent.model.textEditorModel.uri, onWillSaveModelEvent.reason, this.saveTimeout);
+        this.toDispose.push(monacoEditorProvider.registerSaveParticipant(({
+            order: SAVE_PARTICIPANT_DEFAULT_ORDER,
+            applyChangesOnSave: async (
+                editor: MonacoEditor,
+                cancellationToken: CancellationToken,
+                options: SaveOptions): Promise<void> => {
+
+                const saveReason = options.saveReason || SaveReason.Manual;
+
+                const edits = await this.proxy.$acceptModelWillSave(editor.uri.toComponents(), saveReason.valueOf(), this.saveTimeout);
                 const editOperations: monaco.editor.IIdentifiedSingleEditOperation[] = [];
                 for (const edit of edits) {
                     const { range, text } = edit;
@@ -126,15 +135,15 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
                     }
 
                     editOperations.push({
-                        range: range ? monaco.Range.lift(range) : onWillSaveModelEvent.model.textEditorModel.getFullModelRange(),
+                        range: range ? monaco.Range.lift(range) : editor.document.textEditorModel.getFullModelRange(),
                         /* eslint-disable-next-line no-null/no-null */
                         text: text || null,
                         forceMoveMarkers: edit.forceMoveMarkers
                     });
                 }
-                resolve(editOperations);
-            }));
-        }));
+                editor.document.textEditorModel.applyEdits(editOperations);
+            }
+        })));
         this.toDispose.push(modelService.onModelDirtyChanged(m => {
             this.proxy.$acceptDirtyStateChanged(m.textEditorModel.uri, m.dirty);
         }));

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -121,7 +121,7 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
                 cancellationToken: CancellationToken,
                 options: SaveOptions): Promise<void> => {
 
-                const saveReason = options.saveReason || SaveReason.Manual;
+                const saveReason = options.saveReason ?? SaveReason.Manual;
 
                 const edits = await this.proxy.$acceptModelWillSave(editor.uri.toComponents(), saveReason.valueOf(), this.saveTimeout);
                 const editOperations: monaco.editor.IIdentifiedSingleEditOperation[] = [];

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -66,6 +66,7 @@ import { NotebooksAndEditorsMain } from './notebooks/notebook-documents-and-edit
 import { TestingMainImpl } from './test-main';
 import { UriMainImpl } from './uri-main';
 import { LoggerMainImpl } from './logger-main';
+import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const loggerMain = new LoggerMainImpl(container);
@@ -105,8 +106,9 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const shell = container.get(ApplicationShell);
     const untitledResourceResolver = container.get(UntitledResourceResolver);
     const languageService = container.get(MonacoLanguages);
+    const monacoEditorProvider = container.get(MonacoEditorProvider);
     const documentsMain = new DocumentsMainImpl(editorsAndDocuments, notebookDocumentsMain, modelService, rpc,
-        openerService, shell, untitledResourceResolver, languageService);
+        openerService, shell, untitledResourceResolver, languageService, monacoEditorProvider);
     rpc.set(PLUGIN_RPC_CONTEXT.DOCUMENTS_MAIN, documentsMain);
 
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOKS_MAIN, new NotebooksMainImpl(rpc, container, commandRegistryMain));

--- a/packages/plugin-ext/src/main/browser/text-editor-model-service.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-model-service.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { Event, Emitter } from '@theia/core';
-import { MonacoEditorModel, WillSaveMonacoModelEvent } from '@theia/monaco/lib/browser/monaco-editor-model';
+import { MonacoEditorModel } from '@theia/monaco/lib/browser/monaco-editor-model';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
@@ -30,13 +30,11 @@ export class EditorModelService {
     private onModelRemovedEmitter = new Emitter<MonacoEditorModel>();
     private modelDirtyEmitter = new Emitter<MonacoEditorModel>();
     private modelSavedEmitter = new Emitter<MonacoEditorModel>();
-    private onModelWillSavedEmitter = new Emitter<WillSaveMonacoModelEvent>();
 
     readonly onModelDirtyChanged = this.modelDirtyEmitter.event;
     readonly onModelSaved = this.modelSavedEmitter.event;
     readonly onModelModeChanged = this.modelModeChangedEmitter.event;
     readonly onModelRemoved = this.onModelRemovedEmitter.event;
-    readonly onModelWillSave = this.onModelWillSavedEmitter.event;
 
     constructor(@inject(MonacoTextModelService) monacoModelService: MonacoTextModelService,
         @inject(MonacoWorkspace) monacoWorkspace: MonacoWorkspace) {
@@ -62,9 +60,6 @@ export class EditorModelService {
 
         model.onDirtyChanged(_ => {
             this.modelDirtyEmitter.fire(model);
-        });
-        model.onWillSaveModel(willSaveModelEvent => {
-            this.onModelWillSavedEmitter.fire(willSaveModelEvent);
         });
     }
 


### PR DESCRIPTION
#### What it does
The purpose of this PR is to allow for code actions (in particular "organize imports") upon saving an editor. A couple of changes were necessary to implement this:

1. The `onWillSaveDocument` `waitUntilEvent` was replaced by a simple sequential listener implementation for clarity
2. I introduced the concept of "save participants". The are executed in sequence and can make arbitrary changes to the document. If one of the save participants fails, the rest of the participants are still applied. 
3. "format on save" is a save participant that should be applied last
4. I added a `monaco-code-action-save-participant.ts` that applies any configured code actions.

Note that the preference schema for the feature is slightly different in Theia (boolean value instead of "explicit", etc.

Fixes #14955

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Make sure code actions can be configured and applied as described in the issue. Also make sure format on save still works correctly.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups
https://github.com/eclipse-theia/theia/issues/15554
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
