### PR TITLE
Collapse prompt fragment list 1st level by default

### DIFF
--- a/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
@@ -139,7 +139,8 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
         }
 
         if (existingExpandedPromptVariantIds.size === 0) {
-            this.expandedPromptVariantSetIds = new Set(Array.from(this.promptVariantsMap.keys()));
+            // Start with variant sets collapsed by default
+            this.expandedPromptVariantSetIds = new Set();
         } else {
             // Keep existing expansion state but remove entries for prompt variant sets that no longer exist
             this.expandedPromptVariantSetIds = new Set(


### PR DESCRIPTION
fixed #16131

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Collapse the 1st level of the prompt fragment view (see #16131 ). "nd level is not collapsed as the user otherwise might miss the information that a fragment is overidden.

fixed #16131 

#### How to test

Open the prompt fragment view and see that the first level is collapsed by default.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
