### PR TITLE
fix(leak) status bar registry leaked memory on item updates

### DIFF
--- a/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
@@ -70,11 +70,12 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
             args
         };
 
+        const isNewEntry = this.entries.has(id) === undefined;
         this.entries.set(id, entry);
         await this.delegate.setElement(id, entry);
         if (this.toDispose.disposed) {
             this.$dispose(id);
-        } else {
+        } else if (isNewEntry) {
             this.toDispose.push(Disposable.create(() => this.$dispose(id)));
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

resolves #16167

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

One can setInterval in a vscode plugin to update a status bar item.
Number of disposables should not grow in method `async $setMessage`

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
