### PR TITLE
fix: setting service gracefully handles ENOENT

### DIFF
--- a/packages/core/src/node/setting-service.spec.ts
+++ b/packages/core/src/node/setting-service.spec.ts
@@ -1,0 +1,97 @@
+// *****************************************************************************
+// Copyright (C) 2025 and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { promises as fs } from 'fs';
+import { Container } from 'inversify';
+import * as sinon from 'sinon';
+import { EnvVariablesServer } from '../common/env-variables';
+import { ILogger } from '../common/logger';
+import { MockLogger } from '../common/test/mock-logger';
+import { URI } from '../common/uri';
+import { SettingServiceImpl } from './setting-service';
+
+describe('SettingServiceImpl', () => {
+    const mockConfigDirUri = new URI('mock');
+
+    const setup = (): Container => {
+        const container = new Container({ defaultScope: 'Singleton' });
+        container.bind(SettingServiceImpl).toSelf();
+        container.bind(MockLogger).toSelf();
+        container.bind(ILogger).toService(MockLogger);
+        container.bind(EnvVariablesServer).toConstantValue({
+            getConfigDirUri: () => Promise.resolve(mockConfigDirUri.toString()),
+        } as unknown as EnvVariablesServer);
+        return container;
+    };
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should initialize and read settings file', async () => {
+        const container = setup();
+        const settingService = container.get(SettingServiceImpl);
+        const mockLogger = container.get(MockLogger);
+
+        const readFileStub = sinon.stub(fs, 'readFile').resolves(JSON.stringify({ key: 'value' }));
+        const infoSpy = sinon.spy(mockLogger, 'info');
+        const warnSpy = sinon.spy(mockLogger, 'warn');
+
+        const actual = await settingService.get('key');
+        expect(actual).to.be.equal('value');
+
+        expect(readFileStub.calledWith(mockConfigDirUri.resolve('backend-settings.json').path.fsPath())).to.be.true;
+        expect(infoSpy.callCount).to.be.equal(0);
+        expect(warnSpy.callCount).to.be.equal(0);
+    });
+
+    it('should fallback to default and log info when errors with ENOENT', async () => {
+        const container = setup();
+        const settingService = container.get(SettingServiceImpl);
+        const mockLogger = container.get(MockLogger);
+
+        const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        sinon.stub(fs, 'readFile').rejects(enoent);
+        const infoSpy = sinon.spy(mockLogger, 'info');
+        const warnSpy = sinon.spy(mockLogger, 'warn');
+
+        const actual = await settingService.get('key');
+        expect(actual).to.be.undefined;
+
+        expect(infoSpy.callCount).to.be.equal(1);
+        expect(infoSpy.firstCall.args[0]).to.include('Falling back to defaults');
+        expect(warnSpy.callCount).to.be.equal(0);
+    });
+
+    it('should fallback to default and log warn when errors', async () => {
+        const container = setup();
+        const settingService = container.get(SettingServiceImpl);
+        const mockLogger = container.get(MockLogger);
+
+        const enoent = Object.assign(new Error('EISDIR'), { code: 'EISDIR' });
+        sinon.stub(fs, 'readFile').rejects(enoent);
+        const infoSpy = sinon.spy(mockLogger, 'info');
+        const warnSpy = sinon.spy(mockLogger, 'warn');
+
+        const actual = await settingService.get('key');
+        expect(actual).to.be.undefined;
+
+        expect(infoSpy.callCount).to.be.equal(0);
+        expect(warnSpy.callCount).to.be.equal(1);
+        expect(warnSpy.firstCall.args[0]).to.include('Falling back to defaults');
+    });
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Log an info message when the default backend settings file is absent.

Reduce visibility of `writeFile` to `protected`. It's not an API, and is not called from Theia.

Closes: eclipse-theia/theia#15740

#### How to test
1. Ensure the backend-settings.json file is absent.
2. Start Theia, verify the logs:

```
git rev-parse --short HEAD && npm run start:browser
c0ad621d0

> @theia/monorepo@0.0.0 start:browser
> cd examples/browser && npm run start


> @theia/example-browser@1.62.0 start
> theia start --plugins=local-dir:../../plugins --ovsx-router-config=../ovsx-router-config.json

Configuration directory URI: 'file:///Users/kittaakos/.theia'
2025-06-10T12:52:08.890Z root INFO Settings file not found at '/Users/kittaakos/.theia/backend-settings.json'. Falling back to defaults.
Configuring to accept webviews on '^.+\.webview\..+$' hostname.
[...]
```

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
