### PR TITLE
fix(chat): cancel on Espace in chat input

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -313,7 +313,10 @@ export class AIChatInputWidget extends ReactWidget {
     }
 
     protected onEscape(): void {
-        // No op
+        const currentRequest = this._branch?.items?.at(-1)?.element ?? this._chatModel.getRequests().at(-1);
+        if (currentRequest && !EditableChatRequestModel.isEditing(currentRequest) && ChatRequestModel.isInProgress(currentRequest)) {
+            this._onCancel(currentRequest);
+        }
     }
 
     protected async openContextElement(request: AIVariableResolutionRequest): Promise<void> {


### PR DESCRIPTION
#### What it does

We lost the ability to cancel the current request with Escape in the chat input. With this change we restore this functionality.

#### How to test

Start a chat and push `Escape` while you are in the chat input. It should cancel the current request if one is currently in progress. If no request is in progress, it should do nothing.

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
