### PR TITLE
Update OCT integration to v0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21763,33 +21763,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open-collaboration-protocol": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/open-collaboration-protocol/-/open-collaboration-protocol-0.2.0.tgz",
-      "integrity": "sha512-ZaLMTMyVoJJ0vPjoMXGhNZqiycbfyJPbNCkbI9uHTOYRsvZqreRAFhSd7p9RbxLJNS5xeQGNSfldrhhec94Bmg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.5.1",
-        "fflate": "^0.8.2",
-        "msgpackr": "^1.10.2",
-        "semver": "^7.6.2",
-        "socket.io-client": "^4.7.5"
-      }
-    },
-    "node_modules/open-collaboration-yjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/open-collaboration-yjs/-/open-collaboration-yjs-0.2.0.tgz",
-      "integrity": "sha512-HT2JU/HJObIaQMF/MHt5/5VdOnGn+bVTaTJnyYfyaa/vjqg4Z4Glas3Hc9Ua970ssP3cOIRUQoHQumM0giaxrw==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.94",
-        "open-collaboration-protocol": "^0.2.0",
-        "y-protocols": "^1.0.6"
-      },
-      "peerDependencies": {
-        "yjs": "^13.0.0"
-      }
-    },
     "node_modules/openai": {
       "version": "4.91.1",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.91.1.tgz",
@@ -30934,14 +30907,71 @@
         "@theia/monaco-editor-core": "1.96.302",
         "@theia/workspace": "1.61.0",
         "lib0": "^0.2.52",
-        "open-collaboration-protocol": "0.2.0",
-        "open-collaboration-yjs": "0.2.0",
+        "open-collaboration-protocol": "0.3.0",
+        "open-collaboration-yjs": "0.3.0",
         "socket.io-client": "^4.5.3",
         "y-protocols": "^1.0.6",
         "yjs": "^13.6.7"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.61.0"
+      }
+    },
+    "packages/collaboration/node_modules/lib0": {
+      "version": "0.2.108",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.108.tgz",
+      "integrity": "sha512-+3eK/B0SqYoZiQu9fNk4VEc6EX8cb0Li96tPGKgugzoGj/OdRdREtuTLvUW+mtinoB2mFiJjSqOJBIaMkAGhxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "packages/collaboration/node_modules/open-collaboration-protocol": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/open-collaboration-protocol/-/open-collaboration-protocol-0.3.0.tgz",
+      "integrity": "sha512-zvas595nQCGgrV4EDooFG0eGCd4sFyc+wuGqovTdyHD6DsZCYdol3SeHQgy3PZxxvPf18i1QXkPSzRc8RUmgiw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "~1.5.1",
+        "fflate": "~0.8.2",
+        "msgpackr": "~1.11.2",
+        "semver": "~7.7.1",
+        "socket.io-client": "~4.8.1"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "packages/collaboration/node_modules/open-collaboration-yjs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/open-collaboration-yjs/-/open-collaboration-yjs-0.3.0.tgz",
+      "integrity": "sha512-XQk8ywZO5JiQo1QlRWcqR3C9RvEUuWi5FSDooIVqe/jZy9RMwQZs5ywz0a5cP8XQ7sTDhh6WjPwtG67laUP6uw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.103",
+        "open-collaboration-protocol": "~0.3.0",
+        "vscode-languageserver-textdocument": "~1.0.12",
+        "y-protocols": "~1.0.6"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
       }
     },
     "packages/console": {

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -10,8 +10,8 @@
     "@theia/monaco-editor-core": "1.96.302",
     "@theia/workspace": "1.61.0",
     "lib0": "^0.2.52",
-    "open-collaboration-protocol": "0.2.0",
-    "open-collaboration-yjs": "0.2.0",
+    "open-collaboration-protocol": "0.3.0",
+    "open-collaboration-yjs": "0.3.0",
     "socket.io-client": "^4.5.3",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.7"

--- a/packages/collaboration/src/browser/collaboration-frontend-module.ts
+++ b/packages/collaboration/src/browser/collaboration-frontend-module.ts
@@ -22,6 +22,8 @@ import { CollaborationFrontendContribution } from './collaboration-frontend-cont
 import { CollaborationInstance, CollaborationInstanceFactory, CollaborationInstanceOptions, createCollaborationInstanceContainer } from './collaboration-instance';
 import { CollaborationUtils } from './collaboration-utils';
 import { CollaborationWorkspaceService } from './collaboration-workspace-service';
+import { PreferenceContribution } from '@theia/core/lib/browser';
+import { collaborationPreferencesSchema } from './collaboration-preferences';
 
 export default new ContainerModule((bind, _, __, rebind) => {
     bind(CollaborationWorkspaceService).toSelf().inSingletonScope();
@@ -34,4 +36,6 @@ export default new ContainerModule((bind, _, __, rebind) => {
         return container.get(CollaborationInstance);
     });
     bind(CollaborationColorService).toSelf().inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({ schema: collaborationPreferencesSchema });
 });

--- a/packages/collaboration/src/browser/collaboration-preferences.ts
+++ b/packages/collaboration/src/browser/collaboration-preferences.ts
@@ -1,0 +1,31 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { PreferenceSchema } from '@theia/core/lib/browser';
+
+export const collaborationPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'collaboration.serverUrl': {
+            type: 'string',
+            default: 'https://api.open-collab.tools/',
+            title: nls.localize('theia/collaboration/serverUrl', 'Server URL'),
+            description: nls.localize('theia/collaboration/serverUrlDescription', 'URL of the Open Collaboration Tools Server instance for live collaboration sessions'),
+        },
+    },
+    title: nls.localize('theia/collaboration/collaboration', 'Collaboration'),
+};


### PR DESCRIPTION
#### What it does

Updates the OCT integration to version 0.3.0. That way, users can use Theia with the public instance again.

Aside from the dependency upgrade, this includes the ability to use the new `AuthMetaData` to login to the server.

#### How to test

1. Log into the OCT server using the new login mechanism.
2. Assert everything works as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
