### PR TITLE
Add AI model aliases and default models

### DIFF
--- a/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
@@ -116,7 +116,7 @@ export class AskAndContinueChatAgent extends AbstractStreamParsingChatAgent {
     override languageModelRequirements = [
         {
             purpose: 'chat',
-            identifier: 'openai/gpt-4o',
+            identifier: 'default/universal',
         }
     ];
     override prompts = [{ id: systemPrompt.id, defaultVariant: systemPrompt }];

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -42,6 +42,7 @@
     "@theia/ai-openai": "1.63.0",
     "@theia/ai-scanoss": "1.63.0",
     "@theia/ai-terminal": "1.63.0",
+    "@theia/ai-vercel-ai": "1.63.0",
     "@theia/api-provider-sample": "1.63.0",
     "@theia/api-samples": "1.63.0",
     "@theia/bulk-edit": "1.63.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -60,6 +60,9 @@
       "path": "../../packages/ai-terminal"
     },
     {
+      "path": "../../packages/ai-vercel-ai"
+    },
+    {
       "path": "../../packages/bulk-edit"
     },
     {

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -58,6 +58,7 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
             this.preferenceService.onPreferenceChanged(event => {
                 if (event.preferenceName === API_KEY_PREF) {
                     this.manager.setApiKey(event.newValue);
+                    this.updateAllModels();
                 } else if (event.preferenceName === MODELS_PREF) {
                     this.handleModelChanges(event.newValue as string[]);
                 }
@@ -65,7 +66,7 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
 
             this.aiCorePreferences.onPreferenceChanged(event => {
                 if (event.preferenceName === PREFERENCE_NAME_MAX_RETRIES) {
-                    this.updateAllModelsWithNewRetries();
+                    this.updateAllModels();
                 }
             });
         });
@@ -83,7 +84,7 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
         this.prevModels = newModels;
     }
 
-    protected updateAllModelsWithNewRetries(): void {
+    protected updateAllModels(): void {
         const models = this.preferenceService.get<string[]>(MODELS_PREF, []);
         this.manager.createOrUpdateLanguageModels(...models.map(modelId => this.createAnthropicModelDescription(modelId)));
     }
@@ -110,4 +111,5 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
 
         return description;
     }
+
 }

