### PR TITLE
Avoid playwright tests depending on cwd

### DIFF
--- a/examples/playwright/docs/EXTENSIBILITY.md
+++ b/examples/playwright/docs/EXTENSIBILITY.md
@@ -36,7 +36,7 @@ export class MyToolbar extends TheiaPageObject {
   }
 }
 
-const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
+const ws = new TheiaWorkspace([path.resolve(__dirname, '../../src/tests/resources/sample-files1']);
 const app = await TheiaAppLoader.load({ playwright, browser }, ws, MyTheiaApp);
 await app.toolbar.clickItem1();
 ```

--- a/examples/playwright/docs/GETTING_STARTED.md
+++ b/examples/playwright/docs/GETTING_STARTED.md
@@ -45,7 +45,7 @@ At any time, we can also get information from the text editor, such as obtaining
 ```typescript
 test('should undo and redo text changes and correctly update the dirty state', async ({ playwright, browser }) => {
     // 1. set up workspace contents and open Theia app
-    const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
+    const ws = new TheiaWorkspace([path.resolve(__dirname, 'resources/sample-files1']);
     app = await TheiaAppLoader.load( { playwright, browser }, ws);
 
     // 2. open Theia text editor

--- a/examples/playwright/src/tests/theia-application-shell.test.ts
+++ b/examples/playwright/src/tests/theia-application-shell.test.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 
 import { test } from '@playwright/test';
+import * as path from 'path';
 import { TheiaApp } from '../theia-app';
 import { TheiaAppLoader } from '../theia-app-loader';
 import { TheiaExplorerView } from '../theia-explorer-view';
@@ -29,7 +30,7 @@ test.describe('Theia Application Shell', () => {
     let app: TheiaApp;
 
     test.beforeAll(async ({ playwright, browser }) => {
-        const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
+        const ws = new TheiaWorkspace([path.resolve(__dirname, '../../src/tests/resources/sample-files1')]);
         app = await TheiaAppLoader.load({ playwright, browser }, ws);
 
         // The welcome view must be closed because the memory leak only occurs when there are

--- a/examples/playwright/src/tests/theia-explorer-view.test.ts
+++ b/examples/playwright/src/tests/theia-explorer-view.test.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { expect, test } from '@playwright/test';
+import * as path from 'path';
 import { TheiaAppLoader } from '../theia-app-loader';
 import { TheiaApp } from '../theia-app';
 import { PreferenceIds, TheiaPreferenceView } from '../theia-preference-view';
@@ -27,7 +28,7 @@ test.describe('Theia Explorer View', () => {
     let explorer: TheiaExplorerView;
 
     test.beforeAll(async ({ playwright, browser }) => {
-        const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
+        const ws = new TheiaWorkspace([path.resolve(__dirname, '../../src/tests/resources/sample-files1')]);
         app = await TheiaAppLoader.load({ playwright, browser }, ws);
 
         if (app.isElectron) {

--- a/examples/playwright/src/tests/theia-notebook-editor.test.ts
+++ b/examples/playwright/src/tests/theia-notebook-editor.test.ts
@@ -15,13 +15,12 @@
 // *****************************************************************************
 
 import { Locator, PlaywrightWorkerArgs, expect, test } from '@playwright/test';
+import * as path from 'path';
 import { TheiaApp } from '../theia-app';
 import { TheiaAppLoader, TheiaPlaywrightTestConfig } from '../theia-app-loader';
 import { TheiaNotebookCell } from '../theia-notebook-cell';
 import { TheiaNotebookEditor } from '../theia-notebook-editor';
 import { TheiaWorkspace } from '../theia-workspace';
-import path = require('path');
-import fs = require('fs');
 
 // See .github/workflows/playwright.yml for preferred python version
 const preferredKernel = process.env.CI ? 'Python 3.11' : 'Python 3';
@@ -322,11 +321,7 @@ async function firstCell(editor: TheiaNotebookEditor): Promise<TheiaNotebookCell
 }
 
 async function loadApp(args: TheiaPlaywrightTestConfig & PlaywrightWorkerArgs): Promise<TheiaApp> {
-    const workingDir = path.resolve();
-    // correct WS path. When running from IDE the path is workspace root or playwright/configs, with CLI it's playwright/
-    const isWsRoot = fs.existsSync(path.join(workingDir, 'examples', 'playwright'));
-    const prefix = isWsRoot ? 'examples/playwright/' : (workingDir.endsWith('playwright/configs') ? '../' : '');
-    const ws = new TheiaWorkspace([prefix + 'src/tests/resources/notebook-files']);
+    const ws = new TheiaWorkspace([path.resolve(__dirname, '../../src/tests/resources/notebook-files')]);
     const app = await TheiaAppLoader.load(args, ws);
     // auto-save are disabled using settings.json file
     // see examples/playwright/src/tests/resources/notebook-files/.theia/settings.json

--- a/examples/playwright/src/tests/theia-terminal-view.test.ts
+++ b/examples/playwright/src/tests/theia-terminal-view.test.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { expect, test } from '@playwright/test';
+import * as path from 'path';
 import { TheiaApp } from '../theia-app';
 import { TheiaAppLoader } from '../theia-app-loader';
 import { TheiaWorkspace } from '../theia-workspace';
@@ -25,7 +26,7 @@ let app: TheiaApp;
 test.describe('Theia Terminal View', () => {
 
     test.beforeAll(async ({ playwright, browser }) => {
-        const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
+        const ws = new TheiaWorkspace([path.resolve(__dirname, '../../src/tests/resources/sample-files1')]);
         app = await TheiaAppLoader.load({ playwright, browser }, ws);
     });
 

--- a/examples/playwright/src/tests/theia-text-editor.test.ts
+++ b/examples/playwright/src/tests/theia-text-editor.test.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { expect, test } from '@playwright/test';
+import * as path from 'path';
 import { TheiaApp } from '../theia-app';
 import { TheiaAppLoader } from '../theia-app-loader';
 import { DefaultPreferences, PreferenceIds, TheiaPreferenceView } from '../theia-preference-view';
@@ -26,7 +27,7 @@ test.describe('Theia Text Editor', () => {
     let app: TheiaApp;
 
     test.beforeAll(async ({ playwright, browser }) => {
-        const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
+        const ws = new TheiaWorkspace([path.resolve(__dirname, '../../src/tests/resources/sample-files1')]);
         app = await TheiaAppLoader.load({ playwright, browser }, ws);
 
         // set auto-save preference to off

--- a/examples/playwright/src/tests/theia-workspace.test.ts
+++ b/examples/playwright/src/tests/theia-workspace.test.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { expect, test } from '@playwright/test';
+import * as path from 'path';
 import { TheiaAppLoader } from '../theia-app-loader';
 import { DOT_FILES_FILTER, TheiaExplorerView } from '../theia-explorer-view';
 import { TheiaWorkspace } from '../theia-workspace';
@@ -36,7 +37,7 @@ test.describe('Theia Workspace', () => {
     });
 
     test('should be initialized with the contents of a file location', async ({ playwright, browser }) => {
-        const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
+        const ws = new TheiaWorkspace([path.resolve(__dirname, '../../src/tests/resources/sample-files1')]);
         const app = await TheiaAppLoader.load({ playwright, browser }, ws);
         const explorer = await app.openView(TheiaExplorerView);
         // resources/sample-files1 contains two folders and one file
@@ -47,7 +48,9 @@ test.describe('Theia Workspace', () => {
     });
 
     test('should be initialized with the contents of multiple file locations', async ({ playwright, browser }) => {
-        const ws = new TheiaWorkspace(['src/tests/resources/sample-files1', 'src/tests/resources/sample-files2']);
+        const ws = new TheiaWorkspace([
+            path.resolve(__dirname, '../../src/tests/resources/sample-files1'),
+            path.resolve(__dirname, '../../src/tests/resources/sample-files2')]);
         const app = await TheiaAppLoader.load({ playwright, browser }, ws);
         const explorer = await app.openView(TheiaExplorerView);
         // resources/sample-files1 contains two folders and one file
@@ -60,7 +63,7 @@ test.describe('Theia Workspace', () => {
     });
 
     test('open sample.txt via file menu', async ({ playwright, browser }) => {
-        const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
+        const ws = new TheiaWorkspace([path.resolve(__dirname, '../../src/tests/resources/sample-files1')]);
         const app = await TheiaAppLoader.load({ playwright, browser }, ws);
         const menuEntry = app.isElectron ? 'Open File...' : 'Open...';
 


### PR DESCRIPTION

#### What it does

* Avoid playwright tests depending on the current working directory
* Instead use paths relative to __dirname for resources
* This fixes being able to run the tests from the VSCode playwright extension from Microsoft.

#### How to test

Try to run playwright tests from playright VSCode extension from Microsoft.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
