### PR TITLE
Enable multiSelect for the DebugBreakpointsWidget

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -804,18 +804,18 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             isEnabled: () => this.breakpointManager.hasBreakpoints()
         });
         registry.registerCommand(DebugCommands.ENABLE_SELECTED_BREAKPOINTS, {
-            execute: () => this.getSelectedBreakpoints().forEach(breakpoint => breakpoint.setEnabled(true)),
-            isVisible: () => this.getSelectedBreakpoints().some(breakpoint => !breakpoint.enabled),
-            isEnabled: () => this.getSelectedBreakpoints().some(breakpoint => !breakpoint.enabled)
+            execute: () => this.selectedBreakpoints.forEach(breakpoint => breakpoint.setEnabled(true)),
+            isVisible: () => this.selectedBreakpoints.some(breakpoint => !breakpoint.enabled),
+            isEnabled: () => this.selectedBreakpoints.some(breakpoint => !breakpoint.enabled)
         });
         registry.registerCommand(DebugCommands.DISABLE_ALL_BREAKPOINTS, {
             execute: () => this.breakpointManager.enableAllBreakpoints(false),
             isEnabled: () => this.breakpointManager.hasBreakpoints()
         });
         registry.registerCommand(DebugCommands.DISABLE_SELECTED_BREAKPOINTS, {
-            execute: () => this.getSelectedBreakpoints().forEach(breakpoint => breakpoint.setEnabled(false)),
-            isVisible: () => this.getSelectedBreakpoints().some(breakpoint => breakpoint.enabled),
-            isEnabled: () => this.getSelectedBreakpoints().some(breakpoint => breakpoint.enabled)
+            execute: () => this.selectedBreakpoints.forEach(breakpoint => breakpoint.setEnabled(false)),
+            isVisible: () => this.selectedBreakpoints.some(breakpoint => breakpoint.enabled),
+            isEnabled: () => this.selectedBreakpoints.some(breakpoint => breakpoint.enabled)
         });
         registry.registerCommand(DebugCommands.EDIT_BREAKPOINT, {
             execute: async () => {
@@ -826,8 +826,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     await selectedFunctionBreakpoint.open();
                 }
             },
-            isEnabled: () => this.getSelectedBreakpoints().length === 1 && (!!this.selectedBreakpoint || !!this.selectedFunctionBreakpoint),
-            isVisible: () => this.getSelectedBreakpoints().length === 1 && (!!this.selectedBreakpoint || !!this.selectedFunctionBreakpoint)
+            isEnabled: () => this.selectedBreakpoints.length === 1 && (!!this.selectedBreakpoint || !!this.selectedFunctionBreakpoint),
+            isVisible: () => this.selectedBreakpoints.length === 1 && (!!this.selectedBreakpoint || !!this.selectedFunctionBreakpoint)
         });
         registry.registerCommand(DebugCommands.EDIT_LOGPOINT, {
             execute: async () => {
@@ -836,8 +836,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     await this.editors.editBreakpoint(selectedLogpoint);
                 }
             },
-            isEnabled: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedLogpoint,
-            isVisible: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedLogpoint
+            isEnabled: () => this.selectedBreakpoints.length === 1 && !!this.selectedLogpoint,
+            isVisible: () => this.selectedBreakpoints.length === 1 && !!this.selectedLogpoint
         });
         registry.registerCommand(DebugCommands.EDIT_BREAKPOINT_CONDITION, {
             execute: async () => {
@@ -846,8 +846,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     await selectedExceptionBreakpoint.editCondition();
                 }
             },
-            isEnabled: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedExceptionBreakpoint?.data.raw.supportsCondition,
-            isVisible: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedExceptionBreakpoint?.data.raw.supportsCondition
+            isEnabled: () => this.selectedBreakpoints.length === 1 && !!this.selectedExceptionBreakpoint?.data.raw.supportsCondition,
+            isVisible: () => this.selectedBreakpoints.length === 1 && !!this.selectedExceptionBreakpoint?.data.raw.supportsCondition
         });
         registry.registerCommand(DebugCommands.REMOVE_BREAKPOINT, {
             execute: () => {
@@ -856,8 +856,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     selectedBreakpoint.remove();
                 }
             },
-            isEnabled: () => this.getSelectedBreakpoints().length === 1 && Boolean(this.selectedSettableBreakpoint),
-            isVisible: () => this.getSelectedBreakpoints().length === 1 && Boolean(this.selectedSettableBreakpoint),
+            isEnabled: () => this.selectedBreakpoints.length === 1 && Boolean(this.selectedSettableBreakpoint),
+            isVisible: () => this.selectedBreakpoints.length === 1 && Boolean(this.selectedSettableBreakpoint),
         });
         registry.registerCommand(DebugCommands.REMOVE_LOGPOINT, {
             execute: () => {
@@ -866,8 +866,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     selectedLogpoint.remove();
                 }
             },
-            isEnabled: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedLogpoint,
-            isVisible: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedLogpoint
+            isEnabled: () => this.selectedBreakpoints.length === 1 && !!this.selectedLogpoint,
+            isVisible: () => this.selectedBreakpoints.length === 1 && !!this.selectedLogpoint
         });
         registry.registerCommand(DebugCommands.REMOVE_ALL_BREAKPOINTS, {
             execute: () => this.breakpointManager.removeBreakpoints(),
@@ -875,9 +875,9 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             isVisible: widget => !(widget instanceof Widget) || (widget instanceof DebugBreakpointsWidget)
         });
         registry.registerCommand(DebugCommands.REMOVE_SELECTED_BREAKPOINTS, {
-            execute: () => this.getSelectedBreakpoints().forEach(breakpoint => breakpoint.remove()),
-            isEnabled: () => this.getSelectedBreakpoints().length > 1,
-            isVisible: widget => (!(widget instanceof Widget) || (widget instanceof DebugBreakpointsWidget)) && this.getSelectedBreakpoints().length > 1
+            execute: () => this.selectedBreakpoints.forEach(breakpoint => breakpoint.remove()),
+            isEnabled: () => this.selectedBreakpoints.length > 1,
+            isVisible: widget => (!(widget instanceof Widget) || (widget instanceof DebugBreakpointsWidget)) && this.selectedBreakpoints.length > 1
         });
         registry.registerCommand(DebugCommands.TOGGLE_BREAKPOINTS_ENABLED, {
             execute: () => this.breakpointManager.breakpointsEnabled = !this.breakpointManager.breakpointsEnabled,
@@ -1293,6 +1293,13 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         const breakpoint = this.selectedAnyBreakpoint;
         return breakpoint && breakpoint instanceof DebugSourceBreakpoint && !breakpoint.logMessage ? breakpoint : undefined;
     }
+    get selectedBreakpoints(): DebugBreakpoint[] {
+        const { breakpoints } = this;
+        return breakpoints && breakpoints.model.selectedNodes
+            .filter(TreeElementNode.is)
+            .map(node => node.element)
+            .filter(element => element instanceof DebugBreakpoint) as DebugBreakpoint[] || [];
+    }
     get selectedLogpoint(): DebugSourceBreakpoint | undefined {
         const breakpoint = this.selectedAnyBreakpoint;
         return breakpoint && breakpoint instanceof DebugSourceBreakpoint && !!breakpoint.logMessage ? breakpoint : undefined;
@@ -1621,18 +1628,5 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         }
 
         return this.getOption(session.parentSession, option);
-    }
-
-    /**
-     * @returns the breakpoints selected in the breakpoints widget.
-     */
-    protected getSelectedBreakpoints(): DebugBreakpoint[] {
-        const breakpointsWidget = this.widgetManager.tryGetWidget(DebugBreakpointsWidget.FACTORY_ID) as DebugBreakpointsWidget;
-        if (breakpointsWidget) {
-            const selectedTreeNodes = breakpointsWidget.model.selectedNodes as TreeElementNode[];
-            return selectedTreeNodes.map(node => node.element as DebugBreakpoint);
-        } else {
-            return [];
-        }
     }
 }

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -17,6 +17,7 @@
 import {
     AbstractViewContribution, KeybindingRegistry, Widget, CompositeTreeNode, LabelProvider, codicon, OnWillStopAction, FrontendApplicationContribution, ConfirmDialog, Dialog
 } from '@theia/core/lib/browser';
