### PR TITLE
Revert "fix: remove tool results from subsequential requests"

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -150,14 +150,14 @@ export class AnthropicModel implements LanguageModel {
         anthropic: Anthropic,
         request: UserRequest,
         cancellationToken?: CancellationToken,
-        toolMessages: readonly Anthropic.Messages.MessageParam[] = []
+        toolMessages?: readonly Anthropic.Messages.MessageParam[]
     ): Promise<LanguageModelStreamResponse> {
         const settings = this.getSettings(request);
         const { messages, systemMessage } = transformToAnthropicParams(request.messages);
         const tools = this.createTools(request);
         const params: Anthropic.MessageCreateParams = {
             max_tokens: this.maxTokens,
-            messages: [...messages, ...toolMessages],
+            messages: [...messages, ...(toolMessages ?? [])],
             tools,
             tool_choice: tools ? { type: 'auto' } : undefined,
             model: this.model,
@@ -262,23 +262,12 @@ export class AnthropicModel implements LanguageModel {
                             content: that.formatToolCallResult(call.result)
                         }))
                     };
-                    const newToolMessages = toolMessages.map(tm => ({
-                        role: tm.role,
-                        content: Array.isArray(tm.content) ? tm.content.map(c => {
-                            // do not repeat tool results in subsequential request during a multiple tool calls
-                            if (c.type === 'tool_result') {
-                                return { type: c.type, tool_use_id: c.tool_use_id };
-                            };
-                            // return the old content
-                            return { ...c };
-                        }) : tm.content
-                    }));
                     const result = await that.handleStreamingRequest(
                         anthropic,
                         request,
                         cancellationToken,
                         [
-                            ...newToolMessages,
+                            ...(toolMessages ?? []),
                             ...currentMessages.map(m => ({ role: m.role, content: m.content })),
                             toolResponseMessage
                         ]);


### PR DESCRIPTION
This reverts commit ee5e882a7069e72e0ac84f3ca58cedd4e11096d3.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The commit is reverted as it breaks LLM behavior in many use cases, for example when multiple tool results are required to continue. Related PR: https://github.com/eclipse-theia/theia/pull/15702

#### How to test

Ask an Anthropic LLM to modify multiple files, it will likely end up in an "endless" tool call loop

#### Follow-ups

The intent of the original PR was to reduce token usage as tool calls with large results will quickly exhaust Anthropic rate limits with an "agentic-mode" agent. We need to find a different approach to achieve this goal.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
