### PR TITLE
Resolve `.node` files in webpack backend config

### DIFF
--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -415,6 +415,9 @@ const config = {
         __filename: false,
         __dirname: false
     },
+    resolve: {
+        extensions: ['.js', '.json', '.wasm', '.node'],
+    },
     output: {
         filename: '[name].js',
         path: path.resolve(__dirname, 'lib', 'backend'),

--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -21,9 +21,7 @@ import * as os from 'os';
 import type { Compiler } from 'webpack';
 
 const REQUIRE_RIPGREP = '@vscode/ripgrep';
-const REQUIRE_VSCODE_WINDOWS_CA_CERTS = '@vscode/windows-ca-certs';
 const REQUIRE_BINDINGS = 'bindings';
-const REQUIRE_KEYMAPPING = './build/Release/keymapping';
 const REQUIRE_PARCEL_WATCHER = './build/Release/watcher.node';
 const REQUIRE_NODE_PTY_CONPTY = '../build/Release/conpty.node';
 
@@ -62,14 +60,10 @@ export class NativeWebpackPlugin {
             await fs.promises.mkdir(directory, { recursive: true });
             const bindingsFile = (issuer: string) => buildFile(directory, 'bindings.js', bindingsReplacement(issuer, Array.from(this.bindings.entries())));
             const ripgrepFile = () => buildFile(directory, 'ripgrep.js', ripgrepReplacement(this.options.out));
-            const keymappingFile = () => Promise.resolve('./build/Release/keymapping.node');
-            const windowsCaCertsFile = () => Promise.resolve('@vscode/windows-ca-certs/build/Release/crypt32.node');
             replacements = {
                 ...(this.options.replacements ?? {}),
                 [REQUIRE_RIPGREP]: ripgrepFile,
                 [REQUIRE_BINDINGS]: bindingsFile,
-                [REQUIRE_KEYMAPPING]: keymappingFile,
-                [REQUIRE_VSCODE_WINDOWS_CA_CERTS]: windowsCaCertsFile,
                 [REQUIRE_PARCEL_WATCHER]: issuer => Promise.resolve(findNativeWatcherFile(issuer))
             };
             if (process.platform !== 'win32') {


### PR DESCRIPTION
#### What it does

I've noticed that if an adopter adds a package that contains an import like `require("nodeFile")` which targets a file called `nodeFile.node`, webpack is not able to resolve the `.node` file extension correctly when bundling the backend.

This change adds the `.node` extension to the default resolvers and consequently removes the workarounds implemented in the webpack plugin for the `@vscode/windows-ca-certs` and `keymap` packages, which are no longer required.

#### How to test

Assert that the browser app and Electron app still bundle and run as expected. There should be no errors about missing files in require calls.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
