### PR TITLE
Impl #15985 - [plugin-ext] support remote MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30431,7 +30431,7 @@
       "version": "1.63.0",
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.15.1",
         "@theia/ai-core": "1.63.0",
         "@theia/core": "1.63.0"
       },
@@ -30440,9 +30440,9 @@
       }
     },
     "packages/ai-mcp/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
-      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.15.1.tgz",
+      "integrity": "sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -30450,6 +30450,7 @@
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",

--- a/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
@@ -233,6 +233,25 @@ export class AIMCPConfigurationWidget extends ReactWidget {
         );
     }
 
+    protected renderServerHeadersSection(server: MCPServerDescription): React.ReactNode {
+        if (!isRemoteMCPServerDescription(server) || !server.headers) {
+            return;
+        }
+        return (
+            <div className="mcp-server-section">
+                <span className="mcp-section-label">{nls.localize('theia/ai/mcpConfiguration/headers', 'Headers: ')}</span>
+                <div className="mcp-env-block">
+                    {Object.entries(server.headers).map(([key, value]) => (
+                        <div key={key}>
+                            {key}={(key.toLowerCase().includes('token') || key.toLowerCase().includes('authorization')) ? '******' : String(value)}
+                        </div>
+                    ))}
+                </div>
+
+            </div>
+        );
+    }
+
     protected renderAutostartSection(server: MCPServerDescription): React.ReactNode {
         return (
             <div className="mcp-server-section">
@@ -381,6 +400,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                 {this.renderServerUrlSection(server)}
                 {this.renderServerAuthTokenHeaderSection(server)}
                 {this.renderServerAuthTokenSection(server)}
+                {this.renderServerHeadersSection(server)}
                 {this.renderAutostartSection(server)}
                 {this.renderToolsSection(server)}
                 {this.renderServerControls(server)}

--- a/packages/ai-mcp/package.json
+++ b/packages/ai-mcp/package.json
@@ -3,7 +3,7 @@
   "version": "1.63.0",
   "description": "Theia - MCP Integration",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.15.1",
     "@theia/ai-core": "1.63.0",
     "@theia/core": "1.63.0"
   },

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
@@ -35,6 +35,7 @@ interface RemoteMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
     serverUrl: string;
     serverAuthToken?: string;
     serverAuthTokenHeader?: string;
+    headers?: { [key: string]: string };
 }
 
 type MCPServersPreferenceValue = LocalMCPServerPreferenceValue | RemoteMCPServerPreferenceValue;
@@ -53,7 +54,8 @@ namespace MCPServersPreference {
             (!('autostart' in obj) || typeof obj.autostart === 'boolean') &&
             (!('serverUrl' in obj) || typeof obj.serverUrl === 'string') &&
             (!('serverAuthToken' in obj) || typeof obj.serverAuthToken === 'string') &&
-            (!('serverAuthTokenHeader' in obj) || typeof obj.serverAuthTokenHeader === 'string');
+            (!('serverAuthTokenHeader' in obj) || typeof obj.serverAuthTokenHeader === 'string') &&
+            (!('headers' in obj) || !!obj.headers && typeof obj.headers === 'object' && Object.values(obj.headers).every(value => typeof value === 'string'));
     }
 }
 
@@ -166,12 +168,13 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
 
             if ('serverUrl' in description) {
                 // Create RemoteMCPServerDescription by picking only remote-specific properties
-                const { serverUrl, serverAuthToken, serverAuthTokenHeader, autostart } = description;
+                const { serverUrl, serverAuthToken, serverAuthTokenHeader, headers, autostart } = description;
                 filteredDescription = {
                     name,
                     serverUrl,
                     ...(serverAuthToken && { serverAuthToken }),
                     ...(serverAuthTokenHeader && { serverAuthTokenHeader }),
+                    ...(headers && { headers }),
                     autostart: autostart ?? true,
                 };
             } else {

--- a/packages/ai-mcp/src/browser/mcp-preferences.ts
+++ b/packages/ai-mcp/src/browser/mcp-preferences.ts
@@ -103,6 +103,12 @@ Example configuration:\n\
             title: nls.localize('theia/ai/mcp/servers/serverAuthTokenHeader/title', 'Authentication Header Name'),
             markdownDescription: nls.localize('theia/ai/mcp/servers/serverAuthTokenHeader/mdDescription',
               'The header name to use for the server authentication token. If not provided, "Authorization" with "Bearer" will be used.'),
+          },
+          headers: {
+            type: 'object',
+            title: nls.localize('theia/ai/mcp/servers/headers/title', 'Headers'),
+            markdownDescription: nls.localize('theia/ai/mcp/servers/headers/mdDescription',
+              'Optional additional headers included with each request to the server.'),
           }
         },
         required: []

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -136,6 +136,11 @@ export interface RemoteMCPServerDescription extends BaseMCPServerDescription {
      * The header name to use for the server authentication token.
      */
     serverAuthTokenHeader?: string;
+
+    /**
+     * Optional additional headers to include in requests to the server.
+     */
+    headers?: Record<string, string>;
 }
 
 export type MCPServerDescription = LocalMCPServerDescription | RemoteMCPServerDescription;

--- a/packages/plugin-ext/src/plugin/lm-ext.ts
+++ b/packages/plugin-ext/src/plugin/lm-ext.ts
@@ -150,7 +150,7 @@ export class LmExtImpl implements McpServerDefinitionRegistryExt {
     }
 
     registerMcpContributions(mcpContributions: PluginPackageMcpServerDefinitionProviderContribution[]): void {
-        this.announcedMCPProviders = mcpContributions.map(contribution => contribution.id);
+        this.announcedMCPProviders.push(...mcpContributions.map(contribution => contribution.id));
     }
 }
 


### PR DESCRIPTION
#### What it does

Add support to configure headers in a remote MCP server description and extends plugin-ext to support remote mcp server configurations.

#### How to test

Create a VS Code MCP extension according to [[Register an MCP server in your extension](https://code.visualstudio.com/api/extension-guides/ai/mcp#register-an-mcp-server-in-your-extension)](https://code.visualstudio.com/api/extension-guides/ai/mcp#register-an-mcp-server-in-your-extension) and add that extension to a Theia application, e.g. the Theia examples.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
