### PR TITLE
Implement a retry mechanism for Google GenAI calls

### DIFF
--- a/packages/ai-google/src/browser/google-preferences.ts
+++ b/packages/ai-google/src/browser/google-preferences.ts
@@ -20,6 +20,9 @@ import { nls } from '@theia/core';
 
 export const API_KEY_PREF = 'ai-features.google.apiKey';
 export const MODELS_PREF = 'ai-features.google.models';
+export const MAX_RETRIES = 'ai-features.google.maxRetriesOnErrors';
+export const RETRY_DELAY_RATE_LIMIT = 'ai-features.google.retryDelayOnRateLimitError';
+export const RETRY_DELAY_OTHER_ERRORS = 'ai-features.google.retryDelayOnOtherErrors';
 
 export const GooglePreferencesSchema: PreferenceSchema = {
     type: 'object',
@@ -40,5 +43,31 @@ export const GooglePreferencesSchema: PreferenceSchema = {
                 type: 'string'
             }
         },
+        [MAX_RETRIES]: {
+            type: 'integer',
+            description: nls.localize('theia/ai/google/maxRetriesOnErrors/description',
+                'Maximum number of retries in case of errors. If smaller than 1, then the retry logic is disabled'),
+            title: AI_CORE_PREFERENCES_TITLE,
+            default: 3,
+            minimum: 0
+        },
+        [RETRY_DELAY_RATE_LIMIT]: {
+            type: 'number',
+            description: nls.localize('theia/ai/google/retryDelayOnRateLimitError/description',
+                'Delay in seconds between retries in case of rate limit errors. See https://ai.google.dev/gemini-api/docs/rate-limits'),
+            title: AI_CORE_PREFERENCES_TITLE,
+            default: 60,
+            minimum: 0
+        },
+        [RETRY_DELAY_OTHER_ERRORS]: {
+            type: 'number',
+            description: nls.localize('theia/ai/google/retryDelayOnOtherErrors/description',
+                'Delay in seconds between retries in case of other errors (sometimes the Google GenAI reports errors such as incomplete JSON syntax returned from the model \
+                or 500 Internal Server Error). Setting this to -1 prevents retries in these cases. Otherwise a retry happens either immediately (if set to 0) or after \
+                this delay in seconds (if set to a positive number).'),
+            title: AI_CORE_PREFERENCES_TITLE,
+            default: -1,
+            minimum: -1
+        }
     }
 };

--- a/packages/ai-google/src/common/google-language-models-manager.ts
+++ b/packages/ai-google/src/common/google-language-models-manager.ts
@@ -38,9 +38,13 @@ export interface GoogleModelDescription {
     maxTokens?: number;
 
 }
+
 export interface GoogleLanguageModelsManager {
     apiKey: string | undefined;
     setApiKey(key: string | undefined): void;
+    setMaxRetriesOnErrors(maxRetries: number): void;
+    setRetryDelayOnRateLimitError(retryDelay: number): void;
+    setRetryDelayOnOtherErrors(retryDelay: number): void;
     createOrUpdateLanguageModels(...models: GoogleModelDescription[]): Promise<void>;
     removeLanguageModels(...modelIds: string[]): void
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
See https://github.com/eclipse-theia/theia/discussions/15718: 

Google imposes rate limits for its LLMs. Especially with lower tiers (including the free tier - see https://ai.google.dev/gemini-api/docs/rate-limits?hl=de ), it can quickly happen that an agent with tool calls (such as the Coder agent) hits the Requests Per Minute (RPM) rate limit and the agent execution terminates with an error.
Also, in longer conversations, it can happen that the LLM does not return proper JSON which leads to an error in the GenAI API client, or reports 500 Internal Server Errors occasionally.

To make the Google LanguageModel implementation in Theia more robust against these errors, a retry mechanism is now implemented that can resend the last request after a configurable delay in case of an error.

The retry mechanism can be configured using preferences:

* `maxRetriesOnErrors` configures the maximum number of retries per request after which to give up. Defaults to `3`. If smaller than `1`, then the retry logic is disabled.
* `retryDelayOnRateLimitError` configures the delay in seconds to wait in case of a rate limit error. Defaults to `60` (1 minute). If negative, then no retry is attempted and the error is propagated.
* `retryDelayOnOtherErrors` configures the delay in seconds to wait in case of any other error. Defaults to `-1` (disabled). If negative, then no retry is attempted and the error is propagated.

#### How to test

* Get a Google GenAI API key for the free tier.
* Set up Theia with that key and configure the Coder agent to use google/gemini-2.0-flash
* Give a complex instruction to the Coder agent (e.g. with the Theia codebase loaded, ask it something like

```
@Coder Change the Breakpoint widget so that multi-selection of breakpoints is possible.

This means that the TreeWidget of the Breakpoint view should be changed to support multiSelect. If multiple breakpoints are selected, then in the context menu, there should be menu items:

* Enable all selected
* Disable all selected
* Delete all selected

which should behave like the counterpart commands for single breakpoints just applied to multiple ones.
```

Without the change, you should see an message 429 Rate Limit Exceeded after 10 tool calls.
With the change, the conversation will stall for some time in the middle, but eventually continue after 60s of waiting.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
