### PR TITLE
enable Agent-to-Agent Delegation via Tool Calls

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -36,6 +36,7 @@ import {
     ToolCallPartRenderer,
     ThinkingPartRenderer,
     ProgressPartRenderer,
+    DelegationResponseRenderer,
 } from './chat-response-renderer';
 import {
     GitHubSelectionResolver,
@@ -53,6 +54,7 @@ import { ContextVariablePicker } from './context-variable-picker';
 import { ChangeSetActionRenderer, ChangeSetActionService } from './change-set-actions/change-set-action-service';
 import { ChangeSetAcceptAction } from './change-set-actions/change-set-accept-action';
 import { AIChatTreeInputArgs, AIChatTreeInputConfiguration, AIChatTreeInputFactory, AIChatTreeInputWidget } from './chat-tree-view/chat-view-tree-input-widget';
+import { SubChatWidget, SubChatWidgetFactory } from './chat-tree-view/sub-chat-widget';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindViewContribution(bind, AIChatContribution);
@@ -118,6 +120,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(ChatResponsePartRenderer).to(ThinkingPartRenderer).inSingletonScope();
     bind(ChatResponsePartRenderer).to(QuestionPartRenderer).inSingletonScope();
     bind(ChatResponsePartRenderer).to(ProgressPartRenderer).inSingletonScope();
+    bind(ChatResponsePartRenderer).to(DelegationResponseRenderer).inSingletonScope();
     [CommandContribution, MenuContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).to(ChatViewMenuContribution).inSingletonScope()
     );
@@ -144,6 +147,14 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindContributionProvider(bind, ChatNodeToolbarActionContribution);
     bind(DefaultChatNodeToolbarActionContribution).toSelf().inSingletonScope();
     bind(ChatNodeToolbarActionContribution).toService(DefaultChatNodeToolbarActionContribution);
+
+    bind(SubChatWidgetFactory).toFactory(ctx => () => {
+        const container = ctx.container.createChild();
+        container.bind(SubChatWidget).toSelf().inSingletonScope();
+        const widget = container.get(SubChatWidget);
+        return widget;
+    });
+
 });
 
 function bindChatViewWidget(bind: interfaces.Bind): void {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-response-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-response-renderer.tsx
@@ -1,0 +1,106 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { ChatRequestInvocation, ChatResponseContent, ChatResponseModel } from '@theia/ai-chat';
+import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
+import * as React from '@theia/core/shared/react';
+import { DelegationResponseContent, isDelegationResponseContent } from '@theia/ai-chat/lib/browser/delegation-response-content';
+import { ResponseNode } from '../chat-tree-view';
+import { CompositeTreeNode } from '@theia/core/lib/browser';
+import { SubChatWidgetFactory } from '../chat-tree-view/sub-chat-widget';
+
+@injectable()
+export class DelegationResponseRenderer implements ChatResponsePartRenderer<DelegationResponseContent> {
+
+    @inject(SubChatWidgetFactory)
+    subChatWidgetFactory: SubChatWidgetFactory;
+
+    canHandle(response: ChatResponseContent): number {
+        if (isDelegationResponseContent(response)) {
+            return 10;
+        }
+        return -1;
+    }
+    render(response: DelegationResponseContent, parentNode: ResponseNode): React.ReactNode {
+        return this.renderExpandableNode(response, parentNode);
+    }
+
+    private renderExpandableNode(response: DelegationResponseContent, parentNode: ResponseNode): React.ReactNode {
+        return <DelegatedChat
+            response={response.response}
+            agentId={response.agentId}
+            prompt={response.prompt}
+            parentNode={parentNode}
+            subChatWidgetFactory={this.subChatWidgetFactory} />;
+    }
+}
+
+interface DelegatedChatProps {
+    response: ChatRequestInvocation;
+    agentId: string;
+    prompt: string;
+    parentNode: ResponseNode;
+    subChatWidgetFactory: SubChatWidgetFactory;
+}
+
+interface DelegatedChatState {
+    node?: ResponseNode;
+}
+
+class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatState> {
+    private widget: ReturnType<SubChatWidgetFactory>;
+
+    constructor(props: DelegatedChatProps) {
+        super(props);
+        this.state = {
+            node: undefined
+        };
+        this.widget = props.subChatWidgetFactory();
+    }
+
+    override componentDidMount(): void {
+        this.props.response.responseCompleted.then(chatModel => {
+            this.setState({ node: mapResponseToNode(chatModel, this.props.parentNode) });
+        });
+    }
+
+    override render(): React.ReactNode {
+        const { agentId, prompt } = this.props;
+        return (
+            <div className="theia-toolCall">
+                <details className="delegation-response-details">
+                    <summary>
+                        <strong>Agent:</strong> {agentId}
+                    </summary>
+                    <div>
+                        <div><strong>Delegated prompt:</strong> {prompt}</div>
+                        <div className='delegation-response-placeholder'>
+                            {this.state.node && this.widget.renderChatResponse(this.state.node)}
+                        </div>
+                    </div>
+                </details>
+            </div>
+        );
+    }
+}
+
+function mapResponseToNode(response: ChatResponseModel, parentNode: ResponseNode): ResponseNode {
+    return {
+        id: response.id,
+        parent: parentNode as unknown as CompositeTreeNode,
+        response
+    };
+}

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-response-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-response-renderer.tsx
@@ -102,7 +102,6 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
     }
 
     override componentWillUnmount(): void {
-        // Clean up all disposables to prevent memory leaks
         this.toDispose.dispose();
     }
 

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-response-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-response-renderer.tsx
@@ -113,30 +113,53 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
         const isCanceled = this.state.node?.response.isCanceled ?? false;
         const isError = this.state.node?.response.isError ?? false;
 
