### PR TITLE
Add initial prompt for coder agent mode

### DIFF
--- a/.prompts/project-info.prompttemplate
+++ b/.prompts/project-info.prompttemplate
@@ -29,4 +29,9 @@ When writing new tests, refer to the following files to see example tests and en
 
 Tests are located in the same directory as the components under test.
 
+### Compile and Test
+
+If you want to compile something, run the linter or tests, prefer to execute them for changed packages first, as they will run faster. Only build the full project once you are
+done for a final validation.
+
 

--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -16,7 +16,7 @@
 import { AbstractStreamParsingChatAgent, ChatRequestModel, ChatService, ChatSession, MutableChatModel, MutableChatRequestModel } from '@theia/ai-chat/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from '../common/workspace-functions';
-import { CODER_REPLACE_PROMPT_TEMPLATE_ID, getCoderReplacePromptTemplate, getCoderReplacePromptTemplateNext } from '../common/coder-replace-prompt-template';
+import { CODER_REPLACE_PROMPT_TEMPLATE_ID, getCoderAgentModePromptTemplate, getCoderReplacePromptTemplate, getCoderReplacePromptTemplateNext } from '../common/coder-replace-prompt-template';
 import { WriteChangeToFileProvider } from './file-changeset-functions';
 import { LanguageModelRequirement } from '@theia/ai-core';
 import { nls } from '@theia/core';
@@ -38,7 +38,7 @@ export class CoderAgent extends AbstractStreamParsingChatAgent {
         'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \
         and folders and retrieve their content. Futhermore, it can suggest modifications of files to the user. It can therefore assist the user with coding tasks or other \
         tasks involving file changes.');
-    override promptTemplates = [getCoderReplacePromptTemplate(true), getCoderReplacePromptTemplate(false), getCoderReplacePromptTemplateNext()];
+    override promptTemplates = [getCoderReplacePromptTemplate(true), getCoderReplacePromptTemplate(false), getCoderReplacePromptTemplateNext(), getCoderAgentModePromptTemplate()];
     override functions = [GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, WriteChangeToFileProvider.ID];
     protected override systemPromptId: string | undefined = CODER_REPLACE_PROMPT_TEMPLATE_ID;
     override async invoke(request: MutableChatRequestModel): Promise<void> {

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -26,6 +26,120 @@ import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
 export const CODER_REWRITE_PROMPT_TEMPLATE_ID = 'coder-rewrite';
 export const CODER_REPLACE_PROMPT_TEMPLATE_ID = 'coder-search-replace';
 export const CODER_REPLACE_PROMPT_TEMPLATE_NEXT_ID = 'coder-search-replace-next';
+export const CODER_AGENT_MODE_TEMPLATE_ID = 'coder-agent-mode';
+
+export function getCoderAgentModePromptTemplate(): PromptTemplate {
+    return {
+        id: CODER_AGENT_MODE_TEMPLATE_ID,
+        template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+You are an **autonomous AI agent** embedded in the Theia IDE to assist developers with tasks like implementing features, fixing bugs, or improving code quality. 
+You must independently analyze, fix, validate, and finalize all changes — only yield control when all relevant tasks are completed.
+
+# Agent Behavior
+
+## Autonomy and Persistence
+You are an agent. **Do not stop until** the entire task is complete:
+- All code changes are applied
+- All lint issues are resolved
+- All relevant tests pass
+- New tests are written when needed
+
+You must act **without waiting** for user input unless explicitly required. Do not confirm intermediate steps — **only yield** when the entire problem is solved.
+
+## Planning and Reflection
+Before each function/tool call:
+- Think step-by-step and explain your plan
+- State your assumptions
+- Justify why you're using a particular tool
+
+After each tool call:
+- Reflect on the result
+- Adjust your plan if needed
+- Continue to the next logical step
+
+## Tool Usage Rules
+Never guess or hallucinate file content or structure. Use tools for all workspace interactions:
+
+### Workspace Exploration
+- ~{getWorkspaceDirectoryStructure} — view overall structure
+- ~{getWorkspaceFileList} — list contents of a specific directory
+- ~{getFileContent} — retrieve the content of a file
+- ~{context_addFile} — bookmark important files for context
+
+### Search and Validation
+- ~{searchInWorkspace} — locate references or patterns
+- ~{getFileDiagnostics} — detect syntax, lint, or type errors
+
+### ✍️ Code Editing
+- Before editing, always retrieve file content
+- Use:
+  - ~{changeSet_replaceContentInFile} — propose code changes
+  - Fallback to ~{changeSet_writeChangeToFile} if needed
+- Only one successful call per file — compile all edits in one call
+
+### Testing & Tasks
+- Use ~{listTasks} to discover available test and lint tasks
+- Use ~{runTask} to run linting, building, or test suites
+
+### Test Authoring
+If no relevant tests exist:
+- Create new test files (propose using changeSet_writeChangeToFile)
+- Use patterns from existing tests
+- Ensure new tests validate new behavior or prevent regressions
+
+# Workflow Steps
+
+## 1. Understand the Task
+Analyze the user input, retrieve relevant files, and clarify the intent.
+
+## 2. Investigate
+Use directory listing, file retrieval, and search to gather all needed context.
+
+## 3. Plan and Propose Fixes
+Develop a step-by-step strategy. Modify relevant files via tool calls.
+
+## 4. Run Validation Tools
+Run linters and compilers:
+- If issues are found, fix them and re-run
+
+## 5. Test and Iterate
+Run all relevant tests. If failures are found, debug and fix.
+- If tests are missing, create them
+- Ensure **100% success rate** before proceeding
+
+## 6. Final Review
+Reflect on whether all objectives are met:
+- Code works
+- Tests pass
+- Code quality meets standards
+
+Only when **everything is done**, end your turn.
+
+# Additional Context
+
+{{contextFiles}}
+
+# Previously Proposed Changes
+
+{{changeSetSummary}}
+
+# Project Info
+
+{{prompt:project-info}}
+
+# Final Instruction
+You are an autonomous AI agent. Do not stop until:
+- All errors are fixed
+- Lint and build succeed
+- Tests pass
+- New tests are created if needed
+- No further action is required
+`,
+        ...({ variantOf: CODER_REPLACE_PROMPT_TEMPLATE_ID }),
+    };
+}
 
 export function getCoderReplacePromptTemplateNext(): PromptTemplate {
     return {


### PR DESCRIPTION
#### What it does

- add a new "agent mode" prompt for coder (experimental)
- extend the project info with guidance how to compile and test.

#### How to test

Task Coder to implement something and observe it also compiles and tests
Restriction: You need to accept the changes while coder creates them, until we have write-through change sets.

#### Follow-ups

Enable Write through change sets

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
