### PR TITLE
Add `Evaluate in Debug Console` command

### DIFF
--- a/packages/console/src/browser/console-widget.ts
+++ b/packages/console/src/browser/console-widget.ts
@@ -227,9 +227,11 @@ export class ConsoleWidget extends BaseWidget implements StatefulWidget {
         }
     }
 
-    async execute(): Promise<void> {
-        const value = this._input.getControl().getValue();
-        this._input.getControl().setValue('');
+    async execute(value?: string): Promise<void> {
+        if (value === undefined) {
+            value = this._input.getControl().getValue();
+            this._input.getControl().setValue('');
+        }
         this.history.push(value);
         if (this.session) {
             const listener = this.content.model.onNodeRefreshed(() => {

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -259,6 +259,11 @@ export namespace DebugCommands {
         id: 'editor.debug.action.showDebugHover',
         label: 'Debug: Show Hover'
     });
+    export const EVALUATE_IN_DEBUG_CONSOLE = Command.toDefaultLocalizedCommand({
+        id: 'editor.debug.action.selectionToRepl',
+        category: DEBUG_CATEGORY,
+        label: 'Evaluate in Debug Console'
+    });
     export const JUMP_TO_CURSOR = Command.toDefaultLocalizedCommand({
         id: 'editor.debug.action.jumpToCursor',
         category: DEBUG_CATEGORY,
@@ -660,6 +665,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
         const DEBUG_EDITOR_CONTEXT_MENU_GROUP = [...EDITOR_CONTEXT_MENU, '2_debug'];
         registerMenuActions(DEBUG_EDITOR_CONTEXT_MENU_GROUP,
+            DebugCommands.EVALUATE_IN_DEBUG_CONSOLE,
             DebugCommands.JUMP_TO_CURSOR,
             DebugCommands.RUN_TO_CURSOR,
             DebugCommands.RUN_TO_LINE
@@ -913,6 +919,21 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         registry.registerCommand(DebugCommands.SHOW_HOVER, {
             execute: () => this.editors.showHover(),
             isEnabled: () => this.editors.canShowHover()
+        });
+
+        registry.registerCommand(DebugCommands.EVALUATE_IN_DEBUG_CONSOLE, {
+            execute: async () => {
+                const { model } = this.editors;
+                if (model) {
+                    const { editor } = model;
+                    const { selection, document } = editor;
+                    const value = document.getText(selection) || document.getLineContent(selection.start.line + 1).trim();
+                    const consoleWidget = await this.console.openView({ reveal: true, activate: false });
+                    await consoleWidget.execute(value);
+                }
+            },
+            isEnabled: () => !!this.editors.model && !!this.manager.currentFrame,
+            isVisible: () => !!this.editors.model && !!this.manager.currentFrame
         });
 
         registry.registerCommand(DebugCommands.JUMP_TO_CURSOR, {


### PR DESCRIPTION
#### What it does

Closes #10281.

#### How to test

Suspend execution of a launched program (e.g. at a breakpoint), select an expression in the source editor you'd like to evaluate against the current stack frame, right-click on the selection and choose `Evaluate in Debug Console`. (If the selection is empty, it will evaluate the current line's trimmed content, just as in VS Code.)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
