### PR TITLE
feat: enhance mcp server management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3830,6 +3830,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.1.tgz",
       "integrity": "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "raw-body": "^3.0.0",
@@ -3841,6 +3842,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
       "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -13747,6 +13749,27 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
@@ -13876,6 +13899,21 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -16635,6 +16673,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -22904,6 +22948,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -24933,6 +24986,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.9"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -30645,12 +30723,297 @@
       "version": "1.62.0",
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.0.1",
+        "@modelcontextprotocol/sdk": "^1.12.1",
         "@theia/ai-core": "1.62.0",
         "@theia/core": "1.62.0"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.62.0"
+      }
+    },
+    "packages/ai-mcp/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
+      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ai-mcp/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/ai-mcp/node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ai-mcp/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/ai-mcp/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/ai-mcp/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "packages/ai-mcp/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "packages/ai-mcp/node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "packages/ai-mcp/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "packages/ai-mcp/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "packages/ai-mcp/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/ai-mcp/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/ai-mcp/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/ai-mcp/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/ai-mcp/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "packages/ai-mcp/node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "packages/ai-mcp/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/ai-mcp/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/ai-mcp/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "packages/ai-ollama": {

--- a/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
@@ -18,7 +18,14 @@ import { ReactWidget } from '@theia/core/lib/browser';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { HoverService } from '@theia/core/lib/browser/hover-service';
-import { MCPFrontendNotificationService, MCPFrontendService, MCPServerDescription, MCPServerStatus } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import {
+    isLocalMCPServerDescription,
+    isRemoteMCPServerDescription,
+    MCPFrontendNotificationService,
+    MCPFrontendService,
+    MCPServerDescription,
+    MCPServerStatus
+} from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MessageService, nls } from '@theia/core';
 import { PROMPT_VARIABLE } from '@theia/ai-core/lib/common/prompt-variable-contribution';
 
@@ -113,7 +120,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
         const colors = this.getStatusColor(server.status);
         let displayStatus = server.status;
         if (!displayStatus) {
-            displayStatus = server.serverUrl ? MCPServerStatus.NotConnected : MCPServerStatus.NotRunning;
+            displayStatus = isRemoteMCPServerDescription(server) ? MCPServerStatus.NotConnected : MCPServerStatus.NotRunning;
         }
         const spanRef = React.createRef<HTMLSpanElement>();
         const error = server.error;
