### PR TITLE
Evaluate enablement and toggle state of command only once before to show context menu.

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -342,10 +342,12 @@ export class DynamicMenuWidget extends MenuWidget {
 
                 } else if (CommandMenu.is(node)) {
                     const id = !phCommandRegistry.hasCommand(node.id) ? node.id : `${node.id}:${DynamicMenuWidget.nextCommmandId++}`;
+                    const enabled = node.isEnabled(nodePath, ...(this.args || []));
+                    const toggled = node.isToggled ? !!node.isToggled(nodePath, ...(this.args || [])) : false;
                     phCommandRegistry.addCommand(id, {
                         execute: () => { node.run(nodePath, ...(this.args || [])); },
-                        isEnabled: () => node.isEnabled(nodePath, ...(this.args || [])),
-                        isToggled: () => node.isToggled ? !!node.isToggled(nodePath, ...(this.args || [])) : false,
+                        isEnabled: () => enabled,
+                        isToggled: () => toggled,
                         isVisible: () => true,
                         label: node.label,
                         iconClass: node.icon,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR evaluate enablement and toggle state of command only once before to show it. This prevents the enablement to be checked every time the mouse hovers the menu item.

#### How to test

- Check enablement of menu items still work correctly.
- Check enablement/toggle state is only checked once via isEnabled/isToggled (add console.log or breakpoint)


#### Attribution

Contributed on behalf of Lonti.com Pty Ltd.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
