### PR TITLE
Update colors for  editor gutter

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -2638,11 +2638,21 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             {
                 id: 'editorGutter.commentRangeForeground',
                 defaults: {
-                    dark: '#c5c5c5',
-                    light: '#c5c5c5',
+                    dark: '#37373d',
+                    light: '#d5d8e9',
                     hcDark: Color.white,
-                    hcLight: Color.white
+                    hcLight: Color.black
                 }, description: 'Editor gutter decoration color for commenting ranges.'
+            },
+            {
+                id: 'editorGutter.itemGlyphForeground',
+                defaults: {
+                    dark: 'editor.foreground',
+                    light: 'editor.foreground',
+                    hcDark: Color.black,
+                    hcLight: Color.white,
+                },
+                description: 'Editor gutter decoration color for gutter item glyphs.'
             },
             {
                 id: 'breadcrumb.foreground',

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -290,3 +290,7 @@
 .monaco-editor .overlay-button.theia-mod-disabled {
   display: none;
 }
+
+.monaco-diff-editor .gutter .action-item .action-label {
+  color: var(--theia-editorGutter-itemGlyphForeground);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #16015 by updating the styles for `editorGutter.commentRangeForeground` to match their VSCode values and introducing `editorGutter.itemGlyphForeground` in anticipation of pulling in Monaco with https://github.com/microsoft/vscode/pull/240906 .

#### How to test

1. Open a diff with gutter items.
2. Check their display in various themes: (dark, light, HC dark and HC light below)

<img width="66" height="42" alt="image" src="https://github.com/user-attachments/assets/63f1152d-ac10-4e39-b5bb-2904fefb0346" />

<img width="41" height="47" alt="image" src="https://github.com/user-attachments/assets/208c58fd-0355-419e-97ea-0b31452e9042" />

<img width="62" height="35" alt="image" src="https://github.com/user-attachments/assets/2746fd92-ad3c-4cf1-b9b5-86ddb5255c59" />

<img width="34" height="37" alt="image" src="https://github.com/user-attachments/assets/a9d38c40-3ab3-46c3-92b8-056eadc66f65" />


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
