### PR TITLE
15822: improve ChatUI auto-scroll / scroll-lock consistency

### DIFF
--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1128,3 +1128,31 @@ details[open].collapsible-arguments .collapsible-arguments-summary {
   margin-top: 8px;
   min-height: 40px;
 }
+
+/* ChatTree scroll-to-bottom floating button */
+.theia-ChatTree-ScrollToBottom {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  z-index: 10;
+  width: 32px;
+  height: 32px;
+  border-radius: 16px;
+  border: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.10);
+  background: var(--theia-layoutColor3, #ececec);
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 20px;
+  opacity: 0.7;
+  color: var(--theia-button-background, #007acc);
+  transition: opacity 0.18s, background 0.20s, color 0.20s;
+}
+
+.theia-ChatTree-ScrollToBottom:hover {
+  opacity: 1;
+  background: var(--theia-button-background, #007acc);
+  color: var(--theia-button-foreground, #fff);
+}

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -81,6 +81,8 @@ export interface TreeScrollEvent {
 export interface TreeScrollState {
     readonly scrollTop: number;
     readonly isAtBottom: boolean;
+    readonly scrollHeight?: number;
+    readonly clientHeight?: number;
 }
 
 export const TreeProps = Symbol('TreeProps');
@@ -1643,7 +1645,7 @@ export namespace TreeWidget {
     }
     export class View extends React.Component<ViewProps> {
         list: VirtuosoHandle | undefined;
-        private lastScrollState: TreeScrollState = { scrollTop: 0, isAtBottom: true };
+        private lastScrollState: TreeScrollState = { scrollTop: 0, isAtBottom: true, scrollHeight: 0, clientHeight: 0 };
 
         override render(): React.ReactNode {
             const { rows, width, height, scrollToRow, renderNodeRow, onScrollEmitter, ...other } = this.props;
@@ -1665,7 +1667,7 @@ export namespace TreeWidget {
                     const isAtBottom = scrollHeight - scrollTop - clientHeight <= SCROLL_BOTTOM_THRESHOLD;
 
                     // Store scroll state before firing the event to prevent jitter during inference and scrolling
-                    this.lastScrollState = { scrollTop, isAtBottom };
+                    this.lastScrollState = { scrollTop, isAtBottom, scrollHeight, clientHeight };
                     onScrollEmitter?.fire({ scrollTop, scrollLeft: e.target.scrollLeft || 0 });
                 }}
                 totalCount={rows.length}

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1670,6 +1670,13 @@ export namespace TreeWidget {
                     this.lastScrollState = { scrollTop, isAtBottom, scrollHeight, clientHeight };
                     onScrollEmitter?.fire({ scrollTop, scrollLeft: e.target.scrollLeft || 0 });
                 }}
+                atBottomStateChange={(atBottom: boolean) => {
+                    this.lastScrollState = {
+                        ...this.lastScrollState,
+                        isAtBottom: atBottom
+                    };
+                }}
+                atBottomThreshold={SCROLL_BOTTOM_THRESHOLD}
                 totalCount={rows.length}
                 itemContent={index => renderNodeRow(rows[index])}
                 width={width}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- improve consistency of auto-scroll / scroll-lock in the Chat View
  - Always enable (temporary) scroll-lock when user scrolls up
  - Disable (temporary) scroll-lock when user scrolls back down
  - Ignore scroll-events related to content shrinking (layout updates, e.g. end of code block), to avoid scroll jitter
- add "scroll to bottom" button to the Chat View

This reduces scroll-jitter in all identified cases, and makes scrolling overall more fluid and more predictable

#### How to test

Auto-scroll must work as follows:

- if auto-scroll is enabled and agent sends new tokens, scroll to the bottom
- if the user scrolls up, temporarily disable auto-scroll (this is roughly equivalent to enabling scroll lock)
- if the user scrolls back to the bottom (or close to the bottom), restore auto-scroll behavior
- when the view is not scrolled to the bottom, show "Jump to latest message" (scroll to bottom) button

Note: if scroll-lock is disabled ("Turn Auto-scroll off"), the behavior should be unchanged: the chat view should never scroll without explicit user interaction.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

No specific follow-ups at this point, but we could consider adding more specific auto-scroll behaviors (e.g. "scroll to the beginning of the current AI Response" instead of "Always jump to the end", so user can comfortably read the current answer while it's still printing). This would significantly reduce the amount of auto-scroll events.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
