### PR TITLE
Add fall back to default prompts if selected does not exist

### DIFF
--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -32,7 +32,7 @@ describe('PromptService', () => {
     beforeEach(() => {
         const container = new Container();
         container.bind<PromptService>(PromptService).to(PromptServiceImpl).inSingletonScope();
-        const logger = sinon.createStubInstance(Logger)
+        const logger = sinon.createStubInstance(Logger);
 
         const variableService = new DefaultAIVariableService({ getContributions: () => [] }, logger);
         const nameVariable = { id: 'test', name: 'name', description: 'Test name ' };

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -22,7 +22,8 @@ import { PromptService, PromptServiceImpl } from './prompt-service';
 import { DefaultAIVariableService, AIVariableService } from './variable-service';
 import { ToolInvocationRegistry } from './tool-invocation-registry';
 import { ToolRequest } from './language-model';
-import { Logger } from '@theia/core';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { ILogger, Logger } from '@theia/core';
 import * as sinon from 'sinon';
 
 describe('PromptService', () => {
@@ -31,7 +32,7 @@ describe('PromptService', () => {
     beforeEach(() => {
         const container = new Container();
         container.bind<PromptService>(PromptService).to(PromptServiceImpl).inSingletonScope();
-        const logger = sinon.createStubInstance(Logger);
+        const logger = sinon.createStubInstance(Logger)
 
         const variableService = new DefaultAIVariableService({ getContributions: () => [] }, logger);
         const nameVariable = { id: 'test', name: 'name', description: 'Test name ' };
@@ -40,6 +41,7 @@ describe('PromptService', () => {
             resolve: async () => ({ variable: nameVariable, value: 'Jane' })
         });
         container.bind<AIVariableService>(AIVariableService).toConstantValue(variableService);
+        container.bind<ILogger>(ILogger).toConstantValue(new MockLogger);
 
         promptService = container.get<PromptService>(PromptService);
         promptService.addBuiltInPromptFragment({ id: '1', template: 'Hello, {{name}}!' });
@@ -340,6 +342,7 @@ describe('PromptService', () => {
             })
         });
         container.bind<AIVariableService>(AIVariableService).toConstantValue(variableService);
+        container.bind<ILogger>(ILogger).toConstantValue(new MockLogger);
 
         const testPromptService = container.get<PromptService>(PromptService);
         testPromptService.addBuiltInPromptFragment({ id: 'testPrompt', template: 'Template with fragment: {{fragment}}' });

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -544,7 +544,7 @@ export class PromptServiceImpl implements PromptService {
             const variantIds = this.getVariantIds(fragmentId);
             if (!variantIds.includes(defaultVariantId)) {
                 this.logger.error(`Default variant '${defaultVariantId}' for prompt set '${fragmentId}' does not exist.`);
-                return undefined; // Default variant doesn't exist
+                return undefined;
             }
             return defaultVariantId;
         }

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -534,7 +534,7 @@ export class PromptServiceImpl implements PromptService {
             if (!variantIds.includes(selectedVariantId)) {
                 this.logger.warn(`Selected variant '${selectedVariantId}' for prompt set '${fragmentId}' does not exist. Falling back to default variant.`);
             } else {
-                return selectedVariantId; // Selected variant exists, return it
+                return selectedVariantId;
             }
         }
 

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -363,11 +363,6 @@ export interface PromptService {
     getVariantIds(promptVariantSetId: string): string[];
 
     /**
-     * Gets the currently selected variant ID of the given set
-     * @param promptVariantSetId The prompt variant set id
-     * @returns The selected variant ID or the main ID if no variant is selected
-     */
-    /**
      * Gets the explicitly selected variant ID for a prompt fragment from settings.
      * This returns only the variant that was explicitly selected in settings, not the default.
      * @param promptVariantSetId The prompt variant set id

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -525,7 +525,6 @@ export class PromptServiceImpl implements PromptService {
     }
 
     async getEffectiveVariantId(fragmentId: string): Promise<string | undefined> {
-        // First try to get the selected variant from settings
         const selectedVariantId = await this.getSelectedVariantId(fragmentId);
 
         // Check if the selected variant actually exists

--- a/packages/ai-ide/src/browser/ai-configuration/template-settings-renderer.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/template-settings-renderer.tsx
@@ -77,7 +77,7 @@ export const PromptVariantRenderer: React.FC<PromptVariantRendererProps> = ({
                         >
                             {isInvalidVariant && (
                                 <option value="invalid" disabled>
-                                    {nls.localize('theia/ai/core/templateSettings/unavailableVariant', 'The selected variant is no longer available')}
+                                    {nls.localize('theia/ai/core/templateSettings/unavailableVariant', 'Selected variant not available, default will be used')}
                                 </option>
                             )}
                             {variantIds.map(variantId => (


### PR DESCRIPTION
#### What it does

Prompt service return the default prompt if the selected variant does not exist.
This is important as we refactor prompt ids with the upcoming release and if users selected variants, we need a fall-back.

#### How to test

- Create a variant by creating a file that starts with the variant set id in the prompt template folder, e.g. "coder-prompt-fooba.md"
- Select this variant
- Delete the file
- Talk to the agent and observe the default prompt is used


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
