### PR TITLE
Fix chat input widget not tracking branches and pending state

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -452,7 +452,8 @@ export class ChatViewTreeWidget extends TreeWidget {
                             initialValue: editableNode.request.message.request.text,
                             onQuery: async query => {
                                 editableNode.request.submitEdit({ text: query });
-                            }
+                            },
+                            branch: editableNode.branch
                         });
 
                         this.chatInputs.set(editableNode.id, widget);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Update the ChatInput widget to

- track the currently active branch in the session tree
- listen for state changes in the model to show either the cancel button when a request is pending or else the send button

Fixes eclipsesource/theia#228
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

There are two scenarios to test:

First scenario: Test cancelling multiple chat branches (they are created by editing a prompt in the chat view):
1. Start a request that takes a while
2. While the request is running, click the edit button on your initial message. Edit it and send
3. Use the arrows to switch back to the first version of your request and cancel it.
4. Switch back to the second version of your message. It should still be running. Cancel it.
5. Observe: Both requests are cancelled

Second scenario: Testing multiple chats.
1. Start a request that takes a while 
2. While the request is running, start a new chat and send a second request that takes a while
3. Switch back to the first chat and cancel it.
4. Switch back to the second chat. It should still be running. Cancel it.
5. Observe: Both requests are cancelled
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
