### PR TITLE
fix: preserve delegation content

### DIFF
--- a/packages/ai-chat/src/browser/delegation-response-content.ts
+++ b/packages/ai-chat/src/browser/delegation-response-content.ts
@@ -23,6 +23,8 @@ import { ChatRequestInvocation, ChatResponseContent } from '../common';
 export class DelegationResponseContent implements ChatResponseContent {
     kind = 'AgentDelegation';
 
+    responseText: string | undefined;
+
     /**
      * @param agentId The id of the agent to whom the task was delegated
      * @param prompt The prompt that was delegated
@@ -33,13 +35,21 @@ export class DelegationResponseContent implements ChatResponseContent {
         public prompt: string,
         public response: ChatRequestInvocation
     ) {
-        // Empty
+        this.handleResponseComplete();
+    }
+
+    // Wait for the response to be complete, then extract the response
+    // text (for use in asString()).
+    async handleResponseComplete(): Promise<void> {
+        const completeResponse = await this.response.responseCompleted;
+        this.responseText = completeResponse.response.asString();
     }
 
     asString(): string {
         const json = {
             agentId: this.agentId,
-            prompt: this.prompt
+            prompt: this.prompt,
+            response: this.responseText ?? ''
         };
         return JSON.stringify(json);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- in AI Chat, when delegating to another agent, keep the response (plain text) in the Chat Response Model, so it remains part of the conversation for following messages

fixes issues/16064

<img width="768" height="948" alt="image" src="https://github.com/user-attachments/assets/84789783-1343-4a24-a35d-56f0a6767497" />

#### How to test

- Use the delegateToAgent tool, e.g.: `@Architect Using ~delegateToAgent , ask Universal to tell a story. Ignore the result for now`
  - Note: here, we ask to ignore the result to avoid false-positive. Architect will have immediate access to the Tool Call in the first response, and it may decide to summarize the story at this point. We want to make sure it retains the knowledge in the next step; so we shouldn't bias the result with an early summary.
- Once the story is complete, ask for a summary, e.g.: `Okay; now summarize the story`
  - Expected: the agent should still have access to the story, and will be able to summarize it.
  - Check that the summary is consistent with the Delegated result, to ensure it's not hallucinating
- Alternatively: check that the Output view contains the plain-text representation of the delegated content in the last entry. The entry should include the response like this:

<img width="1110" height="529" alt="image" src="https://github.com/user-attachments/assets/a98cfb5e-d17c-4210-aae8-b9831394d7e4" />

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
