### PR TITLE
Start debug instance without Yarn

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -100,6 +100,7 @@
     "lint": "theiaext lint",
     "rebuild": "theia rebuild:electron --cacheRoot ../..",
     "start": "theia start --plugins=local-dir:../../plugins --ovsx-router-config=../ovsx-router-config.json",
+    "start:raw": "theia start",
     "start:debug": "npm run -s start --log-level=debug --remote-debugging-port=9222",
     "start:watch": "concurrently --kill-others -n tsc,bundle,run -c red,yellow,green \"tsc -b -w --preserveWatchOutput\" \"npm run -s watch:bundle\" \"npm run -s start\"",
     "test": "electron-mocha --timeout 60000 \"./lib/test/**/*.espec.js\"",

--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -244,7 +244,7 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
         const processArguments = process.argv;
         let command: string[];
         if (environment.electron.is()) {
-            command = ['npm', 'run', 'theia', 'start'];
+            command = ['npm', 'run', 'start:raw'];
         } else {
             command = processArguments.filter((arg, index, args) => {
                 // remove --port=X and --port X arguments if set


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Before the switch to NPM, the extension host plugin setup for Electron used Yarn's wrapping of the `node_modules/.bin` binaries to invoke the `theia` command. With the switch to NPM, that no longer works, and extension host debugging doesn't successfully launch a new window in Electron. This PR adds a script to the Electron`package.json` to invoke `theia start` with no additional arguments and then uses it in the extension host debug startup process.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Attempt to debug a VSCode extension in Theia's electron app.
2. An extension host window should pop up and you should be able to debug your extension.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
