### PR TITLE
Fix line breakpoints not shifting if lines are inserted above

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -246,8 +246,8 @@ export class DebugEditorModel implements Disposable {
     }
     protected createBreakpointDecoration(breakpoint: SourceBreakpoint): monaco.editor.IModelDeltaDecoration {
         const lineNumber = breakpoint.raw.line;
-        const column = breakpoint.raw.column;
-        const range = typeof column === 'number' ? new monaco.Range(lineNumber, column, lineNumber, column + 1) : new monaco.Range(lineNumber, 1, lineNumber, 2);
+        const column = breakpoint.raw.column || this.editor.getControl().getModel()?.getLineFirstNonWhitespaceColumn(lineNumber) || 1;
+        const range = new monaco.Range(lineNumber, column, lineNumber, column + 1);
         return {
             range,
             options: {


### PR DESCRIPTION
#### What it does

Fixes #16177.

#### How to test

1. Set a line breakpoint on a line that starts with some whitespace.
2. Insert a new line from the start of that line.
3. Observe that the breakpoint now shifts correctly to maintain its position relative to the code.

This is the minimal steps to verify that the issue is fixed. To verify that no regressions have been introduced, try setting line and inline breakpoints around a source file and editing it in a way affecting the breakpoint positions.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
