### PR TITLE
fix: avoid trying to use watchman for file system watcher (#16335)

### DIFF
--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
@@ -24,6 +24,7 @@ import {
 import { FileChangeCollection } from '../file-change-collection';
 import { Deferred, timeout } from '@theia/core/lib/common/promise-util';
 import { subscribe, Options, AsyncSubscription, Event } from '@theia/core/shared/@parcel/watcher';
+import { isOSX, isWindows } from '@theia/core';
 
 export interface ParcelWatcherOptions {
     ignored: IMinimatch[]
@@ -108,6 +109,9 @@ export class ParcelWatcher {
      * @returns `true` if successfully started, `false` if disposed early.
      */
     readonly whenStarted: Promise<boolean>;
+
+    // copied from https://github.com/microsoft/vscode/blob/e3a5acfb517a443235981655413d566533107e92/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts#L158
+    private static readonly PARCEL_WATCHER_BACKEND = isWindows ? 'windows' : isOSX ? 'fs-events' : 'inotify';
 
     constructor(
         /** Initial reference to this handle. */
@@ -255,6 +259,7 @@ export class ParcelWatcher {
                 this.handleWatcherEvents(events);
             }
         }, {
+            backend: ParcelWatcher.PARCEL_WATCHER_BACKEND,
             ...this.parcelFileSystemWatchServerOptions.parcelOptions
         });
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Backport fix for #14890 from master to 1.64.X branch. 
This fix removes the popup window when starting theia based application on windows.

#### How to test

same as https://github.com/eclipse-theia/theia/pull/16335

#### Follow-ups

none

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
