### PR TITLE
Fix ffmpeg cache write promise

### DIFF
--- a/dev-packages/ffmpeg/src/replace-ffmpeg.ts
+++ b/dev-packages/ffmpeg/src/replace-ffmpeg.ts
@@ -59,10 +59,10 @@ export async function replaceFfmpeg(options: ffmpeg.FfmpegOptions = {}): Promise
         }
         // Extract file to cache.
         await fs.mkdirp(path.dirname(ffmpegCachedPath));
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             file.stream()
                 .pipe(fs.createWriteStream(ffmpegCachedPath))
-                .on('finish', () => resolve)
+                .on('finish', resolve)
                 .on('error', reject);
         });
         console.warn(`Downloaded ffmpeg shared library { version: "${electronVersion}", dist: "${electronDist}" }.`);


### PR DESCRIPTION
#### What it does

* type temporary promise as `Promise<void>`
* call resolve instead of returning the function

#### How to test

We tried building a next version of the Theia IDE and noticed that `theia build` for electron did nothing on a first run. It only generated the webpack files and ran webpack on a second invocation.
There were no errors logged and exit codes were 0.

Inspecting the code, the only way this seems possible was during the ffmpeg step.
We did a change here for [https://github.com/eclipse-theia/theia/pull/16218](https://github.com/eclipse-theia/theia/pull/16218) that I think led to the promise not being resolved anymore. This PR should fix it.
See [https://github.com/eclipse-theia/theia/pull/16218/files#diff-8aac47e5ace0cd21356bedd9afbb2448b6f9b101f1371eb1c25fd38783f1d0b5](https://github.com/eclipse-theia/theia/pull/16218/files#diff-8aac47e5ace0cd21356bedd9afbb2448b6f9b101f1371eb1c25fd38783f1d0b5) for the initial change.

I don't know a good way to test this locally.


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
