### PR TITLE
fix: temporary scroll lock when user scrolls up in AI Chat

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -63,6 +63,11 @@ export const TREE_NODE_CAPTION_CLASS = 'theia-TreeNodeCaption';
 export const TREE_NODE_INDENT_GUIDE_CLASS = 'theia-tree-node-indent';
 
 /**
+ * Threshold in pixels to consider the view as being scrolled to the bottom
+ */
+export const SCROLL_BOTTOM_THRESHOLD = 30;
+
+/**
  * Tree scroll event data.
  */
 export interface TreeScrollEvent {
@@ -1198,7 +1203,6 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             return scrollState?.isAtBottom ?? true;
         } else {
             // Fallback to DOM-based calculation for non-virtualized trees
-            const threshold = 30;
             const scrollContainer = this.node;
             const scrollHeight = scrollContainer.scrollHeight;
             const scrollTop = scrollContainer.scrollTop;
@@ -1208,7 +1212,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 return true;
             }
 
-            return scrollHeight - scrollTop - clientHeight <= threshold;
+            return scrollHeight - scrollTop - clientHeight <= SCROLL_BOTTOM_THRESHOLD;
         }
     }
 
@@ -1658,8 +1662,9 @@ export namespace TreeWidget {
                     const scrollTop = e.target.scrollTop;
                     const scrollHeight = e.target.scrollHeight;
                     const clientHeight = e.target.clientHeight;
-                    const isAtBottom = scrollHeight - scrollTop - clientHeight <= 30; // 30px threshold
+                    const isAtBottom = scrollHeight - scrollTop - clientHeight <= SCROLL_BOTTOM_THRESHOLD;
 
+                    // Store scroll state before firing the event to prevent jitter during inference and scrolling
                     this.lastScrollState = { scrollTop, isAtBottom };
                     onScrollEmitter?.fire({ scrollTop, scrollLeft: e.target.scrollLeft || 0 });
                 }}
@@ -1667,8 +1672,9 @@ export namespace TreeWidget {
                 itemContent={index => renderNodeRow(rows[index])}
                 width={width}
                 height={height}
-                // This is a pixel value, it will scan 200px to the top and bottom of the current view
-                overscan={500}
+                // This is a pixel value that determines how many pixels to render outside the visible area
+                // Higher value provides smoother scrolling experience especially during inference, but uses more memory
+                overscan={800}
                 {...other}
             />;
         }

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -16,7 +16,7 @@
 
 import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@lumino/messaging';
-import { Disposable, MenuPath, SelectionService } from '../../common';
+import { Disposable, MenuPath, SelectionService, Event as TheiaEvent, Emitter } from '../../common';
 import { Key, KeyCode, KeyModifier } from '../keyboard/keys';
 import { ContextMenuRenderer } from '../context-menu-renderer';
 import { StatefulWidget } from '../shell';
@@ -61,6 +61,22 @@ export const EXPANDABLE_TREE_NODE_CLASS = 'theia-ExpandableTreeNode';
 export const COMPOSITE_TREE_NODE_CLASS = 'theia-CompositeTreeNode';
 export const TREE_NODE_CAPTION_CLASS = 'theia-TreeNodeCaption';
 export const TREE_NODE_INDENT_GUIDE_CLASS = 'theia-tree-node-indent';
+
+/**
+ * Tree scroll event data.
+ */
+export interface TreeScrollEvent {
+    readonly scrollTop: number;
+    readonly scrollLeft: number;
+}
+
+/**
+ * Tree scroll state data.
+ */
+export interface TreeScrollState {
+    readonly scrollTop: number;
+    readonly isAtBottom: boolean;
+}
 
 export const TreeProps = Symbol('TreeProps');
 
@@ -165,6 +181,9 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected searchBox: SearchBox;
     protected searchHighlights: Map<string, TreeDecoration.CaptionHighlight>;
 
+    protected readonly onScrollEmitter = new Emitter<TreeScrollEvent>();
+    readonly onScroll: TheiaEvent<TreeScrollEvent> = this.onScrollEmitter.event;
+
     @inject(TreeDecoratorService)
     protected readonly decoratorService: TreeDecoratorService;
     @inject(TreeSearch)
@@ -258,6 +277,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         this.node.addEventListener('mouseup', this.handleMiddleClickEvent.bind(this));
         this.node.addEventListener('auxclick', this.handleMiddleClickEvent.bind(this));
         this.toDispose.pushAll([
+            this.onScrollEmitter,
             this.model,
             this.model.onChanged(() => this.updateRows()),
             this.model.onSelectionChanged(() => this.scheduleUpdateScrollToRow({ resize: false })),
@@ -509,6 +529,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 rows={rows}
                 renderNodeRow={this.renderNodeRow}
                 scrollToRow={this.scrollToRow}
+                onScrollEmitter={this.onScrollEmitter}
                 {...this.props.viewProps}
             />;
         }
@@ -1157,6 +1178,40 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         return this.node;
     }
 
