### PR TITLE
Allow to see editor hovers while debugging

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -17,12 +17,9 @@
 import debounce = require('p-debounce');
 import { injectable, inject, postConstruct, interfaces, Container } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
-import { IConfigurationService } from '@theia/monaco-editor-core/esm/vs/platform/configuration/common/configuration';
 import { StandaloneCodeEditor } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 import { IDecorationOptions } from '@theia/monaco-editor-core/esm/vs/editor/common/editorCommon';
-import { IEditorHoverOptions } from '@theia/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
 import URI from '@theia/core/lib/common/uri';
-import { URI as CodeUri } from '@theia/core/shared/vscode-uri';
 import { Disposable, DisposableCollection, MenuPath, isOSX } from '@theia/core';
 import { ContextMenuRenderer } from '@theia/core/lib/browser';
 import { BreakpointManager, SourceBreakpointsChangeEvent } from '../breakpoint/breakpoint-manager';
@@ -35,7 +32,6 @@ import { DebugBreakpointWidget } from './debug-breakpoint-widget';
 import { DebugExceptionWidget } from './debug-exception-widget';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { DebugInlineValueDecorator, INLINE_VALUE_DECORATION_KEY } from './debug-inline-value-decorator';
-import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 
 export const DebugEditorModelFactory = Symbol('DebugEditorModelFactory');
 export type DebugEditorModelFactory = (editor: DebugEditor) => DebugEditorModel;
@@ -146,35 +142,7 @@ export class DebugEditorModel implements Disposable {
         this.toDisposeOnUpdate.dispose();
         this.toggleExceptionWidget();
         await this.updateEditorDecorations();
-        this.updateEditorHover();
     }, 100);
-
-    /**
-     * To disable the default editor-contribution hover from Code when
-     * the editor has the `currentFrame`. Otherwise, both `textdocument/hover`
-     * and the debug hovers are visible at the same time when hovering over a symbol.
-     */
-    protected async updateEditorHover(): Promise<void> {
-        if (this.sessions.isCurrentEditorFrame(this.uri)) {
-            const codeEditor = this.editor.getControl();
-            codeEditor.updateOptions({ hover: { enabled: false } });
-            this.toDisposeOnUpdate.push(Disposable.create(() => {
-                const model = codeEditor.getModel();
-                const overrides = {
-                    resource: CodeUri.parse(this.editor.getResourceUri().toString()),
-                    overrideIdentifier: model?.getLanguageId(),
-                };
-                const { enabled, delay, sticky } = StandaloneServices.get(IConfigurationService).getValue<IEditorHoverOptions>('editor.hover', overrides);
-                codeEditor.updateOptions({
-                    hover: {
-                        enabled,
-                        delay,
-                        sticky
-                    }
-                });
-            }));
-        }
-    }
 
     protected async updateEditorDecorations(): Promise<void> {
         const [newFrameDecorations, inlineValueDecorations] = await Promise.all([

--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -16,23 +16,26 @@
 
 import debounce = require('@theia/core/shared/lodash.debounce');
 
-import { Widget } from '@theia/core/shared/@lumino/widgets';
-import { Message } from '@theia/core/shared/@lumino/messaging';
-import { injectable, postConstruct, inject, Container, interfaces } from '@theia/core/shared/inversify';
+import { ArrayUtils } from '@theia/core';
 import { Key } from '@theia/core/lib/browser';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Message } from '@theia/core/shared/@lumino/messaging';
+import { Widget } from '@theia/core/shared/@lumino/widgets';
+import { Container, inject, injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
+import { URI as CodeUri } from '@theia/core/shared/vscode-uri';
+import * as monaco from '@theia/monaco-editor-core';
+import { CancellationTokenSource } from '@theia/monaco-editor-core/esm/vs/base/common/cancellation';
+import { IEditorHoverOptions } from '@theia/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
+import { Position } from '@theia/monaco-editor-core/esm/vs/editor/common/core/position';
+import { ILanguageFeaturesService } from '@theia/monaco-editor-core/esm/vs/editor/common/services/languageFeatures';
+import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
+import { IConfigurationService } from '@theia/monaco-editor-core/esm/vs/platform/configuration/common/configuration';
+import { DebugVariable } from '../console/debug-console-items';
 import { DebugSessionManager } from '../debug-session-manager';
 import { DebugEditor } from './debug-editor';
 import { DebugExpressionProvider } from './debug-expression-provider';
 import { DebugHoverSource } from './debug-hover-source';
-import { DebugVariable } from '../console/debug-console-items';
-import * as monaco from '@theia/monaco-editor-core';
-import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
-import { ILanguageFeaturesService } from '@theia/monaco-editor-core/esm/vs/editor/common/services/languageFeatures';
-import { CancellationTokenSource } from '@theia/monaco-editor-core/esm/vs/base/common/cancellation';
-import { Position } from '@theia/monaco-editor-core/esm/vs/editor/common/core/position';
-import { ArrayUtils } from '@theia/core';
 
 export interface ShowDebugHoverOptions {
     selection: monaco.Range
@@ -76,6 +79,8 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
 
     allowEditorOverflow = true;
 
+    protected suppressEditorHoverToDispose = new DisposableCollection();
+
     static ID = 'debug.editor.hover';
     getId(): string {
         return DebugHoverWidget.ID;
@@ -115,6 +120,7 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
     }
 
     override dispose(): void {
+        this.suppressEditorHoverToDispose.dispose();
         this.toDispose.dispose();
     }
 
@@ -141,6 +147,8 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
         if (!this.isVisible) {
             return;
         }
+        this.suppressEditorHoverToDispose.dispose();
+
         if (this.domNode.contains(document.activeElement)) {
             this.editor.getControl().focus();
         }
@@ -254,6 +262,8 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
             }
         }
 
+        this.suppressEditorHover();
+
         super.show();
         await new Promise<void>(resolve => {
             setTimeout(() => window.requestAnimationFrame(() => {
@@ -261,6 +271,32 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
                 resolve();
             }), 0);
         });
+    }
+
+    /**
+     * Suppress the default editor-contribution hover from Code.
+     * Otherwise, both `textdocument/hover` and the debug hovers are visible
+     * at the same time when hovering over a symbol.
+     * This will priorize the debug hover over the editor hover.
+     */
+    protected suppressEditorHover(): void {
+        const codeEditor = this.editor.getControl();
+        codeEditor.updateOptions({ hover: { enabled: false } });
+        this.suppressEditorHoverToDispose.push(Disposable.create(() => {
+            const model = codeEditor.getModel();
+            const overrides = {
+                resource: CodeUri.parse(this.editor.getResourceUri().toString()),
+                overrideIdentifier: model?.getLanguageId(),
+            };
+            const { enabled, delay, sticky } = StandaloneServices.get(IConfigurationService).getValue<IEditorHoverOptions>('editor.hover', overrides);
+            codeEditor.updateOptions({
+                hover: {
+                    enabled,
+                    delay,
+                    sticky
+                }
+            });
+        }));
     }
 
     protected isEditorFrame(): boolean {


### PR DESCRIPTION
#### What it does

Currently, when debugging, hovers provided by the LSP server are not displayed, because the are disabled at the start of debugging. This change will disable these hovers only while showing a debug hover. Thus during debugging, debug hovers have priority over editor hovers.

Fixes #15170

#### How to test

* Create a java file with following content:
```
public class Main {
    public static void main(String[] args) {
        for (int i = 0; i < 10; i++) {
            System.out.println("Hello World!");
        }
    }
}
```
* Set breakpoint in main Method
* Start debugging with codeLense Button
* Step once
* Try hovering over i, System, out, println, ...

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
