### PR TITLE
Amend enablement/visibility checks for dirty diff widget toolbar actions

### DIFF
--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -345,10 +345,10 @@ class DirtyDiffPeekView extends MonacoEditorPeekViewWidget {
                         if (CommandMenu.is(item)) {
                             const { id, label, icon } = item;
                             const itemPath = [...menuPath, id];
-                            if (icon && item.isVisible(itemPath, contextKeyService, undefined)) {
+                            if (icon && item.isVisible(itemPath, contextKeyService, undefined, this.widget)) {
                                 // Close editor on successful contributed action.
                                 // https://github.com/microsoft/vscode/blob/1.99.3/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts#L357-L361
-                                this.addAction(id, label, icon, item.isEnabled(itemPath), () => {
+                                this.addAction(id, label, icon, item.isEnabled(itemPath, this.widget), () => {
                                     item.run(itemPath, this.widget).then(() => this.dispose());
                                 });
                             }


### PR DESCRIPTION
#### What it does

I've stumbled across a change to `dirty-diff-widget.ts` made as part of #14676, which doesn't look correct to me (as the original author).

Previously, `this.widget` was passed as an argument to `isVisible` and `isEnabled` methods:

https://github.com/eclipse-theia/theia/blob/a2052f016dea5d0cf89ba646cf1763c49752c202/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts#L347-L353

Currently, it is no longer passed:

https://github.com/eclipse-theia/theia/blob/a7d13dc6a2e989c5dd03f69a5f554375d7f31029/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts#L348-L354

This PR restores the correct behavior.

#### How to test

Verify that there are no regressions in enablement/visibility of dirty diff widget toolbar actions.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
