### PR TITLE
Consolidate Coder Prompts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -841,6 +841,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.52.0.tgz",
+      "integrity": "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      }
+    },
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
@@ -30401,15 +30410,6 @@
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.62.0"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.52.0.tgz",
-      "integrity": "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==",
-      "license": "MIT",
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "packages/ai-chat": {

--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -16,7 +16,7 @@
 import { AbstractStreamParsingChatAgent, ChatRequestModel, ChatService, ChatSession, MutableChatModel, MutableChatRequestModel } from '@theia/ai-chat/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from '../common/workspace-functions';
-import { CODER_SYSTEM_PROMPT_ID, getCoderAgentModePromptTemplate, getCoderReplacePromptTemplate, getCoderReplacePromptTemplateNext } from '../common/coder-replace-prompt-template';
+import { CODER_SYSTEM_PROMPT_ID, getCoderAgentModePromptTemplate, getCoderPromptTemplateEdit, getCoderPromptTemplateSimpleEdit } from '../common/coder-replace-prompt-template';
 import { SuggestFileContent } from './file-changeset-functions';
 import { LanguageModelRequirement, PromptVariantSet } from '@theia/ai-core';
 import { nls } from '@theia/core';
@@ -40,8 +40,8 @@ export class CoderAgent extends AbstractStreamParsingChatAgent {
         tasks involving file changes.');
     override prompts: PromptVariantSet[] = [{
         id: CODER_SYSTEM_PROMPT_ID,
-        defaultVariant: getCoderReplacePromptTemplate(true),
-        variants: [getCoderReplacePromptTemplate(false), getCoderReplacePromptTemplateNext(), getCoderAgentModePromptTemplate()]
+        defaultVariant: getCoderPromptTemplateEdit(),
+        variants: [getCoderPromptTemplateSimpleEdit(), getCoderAgentModePromptTemplate()]
     }];
     override functions = [GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, SuggestFileContent.ID];
     protected override systemPromptId: string | undefined = CODER_SYSTEM_PROMPT_ID;

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -22,9 +22,17 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { ContentReplacer, Replacement } from '@theia/core/lib/common/content-replacer';
 import { URI } from '@theia/core/lib/common/uri';
 
+import {
+    SUGGEST_FILE_CONTENT_ID,
+    WRITE_FILE_CONTENT_ID,
+    SUGGEST_FILE_REPLACEMENTS_ID,
+    WRITE_FILE_REPLACEMENTS_ID,
+    CLEAR_FILE_CHANGES_ID
+} from '../common/file-changeset-function-ids';
+
 @injectable()
 export class SuggestFileContent implements ToolProvider {
-    static ID = 'suggestFileContent';
+    static ID = SUGGEST_FILE_CONTENT_ID;
 
     @inject(WorkspaceFunctionScope)
     protected readonly workspaceFunctionScope: WorkspaceFunctionScope;
@@ -88,7 +96,7 @@ export class SuggestFileContent implements ToolProvider {
 
 @injectable()
 export class WriteFileContent implements ToolProvider {
-    static ID = 'writeFileContent';
+    static ID = WRITE_FILE_CONTENT_ID;
 
     @inject(WorkspaceFunctionScope)
     protected readonly workspaceFunctionScope: WorkspaceFunctionScope;
@@ -421,7 +429,7 @@ export class SimpleWriteFileReplacements implements ToolProvider {
 
 @injectable()
 export class SuggestFileReplacements implements ToolProvider {
-    static ID = 'suggestFileReplacements';
+    static ID = SUGGEST_FILE_REPLACEMENTS_ID;
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
@@ -440,7 +448,7 @@ export class SuggestFileReplacements implements ToolProvider {
 
 @injectable()
 export class WriteFileReplacements implements ToolProvider {
-    static ID = 'writeFileReplacements';
+    static ID = WRITE_FILE_REPLACEMENTS_ID;
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
@@ -459,7 +467,7 @@ export class WriteFileReplacements implements ToolProvider {
 
 @injectable()
 export class ClearFileChanges implements ToolProvider {
-    static ID = 'clearFileChanges';
+    static ID = CLEAR_FILE_CHANGES_ID;
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -27,7 +27,8 @@ import {
     WRITE_FILE_CONTENT_ID,
     SUGGEST_FILE_REPLACEMENTS_ID,
     WRITE_FILE_REPLACEMENTS_ID,
-    CLEAR_FILE_CHANGES_ID
+    CLEAR_FILE_CHANGES_ID,
+    GET_PROPOSED_CHANGES_ID
 } from '../common/file-changeset-function-ids';
 
 @injectable()
@@ -496,14 +497,14 @@ export class ClearFileChanges implements ToolProvider {
 
 @injectable()
 export class GetProposedFileState implements ToolProvider {
-    static ID = 'getProposedFileState';
+    static ID = GET_PROPOSED_CHANGES_ID;
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
     getTool(): ToolRequest {
         return {
-            id: GetProposedFileState.ID,
-            name: GetProposedFileState.ID,
+            id: GET_PROPOSED_CHANGES_ID,
+            name: GET_PROPOSED_CHANGES_ID,
             description: 'Returns the current proposed state of a file, including all pending changes that have been proposed ' +
                 'but not yet applied. This allows you to inspect the current state before making additional changes.',
             parameters: {

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -27,7 +27,8 @@ import {
     WRITE_FILE_CONTENT_ID,
     SUGGEST_FILE_REPLACEMENTS_ID,
     WRITE_FILE_REPLACEMENTS_ID,
-    CLEAR_FILE_CHANGES_ID
+    CLEAR_FILE_CHANGES_ID,
+    GET_PROPOSED_CHANGES_ID
 } from './file-changeset-function-ids';
 
 export const CODER_SYSTEM_PROMPT_ID = 'coder-prompt';
@@ -182,7 +183,7 @@ changes for.
 This also applies for newly created files!
 
 - **Always Retrieve Current Content**: Use getFileContent to get the original content of the target file.
-- **View Pending Changes**: Use ~{changeSet_getProposedFileState} to see the current proposed state of a file, including all pending changes.
+- **View Pending Changes**: Use ~{${GET_PROPOSED_CHANGES_ID}} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
   - ~{${SUGGEST_FILE_REPLACEMENTS_ID}}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
   - ~{${SUGGEST_FILE_CONTENT_ID}}: For complete file rewrites when you need to replace the entire content. 
@@ -251,7 +252,7 @@ changes for.
 This also applies for newly created files!
 
 - **Always Retrieve Current Content**: Use getFileContent to get the original content of the target file.
-- **View Pending Changes**: Use ~{changeSet_getProposedFileState} to see the current proposed state of a file, including all pending changes.
+- **View Pending Changes**: Use ~{${GET_PROPOSED_CHANGES_ID}} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
   - ~{${SUGGEST_FILE_REPLACEMENTS_ID}}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
   - ~{${SUGGEST_FILE_CONTENT_ID}}: For complete file rewrites when you need to replace the entire content. 

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -22,11 +22,18 @@ import {
 } from './workspace-functions';
 import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from './context-variables';
 import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
+import {
+    SUGGEST_FILE_CONTENT_ID,
+    WRITE_FILE_CONTENT_ID,
+    SUGGEST_FILE_REPLACEMENTS_ID,
+    WRITE_FILE_REPLACEMENTS_ID,
+    CLEAR_FILE_CHANGES_ID
+} from './file-changeset-function-ids';
 
 export const CODER_SYSTEM_PROMPT_ID = 'coder-prompt';
-export const CODER_REWRITE_PROMPT_TEMPLATE_ID = 'coder-rewrite';
-export const CODER_REPLACE_PROMPT_TEMPLATE_ID = 'coder-search-replace';
-export const CODER_REPLACE_PROMPT_TEMPLATE_NEXT_ID = 'coder-search-replace-next';
+
+export const CODER_SIMPLE_EDIT_TEMPLATE_ID = 'coder-simple-edit';
+export const CODER_EDIT_TEMPLATE_ID = 'coder-edit';
 export const CODER_AGENT_MODE_TEMPLATE_ID = 'coder-agent-mode';
 
 export function getCoderAgentModePromptTemplate(): BasePromptFragment {
@@ -43,6 +50,7 @@ You must independently analyze, fix, validate, and finalize all changes — only
 ## Autonomy and Persistence
 You are an agent. **Do not stop until** the entire task is complete:
 - All code changes are applied
+- The build succeeds
 - All lint issues are resolved
 - All relevant tests pass
 - New tests are written when needed
@@ -64,28 +72,28 @@ After each tool call:
 Never guess or hallucinate file content or structure. Use tools for all workspace interactions:
 
 ### Workspace Exploration
-- ~{getWorkspaceDirectoryStructure} — view overall structure
-- ~{getWorkspaceFileList} — list contents of a specific directory
-- ~{getFileContent} — retrieve the content of a file
-- ~{context_addFile} — bookmark important files for context
+- ~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}} — view overall structure
+- ~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}} — list contents of a specific directory
+- ~{${FILE_CONTENT_FUNCTION_ID}} — retrieve the content of a file
+- ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}}} — locate references or patterns (only search if you are missing information, always prefer examples that are explicitly provided, never \
+search for files you already know the path for)
+- ~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}} — bookmark important files for context
 
-### Search and Validation
-- ~{searchInWorkspace} — locate references or patterns
-- ~{getFileDiagnostics} — detect syntax, lint, or type errors
-
-### ✍️ Code Editing
+### Code Editing
 - Before editing, always retrieve file content
 - Use:
-  - ~{writeFileReplacements} — to immediately apply targeted code changes (no user review)
-  - ~{writeFileContent} — to immediately overwrite a file with new content (no user review)
-  - ~{simpleWriteFileReplacements} — to immediately apply a simple set of replacements (no user review)
-  - ~{clearFileChanges} — clear all pending changes for a file
-- For incremental changes, use multiple ~{writeFileReplacements} calls
-- Use the reset parameter with ~{writeFileReplacements} to clear previous changes
+  - ~{${WRITE_FILE_REPLACEMENTS_ID}} — to immediately apply targeted code changes (no user review)
+  - ~{${WRITE_FILE_CONTENT_ID}} — to immediately overwrite a file with new content (no user review)
+  - ~{${CLEAR_FILE_CHANGES_ID}} — clear all pending changes for a file
+- For incremental changes, use multiple ~{${WRITE_FILE_REPLACEMENTS_ID}} calls
+- Use the reset parameter with ~{${WRITE_FILE_REPLACEMENTS_ID}} to clear previous changes
+
+### Validation
+- ~{${GET_FILE_DIAGNOSTICS_ID}} — detect syntax, lint, or type errors
 
 ### Testing & Tasks
-- Use ~{listTasks} to discover available test and lint tasks
-- Use ~{runTask} to run linting, building, or test suites
+- Use ~{${LIST_TASKS_FUNCTION_ID}} to discover available test and lint tasks
+- Use ~{${RUN_TASK_FUNCTION_ID}} to run linting, building, or test suites
 
 ### Test Authoring
 If no relevant tests exist:
@@ -126,13 +134,15 @@ The following files have been provided for additional context. Some of them may 
 Always look at the relevant files to understand your task using the function ~{${FILE_CONTENT_FUNCTION_ID}}
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
-# Previously Proposed Changes
+# Previously Changed Files
 
 {{changeSetSummary}}
 
 # Project Info
 
 {{prompt:project-info}}
+
+{{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 
 # Final Instruction
 You are an autonomous AI agent. Do not stop until:
@@ -142,48 +152,56 @@ You are an autonomous AI agent. Do not stop until:
 - New tests are created if needed
 - No further action is required
 `,
-        ...({ variantOf: CODER_REPLACE_PROMPT_TEMPLATE_ID }),
+        ...({ variantOf: CODER_EDIT_TEMPLATE_ID }),
     };
 }
 
-export function getCoderReplacePromptTemplateNext(): BasePromptFragment {
+export function getCoderPromptTemplateEdit(): BasePromptFragment {
     return {
-        id: CODER_REPLACE_PROMPT_TEMPLATE_NEXT_ID,
+        id: CODER_EDIT_TEMPLATE_ID,
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes.
+You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes \
+which will be reviewed and accepted by the user.
 
 ## Context Retrieval
 Use the following functions to interact with the workspace files if you require context:
 - **~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}}**
 - **~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}**
 - **~{${FILE_CONTENT_FUNCTION_ID}}**
-- **~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}}**
+- **~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}}** (only search if you are missing information, always prefer examples that are explicitly provided, never search for files  \
+you already know the path for)
 
 Remember file locations that are relevant for completing your tasks using **~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}}**
 Only add files that are really relevant to look at later.
 
-## File Validation
-Use the following function to retrieve a list of problems in a file if the user requests fixes in a given file: **~{${GET_FILE_DIAGNOSTICS_ID}}**
-
 ## Propose Code Changes
-To propose code changes or any file changes to the user, never print code or new file content in your response.
+To propose code changes or any file changes to the user, never just output them as part of your response, but use the following functions, for each file you want to propose \
+changes for.
+This also applies for newly created files!
 
-Instead, for each file you want to propose changes for:
-- **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the original content of the target file.
-- **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
+- **Always Retrieve Current Content**: Use getFileContent to get the original content of the target file.
+- **View Pending Changes**: Use ~{changeSet_getProposedFileState} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{suggestFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{suggestFileContent}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{suggestFileReplacements} continuously fails use ~{suggestFileContent}.
-  - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.
+  - ~{${SUGGEST_FILE_REPLACEMENTS_ID}}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{${SUGGEST_FILE_CONTENT_ID}}: For complete file rewrites when you need to replace the entire content. 
+  - If ~{${SUGGEST_FILE_REPLACEMENTS_ID}} continuously fails use ~{${SUGGEST_FILE_CONTENT_ID}}.
+  - ~{${CLEAR_FILE_CHANGES_ID}}: To clear all pending changes for a file and start fresh.
 
-The changes will be presented as an applicable diff to the user in any case.
+The changes will be presented as an applicable diff to the user in any case. The user can then accept or reject each change individually. Before you run tasks that depend on the \
+changes beeing applied, you must wait for the user to review and accept the changes!
 
 ## Tasks
 
 The user might want you to execute some task. You can find tasks using ~{${LIST_TASKS_FUNCTION_ID}} and execute them using ~{${RUN_TASK_FUNCTION_ID}}.
+Be aware that tasks operate on the workspace. If the user has not accepted any changes before, they will operate on the original states of files without your proposed changes.
+Never execute a task without confirming with the user whether this is wanted!
+
+## File Validation
+
+Use the following function to retrieve a list of problems in a file if the user requests fixes in a given file: **~{${GET_FILE_DIAGNOSTICS_ID}}**
+Be aware this function operates on the workspace. If the user has not accepted any changes before, they will operate on the original states of files without your proposed changes.
 
 ## Additional Context
 
@@ -198,42 +216,50 @@ You have previously proposed changes for the following files. Some suggestions m
 {{prompt:project-info}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
-`,
-        ...({ variantOf: CODER_REPLACE_PROMPT_TEMPLATE_ID }),
-    };
+
+## Final Instruction
+- Your task is to propose changes to be reviewed by the user
+- Tasks such as building or liniting run on the workspace state, the user has to accept the changes beforehand
+- Do not run a build or any error checking before the users asks you to
+- Focus on the task that the user described
+`};
 }
-export function getCoderReplacePromptTemplate(withSearchAndReplace: boolean = false): BasePromptFragment {
+
+export function getCoderPromptTemplateSimpleEdit(): BasePromptFragment {
     return {
-        id: withSearchAndReplace ? CODER_REPLACE_PROMPT_TEMPLATE_ID : CODER_REWRITE_PROMPT_TEMPLATE_ID,
+        id: CODER_SIMPLE_EDIT_TEMPLATE_ID,
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes.
+You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes \
+which will be reviewed and accepted by the user.
 
 ## Context Retrieval
 Use the following functions to interact with the workspace files if you require context:
-- **~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}}**: Returns the complete directory structure.
-- **~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}**: Lists files and directories in a specific directory.
-- **~{${FILE_CONTENT_FUNCTION_ID}}**: Retrieves the content of a specific file.
-- **~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}}**: Remember file locations that are relevant for completing your tasks. Only add files that are really relevant to look at later.
+- **~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}}**
+- **~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}**
+- **~{${FILE_CONTENT_FUNCTION_ID}}**
+- **~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}}** (only search if you are missing information, always prefer examples that are explicitly provided, never search for files  \
+you already know the path for)
 
-## File Validation
-Use the following function to retrieve a list of problems in a file if the user requests fixes in a given file:
-- **~{${GET_FILE_DIAGNOSTICS_ID}}**: Retrieves a list of problems identified in a given file by tool integrations such as language servers and linters.
+Remember file locations that are relevant for completing your tasks using **~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}}**
+Only add files that are really relevant to look at later.
 
 ## Propose Code Changes
-To propose code changes or any file changes to the user, never print code or new file content in your response.
+To propose code changes or any file changes to the user, never just output them as part of your response, but use the following functions, for each file you want to propose \
+changes for.
+This also applies for newly created files!
 
-Instead, for each file you want to propose changes for:
-- **Always Retrieve Current Content**: Use ${FILE_CONTENT_FUNCTION_ID} to get the original content of the target file.
-- **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
+- **Always Retrieve Current Content**: Use getFileContent to get the original content of the target file.
+- **View Pending Changes**: Use ~{changeSet_getProposedFileState} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{suggestFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{suggestFileContent}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{suggestFileReplacements} continuously fails use ~{suggestFileContent}.
-  - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.
+  - ~{${SUGGEST_FILE_REPLACEMENTS_ID}}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{${SUGGEST_FILE_CONTENT_ID}}: For complete file rewrites when you need to replace the entire content. 
+  - If ~{${SUGGEST_FILE_REPLACEMENTS_ID}} continuously fails use ~{${SUGGEST_FILE_CONTENT_ID}}.
+  - ~{${CLEAR_FILE_CHANGES_ID}}: To clear all pending changes for a file and start fresh.
 
-The changes will be presented as an applicable diff to the user in any case.
+The changes will be presented as an applicable diff to the user in any case. The user can then accept or reject each change individually. Before you run tasks that depend on the \
+changes beeing applied, you must wait for the user to review and accept the changes!
 
 ## Additional Context
 
@@ -241,12 +267,20 @@ The following files have been provided for additional context. Some of them may 
 Always look at the relevant files to understand your task using the function ~{${FILE_CONTENT_FUNCTION_ID}}
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
+## Previously Proposed Changes
+You have previously proposed changes for the following files. Some suggestions may have been accepted by the user, while others may still be pending.
 {{${CHANGE_SET_SUMMARY_VARIABLE_ID}}}
 
 {{prompt:project-info}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
+
+## Final Instruction
+- Your task is to propose changes to be reviewed by the user
+- Tasks such as building or liniting run on the workspace state, the user has to accept the changes beforehand
+- Do not run a build or any error checking before the users asks you to
+- Focus on the task that the user described
 `,
-        ...(!withSearchAndReplace ? { variantOf: CODER_REPLACE_PROMPT_TEMPLATE_ID } : {}),
+        ...({ variantOf: CODER_EDIT_TEMPLATE_ID }),
     };
 }

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -246,7 +246,7 @@ Remember file locations that are relevant for completing your tasks using **~{${
 Only add files that are really relevant to look at later.
 
 ## Propose Code Changes
-To propose code changes or any file changes to the user, never just output them as part of your response, but use the following functions, for each file you want to propose \
+To propose code changes or any file changes to the user, never just output them as part of your response, but use the following functions for each file you want to propose \
 changes for.
 This also applies for newly created files!
 

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -177,7 +177,7 @@ Remember file locations that are relevant for completing your tasks using **~{${
 Only add files that are really relevant to look at later.
 
 ## Propose Code Changes
-To propose code changes or any file changes to the user, never just output them as part of your response, but use the following functions, for each file you want to propose \
+To propose code changes or any file changes to the user, never just output them as part of your response, but use the following functions for each file you want to propose \
 changes for.
 This also applies for newly created files!
 

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -162,7 +162,7 @@ export function getCoderPromptTemplateEdit(): BasePromptFragment {
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes \
+You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes, \
 which will be reviewed and accepted by the user.
 
 ## Context Retrieval

--- a/packages/ai-ide/src/common/file-changeset-function-ids.ts
+++ b/packages/ai-ide/src/common/file-changeset-function-ids.ts
@@ -19,3 +19,4 @@ export const WRITE_FILE_CONTENT_ID = 'writeFileContent';
 export const SUGGEST_FILE_REPLACEMENTS_ID = 'suggestFileReplacements';
 export const WRITE_FILE_REPLACEMENTS_ID = 'writeFileReplacements';
 export const CLEAR_FILE_CHANGES_ID = 'clearFileChanges';
+export const GET_PROPOSED_CHANGES_ID = 'getProposedFileState'

--- a/packages/ai-ide/src/common/file-changeset-function-ids.ts
+++ b/packages/ai-ide/src/common/file-changeset-function-ids.ts
@@ -19,4 +19,4 @@ export const WRITE_FILE_CONTENT_ID = 'writeFileContent';
 export const SUGGEST_FILE_REPLACEMENTS_ID = 'suggestFileReplacements';
 export const WRITE_FILE_REPLACEMENTS_ID = 'writeFileReplacements';
 export const CLEAR_FILE_CHANGES_ID = 'clearFileChanges';
-export const GET_PROPOSED_CHANGES_ID = 'getProposedFileState'
+export const GET_PROPOSED_CHANGES_ID = 'getProposedFileState';

--- a/packages/ai-ide/src/common/file-changeset-function-ids.ts
+++ b/packages/ai-ide/src/common/file-changeset-function-ids.ts
@@ -1,0 +1,21 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export const SUGGEST_FILE_CONTENT_ID = 'suggestFileContent';
+export const WRITE_FILE_CONTENT_ID = 'writeFileContent';
+export const SUGGEST_FILE_REPLACEMENTS_ID = 'suggestFileReplacements';
+export const WRITE_FILE_REPLACEMENTS_ID = 'writeFileReplacements';
+export const CLEAR_FILE_CHANGES_ID = 'clearFileChanges';


### PR DESCRIPTION
#### What it does

Consolidate Coder prompts to:

- Edit (Default): Supposed to support with edits, uses the change set in suggestion mode. Can also run tasks and validate, but should for most LLMs only do this on requequest
- Simple-Edit: same, but no tasks and no validation
- Agent Mode

#### How to test

Use all different prompts. They might behave very differently with different LLMs

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
