### PR TITLE
Improve PreferenceWidget state restoration on start and scope change

### DIFF
--- a/packages/preferences/src/browser/preference-tree-model.ts
+++ b/packages/preferences/src/browser/preference-tree-model.ts
@@ -251,7 +251,8 @@ export class PreferenceTreeModel extends TreeModelImpl {
      */
     selectIfNotSelected(node: SelectableTreeNode): boolean {
         const currentlySelected = this.selectedNodes[0];
-        if (node !== currentlySelected) {
+        if (!node.selected || node !== currentlySelected) {
+            node.selected = true;
             this.selectNode(node);
             return true;
         }

--- a/packages/preferences/src/browser/views/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/views/preference-editor-widget.ts
@@ -119,7 +119,7 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
         } else {
             unreachable(e.source, 'Not all PreferenceFilterChangeSource enum variants handled.');
         }
-        this.resetScroll(currentFirstVisible, e.source === PreferenceFilterChangeSource.Search && !isFiltered);
+        this.resetScroll(currentFirstVisible, e.source === PreferenceFilterChangeSource.Search);
     }
 
     protected handleRegistryChange(): void {
@@ -237,10 +237,12 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
         }
     }
 
-    protected doResetScroll(nodeIDToScrollTo?: string, filterWasCleared: boolean = false): void {
+    protected doResetScroll(nodeIDToScrollTo?: string, filterWasModified: boolean = false): void {
         requestAnimationFrame(() => {
             this.scrollBar?.update();
-            if (!filterWasCleared && nodeIDToScrollTo) {
+            if (filterWasModified) {
+                this.scrollContainer.scrollTop = 0;
+            } else if (nodeIDToScrollTo) {
                 const { id, collection } = this.analyzeIDAndGetRendererGroup(nodeIDToScrollTo);
                 const renderer = collection.get(id);
                 if (renderer?.visible) {
@@ -248,7 +250,7 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
                     return;
                 }
             }
-            this.scrollContainer.scrollTop = 0;
+
         });
     };
 

--- a/packages/preferences/src/browser/views/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/views/preference-editor-widget.ts
@@ -112,8 +112,10 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
             this.handleSearchChange(isFiltered, leavesAreVisible);
         } else if (e.source === PreferenceFilterChangeSource.Scope) {
             this.handleScopeChange(isFiltered);
+            this.showInTree(currentFirstVisible);
         } else if (e.source === PreferenceFilterChangeSource.Schema) {
             this.handleSchemaChange(isFiltered);
+            this.showInTree(currentFirstVisible);
         } else {
             unreachable(e.source, 'Not all PreferenceFilterChangeSource enum variants handled.');
         }
@@ -281,26 +283,30 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
         if (id && id !== this.firstVisibleChildID) {
             this.firstVisibleChildID = id;
             if (!this.shouldUpdateModelSelection) { return; }
-            let currentNode = this.model.getNode(id);
-            let expansionAncestor;
-            let selectionAncestor;
-            while (currentNode && (!expansionAncestor || !selectionAncestor)) {
-                if (!selectionAncestor && SelectableTreeNode.is(currentNode)) {
-                    selectionAncestor = currentNode;
-                }
-                if (!expansionAncestor && ExpandableTreeNode.is(currentNode)) {
-                    expansionAncestor = currentNode;
-                }
-                currentNode = currentNode.parent;
+            this.showInTree(id);
+        }
+    }
+
+    protected showInTree(id: string): void {
+        let currentNode = this.model.getNode(id);
+        let expansionAncestor;
+        let selectionAncestor;
+        while (currentNode && (!expansionAncestor || !selectionAncestor)) {
+            if (!selectionAncestor && SelectableTreeNode.is(currentNode)) {
+                selectionAncestor = currentNode;
             }
-            if (selectionAncestor) {
-                this.currentModelSelectionId = selectionAncestor.id;
-                expansionAncestor = expansionAncestor ?? selectionAncestor;
-                this.model.selectIfNotSelected(selectionAncestor);
-                if (!this.model.isFiltered && id !== this.lastUserSelection) {
-                    this.lastUserSelection = '';
-                    this.model.collapseAllExcept(expansionAncestor);
-                }
+            if (!expansionAncestor && ExpandableTreeNode.is(currentNode)) {
+                expansionAncestor = currentNode;
+            }
+            currentNode = currentNode.parent;
+        }
+        if (selectionAncestor) {
+            this.currentModelSelectionId = selectionAncestor.id;
+            expansionAncestor = expansionAncestor ?? selectionAncestor;
+            this.model.selectIfNotSelected(selectionAncestor);
+            if (!this.model.isFiltered && id !== this.lastUserSelection) {
+                this.lastUserSelection = '';
+                this.model.collapseAllExcept(expansionAncestor);
             }
         }
     }

--- a/packages/preferences/src/browser/views/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/views/preference-editor-widget.ts
@@ -242,7 +242,7 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
                 const { id, collection } = this.analyzeIDAndGetRendererGroup(nodeIDToScrollTo);
                 const renderer = collection.get(id);
                 if (renderer?.visible) {
-                    this.scrollContainer.scrollTo(0, renderer.node.offsetHeight);
+                    this.scrollContainer.scrollTo(0, renderer.node.offsetTop);
                     return;
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #15915 and improves state restoration on start.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Scroll to somewhere in the middle of the preferences.
2. Switch scopes (e.g. user <--> workspace)
3. You should remain scrolled to the same preference, or the top if the preference to which you were scrolled is not available in the new scope.
4. Restart the application.
5. The preferences view should scroll to the same area, and the tree on the left should reflect the preference shown.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
