### PR TITLE
Fix getMenuNode() for leaf nodes

### DIFF
--- a/packages/core/src/browser/menu/menu.spec.ts
+++ b/packages/core/src/browser/menu/menu.spec.ts
@@ -50,7 +50,6 @@ class TestMenuNodeFactory implements MenuNodeFactory {
 }
 
 describe('menu-model-registry', () => {
-
     describe('01 #register', () => {
         it('Should allow to register menu actions.', () => {
             const fileMenu = ['main', 'File'];
@@ -86,6 +85,9 @@ describe('menu-model-registry', () => {
             const openGroup = file.children[0] as Submenu;
             expect(openGroup.children.length).equals(2);
             expect(openGroup.label).undefined;
+
+            expect(service.getMenuNode([...fileOpenMenu, 'open'])).exist;
+            expect(service.getMenuNode([...fileOpenMenu, 'Gurkensalat'])).undefined;
         });
 
         it('Should not allow to register cyclic menus.', () => {

--- a/packages/core/src/common/menu/menu-model-registry.ts
+++ b/packages/core/src/common/menu/menu-model-registry.ts
@@ -311,13 +311,15 @@ export class MenuModelRegistry {
         }
     }
 
-    protected findInNode(root: CompoundMenuNode, menuPath: MenuPath, pathIndex: number): MenuNode | undefined {
+    protected findInNode(root: MenuNode, menuPath: MenuPath, pathIndex: number): MenuNode | undefined {
         if (pathIndex === menuPath.length) {
             return root;
         }
-        const child = root.children.find(c => c.id === menuPath[pathIndex]);
-        if (CompoundMenuNode.is(child)) {
-            return this.findInNode(child, menuPath, pathIndex + 1);
+        if (CompoundMenuNode.is(root)) {
+            const child = root.children.find(c => c.id === menuPath[pathIndex]);
+            if (child) {
+                return this.findInNode(child, menuPath, pathIndex + 1);
+            }
         }
         return undefined;
     }


### PR DESCRIPTION
#### What it does
The Method `MenuModelRegistry.getMenuNode()` was not finding leaf nodes correctly. This lead to duplicate menu entries for stuff contributed by multiple sources (like Theia and the Monaco editor, like for cut/copy/paste.

Fixes #15828
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Make sure the duplicate menu entries from the linked issue are now gone and that the right menu entries are still shown.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
