### PR TITLE
Return undefined instead of throwing when getting non-existent menu

### DIFF
--- a/packages/core/src/browser/context-menu-renderer.ts
+++ b/packages/core/src/browser/context-menu-renderer.ts
@@ -17,7 +17,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { injectable, inject } from 'inversify';
-import { CompoundMenuNode, MenuModelRegistry, MenuPath } from '../common/menu';
+import { CompoundMenuNode, GroupImpl, MenuModelRegistry, MenuPath } from '../common/menu';
 import { Disposable, DisposableCollection } from '../common/disposable';
 import { ContextKeyService, ContextMatcher } from './context-key-service';
 
@@ -84,7 +84,10 @@ export abstract class ContextMenuRenderer {
     }
 
     render(options: RenderContextMenuOptions): ContextMenuAccess {
-        let menu = CompoundMenuNode.is(options.menu) ? options.menu : this.menuRegistry.getMenu(options.menuPath);
+        let menu = options.menu;
+        if (!menu) {
+            menu = this.menuRegistry.getMenu(options.menuPath) || new GroupImpl('emtpyContextMenu');
+        }
 
         const resolvedOptions = this.resolve(options);
 

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.tsx
@@ -38,7 +38,7 @@ abstract class AbstractToolbarMenuWrapper {
     }
 
     protected abstract menuPath?: MenuPath;
-    protected abstract menuNode: MenuNode;
+    protected abstract menuNode?: MenuNode;
     protected abstract id: string;
     protected abstract icon: string | undefined;
     protected abstract tooltip: string | undefined;
@@ -61,7 +61,7 @@ abstract class AbstractToolbarMenuWrapper {
         return this.renderMenuItem(widget);
     }
 
-    toMenuNode?(): MenuNode {
+    toMenuNode?(): MenuNode | undefined {
         return this.menuNode;
     }
 
@@ -194,7 +194,7 @@ export class ToolbarSubmenuWrapper extends AbstractToolbarMenuWrapper implements
         if (this.toolbarItem.isVisible && !this.toolbarItem.isVisible(widget)) {
             return false;
         }
-        if (!menuNode.isVisible(this.effectiveMenuPath, this.contextKeyService, widget.node, widget)) {
+        if (!menuNode?.isVisible(this.effectiveMenuPath, this.contextKeyService, widget.node, widget)) {
             return false;
         }
         if (this.toolbarItem.command) {
@@ -225,14 +225,14 @@ export class ToolbarSubmenuWrapper extends AbstractToolbarMenuWrapper implements
     get tooltip(): string | undefined { return this.toolbarItem.tooltip; }
     get text(): string | undefined { return (this.toolbarItem.group === NAVIGATION || this.toolbarItem.group === undefined) ? undefined : this.toolbarItem.text; }
     get onDidChange(): Event<void> | undefined {
-        return this.menuNode.onDidChange;
+        return this.menuNode?.onDidChange;
     }
 
     get menuPath(): MenuPath {
         return this.toolbarItem.menuPath!;
     }
 
-    get menuNode(): MenuNode {
+    get menuNode(): MenuNode | undefined {
         return this.menuRegistry.getMenu(this.menuPath);
     }
 }

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-registry.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-registry.ts
@@ -138,19 +138,22 @@ export class TabBarToolbarRegistry implements FrontendApplicationContribution {
 
         for (const delegate of this.menuDelegates.values()) {
             if (delegate.isVisible(widget)) {
-                const menu = this.menuRegistry.getMenu(delegate.menuPath)!;
-                for (const child of menu.children) {
-                    if (child.isVisible([...delegate.menuPath, child.id], this.contextKeyService, widget.node)) {
-                        if (CompoundMenuNode.is(child)) {
-                            for (const grandchild of child.children) {
-                                if (grandchild.isVisible([...delegate.menuPath, child.id, grandchild.id], this.contextKeyService, widget.node) && RenderedMenuNode.is(grandchild)) {
-                                    result.push(new ToolbarMenuNodeWrapper([...delegate.menuPath, child.id, grandchild.id], this.commandRegistry, this.menuRegistry,
-                                        this.contextKeyService, this.contextMenuRenderer, grandchild, child.id, delegate.menuPath));
+                const menu = this.menuRegistry.getMenu(delegate.menuPath);
+                if (menu) {
+                    for (const child of menu.children) {
+                        if (child.isVisible([...delegate.menuPath, child.id], this.contextKeyService, widget.node)) {
+                            if (CompoundMenuNode.is(child)) {
+                                for (const grandchild of child.children) {
+                                    if (grandchild.isVisible([...delegate.menuPath, child.id, grandchild.id],
+                                        this.contextKeyService, widget.node) && RenderedMenuNode.is(grandchild)) {
+                                        result.push(new ToolbarMenuNodeWrapper([...delegate.menuPath, child.id, grandchild.id], this.commandRegistry, this.menuRegistry,
+                                            this.contextKeyService, this.contextMenuRenderer, grandchild, child.id, delegate.menuPath));
+                                    }
                                 }
+                            } else if (CommandMenu.is(child)) {
+                                result.push(new ToolbarMenuNodeWrapper([...delegate.menuPath, child.id], this.commandRegistry, this.menuRegistry,
+                                    this.contextKeyService, this.contextMenuRenderer, child, undefined, delegate.menuPath));
                             }
-                        } else if (CommandMenu.is(child)) {
-                            result.push(new ToolbarMenuNodeWrapper([...delegate.menuPath, child.id], this.commandRegistry, this.menuRegistry,
-                                this.contextKeyService, this.contextMenuRenderer, child, undefined, delegate.menuPath));
                         }
                     }
                 }

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-toolbar-item.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-toolbar-item.tsx
@@ -34,7 +34,7 @@ export interface TabBarToolbarItem {
     onDidChange?: Event<void>;
     group?: string;
     priority?: number;
-    toMenuNode?(): MenuNode;
+    toMenuNode?(): MenuNode | undefined;
 }
 
 /**

--- a/packages/core/src/common/menu/menu-model-registry.ts
+++ b/packages/core/src/common/menu/menu-model-registry.ts
@@ -326,8 +326,11 @@ export class MenuModelRegistry {
         return this.findInNode(this.root, menuPath, 0);
     }
 
-    getMenu(menuPath: MenuPath): CompoundMenuNode {
+    getMenu(menuPath: MenuPath): CompoundMenuNode | undefined {
         const node = this.getMenuNode(menuPath);
+        if (!node) {
+            return undefined;
+        }
         if (!CompoundMenuNode.is(node)) {
             throw new Error(`not a compound menu node: ${JSON.stringify(menuPath)}`);
         }

--- a/packages/core/src/common/menu/menu-types.ts
+++ b/packages/core/src/common/menu/menu-types.ts
@@ -97,7 +97,7 @@ export interface RenderedMenuNode extends MenuNode {
 }
 
 export namespace RenderedMenuNode {
-    export function is(node: object): node is RenderedMenuNode {
+    export function is(node: unknown): node is RenderedMenuNode {
         return isObject<RenderedMenuNode>(node) && typeof node.label === 'string';
     }
 }
@@ -105,7 +105,7 @@ export namespace RenderedMenuNode {
 export type CommandMenu = MenuNode & RenderedMenuNode & Action;
 
 export namespace CommandMenu {
-    export function is(node: MenuNode): node is CommandMenu {
+    export function is(node: MenuNode | undefined): node is CommandMenu {
         return RenderedMenuNode.is(node) && Action.is(node);
     }
 }

--- a/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-list-view.tsx
@@ -285,8 +285,8 @@ export interface NotebookCellDividerProps {
 export function NotebookCellDivider({ isVisible, onAddNewCell, onDrop, onDragOver, menuRegistry }: NotebookCellDividerProps): React.JSX.Element {
     const [hover, setHover] = React.useState(false);
 
-    const menuPath = NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_CELL_ADD_GROUP;
-    const menuItems: CommandMenu[] = menuRegistry.getMenu(menuPath).children.filter(item => CommandMenu.is(item)).map(item => item as CommandMenu);
+    const menuPath = NotebookMenus.NOTEBOOK_MAIN_TOOLBAR_CELL_ADD_GROUP; // we contribute into this menu, so it will exist
+    const menuItems: CommandMenu[] = menuRegistry.getMenu(menuPath)!.children.filter(item => CommandMenu.is(item)).map(item => item as CommandMenu);
 
     const renderItem = (item: CommandMenu): React.ReactNode => {
         const execute = (...args: unknown[]) => {

--- a/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-toolbar-factory.tsx
@@ -73,15 +73,18 @@ export class NotebookCellToolbarFactory {
         this.toDisposeOnRender.dispose();
         this.toDisposeOnRender = new DisposableCollection();
         const inlineItems: NotebookCellToolbarItem[] = [];
-        for (const menuNode of this.menuRegistry.getMenu(menuItemPath).children) {
+        const menu = this.menuRegistry.getMenu(menuItemPath);
+        if (menu) {
+            for (const menuNode of menu.children) {
 
-            const itemPath = [...menuItemPath, menuNode.id];
-            if (menuNode.isVisible(itemPath, this.notebookContextManager.getCellContext(cell.handle), this.notebookContextManager.context, itemOptions.commandArgs?.() ?? [])) {
-                if (RenderedMenuNode.is(menuNode)) {
-                    if (menuNode.onDidChange) {
-                        this.toDisposeOnRender.push(menuNode.onDidChange(() => this.onDidChangeContextEmitter.fire()));
+                const itemPath = [...menuItemPath, menuNode.id];
+                if (menuNode.isVisible(itemPath, this.notebookContextManager.getCellContext(cell.handle), this.notebookContextManager.context, itemOptions.commandArgs?.() ?? [])) {
+                    if (RenderedMenuNode.is(menuNode)) {
+                        if (menuNode.onDidChange) {
+                            this.toDisposeOnRender.push(menuNode.onDidChange(() => this.onDidChangeContextEmitter.fire()));
+                        }
+                        inlineItems.push(this.createToolbarItem(itemPath, menuNode, itemOptions));
                     }
-                    inlineItems.push(this.createToolbarItem(itemPath, menuNode, itemOptions));
                 }
             }
         }

--- a/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
+++ b/packages/notebook/src/browser/view/notebook-main-toolbar.tsx
@@ -194,7 +194,7 @@ export class NotebookMainToolbar extends React.Component<NotebookMainToolbarProp
     }
 
     protected getMenuItems(): readonly MenuNode[] {
-        return this.props.menuRegistry.getMenu(NotebookMenus.NOTEBOOK_MAIN_TOOLBAR).children;
+        return this.props.menuRegistry.getMenu(NotebookMenus.NOTEBOOK_MAIN_TOOLBAR)!.children; // we contribute to this menu, so it exists
     }
 
     protected getAdditionalClasses(itemPath: MenuPath, item: CommandMenu): string {

--- a/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
@@ -57,7 +57,6 @@ export class CommentThreadWidget extends BaseWidget {
     protected readonly zoneWidget: MonacoEditorZoneWidget;
     protected readonly containerNodeRoot: Root;
     protected readonly commentGlyphWidget: CommentGlyphWidget;
-    protected readonly contextMenu: CompoundMenuNode;
     protected readonly commentFormRef: RefObject<CommentForm> = React.createRef<CommentForm>();
 
     protected isExpanded?: boolean;
@@ -101,8 +100,8 @@ export class CommentThreadWidget extends BaseWidget {
         this.toDispose.push(this._commentThread.onDidChangeState(_state => {
             this.update();
         }));
-        this.contextMenu = this.menus.getMenu(COMMENT_THREAD_CONTEXT);
-        this.contextMenu.children.forEach(node => {
+        const contextMenu = this.menus.getMenu(COMMENT_THREAD_CONTEXT);
+        contextMenu?.children.forEach(node => {
             if (node.onDidChange) {
                 this.toDispose.push(node.onDidChange(() => {
                     const commentForm = this.commentFormRef.current;
@@ -560,7 +559,7 @@ export class ReviewComment<P extends ReviewComment.Props = ReviewComment.Props> 
                     <span className={'isPending'}>{comment.label}</span>
                     <div className={'theia-comments-inline-actions-container'}>
                         <div className={'theia-comments-inline-actions'} role={'toolbar'}>
-                            {hover && menus.getMenuNode(COMMENT_TITLE) && menus.getMenu(COMMENT_TITLE).children.map((node, index): React.ReactNode => CommandMenu.is(node) &&
+                            {hover && menus.getMenuNode(COMMENT_TITLE) && menus.getMenu(COMMENT_TITLE)?.children.map((node, index): React.ReactNode => CommandMenu.is(node) &&
                                 <CommentsInlineAction key={index} {...{
                                     node, nodePath: [...COMMENT_TITLE, node.id], commands, commentThread, commentUniqueId,
                                     contextKeyService, commentsContext
@@ -662,7 +661,7 @@ export class CommentEditContainer extends React.Component<CommentEditContainer.P
                 </div>
             </div>
             <div className={'form-actions'}>
-                {menus.getMenu(COMMENT_CONTEXT).children.map((node, index): React.ReactNode => {
+                {menus.getMenu(COMMENT_CONTEXT)?.children.map((node, index): React.ReactNode => {
                     const onClick = () => {
                         commands.executeCommand(node.id, {
                             commentControlHandle: commentThread.controllerHandle,
@@ -722,7 +721,7 @@ namespace CommentActions {
         contextKeyService: ContextKeyService;
         commentsContext: CommentsContext;
         menuPath: MenuPath,
-        menu: CompoundMenuNode;
+        menu: CompoundMenuNode | undefined;
         commentThread: CommentThread;
         getInput: () => string;
         clearInput: () => void;
@@ -733,7 +732,7 @@ export class CommentActions extends React.Component<CommentActions.Props> {
     override render(): React.ReactNode {
         const { contextKeyService, commentsContext, menuPath, menu, commentThread, getInput, clearInput } = this.props;
         return <div className={'form-actions'}>
-            {menu.children.map((node, index) => CommandMenu.is(node) &&
+            {menu?.children.map((node, index) => CommandMenu.is(node) &&
                 <CommentAction key={index}
                     nodePath={menuPath}
                     node={node}

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -763,7 +763,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         return this.contextKeys.with({ view: this.id, viewItem: treeViewNode.contextValue }, () => {
             const menu = this.menus.getMenu(VIEW_ITEM_INLINE_MENU);
             const args = this.toContextMenuArgs(treeViewNode);
-            const inlineCommands = menu.children.filter((item): item is CommandMenu => CommandMenu.is(item));
+            const inlineCommands = menu?.children.filter((item): item is CommandMenu => CommandMenu.is(item)) || [];
             const tailDecorations = super.renderTailDecorations(treeViewNode, props);
             return <React.Fragment>
                 {inlineCommands.length > 0 && <div className={TREE_NODE_SEGMENT_CLASS + ' flex'}>

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -340,16 +340,18 @@ class DirtyDiffPeekView extends MonacoEditorPeekViewWidget {
         contextKeyService.with({ originalResourceScheme: this.widget.previousRevisionUri.scheme }, () => {
             for (const menuPath of [SCM_CHANGE_TITLE_MENU, PLUGIN_SCM_CHANGE_TITLE_MENU]) {
                 const menu = menuModelRegistry.getMenu(menuPath);
-                for (const item of menu.children) {
-                    if (CommandMenu.is(item)) {
-                        const { id, label, icon } = item;
-                        const itemPath = [...menuPath, id];
-                        if (icon && item.isVisible(itemPath, contextKeyService, undefined)) {
-                            // Close editor on successful contributed action.
-                            // https://github.com/microsoft/vscode/blob/11b1500e0a2e8b5ba12e98a3905f9d120b8646a0/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts#L356-L361
-                            this.addAction(id, label, icon, item.isEnabled(itemPath), () => {
-                                item.run(itemPath, this.widget).then(() => this.dispose());
-                            });
+                if (menu) {
+                    for (const item of menu.children) {
+                        if (CommandMenu.is(item)) {
+                            const { id, label, icon } = item;
+                            const itemPath = [...menuPath, id];
+                            if (icon && item.isVisible(itemPath, contextKeyService, undefined)) {
+                                // Close editor on successful contributed action.
+                                // https://github.com/microsoft/vscode/blob/1.99.3/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts#L357-L361
+                                this.addAction(id, label, icon, item.isEnabled(itemPath), () => {
+                                    item.run(itemPath, this.widget).then(() => this.dispose());
+                                });
+                            }
                         }
                     }
                 }

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -772,7 +772,7 @@ export class ScmInlineActions extends React.Component<ScmInlineActions.Props> {
         const { hover, menu, menuPath, args, model, treeNode, contextKeys, children } = this.props;
         return <div className='theia-scm-inline-actions-container'>
             <div className='theia-scm-inline-actions'>
-                {hover && menu.children
+                {hover && menu?.children
                     .map((node, index) => CommandMenu.is(node) &&
                         <ScmInlineAction key={index} {...{ node, menuPath, args, model, treeNode, contextKeys }} />)}
             </div>
@@ -783,7 +783,7 @@ export class ScmInlineActions extends React.Component<ScmInlineActions.Props> {
 export namespace ScmInlineActions {
     export interface Props {
         hover: boolean;
-        menu: CompoundMenuNode;
+        menu: CompoundMenuNode | undefined;
         menuPath: MenuPath;
         model: ScmTreeModel;
         treeNode: TreeNode;

--- a/packages/test/src/browser/view/test-tree-widget.tsx
+++ b/packages/test/src/browser/view/test-tree-widget.tsx
@@ -299,7 +299,7 @@ export class TestTreeWidget extends TreeWidget {
         if (TestItemNode.is(node)) {
             const testItem = node.testItem;
             return this.contextKeys.with({ view: this.id, controllerId: node.controller.id, testId: testItem.id, testItemHasUri: !!testItem.uri }, () => {
-                const menu = this.menus.getMenu(TEST_VIEW_INLINE_MENU)!; // we register items into this men, so we know it exists
+                const menu = this.menus.getMenu(TEST_VIEW_INLINE_MENU)!; // we register items into this menu, so we know it exists
                 const args = [node.testItem];
                 const inlineCommands = menu.children.filter((item): item is CommandMenu => CommandMenu.is(item));
                 const tailDecorations = super.renderTailDecorations(node, props);

--- a/packages/test/src/browser/view/test-tree-widget.tsx
+++ b/packages/test/src/browser/view/test-tree-widget.tsx
@@ -299,7 +299,7 @@ export class TestTreeWidget extends TreeWidget {
         if (TestItemNode.is(node)) {
             const testItem = node.testItem;
             return this.contextKeys.with({ view: this.id, controllerId: node.controller.id, testId: testItem.id, testItemHasUri: !!testItem.uri }, () => {
-                const menu = this.menus.getMenu(TEST_VIEW_INLINE_MENU);
+                const menu = this.menus.getMenu(TEST_VIEW_INLINE_MENU)!; // we register items into this men, so we know it exists
                 const args = [node.testItem];
                 const inlineCommands = menu.children.filter((item): item is CommandMenu => CommandMenu.is(item));
                 const tailDecorations = super.renderTailDecorations(node, props);


### PR DESCRIPTION
#### What it does
This PR makes `MenuModelRegistry.getMenu()` return undefined instead of throwing for non-existent menus. 

Fixes #15664

#### How to test
Make sure menus work in all the affected cases in this change. Also, there should be no more console messages at startup.
Make sure the dirty-diff widget appears and can be used. 

#### Follow-ups
https://github.com/eclipse-theia/theia/issues/15793
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
