### PR TITLE
fix store view ,fix #15201

### DIFF
--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -611,7 +611,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     }
 
     storeViewState(): object {
-        return this.editor.saveViewState()!;
+        return this.savedViewState!;
     }
 
     restoreViewState(state: monaco.editor.ICodeEditorViewState): void {

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -616,6 +616,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
 
     restoreViewState(state: monaco.editor.ICodeEditorViewState): void {
         this.editor.restoreViewState(state);
+        this.savedViewState = state;
     }
 
     /* `true` because it is derived from an URI during the instantiation */


### PR DESCRIPTION
I think that the previous modification set the model to null after the editor was hidden, so nothing would be done in editor.saveViewState(). However, savedViewState was set when the editor was hidden, so we only need to read this value. Do you think this is okay?