### PR TITLE
Don't show inline stackframe pointer when line is empty

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -191,7 +191,7 @@ export class DebugEditorModel implements Disposable {
                 range: columnUntilEOLRange
             });
             const firstNonWhitespaceColumn = this.editor.document.textEditorModel.getLineFirstNonWhitespaceColumn(currentFrame.raw.line);
-            if (currentFrame.raw.column > firstNonWhitespaceColumn) {
+            if (firstNonWhitespaceColumn !== 0 && currentFrame.raw.column > firstNonWhitespaceColumn) {
                 decorations.push({
                     options: DebugEditorModel.TOP_STACK_FRAME_INLINE_DECORATION,
                     range: columnUntilEOLRange


### PR DESCRIPTION
#### What it does

When during debugging the current stack frame points to a line that is empty, a second stack frame pointer is displayed:
<img width="234" height="60" alt="image" src="https://github.com/user-attachments/assets/ed7ef165-a4f5-44ce-98b1-40cd0afee3fa" />
This fixes this issue.


#### How to test

* Create a python script with multiple lines of code
* Start debugging of the script
* Add an empty line at the current stack frame position

-> The stack frame now points to the empty line. There should not be a second inline stack frame pointer.

Note: For our use case, pointing to an empty line is a valid use case and does not occur due to the file going out of sync.

#### Attribution

Contributed on behalf of MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
