### PR TITLE
Display warning when selected variant does not exist

### DIFF
--- a/packages/ai-core/src/browser/ai-settings-service.ts
+++ b/packages/ai-core/src/browser/ai-settings-service.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 import { DisposableCollection, Emitter, Event } from '@theia/core';
 import { PreferenceScope, PreferenceService } from '@theia/core/lib/browser';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { JSONObject } from '@theia/core/shared/@lumino/coreutils';
 import { AISettings, AISettingsService, AgentSettings } from '../common';
 
@@ -28,6 +28,17 @@ export class AISettingsServiceImpl implements AISettingsService {
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(
+            this.preferenceService.onPreferenceChanged(event => {
+                if (event.preferenceName === AISettingsServiceImpl.PREFERENCE_NAME) {
+                    this.onDidChangeEmitter.fire();
+                }
+            })
+        );
+    }
 
     async updateAgentSettings(agent: string, agentSettings: Partial<AgentSettings>): Promise<void> {
         const settings = await this.getSettings();

--- a/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
@@ -77,14 +77,19 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
     protected availableAgents: Agent[] = [];
 
     /**
-     * Maps prompt variant set IDs to their currently selected variant IDs
+     * Maps prompt variant set IDs to their resolved variant IDs
      */
-    protected selectedVariantIds: Map<string, string | undefined> = new Map();
+    protected effectiveVariantIds: Map<string, string | undefined> = new Map();
 
     /**
      * Maps prompt variant set IDs to their default variant IDs
      */
     protected defaultVariantIds: Map<string, string | undefined> = new Map();
+
+    /**
+     * Maps prompt variant set IDs to their user selected variant IDs
+     */
+    protected userSelectedVariantIds: Map<string, string | undefined> = new Map();
 
     @inject(PromptService) protected promptService: PromptService;
     @inject(AgentService) protected agentService: AgentService;
@@ -102,10 +107,6 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
         this.toDispose.pushAll([
             this.promptService.onPromptsChange(() => {
                 this.loadPromptFragments();
-            }),
-            this.promptService.onSelectedVariantChange(notification => {
-                this.selectedVariantIds.set(notification.promptVariantSetId, notification.variantId);
-                this.update();
             }),
             this.agentService.onDidChangeAgents(() => {
                 this.loadAgents();
@@ -154,11 +155,13 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
             })
         );
 
-        // Update variant information (selected/default) for prompt variant sets
+        // Update variant information (selected/default/effective) for prompt variant sets
         for (const promptVariantSetId of this.promptVariantsMap.keys()) {
-            const selectedId = await this.promptService.getSelectedVariantId(promptVariantSetId);
-            const defaultId = await this.promptService.getDefaultVariantId(promptVariantSetId);
-            this.selectedVariantIds.set(promptVariantSetId, selectedId);
+            const effectiveId = await this.promptService.getEffectiveVariantId(promptVariantSetId);
+            const defaultId = this.promptService.getDefaultVariantId(promptVariantSetId);
+            const selectedId = await this.promptService.getSelectedVariantId(promptVariantSetId) ?? defaultId;
+            this.userSelectedVariantIds.set(promptVariantSetId, selectedId);
+            this.effectiveVariantIds.set(promptVariantSetId, effectiveId);
             this.defaultVariantIds.set(promptVariantSetId, defaultId);
         }
 
@@ -405,8 +408,9 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
     protected renderPromptVariantSet(promptVariantSetId: string, variantIds: string[]): React.ReactNode {
         const isSectionExpanded = this.expandedPromptVariantSetIds.has(promptVariantSetId);
 
-        // Get selected and default variant IDs from our class properties
-        const selectedVariantId = this.selectedVariantIds.get(promptVariantSetId);
+        // Get selected, effective, and default variant IDs from our class properties
+        const selectedVariantId = this.userSelectedVariantIds.get(promptVariantSetId);
+        const effectiveVariantId = this.effectiveVariantIds.get(promptVariantSetId);
         const defaultVariantId = this.defaultVariantIds.get(promptVariantSetId);
 
         // Get variant fragments grouped by ID
@@ -420,6 +424,31 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
         }
 
         const relatedAgents = this.getAgentsUsingPromptVariantId(promptVariantSetId);
+
+        // Determine warning/error state
+        let variantSetMessage: React.ReactNode | undefined = undefined;
+        if (effectiveVariantId === undefined) {
+            // Error: effectiveId is undefined, so nothing works
+            variantSetMessage = (
+                <div className="prompt-variant-error">
+                    <span className="codicon codicon-error"></span>
+                    {nls.localize('theia/ai/core/promptFragmentsConfiguration/variantSetError',
+                        'The selected variant does not exist and no default could be found. Please check your configuration.')}
+                </div>
+            );
+        } else {
+            const needsWarning = selectedVariantId ? effectiveVariantId !== selectedVariantId : effectiveVariantId !== defaultVariantId;
+            if (needsWarning) {
+                // Warning: selectedId is set but does not exist, so default is used
+                variantSetMessage = (
+                    <div className="prompt-variant-warning">
+                        <span className="codicon codicon-warning"></span>
+                        {nls.localize('theia/ai/core/promptFragmentsConfiguration/variantSetWarning',
+                            'The selected variant does not exist. The default variant is being used instead.')}
+                    </div>
+                );
+            }
+        }
 
         return (
             <div className="prompt-fragment-section" key={`variant-${promptVariantSetId}`}>
@@ -446,6 +475,7 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
                 </div>
                 {isSectionExpanded && (
                     <div className="prompt-fragment-body">
+                        {variantSetMessage}
                         <div className="prompt-fragment-description">
                             <p>{nls.localize('theia/ai/core/promptFragmentsConfiguration/variantsOfSystemPrompt', 'Variants of this prompt variant set:')}</p>
                         </div>

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -337,6 +337,32 @@
   font-style: italic;
 }
 
+.prompt-variant-warning {
+  color: var(--theia-warningForeground, #b89500);
+  background: var(--theia-warningBackground, #fffbe6);
+  border-left: 4px solid var(--theia-warningBorder, #b89500);
+  padding: 6px 12px;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 3px;
+  font-size: 0.95em;
+}
+
+.prompt-variant-error {
+  color: var(--theia-errorForeground, #a1260d);
+  background: var(--theia-errorBackground, #fddede);
+  border-left: 4px solid var(--theia-errorBorder, #a1260d);
+  padding: 6px 12px;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 3px;
+  font-size: 0.95em;
+}
+
 /* Template content collapsable styles */
 .template-content-container {
   padding: 10px;


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Show a warning in the prompt fragment view if selected variant is not valid. Properly update the AISettingsService when preferences change. Debounce onPromptsChange in prompt-service to decrease calls (300 ms).

Fixes #15887 
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
In the settings.json set the selectedVariant of an agent to a value that does not exist and observe that a warning is shown in the prompts fragment view.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
