### PR TITLE
Make sure to add openai stream options only in streaming models

### DIFF
--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -89,9 +89,6 @@ export class OpenAiModel implements LanguageModel {
 
     async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {
         const settings = this.getSettings(request);
-        if (this.id.startsWith(`${OPENAI_PROVIDER_ID}/`)) {
-            settings['stream_options'] = { include_usage: true };
-        }
         const openai = this.initializeOpenAi();
 
         if (request.response_format?.type === 'json_schema' && this.supportsStructuredOutput) {
@@ -100,6 +97,10 @@ export class OpenAiModel implements LanguageModel {
 
         if (this.isNonStreamingModel(this.model) || (typeof settings.stream === 'boolean' && !settings.stream)) {
             return this.handleNonStreamingRequest(openai, request);
+        }
+
+        if (this.id.startsWith(`${OPENAI_PROVIDER_ID}/`)) {
+            settings['stream_options'] = { include_usage: true };
         }
 
         if (cancellationToken?.isCancellationRequested) {


### PR DESCRIPTION
#### What it does

Make sure to add openai stream options only in streaming models.

#### How to test

Try to run code completion with an openai model. 
Without this fix you get an error `The 'stream_options' parameter is only allowed when 'stream' is enabled`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
