### PR TITLE
Improve type safety of remote ssh config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31893,6 +31893,7 @@
         "@theia/core": "1.63.0",
         "@theia/filesystem": "1.63.0",
         "@theia/userstorage": "1.63.0",
+        "@theia/variable-resolver": "1.63.0",
         "archiver": "^5.3.1",
         "decompress": "^4.2.1",
         "decompress-tar": "^4.0.0",

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -6,6 +6,7 @@
     "@theia/core": "1.63.0",
     "@theia/filesystem": "1.63.0",
     "@theia/userstorage": "1.63.0",
+    "@theia/variable-resolver": "1.63.0",
     "archiver": "^5.3.1",
     "decompress": "^4.2.1",
     "decompress-tar": "^4.0.0",

--- a/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
+++ b/packages/remote/src/electron-common/remote-ssh-connection-provider.ts
@@ -27,9 +27,7 @@ export interface RemoteSSHConnectionProviderOptions {
     customConfigFile?: string;
 }
 
-export interface SSHConfig extends Array<SshConfig.Line> {
-    compute(opts: string | SshConfig.MatchOptions): Record<string, string | string[]>;
-}
+export type SSHConfig = Array<SshConfig.Line>;
 
 export interface RemoteSSHConnectionProvider {
     establishConnection(options: RemoteSSHConnectionProviderOptions): Promise<string>;

--- a/packages/remote/tsconfig.json
+++ b/packages/remote/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../userstorage"
+    },
+    {
+      "path": "../variable-resolver"
     }
   ]
 }


### PR DESCRIPTION
#### What it does

I've noticed that https://github.com/eclipse-theia/theia/pull/15499 introduced a bunch of rather unsafe code that could potentially prevent the remote SSH feature from working.

The PR also did a bunch of manual work to replace env variables - this was not necessary, since we can already do this via the `VariablesResolverService`.

#### How to test

1. Assert that the `remote.ssh.connectToConfigHost` command still works as expected (i.e. variable resolving, etc.).
2. Change the value of the `remote.ssh.configFile` preference to point to a non-existing file path, and assert that a notification is shown to the user.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
