### PR TITLE
chore: backport #15731 to 1.61.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -263,6 +263,7 @@
     "dev-packages/ffmpeg": {
       "name": "@theia/ffmpeg",
       "version": "1.61.0",
+      "hasInstallScript": true,
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
         "@electron/get": "^2.0.0",
@@ -715,21 +716,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
-      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -30392,12 +30378,21 @@
       "version": "1.61.0",
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
+        "@anthropic-ai/sdk": "^0.52.0",
         "@theia/ai-core": "1.61.0",
         "@theia/core": "1.61.0"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.61.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.52.0.tgz",
+      "integrity": "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "packages/ai-chat": {

--- a/packages/ai-anthropic/package.json
+++ b/packages/ai-anthropic/package.json
@@ -3,7 +3,7 @@
   "version": "1.61.0",
   "description": "Theia - Anthropic Integration",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
+    "@anthropic-ai/sdk": "^0.52.0",
     "@theia/ai-core": "1.61.0",
     "@theia/core": "1.61.0"
   },

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -79,7 +79,8 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
             id: id,
             model: modelId,
             apiKey: true,
-            enableStreaming: true
+            enableStreaming: true,
+            useCaching: true
         };
 
         if (maxTokens !== undefined) {

--- a/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
+++ b/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
@@ -33,6 +33,10 @@ export interface AnthropicModelDescription {
      */
     enableStreaming: boolean;
     /**
+     * Indicate whether the model supports prompt caching.
+     */
+    useCaching: boolean;
+    /**
      * Maximum number of tokens to generate. Default is 4096.
      */
     maxTokens?: number;

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -66,6 +66,7 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                         modelDescription.id,
                         modelDescription.model,
                         modelDescription.enableStreaming,
+                        modelDescription.useCaching,
                         apiKeyProvider,
                         modelDescription.maxTokens,
                         this.tokenUsageService

--- a/packages/ai-core/src/browser/token-usage-frontend-service.ts
+++ b/packages/ai-core/src/browser/token-usage-frontend-service.ts
@@ -26,6 +26,10 @@ export interface ModelTokenUsageData {
     inputTokens: number;
     /** Number of output tokens used */
     outputTokens: number;
+    /** Number of input tokens written to cache */
+    cachedInputTokens?: number;
+    /** Number of input tokens read from cache */
+    readCachedInputTokens?: number;
     /** Date when the model was last used */
     lastUsed?: Date;
 }

--- a/packages/ai-core/src/common/token-usage-service.ts
+++ b/packages/ai-core/src/common/token-usage-service.ts
@@ -23,6 +23,10 @@ export interface TokenUsage {
     inputTokens: number;
     /** The output token count */
     outputTokens: number;
+    /** Input tokens written to cache */
+    cachedInputTokens?: number;
+    /** Input tokens read from cache */
+    readCachedInputTokens?: number;
     /** The model identifier */
     model: string;
     /** The timestamp of when the tokens were used */
@@ -36,6 +40,10 @@ export interface TokenUsageParams {
     inputTokens: number;
     /** The output token count */
     outputTokens: number;
+    /** Input tokens placed in cache */
+    cachedInputTokens?: number;
+    /** Input tokens read from cache */
+    readCachedInputTokens?: number;
     /** Request identifier */
     requestId: string;
 }

--- a/packages/ai-core/src/node/token-usage-service-impl.ts
+++ b/packages/ai-core/src/node/token-usage-service-impl.ts
@@ -41,6 +41,8 @@ export class TokenUsageServiceImpl implements TokenUsageService {
     async recordTokenUsage(model: string, params: TokenUsageParams): Promise<void> {
         const usage: TokenUsage = {
             inputTokens: params.inputTokens,
+            cachedInputTokens: params.cachedInputTokens,
+            readCachedInputTokens: params.readCachedInputTokens,
             outputTokens: params.outputTokens,
             model,
             timestamp: new Date(),
@@ -50,7 +52,23 @@ export class TokenUsageServiceImpl implements TokenUsageService {
         this.tokenUsages.push(usage);
         this.client?.notifyTokenUsage(usage);
 
-        console.log(`Input Tokens: ${params.inputTokens}; Output Tokens: ${params.outputTokens}; Model: ${model}${params.requestId ? `; RequestId: ${params.requestId}` : ''}`);
+        let logMessage = `Input Tokens: ${params.inputTokens};`;
+
+        if (params.cachedInputTokens) {
+            logMessage += ` Input Tokens written to cache: ${params.cachedInputTokens};`;
+        }
+
+        if (params.readCachedInputTokens) {
+            logMessage += ` Input Tokens read from cache: ${params.readCachedInputTokens};`;
+        }
+
+        logMessage += ` Output Tokens: ${params.outputTokens}; Model: ${model};`;
+
+        if (params.requestId) {
+            logMessage += `; RequestId: ${params.requestId}`;
+        }
+
+        console.debug(logMessage);
         // For now we just store in memory
         // In the future, this could be persisted to disk, a database, or sent to a service
         return Promise.resolve();


### PR DESCRIPTION
#### What it does

This is a backport of #15731 for Theia 1.61.x

Mark system prompts, tools and messages for caching in the Anthropic LanguageModel. For typical agent workflows like `@Coder` this reduces token costs by a large factor and reduces the pressure on the rate limit.

Currently caching is enabled by default for all Anthropic models.

Also updates token tracking functionality to be aware of token caching and updates the Anthropic SDK.


#### How to test

Send a request via an Anthropic model and inspect the token usage statistics. In tool based use cases there should be much more cache reads than cache writes.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
