### PR TITLE
fix: sync selection if props change

### DIFF
--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -61,12 +61,7 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
 
     constructor(props: SelectComponentProps) {
         super(props);
-        let selected = 0;
-        if (typeof props.defaultValue === 'number') {
-            selected = props.defaultValue;
-        } else if (typeof props.defaultValue === 'string') {
-            selected = Math.max(props.options.findIndex(e => e.value === props.defaultValue), 0);
-        }
+        const selected = this.getInitialSelectedIndex(props);
         this.state = {
             selected,
             original: selected,
@@ -81,6 +76,27 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             document.body.appendChild(list);
         }
         this.dropdownElement = list;
+    }
+
+    protected getInitialSelectedIndex(props: SelectComponentProps): number {
+        let selected = 0;
+        if (typeof props.defaultValue === 'number') {
+            selected = props.defaultValue;
+        } else if (typeof props.defaultValue === 'string') {
+            selected = Math.max(props.options.findIndex(e => e.value === props.defaultValue), 0);
+        }
+        return selected;
+    }
+
+    override componentDidUpdate(prevProps: SelectComponentProps): void {
+        if (prevProps.defaultValue !== this.props.defaultValue || prevProps.options !== this.props.options) {
+            const selected = this.getInitialSelectedIndex(this.props);
+            this.setState({
+                selected,
+                original: selected,
+                hover: selected
+            });
+        }
     }
 
     get options(): readonly SelectOption[] {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Class components do not re-run constructors on prop changes. This meant that `defaultValue` and `options` were only evaluated once during the initial mount. As a result, dynamic updates to the selected channel did not reflect in the SelectComponent UI.

This change extracts the selected index logic into a helper method and calls it from both the constructor and `componentDidUpdate` to keep state in sync with prop changes, mimicking behavior of function components using hooks.

Closes: eclipse-theia/theia#15769

#### How to test

See eclipse-theia/theia#15769

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
