### PR TITLE
[vscode] bump vscode API compatibility to 1.101.1

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,4 +18,4 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.99.3';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.101.1';


### PR DESCRIPTION
#### What it does

bump compatibility version to the latest supported APIs. See https://eclipse-theia.github.io/vscode-theia-comparator/status.html and #15874

fix #15886 

#### How to test

Start any browser and electron version. VS Code extensions compatible with 1.101 version shall be installable and start without issues.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

