### PR TITLE
Don't accept/cancel breakpoint editor while its suggest widget is visible

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -1211,7 +1211,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         keybindings.registerKeybinding({
             command: DebugBreakpointWidgetCommands.CLOSE.id,
             keybinding: 'esc',
-            when: 'isBreakpointWidgetVisible || (breakpointWidgetFocus && !suggestWidgetVisible')
+            when: 'isBreakpointWidgetVisible || (breakpointWidgetFocus && !suggestWidgetVisible)'
         });
     }
 


### PR DESCRIPTION
#### What it does

Fixes #16284.

#### How to test

Verify that pressing 'Enter' or 'Escape' while the breakpoint editor's suggest widget is visible will now close the suggest widget (with accepting or ignoring the selected proposal respectively) instead of closing the breakpoint widget.

See #16284 for detailed steps.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
