### PR TITLE
Fix playwright tests on Windows

### DIFF
--- a/examples/playwright/src/theia-app-loader.ts
+++ b/examples/playwright/src/theia-app-loader.ts
@@ -63,7 +63,7 @@ namespace TheiaBrowserAppLoader {
     ): Promise<T> {
         const appFactory = theiaAppFactory<T>(factory);
         const app = new appFactory(page, workspace, false);
-        await loadOrReload(app, '/#' + app.workspace.urlEncodedPath);
+        await loadOrReload(app, '/#' + app.workspace.pathAsPathComponent);
         await app.waitForShellAndInitialized();
         return app;
     }

--- a/examples/playwright/src/theia-explorer-view.ts
+++ b/examples/playwright/src/theia-explorer-view.ts
@@ -21,7 +21,7 @@ import { TheiaMenuItem } from './theia-menu-item';
 import { TheiaRenameDialog } from './theia-rename-dialog';
 import { TheiaTreeNode } from './theia-tree-node';
 import { TheiaView } from './theia-view';
-import { elementContainsClass, normalizeId, OSUtil, urlEncodePath } from './util';
+import { elementContainsClass, normalizeId, OSUtil } from './util';
 
 const TheiaExplorerViewData = {
     tabSelector: '#shell-tab-explorer-view-container',
@@ -195,10 +195,10 @@ export class TheiaExplorerView extends TheiaView {
     }
 
     protected treeNodeId(filePath: string): string {
-        const workspacePath = this.app.workspace.path;
-        const nodeId = `${workspacePath}:${workspacePath}${OSUtil.fileSeparator}${filePath}`;
+        const workspacePath = this.app.workspace.pathAsPathComponent;
+        const nodeId = `${workspacePath}:${workspacePath}/${filePath}`;
         if (OSUtil.isWindows) {
-            return urlEncodePath(nodeId);
+            return nodeId.replace('\\', '/');
         }
         return nodeId;
     }

--- a/examples/playwright/src/theia-notebook-editor.ts
+++ b/examples/playwright/src/theia-notebook-editor.ts
@@ -15,14 +15,13 @@
 // *****************************************************************************
 
 import { Locator } from '@playwright/test';
-import { join } from 'path';
 import { TheiaApp } from './theia-app';
 import { TheiaEditor } from './theia-editor';
 import { TheiaNotebookCell } from './theia-notebook-cell';
 import { TheiaNotebookToolbar } from './theia-notebook-toolbar';
 import { TheiaQuickCommandPalette } from './theia-quick-command-palette';
 import { TheiaToolbarItem } from './theia-toolbar-item';
-import { OSUtil, normalizeId, urlEncodePath } from './util';
+import { normalizeId } from './util';
 
 export namespace NotebookCommands {
     export const SELECT_KERNEL_COMMAND = 'notebook.selectKernel';
@@ -39,8 +38,8 @@ export class TheiaNotebookEditor extends TheiaEditor {
         // shell-tab-notebook::file://<path>
         // notebook:file://<path>
         super({
-            tabSelector: normalizeId(`#shell-tab-notebook:file://${urlEncodePath(join(app.workspace.escapedPath, OSUtil.fileSeparator, filePath))}`),
-            viewSelector: normalizeId(`#notebook:file://${urlEncodePath(join(app.workspace.escapedPath, OSUtil.fileSeparator, filePath))}`)
+            tabSelector: normalizeId(`#shell-tab-notebook:${app.workspace.pathAsUrl(filePath)}`),
+            viewSelector: normalizeId(`#notebook:${app.workspace.pathAsUrl(filePath)}`)
         }, app);
     }
 

--- a/examples/playwright/src/theia-text-editor.ts
+++ b/examples/playwright/src/theia-text-editor.ts
@@ -15,11 +15,10 @@
 // *****************************************************************************
 
 import { ElementHandle, Locator } from '@playwright/test';
-import { join } from 'path';
 
 import { TheiaApp } from './theia-app';
 import { TheiaEditor } from './theia-editor';
-import { normalizeId, OSUtil, urlEncodePath } from './util';
+import { normalizeId } from './util';
 import { TheiaMonacoEditor } from './theia-monaco-editor';
 
 export class TheiaTextEditor extends TheiaEditor {
@@ -30,8 +29,8 @@ export class TheiaTextEditor extends TheiaEditor {
         // shell-tab-code-editor-opener:file:///c%3A/Users/user/AppData/Local/Temp/cloud-ws-JBUhb6/sample.txt:1
         // code-editor-opener:file:///c%3A/Users/user/AppData/Local/Temp/cloud-ws-JBUhb6/sample.txt:1
         super({
-            tabSelector: normalizeId(`#shell-tab-code-editor-opener:file://${urlEncodePath(join(app.workspace.escapedPath, OSUtil.fileSeparator, filePath))}:1`),
-            viewSelector: normalizeId(`#code-editor-opener:file://${urlEncodePath(join(app.workspace.escapedPath, OSUtil.fileSeparator, filePath))}:1`) + '.theia-editor'
+            tabSelector: normalizeId(`#shell-tab-code-editor-opener:${app.workspace.pathAsUrl(filePath)}:1`),
+            viewSelector: normalizeId(`#code-editor-opener:${app.workspace.pathAsUrl(filePath)}:1`) + '.theia-editor'
         }, app);
         this.monacoEditor = new TheiaMonacoEditor(this.page.locator(this.data.viewSelector), app);
     }

--- a/examples/playwright/src/util.ts
+++ b/examples/playwright/src/util.ts
@@ -25,10 +25,6 @@ export function normalizeId(nodeId: string): string {
     return nodeId.replace(/[.:,%/\\]/g, matchedChar => '\\' + matchedChar);
 }
 
-export function urlEncodePath(path: string): string {
-    return path.replace(/\\/g, '/');
-}
-
 export async function toTextContentArray(items: ElementHandle<SVGElement | HTMLElement>[]): Promise<string[]> {
     const contents = items.map(item => item.textContent());
     const resolvedContents = await Promise.all(contents);
@@ -84,8 +80,4 @@ export namespace OSUtil {
     export const fileSeparator = sep;
     // The platform-specific location of the temporary directory.
     export const tmpDir = tmpdir();
-
-    export function osStartsWithFileSeparator(path: string): boolean {
-        return path.startsWith(fileSeparator);
-    }
 }


### PR DESCRIPTION

#### What it does

Simplify helper methods and properties for filesystem paths and urls to workspace.
In my opinion, previously the meaning of urlEncode and escape was not clear. This was part of the reason, the methods didn't work for Windows. I tried to align the naming of the methods with the specific use cases.
Unfortunately, I don't have access to MacOS to test this.

Fixes #15447

#### How to test

Run playwright tests on Windows and Linux.

#### Follow-ups

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
