### PR TITLE
Fix missing new file entries from vscode extensions

### DIFF
--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { MenuPath } from '@theia/core';
-import { SHELL_TABBAR_CONTEXT_MENU } from '@theia/core/lib/browser';
+import { CommonMenus, SHELL_TABBAR_CONTEXT_MENU } from '@theia/core/lib/browser';
 import { Navigatable } from '@theia/core/lib/browser/navigatable';
 import { URI as CodeUri } from '@theia/core/shared/vscode-uri';
 import { DebugStackFramesWidget } from '@theia/debug/lib/browser/view/debug-stack-frames-widget';
@@ -88,6 +88,7 @@ export const codeToTheiaMappings = new Map<string, MenuPath[]>([
     ['editor/title/run', [PLUGIN_EDITOR_TITLE_RUN_MENU]],
     ['editor/lineNumber/context', [EDITOR_LINENUMBER_CONTEXT_MENU]],
     ['explorer/context', [NAVIGATOR_CONTEXT_MENU]],
+    ['file/newFile', [CommonMenus.FILE_NEW_CONTRIBUTIONS]],
     ['scm/change/title', [PLUGIN_SCM_CHANGE_TITLE_MENU]],
     ['scm/resourceFolder/context', [ScmTreeWidget.RESOURCE_FOLDER_CONTEXT_MENU]],
     ['scm/resourceGroup/context', [ScmTreeWidget.RESOURCE_GROUP_CONTEXT_MENU]],


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

In the "File -> New File" quick select, no file types contributed by vscode extensions are listed.

This PR fixes this.

Fixes: #16240

#### How to test

* Install Python extension
* Open File-> New File...
* Check, "New Python File" is listed

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
