### PR TITLE
Add async initialization to ChangeSetFileElement

### DIFF
--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -76,7 +76,9 @@ export class ChangeSetFileElement implements ChangeSetElement {
     protected readonly toDispose = new DisposableCollection();
     protected _state: ChangeSetElementState;
 
-    protected originalContent: string | undefined;
+    private _originalContent: string | undefined;
+    protected _initialized = false;
+    protected _initializationPromise: Promise<void> | undefined;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange = this.onDidChangeEmitter.event;
@@ -85,12 +87,38 @@ export class ChangeSetFileElement implements ChangeSetElement {
 
     @postConstruct()
     init(): void {
+        this._initializationPromise = this.initializeAsync();
         this.toDispose.push(this.onDidChangeEmitter);
     }
 
+    protected async initializeAsync(): Promise<void> {
+        await this.obtainOriginalContent();
+        this.listenForOriginalFileChanges();
+        this._initialized = true;
+    }
+
+    /**
+     * Ensures that the element is fully initialized before proceeding.
+     * This includes loading the original content from the file system.
+     */
+    async ensureInitialized(): Promise<void> {
+        if (this._initializationPromise) {
+            await this._initializationPromise;
+        }
+    }
+
+    /**
+     * Returns true if the element has been fully initialized.
+     */
+    get isInitialized(): boolean {
+        return this._initialized;
+    }
+
     protected async obtainOriginalContent(): Promise<void> {
-        this.originalContent = await this.changeSetFileService.read(this.uri);
-        this.readOnlyResource.update({ contents: this.originalContent ?? '' });
+        this._originalContent = await this.changeSetFileService.read(this.uri);
+        if (this._readOnlyResource) {
+            this.readOnlyResource.update({ contents: this._originalContent ?? '' });
+        }
     }
 
     protected getInMemoryUri(uri: URI): ConfigurableMutableReferenceResource {
@@ -103,7 +131,7 @@ export class ChangeSetFileElement implements ChangeSetElement {
             // If we are applied, the tricky thing becomes the question what to revert to; otherwise, what to apply.
             const newContent = await this.changeSetFileService.read(this.uri).catch(() => '');
             this.readOnlyResource.update({ contents: newContent });
-            if (newContent === this.originalContent) {
+            if (newContent === this._originalContent) {
                 this.state = 'pending';
             } else if (newContent === this.targetState) {
                 this.state = 'applied';
@@ -120,10 +148,19 @@ export class ChangeSetFileElement implements ChangeSetElement {
     protected get readOnlyResource(): ConfigurableMutableReferenceResource {
         if (!this._readOnlyResource) {
             this._readOnlyResource = this.getInMemoryUri(ChangeSetFileElement.toReadOnlyUri(this.uri, this.elementProps.chatSessionId));
-            this._readOnlyResource.update({ autosaveable: false, readOnly: true });
+            this._readOnlyResource.update({
+                autosaveable: false,
+                readOnly: true,
+                contents: this._originalContent ?? ''
+            });
             this.toDispose.push(this._readOnlyResource);
-            this.obtainOriginalContent();
-            this.listenForOriginalFileChanges();
+
+            // If not yet initialized, update the resource once initialization completes
+            if (!this._initialized && this._initializationPromise) {
+                this._initializationPromise.then(() => {
+                    this._readOnlyResource?.update({ contents: this._originalContent ?? '' });
+                });
+            }
         }
         return this._readOnlyResource;
     }
@@ -180,15 +217,33 @@ export class ChangeSetFileElement implements ChangeSetElement {
         return this.elementProps.data;
     };
 
+    get originalContent(): string | undefined {
+        if (!this._initialized && this._initializationPromise) {
+            console.warn('Accessing originalContent before initialization is complete. Consider using async methods.');
+        }
+        return this._originalContent;
+    }
+
+    /**
+     * Gets the original content of the file asynchronously.
+     * Ensures initialization is complete before returning the content.
+     */
+    async getOriginalContent(): Promise<string | undefined> {
+        await this.ensureInitialized();
+        return this._originalContent;
+    }
+
     get targetState(): string {
         return this.elementProps.targetState ?? '';
     }
 
     async open(): Promise<void> {
+        await this.ensureInitialized();
         this.changeSetFileService.open(this);
     }
 
     async openChange(): Promise<void> {
+        await this.ensureInitialized();
         this.changeSetFileService.openDiff(
             this.readOnlyUri,
             this.changedUri
@@ -196,6 +251,7 @@ export class ChangeSetFileElement implements ChangeSetElement {
     }
 
     async apply(contents?: string): Promise<void> {
+        await this.ensureInitialized();
         if (!await this.confirm('Apply')) { return; }
         if (!(await this.changeSetFileService.trySave(this.changedUri))) {
             if (this.type === 'delete') {
@@ -214,16 +270,25 @@ export class ChangeSetFileElement implements ChangeSetElement {
     }
 
     onShow(): void {
-        this.changeResource.update({ contents: this.targetState, onSave: content => this.writeChanges(content) });
+        // Ensure we have the latest state when showing
+        if (!this._initialized && this._initializationPromise) {
+            this._initializationPromise.then(() => {
+                // Update the change resource with the correct target state after initialization
+                this.changeResource.update({ contents: this.targetState, onSave: content => this.writeChanges(content) });
+            });
+        } else {
+            this.changeResource.update({ contents: this.targetState, onSave: content => this.writeChanges(content) });
+        }
     }
 
     async revert(): Promise<void> {
+        await this.ensureInitialized();
         if (!await this.confirm('Revert')) { return; }
         this.state = 'pending';
         if (this.type === 'add') {
             await this.changeSetFileService.delete(this.uri);
-        } else if (this.originalContent) {
-            await this.changeSetFileService.write(this.uri, this.originalContent);
+        } else if (this._originalContent) {
+            await this.changeSetFileService.write(this.uri, this._originalContent);
         }
     }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Ensures proper initialization of originalContent before operations.
UI actions (open, apply, revert, etc.) could occur before originalContent was assigned, leading to invalid states for the change set element.

This was originally raised as a follow-up to https://github.com/eclipse-theia/theia/pull/15717
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- Using the `coder-search-replace` prompt,  trigger the creation of a change set from the chat. Without opening the comparison view for the proposed changes, accept them. Then, use the revert button and observe that reverting works.

- Using `coder-rewrite` with the sample prompt below, trigger the creation of a change set which should automatically be applied. Observe that the state of the `Apply All` button is correct (disabled) and that the revert button is visible and works as expected

<details>
<summary>Sample Prompt</summary>

```

{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
You are an AI assistant integrated into Theia IDE, designed to assist software developers with code tasks. You can interact with the code base and suggest changes.

## Context Retrieval
Use the following functions to interact with the workspace files if you require context:
- **~{getWorkspaceDirectoryStructure}**
- **~{getWorkspaceFileList}**
- **~{getFileContent}**
- **~{searchInWorkspace}**

Remember file locations that are relevant for completing your tasks using **~{context_addFile}**
Only add files that are really relevant to look at later.

## File Validation
Use the following function to retrieve a list of problems in a file if the user requests fixes in a given file: **~{getFileDiagnostics}**

## Propose Code Changes
To propose code changes or any file changes to the user, never print code or new file content in your response.

Instead, for each file you want to propose changes for:
- **Always Retrieve Current Content**: Use getFileContent to get the original content of the target file.
- **View Pending Changes**: Use ~{getProposedFileState} to see the current proposed state of a file, including all pending changes.
- **Change Content**: Use one of these methods to propose changes:
  - ~{writeFileReplacements}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
  - ~{writeFileContent}: For complete file rewrites when you need to replace the entire content. 
  - If ~{writeFileReplacements} continuously fails use ~{suggestFileContent}.
  - ~{clearFileChanges}: To clear all pending changes for a file and start fresh.

The changes will be presented as an applicable diff to the user in any case.

## Tasks

The user might want you to execute some task. You can find tasks using ~{listTasks} and execute them using ~{runTask}.

## Additional Context

The following files have been provided for additional context. Some of them may also be referred to by the user (e.g. "this file" or "the attachment"). Always look at the relevant files to understand your task using the function ~{getFileContent}
{{contextFiles}}

## Previously Proposed Changes
You have previously proposed changes for the following files. Some suggestions may have been accepted by the user, while others may still be pending.
{{changeSetSummary}}

{{prompt:project-info}}

{{taskContextSummary}}

```

</details>

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
