### PR TITLE
Fix #16412: if a resource contains both staged and unstaged changes, selection in the SCM panel was not reliable

### DIFF
--- a/packages/git/src/browser/git-scm-provider.ts
+++ b/packages/git/src/browser/git-scm-provider.ts
@@ -144,6 +144,21 @@ export class GitScmProvider implements ScmProvider {
     get groups(): ScmResourceGroup[] {
         return this.state.groups;
     }
+
+    /**
+     * Find the group that contains the given URI.
+     * @param uri The URI to find.
+     * @returns The resource group that contains the URI, or undefined if not found.
+     */
+    getScmGroupIdForUri(uri: URI): string | undefined {
+        if (uri.query === 'HEAD') {
+            return 'workingTree';
+        } else if (uri.query === 'index') {
+            return 'index';
+        }
+        return undefined;
+    }
+
     get stagedChanges(): GitFileChange[] {
         return this.state.stagedChanges;
     }

--- a/packages/scm/src/browser/scm-provider.ts
+++ b/packages/scm/src/browser/scm-provider.ts
@@ -1,4 +1,4 @@
-// *****************************************************************************
+// ***************************************************************************//
 // Copyright (C) 2019 Red Hat, Inc. and others.
 //
 // This program and the accompanying materials are made available under the
@@ -36,6 +36,13 @@ export interface ScmProvider extends Disposable {
     readonly onDidChangeCommitTemplate: Event<string>;
 
     readonly amendSupport?: ScmAmendSupport;
+
+    /**
+     * Returns the SCM resource group that contains the given URI, or undefined if not found.
+     * @param uri The URI to search for
+     * @returns The SCM resource group containing the URI, or undefined if not found
+     */
+    readonly getScmGroupIdForUri?: (uri: URI) => string | undefined;
 }
 
 export const ScmResourceGroup = Symbol('ScmResourceGroup');

--- a/packages/scm/src/browser/scm-tree-model.ts
+++ b/packages/scm/src/browser/scm-tree-model.ts
@@ -79,7 +79,6 @@ export namespace ScmFileChangeNode {
 
 @injectable()
 export abstract class ScmTreeModel extends TreeModelImpl {
-
     private _languageId: string | undefined;
 
     protected provider: ScmProvider | undefined;
@@ -387,6 +386,13 @@ export abstract class ScmTreeModel extends TreeModelImpl {
      */
     findGroup(groupId: string): ScmResourceGroup | undefined {
         return this.groups.find(g => g.id === groupId);
+    }
+
+    getScmGroupIdForUri(uri: URI): string | undefined {
+        if (this.provider?.getScmGroupIdForUri) {
+            return this.provider?.getScmGroupIdForUri(uri);
+        }
+        return undefined;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -361,7 +361,12 @@ export class ScmTreeWidget extends TreeWidget {
     }
 
     selectNodeByUri(uri: URI): void {
+        const groupId = this.model.getScmGroupIdForUri(uri);
         for (const group of this.model.groups) {
+            if (groupId && group.id !== groupId) {
+                continue;
+            }
+
             const sourceUri = new URI(uri.path.toString());
             const id = `${group.id}:${sourceUri.toString()}`;
             const node = this.model.getNode(id);


### PR DESCRIPTION
#### What it does

Adds the necessary code to resolve the URI back to the ScmGroup.

Missing: handling of PluginScmProvider


#### How to test

Test Setup Instructions:

- Clone a repo with at least one file that can be staged and modified again (let's call it file.txt.
- Ensure Git is enabled in the workspace.
- Switch to the Source Control: Git panel.

Test Cases / Test Steps:

- Edit file.txt, save, and stage the changed file.txt. Verify that file.txt appears in the Staged Changes group.
- Edit file.txt again. Verify that file.txt appears both in the Changes and Staged Changes groups.
- In the SCM panel, click the Unstaged file.txt.
- The diff editor (index vs working tree) is opened.
- The unstaged file.txt is selected in the SCM panel.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

(added `getScmGroupIdForUri()` to ScmProvider interface, but the method is optional, so not actually breaking...)

#### Attribution

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
