### PR TITLE
[debug] Show the error message when setting a variable fails

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -66,6 +66,17 @@ export function debugStateContextValue(state: DebugState): string {
     }
 }
 
+const formatMessageRegexp = /\{([^}]+)\}/g;
+
+/**
+ * Returns a formatted message string. The format is compatible with {@link DebugProtocol.Message.format}.
+ * @param format A format string for the message. Embedded variables have the form `{name}`.
+ * @param variables An object used as a dictionary for looking up the variables in the format string.
+ */
+export function formatMessage(format: string, variables?: { [key: string]: string; }): string {
+    return variables ? format.replace(formatMessageRegexp, (match, group) => variables.hasOwnProperty(group) ? variables[group] : match) : format;
+}
+
 // FIXME: make injectable to allow easily inject services
 export class DebugSession implements CompositeTreeElement {
     protected readonly deferredOnDidConfigureCapabilities = new Deferred<void>();


### PR DESCRIPTION
#### What it does

Fixes #13728.

#### How to test

Using a simple Node.JS program:

```js
let a = 1;
console.log(a);
```

1. Set a breakpoint on line 2 and launch the program.

2. Double-click on the local `a` variable in the `Debug` view.

3. Try entering an invalid value for the variable like `@` or `foo` and press the `OK` button in the dialog.

4. Verify that the `OK` button becomes disabled and the appropriate error message is shown to the user in the dialog.

5. Enter a correct value for the variable, e.g. `123` and press `OK`.

6. Verify that the value has been correctly applied to the variable by the debugger.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
