### PR TITLE
fix: remove obsolete menu workaround

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -311,13 +311,6 @@ export class DynamicMenuWidget extends MenuWidget {
         while (items[items.length - 1]?.type === 'separator') {
             items.pop();
         }
-        // Add at least one entry to avoid empty menus.
-        // This is needed as Lumino does all kind of checks whether a menu is empty and for example prevents activating it
-        // This item will be cleared once the menu is opened via the next update as we don't have empty main menus
-        // See https://github.com/jupyterlab/lumino/issues/729
-        if (items.length === 0) {
-            items.push({ type: 'separator' });
-        }
         for (const item of items) {
             parent.addItem(item);
         }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

We previously used a workaround in the browser-menu-plugin to support initially empty menus, which weren’t compatible with Lumino.

Since the menu refactoring in #14676, this workaround is no longer needed. In fact, it now causes issues like empty submenus appearing in context menus. Removing the workaround fixes this regression.

Fixes #15694

#### How to test

- Check the terminal context menu, it should no longer have an empty submenu
- Check the title bar, that it continues working

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
