### PR TITLE
Use environment variable instead of wmic to get remote architecture

### DIFF
--- a/packages/remote/src/electron-node/setup/remote-setup-service.ts
+++ b/packages/remote/src/electron-node/setup/remote-setup-service.ts
@@ -155,10 +155,10 @@ export class RemoteSetupService {
         }
         let arch: string | undefined;
         if (os === OS.Type.Windows) {
-            const wmicResult = await connection.exec('wmic OS get OSArchitecture');
-            if (wmicResult.stdout.includes('64-bit')) {
+            const processorArchitecture = await connection.exec('cmd /c echo %PROCESSOR_ARCHITECTURE%');
+            if (processorArchitecture.stdout.includes('64')) {
                 arch = 'x64';
-            } else if (wmicResult.stdout.includes('32-bit')) {
+            } else if (processorArchitecture.stdout.includes('x86')) {
                 arch = 'x86';
             }
         } else {


### PR DESCRIPTION
Signed-off-by: Parisa Betel Miri <parisa.betelmiri@microchip.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #15990. Remoting over ssh to a non-admin user on a windows server shows this error:

<img width="522" height="65" alt="465409284-a7f237fc-e69b-4f74-959b-8a805666b9bc" src="https://github.com/user-attachments/assets/9100c9c5-40c2-46e2-ae6f-23da9acd5b83" />

Debugging reveals that it's a permission issue with the wmic command used to determine the remote architecture, which we can instead check using the environment variable: [PROCESSOR_ARCHITECTURE](https://learn.microsoft.com/en-ca/windows/win32/winprog64/wow64-implementation-details?redirectedfrom=MSDN). The command is prefixed `cmd /c` so that it will run in cmd even if the parent shell is powershell (as suggested by @msujew). Below is the output of the command run locally in powershell and cmd:

<img width="598" height="91" alt="image" src="https://github.com/user-attachments/assets/94060df3-5e5d-40e7-8de0-a3870e2145f2" />

<img width="485" height="112" alt="image" src="https://github.com/user-attachments/assets/7fa8c9bf-a607-4e69-bcee-45ef6af8472f" />

#### How to test

Use the ssh extension to connect to a non-admin user on a windows server. Some servers might be configured so that the current implementation doesn't produce an error, but this was not the case on either of the servers I tested. 

https://serverfault.com/a/28523

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
