### PR TITLE
fix: bind Agent ContributionProvider in ai-core to prevent startup crash when 'ai-chat' is not included

### DIFF
--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -60,7 +60,6 @@ import { ImageContextVariableContribution } from './image-context-variable-contr
 import { AgentDelegationTool } from './agent-delegation-tool';
 
 export default new ContainerModule(bind => {
-    bindContributionProvider(bind, Agent);
     bindContributionProvider(bind, ChatAgent);
 
     bind(FrontendChatToolRequestService).toSelf().inSingletonScope();

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -41,7 +41,8 @@ import {
     TOKEN_USAGE_SERVICE_PATH,
     TokenUsageServiceClient,
     AIVariableResourceResolver,
-    ConfigurableInMemoryResources
+    ConfigurableInMemoryResources,
+    Agent
 } from '../common';
 import {
     FrontendLanguageModelRegistryImpl,
@@ -78,6 +79,7 @@ import { OSNotificationService } from './os-notification-service';
 import { WindowBlinkService } from './window-blink-service';
 
 export default new ContainerModule(bind => {
+    bindContributionProvider(bind, Agent);
     bindContributionProvider(bind, LanguageModelProvider);
 
     bind(FrontendLanguageModelRegistryImpl).toSelf().inSingletonScope();


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

'@theia/ai-core' defines and uses agents. However the ContributionProvider was bound in '@theia/ai-chat` which lead to frontend crashes when '@theia/ai-core' was included but '@theia/ai-chat' was not.

fixes #15901

#### How to test

- Remove all ai packages from the example applications
- Observe that the frontend no longer crashes

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
