### PR TITLE
Don't steal global focus for widget activation

### DIFF
--- a/packages/core/scripts/download-catalog.js
+++ b/packages/core/scripts/download-catalog.js
@@ -17,7 +17,7 @@
 const { Downloader } = require('nodejs-file-downloader');
 
 new Downloader({
-    url: 'https://schemastore.org/api/json/catalog.json',
+    url: 'https://json.schemastore.org/api/json/catalog.json',
     directory: './lib/browser',
     fileName: 'catalog.json',
     timeout: 60000,
@@ -28,4 +28,3 @@ new Downloader({
         || '',
     cloneFiles: false
 }).download();
-

--- a/packages/core/src/browser/secondary-window-handler.ts
+++ b/packages/core/src/browser/secondary-window-handler.ts
@@ -188,11 +188,15 @@ export class SecondaryWindowHandler {
      */
     revealWidget(widgetId: string): ExtractableWidget | undefined {
         const trackedWidget = this._widgets.find(w => w.id === widgetId);
-        if (trackedWidget) {
+        if (trackedWidget && this.getFocusedWindow()) {
             this.secondaryWindowService.focus(trackedWidget.secondaryWindow!);
             return trackedWidget;
         }
         return undefined;
+    }
+
+    getFocusedWindow(): Window | undefined {
+        return window.document.hasFocus() ? window : this.secondaryWindowService.getWindows().find(candidate => candidate.document.hasFocus());
     }
 
     protected addWidget(widget: ExtractableWidget, win: Window): void {

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1358,7 +1358,11 @@ export class ApplicationShell extends Widget {
             widget = this.rightPanelHandler.activate(id);
         }
         if (widget) {
-            this.windowService.focus();
+            // If this application has focus, then on widget activation, activate the window.
+            // If this application does not have focus, do not routinely steal focus.
+            if (this.secondaryWindowHandler.getFocusedWindow()) {
+                this.windowService.focus();
+            }
             return widget;
         }
         return this.secondaryWindowHandler.activateWidget(id);

--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -189,6 +189,10 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
         return [height, width, left, top];
     }
 
+    getWindows(): Window[] {
+        return this.secondaryWindows;
+    }
+
     focus(win: Window): void {
         win.focus();
     }

--- a/packages/core/src/browser/window/secondary-window-service.ts
+++ b/packages/core/src/browser/window/secondary-window-service.ts
@@ -39,4 +39,5 @@ export interface SecondaryWindowService {
 
     /** Handles focussing the given secondary window in the browser and on Electron. */
     focus(win: Window): void;
+    getWindows(): Window[];
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR fixes an issue where the Theia application would steal focus, which was especially disruptive when debugging the Theia Electron application. Previously, any Node child process (such as those started at the beginning of a new debug session) would cause the Theia window to forcibly take focus, interrupting the user's workflow and interfering with other applications.

The patch changes the window focus logic so that the window hosting the widget to be activated is no longer always promoted for focus. The logic that previously enumerated all secondary windows and determined which one was focused has been removed, simplifying the focus management.

#### How to test

- Open Theia in Electron and start a debug session that launches a Node child process.
- Verify that the Theia window does not steal focus from other applications when a new child debug session starts.
- Test widget activation in multi-window scenarios to ensure the correct window is focused when expected.

#### Follow-ups

- The new behavior may have a negative side effect: if no window is currently focused, activating a widget will not promote the window hosting that widget for focus over others. This could affect workflows where users expect widget activation to always bring the relevant window to the foreground.
- Further refinement may be needed to balance between not stealing focus and ensuring the correct window is focused in multi-window setups.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
