### PR TITLE
fix: add argument processor for plugin toolbar command arguments

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-ext-argument-processor.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-argument-processor.ts
@@ -1,0 +1,39 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Widget } from '@theia/core/lib/browser';
+import { injectable } from '@theia/core/shared/inversify';
+import { ArgumentProcessor } from '../../common/commands';
+
+/**
+ * This processor handles arguments passed to commands that are contributed by plugins and available as toolbar items.
+ *
+ * When a toolbar item executes a command, it often passes the active widget as an argument. This can lead to
+ * serialization problems. To solve this issue, this processor checks if an argument is a Widget instance and if so, it extracts
+ * and returns only the widget's ID, which can be safely serialized and used to identify the widget in the plugin host.
+ */
+@injectable()
+export class PluginExtToolbarItemArgumentProcessor implements ArgumentProcessor {
+
+    processArgument(arg: unknown): unknown {
+        if (arg instanceof Widget) {
+            return arg.id;
+        }
+
+        return arg;
+    }
+
+}

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -91,6 +91,7 @@ import { WebviewSecondaryWindowSupport } from './webview/webview-secondary-windo
 import { CustomEditorUndoRedoHandler } from './custom-editors/custom-editor-undo-redo-handler';
 import { bindWebviewPreferences } from '../common/webview-preferences';
 import { WebviewFrontendPreferenceContribution } from './webview/webview-frontend-preference-contribution';
+import { PluginExtToolbarItemArgumentProcessor } from './plugin-ext-argument-processor';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
@@ -289,5 +290,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         createCellOutputWebviewContainer(ctx.container).get(CellOutputWebviewImpl)
     );
     bindContributionProvider(bind, ArgumentProcessorContribution);
+
+    bind(PluginExtToolbarItemArgumentProcessor).toSelf().inSingletonScope();
+    bind(ArgumentProcessorContribution).toService(PluginExtToolbarItemArgumentProcessor);
 
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

If commands are triggered from plugin-contributed toolbar items (main or widget toolbars) and the widget is passed as an argument, process the argument and return only the widget ID. This prevents serialization errors and allows the command to execute properly.

This not only fixes custom toolbar items that add extension-contributed commands, it also fixes widget toolbar actions in extension views (if a corresponding handler is registered).

Part of GH-15932
Resolves GH-16223

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Add custom toolbar item to the main toolbar and select a command contributed by an extension (e.g. from GitLens or cSpell). This should be correctly executed now (if the handler is available though). Previously, this was not executed and a ` Error during encoding: 'Maximum call stack size exceeded'` was printed to console.
2. Test a few widget toolbar actions contributed by GitLens for example:
   - File annotations in an editor:
     <img width="371" height="184" alt="image" src="https://github.com/user-attachments/assets/9981a6c3-dfd6-4e56-bd2e-1d4086de1896" />
   - Commit Graph Settings in the GitLens graph view:
     <img width="411" height="124" alt="image" src="https://github.com/user-attachments/assets/7e610613-28fa-4761-bb02-be31a38ff08d" />
   - GitLens actions in the native Theia SCM View
     <img width="620" height="154" alt="image" src="https://github.com/user-attachments/assets/c51524db-6ce0-43f7-87e0-b6856852352d" />


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
