### PR TITLE
feat: add Theia dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:20-bookworm
+
+# Install dependencies needed for Theia development
+RUN apt-get update && apt-get install -y \
+    libxkbfile-dev \
+    libsecret-1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure git to not show the codespaces theme status
+RUN git config --system codespaces-theme.hide-status 1
+
+# Setup workspace directory with proper permissions
+RUN mkdir -p /workspace && chown -R node:node /workspace
+
+# Setup Node user
+USER node
+WORKDIR /workspace
+
+# Install node-gyp globally for native module compilation
+RUN npm install -g node-gyp
+
+# Switch back to root for any remaining setup
+USER root
+
+# Set the default command - the container will run indefinitely
+CMD ["sleep", "infinity"]

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,32 @@
+# Theia Development Container
+
+This directory contains configuration for a development container that provides a consistent environment for Theia development.
+
+## Features
+
+- Node.js 20 development environment
+- Python 3.11 for required scripts
+- Desktop environment with VNC access for GUI applications
+- X11 and audio libraries for Electron support
+- Pre-configured ports for Theia applications
+
+## Usage
+
+### Starting Theia
+
+The container provides several convenience aliases:
+
+- `theia-browser` - Start Theia in browser mode (port 3000)
+- `theia-watch` - Watch for changes in both browser and electron apps
+
+### Ports
+
+- 3000: Theia Browser App
+
+## Customizing
+
+You can customize this development container by:
+
+1. Modifying `devcontainer.json` to add features or extensions
+2. Updating `Dockerfile` to install additional dependencies
+3. Adjusting `post-create.sh` to configure the environment during setup

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,93 @@
+{
+  "name": "Eclipse Theia Browser",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20",
+      "nodeGypDependencies": true
+    }
+  },
+  "containerEnv": {
+    "NODE_OPTIONS": "--max_old_space_size=4096",
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
+  },
+  "overrideCommand": false,
+  "mounts": [
+    "source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,consistency=cached",
+    {
+      "source": "theia-workspace-node-modules",
+      "target": "/workspace/node_modules",
+      "type": "volume"
+    },
+    {
+      "source": "theia-examples-browser-node-modules",
+      "target": "/workspace/examples/browser/node_modules",
+      "type": "volume"
+    },
+    {
+      "source": "theia-examples-browser-only-node-modules",
+      "target": "/workspace/examples/browser-only/node_modules",
+      "type": "volume"
+    },
+    {
+      "source": "theia-cache",
+      "target": "/workspace/.npm-cache",
+      "type": "volume"
+    },
+    {
+      "source": "theia-yarn-cache",
+      "target": "/workspace/.yarn-cache",
+      "type": "volume"
+    },
+    {
+      "source": "theia-build-cache",
+      "target": "/workspace/.build-cache",
+      "type": "volume"
+    },
+    {
+      "source": "theia-typescript-cache",
+      "target": "/workspace/.tscache",
+      "type": "volume"
+    }
+  ],
+  "postCreateCommand": "chmod +x ./.devcontainer/post-create.sh && ./.devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "resmon.show.battery": false,
+        "resmon.show.cpufreq": false,
+        "terminal.integrated.env.linux": {
+          "NODE_OPTIONS": "--max_old_space_size=4096"
+        }
+      },
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "EditorConfig.EditorConfig",
+        "GitHub.vscode-pull-request-github",
+        "ms-vscode.vscode-github-issue-notebooks",
+        "ms-python.python",
+        "mutantdino.resourcemonitor",
+        "ms-vscode-remote.remote-containers-resource-monitor",
+        "DavidAnson.vscode-markdownlint"
+      ]
+    }
+  },
+  "forwardPorts": [
+    3000
+  ],
+  "portsAttributes": {
+    "3000": {
+      "label": "Theia Browser App",
+      "onAutoForward": "notify"
+    }
+  },
+  "hostRequirements": {
+    "memory": "12gb",
+    "cpus": 6
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Install dependencies
+echo "Installing dependencies..."
+npm ci
+
+# Build Theia
+echo "Building Theia..."
+npm run build
+
+# Download plugins for browser mode
+echo "Downloading plugins..."
+npm run download:plugins -- --rate-limit 3
+
+# Add convenience scripts to .bashrc and .zshrc
+BROWSER_SCRIPT='alias theia-browser="npm run start:browser"'
+WATCH_SCRIPT='alias theia-watch="npm run watch:browser"'
+
+echo "$BROWSER_SCRIPT" >> ~/.bashrc
+echo "$WATCH_SCRIPT" >> ~/.bashrc
+
+if [ -f ~/.zshrc ]; then
+    echo "$BROWSER_SCRIPT" >> ~/.zshrc
+    echo "$WATCH_SCRIPT" >> ~/.zshrc
+fi
+
+echo "Setup complete! You can now run:"
+echo "- theia-browser      # to start Theia in browser mode (port 3000)"
+echo "- theia-watch        # to watch browser app"
+echo ""
+echo "For debugging:"
+echo "- Use 'Launch Browser Backend' to debug backend"
+echo "- Open http://localhost:3000 in your browser"
+echo "- Use browser DevTools (F12) to debug frontend"


### PR DESCRIPTION
#### What it does

Adds a devcontainer setup for developing Theia. Currently it only supports debugging browser app (not Electron).

This is not only convenient and useful in general for security, but in the light of AI agents operating and executing commands, it is now even more relevant than ever.

Fixes https://github.com/eclipse-theia/theia/issues/15669

#### How to test

##### Theia

* Open Theia workspace in Theia
* Click in the bottom left corner
* Select *Open in Devcontainer*

**Note**: Currently still fails, to be investigated.

##### VS Code

* Open the Theia workspace in VS Code
* Install [devcontainer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
* Run command: Dev Containers: Open Folder in Container...
* Check that build and launch works
* Connect from the host in a browser to localhost:3000

#### Follow-ups

Not sure if it is needed, but we may want to also look into supporting to start and debug the Electron app.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
