### PR TITLE
Update tree upon becoming visible

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -445,6 +445,13 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         super.onUpdateRequest(msg);
     }
 
+    protected override handleVisiblityChanged(isNowVisible: boolean): void {
+        super.handleVisiblityChanged(isNowVisible);
+        if (isNowVisible) {
+            this.update();
+        }
+    }
+
     protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         this.update();


### PR DESCRIPTION





#### What it does
Updates the tree widget when it becomes visible.

Fixes #15592

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Run through the scenario from the related issue. This change should be safe, since doing an additional widget update should never cause trouble. You can verify the performance impact by hiding a large tree (like the navigator) and showing it again.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups


#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
