### PR TITLE
16098: cancel tool execution confirm dialogs when request is cancelled

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -22,7 +22,7 @@ import { ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 /**
  * States the tool confirmation component can be in
  */
-export type ToolConfirmationState = 'waiting' | 'allowed' | 'denied';
+export type ToolConfirmationState = 'waiting' | 'allowed' | 'denied' | 'rejected';
 
 export interface ToolConfirmationProps {
     response: ToolCallChatResponseContent;

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -145,6 +145,24 @@ interface ToolCallContentProps {
  */
 const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmationMode, toolConfirmationManager, chatId, responseRenderer, renderCollapsibleArguments }) => {
     const [confirmationState, setConfirmationState] = React.useState<ToolConfirmationState>('waiting');
+    const [rejectionReason, setRejectionReason] = React.useState<unknown>(undefined);
+
+    const formatReason = (reason: unknown): string => {
+        if (!reason) {
+            return '';
+        }
+        if (reason instanceof Error) {
+            return reason.message;
+        }
+        if (typeof reason === 'string') {
+            return reason;
+        }
+        try {
+            return JSON.stringify(reason);
+        } catch (e) {
+            return String(reason);
+        }
+    };
 
     React.useEffect(() => {
         if (confirmationMode === ToolConfirmationMode.ALWAYS_ALLOW) {
@@ -156,17 +174,17 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
             setConfirmationState('denied');
             return;
         }
-        response.confirmed.then(
-            confirmed => {
+        response.confirmed
+            .then(confirmed => {
                 if (confirmed === true) {
                     setConfirmationState('allowed');
                 } else {
                     setConfirmationState('denied');
                 }
-            }
-        )
-            .catch(() => {
-                setConfirmationState('denied');
+            })
+            .catch(reason => {
+                setRejectionReason(reason);
+                setConfirmationState('rejected');
             });
     }, [response, confirmationMode]);
 
@@ -188,9 +206,16 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({ response, confirmatio
         response.deny();
     }, [response, toolConfirmationManager, chatId]);
 
+    const reasonText = formatReason(rejectionReason);
+
     return (
         <div className='theia-toolCall'>
-            {confirmationState === 'denied' ? (
+            {confirmationState === 'rejected' ? (
+                <span className='theia-toolCall-rejected'>
+                    <span className={codicon('error')}></span> {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/rejected', 'Execution canceled')}: {response.name}
+                    {reasonText ? <span> — {reasonText}</span> : undefined}
+                </span>
+            ) : confirmationState === 'denied' ? (
                 <span className='theia-toolCall-denied'>
                     <span className={codicon('error')}></span> {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/denied', 'Execution denied')}: {response.name}
                 </span>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Cancel pending tool usage confirmation requests when chat request is canceled

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Enable tool usage confirmation in the AI Configuration view ("Tools" tab)
- Ask Coder to make changes to your workspace (e.g. `@Coder Suggest changes in #_f`)
- Once the "Confirm Tool Execution" dialog shows up, cancel the chat request
- Expected result: the "Confirm Tool Execution" dialog is closed, and shows: `Execution canceled: getFileContent — Chat request canceled`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
