### PR TITLE
Only set `window.titleBarStyle` preference if different from active value

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -164,6 +164,10 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
                 if (!currentValueActive) {
                     this.preferenceService.set('window.titleBarStyle', this.titleBarStyle, PreferenceScope.User);
                 }
+                // Enable the change flag after initialization is complete.
+                // This ensures that user-initiated changes will trigger a restart,
+                // while the synchronization change above (if any) is ignored.
+                this.titleBarStyleChangeFlag = true;
             });
         });
 
@@ -178,7 +182,6 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
                     window.electronTheiaCore.setTitleBarStyle(newTitleBarStyle);
                     this.handleRequiredRestart();
                 }
-                this.titleBarStyleChangeFlag = true;
             }
         });
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #16418 by checking whether writing the preference would be necessary.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Follow steps from #16418
2. Observe that the preference is not written to the file on MacOS.

> [!WARNING]
> Arguably, this 'fix' actually reveals a bug. Since the preference should not be included on MacOS, the `inspect` call should return `undefined`. At the moment, it doesn't: the preference system in fact has added the preference to its schema, with the appropriate default value of `native`. We should likely fix that, and then ensure that the preference isn't active at all in that case, and that all consumers of the value correctly handle its absence.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
