### PR TITLE
Fix two minor spelling/wording issues with the coder prompt

### DIFF
--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -76,7 +76,7 @@ Never guess or hallucinate file content or structure. Use tools for all workspac
 - ~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}} — list contents of a specific directory
 - ~{${FILE_CONTENT_FUNCTION_ID}} — retrieve the content of a file
 - ~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}} — find files matching glob patterns (e.g., '**/*.ts' for all TypeScript files)
-- ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}}} — locate references or patterns (only search if you are missing information, always prefer examples that are explicitly provided, never \
+- ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}} — locate references or patterns (only search if you are missing information, always prefer examples that are explicitly provided, never \
 search for files you already know the path for)
 - ~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}} — bookmark important files for context
 
@@ -100,7 +100,7 @@ search for files you already know the path for)
 
 ### Test Authoring
 If no relevant tests exist:
-- Create new test files (propose using suggestFileContent)
+- Create new test files (propose using ~{${WRITE_FILE_REPLACEMENTS_ID}} or ~{${WRITE_FILE_CONTENT_ID}})
 - Use patterns from existing tests
 - Ensure new tests validate new behavior or prevent regressions
 


### PR DESCRIPTION
#### What it does

The coder prompt contains a runaway `}` and an outdated function reference (that was not detected because it did not use the function ID)

#### How to test

1. In the AI chat send `@Coder this is just a test. Reply with "ok".`.
2. Open the *AI Agent History*, choose *Coder* and find the request that was just sent.
3. In the *Request* part, find the following two lines:

```
- searchInWorkspace} — locate references [...]
```

and 

```
- Create new test files (propose using suggestFileContent)
```

After applying the PR, those should read:

```
- searchInWorkspace — locate references [...]
```
(without the runaway curly brace)

and 

```
- Create new test files (propose using writeFileReplacements or writeFileContent)
```
(using the same file editing functions as in the *Code Editing* section).

#### Follow-ups

none

#### Breaking changes

none

#### Attribution

none

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
