### PR TITLE
Listen for model will save events directly instead of registering a save participant.  

### DIFF
--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -22,6 +22,7 @@ export * from './contribution-filter';
 export * from './contribution-provider';
 export * from './disposable';
 export * from './event';
+export * from './listener';
 export * from './logger';
 export * from './lsp-types';
 export * from './menu';

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -226,7 +226,7 @@ export class MonacoEditorProvider {
         }));
         toDispose.push(editor.onLanguageChanged(() => this.updateMonacoEditorOptions(editor)));
         toDispose.push(editor.onDidChangeReadOnly(() => this.updateReadOnlyMessage(options, model.readOnly)));
-        toDispose.push(editor.document.registerWillSaveModelListener((_, token, o) => this.runSaveParticipants(editor, token, o)));
+        toDispose.push(editor.document.onModelWillSaveModel(e => this.runSaveParticipants(editor, e.token, e.options)));
         return editor;
     }
 

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -16,14 +16,14 @@
 import { DocumentsMain, MAIN_RPC_CONTEXT, DocumentsExt } from '../../common/plugin-api-rpc';
 import { UriComponents } from '../../common/uri-components';
 import { EditorsAndDocumentsMain } from './editors-and-documents-main';
-import { DisposableCollection, Disposable, UntitledResourceResolver, CancellationToken } from '@theia/core';
+import { DisposableCollection, Disposable, UntitledResourceResolver } from '@theia/core';
 import { MonacoEditorModel } from '@theia/monaco/lib/browser/monaco-editor-model';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { EditorModelService } from './text-editor-model-service';
 import { EditorOpenerOptions } from '@theia/editor/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { URI as CodeURI } from '@theia/core/shared/vscode-uri';
-import { ApplicationShell, SaveOptions, SaveReason } from '@theia/core/lib/browser';
+import { ApplicationShell, SaveReason } from '@theia/core/lib/browser';
 import { TextDocumentShowOptions } from '../../common/plugin-api-rpc-model';
 import { Range } from '@theia/core/shared/vscode-languageserver-protocol';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
@@ -33,8 +33,6 @@ import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
 import * as monaco from '@theia/monaco-editor-core';
 import { TextDocumentChangeReason } from '../../plugin/types-impl';
 import { NotebookDocumentsMainImpl } from './notebooks/notebook-documents-main';
-import { MonacoEditorProvider, SAVE_PARTICIPANT_DEFAULT_ORDER } from '@theia/monaco/lib/browser/monaco-editor-provider';
-import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -99,8 +97,7 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
         private openerService: OpenerService,
         private shell: ApplicationShell,
         private untitledResourceResolver: UntitledResourceResolver,
-        private languageService: MonacoLanguages,
-        monacoEditorProvider: MonacoEditorProvider
+        private languageService: MonacoLanguages
     ) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.DOCUMENTS_EXT);
 
@@ -114,36 +111,30 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
         this.toDispose.push(modelService.onModelSaved(m => {
             this.proxy.$acceptModelSaved(m.textEditorModel.uri);
         }));
-        this.toDispose.push(monacoEditorProvider.registerSaveParticipant(({
-            order: SAVE_PARTICIPANT_DEFAULT_ORDER,
-            applyChangesOnSave: async (
-                editor: MonacoEditor,
-                cancellationToken: CancellationToken,
-                options: SaveOptions): Promise<void> => {
+        this.toDispose.push(modelService.onModelWillSave(async e => {
 
-                const saveReason = options.saveReason ?? SaveReason.Manual;
+            const saveReason = e.options?.saveReason ?? SaveReason.Manual;
 
-                const edits = await this.proxy.$acceptModelWillSave(editor.uri.toComponents(), saveReason.valueOf(), this.saveTimeout);
-                const editOperations: monaco.editor.IIdentifiedSingleEditOperation[] = [];
-                for (const edit of edits) {
-                    const { range, text } = edit;
-                    if (!range && !text) {
-                        continue;
-                    }
-                    if (range && range.startLineNumber === range.endLineNumber && range.startColumn === range.endColumn && !edit.text) {
-                        continue;
-                    }
-
-                    editOperations.push({
-                        range: range ? monaco.Range.lift(range) : editor.document.textEditorModel.getFullModelRange(),
-                        /* eslint-disable-next-line no-null/no-null */
-                        text: text || null,
-                        forceMoveMarkers: edit.forceMoveMarkers
-                    });
+            const edits = await this.proxy.$acceptModelWillSave(new URI(e.model.uri).toComponents(), saveReason.valueOf(), this.saveTimeout);
+            const editOperations: monaco.editor.IIdentifiedSingleEditOperation[] = [];
+            for (const edit of edits) {
+                const { range, text } = edit;
+                if (!range && !text) {
+                    continue;
                 }
-                editor.document.textEditorModel.applyEdits(editOperations);
+                if (range && range.startLineNumber === range.endLineNumber && range.startColumn === range.endColumn && !edit.text) {
+                    continue;
+                }
+
+                editOperations.push({
+                    range: range ? monaco.Range.lift(range) : e.model.textEditorModel.getFullModelRange(),
+                    /* eslint-disable-next-line no-null/no-null */
+                    text: text || null,
+                    forceMoveMarkers: edit.forceMoveMarkers
+                });
             }
-        })));
+            e.model.textEditorModel.applyEdits(editOperations);
+        }));
         this.toDispose.push(modelService.onModelDirtyChanged(m => {
             this.proxy.$acceptDirtyStateChanged(m.textEditorModel.uri, m.dirty);
         }));

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -66,7 +66,6 @@ import { NotebooksAndEditorsMain } from './notebooks/notebook-documents-and-edit
 import { TestingMainImpl } from './test-main';
 import { UriMainImpl } from './uri-main';
 import { LoggerMainImpl } from './logger-main';
-import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 import { McpServerDefinitionRegistryMainImpl } from './lm-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
@@ -107,9 +106,8 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const shell = container.get(ApplicationShell);
     const untitledResourceResolver = container.get(UntitledResourceResolver);
     const languageService = container.get(MonacoLanguages);
-    const monacoEditorProvider = container.get(MonacoEditorProvider);
     const documentsMain = new DocumentsMainImpl(editorsAndDocuments, notebookDocumentsMain, modelService, rpc,
-        openerService, shell, untitledResourceResolver, languageService, monacoEditorProvider);
+        openerService, shell, untitledResourceResolver, languageService);
     rpc.set(PLUGIN_RPC_CONTEXT.DOCUMENTS_MAIN, documentsMain);
 
     rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOKS_MAIN, new NotebooksMainImpl(rpc, container, commandRegistryMain));


### PR DESCRIPTION
#### What it does
Ensures `onWillSaveEvent` will be fired when files are open in non-monaco editors.

Fixes #15770

#### How to test
1. Install the vsix from the issue.
2. Open a file that has a custom editor, I use `.drawio` files and the `hediet.drawio` extension from openvxs
3. Make a change and save the file
4. Open the output view and select the channel for the issue vsix
5. Observe: you get the various messages as described in the issue. 

Also make sure the "code actions on save" behavior still works as described in https://github.com/eclipse-theia/theia/pull/15555

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
