### PR TITLE
Fix vscode plugin activation failed error when it uses an already existing key in its settings

### DIFF
--- a/packages/core/src/common/preferences/preference-schema-service.ts
+++ b/packages/core/src/common/preferences/preference-schema-service.ts
@@ -25,8 +25,8 @@ import { PreferenceUtils } from './preference-provider';
 import { ContributionProvider } from '../contribution-provider';
 import { Deferred } from '../promise-util';
 
-const NO_OVERRIDE = {};
-const OVERRIDE_PROPERTY = '\\[(.*)\\]$';
+export const NO_OVERRIDE = {};
+export const OVERRIDE_PROPERTY = '\\[(.*)\\]$';
 
 @injectable()
 export class PreferenceSchemaServiceImpl implements PreferenceSchemaService {
@@ -345,14 +345,14 @@ export class PreferenceSchemaServiceImpl implements PreferenceSchemaService {
         return this.jsonSchemas[scope];
     }
 
-    private setJSONSchemasProperty(key: string, property: PreferenceDataProperty): void {
+    protected setJSONSchemasProperty(key: string, property: PreferenceDataProperty): void {
         for (const scope of this.validScopes) {
             if (this.isValidInScope(key, scope)) {
                 this.setJSONSchemaProperty(this.jsonSchemas[scope], key, property);
             }
         }
     }
-    private deleteFromJSONSchemas(key: string, property: PreferenceDataProperty): void {
+    protected deleteFromJSONSchemas(key: string, property: PreferenceDataProperty): void {
         for (const scope of this.validScopes) {
             if (this.isValidInScope(key, scope)) {
                 const schema = this.jsonSchemas[scope];
@@ -368,7 +368,7 @@ export class PreferenceSchemaServiceImpl implements PreferenceSchemaService {
         }
     }
 
-    private setJSONSchemaProperty(schema: IJSONSchema, key: string, property: PreferenceDataProperty): void {
+    protected setJSONSchemaProperty(schema: IJSONSchema, key: string, property: PreferenceDataProperty): void {
         // Add property to the schema
         const prop = { ...property, default: this.getDefaultValue(key, undefined) };
         schema.properties![key] = prop;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes: https://github.com/eclipse-theia/theia/issues/16367


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

Follow the steps in the original issue.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

