### PR TITLE
Add ai tools for write through file changes

### DIFF
--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -17,7 +17,7 @@ import { AbstractStreamParsingChatAgent, ChatRequestModel, ChatService, ChatSess
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from '../common/workspace-functions';
 import { CODER_SYSTEM_PROMPT_ID, getCoderAgentModePromptTemplate, getCoderReplacePromptTemplate, getCoderReplacePromptTemplateNext } from '../common/coder-replace-prompt-template';
-import { WriteChangeToFileProvider } from './file-changeset-functions';
+import { SuggestFileContent } from './file-changeset-functions';
 import { LanguageModelRequirement, PromptVariantSet } from '@theia/ai-core';
 import { nls } from '@theia/core';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
@@ -43,7 +43,7 @@ export class CoderAgent extends AbstractStreamParsingChatAgent {
         defaultVariant: getCoderReplacePromptTemplate(true),
         variants: [getCoderReplacePromptTemplate(false), getCoderReplacePromptTemplateNext(), getCoderAgentModePromptTemplate()]
     }];
-    override functions = [GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, WriteChangeToFileProvider.ID];
+    override functions = [GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, SuggestFileContent.ID];
     protected override systemPromptId: string | undefined = CODER_SYSTEM_PROMPT_ID;
     override async invoke(request: MutableChatRequestModel): Promise<void> {
         await super.invoke(request);

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -23,8 +23,8 @@ import { ContentReplacer, Replacement } from '@theia/core/lib/common/content-rep
 import { URI } from '@theia/core/lib/common/uri';
 
 @injectable()
-export class WriteChangeToFileProvider implements ToolProvider {
-    static ID = 'changeSet_writeChangeToFile';
+export class SuggestFileContent implements ToolProvider {
+    static ID = 'suggestFileContent';
 
     @inject(WorkspaceFunctionScope)
     protected readonly workspaceFunctionScope: WorkspaceFunctionScope;
@@ -37,8 +37,8 @@ export class WriteChangeToFileProvider implements ToolProvider {
 
     getTool(): ToolRequest {
         return {
-            id: WriteChangeToFileProvider.ID,
-            name: WriteChangeToFileProvider.ID,
+            id: SuggestFileContent.ID,
+            name: SuggestFileContent.ID,
             description: `Proposes writing content to a file. If the file exists, it will be overwritten with the provided content.\n
              If the file does not exist, it will be created. This tool will automatically create any directories needed to write the file.\n
              If the new content is empty, the file will be deleted. To move a file, delete it and re-create it at the new location.\n
@@ -260,16 +260,16 @@ export class ReplaceContentInFileFunctionHelper {
 }
 
 @injectable()
-export class SimpleReplaceContentInFileProvider implements ToolProvider {
-    static ID = 'changeSet_replaceContentInFilev1';
+export class SimpleSuggestFileReplacements implements ToolProvider {
+    static ID = 'simpleSuggestFileReplacements';
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
     getTool(): ToolRequest {
         const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata();
         return {
-            id: SimpleReplaceContentInFileProvider.ID,
-            name: SimpleReplaceContentInFileProvider.ID,
+            id: SimpleSuggestFileReplacements.ID,
+            name: SimpleSuggestFileReplacements.ID,
             description: metadata.description,
             parameters: metadata.parameters,
             handler: async (args: string, ctx: MutableChatRequestModel): Promise<string> =>
@@ -279,16 +279,16 @@ export class SimpleReplaceContentInFileProvider implements ToolProvider {
 }
 
 @injectable()
-export class ReplaceContentInFileProvider implements ToolProvider {
-    static ID = 'changeSet_replaceContentInFile';
+export class SuggestFileReplacements implements ToolProvider {
+    static ID = 'suggestFileReplacements';
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
     getTool(): ToolRequest {
         const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata(true);
         return {
-            id: ReplaceContentInFileProvider.ID,
-            name: ReplaceContentInFileProvider.ID,
+            id: SuggestFileReplacements.ID,
+            name: SuggestFileReplacements.ID,
             description: metadata.description,
             parameters: metadata.parameters,
             handler: async (args: string, ctx: MutableChatRequestModel): Promise<string> =>
@@ -298,15 +298,15 @@ export class ReplaceContentInFileProvider implements ToolProvider {
 }
 
 @injectable()
-export class ClearFileChangesProvider implements ToolProvider {
-    static ID = 'changeSet_clearFileChanges';
+export class ClearFileChanges implements ToolProvider {
+    static ID = 'clearFileChanges';
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
     getTool(): ToolRequest {
         return {
-            id: ClearFileChangesProvider.ID,
-            name: ClearFileChangesProvider.ID,
+            id: ClearFileChanges.ID,
+            name: ClearFileChanges.ID,
             description: 'Clears all pending changes for a specific file, allowing you to start fresh with new modifications.',
             parameters: {
                 type: 'object',
@@ -327,15 +327,15 @@ export class ClearFileChangesProvider implements ToolProvider {
 }
 
 @injectable()
-export class GetProposedFileStateProvider implements ToolProvider {
-    static ID = 'changeSet_getProposedFileState';
+export class GetProposedFileState implements ToolProvider {
+    static ID = 'getProposedFileState';
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
     getTool(): ToolRequest {
         return {
-            id: GetProposedFileStateProvider.ID,
-            name: GetProposedFileStateProvider.ID,
+            id: GetProposedFileState.ID,
+            name: GetProposedFileState.ID,
             description: 'Returns the current proposed state of a file, including all pending changes that have been proposed ' +
                 'but not yet applied. This allows you to inspect the current state before making additional changes.',
             parameters: {

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -181,7 +181,7 @@ export class ReplaceContentInFileFunctionHelper {
         this.replacer = new ContentReplacer();
     }
 
-    getToolMetadata(supportMultipleReplace: boolean = false): { description: string, parameters: ToolRequestParameters } {
+    getToolMetadata(supportMultipleReplace: boolean = false, immediateApplication: boolean = false): { description: string, parameters: ToolRequestParameters } {
         const replacementProperties: ToolRequestParametersProperties = {
             oldContent: {
                 type: 'string',
@@ -230,9 +230,13 @@ export class ReplaceContentInFileFunctionHelper {
             : 'A single occurrence of each old content in the tuples is expected to be replaced. If the number of occurrences in the file does not match the expectation,\
               the function will return an error. In that case try a different approach.';
 
+        const applicationText = immediateApplication
+            ? 'The changes will be applied immediately without user confirmation.'
+            : 'The proposed changes will be applied when the user accepts.';
+
         const replacementDescription = `Propose to replace sections of content in an existing file by providing a list of tuples with old content to be matched and replaced.
             ${replacementSentence}. For deletions, use an empty new content in the tuple.
-            Make sure you use the same line endings and whitespace as in the original file content. The proposed changes will be applied when the user accepts.
+            Make sure you use the same line endings and whitespace as in the original file content. ${applicationText}
             Multiple calls for the same file will merge replacements unless the reset parameter is set to true. Use the reset parameter to clear previous changes and start
             fresh if needed.`;
 
@@ -241,21 +245,6 @@ export class ReplaceContentInFileFunctionHelper {
             parameters: replacementParameters
         };
 
-    }
-
-    getWriteToolMetadata(supportMultipleReplace: boolean = false): { description: string, parameters: ToolRequestParameters } {
-        const metadata = this.getToolMetadata(supportMultipleReplace);
-
-        // Modify the description to indicate immediate application
-        const writeDescription = metadata.description.replace(
-            'The proposed changes will be applied when the user accepts.',
-            'The changes will be applied immediately without user confirmation.'
-        );
-
-        return {
-            description: writeDescription,
-            parameters: metadata.parameters
-        };
     }
 
     async createChangesetFromToolCall(toolCallString: string, ctx: MutableChatRequestModel): Promise<string> {
@@ -426,7 +415,7 @@ export class SimpleWriteFileReplacements implements ToolProvider {
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
     getTool(): ToolRequest {
-        const metadata = this.replaceContentInFileFunctionHelper.getWriteToolMetadata();
+        const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata(false, true);
         return {
             id: SimpleWriteFileReplacements.ID,
             name: SimpleWriteFileReplacements.ID,
@@ -464,7 +453,7 @@ export class WriteFileReplacements implements ToolProvider {
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
     getTool(): ToolRequest {
-        const metadata = this.replaceContentInFileFunctionHelper.getWriteToolMetadata(true);
+        const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata(true, true);
         return {
             id: WriteFileReplacements.ID,
             name: WriteFileReplacements.ID,

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -31,7 +31,10 @@ import {
     ReplaceContentInFileFunctionHelper,
     SuggestFileReplacements,
     SimpleSuggestFileReplacements,
-    SuggestFileContent
+    SuggestFileContent,
+    WriteFileContent,
+    WriteFileReplacements,
+    SimpleWriteFileReplacements
 } from './file-changeset-functions';
 import { OrchestratorChatAgent, OrchestratorChatAgentId } from '../common/orchestrator-chat-agent';
 import { UniversalChatAgent, UniversalChatAgentId } from '../common/universal-chat-agent';
@@ -92,10 +95,12 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindToolProvider(WorkspaceSearchProvider, bind);
 
     bindToolProvider(SuggestFileContent, bind);
+    bindToolProvider(WriteFileContent, bind);
     bindToolProvider(TaskListProvider, bind);
     bindToolProvider(TaskRunnerProvider, bind);
     bind(ReplaceContentInFileFunctionHelper).toSelf().inSingletonScope();
     bindToolProvider(SuggestFileReplacements, bind);
+    bindToolProvider(WriteFileReplacements, bind);
     bindToolProvider(ListChatContext, bind);
     bindToolProvider(ResolveChatContext, bind);
     bind(AIConfigurationSelectionService).toSelf().inSingletonScope();
@@ -127,6 +132,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
         .inSingletonScope();
 
     bindToolProvider(SimpleSuggestFileReplacements, bind);
+    bindToolProvider(SimpleWriteFileReplacements, bind);
     bindToolProvider(ClearFileChanges, bind);
     bindToolProvider(GetProposedFileState, bind);
     bindToolProvider(AddFileToChatContext, bind);

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -26,12 +26,12 @@ import { FrontendApplicationContribution, PreferenceContribution, WidgetFactory,
 import { TaskListProvider, TaskRunnerProvider } from './workspace-task-provider';
 import { WorkspacePreferencesSchema } from './workspace-preferences';
 import {
-    ClearFileChangesProvider,
-    GetProposedFileStateProvider,
+    ClearFileChanges,
+    GetProposedFileState,
     ReplaceContentInFileFunctionHelper,
-    ReplaceContentInFileProvider,
-    SimpleReplaceContentInFileProvider,
-    WriteChangeToFileProvider
+    SuggestFileReplacements,
+    SimpleSuggestFileReplacements,
+    SuggestFileContent
 } from './file-changeset-functions';
 import { OrchestratorChatAgent, OrchestratorChatAgentId } from '../common/orchestrator-chat-agent';
 import { UniversalChatAgent, UniversalChatAgentId } from '../common/universal-chat-agent';
@@ -91,11 +91,11 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(WorkspaceFunctionScope).toSelf().inSingletonScope();
     bindToolProvider(WorkspaceSearchProvider, bind);
 
-    bindToolProvider(WriteChangeToFileProvider, bind);
+    bindToolProvider(SuggestFileContent, bind);
     bindToolProvider(TaskListProvider, bind);
     bindToolProvider(TaskRunnerProvider, bind);
     bind(ReplaceContentInFileFunctionHelper).toSelf().inSingletonScope();
-    bindToolProvider(ReplaceContentInFileProvider, bind);
+    bindToolProvider(SuggestFileReplacements, bind);
     bindToolProvider(ListChatContext, bind);
     bindToolProvider(ResolveChatContext, bind);
     bind(AIConfigurationSelectionService).toSelf().inSingletonScope();
@@ -126,9 +126,9 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
         }))
         .inSingletonScope();
 
-    bindToolProvider(SimpleReplaceContentInFileProvider, bind);
-    bindToolProvider(ClearFileChangesProvider, bind);
-    bindToolProvider(GetProposedFileStateProvider, bind);
+    bindToolProvider(SimpleSuggestFileReplacements, bind);
+    bindToolProvider(ClearFileChanges, bind);
+    bindToolProvider(GetProposedFileState, bind);
     bindToolProvider(AddFileToChatContext, bind);
     bind(AIVariableContribution).to(ContextFilesVariableContribution).inSingletonScope();
     bind(PreferenceContribution).toConstantValue({ schema: AiConfigurationPreferences });

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -76,11 +76,11 @@ Never guess or hallucinate file content or structure. Use tools for all workspac
 ### ✍️ Code Editing
 - Before editing, always retrieve file content
 - Use:
-  - ~{writeFileReplacements} — propose targeted code changes (multiple calls merge changes)
-  - ~{writeFileContent} — completely rewrite a file when needed
+  - ~{suggestFileReplacements} — propose targeted code changes (multiple calls merge changes)
+  - ~{suggestFileContent} — completely rewrite a file when needed
   - ~{clearFileChanges} — clear all pending changes for a file
-- For incremental changes, use multiple ~{writeFileReplacements} calls
-- Use the reset parameter with ~{writeFileReplacements} to clear previous changes
+- For incremental changes, use multiple ~{suggestFileReplacements} calls
+- Use the reset parameter with ~{suggestFileReplacements} to clear previous changes
 
 ### Testing & Tasks
 - Use ~{listTasks} to discover available test and lint tasks
@@ -88,7 +88,7 @@ Never guess or hallucinate file content or structure. Use tools for all workspac
 
 ### Test Authoring
 If no relevant tests exist:
-- Create new test files (propose using writeFileContent)
+- Create new test files (propose using suggestFileContent)
 - Use patterns from existing tests
 - Ensure new tests validate new behavior or prevent regressions
 
@@ -173,9 +173,9 @@ Instead, for each file you want to propose changes for:
 - **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the original content of the target file.
 - **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{writeFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{writeFileContent}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{writeFileReplacements} continuously fails use ~{writeFileContent}.
+  - ~{suggestFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{suggestFileContent}: For complete file rewrites when you need to replace the entire content. 
+  - If ~{suggestFileReplacements} continuously fails use ~{suggestFileContent}.
   - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.
 
 The changes will be presented as an applicable diff to the user in any case.
@@ -227,9 +227,9 @@ Instead, for each file you want to propose changes for:
 - **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the original content of the target file.
 - **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{writeFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{writeFileContent}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{writeFileReplacements} continuously fails use ~{writeFileContent}.
+  - ~{suggestFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{suggestFileContent}: For complete file rewrites when you need to replace the entire content. 
+  - If ~{suggestFileReplacements} continuously fails use ~{suggestFileContent}.
   - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.
 
 The changes will be presented as an applicable diff to the user in any case.

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -33,7 +33,7 @@ export function getCoderAgentModePromptTemplate(): BasePromptFragment {
     return {
         id: CODER_AGENT_MODE_TEMPLATE_ID,
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 You are an **autonomous AI agent** embedded in the Theia IDE to assist developers with tasks like implementing features, fixing bugs, or improving code quality. 
 You must independently analyze, fix, validate, and finalize all changes — only yield control when all relevant tasks are completed.
@@ -76,11 +76,11 @@ Never guess or hallucinate file content or structure. Use tools for all workspac
 ### ✍️ Code Editing
 - Before editing, always retrieve file content
 - Use:
-  - ~{changeSet_replaceContentInFile} — propose targeted code changes (multiple calls merge changes)
-  - ~{changeSet_writeChangeToFile} — completely rewrite a file when needed
-  - ~{changeSet_clearFileChanges} — clear all pending changes for a file
-- For incremental changes, use multiple ~{changeSet_replaceContentInFile} calls
-- Use the reset parameter with ~{changeSet_replaceContentInFile} to clear previous changes
+  - ~{suggestFileReplacements} — propose targeted code changes (multiple calls merge changes)
+  - ~{suggestFileContent} — completely rewrite a file when needed
+  - ~{clearFileChanges} — clear all pending changes for a file
+- For incremental changes, use multiple ~{suggestFileReplacements} calls
+- Use the reset parameter with ~{suggestFileReplacements} to clear previous changes
 
 ### Testing & Tasks
 - Use ~{listTasks} to discover available test and lint tasks
@@ -88,7 +88,7 @@ Never guess or hallucinate file content or structure. Use tools for all workspac
 
 ### Test Authoring
 If no relevant tests exist:
-- Create new test files (propose using changeSet_writeChangeToFile)
+- Create new test files (propose using suggestFileContent)
 - Use patterns from existing tests
 - Ensure new tests validate new behavior or prevent regressions
 
@@ -149,7 +149,7 @@ export function getCoderReplacePromptTemplateNext(): BasePromptFragment {
     return {
         id: CODER_REPLACE_PROMPT_TEMPLATE_NEXT_ID,
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes.
 
@@ -171,12 +171,12 @@ To propose code changes or any file changes to the user, never print code or new
 
 Instead, for each file you want to propose changes for:
 - **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the original content of the target file.
-- **View Pending Changes**: Use ~{changeSet_getProposedFileState} to see the current proposed state of a file, including all pending changes.
+- **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{changeSet_replaceContentInFile}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{changeSet_writeChangeToFile}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{changeSet_replaceContentInFile} continuously fails use ~{changeSet_writeChangeToFile}.
-  - ~{changeSet_clearFileChanges}: To clear all pending changes for a file and start fresh.
+  - ~{suggestFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{suggestFileContent}: For complete file rewrites when you need to replace the entire content. 
+  - If ~{suggestFileReplacements} continuously fails use ~{suggestFileContent}.
+  - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.
 
 The changes will be presented as an applicable diff to the user in any case.
 
@@ -205,7 +205,7 @@ export function getCoderReplacePromptTemplate(withSearchAndReplace: boolean = fa
     return {
         id: withSearchAndReplace ? CODER_REPLACE_PROMPT_TEMPLATE_ID : CODER_REWRITE_PROMPT_TEMPLATE_ID,
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
+Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes.
 
@@ -225,12 +225,12 @@ To propose code changes or any file changes to the user, never print code or new
 
 Instead, for each file you want to propose changes for:
 - **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the original content of the target file.
-- **View Pending Changes**: Use ~{changeSet_getProposedFileState} to see the current proposed state of a file, including all pending changes.
+- **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{changeSet_replaceContentInFile}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{changeSet_writeChangeToFile}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{changeSet_replaceContentInFile} continuously fails use ~{changeSet_writeChangeToFile}.
-  - ~{changeSet_clearFileChanges}: To clear all pending changes for a file and start fresh.
+  - ~{suggestFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{suggestFileContent}: For complete file rewrites when you need to replace the entire content. 
+  - If ~{suggestFileReplacements} continuously fails use ~{suggestFileContent}.
+  - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.
 
 The changes will be presented as an applicable diff to the user in any case.
 

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -76,11 +76,12 @@ Never guess or hallucinate file content or structure. Use tools for all workspac
 ### ✍️ Code Editing
 - Before editing, always retrieve file content
 - Use:
-  - ~{suggestFileReplacements} — propose targeted code changes (multiple calls merge changes)
-  - ~{suggestFileContent} — completely rewrite a file when needed
+  - ~{writeFileReplacements} — to immediately apply targeted code changes (no user review)
+  - ~{writeFileContent} — to immediately overwrite a file with new content (no user review)
+  - ~{simpleWriteFileReplacements} — to immediately apply a simple set of replacements (no user review)
   - ~{clearFileChanges} — clear all pending changes for a file
-- For incremental changes, use multiple ~{suggestFileReplacements} calls
-- Use the reset parameter with ~{suggestFileReplacements} to clear previous changes
+- For incremental changes, use multiple ~{writeFileReplacements} calls
+- Use the reset parameter with ~{writeFileReplacements} to clear previous changes
 
 ### Testing & Tasks
 - Use ~{listTasks} to discover available test and lint tasks

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -76,11 +76,11 @@ Never guess or hallucinate file content or structure. Use tools for all workspac
 ### ✍️ Code Editing
 - Before editing, always retrieve file content
 - Use:
-  - ~{suggestFileReplacements} — propose targeted code changes (multiple calls merge changes)
-  - ~{suggestFileContent} — completely rewrite a file when needed
+  - ~{writeFileReplacements} — propose targeted code changes (multiple calls merge changes)
+  - ~{writeFileContent} — completely rewrite a file when needed
   - ~{clearFileChanges} — clear all pending changes for a file
-- For incremental changes, use multiple ~{suggestFileReplacements} calls
-- Use the reset parameter with ~{suggestFileReplacements} to clear previous changes
+- For incremental changes, use multiple ~{writeFileReplacements} calls
+- Use the reset parameter with ~{writeFileReplacements} to clear previous changes
 
 ### Testing & Tasks
 - Use ~{listTasks} to discover available test and lint tasks
@@ -88,7 +88,7 @@ Never guess or hallucinate file content or structure. Use tools for all workspac
 
 ### Test Authoring
 If no relevant tests exist:
-- Create new test files (propose using suggestFileContent)
+- Create new test files (propose using writeFileContent)
 - Use patterns from existing tests
 - Ensure new tests validate new behavior or prevent regressions
 
@@ -173,9 +173,9 @@ Instead, for each file you want to propose changes for:
 - **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the original content of the target file.
 - **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{suggestFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{suggestFileContent}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{suggestFileReplacements} continuously fails use ~{suggestFileContent}.
+  - ~{writeFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{writeFileContent}: For complete file rewrites when you need to replace the entire content. 
+  - If ~{writeFileReplacements} continuously fails use ~{writeFileContent}.
   - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.
 
 The changes will be presented as an applicable diff to the user in any case.
@@ -227,9 +227,9 @@ Instead, for each file you want to propose changes for:
 - **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the original content of the target file.
 - **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{suggestFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{suggestFileContent}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{suggestFileReplacements} continuously fails use ~{suggestFileContent}.
+  - ~{writeFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{writeFileContent}: For complete file rewrites when you need to replace the entire content. 
+  - If ~{writeFileReplacements} continuously fails use ~{writeFileContent}.
   - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.
 
 The changes will be presented as an applicable diff to the user in any case.


### PR DESCRIPTION
#### What it does

- Rename the existing change set tool functions and classes to align better with that they do
- Add new tool functions to directly write changes to disk
- Adapt Coder prompts to adapt to the renamed tool function classes

#### How to test

1. Ensure current writing to changesets still works, i.e. changes are proposed. This should be the default with the current prompt
2. Adapt the Coder prompt to use the new write functions. Changes should be written directly to disk with this

You can use this prompt:

<details>
<summary>coder prompt</summary>

```
{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes.

## Context Retrieval
Use the following functions to interact with the workspace files if you require context:
- **~{getWorkspaceDirectoryStructure}**
- **~{getWorkspaceFileList}**
- **~{getFileContent}**
- **~{searchInWorkspace}**

Remember file locations that are relevant for completing your tasks using **~{context_addFile}**
Only add files that are really relevant to look at later.

## File Validation
Use the following function to retrieve a list of problems in a file if the user requests fixes in a given file: **~{getFileDiagnostics}**

## Propose Code Changes
To propose code changes or any file changes to the user, never print code or new file content in your response.

Instead, for each file you want to propose changes for:
- **Always Retrieve Current Content**: Use getFileContent to get the original content of the target file.
- **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
- **Change Content**: Use one of these methods to propose changes:
  - ~{writeFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
  - ~{writeFileContent}: For complete file rewrites when you need to replace the entire content. 
  - If ~{writeFileReplacements} continuously fails use ~{suggestFileContent}.
  - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.

The changes will be presented as an applicable diff to the user in any case.

## Tasks

The user might want you to execute some task. You can find tasks using ~{listTasks} and execute them using ~{runTask}.

## Additional Context

The following files have been provided for additional context. Some of them may also be referred to by the user (e.g. "this file" or "the attachment"). Always look at the relevant files to understand your task using the function ~{getFileContent}
{{contextFiles}}

## Previously Proposed Changes
You have previously proposed changes for the following files. Some suggestions may have been accepted by the user, while others may still be pending.
{{changeSetSummary}}

{{prompt:project-info}}

{{taskContextSummary}}

```

</details>

#### Follow-ups

- Handle correct application of the write-through changes in the UI. I.e. the change might not be correctly recognized as applied in the chat view.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
