### PR TITLE
Fix bug that customizations are treated as variants

### DIFF
--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -733,8 +733,12 @@ export class PromptServiceImpl implements PromptService {
             const allCustomizedIds = this.customizationService.getCustomizedPromptFragmentIds();
             // Find customizations that start with the variant set ID
             // These are considered variants of this variant set
+            // Only include IDs that are not the variant set ID itself, start with the variant set ID,
+            // and are not customizations of existing variants in this set
             const customVariants = allCustomizedIds.filter(id =>
-                id !== variantSetId && id.startsWith(variantSetId)
+                id !== variantSetId &&
+                id.startsWith(variantSetId) &&
+                !builtInVariants.includes(id)
             );
 
             if (customVariants.length > 0) {
@@ -759,8 +763,14 @@ export class PromptServiceImpl implements PromptService {
 
             // Add custom variants to existing variant sets
             for (const [variantSetId, variants] of result.entries()) {
+                // Filter out customized fragments that are just customizations of existing variants
+                // so we don't treat them as separate variants themselves
+                // Only include IDs that are not the variant set ID itself, start with the variant set ID,
+                // and are not customizations of existing variants in this set
                 const customVariants = allCustomizedIds.filter(id =>
-                    id !== variantSetId && id.startsWith(variantSetId)
+                    id !== variantSetId &&
+                    id.startsWith(variantSetId) &&
+                    !variants.includes(id)
                 );
 
                 if (customVariants.length > 0) {


### PR DESCRIPTION
#### What it does

Fixes a bug that prompt customizations are treated as variants if they start with the same id as the variant set

#### How to test

- Create a customization of the architect default prompt (the prompts for architect start with architect-system, which is the variant set id)
- Observe that the customizations are shown as variants, so they appear twice in the list.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