+import { TreeElementNode } from '@theia/core/lib/browser/source-tree';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { MenuModelRegistry, CommandRegistry, MAIN_MENU_BAR, Command, Emitter, Mutable } from '@theia/core/lib/common';
@@ -191,10 +192,20 @@ export namespace DebugCommands {
         category: DEBUG_CATEGORY,
         label: 'Add Function Breakpoint',
     });
+    export const ENABLE_SELECTED_BREAKPOINTS = Command.toDefaultLocalizedCommand({
+        id: 'debug.breakpoint.enableSelected',
+        category: DEBUG_CATEGORY,
+        label: 'Enable Selected Breakpoints',
+    });
     export const ENABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.enableAll',
         category: DEBUG_CATEGORY,
         label: 'Enable All Breakpoints',
+    });
+    export const DISABLE_SELECTED_BREAKPOINTS = Command.toDefaultLocalizedCommand({
+        id: 'debug.breakpoint.disableSelected',
+        category: DEBUG_CATEGORY,
+        label: 'Disable Selected Breakpoints',
     });
     export const DISABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.disableAll',
@@ -229,6 +240,11 @@ export namespace DebugCommands {
         category: DEBUG_CATEGORY,
         originalLabel: 'Remove Logpoint',
         label: nlsRemoveBreakpoint('Logpoint')
+    }, '', DEBUG_CATEGORY_KEY);
+    export const REMOVE_SELECTED_BREAKPOINTS = Command.toLocalizedCommand({
+        id: 'debug.breakpoint.removeSelected',
+        category: DEBUG_CATEGORY,
+        label: 'Remove Selected Breakpoints',
     }, '', DEBUG_CATEGORY_KEY);
     export const REMOVE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.removeAll',
