### PR TITLE
[vscode] Support encoding/decoding from workspace and while opening text documents

### DIFF
--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -367,11 +367,11 @@ export class UntitledResourceResolver implements ResourceResolver {
         }
     }
 
-    async createUntitledResource(content?: string, extension?: string, uri?: URI): Promise<UntitledResource> {
+    async createUntitledResource(content?: string, extension?: string, uri?: URI, encoding?: string): Promise<UntitledResource> {
         if (!uri) {
             uri = this.createUntitledURI(extension);
         }
-        return new UntitledResource(this.resources, uri, content);
+        return new UntitledResource(this.resources, uri, content, encoding);
     }
 
     createUntitledURI(extension?: string, parent?: URI): URI {
@@ -394,13 +394,15 @@ export class UntitledResource implements Resource {
     protected readonly onDidChangeContentsEmitter = new Emitter<void>();
     readonly initiallyDirty: boolean;
     readonly autosaveable = false;
+    readonly encoding: string | undefined;
     get onDidChangeContents(): Event<void> {
         return this.onDidChangeContentsEmitter.event;
     }
 
-    constructor(private resources: Map<string, UntitledResource>, public uri: URI, private content?: string) {
+    constructor(private resources: Map<string, UntitledResource>, public uri: URI, private content?: string, encoding?: string) {
         this.initiallyDirty = (content !== undefined && content.length > 0);
         this.resources.set(this.uri.toString(), this);
+        this.encoding = encoding;
     }
 
     dispose(): void {
@@ -427,10 +429,6 @@ export class UntitledResource implements Resource {
     }
 
     get version(): ResourceVersion | undefined {
-        return undefined;
-    }
-
-    get encoding(): string | undefined {
         return undefined;
     }
 }

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -111,6 +111,7 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
         this.toDispose.push(this.onDidChangeContentEmitter);
         this.toDispose.push(this.onDidSaveModelEmitter);
         this.toDispose.push(this.onDirtyChangedEmitter);
+        this.toDispose.push(this.onDidChangeEncodingEmitter);
         this.toDispose.push(this.onDidChangeValidEmitter);
         this.toDispose.push(Disposable.create(() => this.cancelSave()));
         this.toDispose.push(Disposable.create(() => this.cancelSync()));

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -769,6 +769,9 @@ export interface WorkspaceMain {
     $registerCanonicalUriProvider(scheme: string): Promise<void | undefined>;
     $unregisterCanonicalUriProvider(scheme: string): void;
     $getCanonicalUri(uri: string, targetScheme: string, token: theia.CancellationToken): Promise<string | undefined>;
+    $resolveDecoding(resource: UriComponents | undefined, options?: { encoding?: string }): Promise<{ preferredEncoding: string; guessEncoding: boolean; }>;
+    $resolveEncoding(resource: UriComponents | undefined, options?: { encoding?: string }): Promise<{ encoding: string; hasBOM: boolean }>;
+    $validateDetectedEncoding(uri: UriComponents | undefined, detectedEncoding: string | undefined, opts: { encoding: string; } | undefined): Promise<string>;
 }
 
 export interface WorkspaceExt {
@@ -1367,6 +1370,7 @@ export interface ModelAddedData {
     EOL: string;
     modeId: string;
     isDirty: boolean;
+    encoding: string;
 }
 
 export interface TextEditorAddData {
@@ -1420,9 +1424,9 @@ export interface DocumentsExt {
 }
 
 export interface DocumentsMain {
-    $tryCreateDocument(options?: { language?: string; content?: string; }): Promise<UriComponents>;
+    $tryCreateDocument(options?: { language?: string; content?: string; encoding?: string }): Promise<UriComponents>;
     $tryShowDocument(uri: UriComponents, options?: TextDocumentShowOptions): Promise<void>;
-    $tryOpenDocument(uri: UriComponents): Promise<boolean>;
+    $tryOpenDocument(uri: UriComponents, encoding?: string): Promise<boolean>;
     $trySaveDocument(uri: UriComponents): Promise<boolean>;
 }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -771,7 +771,7 @@ export interface WorkspaceMain {
     $getCanonicalUri(uri: string, targetScheme: string, token: theia.CancellationToken): Promise<string | undefined>;
     $resolveDecoding(resource: UriComponents | undefined, options?: { encoding?: string }): Promise<{ preferredEncoding: string; guessEncoding: boolean; }>;
     $resolveEncoding(resource: UriComponents | undefined, options?: { encoding?: string }): Promise<{ encoding: string; hasBOM: boolean }>;
-    $validateDetectedEncoding(uri: UriComponents | undefined, detectedEncoding: string | undefined, opts: { encoding: string; } | undefined): Promise<string>;
+    $getValidEncoding(uri: UriComponents | undefined, detectedEncoding: string | undefined, opts: { encoding: string; } | undefined): Promise<string>;
 }
 
 export interface WorkspaceExt {
@@ -1420,6 +1420,7 @@ export interface DocumentsExt {
     $acceptModelSaved(strUrl: UriComponents): void;
     $acceptModelWillSave(strUrl: UriComponents, reason: theia.TextDocumentSaveReason, saveTimeout: number): Promise<SingleEditOperation[]>;
     $acceptDirtyStateChanged(strUrl: UriComponents, isDirty: boolean): void;
+    $acceptEncodingChanged(strUrl: UriComponents, encoding: string): void;
     $acceptModelChanged(strUrl: UriComponents, e: ModelChangedEvent, isDirty: boolean): void;
 }
 

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
@@ -35,6 +35,7 @@ import { EnvExtImpl } from '../../../plugin/env';
 import { WorkerEnvExtImpl } from './worker-env-ext';
 import { DebugExtImpl } from '../../../plugin/debug/debug-ext';
 import { LocalizationExtImpl } from '../../../plugin/localization-ext';
+import { EncodingService } from '@theia/core/lib/common/encoding-service';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ctx = self as any;
@@ -70,6 +71,7 @@ export default new ContainerModule(bind => {
         child.bind(DebugExtImpl).toSelf();
         return createDebugExtStub(child);
     }).inSingletonScope();
+    bind(EncodingService).toSelf().inSingletonScope();
     bind(EditorsAndDocumentsExtImpl).toSelf().inSingletonScope();
     bind(WorkspaceExtImpl).toSelf().inSingletonScope();
     bind(MessageRegistryExt).toSelf().inSingletonScope();

--- a/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
@@ -37,6 +37,7 @@ import { TerminalServiceExtImpl } from '../../plugin/terminal-ext';
 import { InternalSecretsExt, SecretsExtImpl } from '../../plugin/secrets-ext';
 import { setupPluginHostLogger } from './plugin-host-logger';
 import { LmExtImpl } from '../../plugin/lm-ext';
+import { EncodingService } from '@theia/core/lib/common/encoding-service';
 
 export default new ContainerModule(bind => {
     const channel = new IPCChannel();
@@ -65,6 +66,7 @@ export default new ContainerModule(bind => {
     bind(PreferenceRegistryExtImpl).toSelf().inSingletonScope();
     bind(DebugExtImpl).toSelf().inSingletonScope();
     bind(LmExtImpl).toSelf().inSingletonScope();
+    bind(EncodingService).toSelf().inSingletonScope();
     bind(EditorsAndDocumentsExtImpl).toSelf().inSingletonScope();
     bind(WorkspaceExtImpl).toSelf().inSingletonScope();
     bind(MessageRegistryExt).toSelf().inSingletonScope();

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -138,6 +138,9 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
         this.toDispose.push(modelService.onModelDirtyChanged(m => {
             this.proxy.$acceptDirtyStateChanged(m.textEditorModel.uri, m.dirty);
         }));
+        this.toDispose.push(modelService.onModelEncodingChanged(e => {
+            this.proxy.$acceptEncodingChanged(e.model.textEditorModel.uri, e.encoding);
+        }));
     }
 
     dispose(): void {

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -37,6 +37,7 @@ import { SaveableService } from '@theia/core/lib/browser/saveable-service';
 import { TabsMainImpl } from './tabs/tabs-main';
 import { NotebookCellEditorService, NotebookEditorWidgetService } from '@theia/notebook/lib/browser';
 import { SimpleMonacoEditor } from '@theia/monaco/lib/browser/simple-monaco-editor';
+import { EncodingRegistry } from '@theia/core/lib/browser/encoding-registry';
 
 export class EditorsAndDocumentsMain implements Disposable {
 
@@ -48,6 +49,7 @@ export class EditorsAndDocumentsMain implements Disposable {
     private readonly modelService: EditorModelService;
     private readonly editorManager: EditorManager;
     private readonly saveResourceService: SaveableService;
+    private readonly encodingRegistry: EncodingRegistry;
 
     private readonly onTextEditorAddEmitter = new Emitter<TextEditorMain[]>();
     private readonly onTextEditorRemoveEmitter = new Emitter<string[]>();
@@ -69,6 +71,7 @@ export class EditorsAndDocumentsMain implements Disposable {
         this.editorManager = container.get(EditorManager);
         this.modelService = container.get(EditorModelService);
         this.saveResourceService = container.get(SaveableService);
+        this.encodingRegistry = container.get(EncodingRegistry);
 
         this.stateComputer = new EditorAndDocumentStateComputer(d => this.onDelta(d),
             this.editorManager,
@@ -153,7 +156,8 @@ export class EditorsAndDocumentsMain implements Disposable {
             languageId: model.getLanguageId(),
             EOL: model.textEditorModel.getEOL(),
             modeId: model.languageId,
-            isDirty: model.dirty
+            isDirty: model.dirty,
+            encoding: this.encodingRegistry.getEncodingForResource(URI.fromComponents(model.textEditorModel.uri))
         };
     }
 

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -157,7 +157,7 @@ export class EditorsAndDocumentsMain implements Disposable {
             EOL: model.textEditorModel.getEOL(),
             modeId: model.languageId,
             isDirty: model.dirty,
-            encoding: this.encodingRegistry.getEncodingForResource(URI.fromComponents(model.textEditorModel.uri))
+            encoding: this.encodingRegistry.getEncodingForResource(URI.fromComponents(model.textEditorModel.uri), model.getEncoding())
         };
     }
 

--- a/packages/plugin-ext/src/main/browser/text-editor-model-service.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-model-service.ts
@@ -29,10 +29,12 @@ export class EditorModelService {
     private modelModeChangedEmitter = new Emitter<{ model: MonacoEditorModel, oldModeId: string }>();
     private onModelRemovedEmitter = new Emitter<MonacoEditorModel>();
     private modelDirtyEmitter = new Emitter<MonacoEditorModel>();
+    private modelEncodingEmitter = new Emitter<{ model: MonacoEditorModel, encoding: string }>();
     private modelSavedEmitter = new Emitter<MonacoEditorModel>();
     private onModelWillSaveListeners: ListenerList<WillSaveMonacoModelEvent, Promise<void>> = new ListenerList();
 
     readonly onModelDirtyChanged = this.modelDirtyEmitter.event;
+    readonly onModelEncodingChanged = this.modelEncodingEmitter.event;
     readonly onModelWillSave = this.onModelWillSaveListeners.registration;
     readonly onModelSaved = this.modelSavedEmitter.event;
     readonly onModelModeChanged = this.modelModeChangedEmitter.event;
@@ -66,6 +68,10 @@ export class EditorModelService {
 
         model.onDirtyChanged(_ => {
             this.modelDirtyEmitter.fire(model);
+        });
+
+        model.onDidChangeEncoding(encoding => {
+            this.modelEncodingEmitter.fire({ model, encoding });
         });
     }
 

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -32,6 +32,9 @@ import { SearchInWorkspaceService } from '@theia/search-in-workspace/lib/browser
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { MonacoQuickInputService } from '@theia/monaco/lib/browser/monaco-quick-input-service';
 import { RequestService } from '@theia/core/shared/@theia/request';
+import { UTF16be, UTF16le, UTF8, UTF8_with_bom } from '@theia/core/lib/common/encodings';
+import { EncodingRegistry } from '@theia/core/lib/browser/encoding-registry';
+import { PreferenceService } from '@theia/core/lib/browser/preferences/preference-service';
 
 export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
 
@@ -59,7 +62,11 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
 
     private workspaceTrustService: WorkspaceTrustService;
 
+    private encodingRegistry: EncodingRegistry;
+
     private fsPreferences: FileSystemPreferences;
+
+    private preferenceService: PreferenceService;
 
     protected readonly toDispose = new DisposableCollection();
 
@@ -79,7 +86,9 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
         this.workspaceService = container.get(WorkspaceService);
         this.canonicalUriService = container.get(CanonicalUriService);
         this.workspaceTrustService = container.get(WorkspaceTrustService);
+        this.encodingRegistry = container.get(EncodingRegistry);
         this.fsPreferences = container.get(FileSystemPreferences);
+        this.preferenceService = container.get(PreferenceService);
 
         this.processWorkspaceFoldersChanged(this.workspaceService.tryGetRoots().map(root => root.resource.toString()));
         this.toDispose.push(this.workspaceService.onWorkspaceChanged(roots => {
@@ -317,6 +326,58 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
     async $getCanonicalUri(uri: string, targetScheme: string, token: theia.CancellationToken): Promise<string | undefined> {
         const canonicalUri = await this.canonicalUriService.provideCanonicalUri(new URI(uri), targetScheme, token);
         return isUndefined(canonicalUri) ? undefined : canonicalUri.toString();
+    }
+
+    async $resolveDecoding(resource: UriComponents | undefined, options?: { encoding?: string }): Promise<{ preferredEncoding: string; guessEncoding: boolean }> {
+        const preferredEncoding = await this.getPreferredReadEncoding(resource, options);
+
+        return {
+            preferredEncoding,
+            guessEncoding: this.preferenceService.get('files.autoGuessEncoding', false, resource ? resource.toString() : undefined)
+        };
+    }
+
+    async $resolveEncoding(resource: UriComponents | undefined, options?: { encoding?: string }): Promise<{ encoding: string; hasBOM: boolean }> {
+        let encoding: string;
+        if (resource) {
+            encoding = await this.encodingRegistry.getEncodingForResource(URI.fromComponents(resource), options?.encoding);
+        } else {
+            encoding = options?.encoding ?? UTF8;
+        }
+        // see https://github.com/microsoft/vscode/blob/118f9ecd71a8f101b71ae19e3bf44802aa173209/src/vs/workbench/services/textfile/browser/textFileService.ts#L806
+        const hasBOM = encoding === UTF16be || encoding === UTF16le || encoding === UTF8_with_bom;
+
+        return { encoding, hasBOM };
+    }
+
+    async $validateDetectedEncoding(uri: UriComponents | undefined, detectedEncoding: string | undefined, options: { encoding: string } | undefined): Promise<string> {
+        return this.getPreferredReadEncoding(uri, options, detectedEncoding);
+    }
+
+    async getPreferredReadEncoding(uri: UriComponents | undefined, options?: { encoding?: string }, detectedEncoding?: string): Promise<string> {
+        let preferredEncoding: string | undefined;
+
+        // either encoding is passed as an option
+        // or we have a detected encoding,
+        // or we are looking in the preferences
+        // or we default at UTF8
+        if (options?.encoding) {
+            if (detectedEncoding === UTF8_with_bom && options.encoding === UTF8) {
+                preferredEncoding = UTF8_with_bom; // indicate the file has BOM if we are to resolve with UTF 8
+            } else {
+                preferredEncoding = options.encoding; // give passed in encoding highest priority
+            }
+        } else if (typeof detectedEncoding === 'string') {
+            preferredEncoding = detectedEncoding;
+        }
+        let encoding;
+        if (uri) {
+            encoding = await this.encodingRegistry.getEncodingForResource(URI.fromComponents(uri), preferredEncoding);
+        } else {
+            encoding = preferredEncoding ?? UTF8;
+        }
+
+        return encoding;
     }
 }
 

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -13,7 +13,11 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code was copied and modified from https://github.com/Microsoft/vscode/blob/main/src/vs/workbench/api/browser/mainThreadWorkspace.ts
 import * as theia from '@theia/plugin';
 import { interfaces, injectable } from '@theia/core/shared/inversify';
 import { WorkspaceExt, StorageExt, MAIN_RPC_CONTEXT, WorkspaceMain, WorkspaceFolderPickOptionsMain, FindFilesOptions } from '../../common/plugin-api-rpc';
@@ -350,7 +354,7 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
         return { encoding, hasBOM };
     }
 
-    async $validateDetectedEncoding(uri: UriComponents | undefined, detectedEncoding: string | undefined, options: { encoding: string } | undefined): Promise<string> {
+    async $getValidEncoding(uri: UriComponents | undefined, detectedEncoding: string | undefined, options: { encoding: string } | undefined): Promise<string> {
         return this.getPreferredReadEncoding(uri, options, detectedEncoding);
     }
 

--- a/packages/plugin-ext/src/plugin/document-data.ts
+++ b/packages/plugin-ext/src/plugin/document-data.ts
@@ -34,13 +34,15 @@ export class DocumentDataExt {
 
     private disposed = false;
     private dirty: boolean;
+    private encoding: string;
     private _document: theia.TextDocument;
     private textLines = new Array<theia.TextLine>();
     private lineStarts: PrefixSumComputer | undefined;
 
     constructor(private proxy: DocumentsMain, private uri: URI, private lines: string[], private eol: string,
-        private languageId: string, private versionId: number, isDirty: boolean) {
+        private languageId: string, private versionId: number, isDirty: boolean, encoding: string) {
         this.dirty = isDirty;
+        this.encoding = encoding;
     }
 
     dispose(): void {
@@ -74,6 +76,10 @@ export class DocumentDataExt {
         ok(!this.disposed);
         this.languageId = langId;
     }
+    acceptEncoding(encoding: string): void {
+        ok(!this.disposed);
+        this.encoding = encoding;
+    }
     get document(): theia.TextDocument {
         if (!this._document) {
             const that = this;
@@ -85,6 +91,7 @@ export class DocumentDataExt {
                 get version(): number { return that.versionId; },
                 get isClosed(): boolean { return that.disposed; },
                 get isDirty(): boolean { return that.dirty; },
+                get encoding(): string { return that.encoding; },
                 save(): Promise<boolean> { return that.save(); },
                 getText(range?): string { return range ? that.getTextInRange(range) : that.getText(); },
                 get eol(): theia.EndOfLine { return that.eol === '\n' ? EndOfLine.LF : EndOfLine.CRLF; },

--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -238,13 +238,14 @@ export class DocumentsExtImpl implements DocumentsExt {
         }
     }
 
-    async openDocument(uri: URI): Promise<DocumentDataExt | undefined> {
+    async openDocument(uri: URI, options?: { language?: string; content?: string; encoding?: string }): Promise<DocumentDataExt | undefined> {
+        // If we have the document cached and no encoding options are provided,
+        // we should just return current document
         const cached = this.editorsAndDocuments.getDocument(uri.toString());
-        if (cached) {
+        if (cached && !options?.encoding) {
             return cached;
         }
-
-        await this.proxy.$tryOpenDocument(uri);
+        await this.proxy.$tryOpenDocument(uri, options?.encoding);
         return this.editorsAndDocuments.getDocument(uri.toString());
     }
 
@@ -272,7 +273,7 @@ export class DocumentsExtImpl implements DocumentsExt {
         return this.editorsAndDocuments.getDocument(uri.toString());
     }
 
-    async createDocumentData(options?: { language?: string; content?: string }): Promise<URI> {
+    async createDocumentData(options?: { language?: string; content?: string, encoding?: string }): Promise<URI> {
         return this.proxy.$tryCreateDocument(options).then(data => URI.revive(data));
     }
 

--- a/packages/plugin-ext/src/plugin/editors-and-documents.ts
+++ b/packages/plugin-ext/src/plugin/editors-and-documents.ts
@@ -77,7 +77,8 @@ export class EditorsAndDocumentsExtImpl implements EditorsAndDocumentsExt {
                     data.EOL,
                     data.modeId,
                     data.versionId,
-                    data.isDirty
+                    data.isDirty,
+                    data.encoding
                 );
                 this.documents.set(resource.toString(), documentData);
                 addedDocuments.push(documentData);

--- a/packages/plugin-ext/src/plugin/notebook/notebook-document.ts
+++ b/packages/plugin-ext/src/plugin/notebook/notebook-document.ts
@@ -57,7 +57,8 @@ export class Cell {
             uri: cell.uri,
             isDirty: false,
             versionId: 1,
-            modeId: cell.language
+            modeId: cell.language,
+            encoding: 'utf8' // see https://github.com/microsoft/vscode/blob/118f9ecd71a8f101b71ae19e3bf44802aa173209/src/vs/workbench/api/common/extHostNotebookDocument.ts#L44
         };
     }
 

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -63,7 +63,9 @@ export class WorkspaceExtImpl implements WorkspaceExt {
 
     private proxy: WorkspaceMain;
     private logger: PluginLogger;
-    private encodingService: EncodingService;
+
+    @inject(EncodingService)
+    protected encodingService: EncodingService;
 
     private workspaceFoldersChangedEmitter = new Emitter<theia.WorkspaceFoldersChangeEvent>();
     public readonly onDidChangeWorkspaceFolders: Event<theia.WorkspaceFoldersChangeEvent> = this.workspaceFoldersChangedEmitter.event;
@@ -84,7 +86,6 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     initialize(): void {
         this.proxy = this.rpc.getProxy(Ext.WORKSPACE_MAIN);
         this.logger = new PluginLogger(this.rpc, 'workspace');
-        this.encodingService = new EncodingService();
     }
 
     get rootPath(): string | undefined {
@@ -524,7 +525,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
                     return Promise.resolve(preferredEncoding);
                 }
 
-                return this.proxy.$validateDetectedEncoding(uri, detectedEncoding, opts);
+                return this.proxy.$getValidEncoding(uri, detectedEncoding, opts);
             }
         };
         const stream = (await this.encodingService.decodeStream(BinaryBufferReadableStream.fromBuffer(BinaryBuffer.wrap(content)), decodeStreamOptions)).stream;

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -38,13 +38,16 @@ import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import { Disposable, URI } from './types-impl';
 import { normalize } from '@theia/core/lib/common/paths';
 import { relative } from '../common/paths-util';
-import { Schemes } from '../common/uri-components';
+import { Schemes, UriComponents } from '../common/uri-components';
 import { toWorkspaceFolder } from './type-converters';
 import { MessageRegistryExt } from './message-registry';
 import * as Converter from './type-converters';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { isUndefinedOrNull, isUndefined } from '../common/types';
 import { PluginLogger } from './logger';
+import { consumeStream } from '@theia/core/lib/common/stream';
+import { EncodingService } from '@theia/core/lib/common/encoding-service';
+import { BinaryBuffer, BinaryBufferReadableStream } from '@theia/core/lib/common/buffer';
 
 @injectable()
 export class WorkspaceExtImpl implements WorkspaceExt {
@@ -60,6 +63,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
 
     private proxy: WorkspaceMain;
     private logger: PluginLogger;
+    private encodingService: EncodingService;
 
     private workspaceFoldersChangedEmitter = new Emitter<theia.WorkspaceFoldersChangeEvent>();
     public readonly onDidChangeWorkspaceFolders: Event<theia.WorkspaceFoldersChangeEvent> = this.workspaceFoldersChangedEmitter.event;
@@ -80,6 +84,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     initialize(): void {
         this.proxy = this.rpc.getProxy(Ext.WORKSPACE_MAIN);
         this.logger = new PluginLogger(this.rpc, 'workspace');
+        this.encodingService = new EncodingService();
     }
 
     get rootPath(): string | undefined {
@@ -507,5 +512,37 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     /** @stubbed */
     $registerEditSessionIdentityProvider(scheme: string, provider: theia.EditSessionIdentityProvider): theia.Disposable {
         return Disposable.NULL;
+    }
+
+    async decode(content: Uint8Array, args?: { uri?: theia.Uri; encoding?: string }): Promise<string> {
+        const [uri, opts] = this.asEncodeDecodeParameters(args);
+        const { preferredEncoding, guessEncoding } = await this.proxy.$resolveDecoding(uri, opts);
+        const decodeStreamOptions = {
+            guessEncoding,
+            overwriteEncoding: (detectedEncoding: string | undefined) => {
+                if (detectedEncoding === null || detectedEncoding === preferredEncoding) {
+                    return Promise.resolve(preferredEncoding);
+                }
+
+                return this.proxy.$validateDetectedEncoding(uri, detectedEncoding, opts);
+            }
+        };
+        const stream = (await this.encodingService.decodeStream(BinaryBufferReadableStream.fromBuffer(BinaryBuffer.wrap(content)), decodeStreamOptions)).stream;
+        return consumeStream(stream, s => s.join(''));
+
+    }
+
+    async encode(content: string, args?: { uri?: theia.Uri; encoding?: string }): Promise<Uint8Array> {
+        const [uri, options] = this.asEncodeDecodeParameters(args);
+        const { encoding, hasBOM } = await this.proxy.$resolveEncoding(uri, options);
+        const buffer = this.encodingService.encode(content, { encoding, hasBOM });
+        return buffer.buffer;
+    }
+
+    private asEncodeDecodeParameters(opts?: { uri?: theia.Uri; encoding?: string }): [UriComponents | undefined, { encoding: string } | undefined] {
+        const uri = Converter.isUriComponents(opts?.uri) ? opts.uri : undefined;
+        const encoding = typeof opts?.encoding === 'string' ? opts.encoding : undefined;
+
+        return [uri, encoding ? { encoding } : undefined];
     }
 }


### PR DESCRIPTION
#### What it does

Support the workspace openTextDocument, encode and decode methods with additional encoding options.

fix #15559

#### How to test

The following extension can be used:
- src: [encoding-sample-src.zip](https://github.com/user-attachments/files/20866079/encoding-sample-src.zip)
- zipped vsix: [encoding-sample-1.0.0.zip](https://github.com/user-attachments/files/20866067/encoding-sample-1.0.0.zip)

This extension provides:
- provide an action in the explorer and palette to open a text editor with a chosen encoding
- provide a contextual menu action to  reopen document with encoding in the current active text editor
- provide several actions to test encoding and decoding actions. These actions basically make a call to the API and displays a webview based on the result. Not much to see here, except that the encoding service is properly invoked on encode or decode methods.

Here is also a sample workspace with a set of files with different encodings. This can be used as a test for the Encoding Sample: open with encoding action or reopen editor with encoding actions
[workspace-encoding-sample.zip](https://github.com/user-attachments/files/20866064/workspace-encoding-sample.zip)

https://github.com/user-attachments/assets/25832620-9600-4d5a-9613-61720879d7f4

#### Follow-ups

None known

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
