### PR TITLE
Fix prompt fragment view resetting custom prompt fragments

### DIFF
--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -896,7 +896,9 @@ export class PromptServiceImpl implements PromptService {
     }
 
     async resetToBuiltIn(fragmentId: string): Promise<void> {
-        if (this.customizationService) {
+        const builtIn = this._builtInFragments.find(b => b.id === fragmentId);
+        // Only reset this if it has a built-in, otherwise a delete would be the correct operation
+        if (this.customizationService && builtIn) {
             await this.customizationService.removeAllPromptFragmentCustomizations(fragmentId);
         }
     }

--- a/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
@@ -346,9 +346,7 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
 
         const shouldReset = await dialog.open();
         if (shouldReset) {
-            this.promptFragmentMap.forEach(fragments => {
-                this.promptService.resetToBuiltIn(fragments[0].id);
-            });
+            this.promptService.resetAllToBuiltIn();
         }
     };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Beforehand, when `Reset all prompt fragments` was triggered, custom fragments without a built-in, like project-info were deleted. Now only customizations that include built-in versions are removed. Also add a safe guard to not resetToBuilIn for fragmentIds that do not have a built-in.

Fixes #15773

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- `Reset all prompt fragments` in the prompt fragment view
- Check that the project-info and other custom prompt fragments are not removed if they do not have a built-in
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
