### PR TITLE
Adapt all prompt ids to common schema

### DIFF
--- a/packages/ai-chat/src/common/chat-session-naming-service.ts
+++ b/packages/ai-chat/src/common/chat-session-naming-service.ts
@@ -30,9 +30,9 @@ import { ChatSession } from './chat-service';
 import { generateUuid } from '@theia/core';
 
 const CHAT_SESSION_NAMING_PROMPT: PromptVariantSet = {
-    id: 'chat-session-naming-prompt',
+    id: 'chat-session-naming-system',
     defaultVariant: {
-        id: 'chat-session-naming-prompt',
+        id: 'chat-session-naming-system-default',
         template: '{{!-- Made improvements or adaptations to this prompt template? We\'d love for you to share it with the community! Contribute back here: ' +
             'https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}\n\n' +
             'Provide a short and descriptive name for the given AI chat conversation of an AI-powered tool based on the conversation below.\n\n' +

--- a/packages/ai-chat/src/common/chat-session-summary-agent-prompt.ts
+++ b/packages/ai-chat/src/common/chat-session-summary-agent-prompt.ts
@@ -11,9 +11,9 @@
 import { CHANGE_SET_SUMMARY_VARIABLE_ID } from './context-variables';
 
 export const CHAT_SESSION_SUMMARY_PROMPT = {
-    id: 'chat-session-summary-system-prompt',
+    id: 'chat-session-summary-system',
     defaultVariant: {
-        id: 'chat-session-summary-prompt',
+        id: 'chat-session-summary-system-default',
         template: '{{!-- !-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).\n' +
             'Made improvements or adaptations to this prompt template? We\'d love for you to share it with the community! Contribute back here:  ' +
             'https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}\n\n' +

--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -71,7 +71,7 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
                 return undefined;
             }
             const prompt = await this.promptService
-                .getResolvedPromptFragment('code-completion-prompt', undefined, variableContext)
+                .getResolvedPromptFragment('code-completion-system', undefined, variableContext)
                 .then(p => p?.text);
             if (!prompt) {
                 this.logger.error('No prompt found for code-completion-agent');

--- a/packages/ai-code-completion/src/browser/code-completion-prompt-template.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-prompt-template.ts
@@ -13,9 +13,9 @@ import { PromptVariantSet } from '@theia/ai-core/lib/common';
 import { FILE, LANGUAGE, PREFIX, SUFFIX } from './code-completion-variables';
 
 export const codeCompletionPrompts: PromptVariantSet[] = [{
-    id: 'code-completion-prompt',
+    id: 'code-completion-system',
     variants: [{
-        id: 'code-completion-prompt-previous',
+        id: 'code-completion-system-previous',
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
@@ -28,7 +28,7 @@ Finish the following code snippet.
 Only return the exact replacement for [[MARKER]] to complete the snippet.`
     },
     {
-        id: 'code-completion-prompt-next',
+        id: 'code-completion-system-next',
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
@@ -62,7 +62,7 @@ You are an expert AI code completion assistant focused on generating precise, co
 - Consider language-specific idioms and patterns`
     }],
     defaultVariant: {
-        id: 'code-completion-prompt-default',
+        id: 'code-completion-system-default',
         template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We’d love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}

--- a/packages/ai-ide/src/browser/app-tester-chat-agent.ts
+++ b/packages/ai-ide/src/browser/app-tester-chat-agent.ts
@@ -102,8 +102,8 @@ export class AppTesterChatAgent extends AbstractStreamParsingChatAgent {
       + 'It can automate testing workflows and provide detailed feedback on application functionality.');
 
    override iconClass: string = 'codicon codicon-beaker';
-   protected override systemPromptId: string = 'app-tester-prompt';
-   override prompts = [{ id: 'app-tester-prompt', defaultVariant: appTesterTemplate, variants: [appTesterTemplateVariant] }];
+   protected override systemPromptId: string = 'app-tester-system';
+   override prompts = [{ id: 'app-tester-system', defaultVariant: appTesterTemplate, variants: [appTesterTemplateVariant] }];
 
    /**
     * Override invoke to check if the Playwright MCP server is running, and if not, ask the user if it should be started.

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -31,11 +31,11 @@ import {
     GET_PROPOSED_CHANGES_ID
 } from './file-changeset-function-ids';
 
-export const CODER_SYSTEM_PROMPT_ID = 'coder-prompt';
+export const CODER_SYSTEM_PROMPT_ID = 'coder-system';
 
-export const CODER_SIMPLE_EDIT_TEMPLATE_ID = 'coder-simple-edit';
-export const CODER_EDIT_TEMPLATE_ID = 'coder-edit';
-export const CODER_AGENT_MODE_TEMPLATE_ID = 'coder-agent-mode';
+export const CODER_SIMPLE_EDIT_TEMPLATE_ID = 'coder-system-simple-edit';
+export const CODER_EDIT_TEMPLATE_ID = 'coder-system-edit';
+export const CODER_AGENT_MODE_TEMPLATE_ID = 'coder-system-agent-mode';
 
 export function getCoderAgentModePromptTemplate(): BasePromptFragment {
     return {

--- a/packages/ai-ide/src/common/universal-chat-agent.ts
+++ b/packages/ai-ide/src/common/universal-chat-agent.ts
@@ -35,6 +35,6 @@ export class UniversalChatAgent extends AbstractStreamParsingChatAgent {
       + 'questions the user might ask. The universal agent currently does not have any context by default, i.e. it cannot '
       + 'access the current user context or the workspace.');
 
-   override prompts = [{ id: 'universal-prompt', defaultVariant: universalTemplate, variants: [universalTemplateVariant] }];
-   protected override systemPromptId: string = 'universal-prompt';
+   override prompts = [{ id: 'universal-system', defaultVariant: universalTemplate, variants: [universalTemplateVariant] }];
+   protected override systemPromptId: string = 'universal-system';
 }


### PR DESCRIPTION
#### What it does

Harmoize all prompt ids to the following schema:

variantSetID: agent-system (or agent-user if existent)
promptID: agent-system-variant

#### How to test

Check all prompt templates

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
