### PR TITLE
Introduce debounce for inline AI code completion

### DIFF
--- a/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
+++ b/packages/ai-code-completion/src/browser/ai-code-completion-preference.ts
@@ -19,6 +19,7 @@ import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/browser/ai-core-pr
 import { nls } from '@theia/core';
 
 export const PREF_AI_INLINE_COMPLETION_AUTOMATIC_ENABLE = 'ai-features.codeCompletion.automaticCodeCompletion';
+export const PREF_AI_INLINE_COMPLETION_DEBOUNCE_DELAY = 'ai-features.codeCompletion.debounceDelay';
 export const PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS = 'ai-features.codeCompletion.excludedFileExtensions';
 export const PREF_AI_INLINE_COMPLETION_MAX_CONTEXT_LINES = 'ai-features.codeCompletion.maxContextLines';
 export const PREF_AI_INLINE_COMPLETION_STRIP_BACKTICKS = 'ai-features.codeCompletion.stripBackticks';
@@ -34,6 +35,14 @@ export const AICodeCompletionPreferencesSchema: PreferenceSchema = {
             \n\
             Alternatively, you can manually trigger the code via the command "Trigger Inline Suggestion" or the default shortcut "Ctrl+Alt+Space".'),
             default: false
+        },
+        [PREF_AI_INLINE_COMPLETION_DEBOUNCE_DELAY]: {
+            title: nls.localize('theia/ai/completion/debounceDelay/title', 'Debounce Delay'),
+            type: 'number',
+            description: nls.localize('theia/ai/completion/debounceDelay/description',
+                'Controls the delay in milliseconds before triggering AI completions after changes have been detected in the editor.\
+                Requires `Automatic Code Completion` to be enabled. Enter 0 to disable the debounce delay.'),
+            default: 300
         },
         [PREF_AI_INLINE_COMPLETION_EXCLUDED_EXTENSIONS]: {
             title: nls.localize('theia/ai/completion/excludedFileExts/title', 'Excluded File Extensions'),

--- a/packages/ai-code-completion/src/browser/code-completion-debouncer.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-debouncer.ts
@@ -1,0 +1,35 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export class InlineCompletionDebouncer {
+
+    private timeoutId?: number;
+
+    debounce<T>(callback: () => Promise<T>, debounceDelay: number): Promise<T> {
+        return new Promise<T>((resolve, reject) => {
+            if (this.timeoutId) {
+                window.clearTimeout(this.timeoutId);
+            }
+
+            this.timeoutId = window.setTimeout(() => {
+                callback()
+                    .then(resolve)
+                    .catch(reject);
+                this.timeoutId = undefined;
+            }, debounceDelay);
+        });
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- debounces inline AI code completion requests
- adds new preference `aiFeatures.codeCompletion.debounceDelay` (default 300 ms)
- explicit trigger bypasses the debounce entirely

Closes #15399

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open AI Agent History View and select `Code Completion` agent to monitor outgoing requests
2. Automatic inline completion (AI Features > Code Completion > Automatic Code Completion enabled)
   1. Default delay is 300 ms (or use any custom value in the settings: AI Features > Code Completion > Debounce Delay)
      * Type normally: only one request is sent after you stop typing for the configured time
   2. Set delay to 0 ms  
      * Type freely: every keystroke sends a request
3. Manual completion (AI Features > Code Completion > Automatic Code Completion disabled)
   1. Set the delay to a high value, e.g. 3000 ms
   2. Invoke completion manually with <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Space</kbd> → the request is sent immediately


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

—

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

—

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
