### PR TITLE
add docker file, compose, ignore and github ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,75 @@
+# Node modules - will be reinstalled
+node_modules
+**/node_modules
+
+# Build artifacts - will be rebuilt
+lib
+src-gen
+**/lib
+**/src-gen
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Development and CI files
+Dockerfile*
+.dockerignore
+.git
+.github
+.gitignore
+.gitattributes
+.gitpod.dockerfile
+.gitpod.yml
+devfile.yaml
+.theia/
+.vscode/
+
+# Documentation
+README.md
+*.md
+doc/
+CHANGELOG.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+NOTICE.md
+SECURITY.md
+
+# License files (not needed in runtime)
+LICENSE*
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Test coverage
+coverage
+.nyc_output
+
+# Temporary files
+.tmp
+.temp
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# ESLint cache
+.eslintcache
+
+# npm ignore
+.npmignore
+
+# Security scan baseline
+dependency-check-baseline.json
+
+# Logo assets (not needed for build)
+logo/
+
+# Workspace directories (will be mounted)
+workspace

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,57 @@
+name: Build and Push Docker Image
+
+# Trigger only on git tags
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # Checkout the repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Set up Docker Buildx for multi-platform builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Log in to GitHub Container Registry
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      # Build and push Docker image for multiple platforms
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,175 @@
+# Multi-stage build for Eclipse Theia Monorepo
+FROM node:18-alpine AS builder
+
+ARG UID=1000
+ARG GID=1000
+ARG NAME=theia
+
+# Install necessary system dependencies for building
+RUN apk add --no-cache \
+    shadow \
+    make \
+    gcc \
+    g++ \
+    pkgconfig \
+    libx11-dev \
+    libxkbfile-dev \
+    python3 \
+    py3-setuptools \
+    git \
+    openssh-client \
+    curl \
+    bash
+
+# Prepare user - handle root case specially
+RUN set -eux; \
+    if [ "${UID}" = "0" ] && [ "${GID}" = "0" ] && [ "${NAME}" = "root" ]; then \
+        # Root case - root user already exists, just ensure /theia directory
+        mkdir -p /theia; \
+    else \
+        # Non-root case - create/modify user and group
+        if getent group "${GID}" >/dev/null; then \
+            existing_group="$(getent group "${GID}" | cut -d: -f1)"; \
+            if [ "${existing_group}" != "${NAME}" ]; then \
+                groupmod -n "${NAME}" "${existing_group}"; \
+            fi; \
+        else \
+            addgroup -g "${GID}" -S "${NAME}"; \
+        fi; \
+        if getent passwd "${UID}" >/dev/null; then \
+            existing_user="$(getent passwd "${UID}" | cut -d: -f1)"; \
+            if [ "${existing_user}" != "${NAME}" ]; then \
+                usermod -l "${NAME}" "${existing_user}"; \
+                usermod -d "/theia" -m "${NAME}"; \
+                usermod -g "${NAME}" "${NAME}"; \
+            fi; \
+        else \
+            adduser -S -D -H \
+                -u "${UID}" \
+                -G "${NAME}" \
+                -h "/theia" \
+                -s /bin/bash \
+                "${NAME}"; \
+        fi; \
+        mkdir -p /theia; \
+    fi
+
+# Create working directory
+WORKDIR /theia
+
+# Copy root configuration files for monorepo
+COPY package*.json ./
+COPY lerna.json ./
+COPY tsconfig*.json ./
+COPY tsfmt.json ./
+
+# Copy important directories
+COPY configs/ ./configs/
+COPY dev-packages/ ./dev-packages/
+COPY packages/ ./packages/
+COPY examples/ ./examples/
+# COPY sample-plugins/ ./sample-plugins/
+COPY scripts/ ./scripts/
+
+# Install dependencies for the entire monorepo
+RUN npm install
+
+# Run node-gyp install as specified in preinstall script
+RUN npm run preinstall
+
+# Run postinstall to configure all packages
+RUN npm run postinstall
+
+# Build browser application
+RUN npm run build:browser
+
+# Production stage
+FROM node:18-alpine AS production
+
+ARG UID=1000
+ARG GID=1000
+ARG NAME=theia
+ARG PORT=3000
+
+# Install runtime dependencies
+RUN apk add --no-cache \
+    shadow \
+    git \
+    openssh-client \
+    bash \
+    curl \
+    python3
+
+# Prepare user - handle root case specially
+RUN set -eux; \
+    if [ "${UID}" = "0" ] && [ "${GID}" = "0" ] && [ "${NAME}" = "root" ]; then \
+        # Root case - root user already exists, just ensure /theia directory
+        mkdir -p /theia; \
+    else \
+        # Non-root case - create/modify user and group
+        if getent group "${GID}" >/dev/null; then \
+            existing_group="$(getent group "${GID}" | cut -d: -f1)"; \
+            if [ "${existing_group}" != "${NAME}" ]; then \
+                groupmod -n "${NAME}" "${existing_group}"; \
+            fi; \
+        else \
+            addgroup -g "${GID}" -S "${NAME}"; \
+        fi; \
+        if getent passwd "${UID}" >/dev/null; then \
+            existing_user="$(getent passwd "${UID}" | cut -d: -f1)"; \
+            if [ "${existing_user}" != "${NAME}" ]; then \
+                usermod -l "${NAME}" "${existing_user}"; \
+                usermod -d "/theia" -m "${NAME}"; \
+                usermod -g "${NAME}" "${NAME}"; \
+            fi; \
+        else \
+            adduser -S -D -H \
+                -u "${UID}" \
+                -G "${NAME}" \
+                -h "/theia" \
+                -s /bin/bash \
+                "${NAME}"; \
+        fi; \
+        mkdir -p /theia; \
+    fi
+
+# Create working directory
+WORKDIR /theia
+
+# Copy necessary configuration files
+COPY --from=builder /theia/package*.json ./
+COPY --from=builder /theia/lerna.json ./
+
+# Copy only browser example and its dependencies
+COPY --from=builder /theia/examples ./examples
+COPY --from=builder /theia/node_modules ./node_modules
+
+# Copy built packages
+COPY --from=builder /theia/packages ./packages
+COPY --from=builder /theia/dev-packages ./dev-packages
+
+# Copy plugins
+# COPY --from=builder /theia/plugins ./plugins
+
+# Set file ownership - only for non-root users
+RUN if [ "${UID}" != "0" ]; then \
+        chown -R ${NAME}:${NAME} /theia; \
+    fi
+
+# Switch to specified user
+USER ${NAME}
+
+# Expose port
+EXPOSE ${PORT}
+
+# Environment variables for Theia
+ENV SHELL=/bin/bash \
+    NODE_ENV=production
+
+# Create workspace directory
+RUN mkdir -p /theia/workspace
+
+# Start browser application
+# CMD ["npm", "run", "start:browser", "--", "--hostname=0.0.0.0", "--port=${PORT}"] # still use localhost
+WORKDIR /theia/examples/browser
+CMD npx theia start /theia/workspace --hostname=0.0.0.0 --port ${PORT} --plugins=local-dir:/theia/plugins --ovsx-router-config=../ovsx-router-config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+
+services:
+  theia-ide:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - UID=1000
+        - GID=1000
+    ports:
+      - "3000:3000"
+    volumes:
+      # Mount workspace to persist work
+      - ./workspace:/theia/workspace:rw
+      # Optional: mount additional plugins
+      - ./plugins:/theia/plugins:rw
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+    container_name: theia-ide
+
+  # Alternative service for development with hot-reload
+  theia-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
+      args:
+        - UID=1000
+        - GID=1000
+    ports:
+      - "3001:3000"
+    volumes:
+      - .:/theia
+      - /theia/node_modules
+      - /theia/examples/browser/node_modules
+    environment:
+      - NODE_ENV=development
+    command: ["npm", "run", "watch:browser"]
+    container_name: theia-dev
+    profiles:
+      - dev


### PR DESCRIPTION
#### What it does
Adding docker support for theia browser build:
- Dockerfile for build and distribute
- dockerignore for using in docker build
- docker-compose.yml for local development and usage
- github ci pipeline for building docker images for new git tags and store it in the github docker registry (packages section)

#### How to test
1) `docker compose build`
2) `docker compose up -d`  
Open browser and navigate to `http://localhost:3000`
Verify Theia IDE loads correctly in the browser.
3) For CI pipeline testing: `git tag test && git push --tags`.  
Check GitHub Actions for successful docker image build and push to registry

#### Follow-ups
None

#### Breaking changes
None

#### Attribution
None

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)