### PR TITLE
[Theia AI] Allow to configure proxy settings (#14324)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -277,7 +277,6 @@
     "dev-packages/ffmpeg": {
       "name": "@theia/ffmpeg",
       "version": "1.65.0",
-      "hasInstallScript": true,
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
         "@electron/get": "^2.0.0",
@@ -439,6 +438,7 @@
         "@theia/ai-chat-ui": "1.65.0",
         "@theia/ai-code-completion": "1.65.0",
         "@theia/ai-core": "1.65.0",
+        "@theia/ai-mcp": "1.65.0",
         "@theia/ai-mcp-server": "1.65.0",
         "@theia/core": "1.65.0",
         "@theia/file-search": "1.65.0",
@@ -840,12 +840,23 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.52.0.tgz",
-      "integrity": "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==",
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.65.0.tgz",
+      "integrity": "sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==",
       "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -18640,6 +18651,19 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -22942,27 +22966,6 @@
       },
       "peerDependencies": {
         "yjs": "^13.0.0"
-      }
-    },
-    "node_modules/openai": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
-      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/opener": {
@@ -28915,6 +28918,12 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -29864,7 +29873,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
       "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -31477,9 +31485,10 @@
       "version": "1.65.0",
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.52.0",
+        "@anthropic-ai/sdk": "^0.65.0",
         "@theia/ai-core": "1.65.0",
-        "@theia/core": "1.65.0"
+        "@theia/core": "1.65.0",
+        "undici": "^7.16.0"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.65.0"
@@ -31868,11 +31877,33 @@
         "@theia/core": "1.65.0",
         "@theia/filesystem": "1.65.0",
         "@theia/workspace": "1.65.0",
-        "openai": "^5.0.1",
-        "tslib": "^2.6.2"
+        "openai": "^6.3.0",
+        "tslib": "^2.6.2",
+        "undici": "^7.16.0"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.65.0"
+      }
+    },
+    "packages/ai-openai/node_modules/openai": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.3.0.tgz",
+      "integrity": "sha512-E6vOGtZvdcb4yXQ5jXvDlUG599OhIkb/GjBLZXS+qk0HF+PJReIldEc9hM8Ft81vn+N6dRdFRb7BZNK8bbvXrw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "packages/ai-scanoss": {

--- a/packages/ai-anthropic/package.json
+++ b/packages/ai-anthropic/package.json
@@ -3,9 +3,10 @@
   "version": "1.65.0",
   "description": "Theia - Anthropic Integration",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.52.0",
+    "@anthropic-ai/sdk": "^0.65.0",
     "@theia/ai-core": "1.65.0",
-    "@theia/core": "1.65.0"
+    "@theia/core": "1.65.0",
+    "undici": "^7.16.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -52,6 +52,9 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
             const apiKey = this.preferenceService.get<string>(API_KEY_PREF, undefined);
             this.manager.setApiKey(apiKey);
 
+            const proxyUri = this.preferenceService.get<string>('http.proxy', undefined);
+            this.manager.setProxyUrl(proxyUri);
+
             const models = this.preferenceService.get<string[]>(MODELS_PREF, []);
             this.manager.createOrUpdateLanguageModels(...models.map(modelId => this.createAnthropicModelDescription(modelId)));
             this.prevModels = [...models];
@@ -62,6 +65,8 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
                     this.updateAllModels();
                 } else if (event.preferenceName === MODELS_PREF) {
                     this.handleModelChanges(event.newValue as string[]);
+                } else if (event.preferenceName === 'http.proxy') {
+                    this.manager.setProxyUrl(event.newValue as string);
                 }
             });
 

--- a/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
+++ b/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
@@ -49,6 +49,7 @@ export interface AnthropicModelDescription {
 export interface AnthropicLanguageModelsManager {
     apiKey: string | undefined;
     setApiKey(key: string | undefined): void;
+    setProxyUrl(proxyUrl: string | undefined): void;
     createOrUpdateLanguageModels(...models: AnthropicModelDescription[]): Promise<void>;
     removeLanguageModels(...modelIds: string[]): void
 }

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -23,6 +23,7 @@ import { AnthropicLanguageModelsManager, AnthropicModelDescription } from '../co
 export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageModelsManager {
 
     protected _apiKey: string | undefined;
+    protected _proxyUrl: string | undefined;
 
     @inject(LanguageModelRegistry)
     protected readonly languageModelRegistry: LanguageModelRegistry;
@@ -45,6 +46,15 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                     return modelDescription.apiKey;
                 }
                 return undefined;
+            };
+            const proxyUrlProvider = () => {
+                // first check if the proxy url is provided via Theia settings
+                if (this._proxyUrl) {
+                    return this._proxyUrl;
+                }
+
+                // if not fall back to the environment variables
+                return process.env['https_proxy'];
             };
 
             // Determine status based on API key presence
