### PR TITLE
Fix `Add to Watch` command

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -152,6 +152,9 @@ export class DebugVariable extends ExpressionContainer {
     get name(): string {
         return this.variable.name;
     }
+    get evaluateName(): string | undefined {
+        return this.variable.evaluateName;
+    }
     protected _type: string | undefined;
     get type(): string | undefined {
         return this._type || this.variable.type;

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -1014,13 +1014,13 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         });
         registry.registerCommand(DebugCommands.WATCH_VARIABLE, {
             execute: () => {
-                const { selectedVariable, watch } = this;
-                if (selectedVariable && watch) {
-                    watch.viewModel.addWatchExpression(selectedVariable.name);
+                const evaluateName = this.selectedVariable?.evaluateName;
+                if (evaluateName) {
+                    this.watchManager.addWatchExpression(evaluateName);
                 }
             },
-            isEnabled: () => !!this.selectedVariable && !!this.watch,
-            isVisible: () => !!this.selectedVariable && !!this.watch,
+            isEnabled: () => !!this.selectedVariable?.evaluateName,
+            isVisible: () => !!this.selectedVariable?.evaluateName,
         });
 
         // Debug context menu commands


### PR DESCRIPTION
#### What it does

Currently, the `Add to Watch` command, which adds the variable selected in the Debug Variables widget to the list of watch expressions, is never visible, since it incorrectly assumes that the current widget can simultaneously be `DebugVariablesWidget` and `DebugWatchWidget`.

This PR fixes this issue and also aligns the implementation of this command with VS Code (for reference, see [variablesView.ts](https://github.com/microsoft/vscode/blob/887fc4d185b974b63f19867b5f7800263466dac0/src/vs/workbench/contrib/debug/browser/variablesView.ts#L804) in VS Code).

#### How to test

Using a simple Node.JS program:

```js
let abc = { foo: 1, bar: '' };
console.log(abc);
```

1. Set a breakpoint on line 2 and launch the program.

2. When the breakpoint is hit, right-click on the `abc` variable in the Debug Variables widget, and choose `Add to Watch`.

Verify that the command has the same behavior as in VS Code.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
