### PR TITLE
fix: do not report misleading 'invalid scope' warning for excluded preferences

### DIFF
--- a/packages/preferences/src/common/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/common/abstract-resource-preference-provider.ts
@@ -205,7 +205,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
             const oldValue = oldPrefs[prefName];
             const newValue = newPrefs[prefName];
             const schemaProperty = this.schemaProvider.getSchemaProperty(prefName);
-            if (schemaProperty) {
+            if (schemaProperty && schemaProperty.included) {
                 const scope = schemaProperty.scope;
                 // do not emit the change event if the change is made out of the defined preference scope
                 if (!this.schemaProvider.isValidInScope(prefName, this.getScope())) {


### PR DESCRIPTION
fixes eclipse-theia/theia/issues/16236

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- do no lot a warning about "invalid scopes" for preferences that are excluded (e.g. because of unsupported OS), to avoid misleading users

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- on MacOS: set `"window.titleBarStyle": "custom"` in the User Settings (Use text mode)
- on other OS: set `"window.tabCloseIconPlacement": "start"` in the User Settings (Use text mode)
- then check that this warning is **not** displayed: `WARN Preference window.titleBarStyle in user-storage:/user/settings.json can only be defined in scopes: Default, User.`

(Note: in both cases, as the property is not allowed on the specified OS, you should still see a warning in the Settings Editor, such as: `Property window.tabCloseIconPlacement is not allowed.`)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
