### PR TITLE
fix: DynamicMenuWidget Memory Leak  #15975

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -251,7 +251,7 @@ export class DynamicMenuWidget extends MenuWidget {
     }
 
     protected override onBeforeDetach(msg: Message): void {
-        this.node.ownerDocument.removeEventListener('pointerdown', this);
+        this.node.ownerDocument.removeEventListener('pointerdown', this, true);
         super.onAfterDetach(msg);
     }
 


### PR DESCRIPTION
What it does
Fixes a memory leak in @theia/core/lib/browser/browser-menu-plugin.ts caused by inconsistent usage of addEventListener and removeEventListener.
Previously, an event listener was registered with capture: true, but removed without specifying the same option.
This mismatch prevented the listener from being properly removed, leading to retained memory on repeated context menu interactions.

This change ensures that both addEventListener and removeEventListener use the same options, allowing proper cleanup and stable memory usage.

Fixes #15975 

How to test
Launch Theia and open the browser developer tools (e.g., Chrome DevTools).

Right-click anywhere in the Theia UI to open the context menu, then click elsewhere to close it.

Repeat the open/close operation ~10 times.

Take two memory snapshots before and after.
You should now see that no redundant event listeners remain and memory usage stays stable.

Without the fix, you would observe increasing retained nodes in memory.

Follow-ups
None currently.
Could consider writing automated regression tests if event listener state becomes more observable in future refactoring.

Breaking changes
 This PR does not introduce breaking changes.

Attribution
Contributed by Hbb.