### PR TITLE
Store/Restore navigation locations without warning.

### DIFF
--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -276,9 +276,7 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
     }
 
     protected async storeState(): Promise<void> {
-        this.storageService.setData(EditorNavigationContribution.ID, {
-            locations: this.locationStack.locations().map(NavigationLocation.toObject)
-        });
+        this.storageService.setData(EditorNavigationContribution.ID, this.locationStack.storeState());
         this.storageService.setData(EditorNavigationContribution.CLOSED_EDITORS_KEY, {
             closedEditors: this.shouldStoreClosedEditors() ? this.locationStack.closedEditorsStack.map(RecentlyClosedEditor.toObject) : []
         });
@@ -290,19 +288,9 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
     }
 
     protected async restoreNavigationLocations(): Promise<void> {
-        const raw: { locations?: ArrayLike<object> } | undefined = await this.storageService.getData(EditorNavigationContribution.ID);
-        if (raw && raw.locations) {
-            const locations: NavigationLocation[] = [];
-            for (let i = 0; i < raw.locations.length; i++) {
-                const location = NavigationLocation.fromObject(raw.locations[i]);
-                if (location) {
-                    locations.push(location);
-                } else {
-                    this.logger.warn('Could not restore the state of the editor navigation history.');
-                    return;
-                }
-            }
-            this.locationStack.register(...locations);
+        const raw = await this.storageService.getData(EditorNavigationContribution.ID);
+        if (raw && typeof raw === 'object') {
+            this.locationStack.restoreState(raw);
         }
     }
 

--- a/packages/editor/src/browser/navigation/navigation-location-service.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.ts
@@ -342,4 +342,27 @@ ${this.stack.map((location, i) => `${i}: ${JSON.stringify(NavigationLocation.toO
         this.recentlyClosedEditors = this.recentlyClosedEditors.filter(e => !uri.isEqual(e.uri));
     }
 
+    storeState(): object {
+        const result = {
+            locations: this.stack.map(NavigationLocation.toObject)
+        };
+
+        return result;
+    }
+
+    restoreState(rawState: object): void {
+        const state = rawState as {
+            locations: object[]
+        };
+        this.stack = [];
+        for (let i = 0; i < state.locations.length; i++) {
+            const location = NavigationLocation.fromObject(state.locations[i]);
+            if (location) {
+                this.stack.push(location);
+            } else {
+                this.logger.warn(`Could not restore the state of the editor navigation history for ${JSON.stringify(state.locations[i])}`);
+            }
+        }
+        this.pointer = this.stack.length - 1;
+    }
 }


### PR DESCRIPTION
Fixes #16205

#### What it does
Moves state (re-)store to the navigation location service.

#### How to test
Make sure navigation locations are restored properly after restart and that there are not warnings at startup as mentioned in the issues

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
Contributed on behalf of STMicroelectronics
<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