@@ -615,9 +631,12 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         registerMenuActions(DebugBreakpointsWidget.REMOVE_MENU,
             DebugCommands.REMOVE_BREAKPOINT,
             DebugCommands.REMOVE_LOGPOINT,
+            DebugCommands.REMOVE_SELECTED_BREAKPOINTS,
             DebugCommands.REMOVE_ALL_BREAKPOINTS
         );
         registerMenuActions(DebugBreakpointsWidget.ENABLE_MENU,
+            DebugCommands.ENABLE_SELECTED_BREAKPOINTS,
+            DebugCommands.DISABLE_SELECTED_BREAKPOINTS,
             DebugCommands.ENABLE_ALL_BREAKPOINTS,
             DebugCommands.DISABLE_ALL_BREAKPOINTS
         );
@@ -784,9 +803,19 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             execute: () => this.breakpointManager.enableAllBreakpoints(true),
             isEnabled: () => this.breakpointManager.hasBreakpoints()
         });
+        registry.registerCommand(DebugCommands.ENABLE_SELECTED_BREAKPOINTS, {
+            execute: () => this.getSelectedBreakpoints().forEach(breakpoint => breakpoint.setEnabled(true)),
+            isVisible: () => this.getSelectedBreakpoints().some(breakpoint => !breakpoint.enabled),
+            isEnabled: () => this.getSelectedBreakpoints().some(breakpoint => !breakpoint.enabled)
+        });
         registry.registerCommand(DebugCommands.DISABLE_ALL_BREAKPOINTS, {
             execute: () => this.breakpointManager.enableAllBreakpoints(false),
             isEnabled: () => this.breakpointManager.hasBreakpoints()
+        });
+        registry.registerCommand(DebugCommands.DISABLE_SELECTED_BREAKPOINTS, {
+            execute: () => this.getSelectedBreakpoints().forEach(breakpoint => breakpoint.setEnabled(false)),
+            isVisible: () => this.getSelectedBreakpoints().some(breakpoint => breakpoint.enabled),
+            isEnabled: () => this.getSelectedBreakpoints().some(breakpoint => breakpoint.enabled)
         });
         registry.registerCommand(DebugCommands.EDIT_BREAKPOINT, {
             execute: async () => {
@@ -797,8 +826,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     await selectedFunctionBreakpoint.open();
                 }
             },
-            isEnabled: () => !!this.selectedBreakpoint || !!this.selectedFunctionBreakpoint,
-            isVisible: () => !!this.selectedBreakpoint || !!this.selectedFunctionBreakpoint
+            isEnabled: () => this.getSelectedBreakpoints().length === 1 && (!!this.selectedBreakpoint || !!this.selectedFunctionBreakpoint),
+            isVisible: () => this.getSelectedBreakpoints().length === 1 && (!!this.selectedBreakpoint || !!this.selectedFunctionBreakpoint)
         });
         registry.registerCommand(DebugCommands.EDIT_LOGPOINT, {
             execute: async () => {
@@ -807,8 +836,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     await this.editors.editBreakpoint(selectedLogpoint);
                 }
             },
-            isEnabled: () => !!this.selectedLogpoint,
-            isVisible: () => !!this.selectedLogpoint
+            isEnabled: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedLogpoint,
+            isVisible: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedLogpoint
         });
         registry.registerCommand(DebugCommands.EDIT_BREAKPOINT_CONDITION, {
             execute: async () => {
@@ -817,8 +846,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     await selectedExceptionBreakpoint.editCondition();
                 }
             },
-            isEnabled: () => !!this.selectedExceptionBreakpoint?.data.raw.supportsCondition,
-            isVisible: () => !!this.selectedExceptionBreakpoint?.data.raw.supportsCondition
+            isEnabled: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedExceptionBreakpoint?.data.raw.supportsCondition,
+            isVisible: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedExceptionBreakpoint?.data.raw.supportsCondition
         });
         registry.registerCommand(DebugCommands.REMOVE_BREAKPOINT, {
             execute: () => {
@@ -827,8 +856,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     selectedBreakpoint.remove();
                 }
             },
-            isEnabled: () => Boolean(this.selectedSettableBreakpoint),
-            isVisible: () => Boolean(this.selectedSettableBreakpoint),
+            isEnabled: () => this.getSelectedBreakpoints().length === 1 && Boolean(this.selectedSettableBreakpoint),
+            isVisible: () => this.getSelectedBreakpoints().length === 1 && Boolean(this.selectedSettableBreakpoint),
         });
         registry.registerCommand(DebugCommands.REMOVE_LOGPOINT, {
             execute: () => {
@@ -837,13 +866,18 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     selectedLogpoint.remove();
                 }
             },
-            isEnabled: () => !!this.selectedLogpoint,
-            isVisible: () => !!this.selectedLogpoint
+            isEnabled: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedLogpoint,
+            isVisible: () => this.getSelectedBreakpoints().length === 1 && !!this.selectedLogpoint
         });
         registry.registerCommand(DebugCommands.REMOVE_ALL_BREAKPOINTS, {
             execute: () => this.breakpointManager.removeBreakpoints(),
             isEnabled: () => this.breakpointManager.hasBreakpoints(),
             isVisible: widget => !(widget instanceof Widget) || (widget instanceof DebugBreakpointsWidget)
+        });
+        registry.registerCommand(DebugCommands.REMOVE_SELECTED_BREAKPOINTS, {
+            execute: () => this.getSelectedBreakpoints().forEach(breakpoint => breakpoint.remove()),
+            isEnabled: () => this.getSelectedBreakpoints().length > 1,
+            isVisible: widget => (!(widget instanceof Widget) || (widget instanceof DebugBreakpointsWidget)) && this.getSelectedBreakpoints().length > 1
         });
         registry.registerCommand(DebugCommands.TOGGLE_BREAKPOINTS_ENABLED, {
             execute: () => this.breakpointManager.breakpointsEnabled = !this.breakpointManager.breakpointsEnabled,
@@ -1587,5 +1621,18 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         }
 
         return this.getOption(session.parentSession, option);
+    }
+
+    /**
+     * @returns the breakpoints selected in the breakpoints widget.
+     */
+    protected getSelectedBreakpoints(): DebugBreakpoint[] {
+        const breakpointsWidget = this.widgetManager.tryGetWidget(DebugBreakpointsWidget.FACTORY_ID) as DebugBreakpointsWidget;
+        if (breakpointsWidget) {
+            const selectedTreeNodes = breakpointsWidget.model.selectedNodes as TreeElementNode[];
+            return selectedTreeNodes.map(node => node.element as DebugBreakpoint);
+        } else {
+            return [];
+        }
     }
 }

