### PR TITLE
Fix: correctly handle plugin-icons during menu creation and use tooltip

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.tsx
@@ -97,11 +97,11 @@ abstract class AbstractToolbarMenuWrapper {
     protected renderMenuItem(widget: Widget): React.ReactNode {
         const icon = this.icon || 'ellipsis';
         const contextMatcher: ContextMatcher = this.contextKeyService;
+        const className = `${icon} ${ACTION_ITEM}`;
         if (CompoundMenuNode.is(this.menuNode) && !this.menuNode.isEmpty(this.effectiveMenuPath, this.contextKeyService, widget.node)) {
-
             return <div key={this.id} className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled menu'}>
-                <div className={codicon(icon, true)}
-                    title={this.text}
+                <div className={className}
+                    title={this.tooltip || this.text}
                     onClick={e => this.executeCommand(e)}
                 />
                 <div className={ACTION_ITEM} onClick={event => this.showPopupMenu(widget, this.menuPath!, event, contextMatcher)} >
@@ -110,8 +110,8 @@ abstract class AbstractToolbarMenuWrapper {
             </div>;
         } else {
             return <div key={this.id} className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled menu'}>
-                <div className={codicon(icon, true)}
-                    title={this.text}
+                <div className={className}
+                    title={this.tooltip || this.text}
                     onClick={e => this.executeCommand(e)}
                 />
             </div>;

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -22,7 +22,7 @@ import { MenuModelRegistry } from '@theia/core/lib/common';
 import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { DeployedPlugin, IconUrl, Menu } from '../../../common';
 import { ScmWidget } from '@theia/scm/lib/browser/scm-widget';
-import { KeybindingRegistry, QuickCommandService } from '@theia/core/lib/browser';
+import { KeybindingRegistry, QuickCommandService, codicon } from '@theia/core/lib/browser';
 import {
     CodeEditorWidgetUtil, codeToTheiaMappings, ContributionPoint,
     PLUGIN_EDITOR_TITLE_MENU, PLUGIN_EDITOR_TITLE_RUN_MENU, PLUGIN_SCM_TITLE_MENU, PLUGIN_VIEW_TITLE_MENU
@@ -54,7 +54,7 @@ export class MenusContributionPointHandler {
         this.tabBarToolbar.registerItem({
             id: this.tabBarToolbar.toElementId(PLUGIN_EDITOR_TITLE_RUN_MENU),
             menuPath: PLUGIN_EDITOR_TITLE_RUN_MENU,
-            icon: 'debug-alt',
+            icon: codicon('debug-alt'),
             text: nls.localizeByDefault('Run or Debug...'),
             command: '',
             group: 'navigation',


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #15884

All icon classes were send through the `codicon` function which lead to classNames for which no css rule existed thus breaking plugin contributed icons. Also tooltip is used for instead of text to provide the title for menus.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Install a vscode extension that contributes an icon to a toolbar menu, eg Git Graph.
On main there is an empty space in the SCM View Toolbar which you can click. With the fix the Icon is shown again.
If you use the GitLens extension you will see that toolbar items now have a tooltip if you hover over them. The broken case is shown in the bug report.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