@@ -75,7 +85,8 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                         apiKeyProvider,
                         modelDescription.maxTokens,
                         modelDescription.maxRetries,
-                        this.tokenUsageService
+                        this.tokenUsageService,
+                        proxyUrlProvider()
                     )
                 ]);
             }
@@ -91,6 +102,14 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
             this._apiKey = apiKey;
         } else {
             this._apiKey = undefined;
+        }
+    }
+
+    setProxyUrl(proxyUrl: string | undefined): void {
+        if (proxyUrl) {
+            this._proxyUrl = proxyUrl;
+        } else {
+            this._proxyUrl = undefined;
         }
     }
 

--- a/packages/ai-openai/package.json
+++ b/packages/ai-openai/package.json
@@ -7,8 +7,9 @@
     "@theia/core": "1.65.0",
     "@theia/filesystem": "1.65.0",
     "@theia/workspace": "1.65.0",
-    "openai": "^5.0.1",
-    "tslib": "^2.6.2"
+    "openai": "^6.3.0",
+    "tslib": "^2.6.2",
+    "undici": "^7.16.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -41,6 +41,9 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             const apiKey = this.preferenceService.get<string>(API_KEY_PREF, undefined);
             this.manager.setApiKey(apiKey);
 
+            const proxyUri = this.preferenceService.get<string>('http.proxy', undefined);
+            this.manager.setProxyUrl(proxyUri);
+
             const models = this.preferenceService.get<string[]>(MODELS_PREF, []);
             this.manager.createOrUpdateLanguageModels(...models.map(modelId => this.createOpenAIModelDescription(modelId)));
             this.prevModels = [...models];
@@ -57,6 +60,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     this.handleModelChanges(event.newValue as string[]);
                 } else if (event.preferenceName === CUSTOM_ENDPOINTS_PREF) {
                     this.handleCustomModelChanges(event.newValue as Partial<OpenAiModelDescription>[]);
+                } else if (event.preferenceName === 'http.proxy') {
+                    this.manager.setProxyUrl(event.newValue as string);
                 }
             });
 

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -67,6 +67,7 @@ export interface OpenAiLanguageModelsManager {
     apiKey: string | undefined;
     setApiKey(key: string | undefined): void;
     setApiVersion(version: string | undefined): void;
+    setProxyUrl(proxyUrl: string | undefined): void;
     createOrUpdateLanguageModels(...models: OpenAiModelDescription[]): Promise<void>;
     removeLanguageModels(...modelIds: string[]): void
 }

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -27,6 +27,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
 
     protected _apiKey: string | undefined;
     protected _apiVersion: string | undefined;
+    protected _proxyUrl: string | undefined;
 
     @inject(LanguageModelRegistry)
     protected readonly languageModelRegistry: LanguageModelRegistry;
@@ -75,6 +76,28 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                 }
                 return undefined;
             };
+            const proxyUrlProvider = (url: string | undefined) => {
+                // first check if the proxy url is provided via Theia settings
+                if (this._proxyUrl) {
+                    return this._proxyUrl;
+                }
+
+                // if not fall back to the environment variables
+                let protocolVar;
+                if (url && url.startsWith('http:')) {
+                    protocolVar = 'http_proxy';
+                } else if (url && url.startsWith('https:')) {
+                    protocolVar = 'https_proxy';
+                }
+
+                if (protocolVar) {
+                    // Get the environment variable
+                    return process.env[protocolVar];
+                }
+
+                // neither the settings nor the environment variable is set
+                return undefined;
+            };
 
             // Determine the effective API key for status
             const status = this.calculateStatus(modelDescription, apiKeyProvider());
@@ -111,7 +134,8 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                         this.openAiModelUtils,
                         modelDescription.developerMessageSettings,
                         modelDescription.maxRetries,
-                        this.tokenUsageService
+                        this.tokenUsageService,
+                        proxyUrlProvider(modelDescription.url)
                     )
                 ]);
             }
@@ -135,6 +159,14 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
             this._apiVersion = apiVersion;
         } else {
             this._apiVersion = undefined;
+        }
+    }
+
+    setProxyUrl(proxyUrl: string | undefined): void {
+        if (proxyUrl) {
+            this._proxyUrl = proxyUrl;
+        } else {
+            this._proxyUrl = undefined;
         }
     }
 }


### PR DESCRIPTION
#### What it does

This PR adds the handling of proxy configuration when trying to access a LLM. It currently only adds proxy support for Anthropic and OpenAI as I did not find information about proxy configurations for the other used APIs (e.g. Ollama or Google).

Resolves GH-14324

#### How to test

Be behind a proxy, add a proxy configuration and test if you can access the LLM. It should not work without it.

#### Follow-ups

Need to check if there is proxy support for the other LLM provider APIs.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