--- a/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
@@ -24,6 +24,9 @@ describe('AnthropicModel', () => {
             const model = new AnthropicModel(
                 'test-id',
                 'claude-3-opus-20240229',
+                {
+                    status: 'ready'
+                },
                 true,
                 true,
                 () => 'test-api-key',
@@ -38,6 +41,9 @@ describe('AnthropicModel', () => {
             const model = new AnthropicModel(
                 'test-id',
                 'claude-3-opus-20240229',
+                {
+                    status: 'ready'
+                },
                 true,
                 true,
                 () => 'test-api-key',
@@ -52,6 +58,9 @@ describe('AnthropicModel', () => {
             const model = new AnthropicModel(
                 'test-id',
                 'claude-3-opus-20240229',
+                {
+                    status: 'ready'
+                },
                 true,
                 true,
                 () => 'test-api-key',

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -27,7 +27,8 @@ import {
     UserRequest,
     ImageContent,
     ToolCallResult,
-    ImageMimeType
+    ImageMimeType,
+    LanguageModelStatus
 } from '@theia/ai-core';
 import { CancellationToken, isArray } from '@theia/core';
 import { Anthropic } from '@anthropic-ai/sdk';
@@ -164,6 +165,7 @@ export class AnthropicModel implements LanguageModel {
     constructor(
         public readonly id: string,
         public model: string,
+        public status: LanguageModelStatus,
         public enableStreaming: boolean,
         public useCaching: boolean,
         public apiKey: () => string | undefined,

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -236,7 +236,7 @@ export abstract class AbstractChatAgent implements ChatAgent {
     protected async selectLanguageModel(selector: LanguageModelRequirement): Promise<LanguageModel> {
         const languageModel = await this.languageModelRegistry.selectLanguageModel({ agent: this.id, ...selector });
         if (!languageModel) {
-            throw new Error('Couldn\'t find a language model. Please check your setup!');
+            throw new Error(`Couldn\'t find a ready language model for agent ${this.id}. Please check your setup!`);
         }
         return languageModel;
     }

--- a/packages/ai-chat/src/common/chat-session-naming-service.ts
+++ b/packages/ai-chat/src/common/chat-session-naming-service.ts
@@ -52,7 +52,7 @@ export class ChatSessionNamingAgent implements Agent {
     prompts = [CHAT_SESSION_NAMING_PROMPT];
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat-session-naming',
-        identifier: 'openai/gpt-4o-mini',
+        identifier: 'default/summarize',
     }];
     agentSpecificVariables = [
         { name: 'conversation', usedInPrompt: true, description: 'The content of the chat conversation.' },

--- a/packages/ai-chat/src/common/chat-session-summary-agent.ts
+++ b/packages/ai-chat/src/common/chat-session-summary-agent.ts
@@ -33,7 +33,7 @@ export class ChatSessionSummaryAgent extends AbstractStreamParsingChatAgent impl
     protected readonly defaultLanguageModelPurpose = 'chat-session-summary';
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat-session-summary',
-        identifier: 'openai/gpt-4o',
+        identifier: 'default/summarize',
     }];
     override agentSpecificVariables = [];
     override functions = [];

--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -145,7 +145,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
     languageModelRequirements: LanguageModelRequirement[] = [
         {
             purpose: 'code-completion',
-            identifier: 'openai/gpt-4o',
+            identifier: 'default/code-completion',
         },
     ];
     readonly variables: string[] = [];

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -20,6 +20,8 @@ import {
     ServiceConnectionProvider,
 } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { DefaultLanguageModelAliasRegistry } from './frontend-language-model-alias-registry';
+import { LanguageModelAliasRegistry } from '../common/language-model-alias';
 import {
     AIVariableContribution,
     AIVariableService,
@@ -42,7 +44,8 @@ import {
     TokenUsageServiceClient,
     AIVariableResourceResolver,
     ConfigurableInMemoryResources,
-    Agent
+    Agent,
+    FrontendLanguageModelRegistry
 } from '../common';
 import {
     FrontendLanguageModelRegistryImpl,
@@ -83,6 +86,7 @@ export default new ContainerModule(bind => {
     bindContributionProvider(bind, LanguageModelProvider);
 
     bind(FrontendLanguageModelRegistryImpl).toSelf().inSingletonScope();
+    bind(FrontendLanguageModelRegistry).toService(FrontendLanguageModelRegistryImpl);
     bind(LanguageModelRegistry).toService(FrontendLanguageModelRegistryImpl);
 
     bind(LanguageModelDelegateClientImpl).toSelf().inSingletonScope();
@@ -118,7 +122,8 @@ export default new ContainerModule(bind => {
     bind(CommandContribution).toService(PromptTemplateContribution);
     bind(TabBarToolbarContribution).toService(PromptTemplateContribution);
 
-    bind(AISettingsService).to(AISettingsServiceImpl).inRequestScope();
+    bind(AISettingsServiceImpl).toSelf().inSingletonScope();
+    bind(AISettingsService).toService(AISettingsServiceImpl);
     bindContributionProvider(bind, AIVariableContribution);
     bind(DefaultFrontendVariableService).toSelf().inSingletonScope();
     bind(FrontendVariableService).toService(DefaultFrontendVariableService);
@@ -161,6 +166,9 @@ export default new ContainerModule(bind => {
 
     bind(TokenUsageFrontendService).to(TokenUsageFrontendServiceImpl).inSingletonScope();
     bind(TokenUsageServiceClient).to(TokenUsageServiceClientImpl).inSingletonScope();
+
+    bind(DefaultLanguageModelAliasRegistry).toSelf().inSingletonScope();
+    bind(LanguageModelAliasRegistry).toService(DefaultLanguageModelAliasRegistry);
 
     bind(TokenUsageService).toDynamicValue(ctx => {
         const connection = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);

--- a/packages/ai-core/src/browser/ai-core-preferences.ts
+++ b/packages/ai-core/src/browser/ai-core-preferences.ts
@@ -31,6 +31,8 @@ export const PREFERENCE_NAME_REQUEST_SETTINGS = 'ai-features.modelSettings.reque
 export const PREFERENCE_NAME_MAX_RETRIES = 'ai-features.modelSettings.maxRetries';
 export const PREFERENCE_NAME_DEFAULT_NOTIFICATION_TYPE = 'ai-features.notifications.default';
 
+export const LANGUAGE_MODEL_ALIASES_PREFERENCE = 'ai-features.languageModelAliases';
+
 export const aiCorePreferenceSchema: PreferenceSchema = {
     type: 'object',
     properties: {
@@ -148,6 +150,30 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
             type: 'string',
             enum: [...NOTIFICATION_TYPES],
             default: NOTIFICATION_TYPE_OFF
+        },
+        [LANGUAGE_MODEL_ALIASES_PREFERENCE]: {
+            title: nls.localize('theia/ai/core/preference/languageModelAliases/title', 'Language Model Aliases'),
+            markdownDescription: nls.localize('theia/ai/core/preference/languageModelAliases/description', 'Configure models for each language model alias in the \
+[AI Configuration View]({0}). Alternatiely you can set the settings manually in the settings.json: \n\
+```\n\
+"default/code": {\n\
+  "selectedModel": "anthropic/claude-opus-4-20250514"\n\
+}\n\```',
+                'command:aiConfiguration:open'
+            ),
+            type: 'object',
+            additionalProperties: {
+                type: 'object',
+                properties: {
+                    selectedModel: {
+                        type: 'string',
+                        description: nls.localize('theia/ai/core/preference/languageModelAliases/selectedModel', 'The user-selected model for this alias.')
+                    }
+                },
+                required: ['selectedModel'],
+                additionalProperties: false
+            },
+            default: {},
         }
     }
 };

--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -1,0 +1,166 @@
+// *****************************************************************************
+// Copyright (C) 2024-2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { Emitter, Event } from '@theia/core';
+import { LanguageModelAlias, LanguageModelAliasRegistry } from '../common/language-model-alias';
+import { PreferenceScope, PreferenceService } from '@theia/core/lib/browser';
+import { LANGUAGE_MODEL_ALIASES_PREFERENCE } from './ai-core-preferences';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+
+@injectable()
+export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegistry {
+
+    protected aliases: LanguageModelAlias[] = [
+        {
+            id: 'default/code',
+            defaultModelIds: [
+                'anthropic/claude-3-7-sonnet-latest',
+                'openai/gpt-4.1',
+                'google/gemini-2.5-pro-exp-03-25'
+            ],
+            description: 'Optimized for code understanding and generation tasks.'
+        },
+        {
+            id: 'default/universal',
+            defaultModelIds: [
+                'anthropic/claude-3-7-sonnet-latest',
+                'openai/gpt-4.1',
+                'google/gemini-2.5-pro-exp-03-25'
+            ],
+            description: 'Well-balanced for both code and general language use.'
+        },
+        {
+            id: 'default/code-completion',
+            defaultModelIds: [
+                'anthropic/claude-3-7-sonnet-latest',
+                'openai/gpt-4.1',
+                'google/gemini-2.5-pro-exp-03-25'
+            ],
+            description: 'Best suited for code autocompletion scenarios.'
+        },
+        {
+            id: 'default/summarize',
+            defaultModelIds: [
+                'anthropic/claude-3-7-sonnet-latest',
+                'openai/gpt-4.1',
+                'google/gemini-2.5-pro-exp-03-25'
+            ],
+            description: 'Models prioritized for summarization and condensation of content.'
+        }
+    ];
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    protected readonly _ready = new Deferred<void>();
+    get ready(): Promise<void> {
+        return this._ready.promise;
+    }
+
+    @postConstruct()
+    protected init(): void {
+        this.preferenceService.ready.then(() => {
+            this.loadFromPreference();
+            this.preferenceService.onPreferenceChanged(ev => {
+                if (ev.preferenceName === LANGUAGE_MODEL_ALIASES_PREFERENCE) {
+                    this.loadFromPreference();
+                }
+            });
+            this._ready.resolve();
+        }, err => {
+            this._ready.reject(err);
+        });
+    }
+
+    addAlias(alias: LanguageModelAlias): void {
+        const idx = this.aliases.findIndex(a => a.id === alias.id);
+        if (idx !== -1) {
+            this.aliases[idx] = alias;
+        } else {
+            this.aliases.push(alias);
+        }
+        this.saveToPreference();
+        this.onDidChangeEmitter.fire();
+    }
+
+    removeAlias(id: string): void {
+        const idx = this.aliases.findIndex(a => a.id === id);
+        if (idx !== -1) {
+            this.aliases.splice(idx, 1);
+            this.saveToPreference();
+            this.onDidChangeEmitter.fire();
+        }
+    }
+
+    getAliases(): LanguageModelAlias[] {
+        return [...this.aliases];
+    }
+
+    resolveAlias(id: string): string[] | undefined {
+        const alias = this.aliases.find(a => a.id === id);
+        if (!alias) {
+            return undefined;
+        }
+        if (alias.selectedModelId) {
+            return [alias.selectedModelId];
+        }
+        return alias.defaultModelIds;
+    }
+
+    /**
+     * Set the selected model for the given alias id.
+     * Updates the alias' selectedModelId to the given modelId, persists, and fires onDidChange.
+     */
+    selectModelForAlias(aliasId: string, modelId: string): void {
+        const alias = this.aliases.find(a => a.id === aliasId);
+        if (alias) {
+            alias.selectedModelId = modelId;
+            this.saveToPreference();
+            this.onDidChangeEmitter.fire();
+        }
+    }
+
+    /**
+     * Load aliases from the persisted setting
+     */
+    protected loadFromPreference(): void {
+        const stored = this.preferenceService.get<{ [name: string]: { selectedModel: string } }>(LANGUAGE_MODEL_ALIASES_PREFERENCE) || {};
+        this.aliases.forEach(alias => {
+            if (stored[alias.id] && stored[alias.id].selectedModel) {
+                alias.selectedModelId = stored[alias.id].selectedModel;
+            } else {
+                delete alias.selectedModelId;
+            }
+        });
+    }
+
+    /**
+     * Persist the current aliases and their selected models to the setting
+     */
+    protected saveToPreference(): void {
+        const map: { [name: string]: { selectedModel: string } } = {};
+        for (const alias of this.aliases) {
+            if (alias.selectedModelId) {
+                map[alias.id] = { selectedModel: alias.selectedModelId };
+            }
+        }
+        this.preferenceService.set(LANGUAGE_MODEL_ALIASES_PREFERENCE, map, PreferenceScope.User);
+    }
+}
+

--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -37,8 +37,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/universal',
             defaultModelIds: [
+                'openai/gpt-4o',
                 'anthropic/claude-3-7-sonnet-latest',
-                'openai/gpt-4.1',
                 'google/gemini-2.5-pro-exp-03-25'
             ],
             description: 'Well-balanced for both code and general language use.'
@@ -46,8 +46,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/code-completion',
             defaultModelIds: [
-                'anthropic/claude-3-7-sonnet-latest',
                 'openai/gpt-4.1',
+                'anthropic/claude-3-7-sonnet-latest',
                 'google/gemini-2.5-pro-exp-03-25'
             ],
             description: 'Best suited for code autocompletion scenarios.'
@@ -55,8 +55,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/summarize',
             defaultModelIds: [
-                'anthropic/claude-3-7-sonnet-latest',
                 'openai/gpt-4.1',
+                'anthropic/claude-3-7-sonnet-latest',
                 'google/gemini-2.5-pro-exp-03-25'
             ],
             description: 'Models prioritized for summarization and condensation of content.'

--- a/packages/ai-core/src/browser/index.ts
+++ b/packages/ai-core/src/browser/index.ts
@@ -25,6 +25,7 @@ export * from './ai-core-preferences';
 export * from './ai-settings-service';
 export * from './ai-view-contribution';
 export * from './frontend-language-model-registry';
+export * from './frontend-language-model-alias-registry';
 export * from './frontend-variable-service';
 export * from './prompttemplate-contribution';
 export * from './theia-variable-contribution';

--- a/packages/ai-core/src/common/index.ts
+++ b/packages/ai-core/src/common/index.ts
@@ -20,6 +20,7 @@ export * from './tool-invocation-registry';
 export * from './language-model-delegate';
 export * from './language-model-util';
 export * from './language-model';
+export * from './language-model-alias';
 export * from './prompt-service';
 export * from './prompt-service-util';
 export * from './prompt-text';

--- a/packages/ai-core/src/common/language-model-alias.ts
+++ b/packages/ai-core/src/common/language-model-alias.ts
@@ -1,0 +1,76 @@
+// *****************************************************************************
+// Copyright (C) 2024-2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core';
+
+/**
+ * Represents an alias for a language model, allowing fallback and selection.
+ */
+export interface LanguageModelAlias {
+    /**
+     * The unique identifier for the alias.
+     */
+    id: string;
+    /**
+     * The list of default model IDs to use if no selectedModelId is set.
+     * Ordered by priority. The first entry also serves as fallback.
+     */
+    defaultModelIds: string[];
+    /**
+     * A human-readable description of the alias.
+     */
+    description?: string;
+    /**
+     * The currently selected model ID, if any.
+     */
+    selectedModelId?: string;
+}
+
+export const LanguageModelAliasRegistry = Symbol('LanguageModelAliasRegistry');
+/**
+ * Registry for managing language model aliases.
+ */
+export interface LanguageModelAliasRegistry {
+    /**
+     * Promise that resolves when the registry is ready for use (preferences loaded).
+     */
+    ready: Promise<void>;
+
+    /**
+     * Event that is fired when the alias list changes.
+     */
+    onDidChange: Event<void>;
+    /**
+     * Add a new alias or update an existing one.
+     */
+    addAlias(alias: LanguageModelAlias): void;
+    /**
+     * Remove an alias by its id.
+     */
+    removeAlias(id: string): void;
+    /**
+     * Get all aliases.
+     */
+    getAliases(): LanguageModelAlias[];
+    /**
+     * Resolve an alias or model id to a prioritized list of model ids.
+     * If the id is not an alias, returns [id].
+     * If the alias exists and has a selectedModelId, returns [selectedModelId].
+     * If the alias exists and has no selectedModelId, returns defaultModelIds.
+     * If the alias does not exist, returns undefined.
+     */
+    resolveAlias(id: string): string[] | undefined;
+}

--- a/packages/ai-core/src/common/protocol.ts
+++ b/packages/ai-core/src/common/protocol.ts
@@ -22,6 +22,10 @@ export const LanguageModelRegistryClient = Symbol('LanguageModelRegistryClient')
 export interface LanguageModelRegistryClient {
     languageModelAdded(metadata: LanguageModelMetaData): void;
     languageModelRemoved(id: string): void;
+    /**
+     * Notify the client that a language model was updated.
+     */
+    onLanguageModelUpdated(id: string): void;
 }
 
 export const TOKEN_USAGE_SERVICE_PATH = '/services/token-usage';

--- a/packages/ai-core/src/node/ai-core-backend-module.ts
+++ b/packages/ai-core/src/node/ai-core-backend-module.ts
@@ -41,14 +41,14 @@ import {
     TokenUsageServiceClient,
     TOKEN_USAGE_SERVICE_PATH
 } from '../common';
-import { BackendLanguageModelRegistry } from './backend-language-model-registry';
+import { BackendLanguageModelRegistryImpl } from './backend-language-model-registry';
 import { TokenUsageServiceImpl } from './token-usage-service-impl';
 
 // We use a connection module to handle AI services separately for each frontend.
 const aiCoreConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService, bindFrontendService }) => {
     bindContributionProvider(bind, LanguageModelProvider);
-    bind(BackendLanguageModelRegistry).toSelf().inSingletonScope();
-    bind(LanguageModelRegistry).toService(BackendLanguageModelRegistry);
+    bind(BackendLanguageModelRegistryImpl).toSelf().inSingletonScope();
+    bind(LanguageModelRegistry).toService(BackendLanguageModelRegistryImpl);
 
     bind(TokenUsageService).to(TokenUsageServiceImpl).inSingletonScope();
 

--- a/packages/ai-core/src/node/backend-language-model-registry.ts
+++ b/packages/ai-core/src/node/backend-language-model-registry.ts
@@ -21,7 +21,7 @@ import { DefaultLanguageModelRegistryImpl, LanguageModel, LanguageModelMetaData,
  * Notifies a client whenever a model is added or removed
  */
 @injectable()
-export class BackendLanguageModelRegistry extends DefaultLanguageModelRegistryImpl {
+export class BackendLanguageModelRegistryImpl extends DefaultLanguageModelRegistryImpl {
 
     private client: LanguageModelRegistryClient | undefined;
 
@@ -45,10 +45,18 @@ export class BackendLanguageModelRegistry extends DefaultLanguageModelRegistryIm
         }
     }
 
+    override async patchLanguageModel<T extends LanguageModel = LanguageModel>(id: string, patch: Partial<T>): Promise<void> {
+        await super.patchLanguageModel(id, patch);
+        if (this.client) {
+            this.client.onLanguageModelUpdated(id);
+        }
+    }
+
     mapToMetaData(model: LanguageModel): LanguageModelMetaData {
         return {
             id: model.id,
             name: model.name,
+            status: model.status,
             vendor: model.vendor,
             version: model.version,
             family: model.family,

--- a/packages/ai-core/src/node/language-model-frontend-delegate.ts
+++ b/packages/ai-core/src/node/language-model-frontend-delegate.ts
@@ -30,13 +30,13 @@ import {
     isLanguageModelParsedResponse,
     UserRequest,
 } from '../common';
-import { BackendLanguageModelRegistry } from './backend-language-model-registry';
+import { BackendLanguageModelRegistryImpl } from './backend-language-model-registry';
 
 @injectable()
 export class LanguageModelRegistryFrontendDelegateImpl implements LanguageModelRegistryFrontendDelegate {
 
     @inject(LanguageModelRegistry)
-    private registry: BackendLanguageModelRegistry;
+    private registry: BackendLanguageModelRegistryImpl;
 
     setClient(client: LanguageModelRegistryClient): void {
         this.registry.setClient(client);

--- a/packages/ai-google/src/browser/google-frontend-application-contribution.ts
+++ b/packages/ai-google/src/browser/google-frontend-application-contribution.ts
@@ -48,6 +48,7 @@ export class GoogleFrontendApplicationContribution implements FrontendApplicatio
             this.preferenceService.onPreferenceChanged(event => {
                 if (event.preferenceName === API_KEY_PREF) {
                     this.manager.setApiKey(event.newValue);
+                    this.handleKeyChange(event.newValue);
                 } else if (event.preferenceName === MAX_RETRIES) {
                     this.manager.setMaxRetriesOnErrors(event.newValue);
                 } else if (event.preferenceName === RETRY_DELAY_RATE_LIMIT) {
@@ -59,6 +60,15 @@ export class GoogleFrontendApplicationContribution implements FrontendApplicatio
                 }
             });
         });
+    }
+
+    /**
+     * Called when the API key changes. Updates all Google models on the manager to ensure the new key is used.
+     */
+    protected handleKeyChange(newApiKey: string | undefined): void {
+        if (this.prevModels && this.prevModels.length > 0) {
+            this.manager.createOrUpdateLanguageModels(...this.prevModels.map(modelId => this.createGeminiModelDescription(modelId)));
+        }
     }
 
     protected handleModelChanges(newModels: string[]): void {

--- a/packages/ai-google/src/node/google-language-model.ts
+++ b/packages/ai-google/src/node/google-language-model.ts
@@ -25,7 +25,8 @@ import {
     TokenUsageService,
     UserRequest,
     ImageContent,
-    ToolCallResult
+    ToolCallResult,
+    LanguageModelStatus
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { GoogleGenAI, FunctionCallingConfigMode, FunctionDeclaration, Content, Schema, Part, Modality, FunctionResponse } from '@google/genai';
@@ -124,6 +125,7 @@ export class GoogleModel implements LanguageModel {
     constructor(
         public readonly id: string,
         public model: string,
+        public status: LanguageModelStatus,
         public enableStreaming: boolean,
         public apiKey: () => string | undefined,
         public retrySettings: () => GoogleLanguageModelRetrySettings,

--- a/packages/ai-google/src/node/google-language-models-manager-impl.ts
+++ b/packages/ai-google/src/node/google-language-models-manager-impl.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelRegistry, TokenUsageService } from '@theia/ai-core';
+import { LanguageModelRegistry, LanguageModelStatus, TokenUsageService } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { GoogleModel } from './google-language-model';
 import { GoogleLanguageModelsManager, GoogleModelDescription } from '../common';
@@ -44,6 +44,12 @@ export class GoogleLanguageModelsManagerImpl implements GoogleLanguageModelsMana
         return this._apiKey ?? process.env.GOOGLE_API_KEY ?? process.env.GEMINI_API_KEY;
     }
 
+    protected calculateStatus(effectiveApiKey: string | undefined): LanguageModelStatus {
+        return effectiveApiKey
+            ? { status: 'ready' }
+            : { status: 'unavailable', message: 'No Google API key set' };
+    }
+
     async createOrUpdateLanguageModels(...modelDescriptions: GoogleModelDescription[]): Promise<void> {
         for (const modelDescription of modelDescriptions) {
             const model = await this.languageModelRegistry.getLanguageModel(modelDescription.id);
@@ -58,20 +64,27 @@ export class GoogleLanguageModelsManagerImpl implements GoogleLanguageModelsMana
             };
             const retrySettingsProvider = () => this.retrySettings;
 
+            // Determine the effective API key for status
+            const status = this.calculateStatus(apiKeyProvider());
+
             if (model) {
                 if (!(model instanceof GoogleModel)) {
                     console.warn(`Gemini: model ${modelDescription.id} is not a Gemini model`);
                     continue;
                 }
-                model.model = modelDescription.model;
-                model.enableStreaming = modelDescription.enableStreaming;
-                model.apiKey = apiKeyProvider;
-                model.retrySettings = retrySettingsProvider;
+                await this.languageModelRegistry.patchLanguageModel<GoogleModel>(modelDescription.id, {
+                    model: modelDescription.model,
+                    enableStreaming: modelDescription.enableStreaming,
+                    apiKey: apiKeyProvider,
+                    retrySettings: retrySettingsProvider,
+                    status
+                });
             } else {
                 this.languageModelRegistry.addLanguageModels([
                     new GoogleModel(
                         modelDescription.id,
                         modelDescription.model,
+                        status,
                         modelDescription.enableStreaming,
                         apiKeyProvider,
                         retrySettingsProvider,

--- a/packages/ai-hugging-face/src/browser/huggingface-frontend-application-contribution.ts
+++ b/packages/ai-hugging-face/src/browser/huggingface-frontend-application-contribution.ts
@@ -43,6 +43,7 @@ export class HuggingFaceFrontendApplicationContribution implements FrontendAppli
             this.preferenceService.onPreferenceChanged(event => {
                 if (event.preferenceName === API_KEY_PREF) {
                     this.manager.setApiKey(event.newValue);
+                    this.handleKeyChange(event.newValue);
                 } else if (event.preferenceName === MODELS_PREF) {
                     this.handleModelChanges(event.newValue as string[]);
                 }
@@ -60,6 +61,15 @@ export class HuggingFaceFrontendApplicationContribution implements FrontendAppli
         this.manager.removeLanguageModels(...modelsToRemove.map(model => `${HUGGINGFACE_PROVIDER_ID}/${model}`));
         this.manager.createOrUpdateLanguageModels(...modelsToAdd.map(modelId => this.createHuggingFaceModelDescription(modelId)));
         this.prevModels = newModels;
+    }
+
+    /**
+     * Called when the API key changes. Updates all HuggingFace models on the manager to ensure the new key is used.
+     */
+    protected handleKeyChange(newApiKey: string | undefined): void {
+        if (this.prevModels && this.prevModels.length > 0) {
+            this.manager.createOrUpdateLanguageModels(...this.prevModels.map(modelId => this.createHuggingFaceModelDescription(modelId)));
+        }
     }
 
     protected createHuggingFaceModelDescription(

--- a/packages/ai-hugging-face/src/node/huggingface-language-model.ts
+++ b/packages/ai-hugging-face/src/node/huggingface-language-model.ts
@@ -21,7 +21,8 @@ import {
     LanguageModelResponse,
     LanguageModelStreamResponsePart,
     LanguageModelTextResponse,
-    MessageActor
+    MessageActor,
+    LanguageModelStatus
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { HfInference } from '@huggingface/inference';
@@ -70,6 +71,7 @@ export class HuggingFaceModel implements LanguageModel {
     constructor(
         public readonly id: string,
         public model: string,
+        public status: LanguageModelStatus,
         public apiKey: () => string | undefined,
         public readonly name?: string,
         public readonly vendor?: string,

--- a/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -20,6 +20,7 @@ import {
     AISettingsService,
     AIVariableService,
     BasePromptFragment,
+    FrontendLanguageModelRegistry,
     LanguageModel,
     LanguageModelRegistry,
     matchVariablesRegEx,
@@ -33,6 +34,7 @@ import { inject, injectable, postConstruct } from '@theia/core/shared/inversify'
 import * as React from '@theia/core/shared/react';
 import { AIConfigurationSelectionService } from './ai-configuration-service';
 import { LanguageModelRenderer } from './language-model-renderer';
+import { LanguageModelAliasRegistry, LanguageModelAlias } from '@theia/ai-core/lib/common/language-model-alias';
 import { AIVariableConfigurationWidget } from './variable-configuration-widget';
 import { nls } from '@theia/core';
 import { PromptVariantRenderer } from './template-settings-renderer';
@@ -53,10 +55,13 @@ export class AIAgentConfigurationWidget extends ReactWidget {
     protected readonly agentService: AgentService;
 
     @inject(LanguageModelRegistry)
-    protected readonly languageModelRegistry: LanguageModelRegistry;
+    protected readonly languageModelRegistry: FrontendLanguageModelRegistry;
 
     @inject(PromptFragmentCustomizationService)
     protected readonly promptFragmentCustomizationService: PromptFragmentCustomizationService;
+
+    @inject(LanguageModelAliasRegistry)
+    protected readonly languageModelAliasRegistry: LanguageModelAliasRegistry;
 
     @inject(AISettingsService)
     protected readonly aiSettingsService: AISettingsService;
@@ -74,6 +79,7 @@ export class AIAgentConfigurationWidget extends ReactWidget {
     protected readonly quickInputService: QuickInputService;
 
     protected languageModels: LanguageModel[] | undefined;
+    protected languageModelAliases: LanguageModelAlias[] = [];
 
     @postConstruct()
     protected init(): void {
@@ -85,7 +91,15 @@ export class AIAgentConfigurationWidget extends ReactWidget {
             this.languageModels = models ?? [];
             this.update();
         });
+        this.languageModelAliasRegistry.ready.then(() => {
+            this.languageModelAliases = this.languageModelAliasRegistry.getAliases();
+            this.toDispose.push(this.languageModelAliasRegistry.onDidChange(() => {
+                this.languageModelAliases = this.languageModelAliasRegistry.getAliases();
+                this.update();
+            }));
+        });
         this.toDispose.push(this.languageModelRegistry.onChange(({ models }) => {
+            this.languageModelAliases = this.languageModelAliasRegistry.getAliases();
             this.languageModels = models;
             this.update();
         }));
@@ -183,7 +197,9 @@ export class AIAgentConfigurationWidget extends ReactWidget {
                     agent={agent}
                     languageModels={this.languageModels}
                     aiSettingsService={this.aiSettingsService}
-                    languageModelRegistry={this.languageModelRegistry} />
+                    languageModelRegistry={this.languageModelRegistry}
+                    languageModelAliases={this.languageModelAliases}
+                />
             </div>
             <div>
                 <span>Used Global Variables:</span>

--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-service.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-service.ts
@@ -21,12 +21,16 @@ import { injectable } from '@theia/core/shared/inversify';
 @injectable()
 export class AIConfigurationSelectionService {
     protected activeAgent?: Agent;
+    protected selectedAliasId?: string;
 
     protected readonly onDidSelectConfigurationEmitter = new Emitter<string>();
     onDidSelectConfiguration = this.onDidSelectConfigurationEmitter.event;
 
     protected readonly onDidAgentChangeEmitter = new Emitter<Agent | undefined>();
-    onDidAgentChange = this.onDidSelectConfigurationEmitter.event;
+    onDidAgentChange = this.onDidAgentChangeEmitter.event;
+
+    protected readonly onDidAliasChangeEmitter = new Emitter<string | undefined>();
+    onDidAliasChange = this.onDidAliasChangeEmitter.event;
 
     public getActiveAgent(): Agent | undefined {
         return this.activeAgent;
@@ -35,6 +39,15 @@ export class AIConfigurationSelectionService {
     public setActiveAgent(agent?: Agent): void {
         this.activeAgent = agent;
         this.onDidAgentChangeEmitter.fire(agent);
+    }
+
+    public getSelectedAliasId(): string | undefined {
+        return this.selectedAliasId;
+    }
+
+    public setSelectedAliasId(aliasId?: string): void {
+        this.selectedAliasId = aliasId;
+        this.onDidAliasChangeEmitter.fire(aliasId);
     }
 
     public selectConfigurationTab(widgetId: string): void {

--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-widget.tsx
@@ -25,6 +25,7 @@ import { nls } from '@theia/core';
 import { AIMCPConfigurationWidget } from './mcp-configuration-widget';
 import { AITokenUsageConfigurationWidget } from './token-usage-configuration-widget';
 import { AIPromptFragmentsConfigurationWidget } from './prompt-fragments-configuration-widget';
+import { ModelAliasesConfigurationWidget } from './model-aliases-configuration-widget';
 
 @injectable()
 export class AIConfigurationContainerWidget extends BaseWidget {
@@ -46,6 +47,7 @@ export class AIConfigurationContainerWidget extends BaseWidget {
     protected tokenUsageWidget: AITokenUsageConfigurationWidget;
     protected promptFragmentsWidget: AIPromptFragmentsConfigurationWidget;
     protected toolsWidget: AIToolsConfigurationWidget;
+    protected modelAliasesWidget: ModelAliasesConfigurationWidget;
 
     @postConstruct()
     protected init(): void {
@@ -74,6 +76,7 @@ export class AIConfigurationContainerWidget extends BaseWidget {
         this.tokenUsageWidget = await this.widgetManager.getOrCreateWidget(AITokenUsageConfigurationWidget.ID);
         this.promptFragmentsWidget = await this.widgetManager.getOrCreateWidget(AIPromptFragmentsConfigurationWidget.ID);
         this.toolsWidget = await this.widgetManager.getOrCreateWidget(AIToolsConfigurationWidget.ID);
+        this.modelAliasesWidget = await this.widgetManager.getOrCreateWidget(ModelAliasesConfigurationWidget.ID);
 
         this.dockpanel.addWidget(this.agentsWidget);
         this.dockpanel.addWidget(this.variablesWidget, { mode: 'tab-after', ref: this.agentsWidget });
@@ -81,6 +84,7 @@ export class AIConfigurationContainerWidget extends BaseWidget {
         this.dockpanel.addWidget(this.tokenUsageWidget, { mode: 'tab-after', ref: this.mcpWidget });
         this.dockpanel.addWidget(this.promptFragmentsWidget, { mode: 'tab-after', ref: this.tokenUsageWidget });
         this.dockpanel.addWidget(this.toolsWidget, { mode: 'tab-after', ref: this.promptFragmentsWidget });
+        this.dockpanel.addWidget(this.modelAliasesWidget, { mode: 'tab-after', ref: this.toolsWidget });
 
         this.update();
     }
@@ -99,6 +103,8 @@ export class AIConfigurationContainerWidget extends BaseWidget {
                 this.dockpanel.activateWidget(this.promptFragmentsWidget);
             } else if (widgetId === AIToolsConfigurationWidget.ID) {
                 this.dockpanel.activateWidget(this.toolsWidget);
+            } else if (widgetId === ModelAliasesConfigurationWidget.ID) {
+                this.dockpanel.activateWidget(this.modelAliasesWidget);
             }
         });
     }

--- a/packages/ai-ide/src/browser/ai-configuration/language-model-renderer.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/language-model-renderer.tsx
@@ -14,7 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import * as React from '@theia/core/shared/react';
-import { Agent, AISettingsService, LanguageModel, LanguageModelRegistry, LanguageModelRequirement } from '@theia/ai-core/lib/common';
+import { Agent, AISettingsService, FrontendLanguageModelRegistry, LanguageModel, LanguageModelRequirement } from '@theia/ai-core/lib/common';
+import { LanguageModelAlias } from '@theia/ai-core/lib/common/language-model-alias';
 import { Mutable } from '@theia/core';
 import { nls } from '@theia/core/lib/common/nls';
 
@@ -22,11 +23,12 @@ export interface LanguageModelSettingsProps {
     agent: Agent;
     languageModels?: LanguageModel[];
     aiSettingsService: AISettingsService;
-    languageModelRegistry: LanguageModelRegistry;
+    languageModelRegistry: FrontendLanguageModelRegistry;
+    languageModelAliases: LanguageModelAlias[];
 }
 
 export const LanguageModelRenderer: React.FC<LanguageModelSettingsProps> = (
-    { agent, languageModels, aiSettingsService, languageModelRegistry }) => {
+    { agent, languageModels, aiSettingsService, languageModelRegistry, languageModelAliases: aliases }) => {
 
     const findLanguageModelRequirement = async (purpose: string): Promise<LanguageModelRequirement | undefined> => {
         const requirementSetting = await aiSettingsService.getAgentSettings(agent.id);
@@ -34,6 +36,7 @@ export const LanguageModelRenderer: React.FC<LanguageModelSettingsProps> = (
     };
 
     const [lmRequirementMap, setLmRequirementMap] = React.useState<Record<string, LanguageModelRequirement>>({});
+    const [resolvedAliasModels, setResolvedAliasModels] = React.useState<Record<string, LanguageModel | undefined>>({});
 
     React.useEffect(() => {
         const computeLmRequirementMap = async () => {
@@ -54,32 +57,20 @@ export const LanguageModelRenderer: React.FC<LanguageModelSettingsProps> = (
         computeLmRequirementMap();
     }, []);
 
-    const renderLanguageModelMetadata = (requirement: LanguageModelRequirement, index: number) => {
-        const languageModel = languageModels?.find(model => model.id === requirement.identifier);
-        if (!languageModel) {
-            return <div></div>;
-        }
-
-        return <>
-            <div>{requirement.purpose}</div>
-            <div key={index}>
-                {languageModel.id && <p><strong>{nls.localizeByDefault('Identifier')}: </strong> {languageModel.id}</p>}
-                {languageModel.name && <p><strong>{nls.localizeByDefault('Name')}: </strong> {languageModel.name}</p>}
-                {languageModel.vendor && <p><strong>{nls.localize('theia/ai/core/languageModelRenderer/vendor', 'Vendor')}: </strong> {languageModel.vendor}</p>}
-                {languageModel.version && <p><strong>{nls.localizeByDefault('Version')}: </strong> {languageModel.version}</p>}
-                {languageModel.family && <p><strong>{nls.localize('theia/ai/core/languageModelRenderer/family', 'Family')}: </strong> {languageModel.family}</p>}
-                {languageModel.maxInputTokens &&
-                    <p><strong>
-                        {nls.localize('theia/ai/core/languageModelRenderer/minInputTokens', 'Min Input Tokens')}:
-                    </strong> {languageModel.maxInputTokens}</p>}
-                {languageModel.maxOutputTokens &&
-                    <p><strong>
-                        {nls.localize('theia/ai/core/languageModelRenderer/maxOutputTokens', 'Max Output Tokens')}:
-                    </strong> {languageModel.maxOutputTokens}</p>}
-            </div>
-        </>;
-
-    };
+    // Effect to resolve alias to model whenever requirements.identifier or aliases change
+    React.useEffect(() => {
+        const resolveAliases = async () => {
+            const newResolved: Record<string, LanguageModel | undefined> = {};
+            await Promise.all(Object.values(lmRequirementMap).map(async requirements => {
+                const id = requirements.identifier;
+                if (id && aliases.some(a => a.id === id)) {
+                    newResolved[id] = await languageModelRegistry.getReadyLanguageModel(id);
+                }
+            }));
+            setResolvedAliasModels(newResolved);
+        };
+        resolveAliases();
+    }, [lmRequirementMap, aliases]);
 
     const onSelectedModelChange = (purpose: string, event: React.ChangeEvent<HTMLSelectElement>): void => {
         const newLmRequirementMap = { ...lmRequirementMap, [purpose]: { purpose, identifier: event.target.value } };
@@ -88,35 +79,72 @@ export const LanguageModelRenderer: React.FC<LanguageModelSettingsProps> = (
     };
 
     return <div className='language-model-container'>
-        {Object.values(lmRequirementMap).map((requirements, index) => (
-            <React.Fragment key={index}>
-                <div><strong>{nls.localize('theia/ai/core/languageModelRenderer/purpose', 'Purpose')}:</strong></div>
-                <div>
-                    {/* language model metadata */}
-                    {renderLanguageModelMetadata(requirements, index)}
-                    {/* language model selector */}
-                    <>
-                        <label
-                            className="theia-header no-select"
-                            htmlFor={`model-select-${agent.id}`}>
-                            {nls.localize('theia/ai/core/languageModelRenderer/languageModel', 'Language Model')}:
-                        </label>
-                        <select
-                            className="theia-select"
-                            id={`model-select-${agent.id}`}
-                            value={requirements.identifier}
-                            onChange={event => onSelectedModelChange(requirements.purpose, event)}
-                        >
-                            <option value=""></option>
-                            {languageModels?.sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id)).map(model => (
-                                <option key={model.id} value={model.id}>{model.name ?? model.id}</option>
-                            ))}
-                        </select>
-                    </>
-                    <hr />
-                </div>
-            </React.Fragment>
-        ))}
-
+        {Object.values(lmRequirementMap).map((requirement, index) => {
+            const isAlias = requirement.identifier && aliases.some(a => a.id === requirement.identifier);
+            const resolvedModel = isAlias ? resolvedAliasModels[requirement.identifier] : undefined;
+            return (
+                <React.Fragment key={index}>
+                    <div className="ai-alias-evaluates-to-container">
+                        <strong>{nls.localize('theia/ai/core/languageModelRenderer/purpose', 'Purpose')}:</strong> {requirement.purpose}
+                    </div>
+                    <div>
+                        <div className="ai-alias-evaluates-to-container">
+                            <label
+                                className="theia-header no-select"
+                                htmlFor={`model-select-${agent.id}`}>
+                                {nls.localize('theia/ai/core/languageModelRenderer/languageModel', 'Language Model') + ': '}
+                            </label>
+                            <select
+                                className="theia-select"
+                                id={`model-select-${agent.id}-${requirement.purpose}`}
+                                value={requirement.identifier}
+                                onChange={event => onSelectedModelChange(requirement.purpose, event)}
+                            >
+                                <option value=""></option>
+                                {/* Aliases first, then languange models */}
+                                {aliases?.sort((a, b) => a.id.localeCompare(b.id)).map(alias => (
+                                    <option key={`alias/${alias.id}`} value={alias.id} className='ai-language-model-item-ready'>{`[alias] ${alias.id}`}</option>
+                                ))}
+                                {languageModels?.sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id)).map(model => {
+                                    const isNotReady = model.status.status !== 'ready';
+                                    return (
+                                        <option
+                                            key={model.id}
+                                            value={model.id}
+                                            className={isNotReady ? 'ai-language-model-item-not-ready' : 'ai-language-model-item-ready'}
+                                            title={isNotReady && model.status.message ? model.status.message : undefined}
+                                        >
+                                            {model.name ?? model.id} {isNotReady ? '✗' : '✓'}
+                                        </option>
+                                    );
+                                })}
+                            </select>
+                        </div>
+                        {/* If alias is selected, show what it currently evaluates to */}
+                        {isAlias && (
+                            <div className="ai-alias-evaluates-to-container">
+                                <label className="ai-alias-evaluates-to-label">{nls.localize('theia/ai/core/modelAliasesConfiguration/evaluatesTo', 'Evaluates to')}:</label>
+                                {resolvedModel ? (
+                                    <span className="ai-alias-evaluates-to-value">
+                                        {resolvedModel.name ?? resolvedModel.id}
+                                        {resolvedModel.status.status === 'ready' ? (
+                                            <span className="ai-model-status-ready" title="Ready">✓</span>
+                                        ) : (
+                                            <span className="ai-model-status-not-ready" title={resolvedModel.status.message || 'Not ready'}>✗</span>
+                                        )}
+                                    </span>
+                                ) : (
+                                    <span className="ai-alias-evaluates-to-unresolved">
+                                        {nls.localize('theia/ai/core/modelAliasesConfiguration/noResolvedModel', 'No model ready for this alias.')}
+                                        <span className="ai-model-status-not-ready" title={'No model ready'}>✗</span>
+                                    </span>
+                                )}
+                            </div>
+                        )}
+                        <hr />
+                    </div>
+                </React.Fragment>
+            );
+        })}
     </div>;
 };

--- a/packages/ai-ide/src/browser/ai-configuration/model-aliases-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/model-aliases-configuration-widget.tsx
@@ -1,0 +1,271 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import * as React from '@theia/core/shared/react';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { LanguageModelAliasRegistry, LanguageModelAlias } from '@theia/ai-core/lib/common/language-model-alias';
+import { FrontendLanguageModelRegistry, LanguageModel, LanguageModelRegistry } from '@theia/ai-core/lib/common/language-model';
+import { nls } from '@theia/core/lib/common/nls';
+import { AIConfigurationSelectionService } from './ai-configuration-service';
+import { AgentService, AISettingsService } from '@theia/ai-core';
+
+export interface ModelAliasesConfigurationProps {
+    languageModelAliasRegistry: LanguageModelAliasRegistry;
+    languageModelRegistry: LanguageModelRegistry;
+}
+
+@injectable()
+export class ModelAliasesConfigurationWidget extends ReactWidget {
+    static readonly ID = 'ai-model-aliases-configuration-widget';
+    static readonly LABEL = nls.localize('theia/ai/core/modelAliasesConfiguration/label', 'Model Aliases');
+
+    @inject(LanguageModelAliasRegistry)
+    protected readonly languageModelAliasRegistry: LanguageModelAliasRegistry;
+    @inject(LanguageModelRegistry)
+    protected readonly languageModelRegistry: FrontendLanguageModelRegistry;
+    @inject(AIConfigurationSelectionService)
+    protected readonly aiConfigurationSelectionService: AIConfigurationSelectionService;
+    @inject(AISettingsService)
+    protected readonly aiSettingsService: AISettingsService;
+    @inject(AgentService)
+    protected readonly agentService: AgentService;
+
+    protected aliases: LanguageModelAlias[] = [];
+    protected languageModels: LanguageModel[] = [];
+    /**
+     * Map from alias ID to a list of agent IDs that have a language model requirement for that alias.
+     */
+    protected matchingAgentIdsForAliasMap: Map<string, string[]> = new Map();
+    /**
+     * Map from alias ID to the resolved LanguageModel (what the alias currently evaluates to).
+     */
+    protected resolvedModelForAlias: Map<string, LanguageModel | undefined> = new Map();
+
+    @postConstruct()
+    protected init(): void {
+        this.id = ModelAliasesConfigurationWidget.ID;
+        this.title.label = ModelAliasesConfigurationWidget.LABEL;
+        this.title.closable = false;
+
+        const aliasesPromise = this.loadAliases();
+        const languageModelsPromise = this.loadLanguageModels();
+        const matchingAgentsPromise = this.loadMatchingAgentIdsForAllAliases();
+        Promise.all([aliasesPromise, languageModelsPromise, matchingAgentsPromise]).then(() => this.update());
+
+        this.languageModelAliasRegistry.ready.then(() =>
+            this.toDispose.push(this.languageModelAliasRegistry.onDidChange(async () => {
+                await this.loadAliases();
+                this.update();
+            }))
+        );
+
+        this.toDispose.pushAll([
+            this.languageModelRegistry.onChange(async () => {
+                await this.loadAliases();
+                await this.loadLanguageModels();
+                this.update();
+            }),
+            this.aiSettingsService.onDidChange(async () => {
+                await this.loadMatchingAgentIdsForAllAliases();
+                this.update();
+            }),
+            this.aiConfigurationSelectionService.onDidAliasChange(() => this.update())
+        ]);
+    }
+
+    protected async loadAliases(): Promise<void> {
+        await this.languageModelAliasRegistry.ready;
+        this.aliases = this.languageModelAliasRegistry.getAliases();
+        // Set the initial selection if not set
+        if (this.aliases.length > 0 && !this.aiConfigurationSelectionService.getSelectedAliasId()) {
+            this.aiConfigurationSelectionService.setSelectedAliasId(this.aliases[0].id);
+        }
+        await this.loadMatchingAgentIdsForAllAliases();
+        // Resolve evaluated models for each alias
+        this.resolvedModelForAlias = new Map();
+        for (const alias of this.aliases) {
+            const model = await this.languageModelRegistry.getReadyLanguageModel(alias.id);
+            this.resolvedModelForAlias.set(alias.id, model);
+        }
+    }
+
+    protected async loadLanguageModels(): Promise<void> {
+        this.languageModels = await this.languageModelRegistry.getLanguageModels();
+    }
+
+    /**
+     * Loads a map from alias ID to a list of agent IDs that have a language model requirement for that alias.
+     */
+    protected async loadMatchingAgentIdsForAllAliases(): Promise<void> {
+        const agents = this.agentService.getAllAgents();
+        const aliasMap: Map<string, string[]> = new Map();
+        for (const alias of this.aliases) {
+            const matchingAgentIds: string[] = [];
+            for (const agent of agents) {
+                const requirementSetting = await this.aiSettingsService.getAgentSettings(agent.id);
+                if (requirementSetting?.languageModelRequirements?.find(e => e.identifier === alias.id)) {
+                    matchingAgentIds.push(agent.id);
+                }
+            }
+            aliasMap.set(alias.id, matchingAgentIds);
+        }
+        this.matchingAgentIdsForAliasMap = aliasMap;
+    }
+
+    protected handleAliasSelectedModelIdChange = (alias: LanguageModelAlias, event: React.ChangeEvent<HTMLSelectElement>): void => {
+        const newModelId = event.target.value || undefined;
+        const updatedAlias: LanguageModelAlias = {
+            ...alias,
+            selectedModelId: newModelId
+        };
+        this.languageModelAliasRegistry.ready.then(() => {
+            this.languageModelAliasRegistry.addAlias(updatedAlias);
+        });
+    };
+
+    render(): React.ReactNode {
+        const selectedAliasId = this.aiConfigurationSelectionService.getSelectedAliasId();
+        const selectedAlias = this.aliases.find(alias => alias.id === selectedAliasId);
+        return (
+            <div className="model-alias-configuration-main">
+                <div className="model-alias-configuration-list preferences-tree-widget theia-TreeContainer ai-model-alias-list">
+                    <ul>
+                        {this.aliases.map(alias => (
+                            <li
+                                key={alias.id}
+                                className={`theia-TreeNode theia-CompositeTreeNode${alias.id === selectedAliasId ? ' theia-mod-selected' : ''}`}
+                                onClick={() => this.aiConfigurationSelectionService.setSelectedAliasId(alias.id)}
+                            >
+                                <span>{alias.id}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+                <div className="model-alias-configuration-panel preferences-editor-widget">
+                    {selectedAlias ? this.renderAliasDetail(selectedAlias, this.languageModels) : (
+                        <div>
+                            {nls.localize('theia/ai/core/modelAliasesConfiguration/selectAlias', 'Please select a Model Alias.')}
+                        </div>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
+    protected renderAliasDetail(alias: LanguageModelAlias, languageModels: LanguageModel[]): React.ReactNode {
+        const availableModelIds = languageModels.map(m => m.id);
+        const selectedModelId = alias.selectedModelId ?? '';
+        const isInvalidModel = !!selectedModelId && !availableModelIds.includes(alias.selectedModelId ?? '');
+        const agentIds = this.matchingAgentIdsForAliasMap.get(alias.id) || [];
+        const agents = this.agentService.getAllAgents().filter(agent => agentIds.includes(agent.id));
+        const resolvedModel = this.resolvedModelForAlias.get(alias.id);
+        return (
+            <div>
+                <div className="settings-section-title settings-section-category-title ai-alias-detail-title">
+                    <span>{alias.id}</span>
+                </div>
+                {alias.description && <div className="ai-alias-detail-description">{alias.description}</div>}
+                <div className="ai-alias-detail-selected-model">
+                    <label>{nls.localize('theia/ai/core/modelAliasesConfiguration/selectedModelId', 'Selected Model')}: </label>
+                    <select
+                        className={`theia-select template-variant-selector ${isInvalidModel ? 'error' : ''}`}
+                        value={isInvalidModel ? 'invalid' : selectedModelId}
+                        onChange={event => this.handleAliasSelectedModelIdChange(alias, event)}
+                    >
+                        {isInvalidModel && (
+                            <option value="invalid" disabled>
+                                {nls.localize('theia/ai/core/modelAliasesConfiguration/unavailableModel', 'Selected model is no longer available')}
+                            </option>
+                        )}
+                        <option value="" className='ai-language-model-item-ready'>
+                            {nls.localize('theia/ai/core/modelAliasesConfiguration/defaultList', '[Default list]')}
+                        </option>
+                        {[...languageModels]
+                            .sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id))
+                            .map(model => {
+                                const isNotReady = model.status.status !== 'ready';
+                                return (
+                                    <option
+                                        key={model.id}
+                                        value={model.id}
+                                        className={isNotReady ? 'ai-language-model-item-not-ready' : 'ai-language-model-item-ready'}
+                                        title={isNotReady && model.status.message ? model.status.message : undefined}
+                                    >
+                                        {model.name ?? model.id} {isNotReady ? '✗' : '✓'}
+                                    </option>
+                                );
+                            }
+                            )}
+                    </select>
+                </div>
+                {alias.selectedModelId === undefined &&
+                    <><div className="ai-alias-detail-defaults">
+                        <ol>
+                            {alias.defaultModelIds.map(modelId => {
+                                const model = this.languageModels.find(m => m.id === modelId);
+                                const isReady = model?.status.status === 'ready';
+                                return (
+                                    <li key={modelId}>
+                                        {isReady ? (
+                                            <span className={modelId === resolvedModel?.id ? 'ai-alias-priority-item-resolved' : 'ai-alias-priority-item-ready'}>
+                                                {modelId} <span className="ai-model-status-ready" title="Ready">✓</span>
+                                            </span>
+                                        ) : (
+                                            <span className="ai-model-default-not-ready">
+                                                {modelId} <span className="ai-model-status-not-ready" title="Not ready">✗</span>
+                                            </span>
+                                        )}
+                                    </li>
+                                );
+                            })}
+                        </ol>
+                    </div><div className="ai-alias-evaluates-to-container">
+                            <label className="ai-alias-evaluates-to-label">{nls.localize('theia/ai/core/modelAliasesConfiguration/evaluatesTo', 'Evaluates to')}:</label>
+                            {resolvedModel ? (
+                                <span className="ai-alias-evaluates-to-value">
+                                    {resolvedModel.name ?? resolvedModel.id}
+                                    {resolvedModel.status.status === 'ready' ? (
+                                        <span className="ai-model-status-ready" title="Ready">✓</span>
+                                    ) : (
+                                        <span className="ai-model-status-not-ready" title={resolvedModel.status.message || 'Not ready'}>✗</span>
+                                    )}
+                                </span>
+                            ) : (
+                                <span className="ai-alias-evaluates-to-unresolved">
+                                    {nls.localize('theia/ai/core/modelAliasesConfiguration/noResolvedModel', 'No model ready for this alias.')}
+                                </span>
+                            )}
+                        </div></>
+                }
+                <div className="ai-alias-detail-agents">
+                    <label>{nls.localize('theia/ai/core/modelAliasesConfiguration/agents', 'Agents using this Alias')}:</label>
+                    <ul>
+                        {agents.length > 0 ? (
+                            agents.map(agent => (
+                                <li key={agent.id}>
+                                    <span>{agent.name}</span>
+                                    {agent.id !== agent.name && <span className="ai-alias-agent-id">({agent.id})</span>}
+                                </li>
+                            ))
+                        ) : (
+                            <span>{nls.localize('theia/ai/core/modelAliasesConfiguration/noAgents', 'No agents use this alias.')}</span>
+                        )}
+                    </ul>
+                </div>
+            </div >
+        );
+    }
+}

--- a/packages/ai-ide/src/browser/app-tester-chat-agent.ts
+++ b/packages/ai-ide/src/browser/app-tester-chat-agent.ts
@@ -40,7 +40,7 @@ export class AppTesterChatAgent extends AbstractStreamParsingChatAgent {
     name = AppTesterChatAgentId;
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat',
-        identifier: 'openai/gpt-4o',
+        identifier: 'default/code',
     }];
     protected defaultLanguageModelPurpose: string = 'chat';
     override description = nls.localize('theia/ai/chat/app-tester/description', 'This agent tests your application user interface to verify user-specified test scenarios through the Playwright MCP server. '

--- a/packages/ai-ide/src/browser/architect-agent.ts
+++ b/packages/ai-ide/src/browser/architect-agent.ts
@@ -30,7 +30,7 @@ export class ArchitectAgent extends AbstractStreamParsingChatAgent {
     id = 'Architect';
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat',
-        identifier: 'openai/gpt-4o',
+        identifier: 'default/code',
     }];
     protected defaultLanguageModelPurpose: string = 'chat';
 

--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -30,7 +30,7 @@ export class CoderAgent extends AbstractStreamParsingChatAgent {
     name = 'Coder';
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat',
-        identifier: 'openai/gpt-4o',
+        identifier: 'default/code',
     }];
     protected defaultLanguageModelPurpose: string = 'chat';
 

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -76,6 +76,7 @@ import { CommandContribution } from '@theia/core';
 import { AIPromptFragmentsConfigurationWidget } from './ai-configuration/prompt-fragments-configuration-widget';
 import { BrowserAutomation, browserAutomationPath } from '../common/browser-automation-protocol';
 import { CloseBrowserProvider, IsBrowserRunningProvider, LaunchBrowserProvider, QueryDomProvider } from './app-tester-chat-functions';
+import { ModelAliasesConfigurationWidget } from './ai-configuration/model-aliases-configuration-widget';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
@@ -162,6 +163,14 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
         .toDynamicValue(ctx => ({
             id: AIAgentConfigurationWidget.ID,
             createWidget: () => ctx.container.get(AIAgentConfigurationWidget)
+        }))
+        .inSingletonScope();
+
+    bind(ModelAliasesConfigurationWidget).toSelf();
+    bind(WidgetFactory)
+        .toDynamicValue(ctx => ({
+            id: ModelAliasesConfigurationWidget.ID,
+            createWidget: () => ctx.container.get(ModelAliasesConfigurationWidget)
         }))
         .inSingletonScope();
 

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -64,7 +64,8 @@
 }
 
 #ai-variable-configuration-container-widget,
-#ai-agent-configuration-container-widget {
+#ai-agent-configuration-container-widget,
+#ai-model-aliases-configuration-widget {
   margin-top: 5px;
 }
 
@@ -86,21 +87,24 @@
   grid-template-columns: 1fr 2fr;
 }
 
-/* Agent Settings */
-#ai-agent-configuration-container-widget ul {
+/* Agent and Model Alias Settings */
+#ai-agent-configuration-container-widget ul,
+#ai-model-aliases-configuration-widget .model-alias-configuration-list ul {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 
-.ai-agent-configuration-main {
+.ai-agent-configuration-main,
+.model-alias-configuration-main {
   display: flex;
   flex-direction: row;
 }
 
 #ai-agent-configuration-container-widget
   .ai-agent-configuration-main
-  .configuration-agents-list {
+  .configuration-agents-list,
+#ai-model-aliases-configuration-widget .model-alias-configuration-list {
   min-width: 160px;
   overflow: hidden;
   white-space: nowrap;
@@ -109,7 +113,8 @@
   padding: var(--theia-ui-padding);
 }
 
-.configuration-agent-panel {
+.configuration-agent-panel,
+.model-alias-configuration-panel {
   flex: 1;
 }
 
@@ -771,6 +776,80 @@ h4 {
 }
 
 /* End AI Tools Configuration Widget Styles */
+
+/* AI Model Aliases and Language Model Renderer extracted styles */
+.ai-model-alias-list {
+  width: 25%;
+}
+.ai-alias-detail-title {
+  padding-left: 0;
+  padding-bottom: 10px;
+}
+.ai-alias-detail-description {
+  padding-bottom: 10px;
+}
+.ai-alias-detail-selected-model {
+  margin-bottom: 20px;
+}
+.ai-language-model-item-ready {
+  font-style: normal;
+}
+.ai-language-model-item-not-ready {
+  font-style: italic;
+}
+.ai-alias-priority-item-resolved {
+  font-weight: bold;
+}
+.ai-alias-priority-item-ready {
+  font-style: inherit;
+}
+.ai-alias-priority-item-not-ready {
+  font-style: italic;
+}
+.ai-alias-detail-defaults {
+  margin-bottom: 10px;
+}
+.ai-model-default-not-ready {
+  font-style: italic;
+  color: var(--theia-descriptionForeground);
+}
+.ai-alias-defaults-hint {
+  color: var(--theia-descriptionForeground);
+  margin-top: 8px;
+}
+.ai-alias-evaluates-to-container {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+.ai-alias-evaluates-to-label {
+  font-weight: 600;
+}
+.ai-alias-evaluates-to-value {
+  margin-left: 8px;
+}
+.ai-model-status-ready {
+  color: green;
+  margin-left: 6px;
+}
+.ai-model-status-not-ready {
+  color: red;
+  margin-left: 6px;
+}
+.ai-alias-evaluates-to-unresolved {
+  margin-left: 8px;
+  color: var(--theia-descriptionForeground);
+}
+.ai-alias-detail-agents {
+  margin-bottom: 10px;
+}
+.ai-alias-agent-id {
+  color: var(--theia-descriptionForeground);
+  margin-left: 8px;
+}
+.ai-alias-no-agents {
+  color: var(--theia-descriptionForeground);
+}
+/* End AI Model Aliases and Language Model Renderer extracted styles */
 
 /* Token Usage Configuration Styles */
 .token-usage-configuration-title {

--- a/packages/ai-ide/src/common/command-chat-agents.ts
+++ b/packages/ai-ide/src/common/command-chat-agents.ts
@@ -51,7 +51,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
     name = 'Command';
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'command',
-        identifier: 'openai/gpt-4o',
+        identifier: 'default/universal',
     }];
     protected defaultLanguageModelPurpose: string = 'command';
 

--- a/packages/ai-ide/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-ide/src/common/orchestrator-chat-agent.ts
@@ -32,7 +32,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent {
     name = OrchestratorChatAgentId;
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'agent-selection',
-        identifier: 'openai/gpt-4o',
+        identifier: 'default/universal',
     }];
     protected defaultLanguageModelPurpose: string = 'agent-selection';
 

--- a/packages/ai-ide/src/common/universal-chat-agent.ts
+++ b/packages/ai-ide/src/common/universal-chat-agent.ts
@@ -27,7 +27,7 @@ export class UniversalChatAgent extends AbstractStreamParsingChatAgent {
    name = UniversalChatAgentId;
    languageModelRequirements: LanguageModelRequirement[] = [{
       purpose: 'chat',
-      identifier: 'openai/gpt-4o',
+      identifier: 'default/universal',
    }];
    protected defaultLanguageModelPurpose: string = 'chat';
    override description = nls.localize('theia/ai/chat/universal/description', 'This agent is designed to help software developers by providing concise and accurate '

--- a/packages/ai-llamafile/src/common/llamafile-language-model.ts
+++ b/packages/ai-llamafile/src/common/llamafile-language-model.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModel, LanguageModelMessage, LanguageModelRequest, LanguageModelResponse, LanguageModelStreamResponsePart } from '@theia/ai-core';
+import { LanguageModel, LanguageModelMessage, LanguageModelRequest, LanguageModelResponse, LanguageModelStatus, LanguageModelStreamResponsePart } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 
 const createMessageContent = (message: LanguageModelMessage): string | undefined => {
@@ -36,6 +36,7 @@ export class LlamafileLanguageModel implements LanguageModel {
      */
     constructor(
         public readonly name: string,
+        public status: LanguageModelStatus,
         public readonly uri: string,
         public readonly port: number,
     ) { }

--- a/packages/ai-ollama/src/node/ollama-language-model.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.ts
@@ -26,7 +26,8 @@ import {
     ToolRequest,
     ToolRequestParametersProperties,
     ImageContent,
-    TokenUsageService
+    TokenUsageService,
+    LanguageModelStatus
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { ChatRequest, Message, Ollama, Options, Tool, ToolCall as OllamaToolCall, ChatResponse } from 'ollama';
@@ -52,6 +53,7 @@ export class OllamaModel implements LanguageModel {
     constructor(
         public readonly id: string,
         protected readonly model: string,
+        public status: LanguageModelStatus,
         protected host: () => string | undefined,
         protected readonly tokenUsageService?: TokenUsageService
     ) { }

--- a/packages/ai-ollama/src/package.spec.ts
+++ b/packages/ai-ollama/src/package.spec.ts
@@ -37,7 +37,7 @@ describe('ai-ollama package', () => {
 
 class OllamaModelUnderTest extends OllamaModel {
     constructor() {
-        super('id', 'model', () => '');
+        super('id', 'model', { status: 'ready' }, () => '');
     }
 
     override toOllamaTool(tool: ToolRequest): Tool & { handler: (arg_string: string) => Promise<unknown> } {

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -51,6 +51,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             this.preferenceService.onPreferenceChanged(event => {
                 if (event.preferenceName === API_KEY_PREF) {
                     this.manager.setApiKey(event.newValue);
+                    this.updateAllModels();
                 } else if (event.preferenceName === MODELS_PREF) {
                     this.handleModelChanges(event.newValue as string[]);
                 } else if (event.preferenceName === CUSTOM_ENDPOINTS_PREF) {
@@ -60,7 +61,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
 
             this.aiCorePreferences.onPreferenceChanged(event => {
                 if (event.preferenceName === PREFERENCE_NAME_MAX_RETRIES) {
-                    this.updateAllModelsWithNewRetries();
+                    this.updateAllModels();
                 }
             });
         });
@@ -99,7 +100,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
         this.prevCustomModels = [...newCustomModels];
     }
 
-    protected updateAllModelsWithNewRetries(): void {
+    protected updateAllModels(): void {
         const models = this.preferenceService.get<string[]>(MODELS_PREF, []);
         this.manager.createOrUpdateLanguageModels(...models.map(modelId => this.createOpenAIModelDescription(modelId)));
 

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -24,7 +24,8 @@ import {
     TextMessage,
     TokenUsageService,
     UserRequest,
-    ImageContent
+    ImageContent,
+    LanguageModelStatus
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { injectable } from '@theia/core/shared/inversify';
@@ -86,6 +87,7 @@ export class OpenAiModel implements LanguageModel {
     constructor(
         public readonly id: string,
         public model: string,
+        public status: LanguageModelStatus,
         public enableStreaming: boolean,
         public apiKey: () => string | undefined,
         public apiVersion: () => string | undefined,

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelRegistry, TokenUsageService } from '@theia/ai-core';
+import { LanguageModelRegistry, LanguageModelStatus, TokenUsageService } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { OpenAiModel, OpenAiModelUtils } from './openai-language-model';
 import { OpenAiLanguageModelsManager, OpenAiModelDescription } from '../common';
@@ -42,6 +42,16 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
         return this._apiVersion ?? process.env.OPENAI_API_VERSION;
     }
 
+    protected calculateStatus(modelDescription: OpenAiModelDescription, effectiveApiKey: string | undefined): LanguageModelStatus {
+        // Always mark custom models (models with url) as ready for now as we do not know about API Key requirements
+        if (modelDescription.url) {
+            return { status: 'ready' };
+        }
+        return effectiveApiKey
+            ? { status: 'ready' }
+            : { status: 'unavailable', message: 'No OpenAI API key set' };
+    }
+
     // Triggered from frontend. In case you want to use the models on the backend
     // without a frontend then call this yourself
     async createOrUpdateLanguageModels(...modelDescriptions: OpenAiModelDescription[]): Promise<void> {
@@ -66,24 +76,31 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                 return undefined;
             };
 
+            // Determine the effective API key for status
+            const status = this.calculateStatus(modelDescription, apiKeyProvider());
+
             if (model) {
                 if (!(model instanceof OpenAiModel)) {
                     console.warn(`OpenAI: model ${modelDescription.id} is not an OpenAI model`);
                     continue;
                 }
-                model.model = modelDescription.model;
-                model.enableStreaming = modelDescription.enableStreaming;
-                model.url = modelDescription.url;
-                model.apiKey = apiKeyProvider;
-                model.apiVersion = apiVersionProvider;
-                model.developerMessageSettings = modelDescription.developerMessageSettings || 'developer';
-                model.supportsStructuredOutput = modelDescription.supportsStructuredOutput;
-                model.maxRetries = modelDescription.maxRetries;
+                await this.languageModelRegistry.patchLanguageModel<OpenAiModel>(modelDescription.id, {
+                    model: modelDescription.model,
+                    enableStreaming: modelDescription.enableStreaming,
+                    url: modelDescription.url,
+                    apiKey: apiKeyProvider,
+                    apiVersion: apiVersionProvider,
+                    developerMessageSettings: modelDescription.developerMessageSettings || 'developer',
+                    supportsStructuredOutput: modelDescription.supportsStructuredOutput,
+                    status,
+                    maxRetries: modelDescription.maxRetries
+                });
             } else {
                 this.languageModelRegistry.addLanguageModels([
                     new OpenAiModel(
                         modelDescription.id,
                         modelDescription.model,
+                        status,
                         modelDescription.enableStreaming,
                         apiKeyProvider,
                         apiVersionProvider,

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -55,7 +55,7 @@ export class AiTerminalAgent implements Agent {
     languageModelRequirements: LanguageModelRequirement[] = [
         {
             purpose: 'suggest-terminal-commands',
-            identifier: 'openai/gpt-4o',
+            identifier: 'default/universal',
         }
     ];
 

--- a/packages/ai-vercel-ai/src/browser/vercel-ai-frontend-application-contribution.ts
+++ b/packages/ai-vercel-ai/src/browser/vercel-ai-frontend-application-contribution.ts
@@ -65,7 +65,7 @@ export class VercelAiFrontendApplicationContribution implements FrontendApplicat
 
             this.aiCorePreferences.onPreferenceChanged(event => {
                 if (event.preferenceName === PREFERENCE_NAME_MAX_RETRIES) {
-                    this.updateAllModelsWithNewRetries();
+                    this.updateAllModels();
                 }
             });
         });
@@ -75,9 +75,11 @@ export class VercelAiFrontendApplicationContribution implements FrontendApplicat
         switch (event.preferenceName) {
             case OPENAI_API_KEY_PREF:
                 this.manager.setProviderConfig('openai', { provider: 'openai', apiKey: event.newValue });
+                this.updateAllModels();
                 break;
             case ANTHROPIC_API_KEY_PREF:
                 this.manager.setProviderConfig('anthropic', { provider: 'anthropic', apiKey: event.newValue });
+                this.updateAllModels();
                 break;
             case MODELS_PREF:
                 this.handleModelChanges(event);
@@ -152,7 +154,7 @@ export class VercelAiFrontendApplicationContribution implements FrontendApplicat
         ) as Partial<VercelAiModelDescription>[];
     }
 
-    protected updateAllModelsWithNewRetries(): void {
+    protected updateAllModels(): void {
         const models = this.preferenceService.get<ModelConfig[]>(MODELS_PREF, []);
         this.manager.createOrUpdateLanguageModels(...models.map(model => this.createVercelAiModelDescription(model)));
 

--- a/packages/ai-vercel-ai/src/node/vercel-ai-language-model.ts
+++ b/packages/ai-vercel-ai/src/node/vercel-ai-language-model.ts
@@ -21,6 +21,7 @@ import {
     LanguageModelParsedResponse,
     LanguageModelRequest,
     LanguageModelResponse,
+    LanguageModelStatus,
     LanguageModelStreamResponse,
     LanguageModelStreamResponsePart,
     LanguageModelTextResponse,
@@ -180,6 +181,7 @@ export class VercelAiModel implements LanguageModel {
     constructor(
         public readonly id: string,
         public model: string,
+        public status: LanguageModelStatus,
         public enableStreaming: boolean,
         public supportsStructuredOutput: boolean,
         public url: string | undefined,

--- a/packages/preferences/src/browser/util/preference-layout.ts
+++ b/packages/preferences/src/browser/util/preference-layout.ts
@@ -340,7 +340,7 @@ export const DEFAULT_LAYOUT: PreferenceLayout[] = [
             {
                 id: 'ai-features.modelSettings',
                 label: nls.localize('theia/preferences/ai-features/model-settings', 'Model Settings'),
-                settings: ['ai-features.modelSettings.*']
+                settings: ['ai-features.modelSettings.*', 'ai-features.languageModelAliases']
             },
             {
                 id: 'ai-features.ollama',


### PR DESCRIPTION
#### What it does

Initial implementation of #15395

Introduces support for AI model aliases to facilitate updating many agents' used models at once.
An alias either points to a single model selected by the user or a chain of default/fallback models to consider in priority order.
For the fallback chain, the first ready model (e.g. has an API key configured) is used. For this the language model was extended with a status to be set by its manager.

- Introduces a language model alias registry for registering and retrieving model aliases and chains
- Adds support for chains of default model aliases (`code`, `universal`, `code completion`, `summarize`)
- Selects the first available model (with an API key) from the chain when resolving an alias; falls back to the first in the chain if none are ready
- Enables users to point an alias to use a specific model
- Extends language models to track readiness (e.g., whether an API key is set)
- Adds a new Model Aliases tab to the the AI configuration UI to:
  - Display alias chains
  - Select a mode for an alias


#### How to test

- Open AI configuration view -> agents configuration
- Select an agent (e.g. Coder)
- Open the language model dropdown. Observe:
  - there are 4 aliases at the top of the dropdown
  - models you don't have an API key are not selectable and show a tooltip when hovering over them
- Select the "default/code" alias
- Go to the new Model Aliases tab in the AI configuration view
- Have an anthropic key configured
- open a chat and request something
- observe: tokens for claude 3.7 are used
- remove api key for anthropic and have a openai key configured
- do another request
- observe: tokens for gpt 4.1 are used
- select a model explicitly for the default/code alias (e.g. gpt-4.1-nano)
- do another request and observe tokens for the selected model are used

#### Follow-ups

- ~~Render Agents using an alias in alias view (@sgraband has a WIP implementation)~~
- ~~Show resolved model for an alias in alias config view and in agent config  view~~
- ~~Display in chain the ones that are ready and the one that is chosen (only if applicable)~~
- Configure aliases as default models for agents
- Define fallbackchains for aliases
- Better display that a model is not ready just disabled for now
- Allow to add aliases

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
