### PR TITLE
Prompt management refactoring and view

### DIFF
--- a/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
@@ -24,7 +24,7 @@ import {
     unansweredQuestions,
     ProgressChatResponseContentImpl
 } from '@theia/ai-chat';
-import { Agent, LanguageModelMessage, PromptTemplate } from '@theia/ai-core';
+import { Agent, LanguageModelMessage, BuiltInPromptFragment } from '@theia/ai-core';
 import { injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
 
 export function bindAskAndContinueChatAgentContribution(bind: interfaces.Bind): void {
@@ -33,7 +33,7 @@ export function bindAskAndContinueChatAgentContribution(bind: interfaces.Bind): 
     bind(ChatAgent).toService(AskAndContinueChatAgent);
 }
 
-const systemPrompt: PromptTemplate = {
+const systemPrompt: BuiltInPromptFragment = {
     id: 'askAndContinue-system',
     template: `
 You are an agent demonstrating how to generate questions and continue the conversation based on the user's answers.
@@ -119,7 +119,7 @@ export class AskAndContinueChatAgent extends AbstractStreamParsingChatAgent {
             identifier: 'openai/gpt-4o',
         }
     ];
-    override promptTemplates = [systemPrompt];
+    override systemPrompts = [{ id: systemPrompt.id, defaultVariant: systemPrompt }];
     protected override systemPromptId: string | undefined = systemPrompt.id;
 
     @postConstruct()

--- a/packages/ai-chat/src/browser/custom-agent-frontend-application-contribution.ts
+++ b/packages/ai-chat/src/browser/custom-agent-frontend-application-contribution.ts
@@ -14,9 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { AgentService, CustomAgentDescription, PromptCustomizationService } from '@theia/ai-core';
+import { AgentService, CustomAgentDescription, PromptFragmentCustomizationService } from '@theia/ai-core';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { ChatAgentService } from '../common';
 import { CustomAgentFactory } from './custom-agent-factory';
 
@@ -25,8 +25,8 @@ export class AICustomAgentsFrontendApplicationContribution implements FrontendAp
     @inject(CustomAgentFactory)
     protected readonly customAgentFactory: CustomAgentFactory;
 
-    @inject(PromptCustomizationService)
-    protected readonly customizationService: PromptCustomizationService;
+    @inject(PromptFragmentCustomizationService) @optional()
+    protected readonly customizationService: PromptFragmentCustomizationService;
 
     @inject(AgentService)
     private readonly agentService: AgentService;

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -36,8 +36,8 @@ import {
     LanguageModelService,
     LanguageModelStreamResponse,
     PromptService,
-    PromptTemplate,
-    ResolvedPromptTemplate,
+    ResolvedPromptFragment,
+    SystemPrompt,
     TextMessage,
     ToolCall,
     ToolRequest,
@@ -75,7 +75,7 @@ export interface SystemMessageDescription {
     functionDescriptions?: Map<string, ToolRequest>;
 }
 export namespace SystemMessageDescription {
-    export function fromResolvedPromptTemplate(resolvedPrompt: ResolvedPromptTemplate): SystemMessageDescription {
+    export function fromResolvedPromptFragment(resolvedPrompt: ResolvedPromptFragment): SystemMessageDescription {
         return {
             text: resolvedPrompt.text,
             functionDescriptions: resolvedPrompt.functionDescriptions
@@ -158,7 +158,7 @@ export abstract class AbstractChatAgent implements ChatAgent {
     tags: string[] = ['Chat'];
     description: string = '';
     variables: string[] = [];
-    promptTemplates: PromptTemplate[] = [];
+    systemPrompts: SystemPrompt[] = [];
     agentSpecificVariables: AgentSpecificVariables[] = [];
     functions: string[] = [];
     protected readonly abstract defaultLanguageModelPurpose: string;
@@ -246,7 +246,7 @@ export abstract class AbstractChatAgent implements ChatAgent {
             return undefined;
         }
         const resolvedPrompt = await this.promptService.getPrompt(this.systemPromptId, undefined, context);
-        return resolvedPrompt ? SystemMessageDescription.fromResolvedPromptTemplate(resolvedPrompt) : undefined;
+        return resolvedPrompt ? SystemMessageDescription.fromResolvedPromptFragment(resolvedPrompt) : undefined;
     }
 
     protected async getMessages(

--- a/packages/ai-chat/src/common/chat-session-naming-service.ts
+++ b/packages/ai-chat/src/common/chat-session-naming-service.ts
@@ -23,25 +23,28 @@ import {
     LanguageModelRegistry,
     LanguageModelRequirement,
     PromptService,
-    PromptTemplate,
+    SystemPrompt,
     UserRequest
 } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatSession } from './chat-service';
 import { generateUuid } from '@theia/core';
 
-const CHAT_SESSION_NAMING_PROMPT = {
+const CHAT_SESSION_NAMING_PROMPT: SystemPrompt = {
     id: 'chat-session-naming-prompt',
-    template: '{{!-- Made improvements or adaptations to this prompt template? We\'d love for you to share it with the community! Contribute back here: ' +
-        'https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}\n\n' +
-        'Provide a short and descriptive name for the given AI chat conversation of an AI-powered tool based on the conversation below.\n\n' +
-        'The purpose of the name is for users to recognize the chat conversation easily in a list of conversations. ' +
-        'Use the same language for the chat conversation name as used in the provided conversation, if in doubt default to English. ' +
-        'Start the chat conversation name with an upper-case letter. ' +
-        'Below we also provide the already existing other conversation names, make sure your suggestion for a name is unique with respect to the existing ones.\n\n' +
-        'IMPORTANT: Your answer MUST ONLY CONTAIN THE PROPOSED NAME and must not be preceded or followed by any other text.' +
-        '\n\nOther session names:\n{{listOfSessionNames}}' +
-        '\n\nConversation:\n{{conversation}}',
+    defaultVariant: {
+        id: 'chat-session-naming-prompt',
+        template: '{{!-- Made improvements or adaptations to this prompt template? We\'d love for you to share it with the community! Contribute back here: ' +
+            'https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}\n\n' +
+            'Provide a short and descriptive name for the given AI chat conversation of an AI-powered tool based on the conversation below.\n\n' +
+            'The purpose of the name is for users to recognize the chat conversation easily in a list of conversations. ' +
+            'Use the same language for the chat conversation name as used in the provided conversation, if in doubt default to English. ' +
+            'Start the chat conversation name with an upper-case letter. ' +
+            'Below we also provide the already existing other conversation names, make sure your suggestion for a name is unique with respect to the existing ones.\n\n' +
+            'IMPORTANT: Your answer MUST ONLY CONTAIN THE PROPOSED NAME and must not be preceded or followed by any other text.' +
+            '\n\nOther session names:\n{{listOfSessionNames}}' +
+            '\n\nConversation:\n{{conversation}}',
+    }
 };
 
 @injectable()
@@ -63,7 +66,7 @@ export class ChatSessionNamingAgent implements Agent {
     name = 'Chat Session Naming';
     description = 'Agent for generating chat session names';
     variables = [];
-    promptTemplates: PromptTemplate[] = [CHAT_SESSION_NAMING_PROMPT];
+    systemPrompts = [CHAT_SESSION_NAMING_PROMPT];
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat-session-naming',
         identifier: 'openai/gpt-4o-mini',

--- a/packages/ai-chat/src/common/chat-session-summary-agent-prompt.ts
+++ b/packages/ai-chat/src/common/chat-session-summary-agent-prompt.ts
@@ -11,18 +11,21 @@
 import { CHANGE_SET_SUMMARY_VARIABLE_ID } from './context-variables';
 
 export const CHAT_SESSION_SUMMARY_PROMPT = {
-    id: 'chat-session-summary-prompt',
-    template: `{{!-- !-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We\'d love for you to share it with the community! Contribute back here: ' +
-        'https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}\n\n' +
-        'You are a chat agent for summarizing AI agent chat sessions for later use. \
-Review the conversation above and generate a concise summary that captures every crucial detail, \
-including all requirements, decisions, and pending tasks. \
-Ensure that the summary is sufficiently comprehensive to allow seamless continuation of the workflow. The summary will primarily be used by other AI agents, so tailor your \
-response for use by AI agents. \
-Also consider the system message.
-Make sure you include all necessary context information and use unique references (such as URIs, file paths, etc.).
-If the conversation was about a task, describe the state of the task, i.e. what has been completed and what is open.
-If a changeset is open in the session, describe the state of the suggested changes.
-{{${CHANGE_SET_SUMMARY_VARIABLE_ID}}}`,
+    id: 'chat-session-summary-system-prompt',
+    defaultVariant: {
+        id: 'chat-session-summary-prompt',
+        template: `{{!-- !-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+    Made improvements or adaptations to this prompt template? We\'d love for you to share it with the community! Contribute back here: ' +
+            'https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}\n\n' +
+            'You are a chat agent for summarizing AI agent chat sessions for later use. \
+    Review the conversation above and generate a concise summary that captures every crucial detail, \
+    including all requirements, decisions, and pending tasks. \
+    Ensure that the summary is sufficiently comprehensive to allow seamless continuation of the workflow. The summary will primarily be used by other AI agents, so tailor your \
+    response for use by AI agents. \
+    Also consider the system message.
+    Make sure you include all necessary context information and use unique references (such as URIs, file paths, etc.).
+    If the conversation was about a task, describe the state of the task, i.e. what has been completed and what is open.
+    If a changeset is open in the session, describe the state of the suggested changes.
+    {{${CHANGE_SET_SUMMARY_VARIABLE_ID}}}`,
+    }
 };

--- a/packages/ai-chat/src/common/chat-session-summary-agent.ts
+++ b/packages/ai-chat/src/common/chat-session-summary-agent.ts
@@ -16,7 +16,7 @@
 
 import {
     LanguageModelRequirement,
-    PromptTemplate
+    SystemPrompt
 } from '@theia/ai-core';
 import { injectable } from '@theia/core/shared/inversify';
 import { AbstractStreamParsingChatAgent, ChatAgent } from './chat-agents';
@@ -29,7 +29,7 @@ export class ChatSessionSummaryAgent extends AbstractStreamParsingChatAgent impl
     name = 'Chat Session Summary';
     override description = 'Agent for generating chat session summaries.';
     override variables = [];
-    override promptTemplates: PromptTemplate[] = [CHAT_SESSION_SUMMARY_PROMPT];
+    override systemPrompts: SystemPrompt[] = [CHAT_SESSION_SUMMARY_PROMPT];
     protected readonly defaultLanguageModelPurpose = 'chat-session-summary';
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat-session-summary',

--- a/packages/ai-chat/src/common/custom-chat-agent.ts
+++ b/packages/ai-chat/src/common/custom-chat-agent.ts
@@ -28,6 +28,6 @@ export class CustomChatAgent extends AbstractStreamParsingChatAgent {
     set prompt(prompt: string) {
         // the name is dynamic, so we set the propmptId here
         this.systemPromptId = `${this.name}_prompt`;
-        this.promptTemplates.push({ id: `${this.name}_prompt`, template: prompt });
+        this.systemPrompts.push({ id: this.systemPromptId, defaultVariant: { id: `${this.name}_prompt`, template: prompt } });
     }
 }

--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -17,7 +17,8 @@
 import { LanguageModelService } from '@theia/ai-core/lib/browser';
 import {
     Agent, AgentSpecificVariables, CommunicationRecordingService, getTextOfResponse,
-    LanguageModelRegistry, LanguageModelRequirement, PromptService, PromptTemplate,
+    LanguageModelRegistry, LanguageModelRequirement, PromptService,
+    SystemPrompt,
     UserRequest
 } from '@theia/ai-core/lib/common';
 import { generateUuid, ILogger, nls, ProgressService } from '@theia/core';
@@ -25,7 +26,7 @@ import { PreferenceService } from '@theia/core/lib/browser';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { PREF_AI_INLINE_COMPLETION_MAX_CONTEXT_LINES } from './ai-code-completion-preference';
-import { codeCompletionPromptTemplates } from './code-completion-prompt-template';
+import { codeCompletionSystemPrompts } from './code-completion-prompt-template';
 import { CodeCompletionPostProcessor } from './code-completion-postprocessor';
 
 export const CodeCompletionAgent = Symbol('CodeCompletionAgent');
@@ -198,7 +199,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
     name = 'Code Completion';
     description =
         nls.localize('theia/ai/completion/agent/description', 'This agent provides inline code completion in the code editor in the Theia IDE.');
-    promptTemplates: PromptTemplate[] = codeCompletionPromptTemplates;
+    systemPrompts: SystemPrompt[] = codeCompletionSystemPrompts;
     languageModelRequirements: LanguageModelRequirement[] = [
         {
             purpose: 'code-completion',

--- a/packages/ai-code-completion/src/browser/code-completion-prompt-template.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-prompt-template.ts
@@ -9,12 +9,12 @@
 // SPDX-License-Identifier: MIT
 // *****************************************************************************
 
-import { PromptTemplate } from '@theia/ai-core/lib/common';
+import { SystemPrompt } from '@theia/ai-core/lib/common';
 
-export const codeCompletionPromptTemplates: PromptTemplate[] = [
-    {
+export const codeCompletionSystemPrompts: SystemPrompt[] = [{
+    id: 'code-completion-prompt',
+    variants: [{
         id: 'code-completion-prompt-previous',
-        variantOf: 'code-completion-prompt',
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
@@ -25,9 +25,9 @@ Finish the following code snippet.
 {{prefix}}[[MARKER]]{{suffix}}
 
 Only return the exact replacement for [[MARKER]] to complete the snippet.`
-    },
-    {
-        id: 'code-completion-prompt',
+    }],
+    defaultVariant: {
+        id: 'code-completion-prompt-default',
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
@@ -42,4 +42,5 @@ https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-
 
 Replace [[MARKER]] with the exact code to complete the code snippet. Return only the replacement of [[MARKER]] as plain text.`,
     },
+}
 ];

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -32,7 +32,7 @@ import {
     LanguageModelRegistryClient,
     languageModelRegistryDelegatePath,
     LanguageModelRegistryFrontendDelegate,
-    PromptCustomizationService,
+    PromptFragmentCustomizationService,
     PromptService,
     PromptServiceImpl,
     ToolProvider,
@@ -53,7 +53,7 @@ import { AICoreFrontendApplicationContribution } from './ai-core-frontend-applic
 import { bindAICorePreferences } from './ai-core-preferences';
 import { AgentSettingsPreferenceSchema } from './agent-preferences';
 import { AISettingsServiceImpl } from './ai-settings-service';
-import { FrontendPromptCustomizationServiceImpl } from './frontend-prompt-customization-service';
+import { DefaultPromptFragmentCustomizationService } from './frontend-prompt-customization-service';
 import { DefaultFrontendVariableService, FrontendVariableService } from './frontend-variable-service';
 import { PromptTemplateContribution } from './prompttemplate-contribution';
 import { FileVariableContribution } from './file-variable-contribution';
@@ -101,8 +101,8 @@ export default new ContainerModule(bind => {
     bindAICorePreferences(bind);
     bind(PreferenceContribution).toConstantValue({ schema: AgentSettingsPreferenceSchema });
 
-    bind(FrontendPromptCustomizationServiceImpl).toSelf().inSingletonScope();
-    bind(PromptCustomizationService).toService(FrontendPromptCustomizationServiceImpl);
+    bind(DefaultPromptFragmentCustomizationService).toSelf().inSingletonScope();
+    bind(PromptFragmentCustomizationService).toService(DefaultPromptFragmentCustomizationService);
     bind(PromptServiceImpl).toSelf().inSingletonScope();
     bind(PromptService).toService(PromptServiceImpl);
 

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -17,7 +17,7 @@
 import { DisposableCollection, URI, Event, Emitter } from '@theia/core';
 import { OpenerService } from '@theia/core/lib/browser';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { PromptCustomizationService, CustomAgentDescription } from '../common';
+import { PromptFragmentCustomizationService, CustomAgentDescription, CustomizedPromptFragment } from '../common';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
@@ -26,7 +26,10 @@ import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { load, dump } from 'js-yaml';
 import { PROMPT_TEMPLATE_EXTENSION } from './prompttemplate-contribution';
 
-const templateEntry = {
+/**
+ * Default template entry for creating custom agents
+ */
+const newCustomAgentEntry = {
     id: 'my_agent',
     name: 'My Agent',
     description: 'This is an example agent. Please adapt the properties to fit your needs.',
@@ -44,41 +47,76 @@ Some files and other pieces of data may have been added by the user to the conte
     defaultLLM: 'openai/gpt-4o'
 };
 
-// Template source priorities (higher number = higher priority)
-// Higher priority will "override" lower priority templates
-const enum TemplatePriority {
-    GLOBAL_TEMPLATE_DIR = 1,
-    ADDITIONAL_TEMPLATE_DIR = 2,
-    TEMPLATE_FILE = 3
+export enum CustomizationSource {
+    CUSTOMIZED = 1,
+    FOLDER = 2,
+    FILE = 3,
+}
+
+export function getCustomizationSourceString(origin: CustomizationSource): string {
+    switch (origin) {
+        case CustomizationSource.FILE:
+            return 'Specific file';
+        case CustomizationSource.FOLDER:
+            return 'Workspace folder';
+        default:
+            return 'Global';
+    }
 }
 
 /**
- * Interface defining properties that can be updated in the service
+ * Interface defining properties that can be updated in the customization service
  */
-export interface PromptCustomizationProperties {
+export interface PromptFragmentCustomizationProperties {
     /** Array of directory paths to load templates from */
     directoryPaths?: string[];
+
     /** Array of file paths to treat as templates */
     filePaths?: string[];
+
     /** Array of file extensions to consider as template files */
     extensions?: string[];
 }
 
-interface TemplateEntry {
-    content: string;
-    priority: number;
+/**
+ * Internal representation of a fragment entry in the customization service
+ */
+interface PromptFragmentCustomization {
+    /** The template content */
+    template: string;
+
+    /** Source URI where this template is stored */
     sourceUri: string;
+
+    /** Source type of the customization */
+    origin: CustomizationSource;
+
+    /** Priority level (higher values override lower ones) */
+    priority: number;
+
+    /** Fragment ID */
     id: string;
+
+    /** Unique customization ID */
+    customizationId: string;
 }
 
+/**
+ * Information about a template file being watched for changes
+ */
 interface WatchedFileInfo {
+    /** The URI of the watched file */
     uri: URI;
-    templateId: string;
+
+    /** The fragment ID associated with this file */
+    fragmentId: string;
+
+    /** The customization ID for this file */
+    customizationId: string;
 }
 
 @injectable()
-export class FrontendPromptCustomizationServiceImpl implements PromptCustomizationService {
-
+export class DefaultPromptFragmentCustomizationService implements PromptFragmentCustomizationService {
     @inject(EnvVariablesServer)
     protected readonly envVariablesServer: EnvVariablesServer;
 
@@ -93,32 +131,36 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
 
     /** Stores URI strings of template files from directories currently being monitored for changes. */
     protected trackedTemplateURIs = new Set<string>();
-    /** Contains the currently active templates, mapped by template ID. */
-    protected effectiveTemplates = new Map<string, TemplateEntry>();
-    /** Tracks all loaded templates, including overridden ones, mapped by source URI. */
-    protected allLoadedTemplates = new Map<string, TemplateEntry>();
+
+    /** Contains the currently active customization, mapped by prompt fragment ID. */
+    protected activeCustomizations = new Map<string, PromptFragmentCustomization>();
+
+    /** Tracks all loaded customizations, including overridden ones, mapped by source URI. */
+    protected allCustomizations = new Map<string, PromptFragmentCustomization>();
+
     /** Stores additional directory paths for loading template files. */
     protected additionalTemplateDirs = new Set<string>();
+
     /** Contains file extensions that identify prompt template files. */
     protected templateExtensions = new Set<string>([PROMPT_TEMPLATE_EXTENSION]);
-    /** Stores specific file paths that should be treated as templates. */
-    protected templateFiles = new Set<string>();
+
+    /** Stores specific file paths, provided by the settings, that should be treated as templates. */
+    protected workspaceTemplateFiles = new Set<string>();
+
     /** Maps URI strings to WatchedFileInfo objects for individually watched template files. */
     protected watchedFiles = new Map<string, WatchedFileInfo>();
+
     /** Collection of disposable resources for cleanup when the service updates or is disposed. */
     protected toDispose = new DisposableCollection();
 
-    private readonly onDidChangePromptEmitter = new Emitter<string>();
-    readonly onDidChangePrompt: Event<string> = this.onDidChangePromptEmitter.event;
+    protected readonly onDidChangePromptFragmentCustomizationEmitter = new Emitter<string[]>();
+    readonly onDidChangePromptFragmentCustomization: Event<string[]> = this.onDidChangePromptFragmentCustomizationEmitter.event;
 
-    private readonly onDidChangeCustomAgentsEmitter = new Emitter<void>();
-    readonly onDidChangeCustomAgents = this.onDidChangeCustomAgentsEmitter.event;
+    protected readonly onDidChangeCustomAgentsEmitter = new Emitter<void>();
+    readonly onDidChangeCustomAgents: Event<void> = this.onDidChangeCustomAgentsEmitter.event;
 
     @postConstruct()
     protected init(): void {
-        // Ensure PROMPT_TEMPLATE_EXTENSION is always included in templateExtensions as a default
-        this.templateExtensions.add(PROMPT_TEMPLATE_EXTENSION);
-
         this.preferences.onPreferenceChanged(event => {
             if (event.preferenceName === PREFERENCE_NAME_PROMPT_TEMPLATES) {
                 this.update();
@@ -127,147 +169,210 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
         this.update();
     }
 
+    /**
+     * Updates the service by reloading all template files and watching for changes
+     */
     protected async update(): Promise<void> {
         this.toDispose.dispose();
         // we need to assign local variables, so that updates running in parallel don't interfere with each other
-        const templatesMap = new Map<string, TemplateEntry>();
-        const trackedURIs = new Set<string>();
-        const loadedTemplates = new Map<string, TemplateEntry>();
-        const watchedFilesMap = new Map<string, WatchedFileInfo>();
+        const activeCustomizationsCopy = new Map<string, PromptFragmentCustomization>();
+        const trackedTemplateURIsCopy = new Set<string>();
+        const allCustomizationsCopy = new Map<string, PromptFragmentCustomization>();
+        const watchedFilesCopy = new Map<string, WatchedFileInfo>();
 
         // Process in order of priority (lowest to highest)
-        // First process the main template directory (lowest priority)
-        const templateURI = await this.getTemplatesDirectoryURI();
-        await this.processTemplateDirectory(templatesMap, trackedURIs, loadedTemplates, templateURI, TemplatePriority.GLOBAL_TEMPLATE_DIR);
+        // First process the main templates directory (lowest priority)
+        const templatesURI = await this.getTemplatesDirectoryURI();
+        await this.processTemplateDirectory(
+            activeCustomizationsCopy, trackedTemplateURIsCopy, allCustomizationsCopy, templatesURI, 1, CustomizationSource.CUSTOMIZED); // Priority 1 for customized fragments
 
         // Process additional template directories (medium priority)
         for (const dirPath of this.additionalTemplateDirs) {
             const dirURI = URI.fromFilePath(dirPath);
-            await this.processTemplateDirectory(templatesMap, trackedURIs, loadedTemplates, dirURI, TemplatePriority.ADDITIONAL_TEMPLATE_DIR);
+            await this.processTemplateDirectory(
+                activeCustomizationsCopy, trackedTemplateURIsCopy, allCustomizationsCopy, dirURI, 2, CustomizationSource.FOLDER); // Priority 2 for folder fragments
         }
 
         // Process specific template files (highest priority)
-        await this.processTemplateFiles(templatesMap, trackedURIs, loadedTemplates, watchedFilesMap);
+        await this.processTemplateFiles(activeCustomizationsCopy, trackedTemplateURIsCopy, allCustomizationsCopy, watchedFilesCopy);
 
-        this.effectiveTemplates = templatesMap;
-        this.trackedTemplateURIs = trackedURIs;
-        this.allLoadedTemplates = loadedTemplates;
-        this.watchedFiles = watchedFilesMap;
+        this.activeCustomizations = activeCustomizationsCopy;
+        this.trackedTemplateURIs = trackedTemplateURIsCopy;
+        this.allCustomizations = allCustomizationsCopy;
+        this.watchedFiles = watchedFilesCopy;
 
         this.onDidChangeCustomAgentsEmitter.fire();
     }
 
     /**
-     * Adds a template to the templates map, handling conflicts based on priority
-     * @param templatesMap The map to add the template to
-     * @param id The template ID
-     * @param content The template content
-     * @param priority The template priority
+     * Adds a template to the customizations map, handling conflicts based on priority
+     * @param activeCustomizationsCopy The map to add the customization to
+     * @param id The fragment ID
+     * @param template The template content
      * @param sourceUri The URI of the source file (used to distinguish updates from conflicts)
-     * @param loadedTemplates The map to track all loaded templates
+     * @param allCustomizationsCopy The map to track all loaded customizations
+     * @param priority The customization priority
+     * @param origin The source type of the customization
      */
     protected addTemplate(
-        templatesMap: Map<string, TemplateEntry>,
+        activeCustomizationsCopy: Map<string, PromptFragmentCustomization>,
         id: string,
-        content: string,
-        priority: number,
+        template: string,
         sourceUri: string,
-        loadedTemplates: Map<string, TemplateEntry>
+        allCustomizationsCopy: Map<string, PromptFragmentCustomization>,
+        priority: number,
+        origin: CustomizationSource
     ): void {
-        // Always add to loadedTemplates to keep track of all templates including overridden ones
+        // Generate a unique customization ID based on source URI and priority
+        const customizationId = this.generateCustomizationId(id, sourceUri);
+
+        // Always add to allCustomizationsCopy to keep track of all customizations including overridden ones
         if (sourceUri) {
-            loadedTemplates.set(sourceUri, { id, content, priority, sourceUri });
+            allCustomizationsCopy.set(sourceUri, { id, template, sourceUri, priority, customizationId, origin });
         }
 
-        const existingEntry = templatesMap.get(id);
+        const existingEntry = activeCustomizationsCopy.get(id);
 
         if (existingEntry) {
             // If this is an update to the same file (same source URI)
             if (sourceUri && existingEntry.sourceUri === sourceUri) {
                 // Update the content while keeping the same priority and source
-                templatesMap.set(id, { id, content, priority, sourceUri });
+                activeCustomizationsCopy.set(id, { id, template, sourceUri, priority, customizationId, origin });
                 return;
             }
 
-            // If the new template has higher priority, replace the existing one
+            // If the new customization has higher priority, replace the existing one
             if (priority > existingEntry.priority) {
-                templatesMap.set(id, { id, content, priority, sourceUri });
+                activeCustomizationsCopy.set(id, { id, template, sourceUri, priority, customizationId, origin });
                 return;
             } else if (priority === existingEntry.priority) {
-                // There is a conflict with the same priority, we ignore the new template
+                // There is a conflict with the same priority, we ignore the new customization
                 const conflictSourceUri = existingEntry.sourceUri ? ` (Existing source: ${existingEntry.sourceUri}, New source: ${sourceUri})` : '';
-                console.warn(`Template conflict detected for ID '${id}' with equal priority.${conflictSourceUri}`);
+                console.warn(`Fragment conflict detected for ID '${id}' with equal priority.${conflictSourceUri}`);
             }
             return;
         }
 
-        // No conflict at all, add the template
-        templatesMap.set(id, { id, content, priority, sourceUri });
+        // No conflict at all, add the customization
+        activeCustomizationsCopy.set(id, { id, template, sourceUri, priority, customizationId, origin });
     }
 
     /**
-     * Removes a template from the templates map based on the source URI and fires change event.
-     * Also checks for any lower-priority templates with the same ID that might need to be loaded.
-     * @param sourceUri The URI of the source file being removed
-     * @param loadedTemplates The map of all loaded templates
+     * Generates a unique customization ID based on the fragment ID, source URI, and priority
+     * @param id The fragment ID
+     * @param sourceUri The source URI of the template
+     * @returns A unique customization ID
      */
-    protected removeTemplateBySourceUri(
-        sourceUri: string,
-        loadedTemplates: Map<string, TemplateEntry>
-    ): void {
-        // Get the template entry from loadedTemplates
-        const removedTemplate = loadedTemplates.get(sourceUri);
-        if (!removedTemplate) {
-            return;
-        }
-        const templateId = removedTemplate.id;
-        loadedTemplates.delete(sourceUri);
+    protected generateCustomizationId(id: string, sourceUri: string): string {
+        // Create a customization ID that contains information about the source and priority
+        // This ensures uniqueness across different customization sources
+        const sourceHash = this.hashString(sourceUri);
+        return `${id}_${sourceHash}`;
+    }
 
-        // If the template is in the active templates map, we check if there is another template previously conflicting with it
-        const activeTemplate = this.effectiveTemplates.get(templateId);
-        if (activeTemplate && activeTemplate.sourceUri === sourceUri) {
-            this.effectiveTemplates.delete(templateId);
-            // Find any lower-priority templates with the same ID that were previously ignored
-            const lowerPriorityTemplates = Array.from(loadedTemplates.values())
-                .filter(t => t.id === templateId)
+    /**
+     * Simple hash function to generate a short identifier from a string
+     * @param str The string to hash
+     * @returns A string hash
+     */
+    protected hashString(str: string): string {
+        let hash = 0;
+        for (let i = 0; i < str.length; i++) {
+            const char = str.charCodeAt(i);
+            hash = ((hash << 5) - hash) + char;
+            hash = hash & hash; // Convert to 32bit integer
+        }
+        return Math.abs(hash).toString(36).substring(0, 8);
+    }
+
+    /**
+     * Removes a customization from customizations maps based on the source URI.
+     * Also checks for any lower-priority customizations with the same ID that might need to be loaded.
+     * @param sourceUri The URI of the source file being removed
+     * @param allCustomizationsCopy The map of all loaded customizations
+     * @param activeCustomizationsCopy The map of active customizations
+     * @param trackedTemplateURIsCopy Optional set of tracked URIs to update
+     * @returns The fragment ID that was removed, or undefined if no customization was found
+     */
+    protected removeCustomizationFromMaps(
+        sourceUri: string,
+        allCustomizationsCopy: Map<string, PromptFragmentCustomization>,
+        activeCustomizationsCopy: Map<string, PromptFragmentCustomization>,
+        trackedTemplateURIsCopy: Set<string>
+    ): string | undefined {
+        // Get the customization entry from allCustomizationsCopy
+        const removedCustomization = allCustomizationsCopy.get(sourceUri);
+        if (!removedCustomization) {
+            return undefined;
+        }
+        const fragmentId = removedCustomization.id;
+        allCustomizationsCopy.delete(sourceUri);
+        trackedTemplateURIsCopy.delete(sourceUri);
+
+        // If the customization is in the active customizations map, we check if there is another customization previously conflicting with it
+        const activeCustomization = activeCustomizationsCopy.get(fragmentId);
+        if (activeCustomization && activeCustomization.sourceUri === sourceUri) {
+            activeCustomizationsCopy.delete(fragmentId);
+            // Find any lower-priority customizations with the same ID that were previously ignored
+            const lowerPriorityCustomizations = Array.from(allCustomizationsCopy.values())
+                .filter(t => t.id === fragmentId)
                 .sort((a, b) => b.priority - a.priority); // Sort by priority (highest first)
 
-            // If there are any lower-priority templates, add the highest priority one
-            if (lowerPriorityTemplates.length > 0) {
-                const highestRemainingTemplate = lowerPriorityTemplates[0];
-                this.effectiveTemplates.set(templateId, highestRemainingTemplate);
+            // If there are any lower-priority customizations, add the highest priority one
+            if (lowerPriorityCustomizations.length > 0) {
+                const highestRemainingCustomization = lowerPriorityCustomizations[0];
+                activeCustomizationsCopy.set(fragmentId, highestRemainingCustomization);
             }
-            this.onDidChangePromptEmitter.fire(templateId);
+
         }
+
+        return fragmentId;
     }
 
     /**
      * Process the template files specified by path, watching for changes
-     * and loading their content into the templates map
+     * and loading their content into the customizations map
+     * @param activeCustomizationsCopy Map to store active customizations
+     * @param trackedTemplateURIsCopy Set to track URIs being monitored
+     * @param allCustomizationsCopy Map to store all loaded customizations
+     * @param watchedFilesCopy Map to store file watch information
      */
     protected async processTemplateFiles(
-        templatesMap: Map<string, TemplateEntry>,
-        trackedURIs: Set<string>,
-        loadedTemplates: Map<string, TemplateEntry>,
-        watchedFilesMap: Map<string, WatchedFileInfo>
+        activeCustomizationsCopy: Map<string, PromptFragmentCustomization>,
+        trackedTemplateURIsCopy: Set<string>,
+        allCustomizationsCopy: Map<string, PromptFragmentCustomization>,
+        watchedFilesCopy: Map<string, WatchedFileInfo>
     ): Promise<void> {
+        const priority = 3; // Highest priority for specific files
 
-        for (const filePath of this.templateFiles) {
+        const parsedPromptFragments = new Set<string>();
+
+        for (const filePath of this.workspaceTemplateFiles) {
             const fileURI = URI.fromFilePath(filePath);
-            const templateId = this.getTemplateIdFromFilePath(filePath);
+            const fragmentId = this.getFragmentIdFromFilePath(filePath);
             const uriString = fileURI.toString();
+            const customizationId = this.generateCustomizationId(fragmentId, uriString);
 
-            watchedFilesMap.set(uriString, { uri: fileURI, templateId });
+            watchedFilesCopy.set(uriString, { uri: fileURI, fragmentId, customizationId });
             this.toDispose.push(this.fileService.watch(fileURI, { recursive: false, excludes: [] }));
 
             if (await this.fileService.exists(fileURI)) {
-                trackedURIs.add(uriString);
+                trackedTemplateURIsCopy.add(uriString);
                 const fileContent = await this.fileService.read(fileURI);
-                this.addTemplate(templatesMap, templateId, fileContent.value, TemplatePriority.TEMPLATE_FILE, uriString, loadedTemplates);
+                this.addTemplate(activeCustomizationsCopy, fragmentId, fileContent.value, uriString, allCustomizationsCopy, priority, CustomizationSource.FILE);
+                parsedPromptFragments.add(fragmentId);
             }
         }
 
+        this.onDidChangePromptFragmentCustomizationEmitter.fire(Array.from(parsedPromptFragments));
+
         this.toDispose.push(this.fileService.onDidFilesChange(async (event: FileChangesEvent) => {
+            // Only watch for changes that are in the watchedFiles map
+            if (!event.changes.some(change => this.watchedFiles.get(change.resource.toString()))) {
+                return;
+            }
+            // Track changes for batched notification
+            const changedFragmentIds = new Set<string>();
 
             // Handle deleted files
             for (const deletedFile of event.getDeleted()) {
@@ -275,9 +380,10 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
                 const fileInfo = this.watchedFiles.get(fileUriString);
 
                 if (fileInfo) {
-                    this.removeTemplateBySourceUri(fileUriString, loadedTemplates);
-                    this.trackedTemplateURIs.delete(fileUriString);
-                    this.onDidChangePromptEmitter.fire(fileInfo.templateId);
+                    const removedFragmentId = this.removeCustomizationFromMaps(fileUriString, allCustomizationsCopy, activeCustomizationsCopy, trackedTemplateURIsCopy);
+                    if (removedFragmentId) {
+                        changedFragmentIds.add(removedFragmentId);
+                    }
                 }
             }
 
@@ -289,14 +395,15 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
                 if (fileInfo) {
                     const fileContent = await this.fileService.read(fileInfo.uri);
                     this.addTemplate(
-                        this.effectiveTemplates,
-                        fileInfo.templateId,
+                        this.activeCustomizations,
+                        fileInfo.fragmentId,
                         fileContent.value,
-                        TemplatePriority.TEMPLATE_FILE,
                         fileUriString,
-                        loadedTemplates
+                        this.allCustomizations,
+                        priority,
+                        CustomizationSource.FILE
                     );
-                    this.onDidChangePromptEmitter.fire(fileInfo.templateId);
+                    changedFragmentIds.add(fileInfo.fragmentId);
                 }
             }
 
@@ -308,76 +415,54 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
                 if (fileInfo) {
                     const fileContent = await this.fileService.read(fileInfo.uri);
                     this.addTemplate(
-                        this.effectiveTemplates,
-                        fileInfo.templateId,
+                        this.activeCustomizations,
+                        fileInfo.fragmentId,
                         fileContent.value,
-                        TemplatePriority.TEMPLATE_FILE,
                         fileUriString,
-                        loadedTemplates
+                        this.allCustomizations,
+                        priority,
+                        CustomizationSource.FILE
                     );
                     this.trackedTemplateURIs.add(fileUriString);
-                    this.onDidChangePromptEmitter.fire(fileInfo.templateId);
+                    changedFragmentIds.add(fileInfo.fragmentId);
                 }
             }
+
+            const changedFragmentIdsArray = Array.from(changedFragmentIds);
+            if (changedFragmentIdsArray.length > 0) {
+                this.onDidChangePromptFragmentCustomizationEmitter.fire(changedFragmentIdsArray);
+            };
         }));
     }
 
     /**
-     * Extract a template ID from a file path
+     * Extract a fragment ID from a file path
      * @param filePath The path to the template file
-     * @returns A template ID derived from the file name
+     * @returns A fragment ID derived from the file name
      */
-    protected getTemplateIdFromFilePath(filePath: string): string {
+    protected getFragmentIdFromFilePath(filePath: string): string {
         const uri = URI.fromFilePath(filePath);
         return this.removePromptTemplateSuffix(uri.path.name);
     }
 
+    /**
+     * Processes a directory for template files, adding them to the customizations map
+     * and setting up file watching
+     * @param activeCustomizationsCopy Map to store active customizations
+     * @param trackedTemplateURIsCopy Set to track URIs being monitored
+     * @param allCustomizationsCopy Map to store all loaded customizations
+     * @param dirURI URI of the directory to process
+     * @param priority Priority level for customizations in this directory
+     * @param customizationSource Source type of the customization
+     */
     protected async processTemplateDirectory(
-        templatesMap: Map<string, TemplateEntry>,
-        trackedURIs: Set<string>,
-        loadedTemplates: Map<string, TemplateEntry>,
+        activeCustomizationsCopy: Map<string, PromptFragmentCustomization>,
+        trackedTemplateURIsCopy: Set<string>,
+        allCustomizationsCopy: Map<string, PromptFragmentCustomization>,
         dirURI: URI,
-        priority: TemplatePriority
+        priority: number,
+        customizationSource: CustomizationSource
     ): Promise<void> {
-        this.toDispose.push(this.fileService.watch(dirURI, { recursive: true, excludes: [] }));
-        this.toDispose.push(this.fileService.onDidFilesChange(async (event: FileChangesEvent) => {
-            if (event.changes.some(change => change.resource.toString().endsWith('customAgents.yml'))) {
-                this.onDidChangeCustomAgentsEmitter.fire();
-            }
-
-            // check deleted templates
-            for (const deletedFile of event.getDeleted()) {
-                if (this.trackedTemplateURIs.has(deletedFile.resource.toString())) {
-                    this.trackedTemplateURIs.delete(deletedFile.resource.toString());
-                    const templateId = this.removePromptTemplateSuffix(deletedFile.resource.path.name);
-                    this.removeTemplateBySourceUri(deletedFile.resource.toString(), loadedTemplates);
-                    this.onDidChangePromptEmitter.fire(templateId);
-                }
-            }
-
-            // check updated templates
-            for (const updatedFile of event.getUpdated()) {
-                if (this.trackedTemplateURIs.has(updatedFile.resource.toString())) {
-                    const fileContent = await this.fileService.read(updatedFile.resource);
-                    const templateId = this.removePromptTemplateSuffix(updatedFile.resource.path.name);
-                    this.addTemplate(this.effectiveTemplates, templateId, fileContent.value, priority, updatedFile.resource.toString(), loadedTemplates);
-                    this.onDidChangePromptEmitter.fire(templateId);
-                }
-            }
-
-            // check new templates
-            for (const addedFile of event.getAdded()) {
-                if (addedFile.resource.parent.toString() === dirURI.toString() &&
-                    this.isPromptTemplateExtension(addedFile.resource.path.ext)) {
-                    this.trackedTemplateURIs.add(addedFile.resource.toString());
-                    const fileContent = await this.fileService.read(addedFile.resource);
-                    const templateId = this.removePromptTemplateSuffix(addedFile.resource.path.name);
-                    this.addTemplate(this.effectiveTemplates, templateId, fileContent.value, priority, addedFile.resource.toString(), loadedTemplates);
-                    this.onDidChangePromptEmitter.fire(templateId);
-                }
-            }
-        }));
-
         if (!(await this.fileService.exists(dirURI))) {
             return;
         }
@@ -385,21 +470,76 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
         if (stat.children === undefined) {
             return;
         }
-
+        const parsedPromptFragments = new Set<string>();
         for (const file of stat.children) {
             if (!file.isFile) {
                 continue;
             }
             const fileURI = file.resource;
             if (this.isPromptTemplateExtension(fileURI.path.ext)) {
-                trackedURIs.add(fileURI.toString());
+                trackedTemplateURIsCopy.add(fileURI.toString());
                 const fileContent = await this.fileService.read(fileURI);
-                const templateId = this.removePromptTemplateSuffix(file.name);
-                this.addTemplate(templatesMap, templateId, fileContent.value, priority, fileURI.toString(), loadedTemplates);
-                this.onDidChangePromptEmitter.fire(templateId);
+                const fragmentId = this.removePromptTemplateSuffix(file.name);
+                this.addTemplate(activeCustomizationsCopy, fragmentId, fileContent.value, fileURI.toString(), allCustomizationsCopy, priority, customizationSource);
+                parsedPromptFragments.add(fragmentId);
             }
         }
+        this.onDidChangePromptFragmentCustomizationEmitter.fire(Array.from(parsedPromptFragments));
         this.onDidChangeCustomAgentsEmitter.fire();
+
+        this.toDispose.push(this.fileService.watch(dirURI, { recursive: true, excludes: [] }));
+        this.toDispose.push(this.fileService.onDidFilesChange(async (event: FileChangesEvent) => {
+            // Only watch for changes within provided dir
+            if (!event.changes.some(change => change.resource.toString().startsWith(dirURI.toString()))) {
+                return;
+            }
+            if (event.changes.some(change => change.resource.toString().endsWith('customAgents.yml'))) {
+                this.onDidChangeCustomAgentsEmitter.fire();
+            }
+
+            // Track changes for batched notification
+            const changedFragmentIds = new Set<string>();
+
+            // check deleted templates
+            for (const deletedFile of event.getDeleted()) {
+                const uriString = deletedFile.resource.toString();
+                if (this.trackedTemplateURIs.has(uriString)) {
+                    const removedFragmentId = this.removeCustomizationFromMaps(uriString, this.allCustomizations, this.activeCustomizations, this.trackedTemplateURIs);
+                    if (removedFragmentId) {
+                        changedFragmentIds.add(removedFragmentId);
+                    }
+                }
+            }
+
+            // check updated templates
+            for (const updatedFile of event.getUpdated()) {
+                const uriString = updatedFile.resource.toString();
+                if (this.trackedTemplateURIs.has(uriString)) {
+                    const fileContent = await this.fileService.read(updatedFile.resource);
+                    const fragmentId = this.removePromptTemplateSuffix(updatedFile.resource.path.name);
+                    this.addTemplate(this.activeCustomizations, fragmentId, fileContent.value, uriString, this.allCustomizations, priority, customizationSource);
+                    changedFragmentIds.add(fragmentId);
+                }
+            }
+
+            // check new templates
+            for (const addedFile of event.getAdded()) {
+                if (addedFile.resource.parent.toString() === dirURI.toString() &&
+                    this.isPromptTemplateExtension(addedFile.resource.path.ext)) {
+                    const uriString = addedFile.resource.toString();
+                    this.trackedTemplateURIs.add(uriString);
+                    const fileContent = await this.fileService.read(addedFile.resource);
+                    const fragmentId = this.removePromptTemplateSuffix(addedFile.resource.path.name);
+                    this.addTemplate(this.activeCustomizations, fragmentId, fileContent.value, uriString, this.allCustomizations, priority, customizationSource);
+                    changedFragmentIds.add(fragmentId);
+                }
+            }
+
+            const changedFragmentIdsArray = Array.from(changedFragmentIds);
+            if (changedFragmentIdsArray.length > 0) {
+                this.onDidChangePromptFragmentCustomizationEmitter.fire(changedFragmentIdsArray);
+            };
+        }));
     }
 
     /**
@@ -432,16 +572,15 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
      * @returns Array of file paths
      */
     getTemplateFiles(): string[] {
-        return Array.from(this.templateFiles);
+        return Array.from(this.workspaceTemplateFiles);
     }
 
     /**
      * Updates multiple configuration properties at once, triggering only a single update process.
-     *
      * @param properties An object containing the properties to update
      * @returns Promise that resolves when the update is complete
      */
-    async updateConfiguration(properties: PromptCustomizationProperties): Promise<void> {
+    async updateConfiguration(properties: PromptFragmentCustomizationProperties): Promise<void> {
         if (properties.directoryPaths !== undefined) {
             this.additionalTemplateDirs.clear();
             for (const path of properties.directoryPaths) {
@@ -459,9 +598,9 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
         }
 
         if (properties.filePaths !== undefined) {
-            this.templateFiles.clear();
+            this.workspaceTemplateFiles.clear();
             for (const path of properties.filePaths) {
-                this.templateFiles.add(path);
+                this.workspaceTemplateFiles.add(path);
             }
         }
 
@@ -469,6 +608,10 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
         await this.update();
     }
 
+    /**
+     * Gets the URI of the templates directory
+     * @returns URI of the templates directory
+     */
     protected async getTemplatesDirectoryURI(): Promise<URI> {
         const templatesFolder = this.preferences[PREFERENCE_NAME_PROMPT_TEMPLATES];
         if (templatesFolder && templatesFolder.trim().length > 0) {
@@ -478,10 +621,20 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
         return new URI(theiaConfigDir).resolve('prompt-templates');
     }
 
-    protected async getTemplateURI(templateId: string): Promise<URI> {
-        return (await this.getTemplatesDirectoryURI()).resolve(`${templateId}${PROMPT_TEMPLATE_EXTENSION}`);
+    /**
+     * Gets the URI for a specific template file
+     * @param fragmentId The fragment ID
+     * @returns URI for the template file
+     */
+    protected async getTemplateURI(fragmentId: string): Promise<URI> {
+        return (await this.getTemplatesDirectoryURI()).resolve(`${fragmentId}${PROMPT_TEMPLATE_EXTENSION}`);
     }
 
+    /**
+     * Removes the prompt template extension from a filename
+     * @param filename The filename with extension
+     * @returns The filename without the extension
+     */
     protected removePromptTemplateSuffix(filename: string): string {
         for (const ext of this.templateExtensions) {
             if (filename.endsWith(ext)) {
@@ -491,39 +644,270 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
         return filename;
     }
 
-    isPromptTemplateCustomized(id: string): boolean {
-        return this.effectiveTemplates.has(id);
+    // PromptFragmentCustomizationService interface implementation
+
+    isPromptFragmentCustomized(id: string): boolean {
+        return this.activeCustomizations.has(id);
     }
 
-    getCustomizedPromptTemplate(id: string): string | undefined {
-        const entry = this.effectiveTemplates.get(id);
-        return entry ? entry.content : undefined;
+    getActivePromptFragmentCustomization(id: string): CustomizedPromptFragment | undefined {
+        const entry = this.activeCustomizations.get(id);
+        if (!entry) {
+            return undefined;
+        }
+
+        return {
+            id: entry.id,
+            template: entry.template,
+            customizationId: entry.customizationId,
+            priority: entry.priority
+        };
     }
 
-    getCustomPromptTemplateIDs(): string[] {
-        return Array.from(this.effectiveTemplates.keys());
+    getAllCustomizations(id: string): CustomizedPromptFragment[] {
+        const fragments: CustomizedPromptFragment[] = [];
+
+        // Collect all customizations with matching ID
+        this.allCustomizations.forEach(value => {
+            if (value.id === id) {
+                fragments.push({
+                    id: value.id,
+                    template: value.template,
+                    customizationId: value.customizationId,
+                    priority: value.priority
+                });
+            }
+        });
+
+        // Sort by priority (highest first)
+        return fragments.sort((a, b) => b.priority - a.priority);
     }
 
-    async editTemplate(id: string, defaultContent?: string): Promise<void> {
+    getCustomizedPromptFragmentIds(): string[] {
+        return Array.from(this.activeCustomizations.keys());
+    }
+
+    async createPromptFragmentCustomization(id: string, defaultContent?: string): Promise<void> {
+        await this.editTemplate(id, defaultContent);
+    }
+
+    async createBuiltInPromptFragmentCustomization(id: string): Promise<void> {
+        // Ideally this would fetch the built-in template content to use as default
+        const defaultContent = '';
+        await this.createPromptFragmentCustomization(id, defaultContent);
+    }
+
+    async editPromptFragmentCustomization(id: string, customizationId: string): Promise<void> {
+        // Find the customization with the given customization ID
+        const customization = Array.from(this.allCustomizations.values()).find(t =>
+            t.id === id && t.customizationId === customizationId
+        );
+
+        if (customization) {
+            const uri = new URI(customization.sourceUri);
+            const openHandler = await this.openerService.getOpener(uri);
+            openHandler.open(uri);
+        } else {
+            // Fall back to editing by fragment ID if customization ID not found
+            await this.editTemplate(id);
+        }
+    }
+
+    /**
+     * Edits a template by opening it in the editor, creating it if it doesn't exist
+     * @param id The fragment ID
+     * @param defaultContent Optional default content for new templates
+     */
+    protected async editTemplate(id: string, defaultContent?: string): Promise<void> {
         const editorUri = await this.getTemplateURI(id);
-        if (! await this.fileService.exists(editorUri)) {
+        if (!(await this.fileService.exists(editorUri))) {
             await this.fileService.createFile(editorUri, BinaryBuffer.fromString(defaultContent ?? ''));
         }
         const openHandler = await this.openerService.getOpener(editorUri);
         openHandler.open(editorUri);
     }
 
-    async resetTemplate(id: string): Promise<void> {
-        const editorUri = await this.getTemplateURI(id);
-        if (await this.fileService.exists(editorUri)) {
-            await this.fileService.delete(editorUri);
+    async removePromptFragmentCustomization(id: string, customizationId: string): Promise<void> {
+        // Find the customization with the given customization ID
+        const customization = Array.from(this.allCustomizations.values()).find(t =>
+            t.id === id && t.customizationId === customizationId
+        );
+
+        if (customization) {
+            const sourceUri = customization.sourceUri;
+
+            // Delete the file if it exists
+            const uri = new URI(sourceUri);
+            if (await this.fileService.exists(uri)) {
+                await this.fileService.delete(uri);
+            }
         }
     }
 
-    getTemplateIDFromURI(uri: URI): string | undefined {
+    async removeAllPromptFragmentCustomizations(id: string): Promise<void> {
+        // Get all customizations for this fragment ID
+        const customizations = this.getAllCustomizations(id);
+
+        if (customizations.length === 0) {
+            return; // Nothing to reset
+        }
+
+        // Find and delete all customization files
+        for (const customization of customizations) {
+            const fragment = Array.from(this.allCustomizations.values()).find(t =>
+                t.id === id && t.customizationId === customization.customizationId
+            );
+
+            if (fragment) {
+                const sourceUri = fragment.sourceUri;
+                // Delete the file if it exists
+                const uri = new URI(sourceUri);
+                if (await this.fileService.exists(uri)) {
+                    await this.fileService.delete(uri);
+                }
+            }
+        }
+    }
+
+    async resetToCustomization(id: string, customizationId: string): Promise<void> {
+        const customization = Array.from(this.allCustomizations.values()).find(t =>
+            t.id === id && t.customizationId === customizationId
+        );
+
+        if (customization) {
+            // Get all customizations for this fragment ID
+            const customizations = this.getAllCustomizations(id);
+
+            if (customizations.length === 0) {
+                return; // Nothing to reset
+            }
+
+            // Find the target customization
+            const targetCustomization = customizations.find(c => c.customizationId === customizationId);
+            if (!targetCustomization) {
+                return; // Target customization not found
+            }
+
+            // Find and delete all higher-priority customization files
+            for (const cust of customizations) {
+                if (cust.priority > targetCustomization.priority) {
+                    const fragmentToDelete = Array.from(this.allCustomizations.values()).find(t =>
+                        t.id === cust.id && t.customizationId === cust.customizationId
+                    );
+                    if (fragmentToDelete) {
+                        const sourceUri = fragmentToDelete.sourceUri;
+
+                        // Delete the file if it exists
+                        const uri = new URI(sourceUri);
+                        if (await this.fileService.exists(uri)) {
+                            await this.fileService.delete(uri);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async getPromptFragmentCustomizationDescription(id: string, customizationId: string): Promise<string | undefined> {
+        // Find the customization with the given customization ID
+        const customization = Array.from(this.allCustomizations.values()).find(t =>
+            t.id === id && t.customizationId === customizationId
+        );
+
+        if (customization) {
+            return customization.sourceUri;
+        }
+
+        return undefined;
+    }
+
+    async getPromptFragmentCustomizationType(id: string, customizationId: string): Promise<string | undefined> {
+        // Find the customization with the given customization ID
+        const customization = Array.from(this.allCustomizations.values()).find(t =>
+            t.id === id && t.customizationId === customizationId
+        );
+
+        if (customization) {
+            return getCustomizationSourceString(customization.origin);
+        }
+
+        return undefined;
+    }
+
+    async editBuiltIn(id: string): Promise<void> {
+        // Find an existing built-in customization (those with priority 1)
+        const builtInCustomization = Array.from(this.allCustomizations.values()).find(t =>
+            t.id === id && t.priority === 1
+        );
+
+        if (builtInCustomization) {
+            // Edit the existing built-in customization
+            const uri = new URI(builtInCustomization.sourceUri);
+            const openHandler = await this.openerService.getOpener(uri);
+            openHandler.open(uri);
+        } else {
+            // Create a new built-in customization
+            // Get the template URI in the main templates directory (priority 1)
+            const templateUri = await this.getTemplateURI(id);
+
+            // If template doesn't exist, create it with default content
+            if (!(await this.fileService.exists(templateUri))) {
+                const defaultContent = '';
+                await this.fileService.createFile(templateUri, BinaryBuffer.fromString(defaultContent));
+            }
+
+            // Open the template in the editor
+            const openHandler = await this.openerService.getOpener(templateUri);
+            openHandler.open(templateUri);
+        }
+    }
+
+    async resetBuiltInCustomization(id: string): Promise<void> {
+        // Find a built-in customization (those with priority 1)
+        const builtInCustomization = Array.from(this.allCustomizations.values()).find(t =>
+            t.id === id && t.priority === 1
+        );
+
+        if (!builtInCustomization) {
+            return; // No built-in customization found
+        }
+
+        const sourceUri = builtInCustomization.sourceUri;
+
+        // Delete the file if it exists
+        const uri = new URI(sourceUri);
+        if (await this.fileService.exists(uri)) {
+            await this.fileService.delete(uri);
+        }
+    }
+
+    async editBuiltInPromptFragmentCustomization(id: string): Promise<void> {
+        return this.editBuiltIn(id);
+    }
+
+    /**
+     * Gets the fragment ID from a URI
+     * @param uri URI to check
+     * @returns Fragment ID or undefined if not found
+     */
+    protected getFragmentIDFromURI(uri: URI): string | undefined {
         const id = this.removePromptTemplateSuffix(uri.path.name);
-        if (this.effectiveTemplates.has(id)) {
+        if (this.activeCustomizations.has(id)) {
             return id;
+        }
+        return undefined;
+    }
+
+    /**
+     * Implementation of the generic getPromptFragmentIDFromResource method in the interface
+     * Accepts any resource identifier but only processes URIs
+     * @param resourceId Resource to check
+     * @returns Fragment ID or undefined if not found
+     */
+    getPromptFragmentIDFromResource(resourceId: unknown): string | undefined {
+        // Check if the resource is a URI
+        if (resourceId instanceof URI) {
+            return this.getFragmentIDFromURI(resourceId);
         }
         return undefined;
     }
@@ -535,9 +919,9 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
             const dirURI = URI.fromFilePath(dirPath);
             await this.loadCustomAgentsFromDirectory(dirURI, agentsById);
         }
-        // Then process global template directory (only adding agents that don't conflict)
-        const globalTemplateDir = await this.getTemplatesDirectoryURI();
-        await this.loadCustomAgentsFromDirectory(globalTemplateDir, agentsById);
+        // Then process global templates directory (only adding agents that don't conflict)
+        const globalTemplatesDir = await this.getTemplatesDirectoryURI();
+        await this.loadCustomAgentsFromDirectory(globalTemplatesDir, agentsById);
         // Return the merged list of agents
         return Array.from(agentsById.values());
     }
@@ -587,9 +971,9 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
      */
     async getCustomAgentsLocations(): Promise<{ uri: URI, exists: boolean }[]> {
         const locations: { uri: URI, exists: boolean }[] = [];
-        // Check global template directory
-        const globalTemplateDir = await this.getTemplatesDirectoryURI();
-        const globalAgentsUri = globalTemplateDir.resolve('customAgents.yml');
+        // Check global templates directory
+        const globalTemplatesDir = await this.getTemplatesDirectoryURI();
+        const globalAgentsUri = globalTemplatesDir.resolve('customAgents.yml');
         const globalExists = await this.fileService.exists(globalAgentsUri);
         locations.push({ uri: globalAgentsUri, exists: globalExists });
         // Check additional (workspace) template directories
@@ -608,7 +992,7 @@ export class FrontendPromptCustomizationServiceImpl implements PromptCustomizati
      * @param uri The URI of the customAgents.yml file to open or create
      */
     async openCustomAgentYaml(uri: URI): Promise<void> {
-        const content = dump([templateEntry]);
+        const content = dump([newCustomAgentEntry]);
         if (! await this.fileService.exists(uri)) {
             await this.fileService.createFile(uri, BinaryBuffer.fromString(content));
         } else {

--- a/packages/ai-core/src/browser/prompttemplate-contribution.ts
+++ b/packages/ai-core/src/browser/prompttemplate-contribution.ts
@@ -22,7 +22,7 @@ import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/li
 
 import { codicon, Widget } from '@theia/core/lib/browser';
 import { EditorWidget, ReplaceOperation } from '@theia/editor/lib/browser';
-import { PromptCustomizationService, PromptService, PromptText, ToolInvocationRegistry } from '../common';
+import { PromptService, PromptText, ToolInvocationRegistry } from '../common';
 import { ProviderResult } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
 import { AIVariableService } from '../common/variable-service';
 
@@ -43,9 +43,6 @@ export class PromptTemplateContribution implements LanguageGrammarDefinitionCont
 
     @inject(PromptService)
     private readonly promptService: PromptService;
-
-    @inject(PromptCustomizationService)
-    protected readonly customizationService: PromptCustomizationService;
 
     @inject(ToolInvocationRegistry)
     protected readonly toolInvocationRegistry: ToolInvocationRegistry;
@@ -254,7 +251,7 @@ export class PromptTemplateContribution implements LanguageGrammarDefinitionCont
 
     protected canDiscard(widget: EditorWidget): boolean {
         const resourceUri = widget.editor.uri;
-        const id = this.customizationService.getTemplateIDFromURI(resourceUri);
+        const id = this.promptService.getTemplateIDFromResource(resourceUri);
         if (id === undefined) {
             return false;
         }
@@ -265,7 +262,7 @@ export class PromptTemplateContribution implements LanguageGrammarDefinitionCont
 
     protected async discard(widget: EditorWidget): Promise<void> {
         const resourceUri = widget.editor.uri;
-        const id = this.customizationService.getTemplateIDFromURI(resourceUri);
+        const id = this.promptService.getTemplateIDFromResource(resourceUri);
         if (id === undefined) {
             return;
         }

--- a/packages/ai-core/src/common/agent-service.ts
+++ b/packages/ai-core/src/common/agent-service.ts
@@ -98,8 +98,13 @@ export class AgentServiceImpl implements AgentService {
 
     registerAgent(agent: Agent): void {
         this._agents.push(agent);
-        agent.promptTemplates.forEach(
-            template => this.promptService.storePromptTemplate(template)
+        agent.systemPrompts.forEach(
+            systemPrompt => {
+                this.promptService.addBuiltInPromptFragment(systemPrompt.defaultVariant, systemPrompt.id, true);
+                systemPrompt.variants?.forEach(variant => {
+                    this.promptService.addBuiltInPromptFragment(variant, systemPrompt.id);
+                });
+            }
         );
         this.onDidChangeAgentsEmitter.fire();
     }
@@ -108,8 +113,13 @@ export class AgentServiceImpl implements AgentService {
         const agent = this._agents.find(a => a.id === agentId);
         this._agents = this._agents.filter(a => a.id !== agentId);
         this.onDidChangeAgentsEmitter.fire();
-        agent?.promptTemplates.forEach(
-            template => this.promptService.removePrompt(template.id)
+        agent?.systemPrompts.forEach(
+            systemPrompt => {
+                this.promptService.removePrompt(systemPrompt.defaultVariant.id);
+                systemPrompt.variants?.forEach(variant => {
+                    this.promptService.removePrompt(variant.id);
+                });
+            }
         );
     }
 

--- a/packages/ai-core/src/common/agent.ts
+++ b/packages/ai-core/src/common/agent.ts
@@ -15,12 +15,19 @@
 // *****************************************************************************
 
 import { LanguageModelRequirement } from './language-model';
-import { PromptTemplate } from './prompt-service';
+import { BuiltInPromptFragment } from './prompt-service';
 
 export interface AgentSpecificVariables {
     name: string;
     description: string;
     usedInPrompt: boolean;
+}
+
+export interface SystemPrompt {
+    id: string;
+    // Note, that these are just the initialization values and not the customized or later added variants
+    defaultVariant: BuiltInPromptFragment;
+    variants?: BuiltInPromptFragment[];
 }
 
 export const Agent = Symbol('Agent');
@@ -54,7 +61,7 @@ export interface Agent {
     readonly variables: string[];
 
     /** The prompt templates introduced and used by this agent. */
-    readonly promptTemplates: PromptTemplate[];
+    readonly systemPrompts: SystemPrompt[];
 
     /** Required language models. This includes the purpose and optional language model selector arguments. See #47. */
     readonly languageModelRequirements: LanguageModelRequirement[];

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -42,68 +42,68 @@ describe('PromptService', () => {
         container.bind<AIVariableService>(AIVariableService).toConstantValue(variableService);
 
         promptService = container.get<PromptService>(PromptService);
-        promptService.storePromptTemplate({ id: '1', template: 'Hello, {{name}}!' });
-        promptService.storePromptTemplate({ id: '2', template: 'Goodbye, {{name}}!' });
-        promptService.storePromptTemplate({ id: '3', template: 'Ciao, {{invalid}}!' });
-        promptService.storePromptTemplate({ id: '8', template: 'Hello, {{{name}}}' });
+        promptService.addBuiltInPromptFragment({ id: '1', template: 'Hello, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: '2', template: 'Goodbye, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: '3', template: 'Ciao, {{invalid}}!' });
+        promptService.addBuiltInPromptFragment({ id: '8', template: 'Hello, {{{name}}}' });
     });
 
-    it('should initialize prompts from PromptCollectionService', () => {
-        const allPrompts = promptService.getAllPrompts();
-        expect(allPrompts['1'].template).to.equal('Hello, {{name}}!');
-        expect(allPrompts['2'].template).to.equal('Goodbye, {{name}}!');
-        expect(allPrompts['3'].template).to.equal('Ciao, {{invalid}}!');
-        expect(allPrompts['8'].template).to.equal('Hello, {{{name}}}');
+    it('should successfully initialize and retrieve built-in prompt fragments', () => {
+        const allPrompts = promptService.getActivePrompts();
+        expect(allPrompts.find(prompt => prompt.id === '1')!.template).to.equal('Hello, {{name}}!');
+        expect(allPrompts.find(prompt => prompt.id === '2')!.template).to.equal('Goodbye, {{name}}!');
+        expect(allPrompts.find(prompt => prompt.id === '3')!.template).to.equal('Ciao, {{invalid}}!');
+        expect(allPrompts.find(prompt => prompt.id === '8')!.template).to.equal('Hello, {{{name}}}');
     });
 
-    it('should retrieve raw prompt by id', () => {
+    it('should retrieve raw prompt fragment by id', () => {
         const rawPrompt = promptService.getRawPrompt('1');
         expect(rawPrompt?.template).to.equal('Hello, {{name}}!');
     });
 
-    it('should format prompt with provided arguments', async () => {
+    it('should format prompt fragment with provided arguments', async () => {
         const formattedPrompt = await promptService.getPrompt('1', { name: 'John' });
         expect(formattedPrompt?.text).to.equal('Hello, John!');
     });
 
-    it('should store a new prompt', () => {
-        promptService.storePromptTemplate({ id: '3', template: 'Welcome, {{name}}!' });
+    it('should store a new prompt fragment', () => {
+        promptService.addBuiltInPromptFragment({ id: '3', template: 'Welcome, {{name}}!' });
         const newPrompt = promptService.getRawPrompt('3');
         expect(newPrompt?.template).to.equal('Welcome, {{name}}!');
     });
 
-    it('should replace placeholders with provided arguments', async () => {
+    it('should replace variable placeholders with provided arguments', async () => {
         const prompt = await promptService.getPrompt('1', { name: 'John' });
         expect(prompt?.text).to.equal('Hello, John!');
     });
 
-    it('should use variable service to resolve placeholders if argument value is not provided', async () => {
+    it('should use variable service to resolve placeholders when argument values are not provided', async () => {
         const prompt = await promptService.getPrompt('1');
         expect(prompt?.text).to.equal('Hello, Jane!');
     });
 
-    it('should return the prompt even if there are no replacements', async () => {
+    it('should return the prompt fragment even if there are no valid replacements', async () => {
         const prompt = await promptService.getPrompt('3');
         expect(prompt?.text).to.equal('Ciao, {{invalid}}!');
     });
 
-    it('should return undefined if the prompt id is not found', async () => {
+    it('should return undefined if the prompt fragment id is not found', async () => {
         const prompt = await promptService.getPrompt('4');
         expect(prompt).to.be.undefined;
     });
 
     it('should ignore whitespace in variables', async () => {
-        promptService.storePromptTemplate({ id: '4', template: 'Hello, {{name }}!' });
-        promptService.storePromptTemplate({ id: '5', template: 'Hello, {{ name}}!' });
-        promptService.storePromptTemplate({ id: '6', template: 'Hello, {{ name }}!' });
-        promptService.storePromptTemplate({ id: '7', template: 'Hello, {{       name           }}!' });
+        promptService.addBuiltInPromptFragment({ id: '4', template: 'Hello, {{name }}!' });
+        promptService.addBuiltInPromptFragment({ id: '5', template: 'Hello, {{ name}}!' });
+        promptService.addBuiltInPromptFragment({ id: '6', template: 'Hello, {{ name }}!' });
+        promptService.addBuiltInPromptFragment({ id: '7', template: 'Hello, {{       name           }}!' });
         for (let i = 4; i <= 7; i++) {
             const prompt = await promptService.getPrompt(`${i}`, { name: 'John' });
             expect(prompt?.text).to.equal('Hello, John!');
         }
     });
 
-    it('should retrieve raw prompt by id (three bracket)', () => {
+    it('should retrieve raw prompt fragment by id (three bracket)', () => {
         const rawPrompt = promptService.getRawPrompt('8');
         expect(rawPrompt?.template).to.equal('Hello, {{{name}}}');
     });
@@ -114,10 +114,10 @@ describe('PromptService', () => {
     });
 
     it('should ignore whitespace in variables (three bracket)', async () => {
-        promptService.storePromptTemplate({ id: '9', template: 'Hello, {{{name }}}' });
-        promptService.storePromptTemplate({ id: '10', template: 'Hello, {{{ name}}}' });
-        promptService.storePromptTemplate({ id: '11', template: 'Hello, {{{ name }}}' });
-        promptService.storePromptTemplate({ id: '12', template: 'Hello, {{{       name           }}}' });
+        promptService.addBuiltInPromptFragment({ id: '9', template: 'Hello, {{{name }}}' });
+        promptService.addBuiltInPromptFragment({ id: '10', template: 'Hello, {{{ name}}}' });
+        promptService.addBuiltInPromptFragment({ id: '11', template: 'Hello, {{{ name }}}' });
+        promptService.addBuiltInPromptFragment({ id: '12', template: 'Hello, {{{       name           }}}' });
         for (let i = 9; i <= 12; i++) {
             const prompt = await promptService.getPrompt(`${i}`, { name: 'John' });
             expect(prompt?.text).to.equal('Hello, John');
@@ -125,9 +125,9 @@ describe('PromptService', () => {
     });
 
     it('should ignore invalid prompts with unmatched brackets', async () => {
-        promptService.storePromptTemplate({ id: '9', template: 'Hello, {{name' });
-        promptService.storePromptTemplate({ id: '10', template: 'Hello, {{{name' });
-        promptService.storePromptTemplate({ id: '11', template: 'Hello, name}}}}' });
+        promptService.addBuiltInPromptFragment({ id: '9', template: 'Hello, {{name' });
+        promptService.addBuiltInPromptFragment({ id: '10', template: 'Hello, {{{name' });
+        promptService.addBuiltInPromptFragment({ id: '11', template: 'Hello, name}}}}' });
         const prompt1 = await promptService.getPrompt('9', { name: 'John' });
         expect(prompt1?.text).to.equal('Hello, {{name'); // Not matching due to missing closing brackets
         const prompt2 = await promptService.getPrompt('10', { name: 'John' });
@@ -137,12 +137,12 @@ describe('PromptService', () => {
     });
 
     it('should handle a mixture of two and three brackets correctly', async () => {
-        promptService.storePromptTemplate({ id: '12', template: 'Hi, {{name}}}' });            // (invalid)
-        promptService.storePromptTemplate({ id: '13', template: 'Hello, {{{name}}' });         // (invalid)
-        promptService.storePromptTemplate({ id: '14', template: 'Greetings, {{{name}}}}' });   // (invalid)
-        promptService.storePromptTemplate({ id: '15', template: 'Bye, {{{{name}}}' });         // (invalid)
-        promptService.storePromptTemplate({ id: '16', template: 'Ciao, {{{{name}}}}' });       // (invalid)
-        promptService.storePromptTemplate({ id: '17', template: 'Hi, {{name}}! {{{name}}}' }); // Mixed valid patterns
+        promptService.addBuiltInPromptFragment({ id: '12', template: 'Hi, {{name}}}' });            // (invalid)
+        promptService.addBuiltInPromptFragment({ id: '13', template: 'Hello, {{{name}}' });         // (invalid)
+        promptService.addBuiltInPromptFragment({ id: '14', template: 'Greetings, {{{name}}}}' });   // (invalid)
+        promptService.addBuiltInPromptFragment({ id: '15', template: 'Bye, {{{{name}}}' });         // (invalid)
+        promptService.addBuiltInPromptFragment({ id: '16', template: 'Ciao, {{{{name}}}}' });       // (invalid)
+        promptService.addBuiltInPromptFragment({ id: '17', template: 'Hi, {{name}}! {{{name}}}' }); // Mixed valid patterns
 
         const prompt12 = await promptService.getPrompt('12', { name: 'John' });
         expect(prompt12?.text).to.equal('Hi, {{name}}}');
@@ -164,114 +164,113 @@ describe('PromptService', () => {
     });
 
     it('should strip single-line comments at the start of the template', () => {
-        promptService.storePromptTemplate({ id: 'comment-basic', template: '{{!-- Comment --}}Hello, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-basic', template: '{{!-- Comment --}}Hello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-basic');
         expect(prompt?.template).to.equal('Hello, {{name}}!');
     });
 
     it('should remove line break after first-line comment', () => {
-        promptService.storePromptTemplate({ id: 'comment-line-break', template: '{{!-- Comment --}}\nHello, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-line-break', template: '{{!-- Comment --}}\nHello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-line-break');
         expect(prompt?.template).to.equal('Hello, {{name}}!');
     });
 
     it('should strip multiline comments at the start of the template', () => {
-        promptService.storePromptTemplate({ id: 'comment-multiline', template: '{{!--\nMultiline comment\n--}}\nGoodbye, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-multiline', template: '{{!--\nMultiline comment\n--}}\nGoodbye, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-multiline');
         expect(prompt?.template).to.equal('Goodbye, {{name}}!');
     });
 
     it('should not strip comments not in the first line', () => {
-        promptService.storePromptTemplate({ id: 'comment-second-line', template: 'Hello, {{name}}!\n{{!-- Comment --}}' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-second-line', template: 'Hello, {{name}}!\n{{!-- Comment --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-second-line');
         expect(prompt?.template).to.equal('Hello, {{name}}!\n{{!-- Comment --}}');
     });
 
     it('should treat unclosed comments as regular text', () => {
-        promptService.storePromptTemplate({ id: 'comment-unclosed', template: '{{!-- Unclosed comment' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-unclosed', template: '{{!-- Unclosed comment' });
         const prompt = promptService.getUnresolvedPrompt('comment-unclosed');
         expect(prompt?.template).to.equal('{{!-- Unclosed comment');
     });
 
     it('should treat standalone closing delimiters as regular text', () => {
-        promptService.storePromptTemplate({ id: 'comment-standalone', template: '--}} Hello, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-standalone', template: '--}} Hello, {{name}}!' });
         const prompt = promptService.getUnresolvedPrompt('comment-standalone');
         expect(prompt?.template).to.equal('--}} Hello, {{name}}!');
     });
 
     it('should handle nested comments and stop at the first closing tag', () => {
-        promptService.storePromptTemplate({ id: 'nested-comment', template: '{{!-- {{!-- Nested comment --}} --}}text' });
+        promptService.addBuiltInPromptFragment({ id: 'nested-comment', template: '{{!-- {{!-- Nested comment --}} --}}text' });
         const prompt = promptService.getUnresolvedPrompt('nested-comment');
         expect(prompt?.template).to.equal('--}}text');
     });
 
     it('should handle templates with only comments', () => {
-        promptService.storePromptTemplate({ id: 'comment-only', template: '{{!-- Only comments --}}' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-only', template: '{{!-- Only comments --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-only');
         expect(prompt?.template).to.equal('');
     });
 
     it('should handle mixed delimiters on the same line', () => {
-        promptService.storePromptTemplate({ id: 'comment-mixed', template: '{{!-- Unclosed comment --}}' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-mixed', template: '{{!-- Unclosed comment --}}' });
         const prompt = promptService.getUnresolvedPrompt('comment-mixed');
         expect(prompt?.template).to.equal('');
     });
 
     it('should resolve variables after stripping single-line comments', async () => {
-        promptService.storePromptTemplate({ id: 'comment-resolve', template: '{{!-- Comment --}}Hello, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-resolve', template: '{{!-- Comment --}}Hello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-resolve', { name: 'John' });
         expect(prompt?.text).to.equal('Hello, John!');
     });
 
     it('should resolve variables in multiline templates with comments', async () => {
-        promptService.storePromptTemplate({ id: 'comment-multiline-vars', template: '{{!--\nMultiline comment\n--}}\nHello, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-multiline-vars', template: '{{!--\nMultiline comment\n--}}\nHello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-multiline-vars', { name: 'John' });
         expect(prompt?.text).to.equal('Hello, John!');
     });
 
     it('should resolve variables with standalone closing delimiters', async () => {
-        promptService.storePromptTemplate({ id: 'comment-standalone-vars', template: '--}} Hello, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-standalone-vars', template: '--}} Hello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-standalone-vars', { name: 'John' });
         expect(prompt?.text).to.equal('--}} Hello, John!');
     });
 
     it('should treat unclosed comments as text and resolve variables', async () => {
-        promptService.storePromptTemplate({ id: 'comment-unclosed-vars', template: '{{!-- Unclosed comment\nHello, {{name}}!' });
+        promptService.addBuiltInPromptFragment({ id: 'comment-unclosed-vars', template: '{{!-- Unclosed comment\nHello, {{name}}!' });
         const prompt = await promptService.getPrompt('comment-unclosed-vars', { name: 'John' });
         expect(prompt?.text).to.equal('{{!-- Unclosed comment\nHello, John!');
     });
 
     it('should handle templates with mixed comments and variables', async () => {
-        promptService.storePromptTemplate({ id: 'comment-mixed-vars', template: '{{!-- Comment --}}Hi, {{name}}! {{!-- Another comment --}}' });
+        promptService.addBuiltInPromptFragment(
+            { id: 'comment-mixed-vars', template: '{{!-- Comment --}}Hi, {{name}}! {{!-- Another comment --}}' });
         const prompt = await promptService.getPrompt('comment-mixed-vars', { name: 'John' });
         expect(prompt?.text).to.equal('Hi, John! {{!-- Another comment --}}');
     });
 
     it('should return all variant IDs of a given prompt', () => {
-        promptService.storePromptTemplate({ id: 'main', template: 'Main template' });
-
-        promptService.storePromptTemplate({
+        promptService.addBuiltInPromptFragment({
             id: 'variant1',
             template: 'Variant 1',
-            variantOf: 'main'
-        });
-        promptService.storePromptTemplate({
+        }, 'systemPrompt'
+        );
+        promptService.addBuiltInPromptFragment({
             id: 'variant2',
             template: 'Variant 2',
-            variantOf: 'main'
-        });
-        promptService.storePromptTemplate({
+        }, 'systemPrompt'
+        );
+        promptService.addBuiltInPromptFragment({
             id: 'variant3',
             template: 'Variant 3',
-            variantOf: 'main'
-        });
+        }, 'systemPrompt'
+        );
 
-        const variantIds = promptService.getVariantIds('main');
+        const variantIds = promptService.getVariantIds('systemPrompt');
         expect(variantIds).to.deep.equal(['variant1', 'variant2', 'variant3']);
     });
 
     it('should return an empty array if no variants exist for a given prompt', () => {
-        promptService.storePromptTemplate({ id: 'main', template: 'Main template' });
+        promptService.addBuiltInPromptFragment({ id: 'main', template: 'Main template' });
 
         const variantIds = promptService.getVariantIds('main');
         expect(variantIds).to.deep.equal([]);
@@ -283,25 +282,20 @@ describe('PromptService', () => {
     });
 
     it('should not influence prompts without variants when other prompts have variants', () => {
-        promptService.storePromptTemplate({ id: 'mainWithVariants', template: 'Main template with variants' });
-        promptService.storePromptTemplate({ id: 'mainWithoutVariants', template: 'Main template without variants' });
+        promptService.addBuiltInPromptFragment({ id: 'variant1', template: 'Variant 1' }, 'systemPromptWithVariants', true);
+        promptService.addBuiltInPromptFragment({ id: 'promptFragmentWithoutVariants', template: 'template without variants' });
 
-        promptService.storePromptTemplate({
-            id: 'variant1',
-            template: 'Variant 1',
-            variantOf: 'mainWithVariants'
-        });
-        promptService.storePromptTemplate({
+        promptService.addBuiltInPromptFragment({
             id: 'variant2',
             template: 'Variant 2',
-            variantOf: 'mainWithVariants'
-        });
+        }, 'systemPromptWithVariants'
+        );
 
-        const variantsForMainWithVariants = promptService.getVariantIds('mainWithVariants');
-        const variantsForMainWithoutVariants = promptService.getVariantIds('mainWithoutVariants');
+        const systemPromptWithVariants = promptService.getVariantIds('systemPromptWithVariants');
+        const promptFragmentWithoutVariants = promptService.getVariantIds('promptFragmentWithoutVariants');
 
-        expect(variantsForMainWithVariants).to.deep.equal(['variant1', 'variant2']);
-        expect(variantsForMainWithoutVariants).to.deep.equal([]);
+        expect(systemPromptWithVariants).to.deep.equal(['variant1', 'variant2']);
+        expect(promptFragmentWithoutVariants).to.deep.equal([]);
     });
 
     it('should resolve function references within resolved variable replacements', async () => {
@@ -348,7 +342,7 @@ describe('PromptService', () => {
         container.bind<AIVariableService>(AIVariableService).toConstantValue(variableService);
 
         const testPromptService = container.get<PromptService>(PromptService);
-        testPromptService.storePromptTemplate({ id: 'testPrompt', template: 'Template with fragment: {{fragment}}' });
+        testPromptService.addBuiltInPromptFragment({ id: 'testPrompt', template: 'Template with fragment: {{fragment}}' });
 
         // Get the resolved prompt
         const resolvedPrompt = await testPromptService.getPrompt('testPrompt');

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -14,8 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { URI, Event } from '@theia/core';
-import { inject, injectable, optional } from '@theia/core/shared/inversify';
+import { Event, Emitter, URI } from '@theia/core';
+import { inject, injectable, optional, postConstruct } from '@theia/core/shared/inversify';
 import { AIVariableArg, AIVariableContext, AIVariableService, createAIResolveVariableCache, ResolvedAIVariable } from './variable-service';
 import { ToolInvocationRegistry } from './tool-invocation-registry';
 import { toolRequestToPromptText } from './language-model-util';
@@ -23,189 +23,240 @@ import { ToolRequest } from './language-model';
 import { matchFunctionsRegEx, matchVariablesRegEx } from './prompt-service-util';
 import { AISettingsService } from './settings-service';
 
-export interface PromptTemplate {
+/**
+ * Represents a basic prompt fragment with an ID and template content.
+ */
+export interface BuiltInPromptFragment {
+    /** Unique identifier for this prompt fragment */
     id: string;
+
+    /** The template content, which may contain variables and function references */
     template: string;
-    /**
-     * (Optional) The ID of the main template for which this template is a variant.
-     * If present, this indicates that the current template represents an alternative version of the specified main template.
-     */
-    variantOf?: string;
 }
 
-export interface PromptMap { [id: string]: PromptTemplate }
+/**
+ * Represents a customized prompt fragment with an assigned customization ID and priority.
+ */
+export interface CustomizedPromptFragment extends BuiltInPromptFragment {
+    /**
+     * Unique identifier for this customization
+     */
+    customizationId: string;
 
-export interface ResolvedPromptTemplate {
+    /**
+     * The order/priority of this customization, higher values indicate higher priority
+     * when multiple customizations exist for the same fragment
+     */
+    priority: number;
+}
+
+/**
+ * Union type representing either a built-in or customized prompt fragment
+ */
+export type PromptFragment = BuiltInPromptFragment | CustomizedPromptFragment;
+
+/**
+ * Type guard to check if a PromptFragment is a built-in fragment (not customized)
+ * @param fragment The fragment to check
+ * @returns True if the fragment is a basic BuiltInPromptFragment (not customized)
+ */
+export function isBuiltInPromptFragment(fragment: PromptFragment): fragment is BuiltInPromptFragment {
+    return !('customizationId' in fragment && 'priority' in fragment);
+}
+
+/**
+ * Type guard to check if a PromptFragment is a CustomizedPromptFragment
+ * @param fragment The fragment to check
+ * @returns True if the fragment is a CustomizedPromptFragment
+ */
+export function isCustomizedPromptFragment(fragment: PromptFragment): fragment is CustomizedPromptFragment {
+    return 'customizationId' in fragment && 'priority' in fragment;
+}
+
+/**
+ * Map of prompt fragment IDs to prompt fragments
+ */
+export interface PromptMap { [id: string]: PromptFragment }
+
+/**
+ * Represents a prompt fragment with all variables and function references resolved
+ */
+export interface ResolvedPromptFragment {
+    /** The fragment ID */
     id: string;
-    /** The resolved prompt text with variables and function requests being replaced. */
+
+    /** The resolved prompt text with variables and function requests being replaced */
     text: string;
-    /** All functions referenced in the prompt template. */
+
+    /** All functions referenced in the prompt fragment */
     functionDescriptions?: Map<string, ToolRequest>;
-    /** All variables resolved in the prompt template */
+
+    /** All variables resolved in the prompt fragment */
     variables?: ResolvedAIVariable[];
 }
 
-export const PromptService = Symbol('PromptService');
-export interface PromptService {
-    /**
-     * Retrieve the raw {@link PromptTemplate} object (unresolved variables, functions and including comments).
-     * @param id the id of the {@link PromptTemplate}
-     */
-    getRawPrompt(id: string): PromptTemplate | undefined;
-    /**
-     * Retrieve the unresolved {@link PromptTemplate} object (unresolved variables, functions, excluding comments)
-     * @param id the id of the {@link PromptTemplate}
-     */
-    getUnresolvedPrompt(id: string): PromptTemplate | undefined;
-    /**
-     * Retrieve the default raw {@link PromptTemplate} object.
-     * @param id the id of the {@link PromptTemplate}
-     */
-    getDefaultRawPrompt(id: string): PromptTemplate | undefined;
-    /**
-     * Allows to directly replace placeholders in the prompt. The supported format is 'Hi {{name}}!'.
-     * The placeholder is then searched inside the args object and replaced.
-     * Function references are also supported via format '~{functionId}'.
-     *
-     * All placeholders are replaced before function references are resolved.
-     * This allows to resolve function references contained in placeholders.
-     *
-     * @param id the id of the prompt
-     * @param args the object with placeholders, mapping the placeholder key to the value
-     */
-    getPrompt(id: string, args?: { [key: string]: unknown }, context?: AIVariableContext): Promise<ResolvedPromptTemplate | undefined>;
-
-    /**
-     * Allows to directly replace placeholders in the prompt. The supported format is 'Hi {{name}}!'.
-     * The placeholder is then searched inside the args object and replaced.
-     *
-     * In contrast to {@link getPrompt}, this method does not resolve function references but leaves them as is.
-     * This allows resolving them later as part of the prompt or chat message containing the fragment.
-     *
-     * @param id the id of the prompt
-     * @param args the object with placeholders, mapping the placeholder key to the value
-     * @param context the {@link AIVariableContext} to use during variable resolution
-     * @param resolveVariable the variable resolving method. Fall back to using the {@link AIVariableService} if not given.
-     */
-    getPromptFragment(
-        id: string,
-        args?: { [key: string]: unknown },
-        context?: AIVariableContext,
-        resolveVariable?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>
-    ): Promise<Omit<ResolvedPromptTemplate, 'functionDescriptions'> | undefined>;
-
-    /**
-     * Adds a {@link PromptTemplate} to the list of prompts.
-     * @param promptTemplate the prompt template to store
-     */
-    storePromptTemplate(promptTemplate: PromptTemplate): void;
-    /**
-     * Removes a prompt from the list of prompts.
-     * @param id the id of the prompt
-     */
-    removePrompt(id: string): void;
-    /**
-     * Return all known prompts as a {@link PromptMap map}.
-     */
-    getAllPrompts(): PromptMap;
-    /**
-     * Retrieve all variant IDs of a given {@link PromptTemplate}.
-     * @param id the id of the main {@link PromptTemplate}
-     * @returns an array of string IDs representing the variants of the given template
-     */
-    getVariantIds(id: string): string[];
-    /**
-     * Retrieve the currently selected variant ID for a given main prompt ID.
-     * If a variant is selected for the main prompt, it will be returned.
-     * Otherwise, the main prompt ID will be returned.
-     * @param id the id of the main prompt
-     * @returns the variant ID if one is selected, or the main prompt ID otherwise
-     */
-    getVariantId(id: string): Promise<string>;
-}
-
+/**
+ * Describes a custom agent with its properties
+ */
 export interface CustomAgentDescription {
+    /** Unique identifier for this agent */
     id: string;
+
+    /** Display name for the agent */
     name: string;
+
+    /** Description of the agent's purpose and capabilities */
     description: string;
+
+    /** The prompt fragment for this agent */
     prompt: string;
+
+    /** The default large language model to use with this agent */
     defaultLLM: string;
 }
+
 export namespace CustomAgentDescription {
+    /**
+     * Type guard to check if an object is a CustomAgentDescription
+     */
     export function is(entry: unknown): entry is CustomAgentDescription {
         // eslint-disable-next-line no-null/no-null
         return typeof entry === 'object' && entry !== null
             && 'id' in entry && typeof entry.id === 'string'
             && 'name' in entry && typeof entry.name === 'string'
             && 'description' in entry && typeof entry.description === 'string'
-            && 'prompt' in entry
-            && typeof entry.prompt === 'string'
-            && 'defaultLLM' in entry
-            && typeof entry.defaultLLM === 'string';
+            && 'prompt' in entry && typeof entry.prompt === 'string'
+            && 'defaultLLM' in entry && typeof entry.defaultLLM === 'string';
     }
+
+    /**
+     * Compares two CustomAgentDescription objects for equality
+     */
     export function equals(a: CustomAgentDescription, b: CustomAgentDescription): boolean {
         return a.id === b.id && a.name === b.name && a.description === b.description && a.prompt === b.prompt && a.defaultLLM === b.defaultLLM;
     }
 }
 
-export const PromptCustomizationService = Symbol('PromptCustomizationService');
-export interface PromptCustomizationService {
+/**
+ * Service responsible for customizing prompt fragments
+ */
+export const PromptFragmentCustomizationService = Symbol('PromptFragmentCustomizationService');
+export interface PromptFragmentCustomizationService {
     /**
-     * Whether there is a customization for a {@link PromptTemplate} object
-     * @param id the id of the {@link PromptTemplate} to check
+     * Event fired when a prompt fragment is changed
      */
-    isPromptTemplateCustomized(id: string): boolean;
+    readonly onDidChangePromptFragmentCustomization: Event<string[]>;
 
     /**
-     * Returns the customization of {@link PromptTemplate} object or undefined if there is none
-     * @param id the id of the {@link PromptTemplate} to check
-     */
-    getCustomizedPromptTemplate(id: string): string | undefined
-
-    getCustomPromptTemplateIDs(): string[];
-    /**
-     * Edit the template. If the content is specified, is will be
-     * used to customize the template. Otherwise, the behavior depends
-     * on the implementation. Implementation may for example decide to
-     * open an editor, or request more information from the user, ...
-     * @param id the template id.
-     * @param content optional default content to initialize the template
-     */
-    editTemplate(id: string, defaultContent?: string): void;
-
-    /**
-     * Reset the template to its default value.
-     * @param id the template id.
-     */
-    resetTemplate(id: string): void;
-
-    /**
-     * Return the template id for a given template file.
-     * @param uri the uri of the template file
-     */
-    getTemplateIDFromURI(uri: URI): string | undefined;
-
-    /**
-     * Event which is fired when the prompt template is changed.
-     */
-    readonly onDidChangePrompt: Event<string>;
-
-    /**
-     * Return all custom agents.
-     * @returns all custom agents
-     */
-    getCustomAgents(): Promise<CustomAgentDescription[]>;
-
-    /**
-     * Event which is fired when custom agents are modified.
+     * Event fired when custom agents are modified
      */
     readonly onDidChangeCustomAgents: Event<void>;
 
     /**
-     * Returns all locations of existing customAgents.yml files and potential locations where
-     * new customAgents.yml files could be created.
-     *
-     * @returns An array of objects containing the URI and whether the file exists
+     * Checks if a prompt fragment has customizations
+     * @param fragmentId The prompt fragment ID
+     * @returns Whether the fragment has any customizations
+     */
+    isPromptFragmentCustomized(fragmentId: string): boolean;
+
+    /**
+     * Gets the active customized prompt fragment for a given ID
+     * @param fragmentId The prompt fragment ID
+     * @returns The active customized fragment or undefined if none exists
+     */
+    getActivePromptFragmentCustomization(fragmentId: string): CustomizedPromptFragment | undefined;
+
+    /**
+     * Gets all customizations for a prompt fragment ordered by priority
+     * @param fragmentId The prompt fragment ID
+     * @returns Array of customized fragments ordered by priority (highest first)
+     */
+    getAllCustomizations(fragmentId: string): CustomizedPromptFragment[];
+
+    /**
+     * Gets the IDs of all prompt fragments that have customizations
+     * @returns Array of prompt fragment IDs
+     */
+    getCustomizedPromptFragmentIds(): string[];
+
+    /**
+     * Creates a new customization for a prompt fragment
+     * @param fragmentId The fragment ID to customize
+     * @param defaultContent Optional default content for the customization
+     */
+    createPromptFragmentCustomization(fragmentId: string, defaultContent?: string): Promise<void>;
+
+    /**
+     * Creates a customization based on a built-in fragment
+     * @param fragmentId The ID of the built-in fragment to customize
+     */
+    createBuiltInPromptFragmentCustomization(fragmentId: string): Promise<void>;
+
+    /**
+     * Edits a specific customization of a prompt fragment
+     * @param fragmentId The prompt fragment ID
+     * @param customizationId The customization ID to edit
+     */
+    editPromptFragmentCustomization(fragmentId: string, customizationId: string): Promise<void>;
+
+    /**
+     * Edits the built-in customization of a prompt fragment
+     * @param fragmentId The prompt fragment ID to edit
+     */
+    editBuiltInPromptFragmentCustomization(fragmentId: string): Promise<void>;
+
+    /**
+     * Removes a specific customization of a prompt fragment
+     * @param fragmentId The prompt fragment ID
+     * @param customizationId The customization ID to remove
+     */
+    removePromptFragmentCustomization(fragmentId: string, customizationId: string): Promise<void>;
+
+    /**
+     * Resets a fragment to its built-in version by removing all customizations
+     * @param fragmentId The fragment ID to reset
+     */
+    removeAllPromptFragmentCustomizations(fragmentId: string): Promise<void>;
+
+    /**
+     * Resets to a specific customization by removing higher-priority customizations
+     * @param fragmentId The fragment ID
+     * @param customizationId The customization ID to reset to
+     */
+    resetToCustomization(fragmentId: string, customizationId: string): Promise<void>;
+
+    /**
+     * Gets information about the description of a customization
+     * @param fragmentId The fragment ID
+     * @param customizationId The customization ID
+     * @returns Description of the customization
+     */
+    getPromptFragmentCustomizationDescription(fragmentId: string, customizationId: string): Promise<string | undefined>;
+
+    /**
+     * Gets information about the source/type of a customization
+     * @param fragmentId The fragment ID
+     * @param customizationId The customization ID
+     * @returns Type of the customization source
+     */
+    getPromptFragmentCustomizationType(fragmentId: string, customizationId: string): Promise<string | undefined>;
+
+    /**
+     * Gets the fragment ID from a resource identifier
+     * @param resourceId Resource identifier (implementation specific)
+     * @returns Fragment ID or undefined if not found
+     */
+    getPromptFragmentIDFromResource(resourceId: unknown): string | undefined;
+
+    /**
+     * Gets all custom agent descriptions
+     * @returns Array of custom agent descriptions
+     */
+    getCustomAgents(): Promise<CustomAgentDescription[]>;
+
+    /**
+     * Gets the locations of custom agent configuration files
+     * @returns Array of URIs and existence status
      */
     getCustomAgentsLocations(): Promise<{ uri: URI, exists: boolean }[]>;
 
@@ -217,13 +268,149 @@ export interface PromptCustomizationService {
     openCustomAgentYaml(uri: URI): Promise<void>;
 }
 
+/**
+ * Service for managing and resolving prompt fragments
+ */
+export const PromptService = Symbol('PromptService');
+export interface PromptService {
+    /**
+     * Event fired when the prompts change
+     */
+    readonly onPromptsChange: Event<void>;
+
+    /**
+     * Event fired when the active variant for a system prompt changes
+     */
+    readonly onActiveVariantChange: Event<{ systemPromptId: string, variantId: string }>;
+
+    /**
+     * Gets the raw prompt fragment without any processing
+     * @param fragmentId The prompt fragment ID
+     * @returns The raw fragment or undefined if not found
+     */
+    getRawPrompt(fragmentId: string): PromptFragment | undefined;
+
+    /**
+     * Gets the unprocessed prompt fragment with comments stripped
+     * @param fragmentId The prompt fragment ID
+     * @returns The unprocessed fragment or undefined if not found
+     */
+    getUnresolvedPrompt(fragmentId: string): PromptFragment | undefined;
+
+    /**
+     * Gets the default raw prompt fragment (before any customizations)
+     * @param fragmentId The prompt fragment ID
+     * @returns The default fragment or undefined if not found
+     */
+    getDefaultRawPrompt(fragmentId: string): PromptFragment | undefined;
+
+    /**
+     * Resolves a prompt fragment by replacing variables and function references
+     * @param fragmentId The prompt fragment ID
+     * @param args Optional object with values for variable replacement
+     * @param context Optional context for variable resolution
+     * @returns The resolved prompt fragment or undefined if not found
+     */
+    getPrompt(fragmentId: string, args?: { [key: string]: unknown }, context?: AIVariableContext): Promise<ResolvedPromptFragment | undefined>;
+
+    /**
+     * Resolves a prompt fragment by replacing variables but preserving function references
+     * @param fragmentId The prompt fragment ID
+     * @param args Optional object with values for variable replacement
+     * @param context Optional context for variable resolution
+     * @param resolveVariable Optional custom variable resolution function
+     * @returns The partially resolved prompt fragment or undefined if not found
+     */
+    getPromptFragment(
+        fragmentId: string,
+        args?: { [key: string]: unknown },
+        context?: AIVariableContext,
+        resolveVariable?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>
+    ): Promise<Omit<ResolvedPromptFragment, 'functionDescriptions'> | undefined>;
+
+    /**
+     * Adds a prompt fragment to the service
+     * @param promptFragment The fragment to store
+     * @param systemPromptId Optional ID of the system prompt this is a variant of
+     */
+    addBuiltInPromptFragment(promptFragment: BuiltInPromptFragment, systemPromptId?: string, isDefault?: boolean): void;
+
+    /**
+     * Removes a prompt fragment from the service
+     * @param fragmentId The fragment ID to remove
+     */
+    removePrompt(fragmentId: string): void;
+
+    /**
+     * Gets all known prompts, including variants and customizations
+     * @returns Map of fragment IDs to arrays of fragments
+     */
+    getAllPrompts(): Map<string, PromptFragment[]>;
+
+    /**
+     * Gets all active prompts (highest priority version of each fragment)
+     * @returns Array of active prompt fragments
+     */
+    getActivePrompts(): PromptFragment[];
+
+    /**
+     * Gets IDs of all variants of a fragment
+     * @param systemPromptId The system prompt id
+     * @returns Array of variant IDs
+     */
+    getVariantIds(systemPromptId: string): string[];
+
+    /**
+     * Gets the currently selected variant ID for a fragment
+     * @param systemPromptId The system prompt id
+     * @returns The selected variant ID or the main ID if no variant is selected
+     */
+    getActiveVariantId(systemPromptId: string): Promise<string | undefined>;
+
+    /**
+     * Gets the default variant ID for a fragment
+     * @param systemPromptId The system prompt id
+     * @returns The default variant ID or undefined if no default is set
+     */
+    getDefaultVariantId(systemPromptId: string): string | undefined;
+
+    /**
+     * Updates the active variant for a system prompt
+     * @param agentId The ID of the agent to update
+     * @param systemPromptId The system prompt ID
+     * @param newVariant The new variant ID to set as active
+     */
+    updateActiveVariantId(agentId: string, systemPromptId: string, newVariant: string): Promise<void>;
+
+    /**
+     * Gets all system prompts and their variants
+     * @returns Map of system prompt IDs to arrays of variant IDs
+     */
+    getSystemPrompts(): Map<string, string[]>;
+
+    /**
+     * The following methods delegate to the PromptFragmentCustomizationService
+     */
+    createCustomization(fragmentId: string): Promise<void>;
+    createBuiltInCustomization(fragmentId: string): Promise<void>;
+    editBuiltInCustomization(fragmentId: string): Promise<void>;
+    editCustomization(fragmentId: string, customizationId: string): Promise<void>;
+    removeCustomization(fragmentId: string, customizationId: string): Promise<void>;
+    resetAllToBuiltIn(): Promise<void>;
+    resetToBuiltIn(fragmentId: string): Promise<void>;
+    resetToCustomization(fragmentId: string, customizationId: string): Promise<void>;
+    getCustomizationDescription(fragmentId: string, customizationId: string): Promise<string | undefined>;
+    getCustomizationType(fragmentId: string, customizationId: string): Promise<string | undefined>;
+    getTemplateIDFromResource(resourceId: unknown): string | undefined;
+}
+
 @injectable()
 export class PromptServiceImpl implements PromptService {
     @inject(AISettingsService) @optional()
     protected readonly settingsService: AISettingsService | undefined;
 
-    @inject(PromptCustomizationService) @optional()
-    protected readonly customizationService: PromptCustomizationService | undefined;
+    @inject(PromptFragmentCustomizationService) @optional()
+    protected readonly customizationService: PromptFragmentCustomizationService | undefined;
 
     @inject(AIVariableService) @optional()
     protected readonly variableService: AIVariableService | undefined;
@@ -231,199 +418,481 @@ export class PromptServiceImpl implements PromptService {
     @inject(ToolInvocationRegistry) @optional()
     protected readonly toolInvocationRegistry: ToolInvocationRegistry | undefined;
 
-    protected _prompts: PromptMap = {};
+    // Collection of built-in prompt fragments
+    protected _builtInFragments: BuiltInPromptFragment[] = [];
 
-    getRawPrompt(id: string): PromptTemplate | undefined {
-        if (this.customizationService !== undefined && this.customizationService.isPromptTemplateCustomized(id)) {
-            const template = this.customizationService.getCustomizedPromptTemplate(id);
-            if (template !== undefined) {
-                return { id, template };
+    // Map to store fragment variants (key: fragmentId, value: array of variantIds)
+    protected _systemPromptsMap = new Map<string, string[]>();
+
+    // Map to store default variant for each system prompt (key: systemPromptId, value: variantId)
+    protected _defaultVariantsMap = new Map<string, string>();
+
+    // Event emitter for prompt changes
+    protected _onPromptsChangeEmitter = new Emitter<void>();
+    readonly onPromptsChange = this._onPromptsChangeEmitter.event;
+
+    // Event emitter for active variant changes
+    protected _onActiveVariantChangeEmitter = new Emitter<{ systemPromptId: string, variantId: string }>();
+    readonly onActiveVariantChange = this._onActiveVariantChangeEmitter.event;
+
+    @postConstruct()
+    protected init(): void {
+        if (this.customizationService) {
+            this.customizationService.onDidChangePromptFragmentCustomization(() => {
+                this._onPromptsChangeEmitter.fire();
+            });
+            this.customizationService.onDidChangeCustomAgents(() => {
+                this._onPromptsChangeEmitter.fire();
+            });
+        }
+    }
+
+    // ===== Fragment Retrieval Methods =====
+
+    /**
+     * Finds a built-in fragment by its ID
+     * @param fragmentId The ID of the fragment to find
+     * @returns The built-in fragment or undefined if not found
+     */
+    protected findBuiltInFragmentById(fragmentId: string): BuiltInPromptFragment | undefined {
+        return this._builtInFragments.find(fragment => fragment.id === fragmentId);
+    }
+
+    getRawPrompt(fragmentId: string): PromptFragment | undefined {
+        if (this.customizationService?.isPromptFragmentCustomized(fragmentId)) {
+            const customizedFragment = this.customizationService.getActivePromptFragmentCustomization(fragmentId);
+            if (customizedFragment !== undefined) {
+                return customizedFragment;
             }
         }
-        return this.getDefaultRawPrompt(id);
-    }
-    getDefaultRawPrompt(id: string): PromptTemplate | undefined {
-        return this._prompts[id];
+        return this.getDefaultRawPrompt(fragmentId);
     }
 
-    getUnresolvedPrompt(id: string): PromptTemplate | undefined {
-        const rawPrompt = this.getRawPrompt(id);
-        if (!rawPrompt) {
+    getDefaultRawPrompt(fragmentId: string): PromptFragment | undefined {
+        return this.findBuiltInFragmentById(fragmentId);
+    }
+
+    getUnresolvedPrompt(fragmentId: string): PromptFragment | undefined {
+        const rawFragment = this.getRawPrompt(fragmentId);
+        if (!rawFragment) {
             return undefined;
         }
         return {
-            id: rawPrompt.id,
-            template: this.stripComments(rawPrompt.template)
+            ...rawFragment,
+            template: this.stripComments(rawFragment.template)
         };
     }
 
-    protected stripComments(template: string): string {
+    /**
+     * Strips comments from a template string
+     * @param templateText The template text to process
+     * @returns Template text with comments removed
+     */
+    protected stripComments(templateText: string): string {
         const commentRegex = /^\s*{{!--[\s\S]*?--}}\s*\n?/;
-        return commentRegex.test(template) ? template.replace(commentRegex, '').trimStart() : template;
+        return commentRegex.test(templateText) ? templateText.replace(commentRegex, '').trimStart() : templateText;
     }
 
-    async getVariantId(id: string): Promise<string> {
-        if (this.settingsService !== undefined) {
+    async getActiveVariantId(fragmentId: string): Promise<string | undefined> {
+        if (this.settingsService) {
             const agentSettingsMap = await this.settingsService.getSettings();
 
             for (const agentSettings of Object.values(agentSettingsMap)) {
-                if (agentSettings.selectedVariants && agentSettings.selectedVariants[id]) {
-                    return agentSettings.selectedVariants[id];
+                if (agentSettings.selectedVariants && agentSettings.selectedVariants[fragmentId]) {
+                    return agentSettings.selectedVariants[fragmentId];
                 }
             }
         }
-        return id;
+        return this.getDefaultVariantId(fragmentId);
     }
 
-    async getPrompt(id: string, args?: { [key: string]: unknown }, context?: AIVariableContext): Promise<ResolvedPromptTemplate | undefined> {
-        const variantId = await this.getVariantId(id);
-        const prompt = this.getUnresolvedPrompt(variantId);
-        if (prompt === undefined) {
+    protected async resolvePotentialSystemPrompt(promptFragmentId: string): Promise<PromptFragment | undefined> {
+        if (this._systemPromptsMap.has(promptFragmentId)) {
+            // This is a systemPrompt find the active variant
+            const activeVariantId = await this.getActiveVariantId(promptFragmentId);
+            if (activeVariantId === undefined) {
+                return undefined;
+            }
+            return this.getUnresolvedPrompt(activeVariantId);
+        }
+        return this.getUnresolvedPrompt(promptFragmentId);
+    }
+
+    // ===== Fragment Resolution Methods =====
+
+    async getPrompt(systemOrFragmentId: string, args?: { [key: string]: unknown }, context?: AIVariableContext): Promise<ResolvedPromptFragment | undefined> {
+        const promptFragment = await this.resolvePotentialSystemPrompt(systemOrFragmentId);
+        if (promptFragment === undefined) {
             return undefined;
         }
 
         // First resolve variables and arguments
-        let resolvedTemplate = prompt.template;
-        const variableAndArgReplacements = await this.getVariableAndArgReplacements(prompt.template, args, context);
-        variableAndArgReplacements.replacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
+        let resolvedTemplate = promptFragment.template;
+        const variableAndArgResolutions = await this.resolveVariablesAndArgs(promptFragment.template, args, context);
+        variableAndArgResolutions.replacements.forEach(replacement =>
+            resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
 
         // Then resolve function references with already resolved variables and arguments
         // This allows to resolve function references contained in resolved variables (e.g. prompt fragments)
         const functionMatches = matchFunctionsRegEx(resolvedTemplate);
-        const functions = new Map<string, ToolRequest>();
+        const functionMap = new Map<string, ToolRequest>();
         const functionReplacements = functionMatches.map(match => {
             const completeText = match[0];
             const functionId = match[1];
             const toolRequest = this.toolInvocationRegistry?.getFunction(functionId);
             if (toolRequest) {
-                functions.set(toolRequest.id, toolRequest);
+                functionMap.set(toolRequest.id, toolRequest);
             }
             return {
                 placeholder: completeText,
                 value: toolRequest ? toolRequestToPromptText(toolRequest) : completeText
             };
         });
-        functionReplacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
+        functionReplacements.forEach(replacement =>
+            resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
 
         return {
-            id,
+            id: systemOrFragmentId,
             text: resolvedTemplate,
-            functionDescriptions: functions.size > 0 ? functions : undefined,
-            variables: variableAndArgReplacements.resolvedVariables
+            functionDescriptions: functionMap.size > 0 ? functionMap : undefined,
+            variables: variableAndArgResolutions.resolvedVariables
         };
     }
 
     async getPromptFragment(
-        id: string,
+        systemOrFragmentId: string,
         args?: { [key: string]: unknown },
         context?: AIVariableContext,
         resolveVariable?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>
-    ): Promise<Omit<ResolvedPromptTemplate, 'functionDescriptions'> | undefined> {
-        const variantId = await this.getVariantId(id);
-        const prompt = this.getUnresolvedPrompt(variantId);
-        if (prompt === undefined) {
+    ): Promise<Omit<ResolvedPromptFragment, 'functionDescriptions'> | undefined> {
+        const promptFragment = await this.resolvePotentialSystemPrompt(systemOrFragmentId);
+        if (promptFragment === undefined) {
             return undefined;
         }
 
-        const replacements = await this.getVariableAndArgReplacements(prompt.template, args, context, resolveVariable);
-        let resolvedTemplate = prompt.template;
-        replacements.replacements.forEach(replacement => resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
+        const resolutions = await this.resolveVariablesAndArgs(promptFragment.template, args, context, resolveVariable);
+        let resolvedTemplate = promptFragment.template;
+        resolutions.replacements.forEach(replacement =>
+            resolvedTemplate = resolvedTemplate.replace(replacement.placeholder, replacement.value));
 
         return {
-            id,
+            id: systemOrFragmentId,
             text: resolvedTemplate,
-            variables: replacements.resolvedVariables
+            variables: resolutions.resolvedVariables
         };
     }
 
     /**
      * Calculates all variable and argument replacements for an unresolved template.
      *
-     * @param template the unresolved template text
+     * @param templateText the unresolved template text
      * @param args the object with placeholders, mapping the placeholder key to the value
      * @param context the {@link AIVariableContext} to use during variable resolution
      * @param resolveVariable the variable resolving method. Fall back to using the {@link AIVariableService} if not given.
+     * @returns Object containing replacements and resolved variables
      */
-    protected async getVariableAndArgReplacements(
-        template: string,
+    protected async resolveVariablesAndArgs(
+        templateText: string,
         args?: { [key: string]: unknown },
         context?: AIVariableContext,
         resolveVariable?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>
-    ): Promise<{ replacements: { placeholder: string; value: string }[], resolvedVariables: ResolvedAIVariable[] }> {
-        const matches = matchVariablesRegEx(template);
+    ): Promise<{
+        replacements: { placeholder: string; value: string }[],
+        resolvedVariables: ResolvedAIVariable[]
+    }> {
+        const variableMatches = matchVariablesRegEx(templateText);
         const variableCache = createAIResolveVariableCache();
-        const variableAndArgReplacements: { placeholder: string; value: string }[] = [];
-        const resolvedVariables: Set<ResolvedAIVariable> = new Set();
-        for (const match of matches) {
-            const completeText = match[0];
+        const replacementsList: { placeholder: string; value: string }[] = [];
+        const resolvedVariablesSet: Set<ResolvedAIVariable> = new Set();
+
+        for (const match of variableMatches) {
+            const placeholderText = match[0];
             const variableAndArg = match[1];
             let variableName = variableAndArg;
             let argument: string | undefined;
+
             const parts = variableAndArg.split(':', 2);
             if (parts.length > 1) {
                 variableName = parts[0];
                 argument = parts[1];
             }
-            let value: string;
+
+            let replacementValue: string;
             if (args && args[variableAndArg] !== undefined) {
-                value = String(args[variableAndArg]);
+                replacementValue = String(args[variableAndArg]);
             } else {
-                const toResolve = { variable: variableName, arg: argument };
-                const resolved = resolveVariable
-                    ? await resolveVariable(toResolve)
-                    : await this.variableService?.resolveVariable(toResolve, context ?? {}, variableCache);
+                const variableToResolve = { variable: variableName, arg: argument };
+                const resolvedVariable = resolveVariable
+                    ? await resolveVariable(variableToResolve)
+                    : await this.variableService?.resolveVariable(variableToResolve, context ?? {}, variableCache);
+
                 // Track resolved variable and its dependencies in all resolved variables
-                if (resolved) {
-                    resolvedVariables.add(resolved);
-                    resolved.allResolvedDependencies?.forEach(v => resolvedVariables.add(v));
+                if (resolvedVariable) {
+                    resolvedVariablesSet.add(resolvedVariable);
+                    resolvedVariable.allResolvedDependencies?.forEach(v => resolvedVariablesSet.add(v));
                 }
-                value = String(resolved?.value ?? completeText);
+                replacementValue = String(resolvedVariable?.value ?? placeholderText);
             }
-            variableAndArgReplacements.push({ placeholder: completeText, value });
+            replacementsList.push({ placeholder: placeholderText, value: replacementValue });
         }
 
-        return { replacements: variableAndArgReplacements, resolvedVariables: Array.from(resolvedVariables) };
+        return {
+            replacements: replacementsList,
+            resolvedVariables: Array.from(resolvedVariablesSet)
+        };
     }
 
-    getAllPrompts(): PromptMap {
-        if (this.customizationService !== undefined) {
-            const myCustomization = this.customizationService;
-            const result: PromptMap = {};
-            Object.keys(this._prompts).forEach(id => {
-                if (myCustomization.isPromptTemplateCustomized(id)) {
-                    const template = myCustomization.getCustomizedPromptTemplate(id);
-                    if (template !== undefined) {
-                        result[id] = { id, template };
-                    } else {
-                        result[id] = { ...this._prompts[id] };
-                    }
-                } else {
-                    result[id] = { ...this._prompts[id] };
+    // ===== Fragment Collection Management Methods =====
+
+    getAllPrompts(): Map<string, PromptFragment[]> {
+        const fragmentsMap = new Map<string, PromptFragment[]>();
+
+        if (this.customizationService) {
+            const customizationIds = this.customizationService.getCustomizedPromptFragmentIds();
+            customizationIds.forEach(fragmentId => {
+                const customizations = this.customizationService!.getAllCustomizations(fragmentId);
+                if (customizations.length > 0) {
+                    fragmentsMap.set(fragmentId, customizations);
                 }
             });
-            return result;
+        }
+
+        // Add all built-in fragments
+        for (const fragment of this._builtInFragments) {
+            if (fragmentsMap.has(fragment.id)) {
+                fragmentsMap.get(fragment.id)!.push(fragment);
+            } else {
+                fragmentsMap.set(fragment.id, [fragment]);
+            }
+        }
+
+        return fragmentsMap;
+    }
+
+    getActivePrompts(): PromptFragment[] {
+        const activeFragments: PromptFragment[] = [...this._builtInFragments];
+
+        if (this.customizationService) {
+            // Fetch all customized fragment IDs once
+            const customizedIds = this.customizationService.getCustomizedPromptFragmentIds();
+
+            // For each customized ID, get the active customization
+            for (const fragmentId of customizedIds) {
+                const customFragment = this.customizationService?.getActivePromptFragmentCustomization(fragmentId);
+                if (customFragment) {
+                    // Find and replace existing entry with the same ID instead of just adding
+                    const existingIndex = activeFragments.findIndex(fragment => fragment.id === fragmentId);
+                    if (existingIndex !== -1) {
+                        // Replace existing fragment
+                        activeFragments[existingIndex] = customFragment;
+                    } else {
+                        // Add new fragment if no existing one found
+                        activeFragments.push(customFragment);
+                    }
+                }
+            }
+        }
+        return activeFragments;
+    }
+
+    removePrompt(fragmentId: string): void {
+        const index = this._builtInFragments.findIndex(fragment => fragment.id === fragmentId);
+        if (index !== -1) {
+            this._builtInFragments.splice(index, 1);
+        }
+
+        // Remove any variant references
+        for (const [systemPromptId, variants] of this._systemPromptsMap.entries()) {
+            if (variants.includes(fragmentId)) {
+                this.removeFragmentVariant(systemPromptId, fragmentId);
+            }
+        }
+
+        // Clean up default variants map if needed
+        if (this._defaultVariantsMap.has(fragmentId)) {
+            this._defaultVariantsMap.delete(fragmentId);
+        }
+
+        // Look for this fragmentId as a variant in default variants and remove if found
+        for (const [systemPromptId, defaultVariantId] of this._defaultVariantsMap.entries()) {
+            if (defaultVariantId === fragmentId) {
+                this._defaultVariantsMap.delete(systemPromptId);
+            }
+        }
+
+        this._onPromptsChangeEmitter.fire();
+    }
+
+    getVariantIds(fragmentId: string): string[] {
+        return this._systemPromptsMap.get(fragmentId) || [];
+    }
+
+    getDefaultVariantId(systemPromptId: string): string | undefined {
+        return this._defaultVariantsMap.get(systemPromptId);
+    }
+
+    getSystemPrompts(): Map<string, string[]> {
+        return new Map(this._systemPromptsMap);
+    }
+
+    addBuiltInPromptFragment(promptFragment: BuiltInPromptFragment, systemPromptId?: string, isDefault: boolean = false): void {
+        const existingIndex = this._builtInFragments.findIndex(fragment => fragment.id === promptFragment.id);
+        if (existingIndex !== -1) {
+            // Replace existing fragment with the same ID
+            this._builtInFragments[existingIndex] = promptFragment;
         } else {
-            return { ...this._prompts };
+            // Add new fragment
+            this._builtInFragments.push(promptFragment);
+        }
+
+        // If this is a variant of a system prompt, record it in the variants map
+        if (systemPromptId) {
+            this.addFragmentVariant(systemPromptId, promptFragment.id, isDefault);
+        }
+
+        this._onPromptsChangeEmitter.fire();
+    }
+
+    // ===== Variant Management Methods =====
+
+    /**
+     * Adds a variant ID to the fragment variants map
+     * @param systemPromptId The system prompt id
+     * @param variantId The variant ID to add
+     * @param isDefault Whether this variant should be the default for the system prompt (defaults to false)
+     */
+    protected addFragmentVariant(systemPromptId: string, variantId: string, isDefault: boolean = false): void {
+        if (!this._systemPromptsMap.has(systemPromptId)) {
+            this._systemPromptsMap.set(systemPromptId, []);
+        }
+
+        const variants = this._systemPromptsMap.get(systemPromptId)!;
+        if (!variants.includes(variantId)) {
+            variants.push(variantId);
+        }
+
+        if (isDefault) {
+            this._defaultVariantsMap.set(systemPromptId, variantId);
         }
     }
-    removePrompt(id: string): void {
-        delete this._prompts[id];
-    }
-    getVariantIds(id: string): string[] {
-        const allCustomPromptTemplateIds = this.customizationService?.getCustomPromptTemplateIDs() || [];
-        const knownPromptIds = Object.keys(this._prompts);
 
-        // We filter out known IDs from the custom prompt template IDs, these are no variants, but customizations. Then we retain IDs that start with the main ID
-        const customVariantIds = allCustomPromptTemplateIds.filter(customId =>
-            !knownPromptIds.includes(customId) && customId.startsWith(id)
-        );
-        const variantIds = Object.values(this._prompts)
-            .filter(prompt => prompt.variantOf === id)
-            .map(variant => variant.id);
+    /**
+     * Removes a variant ID from the fragment variants map
+     * @param systemPromptId The system prompt id
+     * @param variantId The variant ID to remove
+     */
+    protected removeFragmentVariant(systemPromptId: string, variantId: string): void {
+        if (!this._systemPromptsMap.has(systemPromptId)) {
+            return;
+        }
 
-        return [...variantIds, ...customVariantIds];
+        const variants = this._systemPromptsMap.get(systemPromptId)!;
+        const index = variants.indexOf(variantId);
+
+        if (index !== -1) {
+            variants.splice(index, 1);
+
+            // Remove the key if no variants left
+            if (variants.length === 0) {
+                this._systemPromptsMap.delete(systemPromptId);
+            }
+        }
     }
-    storePromptTemplate(promptTemplate: PromptTemplate): void {
-        this._prompts[promptTemplate.id] = promptTemplate;
+
+    async updateActiveVariantId(agentId: string, systemPromptId: string, newVariant: string): Promise<void> {
+        if (!this.settingsService) {
+            return;
+        }
+
+        const defaultVariantId = this.getDefaultVariantId(systemPromptId);
+        const agentSettings = await this.settingsService.getAgentSettings(agentId);
+        const selectedVariants = agentSettings?.selectedVariants || {};
+
+        const updatedVariants = { ...selectedVariants };
+        if (newVariant === defaultVariantId) {
+            delete updatedVariants[systemPromptId];
+        } else {
+            updatedVariants[systemPromptId] = newVariant;
+        }
+
+        await this.settingsService.updateAgentSettings(agentId, {
+            selectedVariants: updatedVariants,
+        });
+
+        // Emit the active variant change event
+        this._onActiveVariantChangeEmitter.fire({ systemPromptId, variantId: newVariant });
+    }
+
+    // ===== Customization Service Delegation Methods =====
+
+    async createCustomization(fragmentId: string): Promise<void> {
+        if (this.customizationService) {
+            await this.customizationService.createPromptFragmentCustomization(fragmentId);
+        }
+    }
+
+    async createBuiltInCustomization(fragmentId: string): Promise<void> {
+        if (this.customizationService) {
+            await this.customizationService.createBuiltInPromptFragmentCustomization(fragmentId);
+        }
+    }
+
+    async editCustomization(fragmentId: string, customizationId: string): Promise<void> {
+        if (this.customizationService) {
+            await this.customizationService.editPromptFragmentCustomization(fragmentId, customizationId);
+        }
+    }
+
+    async removeCustomization(fragmentId: string, customizationId: string): Promise<void> {
+        if (this.customizationService) {
+            await this.customizationService.removePromptFragmentCustomization(fragmentId, customizationId);
+        }
+    }
+
+    async resetAllToBuiltIn(): Promise<void> {
+        if (this.customizationService) {
+            for (const fragment of this._builtInFragments) {
+                await this.customizationService.removeAllPromptFragmentCustomizations(fragment.id);
+            }
+        }
+    }
+
+    async resetToBuiltIn(fragmentId: string): Promise<void> {
+        if (this.customizationService) {
+            await this.customizationService.removeAllPromptFragmentCustomizations(fragmentId);
+        }
+    }
+
+    async resetToCustomization(fragmentId: string, customizationId: string): Promise<void> {
+        if (this.customizationService) {
+            await this.customizationService.resetToCustomization(fragmentId, customizationId);
+        }
+    }
+
+    async getCustomizationDescription(fragmentId: string, customizationId: string): Promise<string | undefined> {
+        if (!this.customizationService) {
+            return undefined;
+        }
+        return await this.customizationService.getPromptFragmentCustomizationDescription(fragmentId, customizationId);
+    }
+
+    async getCustomizationType(fragmentId: string, customizationId: string): Promise<string | undefined> {
+        if (!this.customizationService) {
+            return undefined;
+        }
+        return await this.customizationService.getPromptFragmentCustomizationType(fragmentId, customizationId);
+    }
+
+    getTemplateIDFromResource(resourceId: unknown): string | undefined {
+        if (this.customizationService) {
+            return this.customizationService.getPromptFragmentIDFromResource(resourceId);
+        }
+        return undefined;
+    }
+
+    async editBuiltInCustomization(fragmentId: string): Promise<void> {
+        if (this.customizationService) {
+            await this.customizationService.editBuiltInPromptFragmentCustomization(fragmentId);
+        }
     }
 }

--- a/packages/ai-core/src/common/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/common/prompt-variable-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { CommandService, ILogger, nls } from '@theia/core';
-import { injectable, inject, optional } from '@theia/core/shared/inversify';
+import { injectable, inject } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import {
     AIVariable,
@@ -26,7 +26,7 @@ import {
     AIVariableResolverWithVariableDependencies,
     AIVariableArg
 } from './variable-service';
-import { PromptCustomizationService, PromptService } from './prompt-service';
+import { isCustomizedPromptFragment, PromptService } from './prompt-service';
 import { PromptText } from './prompt-text';
 
 export const PROMPT_VARIABLE: AIVariable = {
@@ -46,9 +46,6 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
 
     @inject(PromptService)
     protected readonly promptService: PromptService;
-
-    @inject(PromptCustomizationService) @optional()
-    protected readonly promptCustomizationService: PromptCustomizationService;
 
     @inject(ILogger)
     protected logger: ILogger;
@@ -121,26 +118,24 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
 
         const range = new monaco.Range(position.lineNumber, triggerCharIndex + 2, position.lineNumber, position.column);
 
-        const customPromptIds = this.promptCustomizationService?.getCustomPromptTemplateIDs() ?? [];
-        const builtinPromptIds = Object.keys(this.promptService.getAllPrompts());
+        const activePrompts = this.promptService.getActivePrompts();
+        let builtinPromptCompletions: monaco.languages.CompletionItem[] | undefined = undefined;
 
-        const customPromptCompletions = customPromptIds.map(promptId => ({
-            label: promptId,
-            kind: monaco.languages.CompletionItemKind.Enum,
-            insertText: promptId,
-            range,
-            detail: nls.localize('theia/ai/core/promptVariable/completions/detail/custom', 'Custom prompt template'),
-            sortText: `AAA${promptId}` // Sort before everything else including all built-in prompts
-        }));
-        const builtinPromptCompletions = builtinPromptIds.map(promptId => ({
-            label: promptId,
-            kind: monaco.languages.CompletionItemKind.Variable,
-            insertText: promptId,
-            range,
-            detail: nls.localize('theia/ai/core/promptVariable/completions/detail/builtin', 'Built-in prompt template'),
-            sortText: `AAB${promptId}` // Sort after all custom prompts but before others
-        }));
+        if (activePrompts.length > 0) {
+            builtinPromptCompletions = [];
+            activePrompts.forEach(prompt => (builtinPromptCompletions!.push(
+                {
+                    label: prompt.id,
+                    kind: isCustomizedPromptFragment(prompt) ? monaco.languages.CompletionItemKind.Enum : monaco.languages.CompletionItemKind.Variable,
+                    insertText: prompt.id,
+                    range,
+                    detail: isCustomizedPromptFragment(prompt) ?
+                        nls.localize('theia/ai/core/promptVariable/completions/detail/custom', 'Customized prompt fragment') :
+                        nls.localize('theia/ai/core/promptVariable/completions/detail/builtin', 'Built-in prompt fragment'),
+                    sortText: `${prompt.id}`
+                })));
+        }
 
-        return [...customPromptCompletions, ...builtinPromptCompletions];
+        return builtinPromptCompletions;
     }
 }

--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-widget.tsx
@@ -24,6 +24,7 @@ import { AIConfigurationSelectionService } from './ai-configuration-service';
 import { nls } from '@theia/core';
 import { AIMCPConfigurationWidget } from './mcp-configuration-widget';
 import { AITokenUsageConfigurationWidget } from './token-usage-configuration-widget';
+import { AIPromptFragmentsConfigurationWidget } from './prompt-fragments-configuration-widget';
 
 @injectable()
 export class AIConfigurationContainerWidget extends BaseWidget {
@@ -43,6 +44,7 @@ export class AIConfigurationContainerWidget extends BaseWidget {
     protected variablesWidget: AIVariableConfigurationWidget;
     protected mcpWidget: AIMCPConfigurationWidget;
     protected tokenUsageWidget: AITokenUsageConfigurationWidget;
+    protected promptFragmentsWidget: AIPromptFragmentsConfigurationWidget;
 
     @postConstruct()
     protected init(): void {
@@ -69,11 +71,13 @@ export class AIConfigurationContainerWidget extends BaseWidget {
         this.variablesWidget = await this.widgetManager.getOrCreateWidget(AIVariableConfigurationWidget.ID);
         this.mcpWidget = await this.widgetManager.getOrCreateWidget(AIMCPConfigurationWidget.ID);
         this.tokenUsageWidget = await this.widgetManager.getOrCreateWidget(AITokenUsageConfigurationWidget.ID);
+        this.promptFragmentsWidget = await this.widgetManager.getOrCreateWidget(AIPromptFragmentsConfigurationWidget.ID);
 
         this.dockpanel.addWidget(this.agentsWidget);
         this.dockpanel.addWidget(this.variablesWidget, { mode: 'tab-after', ref: this.agentsWidget });
         this.dockpanel.addWidget(this.mcpWidget, { mode: 'tab-after', ref: this.variablesWidget });
         this.dockpanel.addWidget(this.tokenUsageWidget, { mode: 'tab-after', ref: this.mcpWidget });
+        this.dockpanel.addWidget(this.promptFragmentsWidget, { mode: 'tab-after', ref: this.tokenUsageWidget });
 
         this.update();
     }
@@ -88,6 +92,8 @@ export class AIConfigurationContainerWidget extends BaseWidget {
                 this.dockpanel.activateWidget(this.mcpWidget);
             } else if (widgetId === AITokenUsageConfigurationWidget.ID) {
                 this.dockpanel.activateWidget(this.tokenUsageWidget);
+            } else if (widgetId === AIPromptFragmentsConfigurationWidget.ID) {
+                this.dockpanel.activateWidget(this.promptFragmentsWidget);
             }
         });
     }

--- a/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
@@ -1,0 +1,687 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { ConfirmDialog, ReactWidget, codicon } from '@theia/core/lib/browser';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import {
+    CustomizedPromptFragment,
+    PromptFragment,
+    isCustomizedPromptFragment,
+    isBuiltInPromptFragment,
+    PromptService,
+    BuiltInPromptFragment
+} from '@theia/ai-core/lib/common/prompt-service';
+import * as React from '@theia/core/shared/react';
+import '../../../src/browser/style/index.css';
+import { AgentService } from '@theia/ai-core/lib/common/agent-service';
+import { Agent } from '@theia/ai-core/lib/common/agent';
+
+/**
+ * Widget for configuring AI prompt fragments and system prompts.
+ * Allows users to view, create, edit, and manage various types of prompt
+ * fragments including their customizations and variants.
+ */
+@injectable()
+export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
+
+    static readonly ID = 'ai-prompt-fragments-configuration';
+    static readonly LABEL = nls.localize('theia/ai/core/promptFragmentsConfiguration/label', 'Prompt Fragments');
+
+    /**
+     * Stores all available prompt fragments by ID
+     */
+    protected promptFragmentMap: Map<string, PromptFragment[]> = new Map<string, PromptFragment[]>();
+
+    /**
+     * Stores system prompts and their variant IDs
+     */
+    protected systemPromptsMap: Map<string, string[]> = new Map<string, string[]>();
+
+    /**
+     * Currently active prompt fragments
+     */
+    protected activePromptFragments: PromptFragment[] = [];
+
+    /**
+     * Tracks expanded state of prompt fragment sections in the UI
+     */
+    protected expandedPromptFragmentIds: Set<string> = new Set();
+
+    /**
+     * Tracks expanded state of prompt content display
+     */
+    protected expandedPromptFragmentTemplates: Set<string> = new Set();
+
+    /**
+     * Tracks expanded state of system prompt sections
+     */
+    protected expandedSystemPromptIds: Set<string> = new Set();
+
+    /**
+     * All available agents that may use prompts
+     */
+    protected availableAgents: Agent[] = [];
+
+    /**
+     * Maps system prompt IDs to their currently active variant IDs
+     */
+    protected activeVariantIds: Map<string, string | undefined> = new Map();
+
+    /**
+     * Maps system prompt IDs to their default variant IDs
+     */
+    protected defaultVariantIds: Map<string, string | undefined> = new Map();
+
+    @inject(PromptService) protected promptService: PromptService;
+    @inject(AgentService) protected agentService: AgentService;
+
+    @postConstruct()
+    protected init(): void {
+        this.id = AIPromptFragmentsConfigurationWidget.ID;
+        this.title.label = AIPromptFragmentsConfigurationWidget.LABEL;
+        this.title.caption = AIPromptFragmentsConfigurationWidget.LABEL;
+        this.title.closable = true;
+        this.addClass('ai-configuration-tab-content');
+        this.loadPromptFragments();
+        this.loadAgents();
+
+        this.toDispose.pushAll([
+            this.promptService.onPromptsChange(() => {
+                this.loadPromptFragments();
+            }),
+            this.promptService.onActiveVariantChange(notification => {
+                this.activeVariantIds.set(notification.systemPromptId, notification.variantId);
+                this.update();
+            }),
+            this.agentService.onDidChangeAgents(() => {
+                this.loadAgents();
+            })
+        ]);
+    }
+
+    /**
+     * Loads all prompt fragments and system prompts from the prompt service.
+     * Preserves UI expansion states and updates variant information.
+     */
+    protected async loadPromptFragments(): Promise<void> {
+        this.promptFragmentMap = this.promptService.getAllPrompts();
+        this.systemPromptsMap = this.promptService.getSystemPrompts();
+        this.activePromptFragments = this.promptService.getActivePrompts();
+
+        // Preserve expansion state when reloading
+        const existingExpandedFragmentIds = new Set(this.expandedPromptFragmentIds);
+        const existingExpandedSystemPromptIds = new Set(this.expandedSystemPromptIds);
+        const existingExpandedTemplates = new Set(this.expandedPromptFragmentTemplates);
+
+        // If no sections were previously expanded, expand all by default
+        if (existingExpandedFragmentIds.size === 0) {
+            this.expandedPromptFragmentIds = new Set(Array.from(this.promptFragmentMap.keys()));
+        } else {
+            // Keep existing expansion state but remove entries for fragments that no longer exist
+            this.expandedPromptFragmentIds = new Set(
+                Array.from(existingExpandedFragmentIds).filter(id => this.promptFragmentMap.has(id))
+            );
+        }
+
+        if (existingExpandedSystemPromptIds.size === 0) {
+            this.expandedSystemPromptIds = new Set(Array.from(this.systemPromptsMap.keys()));
+        } else {
+            // Keep existing expansion state but remove entries for system prompts that no longer exist
+            this.expandedSystemPromptIds = new Set(
+                Array.from(existingExpandedSystemPromptIds).filter(id => this.systemPromptsMap.has(id))
+            );
+        }
+
+        // For templates, preserve existing expanded states - don't expand by default
+        this.expandedPromptFragmentTemplates = new Set(
+            Array.from(existingExpandedTemplates).filter(id => {
+                const [fragmentId] = id.split('_');
+                return this.promptFragmentMap.has(fragmentId);
+            })
+        );
+
+        // Update variant information (active/default) for system prompts
+        for (const systemPromptId of this.systemPromptsMap.keys()) {
+            const activeId = await this.promptService.getActiveVariantId(systemPromptId);
+            const defaultId = await this.promptService.getDefaultVariantId(systemPromptId);
+            this.activeVariantIds.set(systemPromptId, activeId);
+            this.defaultVariantIds.set(systemPromptId, defaultId);
+        }
+
+        this.update();
+    }
+
+    /**
+     * Loads all available agents from the agent service
+     */
+    protected loadAgents(): void {
+        this.availableAgents = this.agentService.getAllAgents();
+        this.update();
+    }
+
+    /**
+     * Finds agents that use a specific system prompt
+     * @param systemPromptId ID of the system prompt to match
+     * @returns Array of agents that use the system prompt
+     */
+    protected getAgentsUsingSystemPromptId(systemPromptId: string): Agent[] {
+        return this.availableAgents.filter((agent: Agent) =>
+            agent.systemPrompts.find(systemPrompt => systemPrompt.id === systemPromptId)
+        );
+    }
+
+    protected toggleSystemPromptExpansion = (systemPromptId: string): void => {
+        if (this.expandedSystemPromptIds.has(systemPromptId)) {
+            this.expandedSystemPromptIds.delete(systemPromptId);
+        } else {
+            this.expandedSystemPromptIds.add(systemPromptId);
+        }
+        this.update();
+    };
+
+    protected togglePromptFragmentExpansion = (promptFragmentId: string): void => {
+        if (this.expandedPromptFragmentIds.has(promptFragmentId)) {
+            this.expandedPromptFragmentIds.delete(promptFragmentId);
+        } else {
+            this.expandedPromptFragmentIds.add(promptFragmentId);
+        }
+        this.update();
+    };
+
+    protected toggleTemplateExpansion = (fragmentKey: string, event: React.MouseEvent): void => {
+        event.stopPropagation();
+        if (this.expandedPromptFragmentTemplates.has(fragmentKey)) {
+            this.expandedPromptFragmentTemplates.delete(fragmentKey);
+        } else {
+            this.expandedPromptFragmentTemplates.add(fragmentKey);
+        }
+        this.update();
+    };
+
+    /**
+     * Call the edit action for the provided customized prompt fragment
+     * @param promptFragment Fragment to edit
+     * @param event Mouse event
+     */
+    protected editPromptCustomization = (promptFragment: CustomizedPromptFragment, event: React.MouseEvent): void => {
+        event.stopPropagation();
+        this.promptService.editCustomization(promptFragment.id, promptFragment.customizationId);
+    };
+
+    /**
+     * Determines if a prompt fragment is currently the active one for its ID
+     * @param promptFragment The prompt fragment to check
+     * @returns True if this prompt fragment is the active customization
+     */
+    protected isActiveCustomization(promptFragment: PromptFragment): boolean {
+        const activePromptFragment = this.activePromptFragments.find(activePrompt => activePrompt.id === promptFragment.id);
+        if (!activePromptFragment) {
+            return false;
+        }
+
+        if (isCustomizedPromptFragment(activePromptFragment) && isCustomizedPromptFragment(promptFragment)) {
+            return (
+                activePromptFragment.id === promptFragment.id &&
+                activePromptFragment.template === promptFragment.template &&
+                activePromptFragment.customizationId === promptFragment.customizationId &&
+                activePromptFragment.priority === promptFragment.priority
+            );
+        }
+
+        if (isBuiltInPromptFragment(activePromptFragment) && isBuiltInPromptFragment(promptFragment)) {
+            return (
+                activePromptFragment.id === promptFragment.id &&
+                activePromptFragment.template === promptFragment.template
+            );
+        }
+
+        return false;
+    }
+
+    /**
+     * Resets a prompt fragment to use a specific customization (with confirmation dialog)
+     * @param customization customization to reset to
+     * @param event Mouse event
+     */
+    protected resetToPromptFragment = async (customization: PromptFragment, event: React.MouseEvent): Promise<void> => {
+        event.stopPropagation();
+
+        if (isCustomizedPromptFragment(customization)) {
+            // Get the customization type to show in the confirmation dialog
+            const type = await this.promptService.getCustomizationType(customization.id, customization.customizationId);
+
+            const dialog = new ConfirmDialog({
+                title: 'Reset to Customization',
+                msg: `Are you sure you want to reset the prompt fragment "${customization.id}" to use the ${type} customization?
+                    This will remove all higher-priority customizations.`,
+                ok: 'Reset',
+                cancel: 'Cancel'
+            });
+
+            const shouldReset = await dialog.open();
+            if (shouldReset) {
+                await this.promptService.resetToCustomization(customization.id, customization.customizationId);
+            }
+        } else {
+            const dialog = new ConfirmDialog({
+                title: 'Reset to Built-in',
+                msg: `Are you sure you want to reset the prompt fragment "${customization.id}" to its built-in version? This will remove all customizations.`,
+                ok: 'Reset',
+                cancel: 'Cancel'
+            });
+
+            const shouldReset = await dialog.open();
+            if (shouldReset) {
+                await this.promptService.resetToBuiltIn(customization.id);
+            }
+        }
+    };
+
+    /**
+     * Creates a new customization for a built-in prompt fragment
+     * @param promptFragment Built-in prompt fragment to customize
+     * @param event Mouse event
+     */
+    protected createPromptFragmentCustomization = (promptFragment: BuiltInPromptFragment, event: React.MouseEvent): void => {
+        event.stopPropagation();
+        this.promptService.createCustomization(promptFragment.id);
+    };
+
+    /**
+     * Deletes a customization with confirmation dialog
+     * @param customization Customized prompt fragment to delete
+     * @param event Mouse event
+     */
+    protected deletePromptFragmentCustomization = async (customization: CustomizedPromptFragment, event: React.MouseEvent): Promise<void> => {
+        event.stopPropagation();
+
+        // First get the customization type and description to show in the confirmation dialog
+        const type = await this.promptService.getCustomizationType(customization.id, customization.customizationId) || '';
+        const description = await this.promptService.getCustomizationDescription(customization.id, customization.customizationId) || '';
+
+        const dialog = new ConfirmDialog({
+            title: 'Remove Customization',
+            msg: `Are you sure you want to remove the ${type} customization for prompt fragment "${customization.id}"${description ? ` (${description})` : ''}?`,
+            ok: 'Remove',
+            cancel: 'Cancel'
+        });
+
+        const shouldDelete = await dialog.open();
+        if (shouldDelete) {
+            await this.promptService.removeCustomization(customization.id, customization.customizationId);
+        }
+    };
+
+    /**
+     * Removes all prompt customizations (resets to built-in versions) with confirmation
+     */
+    protected removeAllCustomizations = async (): Promise<void> => {
+        const dialog = new ConfirmDialog({
+            title: 'Reset All Customizations',
+            msg: 'Are you sure you want to reset all prompt fragments to their built-in versions? This will remove all customizations.',
+            ok: 'Reset All',
+            cancel: 'Cancel'
+        });
+
+        const shouldReset = await dialog.open();
+        if (shouldReset) {
+            this.promptFragmentMap.forEach(fragments => {
+                this.promptService.resetToBuiltIn(fragments[0].id);
+            });
+        }
+    };
+
+    /**
+     * Main render method for the widget
+     * @returns Complete UI for the configuration widget
+     */
+    protected render(): React.ReactNode {
+        const nonSystemPromptFragments = this.getNonSystemPromptFragments();
+
+        return (
+            <div className='ai-prompt-fragments-configuration'>
+                <div className="prompt-fragments-header">
+                    <h2>Prompt Fragments</h2>
+                    <div className="global-actions">
+                        <button
+                            className="global-action-button"
+                            onClick={this.removeAllCustomizations}
+                            title="Reset all customizations"
+                        >
+                            Reset all prompt fragments <span className={codicon('clear-all')}></span>
+                        </button>
+                    </div>
+                </div>
+
+                <div className="system-prompts-container">
+                    <h3 className="section-header">System Prompts</h3>
+                    {Array.from(this.systemPromptsMap.entries()).map(([systemPromptId, variantIds]) =>
+                        this.renderSystemPrompt(systemPromptId, variantIds)
+                    )}
+                </div>
+
+                {nonSystemPromptFragments.size > 0 && <div className="prompt-fragments-container">
+                    <h3 className="section-header">Other Prompt Fragments</h3>
+                    {Array.from(nonSystemPromptFragments.entries()).map(([promptFragmentId, fragments]) =>
+                        this.renderPromptFragment(promptFragmentId, fragments)
+                    )}
+                </div>}
+
+                {this.promptFragmentMap.size === 0 && (
+                    <div className="no-fragments">
+                        <p>No prompt fragments available.</p>
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    /**
+     * Renders a system prompt with its variants
+     * @param systemPromptId ID of the system prompt
+     * @param variantIds Array of variant IDs
+     * @returns React node for the system prompt group
+     */
+    protected renderSystemPrompt(systemPromptId: string, variantIds: string[]): React.ReactNode {
+        const isSectionExpanded = this.expandedSystemPromptIds.has(systemPromptId);
+
+        // Get active and default variant IDs from our class properties
+        const activeVariantId = this.activeVariantIds.get(systemPromptId);
+        const defaultVariantId = this.defaultVariantIds.get(systemPromptId);
+
+        // Get variant fragments grouped by ID
+        const variantGroups = new Map<string, PromptFragment[]>();
+
+        // First, collect all actual fragments for each variant ID
+        for (const variantId of variantIds) {
+            if (this.promptFragmentMap.has(variantId)) {
+                variantGroups.set(variantId, this.promptFragmentMap.get(variantId)!);
+            }
+        }
+
+        const relatedAgents = this.getAgentsUsingSystemPromptId(systemPromptId);
+
+        return (
+            <div className="prompt-fragment-section" key={`system-${systemPromptId}`}>
+                <div
+                    className={`prompt-fragment-header ${isSectionExpanded ? 'expanded' : ''}`}
+                    onClick={() => this.toggleSystemPromptExpansion(systemPromptId)}
+                >
+                    <div className="prompt-fragment-title">
+                        <span className="expansion-icon">{isSectionExpanded ? '▼' : '▶'}</span>
+                        <h2>{systemPromptId}</h2>
+                    </div>
+                    {relatedAgents.length > 0 && (
+                        <div className="agent-chips-container">
+                            {relatedAgents.map(agent => (
+                                <span key={agent.id} className="agent-chip" title={`Used by agent: ${agent.name}`} onClick={e => e.stopPropagation()}>
+                                    <span className={codicon('copilot')}></span>
+                                    {agent.name}
+                                </span>
+                            ))}
+                        </div>
+                    )}
+                </div>
+                {isSectionExpanded && (
+                    <div className="prompt-fragment-body">
+                        <div className="prompt-fragment-description">
+                            <p>Variants of this system prompt:</p>
+                        </div>
+                        {Array.from(variantGroups.entries()).map(([variantId, fragments]) => {
+                            const isVariantExpanded = this.expandedPromptFragmentIds.has(variantId);
+
+                            return (
+                                <div key={variantId} className={`prompt-fragment-section ${activeVariantId === variantId ? 'active-variant' : ''}`}>
+                                    <div
+                                        className={`prompt-fragment-header ${isVariantExpanded ? 'expanded' : ''}`}
+                                        onClick={() => this.togglePromptFragmentExpansion(variantId)}
+                                    >
+                                        <div className="prompt-fragment-title">
+                                            <span className="expansion-icon">{isVariantExpanded ? '▼' : '▶'}</span>
+                                            <h4>{variantId}</h4>
+                                            {defaultVariantId === variantId && (
+                                                <span className="badge default-variant" title="Default variant">Default</span>
+                                            )}
+                                            {activeVariantId === variantId && (
+                                                <span className="active-indicator" title="Active variant">Active</span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    {isVariantExpanded && (
+                                        <div className='prompt-fragment-body'>
+                                            <div className="prompt-fragment-description">
+                                                <p>Customizations of this prompt fragment:</p>
+                                            </div>
+                                            {fragments.map(fragment => this.renderPromptFragmentCustomization(fragment))}
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    /**
+     * Gets fragments that aren't part of any system prompt
+     * @returns Map of fragment IDs to their customizations
+     */
+    protected getNonSystemPromptFragments(): Map<string, PromptFragment[]> {
+        const nonSystemPromptFragments = new Map<string, PromptFragment[]>();
+        const allVariantIds = new Set<string>();
+
+        // Collect all variant IDs from system prompts
+        this.systemPromptsMap.forEach((variants, _) => {
+            variants.forEach(variantId => allVariantIds.add(variantId));
+        });
+
+        // Add system prompt main IDs
+        this.systemPromptsMap.forEach((_, systemPromptId) => {
+            allVariantIds.add(systemPromptId);
+        });
+
+        // Filter the fragment map to only include non-system prompt fragments
+        this.promptFragmentMap.forEach((fragments, promptFragmentId) => {
+            if (!allVariantIds.has(promptFragmentId)) {
+                nonSystemPromptFragments.set(promptFragmentId, fragments);
+            }
+        });
+
+        return nonSystemPromptFragments;
+    }
+
+    /**
+     * Renders a prompt fragment with all of its customizations
+     * @param promptFragmentId ID of the prompt fragment
+     * @param customizations Array of the customizations
+     * @returns React node for the prompt fragment
+     */
+    protected renderPromptFragment(promptFragmentId: string, customizations: PromptFragment[]): React.ReactNode {
+        const isSectionExpanded = this.expandedPromptFragmentIds.has(promptFragmentId);
+
+        return (
+            <div className={'prompt-fragment-group'} key={promptFragmentId}>
+                <div
+                    className={`prompt-fragment-header ${isSectionExpanded ? 'expanded' : ''}`}
+                    onClick={() => this.togglePromptFragmentExpansion(promptFragmentId)}
+                >
+                    <div className="prompt-fragment-title">
+                        <span className="expansion-icon">{isSectionExpanded ? '▼' : '▶'}</span>
+                        {promptFragmentId}
+                    </div>
+                </div>
+                {isSectionExpanded && (
+                    <div className="prompt-fragment-body">
+                        {customizations.map(fragment => this.renderPromptFragmentCustomization(fragment))}
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    /**
+     * Renders a single prompt fragment customization with its controls and content
+     * @param promptFragment The prompt fragment to render
+     * @returns React node for the prompt fragment
+     */
+    protected renderPromptFragmentCustomization(promptFragment: PromptFragment): React.ReactNode {
+        const isCustomized = isCustomizedPromptFragment(promptFragment);
+        const isActive = this.isActiveCustomization(promptFragment);
+        // Create a unique key for this fragment to track expansion state
+        const fragmentKey = `${promptFragment.id}_${isCustomized ? promptFragment.customizationId : 'built-in'}`;
+        const isTemplateExpanded = this.expandedPromptFragmentTemplates.has(fragmentKey);
+
+        return (
+            <div
+                className={`prompt-customization ${isActive ? 'active-variant' : ''}`}
+                key={fragmentKey}
+            >
+                <div className="prompt-customization-header">
+                    <div className="prompt-customization-title">
+                        <React.Suspense fallback={<div>Loading...</div>}>
+                            <CustomizationTypeBadge promptFragment={promptFragment} promptService={this.promptService} />
+                        </React.Suspense>
+                        {isActive && (
+                            <span className="active-indicator" title="Active customization">Active</span>
+                        )}
+                    </div>
+                    <div className="prompt-customization-actions">
+                        {!isCustomized && (
+                            <button
+                                className="template-action-button config-button"
+                                onClick={e => this.createPromptFragmentCustomization(promptFragment, e)}
+                                title="Create Customization"
+                            >
+                                <span className={codicon('add')}></span>
+                            </button>
+                        )}
+                        {isCustomized && (
+                            <button
+                                className="source-uri-button"
+                                onClick={e => this.editPromptCustomization(promptFragment, e)}
+                                title={'Edit template'}
+                            >
+                                <span className={codicon('edit')}></span>
+                            </button>
+                        )}
+                        {!isActive && (
+                            <button
+                                className="template-action-button reset-button"
+                                onClick={e => this.resetToPromptFragment(promptFragment, e)}
+                                title={`Reset to this ${!isCustomized ? 'built-in' : 'customization'}`}
+                            >
+                                <span className={codicon('discard')}></span>
+                            </button>
+                        )}
+                        {isCustomized && (
+                            <button
+                                className="template-action-button delete-button"
+                                onClick={e => this.deletePromptFragmentCustomization(promptFragment, e)}
+                                title="Delete Customization"
+                            >
+                                <span className={codicon('trash')}></span>
+                            </button>
+                        )}
+                    </div>
+                </div>
+
+                {isCustomized && (
+                    <React.Suspense fallback={<div>Loading...</div>}>
+                        <DescriptionBadge promptFragment={promptFragment} promptService={this.promptService} />
+                    </React.Suspense>
+                )}
+
+                <div className="template-content-container">
+                    <div
+                        className="template-toggle-button"
+                        onClick={e => this.toggleTemplateExpansion(fragmentKey, e)}
+                    >
+                        <span className="template-expansion-icon">{isTemplateExpanded ? '▼' : '▶'}</span>
+                        <span>Prompt Template Text</span>
+                    </div>
+
+                    {isTemplateExpanded && (
+                        <div className="template-content">
+                            <pre>{promptFragment.template}</pre>
+                        </div>
+                    )}
+                </div>
+            </div>
+        );
+    }
+}
+
+/**
+ * Props for the CustomizationTypeBadge component
+ */
+interface CustomizationTypeBadgeProps {
+    promptFragment: PromptFragment;
+    promptService: PromptService;
+}
+
+/**
+ * Displays a badge indicating the type of a prompt fragment customization (built-in, user, workspace)
+ */
+const CustomizationTypeBadge: React.FC<CustomizationTypeBadgeProps> = ({ promptFragment, promptService }) => {
+    const [typeLabel, setTypeLabel] = React.useState<string>('unknown');
+
+    React.useEffect(() => {
+        const fetchCustomizationType = async () => {
+            if (isCustomizedPromptFragment(promptFragment)) {
+                const customizationType = await promptService.getCustomizationType(promptFragment.id, promptFragment.customizationId);
+                setTypeLabel(`${customizationType ? customizationType + ' customization' : 'Customization'}`);
+            } else {
+                setTypeLabel('Built-in');
+            }
+        };
+
+        fetchCustomizationType();
+    }, [promptFragment, promptService]);
+
+    return <span>{typeLabel}</span>;
+};
+
+/**
+ * Props for the DescriptionBadge component
+ */
+interface CustomizationDescriptionBadgeProps {
+    promptFragment: CustomizedPromptFragment;
+    promptService: PromptService;
+}
+
+/**
+ * Displays the description of a customized prompt fragment if available
+ */
+const DescriptionBadge: React.FC<CustomizationDescriptionBadgeProps> = ({ promptFragment, promptService }) => {
+    const [description, setDescription] = React.useState<string>('');
+
+    React.useEffect(() => {
+        const fetchDescription = async () => {
+            const customizationDescription = await promptService.getCustomizationDescription(
+                promptFragment.id,
+                promptFragment.customizationId
+            );
+            setDescription(customizationDescription || '');
+        };
+
+        fetchDescription();
+    }, [promptFragment.id, promptFragment.customizationId, promptService]);
+
+    return <span className="prompt-customization-description">{description}</span>;
+};

--- a/packages/ai-ide/src/browser/architect-agent.ts
+++ b/packages/ai-ide/src/browser/architect-agent.ts
@@ -16,7 +16,7 @@
 import { AbstractStreamParsingChatAgent, ChatRequestModel, ChatService, ChatSession, MutableChatModel, MutableChatRequestModel } from '@theia/ai-chat/lib/common';
 import { LanguageModelRequirement } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { architectPromptTemplate, architectTaskSummaryPromptTemplate } from '../common/architect-prompt-template';
+import { architectSystemPrompt } from '../common/architect-prompt-template';
 import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID } from '../common/workspace-functions';
 import { nls } from '@theia/core';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
@@ -38,9 +38,9 @@ export class ArchitectAgent extends AbstractStreamParsingChatAgent {
         'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \
          and folders and retrieve their content. It cannot modify files. It can therefore answer questions about the current project, project files and source code in the \
          workspace, such as how to build the project, where to put source code, where to find specific code or configurations, etc.');
-    override promptTemplates = [architectPromptTemplate, architectTaskSummaryPromptTemplate];
+    override systemPrompts = [architectSystemPrompt];
     override functions = [GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID];
-    protected override systemPromptId: string | undefined = architectPromptTemplate.id;
+    protected override systemPromptId: string | undefined = architectSystemPrompt.id;
 
     override async invoke(request: MutableChatRequestModel): Promise<void> {
         await super.invoke(request);

--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -16,10 +16,9 @@
 import { AbstractStreamParsingChatAgent, ChatRequestModel, ChatService, ChatSession, MutableChatModel, MutableChatRequestModel } from '@theia/ai-chat/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from '../common/workspace-functions';
-import { CODER_REPLACE_PROMPT_TEMPLATE_ID, getCoderAgentModePromptTemplate, getCoderReplacePromptTemplate, getCoderReplacePromptTemplateNext }
-    from '../common/coder-replace-prompt-template';
+import { CODER_SYSTEM_PROMPT_ID, getCoderAgentModePromptTemplate, getCoderReplacePromptTemplate, getCoderReplacePromptTemplateNext } from '../common/coder-replace-prompt-template';
 import { WriteChangeToFileProvider } from './file-changeset-functions';
-import { LanguageModelRequirement } from '@theia/ai-core';
+import { LanguageModelRequirement, SystemPrompt } from '@theia/ai-core';
 import { nls } from '@theia/core';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { AI_CHAT_NEW_CHAT_WINDOW_COMMAND, ChatCommands } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
@@ -39,9 +38,13 @@ export class CoderAgent extends AbstractStreamParsingChatAgent {
         'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \
         and folders and retrieve their content. Futhermore, it can suggest modifications of files to the user. It can therefore assist the user with coding tasks or other \
         tasks involving file changes.');
-    override promptTemplates = [getCoderReplacePromptTemplate(true), getCoderReplacePromptTemplate(false), getCoderReplacePromptTemplateNext(), getCoderAgentModePromptTemplate()];
+    override systemPrompts: SystemPrompt[] = [{
+        id: CODER_SYSTEM_PROMPT_ID,
+        defaultVariant: getCoderReplacePromptTemplate(true),
+        variants: [getCoderReplacePromptTemplate(false), getCoderReplacePromptTemplateNext(), getCoderAgentModePromptTemplate()]
+    }];
     override functions = [GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, WriteChangeToFileProvider.ID];
-    protected override systemPromptId: string | undefined = CODER_REPLACE_PROMPT_TEMPLATE_ID;
+    protected override systemPromptId: string | undefined = CODER_SYSTEM_PROMPT_ID;
     override async invoke(request: MutableChatRequestModel): Promise<void> {
         await super.invoke(request);
         this.suggest(request);
@@ -64,4 +67,5 @@ export class CoderAgent extends AbstractStreamParsingChatAgent {
                 + ` or [start a new chat with a summary of this one](command:${ChatCommands.AI_CHAT_NEW_WITH_TASK_CONTEXT.id}).`)]);
         }
     }
+
 }

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -52,6 +52,7 @@ import { TaskContextSummaryVariableContribution } from './task-background-summar
 import { TaskContextFileStorageService } from './task-context-file-storage-service';
 import { TaskContextStorageService } from '@theia/ai-chat/lib/browser/task-context-service';
 import { CommandContribution } from '@theia/core';
+import { AIPromptFragmentsConfigurationWidget } from './ai-configuration/prompt-fragments-configuration-widget';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
@@ -152,4 +153,11 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     rebind(TaskContextStorageService).toService(TaskContextFileStorageService);
 
     bind(CommandContribution).to(SummarizeSessionCommandContribution);
+    bind(AIPromptFragmentsConfigurationWidget).toSelf();
+    bind(WidgetFactory)
+        .toDynamicValue(ctx => ({
+            id: AIPromptFragmentsConfigurationWidget.ID,
+            createWidget: () => ctx.container.get(AIPromptFragmentsConfigurationWidget)
+        }))
+        .inSingletonScope();
 });

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -127,6 +127,317 @@
   margin-left: 0;
 }
 
+/* Prompt Fragments Configuration Styles */
+.ai-prompt-fragments-configuration {
+  padding: var(--theia-ui-padding);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.prompt-fragments-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--theia-panelTitle-activeBorder);
+}
+
+.prompt-fragments-header h2 {
+  margin: 0;
+}
+
+.global-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.global-action-button {
+  padding: 6px 12px;
+  background-color: transparent;
+  color: var(--theia-foreground);
+  border: 1px solid var(--theia-border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.global-action-button:hover {
+  background-color: var(--theia-list-hoverBackground);
+}
+
+.prompt-fragments-container {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.prompt-fragment-group {
+  border: 1px solid var(--theia-panelTitle-activeBorder);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 15px;
+  background-color: var(--theia-editorWidget-background);
+}
+
+.prompt-customization {
+  border: 1px solid var(--theia-panelTitle-activeBorder);
+  border-radius: 6px;
+  margin-bottom: 10px;
+  background-color: var(--theia-editor-background);
+}
+
+.prompt-customization.active-variant {
+  border: 3px solid var(--theia-successBackground);
+}
+
+.prompt-customization-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+}
+
+.prompt-customization-title {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.prompt-customization-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.prompt-customization-description {
+  padding: 0px 15px;
+  color: var(--theia-descriptionForeground);
+  font-size: 12px;
+  margin-bottom: 5px;
+  font-style: italic;
+}
+
+.expansion-icon {
+  color: var(--theia-descriptionForeground);
+  font-size: 14px;
+}
+
+.template-action-button {
+  background-color: transparent;
+  color: var(--theia-foreground);
+  border: 1px solid var(--theia-border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.template-action-button:hover {
+  background-color: var(--theia-list-hoverBackground);
+}
+
+.template-action-button.reset-button {
+  color: var(--theia-foreground);
+  border-color: var(--theia-border);
+}
+
+.template-action-button.config-button {
+  color: var(--theia-foreground);
+  border-color: var(--theia-border);
+}
+
+.template-action-button.delete-button {
+  color: var(--theia-errorForeground);
+  border-color: var(--theia-errorForeground);
+}
+
+.template-action-button.delete-button:hover {
+  background-color: var(--theia-errorBackground);
+}
+
+.badge {
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 12px;
+  font-weight: 500;
+}
+
+.default-variant {
+  background: hsla(0, 0%, 68%, 0.31);
+  color: var(--theia-foreground);
+}
+
+.active-indicator {
+  background-color: var(--theia-successBackground);
+  color: var(--theia-editor-background);
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.source-uri-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--theia-foreground);
+  border: 1px solid var(--theia-border);
+  border-radius: 4px;
+  height: 22px;
+  width: 22px;
+  margin-left: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.source-uri-button:hover {
+  background-color: var(--theia-list-hoverBackground);
+}
+
+.no-fragments {
+  text-align: center;
+  padding: 30px;
+  color: var(--theia-descriptionForeground);
+  font-style: italic;
+}
+
+/* Template content collapsable styles */
+.template-content-container {
+  padding: 10px;
+  background-color: var(--theia-list-focusBackground);
+}
+
+.template-toggle-button {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 5px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.template-toggle-button:hover {
+  background-color: var(--theia-list-hoverBackground);
+}
+
+.template-expansion-icon {
+  margin-right: 8px;
+  color: var(--theia-descriptionForeground);
+  font-size: 14px;
+}
+
+.template-content {
+  margin-top: 10px;
+  padding: 10px;
+  background-color: var(--theia-editor-inactiveSelectionBackground);
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.template-content pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: monospace;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.agent-chips-container {
+  display: flex;
+  gap: 6px;
+}
+
+.agent-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--theia-charts-blue);
+  color: var(--theia-editor-background);
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 500;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  white-space: nowrap;
+}
+
+/* System Prompts improvements */
+.system-prompts-container {
+  margin-bottom: 20px;
+}
+
+.prompt-fragment-section {
+  border: 1px solid var(--theia-panelTitle-activeBorder);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 15px;
+  background-color: var(--theia-editorWidget-background);
+}
+
+.prompt-fragment-section.active-variant {
+  border: 3px solid var(--theia-successBackground);
+}
+
+.prompt-fragment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 15px;
+  cursor: pointer;
+  background-color: var(--theia-editor-background);
+  transition: background-color 0.2s;
+}
+
+.prompt-fragment-header.expanded {
+  border-bottom: 1px solid var(--theia-panelTitle-activeBorder);
+}
+
+.prompt-fragment-header:hover {
+  background-color: var(--theia-list-hoverBackground);
+}
+
+.prompt-fragment-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.prompt-fragment-title h4 {
+  margin-right: 8px;
+  margin: 0;
+}
+
+.prompt-fragment-title .active-indicator {
+  margin-right: 4px;
+}
+
+.prompt-fragment-body {
+  padding: 15px;
+}
+
+.prompt-fragment-description {
+  margin-top: 0;
+  margin-bottom: 10px;
+  color: var(--theia-descriptionForeground);
+}
+
+.section-header {
+  margin: 10px 0;
+  color: var(--theia-foreground);
+  font-size: 14px;
+}
+
 /* MCP Configuration Styles */
 .mcp-configuration-container {
   padding: 16px;

--- a/packages/ai-ide/src/browser/template-preference-contribution.ts
+++ b/packages/ai-ide/src/browser/template-preference-contribution.ts
@@ -16,7 +16,7 @@
 
 import { FrontendApplicationContribution, PreferenceService } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { FrontendPromptCustomizationServiceImpl, PromptCustomizationProperties } from '@theia/ai-core/lib/browser/frontend-prompt-customization-service';
+import { DefaultPromptFragmentCustomizationService, PromptFragmentCustomizationProperties } from '@theia/ai-core/lib/browser/frontend-prompt-customization-service';
 import {
     PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF,
     PROMPT_TEMPLATE_ADDITIONAL_EXTENSIONS_PREF,
@@ -31,8 +31,8 @@ export class TemplatePreferenceContribution implements FrontendApplicationContri
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
 
-    @inject(FrontendPromptCustomizationServiceImpl)
-    protected readonly customizationService: FrontendPromptCustomizationServiceImpl;
+    @inject(DefaultPromptFragmentCustomizationService)
+    protected readonly customizationService: DefaultPromptFragmentCustomizationService;
 
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
@@ -70,7 +70,7 @@ export class TemplatePreferenceContribution implements FrontendApplicationContri
         }
 
         const workspaceRootUri = workspaceRoot.resource;
-        const configProperties: PromptCustomizationProperties = {};
+        const configProperties: PromptFragmentCustomizationProperties = {};
 
         if (!changedPreference || changedPreference === PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF) {
             const relativeDirectories = this.preferenceService.get<string[]>(PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF, []);

--- a/packages/ai-ide/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide/src/common/architect-prompt-template.ts
@@ -8,15 +8,17 @@
 //
 // SPDX-License-Identifier: MIT
 // *****************************************************************************
-import { PromptTemplate } from '@theia/ai-core/lib/common';
+import { SystemPrompt } from '@theia/ai-core/lib/common';
 import { GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from './workspace-functions';
 import { CONTEXT_FILES_VARIABLE_ID } from './context-variables';
 
 export const ARCHITECT_TASK_SUMMARY_PROMPT_TEMPLATE_ID = 'architect-task-summary';
 
-export const architectPromptTemplate = <PromptTemplate>{
+export const architectSystemPrompt = <SystemPrompt>{
     id: 'architect-system',
-    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+    defaultVariant: {
+        id: 'architect-system-default',
+        template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 # Instructions
@@ -44,11 +46,10 @@ Always look at the relevant files to understand your task using the function ~{$
 
 {{prompt:project-info}}
 `
-};
-
-export const architectTaskSummaryPromptTemplate: PromptTemplate = {
-    id: ARCHITECT_TASK_SUMMARY_PROMPT_TEMPLATE_ID,
-    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+    },
+    variants: [{
+        id: ARCHITECT_TASK_SUMMARY_PROMPT_TEMPLATE_ID,
+        template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 
@@ -65,6 +66,6 @@ Skip irrelevant information, e.g. for discussions, only sum up the final result.
 4. If any part of the task is ambiguous, note the ambiguity so that it can be clarified later.
 
 Focus on providing actionable steps and implementation guidance. The coding agent needs practical help with this specific coding task.
-`,
-    variantOf: 'architect-system'
+`
+    }]
 };

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: MIT
 // *****************************************************************************
 
-import { PromptTemplate } from '@theia/ai-core/lib/common';
+import { BuiltInPromptFragment } from '@theia/ai-core/lib/common';
 import { CHANGE_SET_SUMMARY_VARIABLE_ID } from '@theia/ai-chat';
 import {
     GET_WORKSPACE_FILE_LIST_FUNCTION_ID,
@@ -23,12 +23,13 @@ import {
 import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from './context-variables';
 import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
 
+export const CODER_SYSTEM_PROMPT_ID = 'coder-prompt';
 export const CODER_REWRITE_PROMPT_TEMPLATE_ID = 'coder-rewrite';
 export const CODER_REPLACE_PROMPT_TEMPLATE_ID = 'coder-search-replace';
 export const CODER_REPLACE_PROMPT_TEMPLATE_NEXT_ID = 'coder-search-replace-next';
 export const CODER_AGENT_MODE_TEMPLATE_ID = 'coder-agent-mode';
 
-export function getCoderAgentModePromptTemplate(): PromptTemplate {
+export function getCoderAgentModePromptTemplate(): BuiltInPromptFragment {
     return {
         id: CODER_AGENT_MODE_TEMPLATE_ID,
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
@@ -142,7 +143,7 @@ You are an autonomous AI agent. Do not stop until:
     };
 }
 
-export function getCoderReplacePromptTemplateNext(): PromptTemplate {
+export function getCoderReplacePromptTemplateNext(): BuiltInPromptFragment {
     return {
         id: CODER_REPLACE_PROMPT_TEMPLATE_NEXT_ID,
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
@@ -194,7 +195,7 @@ You have previously proposed changes for the following files. Some suggestions m
         ...({ variantOf: CODER_REPLACE_PROMPT_TEMPLATE_ID }),
     };
 }
-export function getCoderReplacePromptTemplate(withSearchAndReplace: boolean = false): PromptTemplate {
+export function getCoderReplacePromptTemplate(withSearchAndReplace: boolean = false): BuiltInPromptFragment {
     return {
         id: withSearchAndReplace ? CODER_REPLACE_PROMPT_TEMPLATE_ID : CODER_REWRITE_PROMPT_TEMPLATE_ID,
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).

--- a/packages/ai-ide/src/common/command-chat-agents.ts
+++ b/packages/ai-ide/src/common/command-chat-agents.ts
@@ -57,7 +57,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
 
     override description = 'This agent is aware of all commands that the user can execute within the Theia IDE, the tool that the user is currently working with. \
     Based on the user request, it can find the right command and then let the user execute it.';
-    override promptTemplates = [commandTemplate];
+    override systemPrompts = [commandTemplate];
     override agentSpecificVariables = [{
         name: 'command-ids',
         description: 'The list of available commands in Theia.',

--- a/packages/ai-ide/src/common/command-chat-agents.ts
+++ b/packages/ai-ide/src/common/command-chat-agents.ts
@@ -75,7 +75,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
         if (systemPrompt === undefined) {
             throw new Error('Couldn\'t get system prompt ');
         }
-        return SystemMessageDescription.fromResolvedPromptTemplate(systemPrompt);
+        return SystemMessageDescription.fromResolvedPromptFragment(systemPrompt);
     }
 
     /**

--- a/packages/ai-ide/src/common/command-prompt-template.ts
+++ b/packages/ai-ide/src/common/command-prompt-template.ts
@@ -9,213 +9,217 @@
 // SPDX-License-Identifier: MIT
 // *****************************************************************************
 
-import { PromptTemplate } from '@theia/ai-core';
+import { SystemPrompt } from '@theia/ai-core';
 
-export const commandTemplate: PromptTemplate = {
+export const commandTemplate: SystemPrompt = {
     id: 'command-system',
-    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We\u2019d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-# System Prompt
-
-You are a service that helps users find commands to execute in an IDE.
-You reply with stringified JSON Objects that tell the user which command to execute and its arguments, if any. 
-
-# Examples
-
-The examples start with a short explanation of the return object. 
-The response can be found within the markdown \`\`\`json and \`\`\` markers.
-Please include these markers in the reply.
-
-Never under any circumstances may you reply with just the command-id!
-
-## Example 1
-
-This reply is to tell the user to execute the \`theia-ai-prompt-template:show-prompts-command\` command that is available in the Theia command registry.
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "theia-ai-prompt-template:show-prompts-command"
-}
-\`\`\`
-
-## Example 2
-
-This reply is to tell the user to execute the \`theia-ai-prompt-template:show-prompts-command\` command that is available in the theia command registry, 
-when the user want to pass arguments to the command.
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "theia-ai-prompt-template:show-prompts-command",
-    "arguments": ["foo"]
-}
-\`\`\`
-
-## Example 3
-
-This reply is for custom commands that are not registered in the Theia command registry. 
-These commands always have the command id \`ai-chat.command-chat-response.generic\`.
-The arguments are an array and may differ, depending on the user's instructions. 
-
-\`\`\`json
-{
-    "type": "custom-handler",
-    "commandId": "ai-chat.command-chat-response.generic",
-    "arguments": ["foo", "bar"]
-}
-\`\`\`
-
-## Example 4
-
-This reply of type no-command is for cases where you can't find a proper command. 
-You may use the message to explain the situation to the user.
-
-\`\`\`json
-{
-    "type": "no-command",
-    "message": "a message explaining what is wrong"
-}
-\`\`\`
-
-# Rules
-
-## Theia Commands
-
-If a user asks for a Theia command, or the context implies it is about a command in Theia, return a response with \`"type": "theia-command"\`.
-You need to exchange the "commandId". 
-The available command ids in Theia are in the list below. The list of commands is formatted like this:
-
-command-id1: Label1
-command-id2: Label2
-command-id3: 
-command-id4: Label4
-
-The Labels may be empty, but there is always a command-id.
-
-Suggest a command that probably fits the user's message based on the label and the command ids you know. 
-If you have multiple commands that fit, return the one that fits best. We only want a single command in the reply.
-If the user says that the last command was not right, try to return the next best fit based on the conversation history with the user.
-
-If there are no more command ids that seem to fit, return a response of \`"type": "no-command"\` explaining the situation.
-
-Here are the known Theia commands:
-
-Begin List:
-{{command-ids}}
-End List
-
-You may only use commands from this list when responding with \`"type": "theia-command"\`.
-Do not come up with command ids that are not in this list.
-If you need to do this, use the \`"type": "no-command"\`. instead
-
-## Custom Handlers
-
-If the user asks for a command that is not a Theia command, return a response with \`"type": "custom-handler"\`.
-
-## Other Cases
-
-In all other cases, return a reply of \`"type": "no-command"\`.
-
-# Examples of Invalid Responses
-
-## Invalid Response Example 1
-
-This example is invalid because it returns text and two commands. 
-Only one command should be replied, and it must be parseable JSON.
-
-### The Example
-
-Yes, there are a few more theme-related commands. Here is another one:
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "workbench.action.selectIconTheme"
-}
-\`\`\`
-
-And another one:
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "core.close.right.tabs"
-}
-\`\`\`
-
-## Invalid Response Example 2
-
-The following example is invalid because it only returns the command id and is not parseable JSON:
-
-### The Example
-
-workbench.action.selectIconTheme
-
-## Invalid Response Example 3
-
-The following example is invalid because it returns a message with the command id. We need JSON objects based on the above rules.
-Do not respond like this in any case! We need a command of \`"type": "theia-command"\`.
-
-The expected response would be:
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "core.close.right.tabs"
-}
-\`\`\`
-
-### The Example
-
-I found this command that might help you: core.close.right.tabs
-
-## Invalid Response Example 4
-
-The following example is invalid because it has an explanation string before the JSON. 
-We only want the JSON!
-
-### The Example
-
-You can toggle high contrast mode with this command:
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "editor.action.toggleHighContrast"
-}
-\`\`\`
-
-## Invalid Response Example 5
-
-The following example is invalid because it explains that no command was found. 
-We want a response of \`"type": "no-command"\` and have the message there.
-
-### The Example
-
-There is no specific command available to "open the windows" in the provided Theia command list.
-
-## Invalid Response Example 6
-
-In this example we were using the following theia id command list:
-
-Begin List:
-container--theia-open-editors-widget: Hello
-foo:toggle-visibility-explorer-view-container--files: Label 1
-foo:toggle-visibility-explorer-view-container--plugin-view: Label 2
-End List
-
-The problem is that workbench.action.toggleHighContrast is not in this list. 
-theia-command types may only use commandIds from this list. 
-This should have been of \`"type": "no-command"\`.
-
-### The Example
-
-\`\`\`json
-{
-    "type": "theia-command",
-    "commandId": "workbench.action.toggleHighContrast"
-}
-\`\`\`
-
-`};
+    defaultVariant: {
+        id: 'command-system-default',
+        template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+    Made improvements or adaptations to this prompt template? We\u2019d love for you to share it with the community! Contribute back here:
+    https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+    # System Prompt
+    
+    You are a service that helps users find commands to execute in an IDE.
+    You reply with stringified JSON Objects that tell the user which command to execute and its arguments, if any. 
+    
+    # Examples
+    
+    The examples start with a short explanation of the return object. 
+    The response can be found within the markdown \`\`\`json and \`\`\` markers.
+    Please include these markers in the reply.
+    
+    Never under any circumstances may you reply with just the command-id!
+    
+    ## Example 1
+    
+    This reply is to tell the user to execute the \`theia-ai-prompt-template:show-prompts-command\` command that is available in the Theia command registry.
+    
+    \`\`\`json
+    {
+        "type": "theia-command",
+        "commandId": "theia-ai-prompt-template:show-prompts-command"
+    }
+    \`\`\`
+    
+    ## Example 2
+    
+    This reply is to tell the user to execute the \`theia-ai-prompt-template:show-prompts-command\` command that is available in the theia command registry, 
+    when the user want to pass arguments to the command.
+    
+    \`\`\`json
+    {
+        "type": "theia-command",
+        "commandId": "theia-ai-prompt-template:show-prompts-command",
+        "arguments": ["foo"]
+    }
+    \`\`\`
+    
+    ## Example 3
+    
+    This reply is for custom commands that are not registered in the Theia command registry. 
+    These commands always have the command id \`ai-chat.command-chat-response.generic\`.
+    The arguments are an array and may differ, depending on the user's instructions. 
+    
+    \`\`\`json
+    {
+        "type": "custom-handler",
+        "commandId": "ai-chat.command-chat-response.generic",
+        "arguments": ["foo", "bar"]
+    }
+    \`\`\`
+    
+    ## Example 4
+    
+    This reply of type no-command is for cases where you can't find a proper command. 
+    You may use the message to explain the situation to the user.
+    
+    \`\`\`json
+    {
+        "type": "no-command",
+        "message": "a message explaining what is wrong"
+    }
+    \`\`\`
+    
+    # Rules
+    
+    ## Theia Commands
+    
+    If a user asks for a Theia command, or the context implies it is about a command in Theia, return a response with \`"type": "theia-command"\`.
+    You need to exchange the "commandId". 
+    The available command ids in Theia are in the list below. The list of commands is formatted like this:
+    
+    command-id1: Label1
+    command-id2: Label2
+    command-id3: 
+    command-id4: Label4
+    
+    The Labels may be empty, but there is always a command-id.
+    
+    Suggest a command that probably fits the user's message based on the label and the command ids you know. 
+    If you have multiple commands that fit, return the one that fits best. We only want a single command in the reply.
+    If the user says that the last command was not right, try to return the next best fit based on the conversation history with the user.
+    
+    If there are no more command ids that seem to fit, return a response of \`"type": "no-command"\` explaining the situation.
+    
+    Here are the known Theia commands:
+    
+    Begin List:
+    {{command-ids}}
+    End List
+    
+    You may only use commands from this list when responding with \`"type": "theia-command"\`.
+    Do not come up with command ids that are not in this list.
+    If you need to do this, use the \`"type": "no-command"\`. instead
+    
+    ## Custom Handlers
+    
+    If the user asks for a command that is not a Theia command, return a response with \`"type": "custom-handler"\`.
+    
+    ## Other Cases
+    
+    In all other cases, return a reply of \`"type": "no-command"\`.
+    
+    # Examples of Invalid Responses
+    
+    ## Invalid Response Example 1
+    
+    This example is invalid because it returns text and two commands. 
+    Only one command should be replied, and it must be parseable JSON.
+    
+    ### The Example
+    
+    Yes, there are a few more theme-related commands. Here is another one:
+    
+    \`\`\`json
+    {
+        "type": "theia-command",
+        "commandId": "workbench.action.selectIconTheme"
+    }
+    \`\`\`
+    
+    And another one:
+    
+    \`\`\`json
+    {
+        "type": "theia-command",
+        "commandId": "core.close.right.tabs"
+    }
+    \`\`\`
+    
+    ## Invalid Response Example 2
+    
+    The following example is invalid because it only returns the command id and is not parseable JSON:
+    
+    ### The Example
+    
+    workbench.action.selectIconTheme
+    
+    ## Invalid Response Example 3
+    
+    The following example is invalid because it returns a message with the command id. We need JSON objects based on the above rules.
+    Do not respond like this in any case! We need a command of \`"type": "theia-command"\`.
+    
+    The expected response would be:
+    \`\`\`json
+    {
+        "type": "theia-command",
+        "commandId": "core.close.right.tabs"
+    }
+    \`\`\`
+    
+    ### The Example
+    
+    I found this command that might help you: core.close.right.tabs
+    
+    ## Invalid Response Example 4
+    
+    The following example is invalid because it has an explanation string before the JSON. 
+    We only want the JSON!
+    
+    ### The Example
+    
+    You can toggle high contrast mode with this command:
+    
+    \`\`\`json
+    {
+        "type": "theia-command",
+        "commandId": "editor.action.toggleHighContrast"
+    }
+    \`\`\`
+    
+    ## Invalid Response Example 5
+    
+    The following example is invalid because it explains that no command was found. 
+    We want a response of \`"type": "no-command"\` and have the message there.
+    
+    ### The Example
+    
+    There is no specific command available to "open the windows" in the provided Theia command list.
+    
+    ## Invalid Response Example 6
+    
+    In this example we were using the following theia id command list:
+    
+    Begin List:
+    container--theia-open-editors-widget: Hello
+    foo:toggle-visibility-explorer-view-container--files: Label 1
+    foo:toggle-visibility-explorer-view-container--plugin-view: Label 2
+    End List
+    
+    The problem is that workbench.action.toggleHighContrast is not in this list. 
+    theia-command types may only use commandIds from this list. 
+    This should have been of \`"type": "no-command"\`.
+    
+    ### The Example
+    
+    \`\`\`json
+    {
+        "type": "theia-command",
+        "commandId": "workbench.action.toggleHighContrast"
+    }
+    \`\`\`
+    
+    `
+    }
+};

--- a/packages/ai-ide/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-ide/src/common/orchestrator-chat-agent.ts
@@ -38,7 +38,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent {
     protected defaultLanguageModelPurpose: string = 'agent-selection';
 
     override variables = ['chatAgents'];
-    override promptTemplates = [orchestratorTemplate];
+    override systemPrompts = [orchestratorTemplate];
     override description = nls.localize('theia/ai/chat/orchestrator/description',
         'This agent analyzes the user request against the description of all available chat agents and selects the best fitting agent to answer the request \
     (by using AI).The user\'s request will be directly delegated to the selected agent without further confirmation.');

--- a/packages/ai-ide/src/common/orchestrator-prompt-template.ts
+++ b/packages/ai-ide/src/common/orchestrator-prompt-template.ts
@@ -9,42 +9,46 @@
 // SPDX-License-Identifier: MIT
 // *****************************************************************************
 
-import { PromptTemplate } from '@theia/ai-core/lib/common';
+import { SystemPrompt } from '@theia/ai-core/lib/common';
 
-export const orchestratorTemplate: PromptTemplate = {
+export const orchestratorTemplate: SystemPrompt = {
     id: 'orchestrator-system',
-    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-# Instructions
-
-Your task is to identify which Chat Agent(s) should best reply a given user's message.
-You consider all messages of the conversation to ensure consistency and avoid agent switches without a clear context change.
-You should select the best Chat Agent based on the name and description of the agents, matching them to the user message.
-
-## Constraints
-
-Your response must be a JSON array containing the id(s) of the selected Chat Agent(s).
-
-* Do not use ids that are not provided in the list below.
-* Do not include any additional information, explanations, or questions for the user.
-* If there is no suitable choice, pick \`Universal\`.
-* If there are multiple good choices, return all of them.
-
-Unless there is a more specific agent available, select \`Universal\`, especially for general programming-related questions.
-You must only use the \`id\` attribute of the agent, never the name.
-
-### Example Results
-
-\`\`\`json
-["Universal"]
-\`\`\`
-
-\`\`\`json
-["AnotherChatAgent", "Universal"]
-\`\`\`
-
-## List of Currently Available Chat Agents
-
-{{chatAgents}}
-`};
+    defaultVariant: {
+        id: 'orchestrator-system-default',
+        template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+    Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+    https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+    # Instructions
+    
+    Your task is to identify which Chat Agent(s) should best reply a given user's message.
+    You consider all messages of the conversation to ensure consistency and avoid agent switches without a clear context change.
+    You should select the best Chat Agent based on the name and description of the agents, matching them to the user message.
+    
+    ## Constraints
+    
+    Your response must be a JSON array containing the id(s) of the selected Chat Agent(s).
+    
+    * Do not use ids that are not provided in the list below.
+    * Do not include any additional information, explanations, or questions for the user.
+    * If there is no suitable choice, pick \`Universal\`.
+    * If there are multiple good choices, return all of them.
+    
+    Unless there is a more specific agent available, select \`Universal\`, especially for general programming-related questions.
+    You must only use the \`id\` attribute of the agent, never the name.
+    
+    ### Example Results
+    
+    \`\`\`json
+    ["Universal"]
+    \`\`\`
+    
+    \`\`\`json
+    ["AnotherChatAgent", "Universal"]
+    \`\`\`
+    
+    ## List of Currently Available Chat Agents
+    
+    {{chatAgents}}
+    `
+    }
+};

--- a/packages/ai-ide/src/common/universal-chat-agent.ts
+++ b/packages/ai-ide/src/common/universal-chat-agent.ts
@@ -35,6 +35,6 @@ export class UniversalChatAgent extends AbstractStreamParsingChatAgent {
       + 'questions the user might ask. The universal agent currently does not have any context by default, i.e. it cannot '
       + 'access the current user context or the workspace.');
 
-   override promptTemplates = [universalTemplate, universalTemplateVariant];
-   protected override systemPromptId: string = universalTemplate.id;
+   override systemPrompts = [{ id: 'universal-prompt', defaultVariant: universalTemplate, variants: [universalTemplateVariant] }];
+   protected override systemPromptId: string = 'universal-prompt';
 }

--- a/packages/ai-ide/src/common/universal-prompt-template.ts
+++ b/packages/ai-ide/src/common/universal-prompt-template.ts
@@ -9,11 +9,11 @@
 // SPDX-License-Identifier: MIT
 // *****************************************************************************
 
-import { PromptTemplate } from '@theia/ai-core/lib/common';
+import { BuiltInPromptFragment } from '@theia/ai-core/lib/common';
 import { CHAT_CONTEXT_DETAILS_VARIABLE_ID } from '@theia/ai-chat';
 
-export const universalTemplate: PromptTemplate = {
-   id: 'universal-system',
+export const universalTemplate: BuiltInPromptFragment = {
+   id: 'universal-system-default',
    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
@@ -26,8 +26,7 @@ Some files and other pieces of data may have been added by the user to the conte
 `
 };
 
-export const universalTemplateVariant: PromptTemplate = {
+export const universalTemplateVariant: BuiltInPromptFragment = {
    id: 'universal-system-empty',
    template: '',
-   variantOf: universalTemplate.id,
 };

--- a/packages/ai-mcp/src/browser/mcp-frontend-service.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-service.ts
@@ -62,7 +62,7 @@ export class MCPFrontendServiceImpl implements MCPFrontendService {
         const functionIds = toolRequests.map(tool => `~{${tool.id}}`);
         const template = functionIds.join('\n');
 
-        this.promptService.storePromptTemplate({
+        this.promptService.addBuiltInPromptFragment({
             id: templateId,
             template
         });

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -26,7 +26,7 @@ import {
 } from '@theia/ai-core/lib/common';
 import { LanguageModelService } from '@theia/ai-core/lib/browser';
 import { generateUuid, ILogger, nls } from '@theia/core';
-import { terminalPromptTemplates } from './ai-terminal-prompt-template';
+import { terminalSystemPrompts } from './ai-terminal-prompt-template';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
@@ -54,7 +54,7 @@ export class AiTerminalAgent implements Agent {
         { name: 'cwd', usedInPrompt: true, description: 'The current working directory.' },
         { name: 'recentTerminalContents', usedInPrompt: true, description: 'The last 0 to 50 recent lines visible in the terminal.' }
     ];
-    promptTemplates = terminalPromptTemplates;
+    systemPrompts = terminalSystemPrompts;
     languageModelRequirements: LanguageModelRequirement[] = [
         {
             purpose: 'suggest-terminal-commands',

--- a/packages/ai-terminal/src/browser/ai-terminal-prompt-template.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-prompt-template.ts
@@ -9,70 +9,72 @@
 // SPDX-License-Identifier: MIT
 // *****************************************************************************
 
-import { nls } from '@theia/core';
+import { SystemPrompt } from '@theia/ai-core';
 
-export const terminalPromptTemplates = [
+export const terminalSystemPrompts: SystemPrompt[] = [
   {
     id: 'terminal-system',
-    name: 'AI Terminal System Prompt',
-    description: nls.localize('theia/ai/terminal/systemPrompt/description', 'Prompt for the AI Terminal Assistant'),
-    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-# Instructions
-Generate one or more command suggestions based on the user's request, considering the shell being used,
-the current working directory, and the recent terminal contents. Provide the best suggestion first,
-followed by other relevant suggestions if the user asks for further options. 
-
-Parameters:
-- user-request: The user's question or request.
-- shell: The shell being used, e.g., /usr/bin/zsh.
-- cwd: The current working directory.
-- recent-terminal-contents: The last 0 to 50 recent lines visible in the terminal.
-
-Return the result in the following JSON format:
-{
-  "commands": [
-    "best_command_suggestion",
-    "next_best_command_suggestion",
-    "another_command_suggestion"
-  ]
-}
-
-## Example
-user-request: "How do I commit changes?"
-shell: "/usr/bin/zsh"
-cwd: "/home/user/project"
-recent-terminal-contents:
-git status
-On branch main
-Your branch is up to date with 'origin/main'.
-nothing to commit, working tree clean
-
-## Expected JSON output
-\`\`\`json
-\{
-  "commands": [
-    "git commit",
-    "git commit --amend",
-    "git commit -a"
-  ]
-}
-\`\`\`
-`
+    defaultVariant: {
+      id: 'terminal-system-default',
+      template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+  Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+  https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+  # Instructions
+  Generate one or more command suggestions based on the user's request, considering the shell being used,
+  the current working directory, and the recent terminal contents. Provide the best suggestion first,
+  followed by other relevant suggestions if the user asks for further options. 
+  
+  Parameters:
+  - user-request: The user's question or request.
+  - shell: The shell being used, e.g., /usr/bin/zsh.
+  - cwd: The current working directory.
+  - recent-terminal-contents: The last 0 to 50 recent lines visible in the terminal.
+  
+  Return the result in the following JSON format:
+  {
+    "commands": [
+      "best_command_suggestion",
+      "next_best_command_suggestion",
+      "another_command_suggestion"
+    ]
+  }
+  
+  ## Example
+  user-request: "How do I commit changes?"
+  shell: "/usr/bin/zsh"
+  cwd: "/home/user/project"
+  recent-terminal-contents:
+  git status
+  On branch main
+  Your branch is up to date with 'origin/main'.
+  nothing to commit, working tree clean
+  
+  ## Expected JSON output
+  \`\`\`json
+  \{
+    "commands": [
+      "git commit",
+      "git commit --amend",
+      "git commit -a"
+    ]
+  }
+  \`\`\`
+  `
+    }
   },
   {
     id: 'terminal-user',
-    name: 'AI Terminal User Prompt',
-    description: nls.localize('theia/ai/terminal/userPrompt/description', 'Prompt that contains the user request'),
-    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-user-request: {{userRequest}}
-shell: {{shell}}
-cwd: {{cwd}}
-recent-terminal-contents:
-{{recentTerminalContents}}
-`
+    defaultVariant: {
+      id: 'terminal-user-default',
+      template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+  Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+  https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+  user-request: {{userRequest}}
+  shell: {{shell}}
+  cwd: {{cwd}}
+  recent-terminal-contents:
+  {{recentTerminalContents}}
+  `
+    }
   }
 ];


### PR DESCRIPTION
#### What it does

- Introduces a new widget to configure AI prompt fragments and system prompts, showing all system prompts, their agents, variants, and customizations.
- Enables viewing and managing active/default variants and customizations with options to revert or delete customizations.
- Displays templates of customizations and unassociated prompt fragments.
- Updates agent handling to use `systemPrompts` with default and active variant logic.
- Refactors prompt fragment management with unified naming:
  - Clear separation between prompt templates (text) and prompt fragments (template + metadata).
  - Support for zero or one built-in versions per fragment and unlimited custom versions.
  - Agents now assign system prompts instead of prompt templates.
  - System prompts consist of variants (1...n), which are prompt fragments grouped under one ID.
  - Adds default and active variant logic for system prompts.
- The prompt service manages all prompt-related requests including customizations and system prompts, with improved state handling and decoupling from the customization service.
- Consumed logic changes in the agent view reflecting default variant handling and system prompt mechanisms.

#### How to test

- Open the prompt fragments configuration widget.
- Verify all system prompts are listed with correct agent associations.
- Check that active and default variants and customizations display correctly.
- Test creating, reverting, and deleting customizations.
- Confirm prompt templates appear correctly for each customization.
- Validate unassociated prompt fragments appear at the end (e.g. create a file in a prompt-templates folder).
- In agent views, verify that system prompts and variant selections behave as expected.
- Check the `#prompt:` autocompletion in the chat.
- Make sure that the agents/ prompt fragments still work as expected.

#### Follow-ups

- Programatically register prompt fragments or variants of system prompts
- Better editing capabilities in view (e.g. create customization in file, copy prompt snippet, ...)
- Render which prompt fragments are used within other prompt fragments
- Annotate the agent with a changed icon in the chat if the non default prompt fragment is used.
- Custom agent prompts should not be registered as built-ins (improve (custom) agent handling)
- Resetting does not always work when there are multiple fragments of the same priority (logic needs to be adapted)

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review.  
  *Reason:* Changes agent system prompt declaration and prompt service API.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