+    /**
+     * Get the current scroll state from the virtualized view.
+     * This should be used instead of accessing the DOM scroll properties directly
+     * when the tree is virtualized.
+     */
+    protected getVirtualizedScrollState(): TreeScrollState | undefined {
+        return this.view?.getScrollState();
+    }
+
+    /**
+     * Check if the tree is scrolled to the bottom.
+     * Works with both virtualized and non-virtualized trees.
+     */
+    isScrolledToBottom(): boolean {
+        if (this.props.virtualized !== false && this.view) {
+            // Use virtualized scroll state
+            const scrollState = this.getVirtualizedScrollState();
+            return scrollState?.isAtBottom ?? true;
+        } else {
+            // Fallback to DOM-based calculation for non-virtualized trees
+            const threshold = 30;
+            const scrollContainer = this.node;
+            const scrollHeight = scrollContainer.scrollHeight;
+            const scrollTop = scrollContainer.scrollTop;
+            const clientHeight = scrollContainer.clientHeight;
+
+            if (scrollHeight <= clientHeight) {
+                return true;
+            }
+
+            return scrollHeight - scrollTop - clientHeight <= threshold;
+        }
+    }
+
     protected override onAfterAttach(msg: Message): void {
         const up = [
             Key.ARROW_UP,
@@ -1577,11 +1632,17 @@ export namespace TreeWidget {
          */
         rows: NodeRow[]
         renderNodeRow: (row: NodeRow) => React.ReactNode
+        /**
+         * Optional scroll event emitter.
+         */
+        onScrollEmitter?: Emitter<TreeScrollEvent>
     }
     export class View extends React.Component<ViewProps> {
         list: VirtuosoHandle | undefined;
+        private lastScrollState: TreeScrollState = { scrollTop: 0, isAtBottom: true };
+
         override render(): React.ReactNode {
-            const { rows, width, height, scrollToRow, renderNodeRow, ...other } = this.props;
+            const { rows, width, height, scrollToRow, renderNodeRow, onScrollEmitter, ...other } = this.props;
             return <Virtuoso
                 ref={list => {
                     this.list = (list || undefined);
@@ -1592,6 +1653,16 @@ export namespace TreeWidget {
                         });
                     }
                 }}
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                onScroll={(e: any) => {
+                    const scrollTop = e.target.scrollTop;
+                    const scrollHeight = e.target.scrollHeight;
+                    const clientHeight = e.target.clientHeight;
+                    const isAtBottom = scrollHeight - scrollTop - clientHeight <= 30; // 30px threshold
+
+                    this.lastScrollState = { scrollTop, isAtBottom };
+                    onScrollEmitter?.fire({ scrollTop, scrollLeft: e.target.scrollLeft || 0 });
+                }}
                 totalCount={rows.length}
                 itemContent={index => renderNodeRow(rows[index])}
                 width={width}
@@ -1600,6 +1671,10 @@ export namespace TreeWidget {
                 overscan={500}
                 {...other}
             />;
+        }
+
+        getScrollState(): TreeScrollState {
+            return { ...this.lastScrollState };
         }
     }
 }


### PR DESCRIPTION
- when user tries to scroll up in the Chat View, temporarily enable scroll lock, even if it is originally disabled
- restore the previous scroll lock state when scrolling back to the bottom

fixes #15049

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR improves the UX for scrolling behavior in the AI Chat view, when the LLM is active:
- If scroll lock is enabled: no change
- If scroll lock is disabled: automatically enable it when scrolling up, then automatically disable it again when scrolling back down

#### How to test

- Open the AI Chat view
- Turn off scroll-lock
- Send a request to a verbose agent (e.g. "`@Universal` Tell me a long story")
  - Reducing the width and height of the Chat window can help to get more scrolling opportunities! :) 
- While the Agent is replying, scroll up: the window should no longer scroll
- Scroll back to the bottom: auto-scroll resumes

Note: if Scroll-lock is explicitly enabled, the new behavior doesn't trigger; auto-scroll will be disabled no matter what

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

The main issue I had was related to how scroll behavior is handled in the base Widget hierarchy. TreeWidget can be virtualized (which it is for the AI Chat), and in that case, it will not use the scroll-related APIs defined by the base Widgets. For example, "getScrollContainer" doesn't work in the AI Chat view. I had to introduce new APIs to handle the Virtuoso scroll events, so we now have at least two sets of APIs in parallel (regular BaseWidget scroll API with PerfectScrollbar, and virtualized TreeWidget APIs with Virtuoso).

These inconsistencies might cause issues and confusion in the future (although this isn't something new - this PR makes it a bit worse)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
