### PR TITLE
Fix styling of main toolbar items so enabled item have a pointer cursor

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -414,7 +414,7 @@
   cursor: pointer;
 }
 
-.lm-TabBar-toolbar :not(.item.enabled) .action-label {
+.lm-TabBar-toolbar > :not(.item.enabled) > .action-label {
   background: transparent;
   cursor: default;
 }

--- a/packages/toolbar/src/browser/style/toolbar.css
+++ b/packages/toolbar/src/browser/style/toolbar.css
@@ -68,7 +68,6 @@
   box-sizing: border-box;
   position: relative;
   background: unset;
-  cursor: pointer;
 }
 
 #main-toolbar .empty-column-space {
@@ -84,13 +83,9 @@
   line-height: var(--theia-toolbar-icon-size);
 }
 
-#main-toolbar
-  .toolbar-item.action-label.enabled:hover:not(.dragging):not(.active) {
-  background-color: var(--theia-toolbar-hoverBackground);
-}
-
-#main-toolbar .toolbar-item.action-label:not(.enabled) {
+#main-toolbar .toolbar-item .item:not(.enabled) .action-label {
   cursor: default;
+  background: transparent;
 }
 
 #main-toolbar .toolbar-item .hover-overlay {

--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -235,7 +235,6 @@ export class ToolbarImpl extends TabBarToolbar {
 
     protected renderItemWithDraggableWrapper(item: TabBarToolbarItem, position: ToolbarItemPosition): React.ReactNode {
         const stringifiedPosition = JSON.stringify(position);
-        const toolbarItemClassNames = '';
         const renderBody = item.render(this);
 
         return (
@@ -246,7 +245,7 @@ export class ToolbarImpl extends TabBarToolbar {
                 id={item.id}
                 data-position={stringifiedPosition}
                 key={`${item.id}-${stringifiedPosition}`}
-                className={`${toolbarItemClassNames} toolbar-item action-label`}
+                className={'toolbar-item'}
                 draggable={true}
                 onDragStart={this.handleOnDragStart}
                 onDragOver={this.handleOnDragEnter}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes the styling of main toolbar items so that enabled items have a pointer cursor.

Closes #15945 

#### How to test

Hover your mouse over enabled and disabled toolbar item in the main toolbar. The enabled item should have a pointer cursor while disabled items should have a default cursor.

The same behavior should be observed on tab bar toolbars (editors and views).

![feature](https://github.com/user-attachments/assets/c1a02fc0-9167-4722-87dd-4f53f1ce816b)


#### Follow-ups

- The enablement of main toolbar items is not updated when the corresponding command is enabled.
- Clicking a disabled main toolbar item executes the command.

#### Attribution

Contributed on behalf of Lonti.com Pty Ltd

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
