### PR TITLE
Do not attempt to update actions in non-existent menus

### DIFF
--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { Position, Range } from '@theia/core/shared/vscode-languageserver-protocol';
-import { CommandMenu, Disposable, Emitter, Event, MenuModelRegistry, MenuPath, URI, nls } from '@theia/core';
+import { CommandMenu, CompoundMenuNode, Disposable, Emitter, Event, MenuModelRegistry, MenuPath, URI, nls } from '@theia/core';
 import { codicon } from '@theia/core/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
@@ -339,7 +339,12 @@ class DirtyDiffPeekView extends MonacoEditorPeekViewWidget {
         const { contextKeyService, menuModelRegistry } = this.widget;
         contextKeyService.with({ originalResourceScheme: this.widget.previousRevisionUri.scheme }, () => {
             for (const menuPath of [SCM_CHANGE_TITLE_MENU, PLUGIN_SCM_CHANGE_TITLE_MENU]) {
-                const menu = menuModelRegistry.getMenu(menuPath);
+                const menu = menuModelRegistry.getMenuNode(menuPath);
+                if (!menu || !CompoundMenuNode.is(menu)) {
+                    // The menu is not registered or is not a menu. Nothing to update
+                    continue;
+                }
+
                 for (const item of menu.children) {
                     if (CommandMenu.is(item)) {
                         const { id, label, icon } = item;


### PR DESCRIPTION
#### What it does

The MenuModelRegistry now throws on attempts to request the menu for an ID that is not registered. As at least one of the menus that the DirtyDiffWidget does not exist in typical installations of Theia IDE, this was causing the diffs not to appear. Because the widget doesn't need to update actions in menus that don't exist, it takes a more lenient approach.

Fixes http://github.com/eclipsesource/theia/issues/253

#### How to test

1. Launch Theia IDE with the panoply of default VSX plugins downloaded and installed.
2. Make a change in some file in Git such that the source editor shows diff markers in the gutter.
3. Click on a diff marker.
4. Observe that the quick diff appears in the Dirty Diff Widget in the editor.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
