### PR TITLE
fix: correctly detach from DOM in DynamicMenuWidget

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -252,7 +252,7 @@ export class DynamicMenuWidget extends MenuWidget {
 
     protected override onBeforeDetach(msg: Message): void {
         this.node.ownerDocument.removeEventListener('pointerdown', this, true);
-        super.onAfterDetach(msg);
+        super.onBeforeDetach(msg);
     }
 
     override handleEvent(event: Event): void {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes `onBeforeDetach` in `DynamicMenuWidget` to call `onBeforeDetach` of the super class instead of `onAfterDetach`.

This fixes a memory leak as the parent was not able to clean up its registered listeners.

#### How to test

1. Start Theia current master
2. Open many context menus, e.g. by right-clicking within the file explorer
3. Check the `Event Listeners` tab of `Elements ` in the Chrome Dev Tools for the root `html` element
4. It will show many registered `mousedown` listeners originating from `browser-menu-plugin`

<img width="336" height="740" alt="image" src="https://github.com/user-attachments/assets/00c45e0f-4dce-4506-8d0a-40479eb66999" />

---

1. Repeat with PR state
2. Check that there are no `mousedown` listeners originating from `browser-menu-plugin`, except for a single one in case a context menu is currently open

<img width="349" height="71" alt="image" src="https://github.com/user-attachments/assets/57982523-e0e4-42dc-9611-b0527cc764be" />


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
