### PR TITLE
Update compile-references.js package is a reserved keyword

### DIFF
--- a/scripts/compile-references.js
+++ b/scripts/compile-references.js
@@ -48,9 +48,9 @@ compileTypeScriptReferences().catch(error => {
  * This script main entry point.
  */
 async function compileTypeScriptReferences() {
-    await Promise.all(Object.values(PACKAGE_LIST).map(async package => {
-        const references = await getTypescriptReferences(package);
-        await configureTypeScriptReferences(package, references);
+    await Promise.all(Object.values(PACKAGE_LIST).map(async pkg => {
+        const references = await getTypescriptReferences(pkg);
+        await configureTypeScriptReferences(pkg, references);
     }))
 }
 
@@ -61,7 +61,7 @@ async function compileTypeScriptReferences() {
 async function getTypescriptReferences(requestedPackage) {
     const dependencies = DEPENDENCIES[requestedPackage.name] || [];
     const references = await Promise.all(dependencies.map(async dependency => {
-        const depWorkspace = PACKAGE_LIST.find(package => package.name === dependency);
+        const depWorkspace = PACKAGE_LIST.find(pkg => pkg.name === dependency);
         if (!depWorkspace) {
             return undefined;
         }


### PR DESCRIPTION
The code did only work because it got bundled or maybe executed without use strict even when it is annotated with it how ever package is a reserved word so renamed it to pkg

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
