### PR TITLE
fix:IDE cannot fully restore to the previous state after restarting.

### DIFF
--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -611,11 +611,16 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     }
 
     storeViewState(): object {
-        return this.editor.saveViewState()!;
+        const state = this.editor.saveViewState();
+        if (state) {
+            this.savedViewState = state;
+        }
+        return this.savedViewState!;
     }
 
     restoreViewState(state: monaco.editor.ICodeEditorViewState): void {
         this.editor.restoreViewState(state);
+        this.savedViewState = state;
     }
 
     /* `true` because it is derived from an URI during the instantiation */


### PR DESCRIPTION
#### What it does
Fixes #15201
I think that the previous modification set the model to null after the editor was hidden, so nothing would be done in editor.saveViewState(). However, savedViewState was set when the editor was hidden, so we only need to read this value.So I modified the storeViewState and restoreViewState functions in monaco-editor

#### How to test

1.I compiled theia-ide application locally, and it was verified that this is effective and can solve the problem #15201
2.For example, the gif image operation in #15201 will get the expected result

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
