### PR TITLE
Fix text misalignment caused by inline breakpoint decoration

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -279,10 +279,10 @@
   position: absolute;
 }
 
-.monaco-editor .theia-debug-breakpoint-column::before {
-  height: 0.9em;
+.monaco-editor .theia-debug-breakpoint-column {
   display: inline-flex;
   vertical-align: middle;
+  margin-top: -1px;
 }
 
 .monaco-editor .theia-debug-top-stack-frame-column::before {


### PR DESCRIPTION
#### What it does

Fixes #16158.

#### How to test

Use the steps from #16158 to verify that the issue is now fixed.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
