### PR TITLE
fix(#16288): add filename attribute to localization function

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -388,7 +388,8 @@ export class WorkspaceCommandContribution implements CommandContribution {
         }
         // do not allow recursive rename
         if (!allowNested && !validFilename(name)) {
-            return nls.localizeByDefault('The name **{0}** is not valid as a file or folder name. Please choose a different name.', this.trimFileName(name));
+            return nls.localizeByDefault('The name **{0}** is not valid as a file or folder name. Please choose a different name.', this.trimFileName(name))
+                .replace(/\*\*/g, '');
         }
         if (name.startsWith('/')) {
             return nls.localizeByDefault('A file or folder name cannot start with a slash.');
@@ -402,7 +403,8 @@ export class WorkspaceCommandContribution implements CommandContribution {
         const childUri = parent.resource.resolve(name);
         const exists = await this.fileService.exists(childUri);
         if (exists) {
-            return nls.localizeByDefault('A file or folder **{0}** already exists at this location. Please choose a different name.', this.trimFileName(name));
+            return nls.localizeByDefault('A file or folder **{0}** already exists at this location. Please choose a different name.', this.trimFileName(name))
+                .replace(/\*\*/g, '');
         }
         return '';
     }


### PR DESCRIPTION
#### What it does

Fixes issue #16288 by adding the filename as an attribute to the localization function.
In addition, the `**` around the filename (for bold text formatting) are removed, due to missing Markdown capabilities in dialogs.

#### How to test

Open theia (browser or electron) and any workspace:
1. Try to create or rename a file/directory with an invalid name (like `foo*`)
2. Try to create or rename a file/directory to an already existing file/directory

Expected behaviour:
1. The dialog should show a message, that the name for the file/directory is invalid
2. The dialog should show a message, that the a file/directory with this name already exists.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
