### PR TITLE
Allow adding variants via files

### DIFF
--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -726,7 +726,24 @@ export class PromptServiceImpl implements PromptService {
     }
 
     getVariantIds(fragmentId: string): string[] {
-        return this._promptVariantSetsMap.get(fragmentId) || [];
+        const builtInVariants = this._promptVariantSetsMap.get(fragmentId) || [];
+
+        // Check for custom variants from customization service
+        if (this.customizationService) {
+            const allCustomizedIds = this.customizationService.getCustomizedPromptFragmentIds();
+            // Find customizations that start with the variant set ID
+            // These are considered variants of this variant set
+            const customVariants = allCustomizedIds.filter(id =>
+                id !== fragmentId && id.startsWith(fragmentId)
+            );
+
+            if (customVariants.length > 0) {
+                // Combine built-in variants with custom variants, without modifying the internal state
+                return [...builtInVariants, ...customVariants];
+            }
+        }
+
+        return builtInVariants;
     }
 
     getDefaultVariantId(promptVariantSetId: string): string | undefined {
@@ -734,7 +751,25 @@ export class PromptServiceImpl implements PromptService {
     }
 
     getPromptVariantSets(): Map<string, string[]> {
-        return new Map(this._promptVariantSetsMap);
+        const result = new Map(this._promptVariantSetsMap);
+
+        // Check for custom variants from customization service
+        if (this.customizationService) {
+            const allCustomizedIds = this.customizationService.getCustomizedPromptFragmentIds();
+
+            // Add custom variants to existing variant sets
+            for (const [variantSetId, variants] of result.entries()) {
+                const customVariants = allCustomizedIds.filter(id =>
+                    id !== variantSetId && id.startsWith(variantSetId)
+                );
+
+                if (customVariants.length > 0) {
+                    // Create a new array without modifying the original
+                    result.set(variantSetId, [...variants, ...customVariants]);
+                }
+            }
+        }
+        return result;
     }
 
     addBuiltInPromptFragment(promptFragment: BasePromptFragment, promptVariantSetId?: string, isDefault: boolean = false): void {


### PR DESCRIPTION
fixed #15794

#### What it does

Re-enable adding prompt variants by placing files that start with a variant set id.

#### How to test

Place a file that starts with the id of a variant set in the global or workspace prompt directory and see that you can use (and modify) it as a variant.

#### Follow-ups

We might consider to load customizations and custom variants into memory as done with the built ins in case we run into memory issues.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
