### PR TITLE
fix: remove tool results from subsequential requests

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -150,14 +150,14 @@ export class AnthropicModel implements LanguageModel {
         anthropic: Anthropic,
         request: UserRequest,
         cancellationToken?: CancellationToken,
-        toolMessages?: readonly Anthropic.Messages.MessageParam[]
+        toolMessages: readonly Anthropic.Messages.MessageParam[] = []
     ): Promise<LanguageModelStreamResponse> {
         const settings = this.getSettings(request);
         const { messages, systemMessage } = transformToAnthropicParams(request.messages);
         const tools = this.createTools(request);
         const params: Anthropic.MessageCreateParams = {
             max_tokens: this.maxTokens,
-            messages: [...messages, ...(toolMessages ?? [])],
+            messages: [...messages, ...toolMessages],
             tools,
             tool_choice: tools ? { type: 'auto' } : undefined,
             model: this.model,
@@ -262,12 +262,23 @@ export class AnthropicModel implements LanguageModel {
                             content: that.formatToolCallResult(call.result)
                         }))
                     };
+                    const newToolMessages = toolMessages.map(tm => ({
+                        role: tm.role,
+                        content: Array.isArray(tm.content) ? tm.content.map(c => {
+                            // do not repeat tool results in subsequential request during a multiple tool calls
+                            if (c.type === 'tool_result') {
+                                return { type: c.type, tool_use_id: c.tool_use_id };
+                            };
+                            // return the old content
+                            return { ...c };
+                        }) : tm.content
+                    }));
                     const result = await that.handleStreamingRequest(
                         anthropic,
                         request,
                         cancellationToken,
                         [
-                            ...(toolMessages ?? []),
+                            ...newToolMessages,
                             ...currentMessages.map(m => ({ role: m.role, content: m.content })),
                             toolResponseMessage
                         ]);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

During multiple tool requests, the anthropic provider was passing all tool results over and over again. This resulted in unreasonable high token usage due to repetetition.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Using a prompt like:
@Architect retrieve the directory structure and then search the workspace for "Jonas" and then search for "Philip"

With Claude before the fix and after the fix should reduce the tokens used drastically.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
