### PR TITLE
fix: show selected prompted variant if configured, show default otherwise

### DIFF
--- a/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -169,7 +169,6 @@ export class AIAgentConfigurationWidget extends ReactWidget {
                                     agentId={agent.id}
                                     promptVariantSet={prompt}
                                     promptService={this.promptService}
-                                    aiSettingsService={this.aiSettingsService}
                                 />
                             </div>
                         ))

--- a/packages/ai-ide/src/browser/ai-configuration/template-settings-renderer.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/template-settings-renderer.tsx
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { AISettingsService, PromptService, PromptVariantSet } from '@theia/ai-core/lib/common';
+import { PromptService, PromptVariantSet } from '@theia/ai-core/lib/common';
 import * as React from '@theia/core/shared/react';
 import { nls } from '@theia/core/lib/common/nls';
 
@@ -21,14 +21,12 @@ export interface PromptVariantRendererProps {
     agentId: string;
     promptVariantSet: PromptVariantSet;
     promptService: PromptService;
-    aiSettingsService: AISettingsService;
 }
 
 export const PromptVariantRenderer: React.FC<PromptVariantRendererProps> = ({
     agentId,
     promptVariantSet,
     promptService,
-    aiSettingsService,
 }) => {
     const variantIds = promptService.getVariantIds(promptVariantSet.id);
     const defaultVariantId = promptService.getDefaultVariantId(promptVariantSet.id);
@@ -38,9 +36,11 @@ export const PromptVariantRenderer: React.FC<PromptVariantRendererProps> = ({
         (async () => {
             const currentVariant =
                 await promptService.getSelectedVariantId(promptVariantSet.id);
-            setSelectedVariant(currentVariant!);
+            if (currentVariant) {
+                setSelectedVariant(currentVariant);
+            }
         })();
-    }, [promptVariantSet.id, aiSettingsService, agentId]);
+    }, [promptVariantSet.id, agentId]);
 
     const isInvalidVariant = !variantIds.includes(selectedVariant);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- The prompt service now returns undefined instead of the default variant when querying the selected variant, so we only set the selected variant if there is a selected one configured in the settings. Otherwise the default variant will be set on first render anyway.
- chore: remove the unused aiSettingsService from the  PromptVariantRenderer

Fixes #15904

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Select an agent that has no specific variant selected in the settings.json
2. The default should be shown in the agent settings.
3. Manually choose an existing variant from the dropdown.
4. Switch to another agent and then switch back.
5. Observe it is still showing the selected variant.
6. Create a custom variant and select it in the dropdown.
7. Delete the custom variant and observe it is showing the expected "selected variant not available"

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

x

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
