### PR TITLE
Reduce formatter selection prompts for changeset elements

### DIFF
--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -349,8 +349,15 @@ export class ChangeSetFileElement implements ChangeSetElement {
         let tempModel: IReference<MonacoEditorModel> | undefined;
         try {
             // Create a temporary model to apply code actions
-            const tempUri = new URI(`untitled://changeset/${Date.now()}${this.uri.path.ext}`);
-            tempResource = this.inMemoryResources.add(tempUri, { contents: this.targetState });
+            const tempUri = URI.fromComponents({
+                scheme: 'untitled',
+                path: this.uri.path.toString(),
+                authority: `changeset-${this.elementProps.chatSessionId}`,
+                query: '',
+                fragment: ''
+            });
+            tempResource = this.getInMemoryUri(tempUri);
+            tempResource.update({ contents: this.targetState });
             tempModel = await this.monacoTextModelService.createModelReference(tempUri);
             tempModel.object.suppressOpenEditorWhenDirty = true;
             tempModel.object.textEditorModel.setValue(this.targetState);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes a bug where changeset elements would request user selection of a formatter where a normal file wouldn't. This was a consequence of the use of a nonce path, which interfered with preference lookup. This PR switches to use the path of the original file so that its configured formatter is looked up as though it were the original file.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Install multiple formatters (e.g. install the Prettier plugin)
2. In a workspace with a configured formatter.
3. Request a change to a file that should be formatted by the configured formatter.
4. Observe that the configured formatter is used, and no selection is requested.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
