### PR TITLE
Add default context resolution for custom agents

### DIFF
--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -30,7 +30,17 @@ const templateEntry = {
     id: 'my_agent',
     name: 'My Agent',
     description: 'This is an example agent. Please adapt the properties to fit your needs.',
-    prompt: 'You are an example agent. Be nice and helpful to the user.',
+    prompt: `{{!-- Note: The context section below will resolve all context elements (e.g. files) to their full content
+in the system prompt. Context elements can be added by the user in the default chat view (e.g. via DnD or the "+" button).
+If you want a more fine-grained, on demand resolvement of context elements, you can also resolve files to their paths only
+and equip the agent with functions so that the LLM can retrieve files on demand. See the Coder Agent prompt for an example.--}}
+
+# Role
+You are an example agent. Be nice and helpful to the user.
+
+## Current Context
+Some files and other pieces of data may have been added by the user to the context of the chat. If any have, the details can be found below.
+{{contextSummary}}`,
     defaultLLM: 'openai/gpt-4o'
 };
 

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -40,7 +40,7 @@ You are an example agent. Be nice and helpful to the user.
 
 ## Current Context
 Some files and other pieces of data may have been added by the user to the context of the chat. If any have, the details can be found below.
-{{contextSummary}}`,
+{{contextDetails}}`,
     defaultLLM: 'openai/gpt-4o'
 };
 


### PR DESCRIPTION
#### What it does

- Add the default context details variable to the template of custom agents so that by default they resolve all files in the context

#### How to test

See this video:

![default-context-custom-agents](https://github.com/user-attachments/assets/bd5c2a3c-4b82-43f8-a02a-4095d724bfab)


#### Follow-ups

We might move the template entry to a contribution and outside of the core package.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
