### PR TITLE
fix React warning for duplicate createRoot calls on singleton ReactDi…

### DIFF
--- a/packages/core/src/browser/dialogs/react-dialog.tsx
+++ b/packages/core/src/browser/dialogs/react-dialog.tsx
@@ -42,6 +42,7 @@ export abstract class ReactDialog<T> extends AbstractDialog<T> {
         super.onUpdateRequest(msg);
         if (!this.isMounted) {
             this.contentNodeRoot = createRoot(this.contentNode);
+            this.isMounted = true;
         }
         this.contentNodeRoot?.render(<>{this.render()}</>);
     }


### PR DESCRIPTION
…alogs

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This PR fixes an issue where singleton ReactDialog components would trigger React warnings about duplicate createRoot() calls after being closed and reopened.
The isMounted flag was only set to true in the constructor.When a singleton dialog was closed, isMounted was set to false via the disposable cleanup.On subsequent openings (onUpdateRequest), the check if (!this.isMounted) would always be true because the flag was never reset.This caused createRoot() to be called again on the same DOM container (this.contentNode), violating React's rule that createRoot() should only be called once per container. This resulted in the warning: Warning: You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before....
​The Fix:​​ Added this.isMounted = true; inside the if (!this.isMounted) block within the onUpdateRequest method.

<img width="1926" height="161" alt="image" src="https://github.com/user-attachments/assets/f63437bc-c04e-4f82-bfb8-9d2fd103e2cf" />

#### How to test

ceate a singleton dialog and close and reopen it.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
