### PR TITLE
deps: Bump nyc to 17.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "nan": "2.22.2",
         "node-abi": "4.9.0",
         "node-gyp": "^9.0.0",
-        "nyc": "^15.0.0",
+        "nyc": "^17.1.0",
         "puppeteer": "23.1.0",
         "puppeteer-core": "23.1.0",
         "puppeteer-to-istanbul": "1.4.0",
@@ -16902,29 +16902,20 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@babel/core": "^7.7.5",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-processinfo": {
@@ -21186,9 +21177,9 @@
       }
     },
     "node_modules/nyc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
+      "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -21199,12 +21190,12 @@
         "decamelize": "^1.2.0",
         "find-cache-dir": "^3.2.0",
         "find-up": "^4.1.0",
-        "foreground-child": "^2.0.0",
+        "foreground-child": "^3.3.0",
         "get-package-type": "^0.1.0",
         "glob": "^7.1.6",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-instrument": "^6.0.2",
         "istanbul-lib-processinfo": "^2.0.2",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
@@ -21224,7 +21215,7 @@
         "nyc": "bin/nyc.js"
       },
       "engines": {
-        "node": ">=8.9"
+        "node": ">=18"
       }
     },
     "node_modules/nyc/node_modules/find-up": {
@@ -21239,6 +21230,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nyc/node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nyc/node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "nan": "2.22.2",
     "node-abi": "4.9.0",
     "node-gyp": "^9.0.0",
-    "nyc": "^15.0.0",
+    "nyc": "^17.1.0",
     "puppeteer": "23.1.0",
     "puppeteer-core": "23.1.0",
     "puppeteer-to-istanbul": "1.4.0",


### PR DESCRIPTION
nyc 17.1.0 depends on foreground-child ^3.3.0 that does not attempt to run `process.exitCode = '128SIGABRT'` (expected is a number, not a string).

Example output when running `npm run test`:

```
@theia/core: free(): double free detected in tcache 2
@theia/core: node:internal/errors:540
@theia/core:       throw error;
@theia/core:       ^
@theia/core: TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type string ('128SIGABRT')
@theia/core:     at process.set [as exitCode] (node:internal/bootstrap/node:122:9)
@theia/core:     at ChildProcess.<anonymous> (/home/runner/work/theia/theia/node_modules/foreground-child/index.js:63:22)
@theia/core:     at ChildProcess.emit (node:events:518:28)
@theia/core:     at maybeClose (node:internal/child_process:1101:16)
@theia/core:     at ChildProcess._handle.onexit (node:internal/child_process:304:5) {
@theia/core:   code: 'ERR_INVALID_ARG_TYPE'
@theia/core: }
@theia/core: Node.js v22.17.0
@theia/core: Exit with failure status (1): nyc mocha --config ../../configs/mocharc.yml "./lib/**/*.*spec.js"
@theia/core: npm error Lifecycle script `test` failed with error:
@theia/core: npm error code 1
@theia/core: npm error path /home/runner/work/theia/theia/packages/core
@theia/core: npm error workspace @theia/core@1.63.0
@theia/core: npm error location /home/runner/work/theia/theia/packages/core
@theia/core: npm error command failed
@theia/core: npm error command sh -c theiaext test
```
(snippet from https://github.com/eclipse-theia/theia/actions/runs/16223378787/job/45809305911#step:7:1017)

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Bumps nyc to 17.1.0.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
`npm install && npm run build && npm run test`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Contributed by STMicroelectronics