### PR TITLE
feat: disable claude code if API key not set

### DIFF
--- a/packages/ai-chat/src/common/chat-agents-variable-contribution.ts
+++ b/packages/ai-chat/src/common/chat-agents-variable-contribution.ts
@@ -65,17 +65,18 @@ export class ChatAgentsVariableContribution implements AIVariableContribution, A
         const agents = this.agents.getAgents().map(agent => ({
             id: agent.id,
             name: agent.name,
-            description: agent.description
+            description: agent.description,
+            status: agent.status
         }));
         const value = agents.map(agent => prettyPrintInMd(agent)).join('\n');
         return { variable: CHAT_AGENTS_VARIABLE, value };
     }
 }
 
-function prettyPrintInMd(agent: { id: string; name: string; description: string; }): string {
+function prettyPrintInMd(agent: { id: string; name: string; description: string; status?: string | undefined }): string {
     return `- ${agent.id}
   - *ID*: ${agent.id}
   - *Name*: ${agent.name}
-  - *Description*: ${agent.description.replace(/\n/g, ' ')}`;
+  - *Description*: ${agent.description.replace(/\n/g, ' ')}${agent.status ? `\n  - *Status*: ${agent.status}` : ''}`;
 }
 

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -133,6 +133,7 @@ export const ChatAgent = Symbol('ChatAgent');
 export interface ChatAgent extends Agent {
     locations: ChatAgentLocation[];
     iconClass?: string;
+    status?: string;
     invoke(request: MutableChatRequestModel, chatAgentService?: ChatAgentService): Promise<void>;
 }
 


### PR DESCRIPTION
#### What it does

Add optional `status` field to `ChatAgent`. This allows for instance the `@Orchestrator` and other consumers of `#agents` to consider potential error states of chat agents to drive the decision whether or not to delegate.

This is now used by `@ClaudeCode` chat agent which returns an error message in `status` if neither the `ANTHROPIC_API_KEY` environment variable nor the `ai-features.anthropic.AnthropicApiKey` preference is set.

#### How to test

Unset the environment variable and the API Key preference and observe the output of `#chatAgents`, as used for instance by the `@Orchestrator`.
Set the API Key preference and observe the value again.
Start Theia with the environment variable set, and observe the value again.

#### Follow-ups

We may also want to check whether Claude Code is installed, and reflect this in its `status`.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
