### PR TITLE
Localize property tooltips for `tasks.json`

### DIFF
--- a/packages/core/src/browser/json-schema-store.ts
+++ b/packages/core/src/browser/json-schema-store.ts
@@ -127,10 +127,15 @@ export class JsonSchemaDataStore {
 
 @injectable()
 export class DefaultJsonSchemaContribution implements JsonSchemaContribution {
+
+    private static excludedSchemaUrls = [
+        'https://www.schemastore.org/task.json'
+    ];
+
     async registerSchemas(context: JsonSchemaRegisterContext): Promise<void> {
         const catalog = require('./catalog.json') as { schemas: DefaultJsonSchemaContribution.SchemaData[] };
         for (const s of catalog.schemas) {
-            if (s.fileMatch) {
+            if (s.fileMatch && this.shouldRegisterSchema(s)) {
                 context.registerSchema({
                     fileMatch: s.fileMatch,
                     url: s.url
@@ -139,6 +144,9 @@ export class DefaultJsonSchemaContribution implements JsonSchemaContribution {
         }
     }
 
+    protected shouldRegisterSchema(s: DefaultJsonSchemaContribution.SchemaData): boolean {
+        return !DefaultJsonSchemaContribution.excludedSchemaUrls.includes(s.url);
+    }
 }
 export namespace DefaultJsonSchemaContribution {
     export interface SchemaData {

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -24,7 +24,7 @@ import * as Ajv from '@theia/core/shared/ajv';
 import debounce = require('p-debounce');
 import { postConstruct, injectable, inject } from '@theia/core/shared/inversify';
 import { JsonSchemaContribution, JsonSchemaDataStore, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
-import { deepClone, Emitter } from '@theia/core/lib/common';
+import { deepClone, Emitter, nls } from '@theia/core/lib/common';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import { inputsSchema } from '@theia/variable-resolver/lib/browser/variable-input-schema';
 import URI from '@theia/core/lib/common/uri';
@@ -160,7 +160,7 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
                 ...defaultTaskType,
                 enum: [def.taskType],
                 default: def.taskType,
-                description: 'The task type to customize'
+                description: nls.localizeByDefault('The task type to customize')
             };
             customizedDetectedTask.properties!.type = taskType;
             const required = def.properties.required || [];
@@ -189,13 +189,15 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
             properties: {
                 version: {
                     type: 'string',
-                    default: '2.0.0'
+                    default: '2.0.0',
+                    description: nls.localizeByDefault("The config's version number.")
                 },
                 tasks: {
                     type: 'array',
                     items: {
                         ...deepClone(taskConfigurationSchema)
-                    }
+                    },
+                    description: nls.localizeByDefault('The task configurations. Usually these are enrichments of task already defined in the external task runner.')
                 },
                 inputs: inputsSchema.definitions!.inputs
             },
@@ -221,12 +223,12 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
 
 const commandSchema: IJSONSchema = {
     type: 'string',
-    description: 'The actual command or script to execute'
+    description: nls.localizeByDefault('The command to be executed. Can be an external program or a shell command.')
 };
 
 const commandArgSchema: IJSONSchema = {
     type: 'array',
-    description: 'A list of strings, each one being one argument to pass to the command',
+    description: nls.localizeByDefault('Arguments passed to the command when this task is invoked.'),
     items: {
         type: 'string'
     }
@@ -234,29 +236,29 @@ const commandArgSchema: IJSONSchema = {
 
 const commandOptionsSchema: IJSONSchema = {
     type: 'object',
-    description: 'The command options used when the command is executed',
+    description: nls.localizeByDefault('Additional command options'),
     properties: {
         cwd: {
             type: 'string',
-            description: 'The directory in which the command will be executed',
+            description: nls.localize('theia/task/schema/commandOptions/cwd',
+                "The current working directory of the executed program or script. If omitted Theia's current workspace root is used."),
             default: '${workspaceFolder}'
         },
         env: {
             type: 'object',
-            description: 'The environment of the executed program or shell. If omitted the parent process\' environment is used'
+            description: nls.localizeByDefault("The environment of the executed program or shell. If omitted the parent process' environment is used.")
         },
         shell: {
             type: 'object',
-            description: 'Configuration of the shell when task type is `shell`',
+            description: nls.localizeByDefault('Configures the shell to be used.'),
             properties: {
                 executable: {
                     type: 'string',
-                    description: 'The shell to use'
+                    description: nls.localizeByDefault('The shell to be used.')
                 },
                 args: {
                     type: 'array',
-                    description: `The arguments to be passed to the shell executable to run in command mode
-                        (e.g ['-c'] for bash or ['/S', '/C'] for cmd.exe)`,
+                    description: nls.localizeByDefault('The shell arguments.'),
                     items: {
                         type: 'string'
                     }
@@ -271,13 +273,13 @@ const defaultTaskTypes = ['shell', 'process'];
 const supportedTaskTypes = [...defaultTaskTypes];
 const taskLabel: IJSONSchema = {
     type: 'string',
-    description: 'A unique string that identifies the task that is also used as task\'s user interface label'
+    description: nls.localizeByDefault("The task's user interface label")
 };
 const defaultTaskType: IJSONSchema = {
     type: 'string',
     enum: supportedTaskTypes,
     default: defaultTaskTypes[0],
-    description: 'Determines what type of process will be used to execute the task. Only shell types will have output shown on the user interface'
+    description: nls.localizeByDefault('Defines whether the task is run as a process or as a command inside a shell.')
 } as const;
 const commandAndArgs = {
     command: commandSchema,
@@ -291,9 +293,9 @@ const group: IJSONSchema = {
             type: 'string',
             enum: ['build', 'test', 'none'],
             enumDescriptions: [
-                'Marks the task as a build task accessible through the \'Run Build Task\' command.',
-                'Marks the task as a test task accessible through the \'Run Test Task\' command.',
-                'Assigns the task to no group'
+                nls.localizeByDefault("Marks the task as a build task accessible through the 'Run Build Task' command."),
+                nls.localizeByDefault("Marks the task as a test task accessible through the 'Run Test Task' command."),
+                nls.localizeByDefault('Assigns the task to no group')
             ]
         },
         {
@@ -302,24 +304,24 @@ const group: IJSONSchema = {
                 kind: {
                     type: 'string',
                     default: 'none',
-                    description: 'The task\'s execution group.',
+                    description: nls.localizeByDefault("The task's execution group."),
                     enum: ['build', 'test', 'none'],
                     enumDescriptions: [
-                        'Marks the task as a build task accessible through the \'Run Build Task\' command.',
-                        'Marks the task as a test task accessible through the \'Run Test Task\' command.',
-                        'Assigns the task to no group'
+                        nls.localizeByDefault("Marks the task as a build task accessible through the 'Run Build Task' command."),
+                        nls.localizeByDefault("Marks the task as a test task accessible through the 'Run Test Task' command."),
+                        nls.localizeByDefault('Assigns the task to no group')
                     ]
                 },
                 isDefault: {
                     type: 'boolean',
                     default: false,
-                    description: 'Defines if this task is the default task in the group.'
+                    description: nls.localizeByDefault('Defines if this task is the default task in the group, or a glob to match the file which should trigger this task.')
                 }
             }
         }
     ],
-    // eslint-disable-next-line max-len
-    description: 'Defines to which execution group this task belongs to. It supports "build" to add it to the build group and "test" to add it to the test group.'
+    description: nls.localizeByDefault(
+        'Defines to which execution group this task belongs to. It supports "build" to add it to the build group and "test" to add it to the test group.')
 };
 
 const problemPattern: IJSONSchema = {
@@ -333,53 +335,53 @@ const problemPattern: IJSONSchema = {
     properties: {
         regexp: {
             type: 'string',
-            description: 'The regular expression to find an error, warning or info in the output.'
+            description: nls.localizeByDefault('The regular expression to find an error, warning or info in the output.')
         },
         kind: {
             type: 'string',
-            description: 'whether the pattern matches a location (file and line) or only a file.'
+            description: nls.localizeByDefault('whether the pattern matches a location (file and line) or only a file.')
         },
         file: {
             type: 'integer',
-            description: 'The match group index of the filename. If omitted 1 is used.'
+            description: nls.localizeByDefault('The match group index of the filename. If omitted 1 is used.')
         },
         location: {
             type: 'integer',
             // eslint-disable-next-line max-len
-            description: 'The match group index of the problem\'s location. Valid location patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn). If omitted (line,column) is assumed.'
+            description: nls.localizeByDefault("The match group index of the problem's location. Valid location patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn). If omitted (line,column) is assumed.")
         },
         line: {
             type: 'integer',
-            description: 'The match group index of the problem\'s line. Defaults to 2'
+            description: nls.localizeByDefault("The match group index of the problem's line. Defaults to 2")
         },
         column: {
             type: 'integer',
-            description: 'The match group index of the problem\'s line character. Defaults to 3'
+            description: nls.localizeByDefault("The match group index of the problem's line character. Defaults to 3")
         },
         endLine: {
             type: 'integer',
-            description: 'The match group index of the problem\'s end line. Defaults to undefined'
+            description: nls.localizeByDefault("The match group index of the problem's end line. Defaults to undefined")
         },
         endColumn: {
             type: 'integer',
-            description: 'The match group index of the problem\'s end line character. Defaults to undefined'
+            description: nls.localizeByDefault("The match group index of the problem's end line character. Defaults to undefined")
         },
         severity: {
             type: 'integer',
-            description: 'The match group index of the problem\'s severity. Defaults to undefined'
+            description: nls.localizeByDefault("The match group index of the problem's severity. Defaults to undefined")
         },
         code: {
             type: 'integer',
-            description: 'The match group index of the problem\'s code. Defaults to undefined'
+            description: nls.localizeByDefault("The match group index of the problem's code. Defaults to undefined")
         },
         message: {
             type: 'integer',
-            description: 'The match group index of the message. If omitted it defaults to 4 if location is specified. Otherwise it defaults to 5.'
+            description: nls.localizeByDefault('The match group index of the message. If omitted it defaults to 4 if location is specified. Otherwise it defaults to 5.')
         },
         loop: {
             type: 'boolean',
             // eslint-disable-next-line max-len
-            description: 'In a multi line matcher loop indicated whether this pattern is executed in a loop as long as it matches. Can only specified on a last pattern in a multi line pattern.'
+            description: nls.localizeByDefault('In a multi line matcher loop indicated whether this pattern is executed in a loop as long as it matches. Can only specified on a last pattern in a multi line pattern.')
         }
     }
 };
@@ -395,11 +397,11 @@ const watchingPattern: IJSONSchema = {
     properties: {
         regexp: {
             type: 'string',
-            description: 'The regular expression to detect the begin or end of a background task.'
+            description: nls.localizeByDefault('The regular expression to detect the begin or end of a background task.')
         },
         file: {
             type: 'integer',
-            description: 'The match group index of the filename. Can be omitted.'
+            description: nls.localizeByDefault('The match group index of the filename. Can be omitted.')
         },
     }
 };
@@ -408,12 +410,12 @@ const patternType: IJSONSchema = {
     anyOf: [
         {
             type: 'string',
-            description: 'The name of a contributed or predefined pattern'
+            description: nls.localizeByDefault('The name of a contributed or predefined pattern')
         },
         problemPattern,
         multiLineProblemPattern
     ],
-    description: 'A problem pattern or the name of a contributed or predefined problem pattern. Can be omitted if base is specified.'
+    description: nls.localizeByDefault('A problem pattern or the name of a contributed or predefined problem pattern. Can be omitted if base is specified.')
 };
 
 const problemMatcherObject: IJSONSchema = {
@@ -422,25 +424,26 @@ const problemMatcherObject: IJSONSchema = {
         base: {
             type: 'string',
             enum: problemMatcherNames,
-            description: 'The name of a base problem matcher to use.'
+            description: nls.localizeByDefault('The name of a base problem matcher to use.')
         },
         owner: {
             type: 'string',
-            description: 'The owner of the problem inside Code. Can be omitted if base is specified. Defaults to \'external\' if omitted and base is not specified.'
+            description: nls.localize('theia/task/schema/problemMatcherObject/owner',
+                "The owner of the problem inside Theia. Can be omitted if base is specified. Defaults to 'external' if omitted and base is not specified.")
         },
         source: {
             type: 'string',
-            description: 'A human-readable string describing the source of this diagnostic, e.g. \'typescript\' or \'super lint\'.'
+            description: nls.localizeByDefault("A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.")
         },
         severity: {
             type: 'string',
             enum: ['error', 'warning', 'info'],
-            description: 'The default severity for captures problems. Is used if the pattern doesn\'t define a match group for severity.'
+            description: nls.localizeByDefault("The default severity for captures problems. Is used if the pattern doesn't define a match group for severity.")
         },
         applyTo: {
             type: 'string',
             enum: ['allDocuments', 'openDocuments', 'closedDocuments'],
-            description: 'Controls if a problem reported on a text document is applied only to open, closed or all documents.'
+            description: nls.localizeByDefault('Controls if a problem reported on a text document is applied only to open, closed or all documents.')
         },
         pattern: patternType,
         fileLocation: {
@@ -456,16 +459,18 @@ const problemMatcherObject: IJSONSchema = {
                     }
                 }
             ],
-            description: 'Defines how file names reported in a problem pattern should be interpreted.'
+            // eslint-disable-next-line max-len
+            description: nls.localizeByDefault('Defines how file names reported in a problem pattern should be interpreted. A relative fileLocation may be an array, where the second element of the array is the path of the relative file location. The search fileLocation mode, performs a deep (and, possibly, heavy) file system search within the directories specified by the include/exclude properties of the second element (or the current workspace directory if not specified).')
         },
         background: {
             type: 'object',
             additionalProperties: false,
-            description: 'Patterns to track the begin and end of a matcher active on a background task.',
+            description: nls.localizeByDefault('Patterns to track the begin and end of a matcher active on a background task.'),
             properties: {
                 activeOnStart: {
                     type: 'boolean',
-                    description: 'If set to true the background monitor is in active mode when the task starts. This is equals of issuing a line that matches the beginsPattern'
+                    description: nls.localizeByDefault(
+                        'If set to true the background monitor starts in active mode. This is the same as outputting a line that matches beginsPattern when the task starts.')
                 },
                 beginsPattern: {
                     oneOf: [
@@ -474,7 +479,7 @@ const problemMatcherObject: IJSONSchema = {
                         },
                         watchingPattern
                     ],
-                    description: 'If matched in the output the start of a background task is signaled.'
+                    description: nls.localizeByDefault('If matched in the output the start of a background task is signaled.')
                 },
                 endsPattern: {
                     oneOf: [
@@ -483,19 +488,20 @@ const problemMatcherObject: IJSONSchema = {
                         },
                         watchingPattern
                     ],
-                    description: 'If matched in the output the end of a background task is signaled.'
+                    description: nls.localizeByDefault('If matched in the output the end of a background task is signaled.')
                 }
             }
         },
         watching: {
             type: 'object',
             additionalProperties: false,
-            deprecationMessage: 'The watching property is deprecated. Use background instead.',
-            description: 'Patterns to track the begin and end of a watching matcher.',
+            deprecationMessage: nls.localizeByDefault('The watching property is deprecated. Use background instead.'),
+            description: nls.localizeByDefault('Patterns to track the begin and end of a watching matcher.'),
             properties: {
                 activeOnStart: {
                     type: 'boolean',
-                    description: 'If set to true the watcher is in active mode when the task starts. This is equals of issuing a line that matches the beginPattern'
+                    description: nls.localizeByDefault(
+                        'If set to true the watcher starts in active mode. This is the same as outputting a line that matches beginsPattern when the task starts.')
                 },
                 beginsPattern: {
                     oneOf: [
@@ -504,7 +510,7 @@ const problemMatcherObject: IJSONSchema = {
                         },
                         watchingPattern
                     ],
-                    description: 'If matched in the output the start of a watching task is signaled.'
+                    description: nls.localizeByDefault('If matched in the output the start of a watching task is signaled.')
                 },
                 endsPattern: {
                     oneOf: [
@@ -513,7 +519,7 @@ const problemMatcherObject: IJSONSchema = {
                         },
                         watchingPattern
                     ],
-                    description: 'If matched in the output the end of a watching task is signaled.'
+                    description: nls.localizeByDefault('If matched in the output the end of a watching task is signaled.')
                 }
             }
         }
@@ -524,12 +530,10 @@ const problemMatcher: IJSONSchema = {
     anyOf: [
         {
             type: 'string',
-            description: 'Name of the problem matcher to parse the output of the task',
             enum: problemMatcherNames
         },
         {
             type: 'array',
-            description: 'Name(s) of the problem matcher(s) to parse the output of the task',
             items: {
                 type: 'string',
                 enum: problemMatcherNames
@@ -538,10 +542,10 @@ const problemMatcher: IJSONSchema = {
         problemMatcherObject,
         {
             type: 'array',
-            description: 'User defined problem matcher(s) to parse the output of the task',
             items: problemMatcherObject
         }
-    ]
+    ],
+    description: nls.localizeByDefault('The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.')
 };
 
 const presentation: IJSONSchema = {
@@ -554,58 +558,59 @@ const presentation: IJSONSchema = {
         showReuseMessage: true,
         clear: false
     },
-    description: 'Configures the panel that is used to present the task\'s output and reads its input.',
+    description: nls.localizeByDefault("Configures the panel that is used to present the task's output and reads its input."),
     additionalProperties: true,
     properties: {
         echo: {
             type: 'boolean',
             default: true,
-            description: 'Controls whether the executed command is echoed to the panel. Default is true.'
+            description: nls.localizeByDefault('Controls whether the executed command is echoed to the panel. Default is true.')
         },
         focus: {
             type: 'boolean',
             default: false,
-            description: 'Controls whether the panel takes focus. Default is false. If set to true the panel is revealed as well.'
+            description: nls.localizeByDefault('Controls whether the panel takes focus. Default is false. If set to true the panel is revealed as well.')
         },
         reveal: {
             type: 'string',
             enum: ['always', 'silent', 'never'],
             enumDescriptions: [
-                'Always reveals the terminal when this task is executed.',
-                'Only reveals the terminal if the task exits with an error or the problem matcher finds an error.',
-                'Never reveals the terminal when this task is executed.'
+                nls.localizeByDefault('Always reveals the terminal when this task is executed.'),
+                nls.localizeByDefault('Only reveals the terminal if the task exits with an error or the problem matcher finds an error.'),
+                nls.localizeByDefault('Never reveals the terminal when this task is executed.')
             ],
             default: 'always',
-            description: 'Controls whether the terminal running the task is revealed or not. May be overridden by option \"revealProblems\". Default is \"always\".'
+            description: nls.localizeByDefault(
+                'Controls whether the terminal running the task is revealed or not. May be overridden by option "revealProblems". Default is "always".')
         },
         panel: {
             type: 'string',
             enum: ['shared', 'dedicated', 'new'],
             enumDescriptions: [
-                'The terminal is shared and the output of other task runs are added to the same terminal.',
+                nls.localize('theia/task/schema/presentation/panel/shared', 'The terminal is shared and the output of other task runs are added to the same terminal.'),
                 // eslint-disable-next-line max-len
-                'The terminal is dedicated to a specific task. If that task is executed again, the terminal is reused. However, the output of a different task is presented in a different terminal.',
-                'Every execution of that task is using a new clean terminal.'
+                nls.localize('theia/task/schema/presentation/panel/dedicated', 'The terminal is dedicated to a specific task. If that task is executed again, the terminal is reused. However, the output of a different task is presented in a different terminal.'),
+                nls.localize('theia/task/schema/presentation/panel/new', 'Every execution of that task is using a new clean terminal.')
             ],
             default: 'shared',
-            description: 'Controls if the panel is shared between tasks, dedicated to this task or a new one is created on every run.'
+            description: nls.localizeByDefault('Controls if the panel is shared between tasks, dedicated to this task or a new one is created on every run.')
         },
         showReuseMessage: {
             type: 'boolean',
             default: true,
-            description: 'Controls whether to show the "Terminal will be reused by tasks" message.'
+            description: nls.localize('theia/task/schema/presentation/showReuseMessage', 'Controls whether to show the "Terminal will be reused by tasks" message.')
         },
         clear: {
             type: 'boolean',
             default: false,
-            description: 'Controls whether the terminal is cleared before this task is run.'
+            description: nls.localizeByDefault('Controls whether the terminal is cleared before executing the task.')
         }
     }
 };
 
 const detail: IJSONSchema = {
     type: 'string',
-    description: 'An optional description of a task that shows in the Run Task quick pick as a detail.'
+    description: nls.localizeByDefault('An optional description of a task that shows in the Run Task quick pick as a detail.')
 };
 
 const taskIdentifier: IJSONSchema = {
@@ -614,7 +619,7 @@ const taskIdentifier: IJSONSchema = {
     properties: {
         type: {
             type: 'string',
-            description: 'The task identifier.'
+            description: nls.localizeByDefault('The task identifier.')
         }
     }
 };
@@ -629,18 +634,18 @@ const processTaskConfigurationSchema: IJSONSchema = {
         isBackground: {
             type: 'boolean',
             default: false,
-            description: 'Whether the executed task is kept alive and is running in the background.'
+            description: nls.localizeByDefault('Whether the executed task is kept alive and is running in the background.')
         },
         dependsOn: {
             anyOf: [
                 {
                     type: 'string',
-                    description: 'Another task this task depends on.'
+                    description: nls.localizeByDefault('Another task this task depends on.')
                 },
                 taskIdentifier,
                 {
                     type: 'array',
-                    description: 'The other tasks this task depends on.',
+                    description: nls.localizeByDefault('The other tasks this task depends on.'),
                     items: {
                         anyOf: [
                             {
@@ -651,31 +656,31 @@ const processTaskConfigurationSchema: IJSONSchema = {
                     }
                 }
             ],
-            description: 'Either a string representing another task or an array of other tasks that this task depends on.'
+            description: nls.localizeByDefault('Either a string representing another task or an array of other tasks that this task depends on.')
         },
         dependsOrder: {
             type: 'string',
             enum: ['parallel', 'sequence'],
             enumDescriptions: [
-                'Run all dependsOn tasks in parallel.',
-                'Run all dependsOn tasks in sequence.'
+                nls.localizeByDefault('Run all dependsOn tasks in parallel.'),
+                nls.localizeByDefault('Run all dependsOn tasks in sequence.')
             ],
             default: 'parallel',
-            description: 'Determines the order of the dependsOn tasks for this task. Note that this property is not recursive.'
+            description: nls.localizeByDefault('Determines the order of the dependsOn tasks for this task. Note that this property is not recursive.')
         },
         windows: {
             type: 'object',
-            description: 'Windows specific command configuration that overrides the command, args, and options',
+            description: nls.localizeByDefault('Windows specific command configuration'),
             properties: commandAndArgs
         },
         osx: {
             type: 'object',
-            description: 'MacOS specific command configuration that overrides the command, args, and options',
+            description: nls.localizeByDefault('Mac specific command configuration'),
             properties: commandAndArgs
         },
         linux: {
             type: 'object',
-            description: 'Linux specific command configuration that overrides the default command, args, and options',
+            description: nls.localizeByDefault('Linux specific command configuration'),
             properties: commandAndArgs
         },
         group,


### PR DESCRIPTION
#### What it does

Fixes #16296.

#### How to test

Using the steps to reproduce given in #16296, verify that property tooltips for `tasks.json` are now localized and aligned with VS Code.

For example, use the following `tasks.json` that includes most of the properties:

```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "echo",
            "type": "shell",
            "command": "echo Hello",
            "args": [],
            "isBackground": true,
            "dependsOn": "",
            "dependsOrder": "parallel",
            "windows": {},
            "osx": {},
            "linux": {},
            "options": {
                "cwd": "",
                "env": {},
                "shell": {
                    "executable": "",
                    "args": []
                }
            },
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "problemMatcher": [{
                "base": "",
                "owner": "",
                "source": "",
                "severity": "error",
                "applyTo": "allDocuments",
                "pattern": [
                    {
                        "regexp": "^([^\\\\s].*)\\\\((\\\\d+,\\\\d+)\\\\):\\\\s*(.*)$",
                        "file": 1,
                        "location": 2,
                        "message": 3
                    }
                ],
                "fileLocation": "absolute",
                "background": {
                    "activeOnStart": true,
                    "beginsPattern": {
                        "file": 0,
                        "regexp": ""
                    },
                    "endsPattern": {
                        "file": 0,
                        "regexp": ""
                    }
                },
            }],
            "presentation": {
                "echo": true,
                "reveal": "always",
                "focus": false,
                "panel": "shared",
                "showReuseMessage": true,
                "clear": false
            },
            "detail": ""
        }
    ]
}
```

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
