### PR TITLE
fix: remove excessive spacing in breakpoint list

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -71,6 +71,10 @@
   border-radius: 2px;
 }
 
+.theia-source-breakpoint > .theia-input {
+  min-height: auto;
+}
+
 .theia-debug-session .status,
 .theia-debug-thread .status {
   text-transform: uppercase;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes a minor regression introduced in #15953, where the updated `min-height` on the `theia-input` class caused breakpoint list entries to have unnecessary vertical spacing

As reference, this is the current styling before this fix:
<img width="487" height="189" alt="image" src="https://github.com/user-attachments/assets/e2b4ab91-3276-4c6b-8056-8e951a1c6ee1" />


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open the Debug view.
2. Add multiple breakpoints in an editor.
3. Observe the list of breakpoints ensure that the spacing between entries is compact and consistent, without excessive vertical padding.
4. Check for possible regressions regarding spacing in the other debug sub views.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
