### PR TITLE
chore: hide suggestions from chat input for message editing

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -87,7 +87,8 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
         container.bind(AIChatTreeInputConfiguration).toConstantValue({
             showContext: true,
             showPinnedAgent: true,
-            showChangeSet: false
+            showChangeSet: false,
+            showSuggestions: false,
         } satisfies AIChatInputConfiguration);
         container.bind(AIChatTreeInputWidget).toSelf().inSingletonScope();
         const widget = container.get(AIChatTreeInputWidget);

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -42,6 +42,7 @@ export interface AIChatInputConfiguration {
     showContext?: boolean;
     showPinnedAgent?: boolean;
     showChangeSet?: boolean;
+    showSuggestions?: boolean;
 }
 
 @injectable()
@@ -180,6 +181,7 @@ export class AIChatInputWidget extends ReactWidget {
                 showContext={this.configuration?.showContext}
                 showPinnedAgent={this.configuration?.showPinnedAgent}
                 showChangeSet={this.configuration?.showChangeSet}
+                showSuggestions={this.configuration?.showSuggestions}
                 labelProvider={this.labelProvider}
                 actionService={this.changeSetActionService}
                 decoratorService={this.changeSetDecoratorService}
@@ -289,6 +291,7 @@ interface ChatInputProperties {
     showContext?: boolean;
     showPinnedAgent?: boolean;
     showChangeSet?: boolean;
+    showSuggestions?: boolean;
     labelProvider: LabelProvider;
     actionService: ChangeSetActionService;
     decoratorService: ChangeSetDecoratorService;
@@ -593,7 +596,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     const contextUI = buildContextUI(props.context, props.labelProvider, props.onDeleteContextElement, props.onOpenContextElement);
 
     return <div className='theia-ChatInput' onDragOver={props.onDragOver} onDrop={props.onDrop}    >
-        {<ChatInputAgentSuggestions suggestions={props.suggestions} opener={props.openerService} />}
+        {props.showSuggestions !== false && <ChatInputAgentSuggestions suggestions={props.suggestions} opener={props.openerService} />}
         {props.showChangeSet && changeSetUI?.elements &&
             <ChangeSetBox changeSet={changeSetUI} />
         }


### PR DESCRIPTION
#### What it does

Remove suggestions from the chat input when editing messages to enhance user experience. This change addresses the unwanted display of suggestions in the chat input field.

Fixes eclipse-theia/theia#15616

#### How to test

* Request a change with `@Coder` so that you'll get a suggestion from Coder to start new tasks.
* Click edit on your input message
* Observe that the suggestion is just shown above the main chat input but not above the editor for changing an earlier chat message

![image](https://github.com/user-attachments/assets/fbf850c3-42a7-414e-8dc4-2bf730d40305)

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
