### PR TITLE
Open AI configuration View at bottom

### DIFF
--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-view-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-view-contribution.ts
@@ -35,7 +35,7 @@ export class AIAgentConfigurationViewContribution extends AIViewContribution<AIC
             widgetId: AIConfigurationContainerWidget.ID,
             widgetName: AIConfigurationContainerWidget.LABEL,
             defaultWidgetOptions: {
-                area: 'main',
+                area: 'bottom',
                 rank: 100
             },
             toggleCommandId: AI_CONFIGURATION_TOGGLE_COMMAND_ID


### PR DESCRIPTION
#### What it does

Open the AI configuration View in the bottom area by default.
This view is different from other setting views, you often want to keep it open, e.g. to see MCP server states, token usage or switch agents.

#### How to test

Open the AI Configuration view, it should be opened in the bottom area.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
