### PR TITLE
fix: show hover tooltip immediately when clicking status bar item

### DIFF
--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -79,6 +79,12 @@ export interface HoverRequest {
      * If implemented, this method will be called when the hover is no longer shown or no longer scheduled to be shown.
      */
     onHide?(): void;
+    /**
+     * When true, the hover will be shown immediately without any delay.
+     * Useful for explicitly triggered hovers (e.g., on click) where the user expects instant feedback.
+     * @default false
+     */
+    skipHoverDelay?: boolean;
 }
 
 @injectable()
@@ -111,7 +117,8 @@ export class HoverService {
 
     requestHover(request: HoverRequest): void {
         this.cancelHover();
-        this.pendingTimeout = disposableTimeout(() => this.renderHover(request), this.getHoverDelay());
+        const delay = request.skipHoverDelay ? 0 : this.getHoverDelay();
+        this.pendingTimeout = disposableTimeout(() => this.renderHover(request), delay);
         this.hoverTarget = request.target;
         this.listenForMouseOut();
         this.listenForMouseClick(request);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes GH-16369

- Allows bypassing the hover delay for instant display in specific scenarios.
- Updated `status-bar.tsx` to utilize the new option when requesting hover information.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Clicking on (TypeScript) language status item should show the hover content immediately
- Test with different hover delays (`workbench.hover.delay`) that this influences the hover, but not the click behaviour

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

x

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
