### PR TITLE
Enhance localization of ai-code-completion, ai-editor, and ai-terminal

### DIFF
--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -152,9 +152,9 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
     readonly variables: string[] = [];
     readonly functions: string[] = [];
     readonly agentSpecificVariables: AgentSpecificVariables[] = [
-        { name: FILE.id, description: 'The URI of the file being edited', usedInPrompt: true },
-        { name: PREFIX.id, description: 'The code before the current cursor position', usedInPrompt: true },
-        { name: SUFFIX.id, description: 'The code after the current cursor position', usedInPrompt: true },
-        { name: LANGUAGE.id, description: 'The languageId of the file being edited', usedInPrompt: true }
+        { name: FILE.id, description: nls.localize('theia/ai/completion/agent/vars/file/description', 'The URI of the file being edited'), usedInPrompt: true },
+        { name: PREFIX.id, description: nls.localize('theia/ai/completion/agent/vars/prefix/description', 'The code before the current cursor position'), usedInPrompt: true },
+        { name: SUFFIX.id, description: nls.localize('theia/ai/completion/agent/vars/suffix/description', 'The code after the current cursor position'), usedInPrompt: true },
+        { name: LANGUAGE.id, description: nls.localize('theia/ai/completion/agent/vars/language/description', 'The languageId of the file being edited'), usedInPrompt: true }
     ];
 }

--- a/packages/ai-code-completion/src/browser/code-completion-variables.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-variables.ts
@@ -15,27 +15,28 @@
 // *****************************************************************************
 
 import { AIVariable } from '@theia/ai-core/lib/common/variable-service';
+import { nls } from '@theia/core';
 
 export const FILE: AIVariable = {
     id: 'codeCompletionFile',
     name: 'codeCompletionFile',
-    description: 'The URI of the file being edited. Only available in code completion context.',
+    description: nls.localize('theia/ai/completion/fileVariable/description', 'The URI of the file being edited. Only available in code completion context.'),
 };
 
 export const PREFIX: AIVariable = {
     id: 'codeCompletionPrefix',
     name: 'codeCompletionPrefix',
-    description: 'The code before the current cursor position. Only available in code completion context.',
+    description: nls.localize('theia/ai/completion/prefixVariable/description', 'The code before the current cursor position. Only available in code completion context.'),
 };
 
 export const SUFFIX: AIVariable = {
     id: 'codeCompletionSuffix',
     name: 'codeCompletionSuffix',
-    description: 'The code after the current cursor position. Only available in code completion context.',
+    description: nls.localize('theia/ai/completion/suffixVariable/description', 'The code after the current cursor position. Only available in code completion context.'),
 };
 
 export const LANGUAGE: AIVariable = {
     id: 'codeCompletionLanguage',
     name: 'codeCompletionLanguage',
-    description: 'The languageId of the file being edited. Only available in code completion context.',
+    description: nls.localize('theia/ai/completion/languageVariable/description', 'The languageId of the file being edited. Only available in code completion context.'),
 };

--- a/packages/ai-editor/src/browser/ai-code-action-provider.ts
+++ b/packages/ai-editor/src/browser/ai-code-action-provider.ts
@@ -21,6 +21,7 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { MonacoEditorService } from '@theia/monaco/lib/browser/monaco-editor-service';
 import { AIActivationService } from '@theia/ai-core/lib/browser/ai-activation-service';
