### PR TITLE
fix(ai-google): conditionally include tools in GoogleModel based on functionDeclarations length

### DIFF
--- a/packages/ai-google/src/node/google-language-model.ts
+++ b/packages/ai-google/src/node/google-language-model.ts
@@ -179,9 +179,11 @@ export class GoogleModel implements LanguageModel {
                     systemInstruction: systemMessage,
                     toolConfig,
                     responseModalities: [Modality.TEXT],
-                    tools: [{
-                        functionDeclarations
-                    }],
+                    ...(functionDeclarations.length > 0 && {
+                        tools: [{
+                            functionDeclarations
+                        }]
+                    }),
                     temperature: 1,
                     ...settings
                 },
@@ -382,7 +384,9 @@ export class GoogleModel implements LanguageModel {
                         mode: FunctionCallingConfigMode.AUTO,
                     }
                 },
-                tools: [{ functionDeclarations }],
+                ...(functionDeclarations.length > 0 && {
+                    tools: [{ functionDeclarations }]
+                }),
                 ...settings
             },
             contents: parts


### PR DESCRIPTION
**What it does** 

- Updates the GoogleModel class to conditionally include the tools property only when functionDeclarations is not empty.

Fixes #16479 

**How to test:**
1-Obtain API Key from https://aistudio.google.com/
2-in ai settings add the google api key
3-in the agent settings for orchestrator select the 2.0 flash model
4-call the orchestrator agent

**Prefix:**
<img width="1809" height="882" alt="Prefix theia" src="https://github.com/user-attachments/assets/7c4815e2-824a-454a-989f-144b46bf8ce4" />

**Post fix**


<img width="1848" height="906" alt="postfix theia" src="https://github.com/user-attachments/assets/6b85aa48-c06c-4c07-9eb7-1127fe7283d5" />

**Breaking Changes**

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

**Review checklist**

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

**Reminder for reviewers**

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
