### PR TITLE
Fix name of memory inspector frontend contribution

### DIFF
--- a/packages/memory-inspector/src/browser/memory-inspector-frontend-contribution.ts
+++ b/packages/memory-inspector/src/browser/memory-inspector-frontend-contribution.ts
@@ -45,7 +45,7 @@ import Long from 'long';
 const ONE_HALF_OPACITY = 0.5;
 
 @injectable()
-export class DebugFrontendContribution extends AbstractViewContribution<MemoryLayoutWidget>
+export class MemoryInspectorFrontendContribution extends AbstractViewContribution<MemoryLayoutWidget>
     implements FrontendApplicationContribution,
     TabBarToolbarContribution,
     ColorContribution {

--- a/packages/memory-inspector/src/browser/memory-inspector-frontend-module.ts
+++ b/packages/memory-inspector/src/browser/memory-inspector-frontend-module.ts
@@ -22,7 +22,7 @@ import { bindViewContribution, FrontendApplicationContribution, WidgetFactory } 
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { DebugFrontendContribution } from './memory-inspector-frontend-contribution';
+import { MemoryInspectorFrontendContribution } from './memory-inspector-frontend-contribution';
 import { MemoryDiffOptionsWidget } from './diff-widget/memory-diff-options-widget';
 import { MemoryDiffSelectWidget } from './diff-widget/memory-diff-select-widget';
 import { MemoryDiffTableWidget, MemoryDiffWidget } from './diff-widget/memory-diff-table-widget';
@@ -44,10 +44,10 @@ import { MemoryLayoutWidget } from './wrapper-widgets/memory-layout-widget';
 import { CDTGDBMemoryProvider } from './memory-provider/cdt-gdb-memory-provider';
 
 export default new ContainerModule(bind => {
-    bindViewContribution(bind, DebugFrontendContribution);
-    bind(ColorContribution).toService(DebugFrontendContribution);
-    bind(TabBarToolbarContribution).toService(DebugFrontendContribution);
-    bind(FrontendApplicationContribution).toService(DebugFrontendContribution);
+    bindViewContribution(bind, MemoryInspectorFrontendContribution);
+    bind(ColorContribution).toService(MemoryInspectorFrontendContribution);
+    bind(TabBarToolbarContribution).toService(MemoryInspectorFrontendContribution);
+    bind(FrontendApplicationContribution).toService(MemoryInspectorFrontendContribution);
 
     bind(MemoryProviderService).toSelf().inSingletonScope();
     bind(DefaultMemoryProvider).toSelf().inSingletonScope();


### PR DESCRIPTION
#### What it does

The class name in the file memory-inspector-frontend-contribution.ts was misleading. (Might have been a copy&paste error)

#### How to test

* The memory inspector still works

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of MVTec Software GmbH

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
