### PR TITLE
fix: enable clicks inside interactive hover tooltips and open tooltip on status-bar click

### DIFF
--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -107,13 +107,11 @@ export class HoverService {
     protected readonly disposeOnHide = new DisposableCollection();
 
     requestHover(request: HoverRequest): void {
-        if (request.target !== this.hoverTarget) {
-            this.cancelHover();
-            this.pendingTimeout = disposableTimeout(() => this.renderHover(request), this.getHoverDelay());
-            this.hoverTarget = request.target;
-            this.listenForMouseOut();
-            this.listenForMouseClick(request);
-        }
+        this.cancelHover();
+        this.pendingTimeout = disposableTimeout(() => this.renderHover(request), this.getHoverDelay());
+        this.hoverTarget = request.target;
+        this.listenForMouseOut();
+        this.listenForMouseClick(request);
     }
 
     protected getHoverDelay(): number {

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -138,6 +138,8 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
             attrs.onClick = this.triggerCommand(entry);
         } else if (entry.onclick) {
             attrs.onClick = e => entry.onclick?.(e.nativeEvent);
+        } else {
+            attrs.onClick = e => this.requestHover(e, entry);
         }
 
         if (viewEntry.compact && viewEntry.alignment !== undefined) {

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -108,13 +108,22 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         </React.Fragment>;
     }
 
-    protected onclick(entry: StatusBarEntry): () => void {
+    protected triggerCommand(entry: StatusBarEntry): () => void {
         return () => {
             if (entry.command) {
                 const args = entry.arguments || [];
                 this.commands.executeCommand(entry.command, ...args);
             }
         };
+    }
+
+    protected requestHover(e: React.MouseEvent<HTMLElement, MouseEvent>, entry: StatusBarEntry): void {
+        this.hoverService.requestHover({
+            content: entry.tooltip!,
+            target: e.currentTarget,
+            position: 'top',
+            interactive: entry.tooltip instanceof HTMLElement,
+        });
     }
 
     protected createAttributes(viewEntry: StatusBarViewEntry): React.Attributes & React.HTMLAttributes<HTMLElement> {
@@ -126,7 +135,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
             attrs.className += ' hasCommand';
         }
         if (entry.command) {
-            attrs.onClick = this.onclick(entry);
+            attrs.onClick = this.triggerCommand(entry);
         } else if (entry.onclick) {
             attrs.onClick = e => entry.onclick?.(e.nativeEvent);
         }
@@ -136,11 +145,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         }
 
         if (entry.tooltip) {
-            attrs.onMouseEnter = e => this.hoverService.requestHover({
-                content: entry.tooltip!,
-                target: e.currentTarget,
-                position: 'top'
-            });
+            attrs.onMouseEnter = e => this.requestHover(e, entry);
         }
         if (entry.className) {
             attrs.className += ' ' + entry.className;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- fix: interactive elements in hover tooltips are not clickable 
    - Add interactive flag to HoverRequest to signal clickable content
    - Update hover mouse-event handling to route clicks to interactive elements instead of cancelling the tooltip
    
    Fixes GH-15970

- fix: open tooltip on status-bar click when no other handler is set 
    
    Clicking a status-bar item that only shows an interactive tooltip should open that tooltip.
    If the item lacks a bound command and onClick handler, open its hover on click.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start Theia with an extension that adds a language-status bar item containing interactive hover content (e.g. the built-in JSON lanugage basics or also the cSpell Code Spell Checker).
2. Open a *.json file
3. Hover the editor language status status-bar item `{}` to open its tooltip.
    - ![image](https://github.com/user-attachments/assets/c5f7f71a-6b3e-40e4-bbab-490cbcd987aa)
    - Attempt to click an interactive element inside the tooltip (such as the pin icon to add the JSON Schema validation to the statusbar) → the click should be forwarded and the expected action executed
4. Click the status-bar item itself
   - If it does not define `command`/`onClick`, the tooltip should open on click (mirrors the hover behaviour). E.g., the item  `{}` mentioned above.
   - If a handler is present, current behaviour remains unchanged. E.g., click the 'Go to line' item ![image](https://github.com/user-attachments/assets/27d3f24f-9875-45ed-8f7b-cd546cf55c4a) which triggers a command.


Regression check: other hover tooltips (such as simple title tooltips, tree node tooltips or also visual previews in the editor tab bar) and existing status-bar commands should behave as before.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

x

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
