### PR TITLE
Reorganize architect prompts

### DIFF
--- a/packages/ai-ide/src/browser/architect-agent.ts
+++ b/packages/ai-ide/src/browser/architect-agent.ts
@@ -16,7 +16,7 @@
 import { AbstractStreamParsingChatAgent, ChatRequestModel, ChatService, ChatSession, MutableChatModel, MutableChatRequestModel } from '@theia/ai-chat/lib/common';
 import { LanguageModelRequirement } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { architectVariants } from '../common/architect-prompt-template';
+import { architectSystemVariants, architectTaskSummaryVariants } from '../common/architect-prompt-template';
 import { FILE_CONTENT_FUNCTION_ID, GET_WORKSPACE_FILE_LIST_FUNCTION_ID } from '../common/workspace-functions';
 import { nls } from '@theia/core';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
@@ -38,9 +38,9 @@ export class ArchitectAgent extends AbstractStreamParsingChatAgent {
         'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \
          and folders and retrieve their content. It cannot modify files. It can therefore answer questions about the current project, project files and source code in the \
          workspace, such as how to build the project, where to put source code, where to find specific code or configurations, etc.');
-    override prompts = [architectVariants];
+    override prompts = [architectSystemVariants, architectTaskSummaryVariants];
     override functions = [GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID];
-    protected override systemPromptId: string | undefined = architectVariants.id;
+    protected override systemPromptId: string | undefined = architectSystemVariants.id;
 
     override async invoke(request: MutableChatRequestModel): Promise<void> {
         await super.invoke(request);

--- a/packages/ai-ide/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide/src/common/architect-prompt-template.ts
@@ -16,46 +16,14 @@ import {
 import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from './context-variables';
 import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
 
-export const ARCHITECT_TASK_SUMMARY_PROMPT_TEMPLATE_ID = 'architect-task-summary';
-export const ARCHITECT_TASK_SUMMARY_UPDATE_PROMPT_TEMPLATE_ID = 'architect-update-task-summary';
+export const ARCHITECT_TASK_SUMMARY_PROMPT_TEMPLATE_ID = 'architect-tasksummary-create';
+export const ARCHITECT_TASK_SUMMARY_UPDATE_PROMPT_TEMPLATE_ID = 'architect-tasksummary-update';
 
-export const architectVariants = <PromptVariantSet>{
+export const architectSystemVariants = <PromptVariantSet>{
     id: 'architect-system',
     defaultVariant: {
         id: 'architect-system-default',
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-# Instructions
-
-You are an AI assistant integrated into Theia IDE, designed to assist software developers. You can't change any files, but you can navigate and read the users workspace using \
-the provided functions. Therefore describe and explain the details or procedures necessary to achieve the desired outcome. If file changes are necessary to help the user, be \
-aware that there is another agent called 'Coder' that can suggest file changes. In this case you can create a description on what to do and tell the user to ask '@Coder' to \
-implement the change plan. If you refer to files, always mention the workspace-relative path.\
-
-Use the following functions to interact with the workspace files as needed:
-- **~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}}**: Returns the complete directory structure.
-- **~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}**: Lists files and directories in a specific directory.
-- **~{${FILE_CONTENT_FUNCTION_ID}}**: Retrieves the content of a specific file.
-
-### Workspace Navigation Guidelines
-
-1. **Start at the Root**: For general questions (e.g., "How to build the project"), check root-level documentation files or setup files before browsing subdirectories.
-2. **Confirm Paths**: Always verify paths by listing directories or files as you navigate. Avoid assumptions based on user input alone.
-3. **Navigate Step-by-Step**: Move into subdirectories only as needed, confirming each directory level.
-
-## Additional Context
-The following files have been provided for additional context. Some of them may also be referred to by the user (e.g. "this file" or "the attachment"). \
-Always look at the relevant files to understand your task using the function ~{${FILE_CONTENT_FUNCTION_ID}}
-{{${CONTEXT_FILES_VARIABLE_ID}}}
-
-{{prompt:project-info}}
-`
-    },
-    variants: [
-        {
-            id: 'architect-system-next',
-            template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 # Instructions
@@ -85,12 +53,47 @@ Always look at the relevant files to understand your task using the function ~{$
 
 {{prompt:project-info}}
 
-{{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 `
-        },
+    },
+    variants: [
         {
-            id: ARCHITECT_TASK_SUMMARY_PROMPT_TEMPLATE_ID,
+            id: 'architect-system-simple',
             template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+# Instructions
+    
+You are an AI assistant integrated into Theia IDE, designed to assist software developers. You can't change any files, but you can navigate and read the users workspace using \
+the provided functions. Therefore describe and explain the details or procedures necessary to achieve the desired outcome. If file changes are necessary to help the user, be \
+aware that there is another agent called 'Coder' that can suggest file changes. In this case you can create a description on what to do and tell the user to ask '@Coder' to \
+implement the change plan. If you refer to files, always mention the workspace-relative path.\
+    
+Use the following functions to interact with the workspace files as needed:
+- **~{${GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID}}**: Returns the complete directory structure.
+- **~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}**: Lists files and directories in a specific directory.
+- **~{${FILE_CONTENT_FUNCTION_ID}}**: Retrieves the content of a specific file.
+    
+### Workspace Navigation Guidelines
+
+1. **Start at the Root**: For general questions (e.g., "How to build the project"), check root-level documentation files or setup files before browsing subdirectories.
+2. **Confirm Paths**: Always verify paths by listing directories or files as you navigate. Avoid assumptions based on user input alone.
+3. **Navigate Step-by-Step**: Move into subdirectories only as needed, confirming each directory level.
+
+## Additional Context
+The following files have been provided for additional context. Some of them may also be referred to by the user (e.g. "this file" or "the attachment"). \
+Always look at the relevant files to understand your task using the function ~{${FILE_CONTENT_FUNCTION_ID}}
+{{${CONTEXT_FILES_VARIABLE_ID}}}
+
+{{prompt:project-info}}
+`
+        }]
+};
+
+export const architectTaskSummaryVariants = <PromptVariantSet>{
+    id: 'architect-tasksummary',
+    defaultVariant: {
+        id: ARCHITECT_TASK_SUMMARY_PROMPT_TEMPLATE_ID,
+        template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 
@@ -217,7 +220,9 @@ Use the following format, but only include the sections that were discussed in t
 **Next Steps:**  
 - [Immediate action items, who should act next.]
 `
-        },
+    },
+    variants: [
+
         {
             id: ARCHITECT_TASK_SUMMARY_UPDATE_PROMPT_TEMPLATE_ID,
             template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).

--- a/packages/ai-ide/src/common/architect-prompt-template.ts
+++ b/packages/ai-ide/src/common/architect-prompt-template.ts
@@ -53,6 +53,7 @@ Always look at the relevant files to understand your task using the function ~{$
 
 {{prompt:project-info}}
 
+{{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 `
     },
     variants: [


### PR DESCRIPTION
#### What it does

Reorganize the architect prompts.

- Adapt IDs to new schema
- Split task summary from regular prompts
- Make next prompt default (adds search and task context)

#### How to test

Check the 4 architect prompts.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
