### PR TITLE
Replace YOLO terminology with "Always Allow" 

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -22,38 +22,38 @@ import { ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 /**
  * States the tool confirmation component can be in
  */
-export type ToolConfirmationState = 'waiting' | 'approved' | 'denied';
+export type ToolConfirmationState = 'waiting' | 'allowed' | 'denied';
 
 export interface ToolConfirmationProps {
     response: ToolCallChatResponseContent;
-    onApprove: (mode?: 'once' | 'session' | 'forever') => void;
+    onAllow: (mode?: 'once' | 'session' | 'forever') => void;
     onDeny: (mode?: 'once' | 'session' | 'forever') => void;
 }
 
 /**
  * Component that displays approval/denial buttons for tool execution
  */
-export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, onApprove, onDeny }) => {
+export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, onAllow, onDeny }) => {
     const [state, setState] = React.useState<ToolConfirmationState>('waiting');
     // Track selected mode for each action
-    const [approveMode, setApproveMode] = React.useState<'once' | 'session' | 'forever'>('once');
+    const [allowMode, setAllowMode] = React.useState<'once' | 'session' | 'forever'>('once');
     const [denyMode, setDenyMode] = React.useState<'once' | 'session' | 'forever'>('once');
-    const [dropdownOpen, setDropdownOpen] = React.useState<'approve' | 'deny' | undefined>(undefined);
+    const [dropdownOpen, setDropdownOpen] = React.useState<'allow' | 'deny' | undefined>(undefined);
 
-    const handleApprove = React.useCallback(() => {
-        setState('approved');
-        onApprove(approveMode);
-    }, [onApprove, approveMode]);
+    const handleAllow = React.useCallback(() => {
+        setState('allowed');
+        onAllow(allowMode);
+    }, [onAllow, allowMode]);
 
     const handleDeny = React.useCallback(() => {
         setState('denied');
         onDeny(denyMode);
     }, [onDeny, denyMode]);
 
-    if (state === 'approved') {
+    if (state === 'allowed') {
         return (
-            <div className="theia-tool-confirmation-status approved">
-                <span className={codicon('check')}></span> {nls.localize('theia/ai/chat-ui/toolconfirmation/approved', 'Tool execution approved')}
+            <div className="theia-tool-confirmation-status allowed">
+                <span className={codicon('check')}></span> {nls.localize('theia/ai/chat-ui/toolconfirmation/allowed', 'Tool execution allowed')}
             </div>
         );
     }
@@ -69,12 +69,12 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, on
     // Helper for dropdown options
     const MODES: Array<'once' | 'session' | 'forever'> = ['once', 'session', 'forever'];
     // Unified labels for both main button and dropdown, as requested
-    const modeLabel = (type: 'approve' | 'deny', mode: 'once' | 'session' | 'forever') => {
-        if (type === 'approve') {
+    const modeLabel = (type: 'allow' | 'deny', mode: 'once' | 'session' | 'forever') => {
+        if (type === 'allow') {
             switch (mode) {
-                case 'once': return nls.localize('theia/ai/chat-ui/toolconfirmation/approve', 'Approve');
-                case 'session': return nls.localize('theia/ai/chat-ui/toolconfirmation/approve-session', 'Approve for this Chat');
-                case 'forever': return nls.localize('theia/ai/chat-ui/toolconfirmation/approve-forever', 'Always Approve');
+                case 'once': return nls.localize('theia/ai/chat-ui/toolconfirmation/allow', 'Allow');
+                case 'session': return nls.localize('theia/ai/chat-ui/toolconfirmation/allow-session', 'Allow for this Chat');
+                case 'forever': return nls.localize('theia/ai/chat-ui/toolconfirmation/allow-forever', 'Always Allow');
             }
         } else {
             switch (mode) {
@@ -88,12 +88,12 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, on
     const mainButtonLabel = modeLabel; // Use the same function for both
 
     // Tooltips for dropdown options
-    const modeTooltip = (type: 'approve' | 'deny', mode: 'once' | 'session' | 'forever') => {
-        if (type === 'approve') {
+    const modeTooltip = (type: 'allow' | 'deny', mode: 'once' | 'session' | 'forever') => {
+        if (type === 'allow') {
             switch (mode) {
-                case 'once': return nls.localize('theia/ai/chat-ui/toolconfirmation/approve-tooltip', 'Approve this tool call once');
-                case 'session': return nls.localize('theia/ai/chat-ui/toolconfirmation/approve-session-tooltip', 'Approve all calls of this tool for this chat session');
-                case 'forever': return nls.localize('theia/ai/chat-ui/toolconfirmation/approve-forever-tooltip', 'Always approve this tool');
+                case 'once': return nls.localize('theia/ai/chat-ui/toolconfirmation/allow-tooltip', 'Allow this tool call once');
+                case 'session': return nls.localize('theia/ai/chat-ui/toolconfirmation/allow-session-tooltip', 'Allow all calls of this tool for this chat session');
+                case 'forever': return nls.localize('theia/ai/chat-ui/toolconfirmation/allow-forever-tooltip', 'Always allow this tool');
             }
         } else {
             switch (mode) {
@@ -105,27 +105,27 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, on
     };
 
     // Split button for approve/deny
-    const renderSplitButton = (type: 'approve' | 'deny') => {
-        const selectedMode = type === 'approve' ? approveMode : denyMode;
-        const setMode = type === 'approve' ? setApproveMode : setDenyMode;
-        const handleMain = type === 'approve' ? handleApprove : handleDeny;
+    const renderSplitButton = (type: 'allow' | 'deny') => {
+        const selectedMode = type === 'allow' ? allowMode : denyMode;
+        const setMode = type === 'allow' ? setAllowMode : setDenyMode;
+        const handleMain = type === 'allow' ? handleAllow : handleDeny;
         const otherModes = MODES.filter(m => m !== selectedMode);
         return (
             <div className={`theia-tool-confirmation-split-button ${type}`}
                 style={{ display: 'inline-flex', position: 'relative' }}>
                 <button
-                    className={`theia-button ${type === 'approve' ? 'primary' : 'secondary'} theia-tool-confirmation-main-btn`}
+                    className={`theia-button ${type === 'allow' ? 'primary' : 'secondary'} theia-tool-confirmation-main-btn`}
                     onClick={handleMain}
                 >
                     {mainButtonLabel(type, selectedMode)}
                 </button>
                 <button
-                    className={`theia-button ${type === 'approve' ? 'primary' : 'secondary'} theia-tool-confirmation-chevron-btn`}
+                    className={`theia-button ${type === 'allow' ? 'primary' : 'secondary'} theia-tool-confirmation-chevron-btn`}
                     onClick={() => setDropdownOpen(dropdownOpen === type ? undefined : type)}
                     aria-haspopup="true"
                     aria-expanded={dropdownOpen === type}
                     tabIndex={0}
-                    title={type === 'approve' ? 'More Approve Options' : 'More Deny Options'}
+                    title={type === 'allow' ? 'More Allow Options' : 'More Deny Options'}
                 >
                     <span className={codicon('chevron-down')}></span>
                 </button>
@@ -166,7 +166,7 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, on
             </div>
             <div className="theia-tool-confirmation-actions">
                 {renderSplitButton('deny')}
-                {renderSplitButton('approve')}
+                {renderSplitButton('allow')}
             </div>
         </div>
     );

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -122,7 +122,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
     React.useEffect(() => {
         if (confirmationMode === ToolConfirmationMode.ALWAYS_ALLOW) {
             response.confirm();
-            setConfirmationState('approved');
+            setConfirmationState('allowed');
             return;
         } else if (confirmationMode === ToolConfirmationMode.DISABLED) {
             response.deny();
@@ -132,7 +132,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
         response.confirmed.then(
             confirmed => {
                 if (confirmed === true) {
-                    setConfirmationState('approved');
+                    setConfirmationState('allowed');
                 } else {
                     setConfirmationState('denied');
                 }
@@ -143,7 +143,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
             });
     }, [response, confirmationMode]);
 
-    const handleApprove = React.useCallback((mode: 'once' | 'session' | 'forever' = 'once') => {
+    const handleAllow = React.useCallback((mode: 'once' | 'session' | 'forever' = 'once') => {
         if (mode === 'forever' && response.name) {
             toolConfirmationManager.setConfirmationMode(response.name, ToolConfirmationMode.ALWAYS_ALLOW);
         } else if (mode === 'session' && response.name) {
@@ -176,7 +176,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
                         <pre>{tryPrettyPrintJson(response)}</pre>
                     </details>
                 ) : (
-                    confirmationState === 'approved' && (
+                    confirmationState === 'allowed' && (
                         <span>
                             <Spinner /> {nls.localizeByDefault('Running')} {response.name}
                         </span>
@@ -184,11 +184,11 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
                 )}
             </h4>
 
-            {/* Show confirmation UI when waiting for approval */}
+            {/* Show confirmation UI when waiting for allow */}
             {confirmationState === 'waiting' && (
                 <ToolConfirmation
                     response={response}
-                    onApprove={handleApprove}
+                    onAllow={handleAllow}
                     onDeny={handleDeny}
                 />
             )}

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -120,7 +120,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
     const [confirmationState, setConfirmationState] = React.useState<ToolConfirmationState>('waiting');
 
     React.useEffect(() => {
-        if (confirmationMode === ToolConfirmationMode.YOLO) {
+        if (confirmationMode === ToolConfirmationMode.ALWAYS_ALLOW) {
             response.confirm();
             setConfirmationState('approved');
             return;
@@ -145,9 +145,9 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
 
     const handleApprove = React.useCallback((mode: 'once' | 'session' | 'forever' = 'once') => {
         if (mode === 'forever' && response.name) {
-            toolConfirmationManager.setConfirmationMode(response.name, ToolConfirmationMode.YOLO);
+            toolConfirmationManager.setConfirmationMode(response.name, ToolConfirmationMode.ALWAYS_ALLOW);
         } else if (mode === 'session' && response.name) {
-            toolConfirmationManager.setSessionConfirmationMode(response.name, ToolConfirmationMode.YOLO, chatId);
+            toolConfirmationManager.setSessionConfirmationMode(response.name, ToolConfirmationMode.ALWAYS_ALLOW, chatId);
         }
         response.confirm();
     }, [response, toolConfirmationManager, chatId]);

--- a/packages/ai-chat/src/browser/chat-tool-preferences.ts
+++ b/packages/ai-chat/src/browser/chat-tool-preferences.ts
@@ -29,7 +29,7 @@ import {
  * Enum for tool confirmation modes
  */
 export enum ToolConfirmationMode {
-    YOLO = 'yolo',
+    ALWAYS_ALLOW = 'always_allow',
     CONFIRM = 'confirm',
     DISABLED = 'disabled'
 }
@@ -43,7 +43,7 @@ export const chatToolPreferences: PreferenceSchema = {
             type: 'object',
             additionalProperties: {
                 type: 'string',
-                enum: [ToolConfirmationMode.YOLO, ToolConfirmationMode.CONFIRM, ToolConfirmationMode.DISABLED],
+                enum: [ToolConfirmationMode.ALWAYS_ALLOW, ToolConfirmationMode.CONFIRM, ToolConfirmationMode.DISABLED],
                 enumDescriptions: [
                     nls.localize('theia/ai/chat/toolConfirmation/yolo/description', 'Execute tools automatically without confirmation'),
                     nls.localize('theia/ai/chat/toolConfirmation/confirm/description', 'Ask for confirmation before executing tools'),
@@ -110,7 +110,7 @@ export class ToolConfirmationManager {
         if (toolConfirmation['*']) {
             return toolConfirmation['*'];
         }
-        return ToolConfirmationMode.YOLO; // Default to YOLO
+        return ToolConfirmationMode.ALWAYS_ALLOW; // Default to Always Allow
     }
 
     /**
@@ -121,7 +121,7 @@ export class ToolConfirmationManager {
         // Determine the global default (star entry), or fallback to schema default
         let starMode = current['*'];
         if (starMode === undefined) {
-            starMode = ToolConfirmationMode.YOLO;
+            starMode = ToolConfirmationMode.ALWAYS_ALLOW;
         }
         if (mode === starMode) {
             // Remove the toolId entry if it exists

--- a/packages/ai-chat/src/browser/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/browser/chat-tool-request-service.ts
@@ -42,7 +42,7 @@ export class FrontendChatToolRequestService extends ChatToolRequestService {
                     case ToolConfirmationMode.DISABLED:
                         return { denied: true, message: `Tool ${toolRequest.id} is disabled` };
 
-                    case ToolConfirmationMode.YOLO:
+                    case ToolConfirmationMode.ALWAYS_ALLOW:
                         // Execute immediately without confirmation
                         return toolRequest.handler(arg_string, request);
 

--- a/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
@@ -20,10 +20,10 @@ import * as React from '@theia/core/shared/react';
 import { ToolConfirmationManager, ToolConfirmationMode } from '@theia/ai-chat/lib/browser/chat-tool-preferences';
 import { ToolInvocationRegistry } from '@theia/ai-core';
 
-const TOOL_OPTIONS: { value: ToolConfirmationMode, label: string, icon: string, color: string }[] = [
-    { value: ToolConfirmationMode.DISABLED, label: 'Disabled', icon: 'close', color: 'var(--theia-errorForeground)' },
-    { value: ToolConfirmationMode.CONFIRM, label: 'Confirm', icon: 'question', color: 'var(--theia-descriptionForeground)' },
-    { value: ToolConfirmationMode.ALWAYS_ALLOW, label: 'Always Allow', icon: 'thumbsup', color: 'var(--theia-successForeground)' },
+const TOOL_OPTIONS: { value: ToolConfirmationMode, label: string, icon: string }[] = [
+    { value: ToolConfirmationMode.DISABLED, label: 'Disabled', icon: 'close' },
+    { value: ToolConfirmationMode.CONFIRM, label: 'Confirm', icon: 'question' },
+    { value: ToolConfirmationMode.ALWAYS_ALLOW, label: 'Always Allow', icon: 'thumbsup' },
 ];
 
 @injectable()
@@ -102,18 +102,6 @@ export class AIToolsConfigurationWidget extends ReactWidget {
         await this.updateDefaultConfirmation(newState);
     };
 
-    protected getColoring(mode: ToolConfirmationMode, renderDefault = false): string {
-        if (!renderDefault && mode === this.defaultState) {
-            return '';
-        }
-        if (mode === ToolConfirmationMode.ALWAYS_ALLOW) {
-            return ' ai-tools-configuration-tool-select--always-allow';
-        } else if (mode === ToolConfirmationMode.DISABLED) {
-            return ' ai-tools-configuration-tool-select--disabled';
-        }
-        return ' ai-tools-configuration-tool-select--confirm';
-    }
-
     protected async resetAllToolsToDefault(): Promise<void> {
         const dialog = new ConfirmDialog({
             title: 'Reset All Tool Confirmation Modes',
@@ -135,13 +123,13 @@ export class AIToolsConfigurationWidget extends ReactWidget {
             <div className='ai-tools-configuration-default-section' style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <div className='ai-tools-configuration-default-label'>Default Tool Confirmation Mode:</div>
                 <select
-                    className={`ai-tools-configuration-default-select ${this.getColoring(this.defaultState, true)}`}
+                    className="ai-tools-configuration-default-select"
                     value={this.defaultState}
                     onChange={this.handleDefaultStateChange}
                     style={{ marginLeft: 8 }}
                 >
                     {TOOL_OPTIONS.map(opt => (
-                        <option className={this.getColoring(opt.value, true)} key={opt.value} value={opt.value}>{opt.label}</option>
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
                     ))}
                 </select>
                 <button
@@ -159,10 +147,7 @@ export class AIToolsConfigurationWidget extends ReactWidget {
                     {this.tools.map(tool => {
                         const state = this.toolConfirmationModes[tool] || this.defaultState;
                         const isDefault = state === this.defaultState;
-                        let selectClass = 'ai-tools-configuration-tool-select';
-                        if (!isDefault) {
-                            selectClass += `${this.getColoring(state)}`;
-                        }
+                        const selectClass = 'ai-tools-configuration-tool-select';
                         return (
                             <li
                                 key={tool}
@@ -178,7 +163,7 @@ export class AIToolsConfigurationWidget extends ReactWidget {
                                     onChange={e => this.handleToolConfirmationModeChange(tool, e)}
                                 >
                                     {TOOL_OPTIONS.map(opt => (
-                                        <option className={this.getColoring(opt.value, true)} key={opt.value} value={opt.value}>
+                                        <option key={opt.value} value={opt.value}>
                                             {opt.label}
                                         </option>
                                     ))}

--- a/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
@@ -23,7 +23,7 @@ import { ToolInvocationRegistry } from '@theia/ai-core';
 const TOOL_OPTIONS: { value: ToolConfirmationMode, label: string, icon: string, color: string }[] = [
     { value: ToolConfirmationMode.DISABLED, label: 'Disabled', icon: 'close', color: 'var(--theia-errorForeground)' },
     { value: ToolConfirmationMode.CONFIRM, label: 'Confirm', icon: 'question', color: 'var(--theia-descriptionForeground)' },
-    { value: ToolConfirmationMode.YOLO, label: 'Yolo', icon: 'thumbsup', color: 'var(--theia-successForeground)' },
+    { value: ToolConfirmationMode.ALWAYS_ALLOW, label: 'Always Allow', icon: 'thumbsup', color: 'var(--theia-successForeground)' },
 ];
 
 @injectable()
@@ -106,8 +106,8 @@ export class AIToolsConfigurationWidget extends ReactWidget {
         if (!renderDefault && mode === this.defaultState) {
             return '';
         }
-        if (mode === ToolConfirmationMode.YOLO) {
-            return ' ai-tools-configuration-tool-select--yolo';
+        if (mode === ToolConfirmationMode.ALWAYS_ALLOW) {
+            return ' ai-tools-configuration-tool-select--always-allow';
         } else if (mode === ToolConfirmationMode.DISABLED) {
             return ' ai-tools-configuration-tool-select--disabled';
         }

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -746,7 +746,7 @@ h4 {
   font-size: 18px;
 }
 
-.ai-tools-configuration-tool-select--yolo {
+.ai-tools-configuration-tool-select--always-allow {
   color: green !important;
 }
 .ai-tools-configuration-tool-select--disabled {

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -698,7 +698,6 @@ h4 {
 }
 
 .ai-tools-configuration-default-select {
-  font-weight: bold;
   font-size: 14px;
   padding: 4px;
 }
@@ -738,7 +737,6 @@ h4 {
 }
 
 .ai-tools-configuration-tool-select {
-  font-weight: bold;
   margin-right: 8px;
 }
 
@@ -746,15 +744,6 @@ h4 {
   font-size: 18px;
 }
 
-.ai-tools-configuration-tool-select--always-allow {
-  color: green !important;
-}
-.ai-tools-configuration-tool-select--disabled {
-  color: red !important;
-}
-.ai-tools-configuration-tool-select--confirm {
-  color: orange !important;
-}
 /* End AI Tools Configuration Widget Styles */
 
 /* Token Usage Configuration Styles */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Replaces "YOLO" terminology in the Tool Configuration UI for AI Chat with more industry-typical "Allow" terminology. Also in the settings schema, which is user-facing even if less obvious.

Corollaries are implemented in separate commits to be rejected or accepted by reviewers as warranted:

- remove colouring of the tool permission settings in the configuration UI, as this is not necessary and can cause issues for users with reduced vision
- update the UI for the tool calls in the chat to use Allow terminology instead of Approve to align with the configuration UI

#### How to test

1. Open the Tools tab of the AI Configuration view.
2. See that the permission settings for tools individually and for the default include Allow instead of YOLO and are not coloured.
3. Observe that the UI for tool permissions in the chat likewise uses Allow terminology (not Approve as before) and verify that the various responses still function as before.

> [!NOTE]
> As this PR changes the value used in settings.json, you may wish to revert the settings to defaults before working with this branch.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
