### PR TITLE
Fix existence check when contributing monaco menu items

### DIFF
--- a/packages/monaco/src/browser/monaco-menu.ts
+++ b/packages/monaco/src/browser/monaco-menu.ts
@@ -49,7 +49,7 @@ export class MonacoEditorMenuContribution implements MenuContribution {
             if (commandId) {
                 const nodeId = MonacoCommands.COMMON_ACTIONS.get(commandId) || commandId;
                 const menuPath = item.group ? [...EDITOR_CONTEXT_MENU, item.group] : EDITOR_CONTEXT_MENU;
-                if (registry.getMenuNode([...menuPath, nodeId])) {
+                if (!registry.getMenuNode([...menuPath, nodeId])) {
                     // Don't add additional actions if the item is already registered.
                     registry.registerMenuAction(menuPath, this.buildMenuAction(commandId, item));
                 }


### PR DESCRIPTION
#### What it does
Fixes #15691

#### How to test
Open a typescript file and check that the missing menus now show up, in particular the "Go to XXX" actions. The fix only affects what is added to the monaco editor context menu, so effects should be very localized.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
