### PR TITLE
Add next prompt for architect

### DIFF
--- a/packages/ai-ide/src/browser/architect-agent.ts
+++ b/packages/ai-ide/src/browser/architect-agent.ts
@@ -16,7 +16,7 @@
 import { AbstractStreamParsingChatAgent, ChatRequestModel, ChatService, ChatSession, MutableChatModel, MutableChatRequestModel } from '@theia/ai-chat/lib/common';
 import { LanguageModelRequirement } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { architectPromptTemplate, architectTaskSummaryPromptTemplate } from '../common/architect-prompt-template';
+import { architectNextPromptTemplate, architectPromptTemplate, architectTaskSummaryPromptTemplate } from '../common/architect-prompt-template';
 import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID } from '../common/workspace-functions';
 import { nls } from '@theia/core';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
@@ -38,7 +38,7 @@ export class ArchitectAgent extends AbstractStreamParsingChatAgent {
         'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \
          and folders and retrieve their content. It cannot modify files. It can therefore answer questions about the current project, project files and source code in the \
          workspace, such as how to build the project, where to put source code, where to find specific code or configurations, etc.');
-    override promptTemplates = [architectPromptTemplate, architectTaskSummaryPromptTemplate];
+    override promptTemplates = [architectPromptTemplate, architectNextPromptTemplate, architectTaskSummaryPromptTemplate];
     override functions = [GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID];
     protected override systemPromptId: string | undefined = architectPromptTemplate.id;
 

--- a/packages/ai-ide/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide/src/common/architect-prompt-template.ts
@@ -9,8 +9,12 @@
 // SPDX-License-Identifier: MIT
 // *****************************************************************************
 import { PromptTemplate } from '@theia/ai-core/lib/common';
-import { GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from './workspace-functions';
-import { CONTEXT_FILES_VARIABLE_ID } from './context-variables';
+import {
+    GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID, SEARCH_IN_WORKSPACE_FUNCTION_ID,
+    GET_FILE_DIAGNOSTICS_ID
+} from './workspace-functions';
+import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from './context-variables';
+import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
 
 export const ARCHITECT_TASK_SUMMARY_PROMPT_TEMPLATE_ID = 'architect-task-summary';
 
@@ -43,6 +47,42 @@ Always look at the relevant files to understand your task using the function ~{$
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
 {{prompt:project-info}}
+`
+};
+
+export const architectNextPromptTemplate = <PromptTemplate>{
+    id: 'architect-system-next',
+    variantOf: architectPromptTemplate.id,
+    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+# Instructions
+
+You are an AI assistant integrated into Theia IDE, designed to assist software developers. You can't change any files, but you can navigate and read the users workspace using \
+the provided functions. Therefore describe and explain the details or procedures necessary to achieve the desired outcome. If file changes are necessary to help the user, be \
+aware that there is another agent called 'Coder' that can suggest file changes. In this case you can create a description on what to do and tell the user to ask '@Coder' to \
+implement the change plan. If you refer to files, always mention the workspace-relative path.\
+
+## Context Retrieval
+Use the following functions to interact with the workspace files if you require context:
+- **~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}}**
+- **~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}**
+- **~{${FILE_CONTENT_FUNCTION_ID}}**
+- **~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}}**
+
+Remember file locations that are relevant for completing your tasks using **~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}}**
+Only add files that are really relevant to look at later. Only add files that are really relevant to look at later.
+
+## File Validation
+Use the following function to retrieve a list of problems in a file if the user requests fixes in a given file: **~{${GET_FILE_DIAGNOSTICS_ID}}**
+## Additional Context
+The following files have been provided for additional context. Some of them may also be referred to by the user (e.g. "this file" or "the attachment"). \
+Always look at the relevant files to understand your task using the function ~{${FILE_CONTENT_FUNCTION_ID}}
+{{${CONTEXT_FILES_VARIABLE_ID}}}
+
+{{prompt:project-info}}
+
+{{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 `
 };
 


### PR DESCRIPTION
#### What it does

Adds a new "next" prompt for the architect agent that uses the new functions from the coder next prompt

#### How to test

- Switch architect to the next prompt variant
- Ask it to search something in the workspace

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
