### PR TITLE
Put new prompt templates under MIT

### DIFF
--- a/packages/ai-chat/src/common/chat-session-naming-prompt-template.ts
+++ b/packages/ai-chat/src/common/chat-session-naming-prompt-template.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/tslint/config */
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH and others.
+//
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
+//
+// SPDX-License-Identifier: MIT
+// *****************************************************************************
+
+import { PromptVariantSet } from '@theia/ai-core';
+
+export const CHAT_SESSION_NAMING_PROMPT: PromptVariantSet = {
+    id: 'chat-session-naming-system',
+    defaultVariant: {
+        id: 'chat-session-naming-system-default',
+        template: '{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).\n' +
+            'Made improvements or adaptations to this prompt template? We\'d love for you to share it with the community! Contribute back here: ' +
+            'https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}\n\n' +
+            'Provide a short and descriptive name for the given AI chat conversation of an AI-powered tool based on the conversation below.\n\n' +
+            'The purpose of the name is for users to recognize the chat conversation easily in a list of conversations. ' +
+            'Use the same language for the chat conversation name as used in the provided conversation, if in doubt default to English. ' +
+            'Start the chat conversation name with an upper-case letter. ' +
+            'Below we also provide the already existing other conversation names, make sure your suggestion for a name is unique with respect to the existing ones.\n\n' +
+            'IMPORTANT: Your answer MUST ONLY CONTAIN THE PROPOSED NAME and must not be preceded or followed by any other text.' +
+            '\n\nOther session names:\n{{listOfSessionNames}}' +
+            '\n\nConversation:\n{{conversation}}',
+    }
+};

--- a/packages/ai-chat/src/common/chat-session-naming-service.ts
+++ b/packages/ai-chat/src/common/chat-session-naming-service.ts
@@ -22,29 +22,13 @@ import {
     LanguageModelRequirement,
     LanguageModelService,
     PromptService,
-    PromptVariantSet,
     UserRequest
 } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatSession } from './chat-service';
 import { generateUuid } from '@theia/core';
 
