### PR TITLE
Fix localization of files in `electron-browser`

### DIFF
--- a/packages/remote/src/electron-browser/remote-ssh-contribution.ts
+++ b/packages/remote/src/electron-browser/remote-ssh-contribution.ts
@@ -26,17 +26,17 @@ export namespace RemoteSSHCommands {
         id: 'remote.ssh.connect',
         category: 'SSH',
         label: 'Connect to Host...',
-    }, 'theia/remoteSSH/connect');
+    }, 'theia/remote/ssh/connect');
     export const CONNECT_CURRENT_WINDOW: Command = Command.toLocalizedCommand({
         id: 'remote.ssh.connectCurrentWindow',
         category: 'SSH',
         label: 'Connect Current Window to Host...',
-    }, 'theia/remoteSSH/connect');
+    }, 'theia/remote/ssh/connect');
     export const CONNECT_CURRENT_WINDOW_TO_CONFIG_HOST: Command = Command.toLocalizedCommand({
         id: 'remote.ssh.connectToConfigHost',
         category: 'SSH',
         label: 'Connect Current Window to Host in Config File...',
-    }, 'theia/remoteSSH/connectToConfigHost');
+    }, 'theia/remote/ssh/connectToConfigHost');
 }
 
 @injectable()
@@ -110,7 +110,7 @@ export class RemoteSSHContribution extends AbstractRemoteRegistryContribution {
                 const remotePort = await this.sendSSHConnect(host, user);
                 this.openRemote(remotePort, false);
             } catch (err) {
-                this.messageService.error(`${nls.localize('theia/remote/sshFailure', 'Could not open SSH connection to remote.')} ${err.message ?? String(err)}`);
+                this.messageService.error(`${nls.localize('theia/remote/ssh/failure', 'Could not open SSH connection to remote.')} ${err.message ?? String(err)}`);
             }
         }
     }
@@ -119,11 +119,11 @@ export class RemoteSSHContribution extends AbstractRemoteRegistryContribution {
         let host: string | undefined;
         let user: string | undefined;
         host = await this.quickInputService.input({
-            title: nls.localize('theia/remote/enterHost', 'Enter SSH host name'),
-            placeHolder: nls.localize('theia/remote/hostPlaceHolder', 'E.g. hello@example.com')
+            title: nls.localize('theia/remote/ssh/enterHost', 'Enter SSH host name'),
+            placeHolder: nls.localize('theia/remote/ssh/hostPlaceHolder', 'E.g. hello@example.com')
         });
         if (!host) {
-            this.messageService.error(nls.localize('theia/remote/needsHost', 'Please enter a host name.'));
+            this.messageService.error(nls.localize('theia/remote/ssh/needsHost', 'Please enter a host name.'));
             return;
         }
         if (host.includes('@')) {
@@ -142,12 +142,12 @@ export class RemoteSSHContribution extends AbstractRemoteRegistryContribution {
         }
         if (!user) {
             user = await this.quickInputService.input({
-                title: nls.localize('theia/remote/enterUser', 'Enter SSH user name'),
-                placeHolder: nls.localize('theia/remote/userPlaceHolder', 'E.g. hello')
+                title: nls.localize('theia/remote/ssh/enterUser', 'Enter SSH user name'),
+                placeHolder: nls.localize('theia/remote/ssh/userPlaceHolder', 'E.g. hello')
             });
         }
         if (!user) {
-            this.messageService.error(nls.localize('theia/remote/needsUser', 'Please enter a user name.'));
+            this.messageService.error(nls.localize('theia/remote/ssh/needsUser', 'Please enter a user name.'));
             return;
         }
 
@@ -155,7 +155,7 @@ export class RemoteSSHContribution extends AbstractRemoteRegistryContribution {
             const remotePort = await this.sendSSHConnect(host!, user!);
             this.openRemote(remotePort, newWindow);
         } catch (err) {
-            this.messageService.error(`${nls.localize('theia/remote/sshFailure', 'Could not open SSH connection to remote.')} ${err.message ?? String(err)}`);
+            this.messageService.error(`${nls.localize('theia/remote/ssh/failure', 'Could not open SSH connection to remote.')} ${err.message ?? String(err)}`);
         }
     }
 

--- a/scripts/translation-update.js
+++ b/scripts/translation-update.js
@@ -21,7 +21,7 @@ function performNlsExtract() {
         'theia', 'nls-extract',
         '-o', './packages/core/i18n/nls.json',
         '-e', 'vscode',
-        '-f', './packages/**/browser/**/*.{ts,tsx}'
+        '-f', './packages/**/{browser,electron-browser}/**/*.{ts,tsx}'
     ], {
         shell: true,
         stdio: 'inherit'


### PR DESCRIPTION
#### What it does

I was a bit confused that the changes from https://github.com/eclipse-theia/theia/pull/15667 didn't include the localizations from #15543. However, it seems like our translation script didn't take files from `electron-browser` into account.

This change fixes that and also adjusts some of the translations in the remote related packages to use better translation keys.

#### How to test

Run the following command manually:

```
npx theia nls-extract -o ./packages/core/i18n/nls.json -e vscode -f "./packages/**/{browser,electron-browser}/**/*.{ts,tsx}"
```

It should result in changes to the `nls.json` file that include the localized values from the `electron-browser` directories of some packages.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
