### PR TITLE
Cancel hover preview on right mouse click

### DIFF
--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -107,6 +107,7 @@ export class HoverService {
             this.pendingTimeout = disposableTimeout(() => this.renderHover(request), this.getHoverDelay());
             this.hoverTarget = request.target;
             this.listenForMouseOut();
+            this.listenForMouseClick();
         }
     }
 
@@ -220,6 +221,18 @@ export class HoverService {
         this.unRenderHover();
         this.disposeOnHide.dispose();
         this.hoverTarget = undefined;
+    }
+
+    /**
+     * Listen for any mouse click (mousedown) event and cancel the hover if detected.
+     * This ensures the hover is dismissed when the user clicks anywhere (including on the target or elsewhere).
+     */
+    protected listenForMouseClick(): void {
+        const handleMouseDown = (e: MouseEvent) => {
+            this.cancelHover();
+        };
+        document.addEventListener('mousedown', handleMouseDown, true);
+        this.disposeOnHide.push({ dispose: () => document.removeEventListener('mousedown', handleMouseDown, true) });
     }
 
     protected unRenderHover(): void {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR improves the behavior of the built-in hover service by cancelling the hover when a mouse click occurs. This is particularly important for UI elements like tab previews, where the hover can overlap menus or other UI components and should be dismissed as soon as the user interacts with the interface.

The hover is now cancelled when a mouse button is pressed (mousedown event).
This ensures that, for example, when a user right-clicks to open a context menu on a tab, the hover preview is dismissed and does not overlap the menu.


##### Current Limitation

- This fix currently works for right-clicks (context menu) and middle-clicks.
- For left-clicks on the target, the hover is still shown. This is likely because the left-click event does not propagate to the document level (it may be stopped for propagation by the tab or widget implementation). As a result, our global event listener does not receive the left-click event.
- However, imho it is not critical to remove the hover on a left-click, since left-clicking typically results in a tab switch or other UI change, which will naturally dismiss the hover.

Fixes #15825
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Set the window.tabbar.enhancedPreview setting to either enhanced or visual (to use the built-in hover service).
2. Hover over a tab to trigger the preview hover.
3. Right-click on the tab (the hovered target):
 -> The hover preview should disappear and not overlap the context menu.
4. Left-click on the tab (the hovered target):
-> The hover preview is not dismissed, as the event does not reach the global handler.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
