### PR TITLE
fix: migrate to claude agent sdk

### DIFF
--- a/packages/ai-claude-code/src/common/claude-code-service.ts
+++ b/packages/ai-claude-code/src/common/claude-code-service.ts
@@ -94,7 +94,7 @@ export interface ClaudeCodeService {
     handleApprovalResponse(response: ToolApprovalResponseMessage): void;
 }
 
-// Types that match @anthropic-ai/claude-code interfaces
+// Types that match @anthropic-ai/claude-agent-sdk interfaces
 export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
 
 export interface NonNullableUsage {
@@ -158,7 +158,11 @@ export interface RedactedThinkingBlock {
 export interface WebSearchToolResultBlock {
     type: 'web_search_tool_result';
     tool_use_id: string;
-    content: Array<{ title: string; url: string; [key: string]: unknown }>;
+    content: Array<{
+        title: string;
+        url: string;
+        [key: string]: unknown
+    }>;
 }
 
 export type ContentBlock = TextBlock | ToolUseContentBlock | ToolResultBlock | ThinkingBlock | RedactedThinkingBlock | WebSearchToolResultBlock;
@@ -222,7 +226,11 @@ export interface ClaudeCodeOptions {
         signal: AbortController['signal'];
     }) => Promise<{ behavior: 'allow' | 'deny'; message?: string; updatedInput?: unknown }>;
     continue?: boolean;
-    customSystemPrompt?: string;
+    systemPrompt?: string | {
+        type: 'preset';
+        preset: 'claude_code';
+        append?: string;
+    };
     disallowedTools?: string[];
     env?: Record<string, string>;
     executable?: 'bun' | 'deno' | 'node';

--- a/packages/ai-claude-code/src/node/claude-code-service-impl.ts
+++ b/packages/ai-claude-code/src/node/claude-code-service-impl.ts
@@ -90,6 +90,8 @@ export class ClaudeCodeServiceImpl implements ClaudeCodeService {
                 options: <typeof Options>{
                     ...request.options,
                     abortController,
+                    cwd,
+                    settingSources: ['user', 'project', 'local'],
                     canUseTool: (toolName: string, toolInput: unknown) => this.requestToolApproval(streamId, toolName, toolInput),
                     env: { ...process.env, ANTHROPIC_API_KEY: apiKey, NODE_OPTIONS: '' },
                     stderr: (data: unknown) => {
@@ -162,7 +164,7 @@ export class ClaudeCodeServiceImpl implements ClaudeCodeService {
         // Check if file exists before importing
         if (!existsSync(sdkPath)) {
             throw new Error(nls.localize('theia/ai/claude-code/installationNotFoundAt', 'Claude Code installation not found. ' +
-                'Please install with: `npm install -g @anthropic-ai/claude-code` ' +
+                'Please install with: `npm install -g @anthropic-ai/claude-agent-sdk` ' +
                 'and/or specify the path to the executable in the settings. ' +
                 'We looked at {0}', sdkPath));
         }
@@ -179,11 +181,11 @@ export class ClaudeCodeServiceImpl implements ClaudeCodeService {
     protected resolveClaudeCodePath(): string {
         try {
             const globalPath = execSync('npm root -g', { encoding: 'utf8' }).trim();
-            return path.join(globalPath, '@anthropic-ai/claude-code');
+            return path.join(globalPath, '@anthropic-ai/claude-agent-sdk');
         } catch (error) {
             this.logger.error('Failed to resolve global npm path:', error);
             throw new Error(nls.localize('theia/ai/claude-code/installationNotFound', 'Claude Code installation not found. ' +
-                'Please install with: `npm install -g @anthropic-ai/claude-code` ' +
+                'Please install with: `npm install -g @anthropic-ai/claude-agent-sdk` ' +
                 'and/or specify the path to the executable in the settings.'));
         }
     }


### PR DESCRIPTION
Fixes https://github.com/eclipse-theia/theia/issues/16490

#### What it does

Migrates to Claude Agent SDK. This involved fixing a few issues:
* Path of the SDK for lookup and messages to the user
* Adapting how we specify the system message
* Specifying where to load settings from (also to make hooks work again)
* Specifying the cwd explicitly

#### How to test

Test Claude Code in general, and in particular:
* Whether it is aware of the IDE context (like active editor)
* Whether it knows locally configured slash commands (not just completion but also executing them)
* Whether it correctly shows diffs of changes it did (tests whether hooks actually worked)

#### Follow-ups

It might be worth looking through the Agent SDK now more in detail to find out if there is anything we can simplify now, e.g. omit the hooks to track file changes, etc. But nothing that should block merging this PR for now, imho.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