+import { nls } from '@theia/core';
 
 export const AI_EDITOR_SEND_TO_CHAT = {
     id: 'ai-editor.sendToChat',
@@ -80,28 +81,28 @@ export class AICodeActionProvider implements FrontendApplicationContribution {
                 // Create code actions for each error marker: Fix with AI and Explain with AI
                 errorMarkers.forEach(marker => {
                     actions.push({
-                        title: 'Fix with AI',
+                        title: nls.localize('theia/ai/editor/fixWithAI/title', 'Fix with AI'),
                         diagnostics: [marker],
                         isAI: true,
                         kind: 'quickfix',
                         command: {
                             id: AI_EDITOR_SEND_TO_CHAT.id,
-                            title: 'Fix with AI',
+                            title: nls.localize('theia/ai/editor/fixWithAI/title', 'Fix with AI'),
                             arguments: [{
-                                prompt: `@Coder Help to fix this error: "${marker.message}"`
+                                prompt: `@Coder ${nls.localize('theia/ai/editor/fixWithAI/prompt', 'Help to fix this error')}: "${marker.message}"`
                             }]
                         }
                     });
                     actions.push({
-                        title: 'Explain with AI',
+                        title: nls.localize('theia/ai/editor/explainWithAI/title', 'Explain with AI'),
                         diagnostics: [marker],
                         kind: 'quickfix',
                         isAI: true,
                         command: {
                             id: AI_EDITOR_SEND_TO_CHAT.id,
-                            title: 'Explain with AI',
+                            title: nls.localize('theia/ai/editor/explainWithAI/title', 'Explain with AI'),
                             arguments: [{
-                                prompt: `@Architect Explain this error: "${marker.message}"`
+                                prompt: `@Architect ${nls.localize('theia/ai/editor/explainWithAI/prompt', 'Explain this error')}: "${marker.message}"`
                             }]
                         }
                     });

--- a/packages/ai-editor/src/browser/ai-editor-context-variable.ts
+++ b/packages/ai-editor/src/browser/ai-editor-context-variable.ts
@@ -22,12 +22,13 @@ import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import * as monaco from '@theia/monaco-editor-core';
+import { nls } from '@theia/core';
 
 export const EDITOR_CONTEXT_VARIABLE: AIVariable = {
     id: 'editorContext',
-    description: 'Resolves editor specific context information',
+    description: nls.localize('theia/ai/editor/editorContextVariable/description', 'Resolves editor specific context information'),
     name: 'editorContext',
-    label: 'EditorContext',
+    label: nls.localize('theia/ai/editor/editorContextVariable/label', 'EditorContext'),
     iconClasses: codiconArray('file'),
     isContextVariable: true,
     args: []

--- a/packages/ai-terminal/src/browser/ai-terminal-agent.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-agent.ts
@@ -46,10 +46,26 @@ export class AiTerminalAgent implements Agent {
     variables = [];
     functions = [];
     agentSpecificVariables = [
-        { name: 'userRequest', usedInPrompt: true, description: 'The user\'s question or request.' },
-        { name: 'shell', usedInPrompt: true, description: 'The shell being used, e.g., /usr/bin/zsh.' },
-        { name: 'cwd', usedInPrompt: true, description: 'The current working directory.' },
-        { name: 'recentTerminalContents', usedInPrompt: true, description: 'The last 0 to 50 recent lines visible in the terminal.' }
+        {
+            name: 'userRequest',
+            usedInPrompt: true,
+            description: nls.localize('theia/ai/terminal/agent/vars/userRequest/description', 'The user\'s question or request.')
+        },
+        {
+            name: 'shell',
+            usedInPrompt: true,
+            description: nls.localize('theia/ai/terminal/agent/vars/shell/description', 'The shell being used, e.g., /usr/bin/zsh.')
+        },
+        {
+            name: 'cwd',
+            usedInPrompt: true,
+            description: nls.localize('theia/ai/terminal/agent/vars/cwd/description', 'The current working directory.')
+        },
+        {
+            name: 'recentTerminalContents',
+            usedInPrompt: true,
+            description: nls.localize('theia/ai/terminal/agent/vars/recentTerminalContents/description', 'The last 0 to 50 recent lines visible in the terminal.')
+        }
     ];
     prompts = terminalPrompts;
     languageModelRequirements: LanguageModelRequirement[] = [


### PR DESCRIPTION
#### What it does

This PR provides localization enhancements for the `ai-code-completion`, `ai-editor`, and `ai-terminal` packages.

#### How to test

There are no testing steps as such. This PR is strictly about localization enhacements. Hopefully, it can be verified by reviewing the actual code changes.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
