### PR TITLE
Adapt the default of the summary agent to GTP-4o

### DIFF
--- a/packages/ai-chat/src/common/chat-session-summary-agent.ts
+++ b/packages/ai-chat/src/common/chat-session-summary-agent.ts
@@ -33,7 +33,7 @@ export class ChatSessionSummaryAgent extends AbstractStreamParsingChatAgent impl
     protected readonly defaultLanguageModelPurpose = 'chat-session-summary';
     languageModelRequirements: LanguageModelRequirement[] = [{
         purpose: 'chat-session-summary',
-        identifier: 'openai/gpt-4o-mini',
+        identifier: 'openai/gpt-4o',
     }];
     override agentSpecificVariables = [];
     override functions = [];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Set the default model for the chat summary agnt to GPT4o, the performance of GPT-mini is really bad.

#### How to test

Summarize a chat session or an architect session for coder and observe significantly imporved results.

#### Follow-ups

When the new default model management is merged, we should set this to a good default model, it actually matters.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
