### PR TITLE
Fix memory leak in RenderedToolbarItemImpl

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-toolbar-item.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-toolbar-item.tsx
@@ -95,6 +95,10 @@ export class RenderedToolbarItemImpl extends AbstractToolbarItemImpl<RenderedToo
         if (action.onDidChange) {
             this.disposables.push(action.onDidChange(() => this.onDidChangeEmitter.fire()));
         }
+
+        this.disposables.push(Disposable.create(() =>
+            this.contextKeyListener?.dispose()
+        ));
     }
 
     dispose(): void {
@@ -102,6 +106,10 @@ export class RenderedToolbarItemImpl extends AbstractToolbarItemImpl<RenderedToo
     }
 
     updateContextKeyListener(when: string): void {
+        if (this.contextKeyListener) {
+            this.contextKeyListener.dispose();
+            this.contextKeyListener = undefined;
+        }
         const contextKeys = new Set<string>();
         this.contextKeyService.parseKeys(when)?.forEach(key => contextKeys.add(key));
         if (contextKeys.size > 0) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR fixes a memory leak in RenderedToolbarItemImpl. It disposes the context key listener when the toolbar item is disposed or the context key listener is updated.

Closes #15883 

#### How to test

- Open two editors with tab toolbar items, like diff editors.
- Quickly navigate back and forth between the two editors (e.g. using the alt+left/right arrow shorcuts).
- No memory leak warning should appear in the console.

#### Attribution

Contributed on behalf of Lonti.com Pty Ltd

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
