### PR TITLE
ci: update publish-release workflow for release automation

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,7 @@ name: Publish Release
 permissions:
   id-token: write
   contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -81,18 +82,20 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: "true"
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      
-      - name: Commit and Push Changes
+
+      - name: Submit PR for package updates
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Configure git
           git config --local user.email "eclipse-theia-bot@eclipse.org"
           git config --local user.name "eclipse-theia-bot"
-          
+
           # Get the version from lerna.json after publishing
           VERSION=$(node -p "require('./lerna.json').version")
           echo "Lerna Version: $VERSION"
-          
+
           # First commit: Update packages/core/README.md
           if git diff --name-only | grep -q "packages/core/README.md"; then
             git add packages/core/README.md
@@ -101,20 +104,42 @@ jobs:
           else
             echo "No changes to packages/core/README.md"
           fi
-          
+
           # Second commit: Add all other changes
           git add .
           if git diff --staged --quiet; then
             echo "No other changes to commit"
           else
-            git commit -m "v${VERSION} - WIP (update remaining packages locally)"
+            git commit -m "v${VERSION}"
             echo "Second commit created for remaining changes"
           fi
-          
-          # Push all commits
+
+          # Submit PR
           if git log origin/${{ github.ref_name }}..HEAD | grep -q "commit"; then
-            git push origin ${{ github.ref_name }}
-            echo "Changes pushed to remote"
+            # Define PR body
+            PR_BODY="Automated package updates for release v${VERSION}
+            
+            To complete the release:
+            - Update all remaining package versions locally
+            - Amend the commits with your author details (to ensure the ECA check passes)
+            - Keep the commits split (the re-export commit on the readme needs to be separate)
+            - Force push the branch
+            - Verify that all checks pass, and then \`rebase and merge\`"
+            
+            # Create a new branch for the PR
+            BRANCH_NAME="${{ github.ref_name }}-package-updates"
+            git checkout -b "$BRANCH_NAME"
+            git push origin "$BRANCH_NAME"
+
+            # Create PR using GitHub CLI
+            gh pr create \
+              --title "Release v${VERSION} - Package updates" \
+              --body "$PR_BODY" \
+              --base "${{ github.ref_name }}" \
+              --head "$BRANCH_NAME"
+
+            echo "PR created for branch $BRANCH_NAME"
           else
             echo "No commits to push"
           fi
+


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-16314

- add is_patch_to_previous input to support patching previous release branches, with input validation
- clarify release_type input documentation
- fetch full git history to support accurate versioning
- split publish steps: separate steps for latest and previous patch publishing
- submit a pull request with the package updates using the eclipse-theia-bot account

Contributed on behalf of STMicroelectronics

**_Some notes:_**
- I saw the initial attempts to this workflow (https://github.com/eclipse-theia/theia/pull/13399/)
- As we have a successful workflow to publish next versions, I would like to achieve that also for the release publishing.
- And we could benefit from the provenance attestation when publishing via the workflow (as we already have for the next builds)


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- I did test runs: https://github.com/eclipse-theia/theia/actions/workflows/publish-release.yml
- [The first one](https://github.com/eclipse-theia/theia/actions/runs/18495400939) tests the input validation 
- [Final test run](https://github.com/eclipse-theia/theia/actions/runs/18502369171/job/52722352117)
   - planned to fail to avoid publishing packages)  
   - Resulting package update PR: #16438


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

x

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
