### PR TITLE
fix error in previous PR

### DIFF
--- a/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
@@ -70,7 +70,7 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
             args
         };
 
-        const isNewEntry = this.entries.has(id) === undefined;
+        const isNewEntry = !this.entries.has(id);
         this.entries.set(id, entry);
         await this.delegate.setElement(id, entry);
         if (this.toDispose.disposed) {


### PR DESCRIPTION
#### What it does

In previous PR https://github.com/eclipse-theia/theia/pull/16168
I made a mistake of comparing .has() with undefined, when it returns `boolean`.
It does prevent a leak that we have, but introduces a new "bug" that status-bar-items can stay in memory after "disposal"

This PR fixes that new error

#### How to test

Adding a new item to status bar should create a new disposable.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
