### PR TITLE
fix: Ensure Output Channel methods stay within this context

### DIFF
--- a/packages/plugin-ext/src/plugin/output-channel/log-output-channel.ts
+++ b/packages/plugin-ext/src/plugin/output-channel/log-output-channel.ts
@@ -32,6 +32,16 @@ export class LogOutputChannelImpl extends OutputChannelImpl implements theia.Log
     constructor(name: string, proxy: OutputChannelRegistryMain, pluginInfo: PluginInfo) {
         super(name, proxy, pluginInfo);
         this.setLogLevel(LogLevel.Info);
+
+        // Bind overridden and new methods to preserve 'this' context
+        // These bindings are needed because the parent class bindings don't apply to overridden methods
+        this.append = this.append.bind(this);
+        this.appendLine = this.appendLine.bind(this);
+        this.trace = this.trace.bind(this);
+        this.debug = this.debug.bind(this);
+        this.info = this.info.bind(this);
+        this.warn = this.warn.bind(this);
+        this.error = this.error.bind(this);
     }
 
     setLogLevel(level: theia.LogLevel): void {

--- a/packages/plugin-ext/src/plugin/output-channel/output-channel-item.ts
+++ b/packages/plugin-ext/src/plugin/output-channel/output-channel-item.ts
@@ -21,6 +21,14 @@ export class OutputChannelImpl implements theia.OutputChannel {
     private disposed: boolean;
 
     constructor(readonly name: string, protected readonly proxy: OutputChannelRegistryMain, protected readonly pluginInfo: PluginInfo) {
+        // Bind methods to preserve 'this' context when passed as callbacks
+        // This ensures compatibility with extensions that pass these methods as function references
+        this.append = this.append.bind(this);
+        this.appendLine = this.appendLine.bind(this);
+        this.replace = this.replace.bind(this);
+        this.clear = this.clear.bind(this);
+        this.show = this.show.bind(this);
+        this.hide = this.hide.bind(this);
     }
 
     dispose(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #16395 

Bind 'this' to Output Channel (defensive programming). This ensures compatibility with extensions that pass these methods as function references.

As an example, see Cline's initialization: (Cline repo)/src/extension.ts
```ts
	HostProvider.initialize(
		createWebview,
		createDiffView,
		vscodeHostBridgeClient,
		outputChannel.appendLine,     // <-------- The 'this' context is lost here.
		getCallbackUrl,
		getBinaryLocation,
		context.extensionUri.fsPath,
		context.globalStorageUri.fsPath,
	)
```

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Install Cline plugin: 
```json
 "theiaPlugins": {
    "saoudrizwan.claude-dev": "https://open-vsx.org/api/saoudrizwan/claude-dev/3.32.6/file/saoudrizwan.claude-dev-3.32.6.vsix"
  }
```
Start Theia. Cline should work normally.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
