### PR TITLE
[vscode] Support CommentAuthorInformation in CommentThread canreply

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -743,8 +743,8 @@ export interface CommentThread {
     onDidChangeState: TheiaEvent<CommentThreadState | undefined>;
     onDidChangeCollapsibleState: TheiaEvent<CommentThreadCollapsibleState | undefined>;
     isDisposed: boolean;
-    canReply: boolean;
-    onDidChangeCanReply: TheiaEvent<boolean>;
+    canReply: boolean | theia.CommentAuthorInformation;
+    onDidChangeCanReply: TheiaEvent<boolean | theia.CommentAuthorInformation>;
 }
 
 export interface CommentThreadChangedEventMain extends CommentThreadChangedEvent {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -2091,7 +2091,7 @@ export type CommentThreadChanges = Partial<{
     comments: Comment[],
     collapseState: CommentThreadCollapsibleState;
     state: CommentThreadState;
-    canReply: boolean;
+    canReply: boolean | theia.CommentAuthorInformation;
 }>;
 
 export interface CommentsMain {

--- a/packages/plugin-ext/src/main/browser/comments/comments-main.ts
+++ b/packages/plugin-ext/src/main/browser/comments/comments-main.ts
@@ -40,6 +40,7 @@ import { RPCProtocol } from '../../../common/rpc-protocol';
 import { interfaces } from '@theia/core/shared/inversify';
 import { generateUuid } from '@theia/core/lib/common/uuid';
 import { CommentsContribution } from './comments-contribution';
+import { CommentAuthorInformation } from '@theia/plugin';
 
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -139,7 +140,7 @@ export class CommentThreadImpl implements CommentThread, Disposable {
     private readonly onDidChangeStateEmitter = new Emitter<CommentThreadState | undefined>();
     readonly onDidChangeState = this.onDidChangeStateEmitter.event;
 
-    private readonly onDidChangeCanReplyEmitter = new Emitter<boolean>();
+    private readonly onDidChangeCanReplyEmitter = new Emitter<boolean | CommentAuthorInformation>();
     readonly onDidChangeCanReply = this.onDidChangeCanReplyEmitter.event;
 
     private _isDisposed: boolean;
@@ -148,12 +149,12 @@ export class CommentThreadImpl implements CommentThread, Disposable {
         return this._isDisposed;
     }
 
-    private _canReply: boolean = true;
-    get canReply(): boolean {
+    private _canReply: boolean | CommentAuthorInformation = true;
+    get canReply(): boolean | CommentAuthorInformation {
         return this._canReply;
     }
 
-    set canReply(canReply: boolean) {
+    set canReply(canReply: boolean | CommentAuthorInformation) {
         this._canReply = canReply;
         this.onDidChangeCanReplyEmitter.fire(this._canReply);
     }

--- a/packages/plugin-ext/src/main/browser/style/comments.css
+++ b/packages/plugin-ext/src/main/browser/style/comments.css
@@ -8,6 +8,7 @@
     margin-left: 5px;
     cursor: pointer;
 }
+
 .comment-range-glyph:before {
     position: absolute;
     content: '';
@@ -36,6 +37,7 @@
     border-left: 3px solid var(--theia-editorGutter-commentRangeForeground);
     transition: opacity 0.5s;
 }
+
 .monaco-editor .comment-diff-added:before {
     background: var(--theia-editorGutter-commentRangeForeground);
 }
@@ -123,6 +125,7 @@
 }
 
 .monaco-editor .review-widget .body .review-comment .avatar-container {
+    margin-right: 8px !important;
     margin-top: 4px !important;
 }
 
@@ -138,7 +141,6 @@
 }
 
 .monaco-editor .review-widget .body .review-comment .review-comment-contents {
-    padding-left: 20px;
     user-select: text;
     -webkit-user-select: text;
     width: 100%;
@@ -253,6 +255,12 @@
 
 .monaco-editor .review-widget .body .comment-body img {
     max-width: 100%;
+}
+
+.monaco-editor .review-widget .body .comment-form {
+    flex: 1;
+    margin: 0px;
+    /* Reset margin as it's handled by container */
 }
 
 .monaco-editor .review-widget .body .comment-form .form-actions {

--- a/packages/plugin-ext/src/plugin/comments.ts
+++ b/packages/plugin-ext/src/plugin/comments.ts
@@ -201,7 +201,7 @@ type CommentThreadModification = Partial<{
     comments: theia.Comment[],
     collapsibleState: theia.CommentThreadCollapsibleState
     state: theia.CommentThreadState
-    canReply: boolean;
+    canReply: boolean | theia.CommentAuthorInformation;
 }>;
 
 export class ExtHostCommentThread implements theia.CommentThread, theia.Disposable {
@@ -315,12 +315,12 @@ export class ExtHostCommentThread implements theia.CommentThread, theia.Disposab
         return this._isDisposed;
     }
 
-    private _canReply: boolean = true;
-    get canReply(): boolean {
+    private _canReply: boolean | theia.CommentAuthorInformation = true;
+    get canReply(): boolean | theia.CommentAuthorInformation {
         return this._canReply;
     }
 
-    set canReply(canReply: boolean) {
+    set canReply(canReply: boolean | theia.CommentAuthorInformation) {
         this._canReply = canReply;
         this.modifications.canReply = canReply;
         this._onDidUpdateCommentThread.fire();

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -13871,7 +13871,7 @@ export module '@theia/plugin' {
         /**
          * Whether the thread supports reply. Defaults to true.
          */
-        canReply: boolean;
+        canReply: boolean | CommentAuthorInformation;
     }
 
     /**


### PR DESCRIPTION
#### What it does

Adds the support of the CommentAuthorInformation in the canReply CommentThread property. This property was only boolean before, and still defaults to true currently. 

There were also some adaptation needed in the CommentThreadWidget widget. The canReply property drives the content of the reply text area, where only the text area is displayed when canReply is true, and the author information (icon and name) are displayed when canReply has some AuthorInformation. 

Finally, some adaptations were required since the widget did not work anymore with the refactoring on menu nodes (https://github.com/eclipse-theia/theia/pull/14676). Arguments were not initially available to test for visibility and enablement of the action, and the widget was failing.

fixes #15558

#### How to test

1. Install following extension:
- src:[vscode-comment-api-example-0.0.5-src.zip](https://github.com/user-attachments/files/20225896/vscode-comment-api-example-0.0.5-src.zip)
- vsix zipped: [vscode-comment-api-example-0.0.5.zip](https://github.com/user-attachments/files/20225903/vscode-comment-api-example-0.0.5.zip)
2. Have in the workspace 2 different markdown files, more specifically ones that have the 'md' extension
3. Compare both of them
4. The Comment widget comes, with several actions. The "Toggle Reply" action cycle between canReply is true and canReply has some author information. The "Disable CanReply" action sets the canReply to false, and then all actions are disabled on the widget. The reply button let you enter a new comment in the thread.

#### Follow-ups

When menus are the ones mapped from vscode, e.g. from this mapping:
https://github.com/eclipse-theia/theia/blob/23e0bec71cf0df5b2537332808c4642d8efd681d/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts#L76
It likely seems that the menu node is undefined if no contributions are made to the menu. 
That causes an error message from the menu registry. See
https://github.com/eclipse-theia/theia/blob/23e0bec71cf0df5b2537332808c4642d8efd681d/packages/core/src/common/menu/menu-model-registry.ts#L331
 
This may pollute the error log. I added some check there: 
https://github.com/eclipse-theia/theia/commit/6bad05bd37084c5c76cf9906a5d12d286f320be9#diff-9030451153f2a294811451cfe5660a9df850b425d6b4f5a342246e15dc5eb066R563
I don't think this would be a long term solution.  

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
