### PR TITLE
Subscribe to decoration changes at initialization

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -121,8 +121,7 @@ export class DebugEditorModel implements Disposable {
             }),
             this.breakpoints.onDidChangeBreakpoints(event => this.closeBreakpointIfAffected(event)),
         ]);
-        this.update();
-        this.render();
+        this.updateModel();
     }
 
     protected updateModel(): void {


### PR DESCRIPTION
#### What it does

When the DebugEditorModel attaches to the editor, it initially does not receive decorations updates. Only when changing the file, decorations are updated.

Fixes #15567


#### How to test

1. Open a fresh theia instance
2. Create a file of any type with multiple lines
3. Set a breakpoint at the last line
4. Verify breakpoint line in debug sidebar
5. Add or remove a line above
6. The breakpoint line position in the debug sidebar should be updated.


#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
