### PR TITLE
Add symbol icon default colors

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -141,6 +141,7 @@ import { OpenWithService } from './open-with-service';
 import { ViewColumnService } from './shell/view-column-service';
 import { DomInputUndoRedoHandler, UndoRedoHandler, UndoRedoHandlerService } from './undo-redo-handler';
 import { WidgetStatusBarContribution, WidgetStatusBarService } from './widget-status-bar-service';
+import { SymbolIconColorContribution } from './symbol-icon-color-contribution';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -289,6 +290,8 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     [FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution, ColorContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(CommonFrontendContribution)
     );
+    bind(SymbolIconColorContribution).toSelf().inSingletonScope();
+    bind(ColorContribution).toService(SymbolIconColorContribution);
 
     bindCommonStylingParticipants(bind);
 

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -345,3 +345,4 @@ button.secondary[disabled],
 @import "./breadcrumbs.css";
 @import "./tooltip.css";
 @import "./split-widget.css";
+@import "./symbol-icon.css";

--- a/packages/core/src/browser/style/symbol-icon.css
+++ b/packages/core/src/browser/style/symbol-icon.css
@@ -1,0 +1,258 @@
+/********************************************************************************
+ * Copyright (C) 2025 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/*
+  We need to explicitly select the specific panels
+  Otherwise, the codicon styles are applied to all codicons in the application.
+  This leads to issues in the side panels, where the codicons are supposed to use the foreground color.
+ */
+
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-array {
+    color: var(--theia-symbolIcon-arrayForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-boolean {
+    color: var(--theia-symbolIcon-booleanForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-class {
+    color: var(--theia-symbolIcon-classForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-method {
+    color: var(--theia-symbolIcon-methodForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-color {
+    color: var(--theia-symbolIcon-colorForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-constant {
+    color: var(--theia-symbolIcon-constantForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-constructor {
+    color: var(--theia-symbolIcon-constructorForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-value,
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-enum {
+    color: var(--theia-symbolIcon-enumeratorForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-enum-member {
+    color: var(--theia-symbolIcon-enumeratorMemberForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-event {
+    color: var(--theia-symbolIcon-eventForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-field {
+    color: var(--theia-symbolIcon-fieldForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-file {
+    color: var(--theia-symbolIcon-fileForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-folder {
+    color: var(--theia-symbolIcon-folderForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-function {
+    color: var(--theia-symbolIcon-functionForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-interface {
+    color: var(--theia-symbolIcon-interfaceForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-key {
+    color: var(--theia-symbolIcon-keyForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-keyword {
+    color: var(--theia-symbolIcon-keywordForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-module {
+    color: var(--theia-symbolIcon-moduleForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-namespace {
+    color: var(--theia-symbolIcon-namespaceForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-null {
+    color: var(--theia-symbolIcon-nullForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-number {
+    color: var(--theia-symbolIcon-numberForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-object {
+    color: var(--theia-symbolIcon-objectForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-operator {
+    color: var(--theia-symbolIcon-operatorForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-package {
+    color: var(--theia-symbolIcon-packageForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-property {
+    color: var(--theia-symbolIcon-propertyForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-reference {
+    color: var(--theia-symbolIcon-referenceForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-snippet {
+    color: var(--theia-symbolIcon-snippetForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-string {
+    color: var(--theia-symbolIcon-stringForeground);
+}
+
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-struct {
+    color: var(--theia-symbolIcon-structForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-text {
+    color: var(--theia-symbolIcon-textForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-type-parameter {
+    color: var(--theia-symbolIcon-typeParameterForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-unit {
+    color: var(--theia-symbolIcon-unitForeground);
+}
+
+:is(#theia-main-content-panel,
+    #theia-left-side-panel,
+    #theia-right-side-panel,
+    #theia-bottom-content-panel) .codicon.codicon-symbol-variable {
+    color: var(--theia-symbolIcon-variableForeground);
+}

--- a/packages/core/src/browser/symbol-icon-color-contribution.ts
+++ b/packages/core/src/browser/symbol-icon-color-contribution.ts
@@ -1,0 +1,242 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from 'inversify';
+import { ColorContribution } from './color-application-contribution';
+import { ColorRegistry } from './color-registry';
+
+@injectable()
+export class SymbolIconColorContribution implements ColorContribution {
+    registerColors(colors: ColorRegistry): void {
+        colors.register(
+            {
+                id: 'symbolIcon.arrayForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for array symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.booleanForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for boolean symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.classForeground',
+                defaults: {
+                    dark: '#EE9D28',
+                    light: '#D67E00',
+                    hcDark: '#EE9D28',
+                    hcLight: '#D67E00'
+                },
+                description: 'The foreground color for class symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.colorForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for color symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.constantForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for constant symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.constructorForeground',
+                defaults: {
+                    dark: '#B180D7',
+                    light: '#652D90',
+                    hcDark: '#B180D7',
+                    hcLight: '#652D90'
+                },
+                description: 'The foreground color for constructor symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.enumeratorForeground',
+                defaults: {
+                    dark: '#EE9D28',
+                    light: '#D67E00',
+                    hcDark: '#EE9D28',
+                    hcLight: '#D67E00'
+                },
+                description: 'The foreground color for enumerator symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.enumeratorMemberForeground',
+                defaults: {
+                    dark: '#75BEFF',
+                    light: '#007ACC',
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC'
+                },
+                description: 'The foreground color for enumerator member symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.eventForeground',
+                defaults: {
+                    dark: '#EE9D28',
+                    light: '#D67E00',
+                    hcDark: '#EE9D28',
+                    hcLight: '#D67E00'
+                },
+                description: 'The foreground color for event symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.fieldForeground',
+                defaults: {
+                    dark: '#75BEFF',
+                    light: '#007ACC',
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC'
+                },
+                description: 'The foreground color for field symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.fileForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for file symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.folderForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for folder symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.functionForeground',
+                defaults: {
+                    dark: '#B180D7',
+                    light: '#652D90',
+                    hcDark: '#B180D7',
+                    hcLight: '#652D90'
+                },
+                description: 'The foreground color for function symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.interfaceForeground',
+                defaults: {
+                    dark: '#75BEFF',
+                    light: '#007ACC',
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC'
+                },
+                description: 'The foreground color for interface symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.keyForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for key symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.keywordForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for keyword symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.methodForeground',
+                defaults: {
+                    dark: '#B180D7',
+                    light: '#652D90',
+                    hcDark: '#B180D7',
+                    hcLight: '#652D90'
+                },
+                description: 'The foreground color for method symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.moduleForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for module symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.namespaceForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for namespace symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.nullForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for null symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.numberForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for number symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.objectForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for object symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.operatorForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for operator symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.packageForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for package symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.propertyForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for property symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.referenceForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for reference symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.snippetForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for snippet symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.stringForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for string symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.structForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for struct symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.textForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for text symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.typeParameterForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for type parameter symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.unitForeground',
+                defaults: 'editor.foreground',
+                description: 'The foreground color for unit symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            },
+            {
+                id: 'symbolIcon.variableForeground',
+                defaults: {
+                    dark: '#75BEFF',
+                    light: '#007ACC',
+                    hcDark: '#75BEFF',
+                    hcLight: '#007ACC'
+                },
+                description: 'The foreground color for variable symbols. These symbols appear in the outline, breadcrumb, and suggest widget.'
+            }
+        );
+    }
+}

--- a/packages/core/src/common/color.ts
+++ b/packages/core/src/common/color.ts
@@ -14,6 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { isObject } from './types';
+
 /**
  * Either be a reference to an existing color or a color value as a hex string, rgba, or hsla.
  */
@@ -36,11 +38,19 @@ export namespace Color {
     export function darken(v: string, f: number): ColorTransformation {
         return { v, f, kind: 'darken' };
     }
+    export function is(value: unknown): value is Color {
+        return typeof value === 'string' || (ColorTransformation.is(value) || RGBA.is(value) || HSLA.is(value));
+    }
 }
 export interface ColorTransformation {
     kind: 'transparent' | 'lighten' | 'darken'
     v: string
     f: number
+}
+export namespace ColorTransformation {
+    export function is(value: unknown): value is ColorTransformation {
+        return isObject(value) && typeof value.kind === 'string' && typeof value.v === 'string' && typeof value.f === 'number';
+    }
 }
 export interface RGBA {
     /**
@@ -63,6 +73,11 @@ export interface RGBA {
      */
     readonly a: number;
 }
+export namespace RGBA {
+    export function is(value: unknown): value is RGBA {
+        return isObject(value) && typeof value.r === 'number' && typeof value.g === 'number' && typeof value.b === 'number' && typeof value.a === 'number';
+    }
+}
 export interface HSLA {
     /**
      * Hue: integer in [0, 360]
@@ -81,6 +96,11 @@ export interface HSLA {
      */
     readonly a: number;
 }
+export namespace HSLA {
+    export function is(value: unknown): value is HSLA {
+        return isObject(value) && typeof value.h === 'number' && typeof value.s === 'number' && typeof value.l === 'number' && typeof value.a === 'number';
+    }
+}
 
 export interface ColorDefaults {
     light?: Color
@@ -91,9 +111,36 @@ export interface ColorDefaults {
     hcLight?: Color;
 }
 
+export namespace ColorDefaults {
+    export function getLight(defaults: ColorDefaults | Color | undefined): Color | undefined {
+        if (Color.is(defaults)) {
+            return defaults;
+        }
+        return defaults?.light;
+    }
+    export function getDark(defaults: ColorDefaults | Color | undefined): Color | undefined {
+        if (Color.is(defaults)) {
+            return defaults;
+        }
+        return defaults?.dark;
+    }
+    export function getHCDark(defaults: ColorDefaults | Color | undefined): Color | undefined {
+        if (Color.is(defaults)) {
+            return defaults;
+        }
+        return defaults?.hcDark ?? defaults?.hc;
+    }
+    export function getHCLight(defaults: ColorDefaults | Color | undefined): Color | undefined {
+        if (Color.is(defaults)) {
+            return defaults;
+        }
+        return defaults?.hcLight;
+    }
+}
+
 export interface ColorDefinition {
     id: string
-    defaults?: ColorDefaults
+    defaults?: ColorDefaults | Color;
     description: string
 }
 

--- a/packages/monaco/src/browser/monaco-color-registry.ts
+++ b/packages/monaco/src/browser/monaco-color-registry.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from '@theia/core/shared/inversify';
 import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
-import { Color, ColorDefinition } from '@theia/core/lib/common/color';
+import { Color, ColorDefaults as TheiaColorDefaults, ColorDefinition } from '@theia/core/lib/common/color';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { ColorDefaults, ColorValue, getColorRegistry } from '@theia/monaco-editor-core/esm/vs/platform/theme/common/colorRegistry';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
@@ -46,10 +46,10 @@ export class MonacoColorRegistry extends ColorRegistry {
 
     protected override doRegister(definition: ColorDefinition): Disposable {
         const defaults: ColorDefaults = {
-            dark: this.toColor(definition.defaults?.dark),
-            light: this.toColor(definition.defaults?.light),
-            hcDark: this.toColor(definition.defaults?.hcDark ?? definition.defaults?.hc),
-            hcLight: this.toColor(definition.defaults?.hcLight),
+            dark: this.toColor(TheiaColorDefaults.getDark(definition.defaults)),
+            light: this.toColor(TheiaColorDefaults.getLight(definition.defaults)),
+            hcDark: this.toColor(TheiaColorDefaults.getHCDark(definition.defaults)),
+            hcLight: this.toColor(TheiaColorDefaults.getHCLight(definition.defaults)),
         };
         const identifier = this.monacoColorRegistry.registerColor(definition.id, defaults, definition.description);
         return Disposable.create(() => this.monacoColorRegistry.deregisterColor(identifier));


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13971

Adds a level of default coloring (affected by the applied color theme) to the symbol icons used in services such as the breadcrumbs and outline view.

Also improves our color contribution API a bit to make it easier to supply one value to be used for all theme types.

#### How to test

1. Open a typescript file.
2. Ensure that the breadcrumbs and outline view have the expected icon coloring.
3. Ensure that other codicons (such as the one used by the outline view) still have the normal, expected colors.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
