### PR TITLE
Render groups correctly in "more" tab bar menu

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -163,19 +163,22 @@ export class TabBarToolbar extends ReactWidget {
             if (item.toMenuNode) {
                 const node = item.toMenuNode();
                 if (node) {
-                    menu.addNode(node);
+                    if (item.group) {
+                        menu.getOrCreate([item.group], 0, 1).addNode(node);
+                    } else {
+                        menu.addNode(node);
+                    }
                 }
             }
         }
         return this.contextMenuRenderer.render({
-            menu: menu!,
+            menu: MenuModelRegistry.removeSingleRootNodes(menu),
             menuPath: ['contextMenu'],
             args: [this.current],
             anchor,
             context: this.current?.node || this.node,
             contextKeyService: this.contextKeyService,
-            onHide: () => toDisposeOnHide.dispose(),
-            skipSingleRootNode: true,
+            onHide: () => toDisposeOnHide.dispose()
         });
     }
 

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -345,7 +345,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
 
     protected updateToolbarItems(allParts: ViewContainerPart[]): void {
         if (allParts.length > 1) {
-            const group = new SubmenuImpl(`toggleParts-${this.id}`, this.getToggleVisibilityGroupLabel(), undefined);
+            const group = new SubmenuImpl(`toggleParts-${this.id}`, this.getToggleVisibilityGroupLabel(), undefined, '000');
             for (const part of allParts) {
                 const existingId = this.toggleVisibilityCommandId(part);
                 const { label } = part.wrapped.title;
@@ -358,13 +358,13 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
             // widget === this.getTabBarDelegate()
 
             const toolbarItem = new PartsMenuToolbarItem(() => this.getTabBarDelegate(), [this.id], this.commandRegistry, this.menuRegistry,
-                this.contextKeyService, this.contextMenuRenderer, group, 'view', [this.id]);
+                this.contextKeyService, this.contextMenuRenderer, group, '000_views', [this.id]);
             this.toDisposeOnUpdateTitle.push(this.toolbarRegistry.doRegisterItem(toolbarItem));
         }
     }
 
     protected getToggleVisibilityGroupLabel(): string {
-        return 'view';
+        return 'Views';
     }
 
     protected findOriginalPart(): ViewContainerPart | undefined {
@@ -613,8 +613,8 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
                 }
                 return false;
             },
-            isEnabled: arg => toRegister.canHide && (!this.titleOptions || !(arg instanceof Widget) || (arg instanceof ViewContainer && arg.id === this.id)),
-            isVisible: arg => !this.titleOptions || !(arg instanceof Widget) || (arg instanceof ViewContainer && arg.id === this.id)
+            isEnabled: arg => toRegister.canHide && (!this.titleOptions || !(arg instanceof Widget) || arg === this.getTabBarDelegate()),
+            isVisible: arg => !this.titleOptions || !(arg instanceof Widget) || arg === this.getTabBarDelegate()
         });
     }
 

--- a/packages/core/src/common/menu/menu-model-registry.ts
+++ b/packages/core/src/common/menu/menu-model-registry.ts
@@ -334,6 +334,16 @@ export class MenuModelRegistry {
         return node;
     }
 
+    static removeSingleRootNodes(fullMenuModel: CompoundMenuNode): CompoundMenuNode {
+        let current = fullMenuModel;
+        let previous = undefined;
+        while (current !== previous) {
+            previous = current;
+            current = this.removeSingleRootNode(current);
+        }
+        return current;
+    }
+
     /**
      * Checks the given menu model whether it will show a menu with a single submenu.
      *


### PR DESCRIPTION
#### What it does

Fixes #15636

#### How to test
Make sure the "more" context menu reners correctly (i.e. compare to VS Code) in the view tab bars. Cases to consider:

- "Views" menu renders correctly
- Close all but one viewlet: the menu should now contain the contents of the single view's toolbar.
- consider toolbars in the bottom area as well. 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