--- a/packages/debug/src/browser/view/debug-breakpoints-widget.ts
+++ b/packages/debug/src/browser/view/debug-breakpoints-widget.ts
@@ -35,7 +35,8 @@ export class DebugBreakpointsWidget extends SourceTreeWidget {
         const child = SourceTreeWidget.createContainer(parent, {
             contextMenuPath: DebugBreakpointsWidget.CONTEXT_MENU,
             virtualized: false,
-            scrollIfActive: true
+            scrollIfActive: true,
+            multiSelect: true
         });
         child.bind(DebugBreakpointsSource).toSelf();
         child.unbind(SourceTreeWidget);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

I found it impractical that I could only enable/disable/remove all breakpoints at once, or only one by one, but not select multiple ones and enable/disable/remove them in one operation. Therefore, I implemented this functionality.

#### What it does

* Enable multiSelect for breakpoints in the DebugBreakpointsWidget
* Add commands to remove/enable/disable the selected breakpoints

The commands are shown only if the selection is set accordingly:
* enable is only shown if at least one disabled breakpoint is selected
* disable is only shown if at least one enabled breakpoint is selected
* remove is only shown if more than one breakpoint is selected

I have also changed the visibility of the existing menu items (edit, remove single breakpoint), so menu items that only make sense for a single selected item are not visible in case multiple items are selected.

#### How to test

Open any source file(s) and place multiple breakpoints (also consider adding breakpoints of multiple types, such as line breakpoints, instruction breakpoints, function breakpoints).

Then go to the debug panel, open the breakpoints widget and select multiple breakpoints (using the usual modifier keys available for multi-selection of items).

In the context menu there should now be additional menu items (Remove/Enable/Disable Selected Breakpoints) that behave as if the same operation would be executed one by one for all the selected items.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
