### PR TITLE
Enable specifying original state in change sets

### DIFF
--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -33,6 +33,7 @@ import { bindSampleFileSystemCapabilitiesCommands } from './file-system/sample-f
 import { bindChatNodeToolbarActionContribution } from './chat/chat-node-toolbar-action-contribution';
 import { bindAskAndContinueChatAgentContribution } from './chat/ask-and-continue-chat-agent-contribution';
 import { bindChangeSetChatAgentContribution } from './chat/change-set-chat-agent-contribution';
+import { bindOriginalStateTestAgentContribution } from './chat/original-state-test-agent-contribution';
 import { bindSampleCodeCompletionVariableContribution } from './ai-code-completion/sample-code-completion-variable-contribution';
 
 export default new ContainerModule((
@@ -43,6 +44,7 @@ export default new ContainerModule((
 ) => {
     bindAskAndContinueChatAgentContribution(bind);
     bindChangeSetChatAgentContribution(bind);
+    bindOriginalStateTestAgentContribution(bind);
     bindChatNodeToolbarActionContribution(bind);
     bindDynamicLabelProvider(bind);
     bindSampleUnclosableView(bind);

--- a/examples/api-samples/src/browser/chat/original-state-test-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/original-state-test-agent-contribution.ts
@@ -1,0 +1,169 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import {
+    AbstractStreamParsingChatAgent,
+    ChatAgent,
+    MutableChatRequestModel,
+    MarkdownChatResponseContentImpl,
+    SystemMessageDescription
+} from '@theia/ai-chat';
+import { ChangeSetFileElementFactory } from '@theia/ai-chat/lib/browser/change-set-file-element';
+import { Agent, LanguageModelRequirement } from '@theia/ai-core';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+
+export function bindOriginalStateTestAgentContribution(bind: interfaces.Bind): void {
+    bind(OriginalStateTestAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(OriginalStateTestAgent);
+    bind(ChatAgent).toService(OriginalStateTestAgent);
+}
+
+/**
+ * This is a test agent demonstrating how to test originalState functionality in change sets.
+ * It creates change set elements with original content provided and tests sequential updates.
+ */
+@injectable()
+export class OriginalStateTestAgent extends AbstractStreamParsingChatAgent {
+    readonly id = 'OriginalStateTest';
+    readonly name = 'OriginalStateTest';
+    readonly defaultLanguageModelPurpose = 'chat';
+    override readonly description = 'This chat will test originalState functionality with sequential changes.';
+    override languageModelRequirements: LanguageModelRequirement[] = [];
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(ChangeSetFileElementFactory)
+    protected readonly fileChangeFactory: ChangeSetFileElementFactory;
+
+    override async invoke(request: MutableChatRequestModel): Promise<void> {
+        const roots = this.workspaceService.tryGetRoots();
+        if (roots.length === 0) {
+            request.response.response.addContent(new MarkdownChatResponseContentImpl(
+                'No workspace is open. For using this test agent, please open a workspace with at least one file.'
+            ));
+            request.response.complete();
+            return;
+        }
+
+        const root = roots[0];
+        const files = root.children?.filter(child => child.isFile);
+        if (!files || files.length === 0) {
+            request.response.response.addContent(new MarkdownChatResponseContentImpl(
+                'The workspace does not contain any files. For using this test agent, please add at least one file in the root.'
+            ));
+            request.response.complete();
+            return;
+        }
+
+        const chatSessionId = request.session.id;
+        const requestId = request.id;
+
+        request.response.response.addContent(new MarkdownChatResponseContentImpl(
+            'Testing originalState functionality...\n\n' +
+            'Three sequential changes to an existing file with 1000ms delays between each.'
+        ));
+
+        await this.delay(1000);
+        request.session.changeSet.setTitle('Original State Test Changes');
+
+        // Select an existing file for sequential modifications
+        const existingFile = files[Math.floor(Math.random() * files.length)];
+        const existingFileUri = existingFile.resource;
+
+        // Read the current content to use as originalState
+        const currentContent = await this.fileService.read(existingFileUri);
+        const originalState = currentContent.value.toString();
+
+        // First modification with originalState provided
+        request.response.response.addContent(new MarkdownChatResponseContentImpl('\n\nCreate modification 1'));
+        const modifiedContent1 = await this.computeModifiedState(originalState, 1);
+        await this.fileService.write(existingFileUri, modifiedContent1);
+        const firstModification = this.fileChangeFactory({
+            uri: existingFileUri,
+            type: 'modify',
+            state: 'applied',
+            originalState,
+            targetState: modifiedContent1,
+            requestId,
+            chatSessionId
+        });
+
+        request.session.changeSet.addElements(firstModification);
+        await this.delay(1000);
+
+        // Second modification with originalState from previous change
+        request.response.response.addContent(new MarkdownChatResponseContentImpl('\n\nCreate modification 2'));
+        const modifiedContent2 = await this.computeModifiedState(modifiedContent1, 2);
+        await this.fileService.write(existingFileUri, modifiedContent2);
+        const secondModification = this.fileChangeFactory({
+            uri: existingFileUri,
+            type: 'modify',
+            state: 'applied',
+            originalState,
+            targetState: modifiedContent2,
+            requestId,
+            chatSessionId
+        });
+
+        request.session.changeSet.addElements(secondModification);
+        await this.delay(1000);
+
+        // Third modification with originalState from previous change
+        request.response.response.addContent(new MarkdownChatResponseContentImpl('\n\nCreate modification 3'));
+        const modifiedContent3 = await this.computeModifiedState(modifiedContent2, 3);
+        await this.fileService.write(existingFileUri, modifiedContent3);
+        const thirdModification = this.fileChangeFactory({
+            uri: existingFileUri,
+            type: 'modify',
+            state: 'applied',
+            originalState,
+            targetState: modifiedContent3,
+            requestId,
+            chatSessionId
+        });
+
+        request.session.changeSet.addElements(thirdModification);
+
+        request.response.response.addContent(new MarkdownChatResponseContentImpl('\n\nTest completed!'));
+        request.response.complete();
+    }
+
+    async computeModifiedState(content: string, changeNumber: number): Promise<string> {
+        // Add a comment at the beginning to show the change
+        const changeComment = `// Modified by Original State Test Agent - Change ${changeNumber}\n`;
+
+        if (content.length < 50) {
+            return changeComment + content + `\n// Addition from change ${changeNumber}`;
+        }
+
+        // Insert the change comment at the beginning and add some content
+        return changeComment + content + `\n// This line was added by change ${changeNumber} at ${new Date().toISOString()}`;
+    }
+
+    private delay(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    protected override async getSystemMessageDescription(): Promise<SystemMessageDescription | undefined> {
+        return undefined;
+    }
+}

--- a/examples/api-samples/src/browser/chat/original-state-test-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/original-state-test-agent-contribution.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2024 EclipseSource GmbH.
+// Copyright (C) 2025 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,6 +24,7 @@ import {
 import { ChangeSetFileElementFactory } from '@theia/ai-chat/lib/browser/change-set-file-element';
 import { Agent, LanguageModelRequirement } from '@theia/ai-core';
 import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { wait } from '@theia/core/lib/common/promise-util';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 
@@ -82,7 +83,7 @@ export class OriginalStateTestAgent extends AbstractStreamParsingChatAgent {
             'Three sequential changes to an existing file with 1000ms delays between each.'
         ));
 
-        await this.delay(1000);
+        await wait(1000);
         request.session.changeSet.setTitle('Original State Test Changes');
 
         // Select an existing file for sequential modifications
@@ -108,7 +109,7 @@ export class OriginalStateTestAgent extends AbstractStreamParsingChatAgent {
         });
 
         request.session.changeSet.addElements(firstModification);
-        await this.delay(1000);
+        await wait(1000);
 
         // Second modification with originalState from previous change
         request.response.response.addContent(new MarkdownChatResponseContentImpl('\n\nCreate modification 2'));
@@ -125,7 +126,7 @@ export class OriginalStateTestAgent extends AbstractStreamParsingChatAgent {
         });
 
         request.session.changeSet.addElements(secondModification);
-        await this.delay(1000);
+        await wait(1000);
 
         // Third modification with originalState from previous change
         request.response.response.addContent(new MarkdownChatResponseContentImpl('\n\nCreate modification 3'));
@@ -148,19 +149,8 @@ export class OriginalStateTestAgent extends AbstractStreamParsingChatAgent {
     }
 
     async computeModifiedState(content: string, changeNumber: number): Promise<string> {
-        // Add a comment at the beginning to show the change
         const changeComment = `// Modified by Original State Test Agent - Change ${changeNumber}\n`;
-
-        if (content.length < 50) {
-            return changeComment + content + `\n// Addition from change ${changeNumber}`;
-        }
-
-        // Insert the change comment at the beginning and add some content
         return changeComment + content + `\n// This line was added by change ${changeNumber} at ${new Date().toISOString()}`;
-    }
-
-    private delay(ms: number): Promise<void> {
-        return new Promise(resolve => setTimeout(resolve, ms));
     }
 
     protected override async getSystemMessageDescription(): Promise<SystemMessageDescription | undefined> {

--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -141,11 +141,7 @@ export class ChangeSetFileElement implements ChangeSetElement {
     }
 
     protected async obtainOriginalContent(): Promise<void> {
-        if (this.elementProps.originalState) {
-            this._originalContent = this.elementProps.originalState;
-            return;
-        }
-        this._originalContent = await this.changeSetFileService.read(this.uri);
+        this._originalContent = this.elementProps.originalState ?? await this.changeSetFileService.read(this.uri);
         if (this._readOnlyResource) {
             this.readOnlyResource.update({ contents: this._originalContent ?? '' });
         }
@@ -189,7 +185,7 @@ export class ChangeSetFileElement implements ChangeSetElement {
             this._readOnlyResource.update({
                 autosaveable: false,
                 readOnly: true,
-                contents: this.elementProps.originalState ?? this._originalContent ?? ''
+                contents: this._originalContent ?? ''
             });
             this.toDispose.push(this._readOnlyResource);
 
@@ -257,9 +253,6 @@ export class ChangeSetFileElement implements ChangeSetElement {
     };
 
     get originalContent(): string | undefined {
-        if (this.elementProps.originalState) {
-            return this.elementProps.originalState;
-        }
         if (!this._initialized && this._initializationPromise) {
             console.warn('Accessing originalContent before initialization is complete. Consider using async methods.');
         }
@@ -271,9 +264,6 @@ export class ChangeSetFileElement implements ChangeSetElement {
      * Ensures initialization is complete before returning the content.
      */
     async getOriginalContent(): Promise<string | undefined> {
-        if (this.elementProps.originalState) {
-            return this.elementProps.originalState;
-        }
         await this.ensureInitialized();
         return this._originalContent;
     }

--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -56,8 +56,9 @@ export interface ChangeSetElementArgs extends Partial<ChangeSetElement> {
      */
     targetState?: string;
     /**
-     * The state before the change has been applied, will be derived from file system
-     * if not specified.
+     * The state before the change has been applied. If it is specified, we don't care
+     * about the state of the original file on disk but just use the specified `originalState`.
+     * If it isn't specified, we'll derived and observe the state from the file system.
      */
     originalState?: string;
     /**
@@ -155,6 +156,10 @@ export class ChangeSetFileElement implements ChangeSetElement {
     }
 
     protected listenForOriginalFileChanges(): void {
+        if (this.elementProps.originalState) {
+            // if we have an original state, we are not interested in the original file on disk but always use `originalState`
+            return;
+        }
         this.toDispose.push(this.fileService.onDidFilesChange(async event => {
             if (!event.contains(this.uri)) { return; }
             if (!this._initialized && this._initializationPromise) {


### PR DESCRIPTION
I'm working on a use case where I have an external agent that I integrate as a Theia AI agent. This external agent modifies workspaces resources directly and only notifies our Theia agent after the change, but it'll store a backup of the original in the file system, which we can obtain.

I want to use this in order to track and show file changes in a change set, so the user has a central place where they see all applied changes. Therefore, I experimented with extending the change set file element with an `originalState` that is passed from the agent, instead of being read from the file system.