### PR TITLE
Fix "Show all opened editors" dropdown display by using correct icon class type

### DIFF
--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -34,6 +34,7 @@ import { nls } from '@theia/core/lib/common/nls';
 import { CurrentWidgetCommandAdapter } from '@theia/core/lib/browser/shell/current-widget-command-adapter';
 import { EditorWidget } from './editor-widget';
 import { EditorLanguageStatusService } from './language-status/editor-language-status-service';
+import { QuickEditorService } from './quick-editor-service';
 
 @injectable()
 export class EditorContribution implements FrontendApplicationContribution,
@@ -143,7 +144,7 @@ export class EditorContribution implements FrontendApplicationContribution,
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(EditorCommands.SHOW_ALL_OPENED_EDITORS, {
-            execute: () => this.quickInputService?.open('edt ')
+            execute: () => this.quickInputService?.open(QuickEditorService.PREFIX)
         });
         const splitHandlerFactory = (splitMode: DockLayout.InsertMode): CommandHandler => new CurrentWidgetCommandAdapter(this.shell, {
             isEnabled: title => title?.owner instanceof EditorWidget,

--- a/packages/editor/src/browser/quick-editor-service.ts
+++ b/packages/editor/src/browser/quick-editor-service.ts
@@ -80,7 +80,7 @@ export class QuickEditorService implements QuickAccessContribution, QuickAccessP
     protected toItem(widget: NavigatableWidget): QuickPickItem {
         const uri = NavigatableWidget.getUri(widget)!;
         const icon = this.labelProvider.getIcon(uri);
-        const iconClasses = icon === '' ? undefined : [icon + ' file-icon'];
+        const iconClasses: string[] = icon ? icon.split(' ').concat('file-icon') : [];
 
         return {
             label: this.labelProvider.getName(uri),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #15623

- Fixes rendering issue in "Show all opened editors" quick pick dropdown caused by icon classes being passed as a string instead of a string array.
- Also refactors to reuse the existing constant for the quick input prefix when executing the command.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open multiple editors in a Theia workspace.
2. Press `Ctrl+K Ctrl+P` to trigger the "Show all opened editors" quick pick.
3. Ensure the quick pick displays all open editors correctly, with proper layout and icons.
4. Verify that other quick pick dropdowns (e.g., command palette) still work as expected and are unaffected.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

—

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

—

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
