### PR TITLE
Fix: bug with incorrect height calculation of the search field in "search-in-workspace" (#15229)

### DIFF
--- a/packages/search-in-workspace/src/browser/components/search-in-workspace-textarea.tsx
+++ b/packages/search-in-workspace/src/browser/components/search-in-workspace-textarea.tsx
@@ -80,6 +80,10 @@ export class SearchInWorkspaceTextArea extends React.Component<TextareaAttribute
             e.preventDefault();
         }
 
+        setTimeout(() => {
+            this.forceUpdate();
+        }, 0);
+
         this.props.onKeyDown?.(e);
     };
 
@@ -114,6 +118,7 @@ export class SearchInWorkspaceTextArea extends React.Component<TextareaAttribute
      */
     protected readonly onChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
         this.addToHistory();
+        this.forceUpdate();
         this.props.onChange?.(e);
     };
 
@@ -135,19 +140,21 @@ export class SearchInWorkspaceTextArea extends React.Component<TextareaAttribute
 
     override render(): React.ReactNode {
         const { onResize, ...filteredProps } = this.props;
+        /* One row for an empty search input box (fixes bug #15229), seven rows for the normal state (from VS Code) */
+        const maxRows = this.value.length ? 7 : 1;
+
         return (
             <TextareaAutosize
                 {...filteredProps}
                 autoCapitalize="off"
                 autoCorrect="off"
-                maxRows={7} /* from VS Code */
+                maxRows={maxRows}
                 onChange={this.onChange}
                 onKeyDown={this.onKeyDown}
                 ref={this.textarea}
                 rows={1}
                 spellCheck={false}
-            >
-            </TextareaAutosize>
+            />
         );
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes https://github.com/eclipse-theia/theia/issues/15229

Bug caused by the `react-textarea-autosize` component, which sets the height of the search input textarea based on the placeholder length and ignores the fact that this placeholder has a white-space: nowrap style. So the fix is pretty simple: just limit maxRows for this component while the field is empty and the placeholder is shown. I also added forceUpdate just to be sure that maxRows updates immediately (without it, the textarea size updates only after the search task is finished).

#### How to test
Check bug:
https://github.com/eclipse-theia/theia/issues/15229

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
