### PR TITLE
Fix cannot drop explorer view files on AI chat input on Windows

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -656,7 +656,7 @@ export class ApplicationShell extends Widget {
         this.additionalDraggedUris = undefined;
     }
 
-    protected static getDraggedEditorUris(dataTransfer: DataTransfer): URI[] {
+    static getDraggedEditorUris(dataTransfer: DataTransfer): URI[] {
         const data = dataTransfer.getData('theia-editor-dnd');
         return data ? data.split('\n').map(entry => new URI(entry)) : [];
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR better handles the file drops from the explorer view into the AI chat input so that it also works on Windows.
The drop data contains node ids which follow the format `wsRootPath:filePath`. So to resolve the file path, I find the workspace root path corresponding to this id and substract it. This also work with paths containing drive letters on Windows unlike the previous implementation which splitted the id by `:` .

Closes #15976 

#### How to test

1. Open the Explorer and AI Chat
2. Select a file and drop it into the chat input
3. The file should properly show as context on the chat input

I only tested it on Windows, if someone could test it on linux or macOS that would be nice.

![feature](https://github.com/user-attachments/assets/9eb264f5-6004-479b-9a1d-dab1779caeb0)

#### Attribution

Contributed on behalf of Lonti.com Pty Ltd.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
