### PR TITLE
Fix: Replace links in StatusBarItems which provide Markdown with SafeCommands

### DIFF
--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -26,6 +26,7 @@ import { StatusBar, StatusBarEntry, StatusBarAlignment, StatusBarViewEntry } fro
 import { StatusBarViewModel } from './status-bar-view-model';
 import { HoverService } from '../hover-service';
 import { codicon } from '../widgets';
+import { MarkdownString } from '../../common/markdown-rendering';
 export { StatusBar, StatusBarAlignment, StatusBarEntry };
 
 @injectable()
@@ -122,7 +123,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
             content: entry.tooltip!,
             target: e.currentTarget,
             position: 'top',
-            interactive: entry.tooltip instanceof HTMLElement,
+            interactive: entry.tooltip instanceof HTMLElement || MarkdownString.is(entry.tooltip),
         });
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -333,7 +333,7 @@ export function createAPIFactory(
     const notebookRenderers = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_RENDERERS_EXT, new NotebookRenderersExtImpl(rpc, notebooksExt));
     const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry, webviewExt, workspaceExt));
     const notebookDocuments = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_EXT, new NotebookDocumentsExtImpl(notebooksExt));
-    const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
+    const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc, commandRegistry);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
     const outputChannelRegistryExt = rpc.set(MAIN_RPC_CONTEXT.OUTPUT_CHANNEL_REGISTRY_EXT, new OutputChannelRegistryExtImpl(rpc));
     const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry));

--- a/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
+++ b/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
@@ -20,6 +20,7 @@ import {
 } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { StatusBarItemImpl } from './status-bar/status-bar-item';
+import { CommandRegistryImpl } from './command-registry';
 
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -32,7 +33,7 @@ export class StatusBarMessageRegistryExt {
 
     protected readonly statusMessage: StatusBarMessage;
 
-    constructor(rpc: RPCProtocol) {
+    constructor(rpc: RPCProtocol, readonly commandRegistry: CommandRegistryImpl) {
         this.proxy = rpc.getProxy(Ext.STATUS_BAR_MESSAGE_REGISTRY_MAIN);
         this.statusMessage = new StatusBarMessage(this);
     }
@@ -58,7 +59,7 @@ export class StatusBarMessageRegistryExt {
     }
 
     createStatusBarItem(alignment?: StatusBarAlignment, priority?: number, id?: string): StatusBarItem {
-        return new StatusBarItemImpl(this.proxy, alignment, priority, id);
+        return new StatusBarItemImpl(this.proxy, this.commandRegistry, alignment, priority, id);
     }
 
 }

--- a/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts
+++ b/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts
@@ -17,6 +17,9 @@ import * as theia from '@theia/plugin';
 import { ThemeColor, StatusBarAlignment } from '../types-impl';
 import { StatusBarMessageRegistryMain } from '../../common/plugin-api-rpc';
 import { UUID } from '@theia/core/shared/@lumino/coreutils';
+import { CommandRegistryImpl } from '../command-registry';
+import { MarkdownString } from '../markdown-string';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
 
 export class StatusBarItemImpl implements theia.StatusBarItem {
 
@@ -45,6 +48,7 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
     _proxy: StatusBarMessageRegistryMain;
 
     constructor(_proxy: StatusBarMessageRegistryMain,
+        private readonly commandRegistry: CommandRegistryImpl,
         alignment: StatusBarAlignment = StatusBarAlignment.Left,
         priority: number = 0,
         id = StatusBarItemImpl.nextId()) {
@@ -105,6 +109,60 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
     }
 
     public set tooltip(tooltip: string | theia.MarkdownString | undefined) {
+        if (tooltip && MarkdownString.isMarkdownString(tooltip)) {
+            const markdownTooltip = tooltip;
+            const content = markdownTooltip.value;
+            // Find all command links in the markdown content
+            const regex = /\[([^\]]+)\]\(command:([^?\s\)]+)(?:\?([^\s\)]+))?([^\)]*)\)/g;
+            let match;
+            let updatedContent = content;
+
+            while ((match = regex.exec(content)) !== null) {
+                const linkText = match[1];
+                const commandId = match[2];
+                const argsEncoded = match[3]; // This captures the encoded arguments
+                const tooltipPart = match[4] || ''; // This captures any tooltip or additional content after the command and args
+
+                // Parse arguments if present
+                let args: unknown[] = [];
+                if (argsEncoded) {
+                    try {
+                        const decoded = decodeURIComponent(argsEncoded);
+                        args = JSON.parse(decoded);
+                    } catch (e) {
+                        // If parsing fails, continue with empty args
+                        console.error('Failed to parse command arguments:', e);
+                    }
+                }
+
+                // Convert command to safe command using linkText as title and parsed arguments
+                const safeCommand = this.commandRegistry.converter.toSafeCommand(
+                    {
+                        command: commandId,
+                        title: linkText,
+                        arguments: Array.isArray(args) ? args : [args]
+                    },
+                    new DisposableCollection()
+                );
+
+                if (safeCommand?.id) {
+                    // Construct new arguments string from the safe command
+                    let newArgsPart = '';
+                    if (safeCommand.arguments && safeCommand.arguments.length > 0) {
+                        newArgsPart = `?${encodeURIComponent(JSON.stringify(safeCommand.arguments))}`;
+                    }
+
+                    const argsPart = argsEncoded ? `?${argsEncoded}` : '';
+                    const originalLink = `[${linkText}](command:${commandId}${argsPart}${tooltipPart})`;
+                    const safeLink = `[${linkText}](command:${safeCommand.id}${newArgsPart}${tooltipPart})`;
+                    updatedContent = updatedContent.replace(originalLink, safeLink);
+                }
+            }
+
+            if (updatedContent !== content) {
+                markdownTooltip.value = updatedContent;
+            }
+        }
         this._tooltip = tooltip;
         this.update();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #16164

- StatusBar now sets tooltips that provide a MarkdownString also as interactive
- StatusBar Items coming from a plugin contribution use SafeCommand for the rpc boundary

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Follow the steps in the original Bug and see that many of the links now work.
Eg the cogwheel or the connect integration.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

Many of the actions in that Tooltip try to call: `workbench.action.openWalkthrough`
This command is defined as follows in vscode:
```
workbench.action.openWalkthrough - Open the walkthrough.

walkthroughID - ID of the walkthrough to open.
toSide - Opens the walkthrough in a new editor group to the side.
```

In Theia the command is missing.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
