### PR TITLE
[fix] restore location for the clear all actions in vsx extension view

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
@@ -173,7 +173,6 @@ export class VSXExtensionsViewContainer extends ViewContainer {
             id: VSXExtensionsCommands.CLEAR_ALL.id,
             command: VSXExtensionsCommands.CLEAR_ALL.id,
             text: VSXExtensionsCommands.CLEAR_ALL.label,
-            group: 'other_1',
             priority: 1,
             onDidChange: this.model.onDidChange,
             isVisible: (widget: Widget) => widget === this.getTabBarDelegate()


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Restore Clear All action toolbar button above the search area, not in sub-menus

fix #15916

#### How to test

Compile and Run browser or electron example. The clear all action in the extension view should be visiblein the toolbar above search menu, not in the '...' sub menu.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