@@ -149,7 +156,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
     }
 
     protected renderCommandSection(server: MCPServerDescription): React.ReactNode {
-        if (!server.command) {
+        if (!isLocalMCPServerDescription(server)) {
             return;
         }
         return (
@@ -161,7 +168,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
     }
 
     protected renderArgumentsSection(server: MCPServerDescription): React.ReactNode {
-        if (!server.args || server.args.length === 0) {
+        if (!isLocalMCPServerDescription(server) || !server.args || server.args.length === 0) {
             return;
         }
         return (
@@ -173,7 +180,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
     }
 
     protected renderEnvironmentSection(server: MCPServerDescription): React.ReactNode {
-        if (!server.env || Object.keys(server.env).length === 0) {
+        if (!isLocalMCPServerDescription(server) || !server.env || Object.keys(server.env).length === 0) {
             return;
         }
         return (
@@ -182,7 +189,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                 <div className="mcp-env-block">
                     {Object.entries(server.env).map(([key, value]) => (
                         <div key={key}>
-                            {key}={key.toLowerCase().includes('token') ? '******' : value}
+                            {key}={key.toLowerCase().includes('token') ? '******' : String(value)}
                         </div>
                     ))}
                 </div>
@@ -191,7 +198,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
     }
 
     protected renderServerUrlSection(server: MCPServerDescription): React.ReactNode {
-        if (!server.serverUrl) {
+        if (!isRemoteMCPServerDescription(server)) {
             return;
         }
         return (
@@ -203,7 +210,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
     }
 
     protected renderServerAuthTokenHeaderSection(server: MCPServerDescription): React.ReactNode {
-        if (!server.serverAuthTokenHeader) {
+        if (!isRemoteMCPServerDescription(server) || !server.serverAuthTokenHeader) {
             return;
         }
         return (
@@ -215,7 +222,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
     }
 
     protected renderServerAuthTokenSection(server: MCPServerDescription): React.ReactNode {
-        if (!server.serverAuthToken) {
+        if (!isRemoteMCPServerDescription(server) || !server.serverAuthToken) {
             return;
         }
         return (
@@ -340,10 +347,10 @@ export class AIMCPConfigurationWidget extends ReactWidget {
             || server.status === MCPServerStatus.NotConnected
             || server.status === MCPServerStatus.Errored;
 
-        const startLabel = server.serverUrl
+        const startLabel = isRemoteMCPServerDescription(server)
             ? nls.localize('theia/ai/mcpConfiguration/connectServer', 'Connnect')
             : nls.localize('theia/ai/mcpConfiguration/startServer', 'Start Server');
-        const stopLabel = server.serverUrl
+        const stopLabel = isRemoteMCPServerDescription(server)
             ? nls.localize('theia/ai/mcpConfiguration/disconnectServer', 'Disconnnect')
             : nls.localize('theia/ai/mcpConfiguration/stopServer', 'Stop Server');
         return (

--- a/packages/ai-mcp/package.json
+++ b/packages/ai-mcp/package.json
@@ -3,7 +3,7 @@
   "version": "1.62.0",
   "description": "Theia - MCP Integration",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.0.1",
+    "@modelcontextprotocol/sdk": "^1.12.1",
     "@theia/ai-core": "1.62.0",
     "@theia/core": "1.62.0"
   },

--- a/packages/ai-mcp/src/browser/mcp-command-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-command-contribution.ts
@@ -57,7 +57,7 @@ export class MCPCommandContribution implements CommandContribution {
                 try {
                     const startedServers = await this.mcpFrontendService.getStartedServers();
                     if (!startedServers || startedServers.length === 0) {
-                        await this.messageService.error(nls.localize('theia/ai/mcp/error/noRunningServers', 'No MCP servers running.'));
+                        this.messageService.error(nls.localize('theia/ai/mcp/error/noRunningServers', 'No MCP servers running.'));
                         return;
                     }
                     const selection = await this.getMCPServerSelection(startedServers);
@@ -79,9 +79,9 @@ export class MCPCommandContribution implements CommandContribution {
                     const startableServers = servers.filter(server => !startedServers.includes(server));
                     if (!startableServers || startableServers.length === 0) {
                         if (startedServers && startedServers.length > 0) {
-                            await this.messageService.error(nls.localize('theia/ai/mcp/error/allServersRunning', 'All MCP servers are already running.'));
+                            this.messageService.error(nls.localize('theia/ai/mcp/error/allServersRunning', 'All MCP servers are already running.'));
                         } else {
-                            await this.messageService.error(nls.localize('theia/ai/mcp/error/noServersConfigured', 'No MCP servers configured.'));
+                            this.messageService.error(nls.localize('theia/ai/mcp/error/noServersConfigured', 'No MCP servers configured.'));
                         }
                         return;
                     }
@@ -99,7 +99,7 @@ export class MCPCommandContribution implements CommandContribution {
                             if (serverDescription.tools) {
                                 toolNames = serverDescription.tools.map(tool => tool.name).join(',');
                             }
-                            await this.messageService.info(
+                            this.messageService.info(
                                 nls.localize('theia/ai/mcp/info/serverStarted', 'MCP server "{0}" successfully started. Registered tools: {1}', selection, toolNames ||
                                     nls.localize('theia/ai/mcp/tool/noTools', 'No tools available.'))
                             );
@@ -109,9 +109,9 @@ export class MCPCommandContribution implements CommandContribution {
                             console.error('Error while starting MCP server:', serverDescription.error);
                         }
                     }
-                    await this.messageService.error(nls.localize('theia/ai/mcp/error/startFailed', 'An error occurred while starting the MCP server.'));
+                    this.messageService.error(nls.localize('theia/ai/mcp/error/startFailed', 'An error occurred while starting the MCP server.'));
                 } catch (error) {
-                    await this.messageService.error(nls.localize('theia/ai/mcp/error/startFailed', 'An error occurred while starting the MCP server.'));
+                    this.messageService.error(nls.localize('theia/ai/mcp/error/startFailed', 'An error occurred while starting the MCP server.'));
                     console.error('Error while starting MCP server:', error);
                 }
             }

--- a/packages/ai-mcp/src/browser/mcp-command-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-command-contribution.ts
@@ -57,7 +57,7 @@ export class MCPCommandContribution implements CommandContribution {
                 try {
                     const startedServers = await this.mcpFrontendService.getStartedServers();
                     if (!startedServers || startedServers.length === 0) {
-                        this.messageService.error(nls.localize('theia/ai/mcp/error/noRunningServers', 'No MCP servers running.'));
+                        await this.messageService.error(nls.localize('theia/ai/mcp/error/noRunningServers', 'No MCP servers running.'));
                         return;
                     }
                     const selection = await this.getMCPServerSelection(startedServers);
@@ -79,9 +79,9 @@ export class MCPCommandContribution implements CommandContribution {
                     const startableServers = servers.filter(server => !startedServers.includes(server));
                     if (!startableServers || startableServers.length === 0) {
                         if (startedServers && startedServers.length > 0) {
-                            this.messageService.error(nls.localize('theia/ai/mcp/error/allServersRunning', 'All MCP servers are already running.'));
+                            await this.messageService.error(nls.localize('theia/ai/mcp/error/allServersRunning', 'All MCP servers are already running.'));
                         } else {
-                            this.messageService.error(nls.localize('theia/ai/mcp/error/noServersConfigured', 'No MCP servers configured.'));
+                            await this.messageService.error(nls.localize('theia/ai/mcp/error/noServersConfigured', 'No MCP servers configured.'));
                         }
                         return;
                     }
@@ -93,12 +93,13 @@ export class MCPCommandContribution implements CommandContribution {
                     await this.mcpFrontendService.startServer(selection);
                     const serverDescription = await this.mcpFrontendService.getServerDescription(selection);
                     if (serverDescription && serverDescription.status) {
-                        if (serverDescription.status === MCPServerStatus.Running) {
+                        if (serverDescription.status === MCPServerStatus.Running
+                            || serverDescription.status === MCPServerStatus.Connected) {
                             let toolNames: string | undefined = undefined;
                             if (serverDescription.tools) {
                                 toolNames = serverDescription.tools.map(tool => tool.name).join(',');
                             }
-                            this.messageService.info(
+                            await this.messageService.info(
                                 nls.localize('theia/ai/mcp/info/serverStarted', 'MCP server "{0}" successfully started. Registered tools: {1}', selection, toolNames ||
                                     nls.localize('theia/ai/mcp/tool/noTools', 'No tools available.'))
                             );
@@ -108,9 +109,9 @@ export class MCPCommandContribution implements CommandContribution {
                             console.error('Error while starting MCP server:', serverDescription.error);
                         }
                     }
-                    this.messageService.error(nls.localize('theia/ai/mcp/error/startFailed', 'An error occurred while starting the MCP server.'));
+                    await this.messageService.error(nls.localize('theia/ai/mcp/error/startFailed', 'An error occurred while starting the MCP server.'));
                 } catch (error) {
-                    this.messageService.error(nls.localize('theia/ai/mcp/error/startFailed', 'An error occurred while starting the MCP server.'));
+                    await this.messageService.error(nls.localize('theia/ai/mcp/error/startFailed', 'An error occurred while starting the MCP server.'));
                     console.error('Error while starting MCP server:', error);
                 }
             }

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
@@ -22,10 +22,13 @@ import { JSONObject } from '@theia/core/shared/@lumino/coreutils';
 import { MCPFrontendService } from '../common/mcp-server-manager';
 
 interface MCPServersPreferenceValue {
-    command: string;
+    command?: string;
     args?: string[];
     env?: { [key: string]: string };
     autostart?: boolean;
+    serverUrl?: string;
+    serverAuthToken?: string;
+    serverAuthTokenHeader?: string;
 };
 
 interface MCPServersPreference {
@@ -35,10 +38,13 @@ interface MCPServersPreference {
 namespace MCPServersPreference {
     export function isValue(obj: unknown): obj is MCPServersPreferenceValue {
         return !!obj && typeof obj === 'object' &&
-            'command' in obj && typeof obj.command === 'string' &&
+            (!('command' in obj) || typeof obj.command === 'string') &&
             (!('args' in obj) || Array.isArray(obj.args) && obj.args.every(arg => typeof arg === 'string')) &&
             (!('env' in obj) || !!obj.env && typeof obj.env === 'object' && Object.values(obj.env).every(value => typeof value === 'string')) &&
-            (!('autostart' in obj) || typeof obj.autostart === 'boolean');
+            (!('autostart' in obj) || typeof obj.autostart === 'boolean') &&
+            (!('serverUrl' in obj) || typeof obj.serverUrl === 'string') &&
+            (!('serverAuthToken' in obj) || typeof obj.serverAuthToken === 'string') &&
+            (!('serverAuthTokenHeader' in obj) || typeof obj.serverAuthTokenHeader === 'string');
     }
 }
 

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
@@ -21,15 +21,23 @@ import { MCP_SERVERS_PREF } from './mcp-preferences';
 import { JSONObject } from '@theia/core/shared/@lumino/coreutils';
 import { MCPFrontendService } from '../common/mcp-server-manager';
 
-interface MCPServersPreferenceValue {
-    command?: string;
+interface BaseMCPServerPreferenceValue {
+    autostart?: boolean;
+}
+
+interface LocalMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
+    command: string;
     args?: string[];
     env?: { [key: string]: string };
-    autostart?: boolean;
-    serverUrl?: string;
+}
+
+interface RemoteMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
+    serverUrl: string;
     serverAuthToken?: string;
     serverAuthTokenHeader?: string;
-};
+}
+
+type MCPServersPreferenceValue = LocalMCPServerPreferenceValue | RemoteMCPServerPreferenceValue;
 
 interface MCPServersPreference {
     [name: string]: MCPServersPreferenceValue
@@ -38,6 +46,7 @@ interface MCPServersPreference {
 namespace MCPServersPreference {
     export function isValue(obj: unknown): obj is MCPServersPreferenceValue {
         return !!obj && typeof obj === 'object' &&
+            ('command' in obj || 'serverUrl' in obj) &&
             (!('command' in obj) || typeof obj.command === 'string') &&
             (!('args' in obj) || Array.isArray(obj.args) && obj.args.every(arg => typeof arg === 'string')) &&
             (!('env' in obj) || !!obj.env && typeof obj.env === 'object' && Object.values(obj.env).every(value => typeof value === 'string')) &&
@@ -153,12 +162,31 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
     protected convertToMap(servers: MCPServersPreference): Map<string, MCPServerDescription> {
         const map = new Map<string, MCPServerDescription>();
         Object.entries(servers).forEach(([name, description]) => {
-            map.set(name, {
-                name,
-                ...description,
-                autostart: 'autostart' in description ? description.autostart : true,
-                env: description.env || undefined
-            });
+            let filteredDescription: MCPServerDescription;
+
+            if ('serverUrl' in description) {
+                // Create RemoteMCPServerDescription by picking only remote-specific properties
+                const { serverUrl, serverAuthToken, serverAuthTokenHeader, autostart } = description;
+                filteredDescription = {
+                    name,
+                    serverUrl,
+                    ...(serverAuthToken && { serverAuthToken }),
+                    ...(serverAuthTokenHeader && { serverAuthTokenHeader }),
+                    autostart: autostart ?? true,
+                };
+            } else {
+                // Create LocalMCPServerDescription by picking only local-specific properties
+                const { command, args, env, autostart } = description;
+                filteredDescription = {
+                    name,
+                    command,
+                    ...(args && { args }),
+                    ...(env && { env }),
+                    autostart: autostart ?? true,
+                };
+            }
+
+            map.set(name, filteredDescription);
         });
         return map;
     }

--- a/packages/ai-mcp/src/browser/mcp-preferences.ts
+++ b/packages/ai-mcp/src/browser/mcp-preferences.ts
@@ -24,9 +24,10 @@ export const McpServersPreferenceSchema: PreferenceSchema = {
   properties: {
     [MCP_SERVERS_PREF]: {
       type: 'object',
-      title: nls.localize('theia/ai/mcp/servers/title', 'MCP Servers Configuration'),
-      markdownDescription: nls.localize('theia/ai/mcp/servers/mdDescription', 'Configure MCP servers with command, arguments, optionally environment variables, and autostart \
-(true by default). Each server is identified by a unique key, such as "brave-search" or "filesystem". \
+      title: nls.localize('theia/ai/mcp/servers/title', 'MCP Server Configuration'),
+      markdownDescription: nls.localize('theia/ai/mcp/servers/mdDescription', 'Configure MCP servers either local with command, arguments and optionally environment variables, \
+or remote with server URL, authentication token and optionally an authentication header name. Additionally it is possible to configure autostart (true by default). \
+Each server is identified by a unique key, such as "brave-search" or "filesystem". \
 To start a server, use the "MCP: Start MCP Server" command, which enables you to select the desired server. \
 To stop a server, use the "MCP: Stop MCP Server" command. \
 Please note that autostart will only take effect after a restart, you need to start a server manually for the first time.\
@@ -51,6 +52,10 @@ Example configuration:\n\
       "CUSTOM_ENV_VAR": "custom-value"\n\
     },\n\
     "autostart": false\n\
+  },\n\
+  "jira": {\n\
+    "serverUrl": "YOUR_JIRA_MCP_SERVER_URL",\n\
+    "serverAuthToken": "YOUR_JIRA_MCP_SERVER_TOKEN"\n\
   }\n\
 }\n```'),
       additionalProperties: {
@@ -80,9 +85,27 @@ Example configuration:\n\
             markdownDescription: nls.localize('theia/ai/mcp/servers/autostart/mdDescription',
               'Automatically start this server when the frontend starts. Newly added servers are not immediately auto started, but on restart'),
             default: true
+          },
+          serverUrl: {
+            type: 'string',
+            title: nls.localize('theia/ai/mcp/servers/serverUrl/title', 'Server URL'),
+            markdownDescription: nls.localize('theia/ai/mcp/servers/serverUrl/mdDescription',
+              'The URL of the remote MCP server. If provided, the server will connect to this URL instead of starting a local process.'),
+          },
+          serverAuthToken: {
+            type: 'string',
+            title: nls.localize('theia/ai/mcp/servers/serverAuthToken/title', 'Authentication Token'),
+            markdownDescription: nls.localize('theia/ai/mcp/servers/serverAuthToken/mdDescription',
+              'The authentication token for the server, if required. This is used to authenticate with the remote server.'),
+          },
+          serverAuthTokenHeader: {
+            type: 'string',
+            title: nls.localize('theia/ai/mcp/servers/serverAuthTokenHeader/title', 'Authentication Header Name'),
+            markdownDescription: nls.localize('theia/ai/mcp/servers/serverAuthTokenHeader/mdDescription',
+              'The header name to use for the server authentication token. If not provided, "Authorization" with "Bearer" will be used.'),
           }
         },
-        required: ['command', 'args']
+        required: []
       }
     }
   }

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { CallToolResult, ListToolsResult } from '@modelcontextprotocol/sdk/types';
+import { CallToolResult, ListResourcesResult, ListToolsResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types';
 import { Event } from '@theia/core/lib/common/event';
 
 export const MCPFrontendService = Symbol('MCPFrontendService');
@@ -41,6 +41,8 @@ export interface MCPFrontendNotificationService {
 export interface MCPServer {
     callTool(toolName: string, arg_string: string): Promise<CallToolResult>;
     getTools(): Promise<ListToolsResult>;
+    readResource(resourceId: string): Promise<ReadResourceResult>;
+    getResources(): Promise<ListResourcesResult>;
     description: MCPServerDescription;
 }
 
@@ -56,6 +58,8 @@ export interface MCPServerManager {
     getRunningServers(): Promise<string[]>;
     setClient(client: MCPFrontendNotificationService): void;
     disconnectClient(client: MCPFrontendNotificationService): void;
+    readResource(serverName: string, resourceId: string): Promise<ReadResourceResult>;
+    getResources(serverName: string): Promise<ListResourcesResult>;
 }
 
 export interface ToolInformation {
@@ -65,8 +69,11 @@ export interface ToolInformation {
 
 export enum MCPServerStatus {
     NotRunning = 'Not Running',
+    NotConnected = 'Not Connected',
     Starting = 'Starting',
+    Connecting = 'Connecting',
     Running = 'Running',
+    Connected = 'Connected',
     Errored = 'Errored'
 }
 
@@ -79,7 +86,7 @@ export interface MCPServerDescription {
     /**
      * The command to execute the MCP server.
      */
-    command: string;
+    command?: string;
 
     /**
      * An array of arguments to pass to the command.
@@ -90,6 +97,21 @@ export interface MCPServerDescription {
      * Optional environment variables to set when starting the server.
      */
     env?: { [key: string]: string };
+
+    /**
+     * The URL of the remote MCP server.
+     */
+    serverUrl?: string;
+
+    /**
+     * The authentication token for the server, if required.
+     */
+    serverAuthToken?: string;
+
+    /**
+     * The header name to use for the server authentication token.
+     */
+    serverAuthTokenHeader?: string;
 
     /**
      * Flag indicating whether the server should automatically start when the application starts.

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -77,41 +77,11 @@ export enum MCPServerStatus {
     Errored = 'Errored'
 }
 
-export interface MCPServerDescription {
+export interface BaseMCPServerDescription {
     /**
      * The unique name of the MCP server.
      */
     name: string;
-
-    /**
-     * The command to execute the MCP server.
-     */
-    command?: string;
-
-    /**
-     * An array of arguments to pass to the command.
-     */
-    args?: string[];
-
-    /**
-     * Optional environment variables to set when starting the server.
-     */
-    env?: { [key: string]: string };
-
-    /**
-     * The URL of the remote MCP server.
-     */
-    serverUrl?: string;
-
-    /**
-     * The authentication token for the server, if required.
-     */
-    serverAuthToken?: string;
-
-    /**
-     * The header name to use for the server authentication token.
-     */
-    serverAuthTokenHeader?: string;
 
     /**
      * Flag indicating whether the server should automatically start when the application starts.
@@ -132,6 +102,49 @@ export interface MCPServerDescription {
      * List of available tools for the server. Returns the name and description if available.
      */
     tools?: ToolInformation[];
+}
+
+export interface LocalMCPServerDescription extends BaseMCPServerDescription {
+    /**
+     * The command to execute the MCP server.
+     */
+    command: string;
+
+    /**
+     * An array of arguments to pass to the command.
+     */
+    args?: string[];
+
+    /**
+     * Optional environment variables to set when starting the server.
+     */
+    env?: { [key: string]: string };
+}
+
+export interface RemoteMCPServerDescription extends BaseMCPServerDescription {
+    /**
+     * The URL of the remote MCP server.
+     */
+    serverUrl: string;
+
+    /**
+     * The authentication token for the server, if required.
+     */
+    serverAuthToken?: string;
+
+    /**
+     * The header name to use for the server authentication token.
+     */
+    serverAuthTokenHeader?: string;
+}
+
+export type MCPServerDescription = LocalMCPServerDescription | RemoteMCPServerDescription;
+
+export function isLocalMCPServerDescription(description: MCPServerDescription): description is LocalMCPServerDescription {
+    return (description as LocalMCPServerDescription).command !== undefined;
+}
+export function isRemoteMCPServerDescription(description: MCPServerDescription): description is RemoteMCPServerDescription {
+    return (description as RemoteMCPServerDescription).serverUrl !== undefined;
 }
 
 export const MCPServerManager = Symbol('MCPServerManager');

--- a/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
+++ b/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
@@ -17,7 +17,7 @@ import { injectable } from '@theia/core/shared/inversify';
 import { MCPServerDescription, MCPServerManager, MCPFrontendNotificationService } from '../common/mcp-server-manager';
 import { MCPServer } from './mcp-server';
 import { Disposable } from '@theia/core/lib/common/disposable';
-import { CallToolResult } from '@modelcontextprotocol/sdk/types';
+import { CallToolResult, ListResourcesResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types';
 
 @injectable()
 export class MCPServerManagerImpl implements MCPServerManager {
@@ -31,7 +31,7 @@ export class MCPServerManagerImpl implements MCPServerManager {
         if (!server) {
             throw new Error(`MCP server "${serverName}" not found.`);
         }
-        server.stop();
+        await server.stop();
         console.log(`MCP server "${serverName}" stopped.`);
         this.notifyClients();
     }
@@ -69,7 +69,7 @@ export class MCPServerManagerImpl implements MCPServerManager {
 
     async getServerDescription(name: string): Promise<MCPServerDescription | undefined> {
         const server = this.servers.get(name);
-        return server ? server.getDescription() : undefined;
+        return server ? await server.getDescription() : undefined;
     }
 
     public async getTools(serverName: string): ReturnType<MCPServer['getTools']> {
@@ -77,7 +77,7 @@ export class MCPServerManagerImpl implements MCPServerManager {
         if (!server) {
             throw new Error(`MCP server "${serverName}" not found.`);
         }
-        return server.getTools();
+        return await server.getTools();
     }
 
     addOrUpdateServer(description: MCPServerDescription): void {
@@ -134,5 +134,21 @@ export class MCPServerManagerImpl implements MCPServerManager {
 
     private notifyClients(): void {
         this.clients.forEach(client => client.didUpdateMCPServers());
+    }
+
+    readResource(serverName: string, resourceId: string): Promise<ReadResourceResult> {
+        const server = this.servers.get(serverName);
+        if (!server) {
+            throw new Error(`MCP server "${serverName}" not found.`);
+        }
+        return server.readResource(resourceId);
+    }
+
+    getResources(serverName: string): Promise<ListResourcesResult> {
+        const server = this.servers.get(serverName);
+        if (!server) {
+            throw new Error(`MCP server "${serverName}" not found.`);
+        }
+        return server.getResources();
     }
 }


### PR DESCRIPTION
#### What it does

This PR is an enhancement to https://github.com/eclipse-theia/theia/pull/15413

It adds the ability to connect to a remote MCP server. Compared to the original PR, this PR supports SSE and StreamableHttp, which is the successor to the SSE implementation. The implementation first tries to access the remote MCP server via StreamableHttp, if that fails it tries to fallback to SSE. While you could argue that this could also be a configuration value instead of the fallback solution, the question is on the user side. Is a user of a remote MCP server aware of the communication protocol? We therefore decided for the fallback solution, to make the configuration more convenient.

We also changed the configuration. While the original PR used the `env` for the server configuration, we introduced new top level configurations and made `command` optional. So with this PR you can either create a local MCP server configuration with `command`, `args` and `env`, or you create a remove MCP server configuration with `serverUrl`, `serverAuthToken` and an optional `serverAuthTokenHeader` in case the server uses a non-default authorization token header name.

#### How to test

Configure a remote MCP server and try to use it. You could also try to start an MCP server locally and access it via server URL. But I haven't tested this scenario, as we have remote MCP servers in our setup to test against.

I found a simple free accessible MCP that does not require a token.

```json
    "ai-features.mcp.mcpServers": {
      "cloudflare" :{
        "serverUrl": "https://demo-day.mcp.cloudflare.com/sse"
      }
    },
```

As you can see from the URL, it uses SSE, so it can be used to verify the automatic fallback.

Once connected, paste the following to the AI chat to see that it works:

_Can you tell be something about the Cloudflare Demo Day. Use ~mcp_cloudflare_mcp_demo_day_info  to answer the question._


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