-        let statusIndicator = '';
-        if (hasNode && !isComplete) {
-            if (isCanceled) {
-                statusIndicator = ' (canceled)';
+        let statusIcon = '';
+        let statusText = '';
+        if (hasNode) {
+            if (isComplete) {
+                statusIcon = 'codicon-check';
+                statusText = 'completed';
+            } else if (isCanceled) {
+                statusIcon = 'codicon-cancel';
+                statusText = 'canceled';
             } else if (isError) {
-                statusIndicator = ' (error)';
+                statusIcon = 'codicon-error';
+                statusText = 'error';
             } else {
-                statusIndicator = ' (generating...)';
+                statusIcon = 'codicon-loading';
+                statusText = 'generating...';
             }
+        } else {
+            statusIcon = 'codicon-loading';
+            statusText = 'starting...';
         }
 
         return (
-            <div className="theia-toolCall">
+            <div className="theia-delegation-container">
                 <details className="delegation-response-details">
-                    <summary>
-                        <strong>Agent:</strong> {agentId}
-                        {statusIndicator && <span className="theia-ChatContentInProgress">{statusIndicator}</span>}
+                    <summary className="delegation-summary">
+                        <div className="delegation-header">
+                            <span className="delegation-agent">
+                                <strong>Agent:</strong> {agentId}
+                            </span>
+                            <span className="delegation-status">
+                                <span className={`codicon ${statusIcon} delegation-status-icon`}></span>
+                                <span className="delegation-status-text">{statusText}</span>
+                            </span>
+                        </div>
                     </summary>
-                    <div>
-                        <div><strong>Delegated prompt:</strong> {prompt}</div>
-                        <div className='delegation-response-placeholder'>
-                            {hasNode && this.state.node ? this.widget.renderChatResponse(this.state.node) :
-                                <div className="theia-ChatContentInProgress">Starting delegation...</div>
-                            }
+                    <div className="delegation-content">
+                        <div className="delegation-prompt-section">
+                            <strong>Delegated prompt:</strong>
+                            <div className="delegation-prompt">{prompt}</div>
+                        </div>
+                        <div className="delegation-response-section">
+                            <strong>Response:</strong>
+                            <div className='delegation-response-placeholder'>
+                                {hasNode && this.state.node ? this.widget.renderChatResponse(this.state.node) :
+                                    <div className="theia-ChatContentInProgress">Starting delegation...</div>
+                                }
+                            </div>
                         </div>
                     </div>
                 </details>

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/index.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/index.ts
@@ -24,3 +24,4 @@ export * from './toolcall-part-renderer';
 export * from './thinking-part-renderer';
 export * from './progress-part-renderer';
 export * from './tool-confirmation';
+export * from './delegation-response-renderer';

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/sub-chat-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/sub-chat-widget.tsx
@@ -1,0 +1,101 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { ProgressMessage } from '../chat-progress-message';
+import { ChatViewTreeWidget, ResponseNode } from './chat-view-tree-widget';
+import * as React from '@theia/core/shared/react';
+import { ContributionProvider } from '@theia/core';
+import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
+import { ChatNodeToolbarActionContribution } from '../chat-node-toolbar-action-contribution';
+import { ChatResponseContent } from '@theia/ai-chat';
+import { ContextMenuRenderer, TreeNode } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/common/nls';
+
+/**
+ * Subset of the ChatViewTreeWidget used to render ResponseNodes for delegated prompts.
+ */
+@injectable()
+export class SubChatWidget {
+
+    @inject(ContributionProvider) @named(ChatResponsePartRenderer)
+    protected readonly chatResponsePartRenderers: ContributionProvider<ChatResponsePartRenderer<ChatResponseContent>>;
+
+    @inject(ContributionProvider) @named(ChatNodeToolbarActionContribution)
+    protected readonly chatNodeToolbarActionContributions: ContributionProvider<ChatNodeToolbarActionContribution>;
+
+    @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer;
+
+    renderChatResponse(node: ResponseNode): React.ReactNode {
+        return (
+            <div className={'theia-ResponseNode'}>
+                {!node.response.isComplete
+                    && node.response.response.content.length === 0
+                    && node.response.progressMessages
+                        .filter(c => c.show === 'untilFirstContent')
+                        .map((c, i) =>
+                            <ProgressMessage {...c} key={`${node.id}-progress-untilFirstContent-${i}`} />
+                        )
+                }
+                {node.response.response.content.map((c, i) =>
+                    <div className='theia-ResponseNode-Content' key={`${node.id}-content-${i}`}>{this.getChatResponsePartRenderer(c, node)}</div>
+                )}
+                {!node.response.isComplete
+                    && node.response.progressMessages
+                        .filter(c => c.show === 'whileIncomplete')
+                        .map((c, i) =>
+                            <ProgressMessage {...c} key={`${node.id}-progress-whileIncomplete-${i}`} />
+                        )
+                }
+                {node.response.progressMessages
+                    .filter(c => c.show === 'forever')
+                    .map((c, i) =>
+                        <ProgressMessage {...c} key={`${node.id}-progress-afterComplete-${i}`} />
+                    )
+                }
+            </div>
+        );
+    }
+
+    protected getChatResponsePartRenderer(content: ChatResponseContent, node: ResponseNode): React.ReactNode {
+        const renderer = this.chatResponsePartRenderers.getContributions().reduce<[number, ChatResponsePartRenderer<ChatResponseContent> | undefined]>(
+            (prev, current) => {
+                const prio = current.canHandle(content);
+                if (prio > prev[0]) {
+                    return [prio, current];
+                } return prev;
+            },
+            [-1, undefined])[1];
+        if (!renderer) {
+            console.error('No renderer found for content', content);
+            return <div>{nls.localize('theia/ai/chat-ui/chat-view-tree-widget/noRenderer', 'Error: No renderer found')}</div>;
+        }
+        return renderer.render(content, node);
+    }
+
+    protected handleContextMenu(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        this.contextMenuRenderer.render({
+            menuPath: ChatViewTreeWidget.CONTEXT_MENU,
+            anchor: { x: event.clientX, y: event.clientY },
+            args: [node],
+            context: event.currentTarget
+        });
+        event.preventDefault();
+    }
+}
+
+export const SubChatWidgetFactory = Symbol('SubChatWidgetFactory');
+export type SubChatWidgetFactory = () => SubChatWidget;

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -958,3 +958,144 @@ details[open].collapsible-arguments .collapsible-arguments-summary {
   padding-block-end: 8px;
   user-select: none;
 }
+
+/* Delegation response styles */
+.theia-delegation-container {
+  border: 2px solid var(--theia-sideBarSectionHeader-border);
+  border-radius: 8px;
+  margin: 8px 0;
+  background-color: var(--theia-sideBar-background);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.delegation-response-details {
+  width: 100%;
+}
+
+.delegation-summary {
+  cursor: pointer;
+  padding: 12px 16px;
+  background-color: var(--theia-editorGroupHeader-tabsBackground);
+  border-radius: 6px 6px 0 0;
+  border-bottom: 1px solid var(--theia-sideBarSectionHeader-border);
+  list-style: none;
+  position: relative;
+}
+
+.delegation-summary:hover {
+  background-color: var(--theia-toolbar-hoverBackground);
+}
+
+.delegation-summary::before {
+  content: '\25BC';
+  /* Down arrow */
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  transition: transform 0.2s ease;
+  color: var(--theia-descriptionForeground);
+  font-size: 12px;
+}
+
+.delegation-response-details:not([open]) .delegation-summary::before {
+  transform: translateY(-50%) rotate(-90deg);
+  /* Right arrow when closed */
+}
+
+.delegation-response-details:not([open]) .delegation-summary {
+  border-bottom: none;
+  border-radius: 6px;
+}
+
+.delegation-summary::-webkit-details-marker {
+  display: none;
+}
+
+.delegation-summary::marker {
+  content: '';
+}
+
+.delegation-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 16px;
+}
+
+.delegation-agent {
+  flex: 1;
+  /* Takes up available space */
+  font-size: 14px;
+  color: var(--theia-foreground);
+}
+
+.delegation-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  /* Leave space for the arrow */
+  margin-right: 24px;
+}
+
+.delegation-status-icon {
+  font-size: 16px;
+}
+
+.delegation-status-icon.codicon-loading {
+  animation: spin 2s linear infinite;
+  color: var(--theia-progressBar-background);
+}
+
+.delegation-status-icon.codicon-check {
+  color: var(--theia-charts-green);
+}
+
+.delegation-status-icon.codicon-error {
+  color: var(--theia-errorForeground);
+}
+
+.delegation-status-icon.codicon-cancel {
+  color: var(--theia-charts-orange);
+}
+
+.delegation-status-text {
+  color: var(--theia-descriptionForeground);
+  font-weight: normal;
+}
+
+.delegation-content {
+  padding: 16px;
+}
+
+.delegation-prompt-section {
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--theia-sideBarSectionHeader-border);
+}
+
+.delegation-prompt {
+  margin-top: 6px;
+  padding: 8px 12px;
+  background-color: var(--theia-editor-background);
+  border-radius: 4px;
+  border: 1px solid var(--theia-dropdown-border);
+  font-style: italic;
+  color: var(--theia-descriptionForeground);
+}
+
+.delegation-response-section {
+  margin-top: 16px;
+}
+
+.delegation-response-section>strong {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--theia-foreground);
+}
+
+.delegation-response-placeholder {
+  margin-top: 8px;
+  min-height: 40px;
+}

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2024 EclipseSource GmbH.
+// Copyright (C) 2025 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -1,0 +1,154 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ToolProvider, ToolRequest } from '@theia/ai-core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import {
+    ChatAgentService,
+    ChatAgentServiceFactory,
+    ChatRequest,
+    ChatService,
+    ChatServiceFactory,
+    MutableChatRequestModel,
+} from '../common';
+import { DelegationResponseContent } from './delegation-response-content';
+
+export const AGENT_DELEGATION_FUNCTION_ID = 'delegateToAgent';
+
+@injectable()
+export class AgentDelegationTool implements ToolProvider {
+    static ID = AGENT_DELEGATION_FUNCTION_ID;
+
+    @inject(ChatAgentServiceFactory)
+    protected readonly getChatAgentService: () => ChatAgentService;
+
+    @inject(ChatServiceFactory)
+    protected readonly getChatService: () => ChatService;
+
+    getTool(): ToolRequest {
+        return {
+            id: AgentDelegationTool.ID,
+            name: AgentDelegationTool.ID,
+            description:
+                'Delegate a task or question to a specific AI agent. This tool allows you to route requests to specialized agents based on their capabilities.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    agentName: {
+                        type: 'string',
+                        description:
+                            'The name/ID of the AI agent to delegate the task to. Available agents can be found using the chatAgents variable.',
+                    },
+                    prompt: {
+                        type: 'string',
+                        description:
+                            'The task, question, or prompt to pass to the specified agent.',
+                    },
+                },
+                required: ['agentName', 'prompt'],
+            },
+            handler: (arg_string: string, ctx: MutableChatRequestModel) =>
+                this.delegateToAgent(arg_string, ctx),
+        };
+    }
+
+    private async delegateToAgent(
+        arg_string: string,
+        ctx: MutableChatRequestModel
+    ): Promise<string> {
+        try {
+            const args = JSON.parse(arg_string);
+            const { agentName, prompt } = args;
+
+            if (!agentName || !prompt) {
+                const errorMsg = 'Both agentName and prompt parameters are required.';
+                console.error(errorMsg, { agentName, prompt });
+                return errorMsg;
+            }
+
+            // Check if the specified agent exists
+            const agent = this.getChatAgentService().getAgent(agentName);
+            if (!agent) {
+                const availableAgents = this.getChatAgentService()
+                    .getAgents()
+                    .map(a => a.id);
+                const errorMsg = `Agent '${agentName}' not found or not enabled. Available agents: ${availableAgents.join(', ')}`;
+                console.error(errorMsg);
+                return errorMsg;
+            }
+
+            let newSession;
+            try {
+                // FIXME: this creates a new conversation visible in the UI (Panel), which we don't want
+                // It is not possible to start a session without specifying a location (default=Panel)
+                const chatService = this.getChatService();
+                newSession = chatService.createSession(
+                    undefined,
+                    { focus: false },
+                    agent
+                );
+            } catch (sessionError) {
+                const errorMsg = `Failed to create chat session for agent '${agentName}': ${sessionError instanceof Error ? sessionError.message : sessionError}`;
+                console.error(errorMsg, sessionError);
+                return errorMsg;
+            }
+
+            // Send the request
+            const chatRequest: ChatRequest = {
+                text: prompt,
+            };
+
+            let response;
+            try {
+                const chatService = this.getChatService();
+                response = await chatService.sendRequest(
+                    newSession.id,
+                    chatRequest
+                );
+            } catch (sendError) {
+                const errorMsg = `Failed to send request to agent '${agentName}': ${sendError instanceof Error ? sendError.message : sendError}`;
+                console.error(errorMsg, sendError);
+                return errorMsg;
+            }
+
+            if (response) {
+                try {
+                    const result = await response.responseCompleted;
+                    const stringResult = result.response.asString();
+                    // Add a new response part that will be fully rendered in its own section
+                    ctx.response.response.addContent(
+                        new DelegationResponseContent(agentName, prompt, response)
+                    );
+                    // Also return the raw text to the top-level Agent, as a tool result
+                    return stringResult;
+                } catch (completionError) {
+                    const errorMsg = `Failed to complete response from agent '${agentName}': ${completionError instanceof Error ? completionError.message : completionError}`;
+                    console.error(errorMsg, completionError);
+                    return errorMsg;
+                }
+            } else {
+                const errorMsg = `Delegation to agent '${agentName}' has failed: no response returned.`;
+                console.error(errorMsg);
+                return errorMsg;
+            }
+        } catch (error) {
+            console.error('Failed to delegate to agent', error);
+            return JSON.stringify({
+                error: `Failed to parse arguments or delegate to agent: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            });
+        }
+    }
+}

--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Agent, AgentService, AIVariableContribution } from '@theia/ai-core/lib/common';
+import { Agent, AgentService, AIVariableContribution, bindToolProvider } from '@theia/ai-core/lib/common';
 import { bindContributionProvider, CommandContribution } from '@theia/core';
 import { FrontendApplicationContribution, LabelProviderContribution, PreferenceContribution } from '@theia/core/lib/browser';
 import { ContainerModule } from '@theia/core/shared/inversify';
@@ -26,7 +26,9 @@ import {
     ChatRequestParserImpl,
     ChatService,
     ToolCallChatResponseContentFactory,
-    PinChatAgent
+    PinChatAgent,
+    ChatServiceFactory,
+    ChatAgentServiceFactory
 } from '../common';
 import { ChatAgentsVariableContribution } from '../common/chat-agents-variable-contribution';
 import { CustomChatAgent } from '../common/custom-chat-agent';
@@ -55,6 +57,7 @@ import { TaskContextService, TaskContextStorageService } from './task-context-se
 import { InMemoryTaskContextStorage } from './task-context-storage-service';
 import { AIChatFrontendContribution } from './ai-chat-frontend-contribution';
 import { ImageContextVariableContribution } from './image-context-variable-contribution';
+import { AgentDelegationTool } from './agent-delegation-tool';
 
 export default new ContainerModule(bind => {
     bindContributionProvider(bind, Agent);
@@ -83,6 +86,13 @@ export default new ContainerModule(bind => {
 
     bind(FrontendChatServiceImpl).toSelf().inSingletonScope();
     bind(ChatService).toService(FrontendChatServiceImpl);
+
+    bind(ChatServiceFactory).toDynamicValue(ctx => () =>
+        ctx.container.get<ChatService>(ChatService)
+    );
+    bind(ChatAgentServiceFactory).toDynamicValue(ctx => () =>
+        ctx.container.get<ChatAgentService>(ChatAgentService)
+    );
 
     bind(PreferenceContribution).toConstantValue({ schema: aiChatPreferences });
 
@@ -146,4 +156,6 @@ export default new ContainerModule(bind => {
     bind(TaskContextStorageService).toService(InMemoryTaskContextStorage);
     bind(AIChatFrontendContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(AIChatFrontendContribution);
+
+    bindToolProvider(AgentDelegationTool, bind);
 });

--- a/packages/ai-chat/src/browser/delegation-response-content.ts
+++ b/packages/ai-chat/src/browser/delegation-response-content.ts
@@ -1,0 +1,55 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { isObject } from '@theia/core';
+import { ChatRequestInvocation, ChatResponseContent } from '../common';
+
+/**
+ * Response Content created when an Agent delegates a prompt to another agent.
+ * Contains agent id, delegated prompt, and the response.
+ */
+export class DelegationResponseContent implements ChatResponseContent {
+    kind = 'AgentDelegation';
+
+    /**
+     * @param agentId The id of the agent to whom the task was delegated
+     * @param prompt The prompt that was delegated
+     * @param response The response from the delegated agent
+     */
+    constructor(
+        public agentId: string,
+        public prompt: string,
+        public response: ChatRequestInvocation
+    ) {
+        // Empty
+    }
+
+    asString(): string {
+        const json = {
+            agentId: this.agentId,
+            prompt: this.prompt
+        };
+        return JSON.stringify(json);
+    }
+}
+
+export function isDelegationResponseContent(
+    value: unknown
+): value is DelegationResponseContent {
+    return (
+        isObject<DelegationResponseContent>(value) &&
+        value.kind === 'AgentDelegation'
+    );
+}

--- a/packages/ai-chat/src/common/chat-agent-service.ts
+++ b/packages/ai-chat/src/common/chat-agent-service.ts
@@ -25,6 +25,7 @@ import { ChatAgent } from './chat-agents';
 import { AgentService } from '@theia/ai-core';
 
 export const ChatAgentService = Symbol('ChatAgentService');
+export const ChatAgentServiceFactory = Symbol('ChatAgentServiceFactory');
 /**
  * The ChatAgentService provides access to the available chat agents.
  */

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -119,6 +119,7 @@ export const PinChatAgent = Symbol('PinChatAgent');
 export type PinChatAgent = boolean;
 
 export const ChatService = Symbol('ChatService');
+export const ChatServiceFactory = Symbol('ChatServiceFactory');
 export interface ChatService {
     onSessionEvent: Event<ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent>
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Add a new AI Tool Provider allowing an Agent to delegate a prompt to another Agent and get the result back. The result is also displayed in a (collapsed) section in the main conversation. The delegation supports the following features:

- Display the delegated chat in a collapsed section
- Bubble-up the change sets from the delegated chat to the current chat
- Support streaming mode in the delegated chat

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The tool needs to be added to your system prompt. For example:

```md
## Delegation
You can delegate tasks to other agents with this tool:
- **~{delegateToAgent}**

Agents available for delegation are:
- `Architect`: to analyse the current code base and design new features
- `Coder`: to implement code
- `Universal`: for general purpose questions
```

Then prompt for delegation (For real-world use cases, the Agents might be smart enough to delegate on their own when they need to; but for testing it's easier to just explicitly request it). Example prompt:

`@Architect ask Universal why the sky is blue, then give me a summary`

![image](https://github.com/user-attachments/assets/0ba0adef-6ced-4d9e-b909-0b9d41ab30a7)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- Currently, we create a new session to handle the delegated prompt. This is shown as a regular Chat in the UI, with which the user can interact. We should probably hide it somehow.
- Scrolling could be improved (the parent chat only updates scroll when receiving new tokens; but in this case, the tokens are coming to the delegated chat. Parent UI is not aware of this). This is only an issue when the delegated chat section is expanded.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
