### PR TITLE
Make Workspace Search function more efficient / use less tokens

### DIFF
--- a/packages/ai-ide/src/browser/workspace-preferences.ts
+++ b/packages/ai-ide/src/browser/workspace-preferences.ts
@@ -52,7 +52,7 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
             title: nls.localize('theia/ai/workspace/searchMaxResults/title', 'Maximum Search Results'),
             description: nls.localize('theia/ai/workspace/searchMaxResults/description',
                 'Maximum number of search results returned by the workspace search function.'),
-            default: 50,
+            default: 30,
             minimum: 1
         },
         [PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF]: {

--- a/packages/ai-ide/src/browser/workspace-preferences.ts
+++ b/packages/ai-ide/src/browser/workspace-preferences.ts
@@ -19,6 +19,7 @@ import { PreferenceSchema } from '@theia/core/lib/browser/preferences/preference
 
 export const CONSIDER_GITIGNORE_PREF = 'ai-features.workspaceFunctions.considerGitIgnore';
 export const USER_EXCLUDE_PATTERN_PREF = 'ai-features.workspaceFunctions.userExcludes';
+export const SEARCH_IN_WORKSPACE_MAX_RESULTS_PREF = 'ai-features.workspaceFunctions.searchMaxResults';
 export const PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF = 'ai-features.promptTemplates.WorkspaceTemplateDirectories';
 export const PROMPT_TEMPLATE_ADDITIONAL_EXTENSIONS_PREF = 'ai-features.promptTemplates.TemplateExtensions';
 export const PROMPT_TEMPLATE_WORKSPACE_FILES_PREF = 'ai-features.promptTemplates.WorkspaceTemplateFiles';
@@ -45,6 +46,14 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
             items: {
                 type: 'string'
             }
+        },
+        [SEARCH_IN_WORKSPACE_MAX_RESULTS_PREF]: {
+            type: 'number',
+            title: nls.localize('theia/ai/workspace/searchMaxResults/title', 'Maximum Search Results'),
+            description: nls.localize('theia/ai/workspace/searchMaxResults/description',
+                'Maximum number of search results returned by the workspace search function.'),
+            default: 50,
+            minimum: 1
         },
         [PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF]: {
             type: 'array',

--- a/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
@@ -1,0 +1,279 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { SearchInWorkspaceResult, LinePreview } from '@theia/search-in-workspace/lib/common/search-in-workspace-interface';
+
+// Import the workspace-search-provider for accessing the private method
+// We'll test the optimizeSearchResults method directly
+class WorkspaceSearchProviderTest {
+    /**
+     * Copy of the optimizeSearchResults method for testing
+     */
+    public optimizeSearchResults(results: SearchInWorkspaceResult[], workspaceRoot: URI): Array<{ file: string; matches: Array<{ line: number; text: string }> }> {
+        return results.map(result => {
+            const fileUri = new URI(result.fileUri);
+            const relativePath = workspaceRoot.relative(fileUri);
+
+            return {
+                file: relativePath ? relativePath.toString() : result.fileUri,
+                matches: result.matches.map(match => {
+                    // Preserve all information while applying conservative whitespace optimization
+                    let lineText: string;
+                    if (typeof match.lineText === 'string') {
+                        lineText = match.lineText;
+                    } else {
+                        // Handle LinePreview case
+                        const linePreview = match.lineText as LinePreview;
+                        lineText = linePreview.text || '';
+                    }
+
+                    // Only trim leading and trailing whitespace, preserving semantic spacing
+                    return {
+                        line: match.line,
+                        text: lineText.trim()
+                    };
+                })
+            };
+        });
+    }
+}
+
+describe('WorkspaceSearchProvider - Token Optimization', () => {
+    let testProvider: WorkspaceSearchProviderTest;
+
+    beforeEach(() => {
+        testProvider = new WorkspaceSearchProviderTest();
+    });
+
+    describe('optimizeSearchResults method', () => {
+        it('should preserve all information while optimizing format', () => {
+            const workspaceRoot = new URI('file:///workspace');
+            const mockResults: SearchInWorkspaceResult[] = [
+                {
+                    root: 'file:///workspace',
+                    fileUri: 'file:///workspace/src/test.ts',
+                    matches: [
+                        {
+                            line: 1,
+                            character: 5,
+                            length: 8,
+                            lineText: '  const test = "hello";  '
+                        },
+                        {
+                            line: 5,
+                            character: 10,
+                            length: 4,
+                            lineText: '\t\tfunction test() { }\n'
+                        }
+                    ]
+                },
+                {
+                    root: 'file:///workspace',
+                    fileUri: 'file:///workspace/lib/utils.js',
+                    matches: [
+                        {
+                            line: 10,
+                            character: 0,
+                            length: 6,
+                            lineText: 'export default function() {}'
+                        }
+                    ]
+                }
+            ];
+
+            const result = testProvider.optimizeSearchResults(mockResults, workspaceRoot);
+
+            expect(result).to.have.length(2);
+
+            // First file
+            expect(result[0]).to.deep.equal({
+                file: 'src/test.ts',
+                matches: [
+                    {
+                        line: 1,
+                        text: 'const test = "hello";'
+                    },
+                    {
+                        line: 5,
+                        text: 'function test() { }'
+                    }
+                ]
+            });
+
+            // Second file
+            expect(result[1]).to.deep.equal({
+                file: 'lib/utils.js',
+                matches: [
+                    {
+                        line: 10,
+                        text: 'export default function() {}'
+                    }
+                ]
+            });
+        });
+
+        it('should handle LinePreview objects correctly', () => {
+            const workspaceRoot = new URI('file:///workspace');
+            const linePreview: LinePreview = {
+                text: '  preview text with spaces  ',
+                character: 5
+            };
+
+            const mockResults: SearchInWorkspaceResult[] = [
+                {
+                    root: 'file:///workspace',
+                    fileUri: 'file:///workspace/preview.ts',
+                    matches: [
+                        {
+                            line: 3,
+                            character: 5,
+                            length: 7,
+                            lineText: linePreview
+                        }
+                    ]
+                }
+            ];
+
+            const result = testProvider.optimizeSearchResults(mockResults, workspaceRoot);
+
+            expect(result[0].matches[0]).to.deep.equal({
+                line: 3,
+                text: 'preview text with spaces'
+            });
+        });
+
+        it('should handle empty LinePreview text gracefully', () => {
+            const workspaceRoot = new URI('file:///workspace');
+            const linePreview: LinePreview = {
+                text: '',
+                character: 0
+            };
+
+            const mockResults: SearchInWorkspaceResult[] = [
+                {
+                    root: 'file:///workspace',
+                    fileUri: 'file:///workspace/empty.ts',
+                    matches: [
+                        {
+                            line: 1,
+                            character: 0,
+                            length: 0,
+                            lineText: linePreview
+                        }
+                    ]
+                }
+            ];
+
+            const result = testProvider.optimizeSearchResults(mockResults, workspaceRoot);
+
+            expect(result[0].matches[0]).to.deep.equal({
+                line: 1,
+                text: ''
+            });
+        });
+
+        it('should preserve semantic whitespace within lines', () => {
+            const workspaceRoot = new URI('file:///workspace');
+            const mockResults: SearchInWorkspaceResult[] = [
+                {
+                    root: 'file:///workspace',
+                    fileUri: 'file:///workspace/spaces.ts',
+                    matches: [
+                        {
+                            line: 1,
+                            character: 0,
+                            length: 20,
+                            lineText: '  if (a    &&    b) {  '
+                        }
+                    ]
+                }
+            ];
+
+            const result = testProvider.optimizeSearchResults(mockResults, workspaceRoot);
+
+            expect(result[0].matches[0].text).to.equal('if (a    &&    b) {');
+        });
+
+        it('should use absolute URI when relative path cannot be determined', () => {
+            const workspaceRoot = new URI('file:///different-workspace');
+            const mockResults: SearchInWorkspaceResult[] = [
+                {
+                    root: 'file:///workspace',
+                    fileUri: 'file:///workspace/outside.ts',
+                    matches: [
+                        {
+                            line: 1,
+                            character: 0,
+                            length: 4,
+                            lineText: 'test'
+                        }
+                    ]
+                }
+            ];
+
+            const result = testProvider.optimizeSearchResults(mockResults, workspaceRoot);
+
+            expect(result[0].file).to.equal('file:///workspace/outside.ts');
+        });
+    });
+
+    describe('token efficiency validation', () => {
+        it('should produce more compact JSON than original format', () => {
+            const workspaceRoot = new URI('file:///workspace');
+            const mockResults: SearchInWorkspaceResult[] = [
+                {
+                    root: 'file:///workspace',
+                    fileUri: 'file:///workspace/src/test.ts',
+                    matches: [
+                        {
+                            line: 1,
+                            character: 5,
+                            length: 8,
+                            lineText: '  const test = "hello";  '
+                        }
+                    ]
+                }
+            ];
+
+            // Original format (simulated)
+            const originalFormat = JSON.stringify([{
+                root: 'file:///workspace',
+                fileUri: 'file:///workspace/src/test.ts',
+                matches: [{
+                    line: 1,
+                    character: 5,
+                    length: 8,
+                    lineText: '  const test = "hello";  '
+                }]
+            }]);
+
+            // Optimized format
+            const optimizedResults = testProvider.optimizeSearchResults(mockResults, workspaceRoot);
+            const optimizedFormat = JSON.stringify(optimizedResults);
+
+            // The optimized format should be significantly shorter
+            expect(optimizedFormat.length).to.be.lessThan(originalFormat.length);
+
+            // But should preserve essential information
+            const parsed = JSON.parse(optimizedFormat);
+            expect(parsed[0].file).to.equal('src/test.ts');
+            expect(parsed[0].matches[0].line).to.equal(1);
+            expect(parsed[0].matches[0].text).to.equal('const test = "hello";');
+        });
+    });
+});


### PR DESCRIPTION
#### What it does

* The function now has a preference to control the max number of search results. If the number of results exceeds the limit, we no longer return an incomplete list but raise an error instead.
  * Very eager models might try to work around this by searching subdirectories or some other things
  * However, working with incomplete data is likely to cause other issues, because I think the LLM is not aware that it is incomplete?
* The default limit is now 30 instead of 50
  * We'll likely need to fine-tune this through testing. Lowering the limit might not be the most effective way to reduce token usage - improving prompts or tool descriptions to encourage subdirectory searches could be a better option
* Subdirectory search is now supported
* The search result format should consume fewer tokens, mainly by using relative paths and trimming excess whitespace


#### How to test

Some sample prompts

```
@Universal ~searchInWorkspace Find the string SEARCH_IN_WORKSPACE_FUNCTION_ID 

@Universal ~searchInWorkspace Find the string SEARCH_IN_WORKSPACE_FUNCTION_ID in the packages subdirectory

@Coder Find the string SEARCH_IN_WORKSPACE_FUNCTION_ID in all typescript files and update it to SEARCH_IN_WORKSPACE_FUNCTION_TOOL_ID
```

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
