### PR TITLE
chore: add sbom generation and upload workflow

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -1,0 +1,77 @@
+name: Generate NPM SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version"
+        default: "master"
+        required: true
+
+env:
+  NODE_VERSION: "20.x"
+  REGISTRY_URL: "https://registry.npmjs.org"
+  PRODUCT_PATH: "./"
+  CDXGEN_VERSION: "11.7.0"
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-22.04
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
+    permissions:
+      packages: read
+
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}"
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version: $VERSION"
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.version.outputs.PROJECT_VERSION }}
+
+      - name: Setup Node SDK
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: ${{ env.REGISTRY_URL }}
+
+      - name: Install dependencies
+        run: |
+          npm ci
+
+      - name: Install cdxgen
+        run: |
+          npm install -g @cyclonedx/cdxgen@${{ env.CDXGEN_VERSION }}
+
+      - name: Generate SBOM
+        run: |
+          cdxgen -r -o ${{ env.PRODUCT_PATH }}bom.json
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: sbom
+          path: ${{ env.PRODUCT_PATH }}/bom.json
+
+  store-sbom-data: # stores sbom and metadata in a predefined format for otterdog to pick up
+    needs: ["generate-sbom"]
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: "theia"
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: "sbom"
+      bomFilename: "bom.json"
+      parentProject: "2b55dbe6-7a7e-4659-a803-babf4138e03f"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Read below how to engage with Theia community:
   - [Code Organization](doc/code-organization.md)
   - [Plugin and VSCode API](doc/Plugin-API.md)
 
+## SBOM
+
+To enhance supply chain security and offer users clear insight into project  components, Eclipse Theia now generates a Software Bill of Materials (SBOM) for every release. These are published to the Eclipse Foundation SBOM registry, with access instructions and usage details available in this [documentation](https://eclipse-csi.github.io/security-handbook/sbom/registry.html).
+
 ## License
 
 - [Eclipse Public License 2.0](LICENSE-EPL)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This PR aims to bootstrap the EF Security Team initiative of supporting projects in implementing automated SBOM generation and upload workflows, with the goal of enhancing software supply chain security.

We wanted this to seamlessly integrate with your existing release processes, so we implemented 1 workflow meant to generate an SBOM for the `theia` product (npm packages).

Currently the workflow is triggered by new releases being published. A polyglot tool (`cdxgen`) is used to generate the SBOM, which is then uploaded as an artifact. The `store-sbom-data` reusable workflow stores additional metadata about the project and upon completion, the self service system downloads the SBOM from artifacts and uploads it to our DependencyTrack [instance](https://sbom.eclipse.org/), under the `Eclipse Theia/theia` entry. After a successful workflow run, to view the uploaded results, you can log into the instance by using your EF account credentials.

We have tested the SBOM generation separately and everything worked successfully. However, due to limited permissions, inability to simulate the trigger event and possibly incomplete knowledge of your release processes, if the changes get merged, we'd ask if you could manually run it once so we can confirm the upload to our instance works as expected (the latest release tag value can be used).

For any inconsistencies or potential integration issues with existing release processes that we might have missed, please feel free to update the workflow as needed, edits by maintainers are enabled. Additionally, if maintaining multiple parallel branches for releases, a version of the workflow should run on them as well.

More details about our SBOM Early Adopters initiative at EF can be found in our [Security Handbook](https://eclipse-csi.github.io/security-handbook/sbom/index.html), alongside documentation on what is an SBOM, what are they used for, tooling ecosystem and our upload integration. Previous successful early adopters workflow examples are listed in the table at [SBOM Early Adopters](https://eclipse-csi.github.io/security-handbook/sbom/earlyadopters.html). Additionally, more information about our DependencyTrack instance can be found at [SBOM Registry](https://eclipse-csi.github.io/security-handbook/sbom/registry.html).

Please let us know if you have any questions we can help with.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
SBOMs will be generated when a new Github Release is created. In order to test, there's the option to do a manual run of the workflow. For input, the value of the latest release tag can be used, together with the default branch. Allow a couple of minutes after completion for otterdog to pick up the SBOM. Afterwards, it should appear on our DependencyTrack instance. Instructions on how to log into it can be found in our [Security Handbook/SBOM Registry](https://eclipse-csi.github.io/security-handbook/sbom/registry.html).
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
Extending this initiative to other Eclipse Theia outputs/products would be great to improve supply chain security and visibility over potentially vulnerable dependencies.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes (to the extent permissions and context allow) and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
