### PR TITLE
Fix default locale issue

### DIFF
--- a/packages/core/src/browser/preload/i18n-preload-contribution.ts
+++ b/packages/core/src/browser/preload/i18n-preload-contribution.ts
@@ -43,7 +43,7 @@ export class I18nPreloadContribution implements PreloadContribution {
             const localization = await this.localizationServer.loadLocalization(locale);
             if (localization.languagePack) {
                 nls.localization = localization;
-            } else {
+            } else if (locale !== nls.defaultLocale) {
                 // In case the localization that we've loaded doesn't localize Theia completely (languagePack is false)
                 // We simply reset the locale to the default again
                 Object.assign(nls, {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/13283

Ensures that we don't actually reset the locale if the user has selected `en` as their locale. This led to unexpected behavior in case the Theia app developer set their default locale to something other than `en`.

#### How to test

Follow the steps in https://github.com/eclipse-theia/theia/issues/13283. Ensure that you can seamlessly switch between the languages.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
