### PR TITLE
Refactor local plugin readme resolution

### DIFF
--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -73,8 +73,8 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
             entryPoint,
             iconUrl: plugin.icon && PluginPackage.toPluginUrl(plugin, plugin.icon),
             l10n: plugin.l10n,
-            readmeUrl: PluginPackage.toPluginUrl(plugin, './README.md'),
-            licenseUrl: PluginPackage.toPluginUrl(plugin, './LICENSE')
+            readmeUrl: this.getReadmeUrl(plugin),
+            licenseUrl: this.getLicenseUrl(plugin)
         };
         return result;
     }

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -33,7 +33,6 @@ import { OVSXClientProvider } from '../common/ovsx-client-provider';
 import { RequestContext, RequestService } from '@theia/core/shared/@theia/request';
 import { OVSXApiFilterProvider } from '@theia/ovsx-client';
 import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
-import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { HostedPluginServer, PluginIdentifiers, PluginType } from '@theia/plugin-ext';
 import { HostedPluginWatcher } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin-watcher';
 
@@ -92,9 +91,6 @@ export class VSXExtensionsModel {
 
     @inject(OVSXApiFilterProvider)
     protected vsxApiFilter: OVSXApiFilterProvider;
-
-    @inject(FileService)
-    protected readonly fileService: FileService;
 
     @inject(ApplicationServer)
     protected readonly applicationServer: ApplicationServer;
@@ -166,29 +162,15 @@ export class VSXExtensionsModel {
     resolve(id: string): Promise<VSXExtension> {
         return this.doChange(async () => {
             await this.initialized;
-            const extension = await this.refresh(id) ?? this.getExtension(id);
+            const extension = await this.refresh(id);
             if (!extension) {
                 throw new Error(`Failed to resolve ${id} extension.`);
             }
-            if (extension.readme === undefined) {
+            if (extension.readme === undefined && extension.readmeUrl) {
                 try {
-                    let rawReadme: string = '';
-                    const installedReadme = await this.findReadmeFile(extension);
-                    // Attempt to read the local readme first
-                    // It saves network resources and is faster
-                    if (installedReadme) {
-                        try {
-                            const readmeContent = await this.fileService.readFile(installedReadme);
-                            rawReadme = readmeContent.value.toString();
-                        } catch {
-                            // fall through
-                        }
-                    }
-                    if (!rawReadme && extension.readmeUrl) {
-                        rawReadme = RequestContext.asText(
-                            await this.request.request({ url: extension.readmeUrl })
-                        );
-                    }
+                    const rawReadme = RequestContext.asText(
+                        await this.request.request({ url: extension.readmeUrl })
+                    );
                     const readme = this.compileReadme(rawReadme);
                     extension.update({ readme });
                 } catch (e) {
@@ -199,21 +181,6 @@ export class VSXExtensionsModel {
             }
             return extension;
         });
-    }
-
-    protected async findReadmeFile(extension: VSXExtension): Promise<URI | undefined> {
-        if (!extension.plugin) {
-            return undefined;
-        }
-        // Since we don't know the exact capitalization of the readme file (might be README.md, readme.md, etc.)
-        // We attempt to find the readme file by searching through the plugin's directories
-        const packageUri = new URI(extension.plugin.metadata.model.packageUri);
-        const pluginDirStat = await this.fileService.resolve(packageUri);
-        const possibleNames = ['readme.md', 'readme.txt', 'readme'];
-        const readmeFileUri = pluginDirStat.children
-            ?.find(child => possibleNames.includes(child.name.toLowerCase()))
-            ?.resource;
-        return readmeFileUri;
     }
 
     protected async initInstalled(): Promise<void> {
@@ -498,11 +465,8 @@ export class VSXExtensionsModel {
                     targetPlatform
                 });
             }
-            if (!data) {
-                return;
-            }
-            if (data.error) {
-                return this.onDidFailRefresh(id, data.error);
+            if (!data || data.error) {
+                return this.onDidFailRefresh(id, data?.error ?? 'No data found');
             }
             if (!data.verified) {
                 if (data.publishedBy.loginName === 'open-vsx') {


### PR DESCRIPTION
#### What it does

Another iteration on https://github.com/eclipse-theia/theia/pull/14699. Adjusts the `readmeUrl` of locally installed plugins to point to the actual readme file on disk. Removes the two-way approach of using the `FileService` to look for the file.

#### How to test

See https://github.com/eclipse-theia/theia/pull/16376 for testing steps. The change is just a refactoring that should have no impact on the behavior of the feature.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
