### PR TITLE
chore: unify tool call result handling

### DIFF
--- a/packages/ai-chat/src/browser/delegation-response-content.ts
+++ b/packages/ai-chat/src/browser/delegation-response-content.ts
@@ -23,8 +23,6 @@ import { ChatRequestInvocation, ChatResponseContent } from '../common';
 export class DelegationResponseContent implements ChatResponseContent {
     kind = 'AgentDelegation';
 
-    responseText: string | undefined;
-
     /**
      * @param agentId The id of the agent to whom the task was delegated
      * @param prompt The prompt that was delegated
@@ -34,24 +32,11 @@ export class DelegationResponseContent implements ChatResponseContent {
         public agentId: string,
         public prompt: string,
         public response: ChatRequestInvocation
-    ) {
-        this.handleResponseComplete();
-    }
+    ) { }
 
-    // Wait for the response to be complete, then extract the response
-    // text (for use in asString()).
-    async handleResponseComplete(): Promise<void> {
-        const completeResponse = await this.response.responseCompleted;
-        this.responseText = completeResponse.response.asString();
-    }
-
-    asString(): string {
-        const json = {
-            agentId: this.agentId,
-            prompt: this.prompt,
-            response: this.responseText ?? ''
-        };
-        return JSON.stringify(json);
+    asString(): string | undefined {
+        // The delegation and response is already part of a tool call and therefore does not need to be repeated
+        return undefined;
     }
 }
 


### PR DESCRIPTION


#### What it does

Adapts the Anthropic LanguageModel to not throw away tool call results in subsequent requests.

Adapts the DelegationContent to not be included in LLM messages as its content is now consistently available via the corresponding ToolCallContent.

Resolves #16105

#### How to test

##### Message Retention

- Select an Anthropic Model for `Universal`
- Instruct it to read a file and mention the file content tool call:
  ```
  @Universal  ~getFileContent  What is the name defined in the root package.json file
  ```
- In a subsequent request, ask about the file again without mentioning the tool call
  ```
  What dependencies are declared in the file
  ```

The Anthropic Model should be able to properly answer these questions. Without this PR it will hallucinate.

##### Delegation Use Case

- Trigger a model delegation, e.g.
  ```
  @Universal Delegate to "Architect" agent to check the root package.json file ~delegateToAgent  
  ```
- Send a follow up request, e.g. "hi"
- Check the AI history view for the request and observe that the delegation is only contained once within a tool call request / response pair of messages.


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
