### PR TITLE
Adapt workspace functions preferences

### DIFF
--- a/packages/ai-ide/src/common/workspace-preferences.ts
+++ b/packages/ai-ide/src/common/workspace-preferences.ts
@@ -34,13 +34,13 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
             title: nls.localize('theia/ai/workspace/considerGitignore/title', 'Consider .gitignore'),
             description: nls.localize('theia/ai/workspace/considerGitignore/description',
                 'If enabled, excludes files/folders specified in a global .gitignore file (expected location is the workspace root).'),
-            default: false
+            default: true
         },
         [USER_EXCLUDE_PATTERN_PREF]: {
             type: 'array',
             title: nls.localize('theia/ai/workspace/excludedPattern/title', 'Excluded File Patterns'),
             description: nls.localize('theia/ai/workspace/excludedPattern/description', 'List of patterns (glob or regex) for files/folders to exclude.'),
-            default: ['node_modules', 'lib', '.*'],
+            default: ['node_modules', 'lib'],
             items: {
                 type: 'string'
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Adapts the preferences controlling which directories are ignored by the workspace functions (search, list files, search files by pattern). These "ignores" help improving the efficiency, e.g. to not search in node_module directories.

- Set CONSIDER_GITIGNORE_PREF default to true
- Remove '.*' from USER_EXCLUDE_PATTERN_PREF default array

Rationale: This change makes AI workspace functions more developer-intuitive by leveraging existing .gitignore files rather than applying a blanket exclusion of all hidden files.

- Preserves important config files: .eslintrc, .prettierrc, .github/workflows/ etc. remain accessible to AI
- Self-maintaining: AI exclusions automatically update when developers modify gitignore
- Partial Backward compatibility: Maintains node_modules and lib as hard-coded defaults for projects without comprehensive gitignore files.

#### How to test

Ask an agent to find a file in a "." directory that is not in the .gitignore

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