-const CHAT_SESSION_NAMING_PROMPT: PromptVariantSet = {
-    id: 'chat-session-naming-system',
-    defaultVariant: {
-        id: 'chat-session-naming-system-default',
-        template: '{{!-- Made improvements or adaptations to this prompt template? We\'d love for you to share it with the community! Contribute back here: ' +
-            'https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}\n\n' +
-            'Provide a short and descriptive name for the given AI chat conversation of an AI-powered tool based on the conversation below.\n\n' +
-            'The purpose of the name is for users to recognize the chat conversation easily in a list of conversations. ' +
-            'Use the same language for the chat conversation name as used in the provided conversation, if in doubt default to English. ' +
-            'Start the chat conversation name with an upper-case letter. ' +
-            'Below we also provide the already existing other conversation names, make sure your suggestion for a name is unique with respect to the existing ones.\n\n' +
-            'IMPORTANT: Your answer MUST ONLY CONTAIN THE PROPOSED NAME and must not be preceded or followed by any other text.' +
-            '\n\nOther session names:\n{{listOfSessionNames}}' +
-            '\n\nConversation:\n{{conversation}}',
-    }
-};
+import { CHAT_SESSION_NAMING_PROMPT } from './chat-session-naming-prompt-template';
 
 @injectable()
 export class ChatSessionNamingService {

--- a/packages/ai-ide/src/browser/app-tester-chat-agent.ts
+++ b/packages/ai-ide/src/browser/app-tester-chat-agent.ts
@@ -16,83 +16,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { CHAT_CONTEXT_DETAILS_VARIABLE_ID } from '@theia/ai-chat';
 import { AbstractStreamParsingChatAgent } from '@theia/ai-chat/lib/common/chat-agents';
 import { ErrorChatResponseContentImpl, MarkdownChatResponseContentImpl, MutableChatRequestModel, QuestionResponseContentImpl } from '@theia/ai-chat/lib/common/chat-model';
-import { BasePromptFragment, LanguageModelRequirement } from '@theia/ai-core/lib/common';
+import { LanguageModelRequirement } from '@theia/ai-core/lib/common';
 import { MCPFrontendService, MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { nls } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/browser/mcp-preferences';
 import { PreferenceScope, PreferenceService } from '@theia/core/lib/browser';
-import { QUERY_DOM_FUNCTION_ID, LAUNCH_BROWSER_FUNCTION_ID, CLOSE_BROWSER_FUNCTION_ID, IS_BROWSER_RUNNING_FUNCTION_ID } from '../common/app-tester-chat-functions';
-
-export const REQUIRED_MCP_SERVERS: MCPServerDescription[] = [
-    {
-        name: 'playwright',
-        command: 'npx',
-        args: ['-y', '@playwright/mcp@latest',
-            '--cdp-endpoint',
-            'http://localhost:9222/'],
-        autostart: false,
-        env: {},
-    },
-    {
-        name: 'playwright-visual',
-        command: 'npx',
-        args: ['-y', '@playwright/mcp@latest', '--vision',
-            '--cdp-endpoint',
-            'http://localhost:9222/'],
-        autostart: false,
-        env: {},
-    }
-];
-
-// Prompt templates
-export const appTesterTemplate: BasePromptFragment = {
-    id: 'app-tester-system-default',
-    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
-Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
-https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
-
-You are AppTester, an AI assistant integrated into Theia IDE specifically designed to help developers test running applications using Playwright.
-Your role is to inspect the application for user-specified test scenarios through the Playwright MCP server.
-
-## Your Workflow
-1. Help the user build and launch their application
-2. Use Playwright browser automation to validate test scenarios
-3. Report results and provide actionable feedback 
-4. Help fix issues when needed
-
-## Available Playwright Testing Tools
-You have access to these powerful automation tools:
-${REQUIRED_MCP_SERVERS.map(server => `{{prompt:mcp_${server.name}_tools}}`)}
-
-- **~{${LAUNCH_BROWSER_FUNCTION_ID}}**: Launch the browser. This is required before performing any browser interactions. Always launch a new browser when starting a test session.
-- **~{${IS_BROWSER_RUNNING_FUNCTION_ID}}**: Check if the browser is running. If a tool fails by saying that the connection failed, you can verify the connection by using this tool.
-- **~{${CLOSE_BROWSER_FUNCTION_ID}}**: Close the browser.
-- **~{${QUERY_DOM_FUNCTION_ID}}**: Query the DOM for specific elements and their properties. Only use when explicitly requested by the user.
-- **browser_snapshot**: Capture the current state of the page for verification or debugging purposes.
-
-Prefer snapshots for investigating the page.
-
-## Workflow Approach
-1. **Understand Requirements**: Ask the user to clearly define what needs to be tested
-2. **Launch Browser**: Start a fresh browser instance for testing
-3. **Navigate and Test**: Execute the test scenario methodically
-4. **Document Results**: Provide detailed results with screenshots when helpful
-5. **Clean Up**: Always close the browser when testing is complete
-
-## Current Context
-Some files and other pieces of data may have been added by the user to the context of the chat. If any have, the details can be found below.
-{{${CHAT_CONTEXT_DETAILS_VARIABLE_ID}}}
-`
-};
-
-export const appTesterTemplateVariant: BasePromptFragment = {
-    id: 'app-tester-system-empty',
-    template: '',
-};
+import { appTesterTemplate, appTesterTemplateVariant, REQUIRED_MCP_SERVERS } from './app-tester-prompt-template';
 
 export const AppTesterChatAgentId = 'AppTester';
 @injectable()
@@ -115,8 +47,8 @@ export class AppTesterChatAgent extends AbstractStreamParsingChatAgent {
         + 'It can automate testing workflows and provide detailed feedback on application functionality.');
 
     override iconClass: string = 'codicon codicon-beaker';
-   protected override systemPromptId: string = 'app-tester-system';
-   override prompts = [{ id: 'app-tester-system', defaultVariant: appTesterTemplate, variants: [appTesterTemplateVariant] }];
+    protected override systemPromptId: string = 'app-tester-system';
+    override prompts = [{ id: 'app-tester-system', defaultVariant: appTesterTemplate, variants: [appTesterTemplateVariant] }];
 
     /**
      * Override invoke to check if the Playwright MCP server is running, and if not, ask the user if it should be started.

--- a/packages/ai-ide/src/browser/app-tester-prompt-template.ts
+++ b/packages/ai-ide/src/browser/app-tester-prompt-template.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/tslint/config */
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH and others.
+//
+// This file is licensed under the MIT License.
+// See LICENSE-MIT.txt in the project root for license information.
+// https://opensource.org/license/mit.
+//
+// SPDX-License-Identifier: MIT
+// *****************************************************************************
+
+import { BasePromptFragment } from '@theia/ai-core/lib/common';
+import { CHAT_CONTEXT_DETAILS_VARIABLE_ID } from '@theia/ai-chat';
+import { QUERY_DOM_FUNCTION_ID, LAUNCH_BROWSER_FUNCTION_ID, CLOSE_BROWSER_FUNCTION_ID, IS_BROWSER_RUNNING_FUNCTION_ID } from '../common/app-tester-chat-functions';
+import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+
+export const REQUIRED_MCP_SERVERS: MCPServerDescription[] = [
+    {
+        name: 'playwright',
+        command: 'npx',
+        args: ['-y', '@playwright/mcp@latest',
+            '--cdp-endpoint',
+            'http://localhost:9222/'],
+        autostart: false,
+        env: {},
+    },
+    {
+        name: 'playwright-visual',
+        command: 'npx',
+        args: ['-y', '@playwright/mcp@latest', '--vision',
+            '--cdp-endpoint',
+            'http://localhost:9222/'],
+        autostart: false,
+        env: {},
+    }
+];
+
+export const appTesterTemplate: BasePromptFragment = {
+    id: 'app-tester-system-default',
+    template: `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+
+You are AppTester, an AI assistant integrated into Theia IDE specifically designed to help developers test running applications using Playwright.
+Your role is to inspect the application for user-specified test scenarios through the Playwright MCP server.
+
+## Your Workflow
+1. Help the user build and launch their application
+2. Use Playwright browser automation to validate test scenarios
+3. Report results and provide actionable feedback 
+4. Help fix issues when needed
+
+## Available Playwright Testing Tools
+You have access to these powerful automation tools:
+${REQUIRED_MCP_SERVERS.map(server => `{{prompt:mcp_${server.name}_tools}}`)}
+
+- **~{${LAUNCH_BROWSER_FUNCTION_ID}}**: Launch the browser. This is required before performing any browser interactions. Always launch a new browser when starting a test session.
+- **~{${IS_BROWSER_RUNNING_FUNCTION_ID}}**: Check if the browser is running. If a tool fails by saying that the connection failed, you can verify the connection by using this tool.
+- **~{${CLOSE_BROWSER_FUNCTION_ID}}**: Close the browser.
+- **~{${QUERY_DOM_FUNCTION_ID}}**: Query the DOM for specific elements and their properties. Only use when explicitly requested by the user.
+- **browser_snapshot**: Capture the current state of the page for verification or debugging purposes.
+
+Prefer snapshots for investigating the page.
+
+## Workflow Approach
+1. **Understand Requirements**: Ask the user to clearly define what needs to be tested
+2. **Launch Browser**: Start a fresh browser instance for testing
+3. **Navigate and Test**: Execute the test scenario methodically
+4. **Document Results**: Provide detailed results with screenshots when helpful
+5. **Clean Up**: Always close the browser when testing is complete
+
+## Current Context
+Some files and other pieces of data may have been added by the user to the context of the chat. If any have, the details can be found below.
+{{${CHAT_CONTEXT_DETAILS_VARIABLE_ID}}}
+`
+};
+
+export const appTesterTemplateVariant: BasePromptFragment = {
+    id: 'app-tester-system-empty',
+    template: '',
+};


### PR DESCRIPTION
#### What it does

Moved the prompt fragments of AppTester and SessionNameAgent to separate files and under MIT.

#### How to test

Use the two agents with the changed prompts.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
