### PR TITLE
Add support for context menu in debug hover

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -61,6 +61,7 @@ import { DebugToolBar } from './view/debug-toolbar-widget';
 import { ConsoleWidget } from '@theia/console/lib/browser/console-widget';
 import { ConsoleContentWidget } from '@theia/console/lib/browser/console-content-widget';
 import { ConsoleContextMenu } from '@theia/console/lib/browser/console-contribution';
+import { DebugHoverWidget } from './editor/debug-hover-widget';
 
 export namespace DebugMenus {
     export const DEBUG = [...MAIN_MENU_BAR, '6_debug'];
@@ -640,6 +641,13 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             DebugCommands.COPY_VARIABLE_AS_EXPRESSION
         );
         registerMenuActions(DebugVariablesWidget.WATCH_MENU,
+            DebugCommands.WATCH_VARIABLE
+        );
+        registerMenuActions(DebugHoverWidget.EDIT_MENU,
+            DebugCommands.COPY_VARIABLE_VALUE,
+            DebugCommands.COPY_VARIABLE_AS_EXPRESSION
+        );
+        registerMenuActions(DebugHoverWidget.WATCH_MENU,
             DebugCommands.WATCH_VARIABLE
         );
 
@@ -1507,7 +1515,11 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         const { currentWidget } = this.shell;
         return currentWidget instanceof DebugVariablesWidget && currentWidget || undefined;
     }
-    get variablesSource(): DebugVariablesWidget | ConsoleContentWidget | undefined {
+    get variablesSource(): DebugHoverWidget | DebugVariablesWidget | ConsoleContentWidget | undefined {
+        const hover = this.editors.model?.hover;
+        if (hover?.isVisible) {
+            return hover;
+        }
         return this.variables ?? this.consoleWidget?.content;
     }
     get selectedVariable(): DebugVariable | undefined {

--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -16,7 +16,7 @@
 
 import debounce = require('@theia/core/shared/lodash.debounce');
 
-import { ArrayUtils } from '@theia/core';
+import { ArrayUtils, MenuPath } from '@theia/core';
 import { Key } from '@theia/core/lib/browser';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
@@ -52,6 +52,7 @@ export interface HideDebugHoverOptions {
 
 export function createDebugHoverWidgetContainer(parent: interfaces.Container, editor: DebugEditor): Container {
     const child = SourceTreeWidget.createContainer(parent, {
+        contextMenuPath: DebugHoverWidget.CONTEXT_MENU,
         virtualized: false
     });
     child.bind(DebugEditor).toConstantValue(editor);
@@ -64,6 +65,10 @@ export function createDebugHoverWidgetContainer(parent: interfaces.Container, ed
 
 @injectable()
 export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.IContentWidget {
+
+    static CONTEXT_MENU: MenuPath = ['debug-hover-context-menu'];
+    static EDIT_MENU: MenuPath = [...DebugHoverWidget.CONTEXT_MENU, 'a_edit'];
+    static WATCH_MENU: MenuPath = [...DebugHoverWidget.CONTEXT_MENU, 'b_watch'];
 
     @inject(DebugEditor)
     protected readonly editor: DebugEditor;


### PR DESCRIPTION
#### What it does

VS Code supports context menu in debug hover. This PR adds similar support to Theia.

<img width="938" height="527" alt="Screenshot 2025-10-03 at 13 05 30" src="https://github.com/user-attachments/assets/5b798ca0-a19b-4f5a-ae7c-afd65ef67f79" />

#### How to test

Using a simple Node.JS program:

```js
let abc = { foo: 1, bar: '' };
console.log(abc);
```

1. Set a breakpoint on line 2 and launch the program.

2. Hover over the `abc` variable to display the debug hover.

3. Right-click on a child variable (e.g. `foo`) in the debug hover and choose a command in the context menu like `Copy Value`, `Copy as Expression`, or `Add to Watch`. Verify that the commands behave the same as in the Debug Variables widget.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
