### PR TITLE
Add `Run to Cursor` and `Run to Line` commands

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -1324,7 +1324,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             if (thread.stopped && thread === this.manager.currentThread) {
                 return true;
             }
-            console.warn('Cannot run to the given location. The current thread has changed or is not stopped.');
+            console.warn('Cannot run to the specified location. The current thread has changed or is not stopped.');
             return false;
         };
         if (!checkThread()) {
@@ -1346,7 +1346,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             }
             if (!sessionBreakpoint || !sessionBreakpoint.installed || !sessionBreakpoint.verified) {
                 this.messageService.warn(nls.localize('theia/debug/cannotRunToThisLocation',
-                    'Cannot run the current thread to the given location. Stopping the current thread would not be possible at the given location.'
+                    'Could not run the current thread to the specified location.'
                 ));
                 return;
             }
@@ -1354,7 +1354,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             if (rawBreakpoint.line !== line || (column && rawBreakpoint.column !== column)) {
                 const shouldRun = await new ConfirmDialog({
                     title: nls.localize('theia/debug/confirmRunToShiftedPosition_title',
-                        'Cannot run the current thread to exactly the given location'),
+                        'Cannot run the current thread to exactly the specified location'),
                     msg: nls.localize('theia/debug/confirmRunToShiftedPosition_msg',
                         'The target position will be shifted to Ln {0}, Col {1}. Run anyway?', rawBreakpoint.line, rawBreakpoint.column || 1),
                     ok: Dialog.YES,


### PR DESCRIPTION
#### What it does

Closes #14698, #3424.

This PR adds the `Run to Cursor` and `Run to Line` commands, which continue execution of the current thread to the current cursor position and to the current line, respectively. Both commands can be accessed through the command palette and the editor's context menu. The `Run to Line` command can also be accessed through the editor's line number context menu. The commands are visible and enabled while the current thread is paused and there is the current text editor.

#### How to test

Use the [attached project](https://github.com/user-attachments/files/21990353/hello.zip), which contains files `hello.js` and `hi.js`, and a configuration for launching `hello.js` as a Node.JS program.

1. Set a breakpoint on line 1 in `hello.js` and launch the program.

2. After the breakpoint is hit, open the editor's line number context menu on line 5 and choose `Run to Line`.

   The program will sleep in a loop for 5s before stopping at line 5. This 5s delay can be used to verify that the `Run to Line` command did set a temporary breakpoint on line 5. This delay can also be used to verify that the temporary breakpoint is removed when the current session is paused or stopped (e.g. explicitly by the user) even before the temporary breakpoint is hit. Also, this delay can be used to verify that neither `Run to Line` nor `Run to Cursor` commands are available while the current thread is running.

3. After the program stops at line 5, verify that the temporary breakpoint has been removed. Open the editor's context menu at the very end of line 5 and choose `Run to Cursor`. Verify that a dialog is opened informing the user that the target position will need to be shifted to Ln 8, Col 5 and asking the user to confirm running to the shifted position. Click the `No` button in the dialog and verify that the temporary breakpoint set at 8:5 has been removed.

4. Open the editor's context menu at line 5, column 9 and choose `Run to Cursor`. The current thread should run to the current cursor position and the temporary breakpoint set at 5:9 should be removed once it is hit.

5. Open the `hi.js` file, which is not part of the launched program. Open the editor's context menu on line 1 and choose `Run to Line`. Verify that a temporary breakpoint has been set on line 1, but it is disabled (i.e. not verified). After about 2s, the temporary breakpoint should be removed and a warning message should appear informing the user that the command could not be executed successfully, because stopping the current thread would not be possible at the given location.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
