### PR TITLE
fix: agent tree selection highlighting in AI configuration widget

### DIFF
--- a/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -99,13 +99,15 @@ export class AIAgentConfigurationWidget extends ReactWidget {
 
     protected render(): React.ReactNode {
         return <div className='ai-agent-configuration-main'>
-            <div className='configuration-agents-list preferences-tree-widget theia-TreeContainer' style={{ width: '25%' }}>
+            <div className='configuration-agents-list theia-Tree theia-TreeContainer' style={{ width: '25%' }}>
                 <ul>
-                    {this.agentService.getAllAgents().map(agent =>
-                        <li key={agent.id} className='theia-TreeNode theia-CompositeTreeNode theia-ExpandableTreeNode' onClick={() => this.setActiveAgent(agent)}>
+                    {this.agentService.getAllAgents().map(agent => {
+                        const isActive = this.aiConfigurationSelectionService.getActiveAgent()?.id === agent.id;
+                        const className = `theia-TreeNode theia-CompositeTreeNode theia-ExpandableTreeNode${isActive ? ' theia-mod-selected' : ''}`;
+                        return <li key={agent.id} className={className} onClick={() => this.setActiveAgent(agent)}>
                             {this.renderAgentName(agent)}
-                        </li>
-                    )}
+                        </li>;
+                    })}
                 </ul>
                 <div className='configuration-agents-add'>
                     <button


### PR DESCRIPTION
#### What it does

Marks the currently selected agent in the AI agent configuration view.

#### How to test

* Open the AI configuration view
* Select an agent

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
