### PR TITLE
fix: preference categorization for MCP server and SCANOSS preferences

### DIFF
--- a/packages/ai-mcp/src/common/mcp-preferences.ts
+++ b/packages/ai-mcp/src/common/mcp-preferences.ts
@@ -102,41 +102,16 @@ Example configuration:\n\
                         title: nls.localize('theia/ai/mcp/servers/serverAuthTokenHeader/title', 'Authentication Header Name'),
                         markdownDescription: nls.localize('theia/ai/mcp/servers/serverAuthTokenHeader/mdDescription',
                             'The header name to use for the server authentication token. If not provided, "Authorization" with "Bearer" will be used.'),
+                    },
+                    headers: {
+                        type: 'object',
+                        title: nls.localize('theia/ai/mcp/servers/headers/title', 'Headers'),
+                        markdownDescription: nls.localize('theia/ai/mcp/servers/headers/mdDescription',
+                            'Optional additional headers included with each request to the server.'),
                     }
                 },
                 required: []
             }
-        },
-        autostart: {
-            type: 'boolean',
-            title: nls.localize('theia/ai/mcp/servers/autostart/title', 'Autostart'),
-            markdownDescription: nls.localize('theia/ai/mcp/servers/autostart/mdDescription',
-                'Automatically start this server when the frontend starts. Newly added servers are not immediately auto started, but on restart'),
-            default: true
-        },
-        serverUrl: {
-            type: 'string',
-            title: nls.localize('theia/ai/mcp/servers/serverUrl/title', 'Server URL'),
-            markdownDescription: nls.localize('theia/ai/mcp/servers/serverUrl/mdDescription',
-                'The URL of the remote MCP server. If provided, the server will connect to this URL instead of starting a local process.'),
-        },
-        serverAuthToken: {
-            type: 'string',
-            title: nls.localize('theia/ai/mcp/servers/serverAuthToken/title', 'Authentication Token'),
-            markdownDescription: nls.localize('theia/ai/mcp/servers/serverAuthToken/mdDescription',
-                'The authentication token for the server, if required. This is used to authenticate with the remote server.'),
-        },
-        serverAuthTokenHeader: {
-            type: 'string',
-            title: nls.localize('theia/ai/mcp/servers/serverAuthTokenHeader/title', 'Authentication Header Name'),
-            markdownDescription: nls.localize('theia/ai/mcp/servers/serverAuthTokenHeader/mdDescription',
-                'The header name to use for the server authentication token. If not provided, "Authorization" with "Bearer" will be used.'),
-        },
-        headers: {
-            type: 'object',
-            title: nls.localize('theia/ai/mcp/servers/headers/title', 'Headers'),
-            markdownDescription: nls.localize('theia/ai/mcp/servers/headers/mdDescription',
-                'Optional additional headers included with each request to the server.'),
         }
-    },
+    }
 };

--- a/packages/scanoss/src/common/scanoss-preferences.ts
+++ b/packages/scanoss/src/common/scanoss-preferences.ts
@@ -16,7 +16,7 @@
 
 import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
 
-export const SCAN_OSS_API_KEY_PREF = 'SCANOSS.apiKey';
+export const SCAN_OSS_API_KEY_PREF = 'ai-features.SCANOSS.apiKey';
 
 export const ScanOSSPreferencesSchema: PreferenceSchema = {
     properties: {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes GH-16338

- McpServersPreferenceSchema: remove duplicate entries and ensure headers preference is included in additionalProperties
- Update SCANOSS API key preference to be categorized under AI features.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. MCP Server Preferences
  - Verify that MCP server preferences no longer appear in the settings UI.
  - Confirm they are still correctly supported and editable in settings.json.
2. SCANOSS API Key Preference
  - Ensure the SCANOSS API key preference is now categorized under AI features in the settings UI

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
