### PR TITLE
fix: show breakpoints from all active sessions as verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ old behavior and the new view. Default is the old behavior. [#16604](https://git
 
 - [core] `CommonCommands` has been extracted from `common-frontend-contribution.ts` into its own file `common-commands.ts`. This only affects code using deep imports: imports of `CommonCommands` from `@theia/core/lib/browser/common-frontend-contribution` should be updated to use the standard barrel export `@theia/core/lib/browser` instead.
 - [core] `CommonMenus` has been extracted from `common-frontend-contribution.ts` into its own file `common-menus.ts`. This only affects code using deep imports: imports of `CommonMenus` from `@theia/core/lib/browser/common-frontend-contribution` should be updated to use the standard barrel export `@theia/core/lib/browser` instead.
+- [debug] `DebugSessionManager.getFunctionBreakpoints()`, `DebugSessionManager.getInstructionBreakpoints()`, and `DebugSessionManager.getBreakpoints()` no longer default to the current session when called without arguments. Callers that relied on the implicit default to `currentSession` must now pass `this.currentSession` explicitly. [#16537](https://github.com/eclipse-theia/theia/pull/16537)
 - [debug] refactored some of the debug model elements as part of [#16689](https://github.com/eclipse-theia/theia/pull/16689):
   - added required `id` parameter to `DebugStackFrame` and `DebugScope` constructors
   - changed type of keys in the `DebugThread._frames` map from `number` to `string`

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -987,7 +987,11 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             ...options
         };
         const debugWidget = await this.openView({ reveal });
-        debugWidget.sessionManager.currentSession = session;
+        // Only switch to this session if it has a stopped thread
+        // Don't switch to background sessions that are just starting up
+        if (session.currentThread && session.currentThread.stopped) {
+            debugWidget.sessionManager.currentSession = session;
+        }
         return debugWidget['sessionWidget'];
     }
 

--- a/packages/debug/src/browser/model/debug-breakpoint.tsx
+++ b/packages/debug/src/browser/model/debug-breakpoint.tsx
@@ -78,7 +78,7 @@ export abstract class DebugBreakpoint<T extends BaseBreakpoint = BaseBreakpoint>
     }
 
     get verified(): boolean {
-        return !!this.raw ? this.raw.verified : true;
+        return !!this.raw ? this.raw.verified : false;
     }
 
     get message(): string {

--- a/packages/debug/src/browser/view/debug-threads-widget.ts
+++ b/packages/debug/src/browser/view/debug-threads-widget.ts
@@ -16,8 +16,9 @@
 
 import { injectable, inject, postConstruct, interfaces, Container } from '@theia/core/shared/inversify';
 import { MenuPath } from '@theia/core';
-import { TreeNode, NodeProps, SelectableTreeNode } from '@theia/core/lib/browser';
+import { TreeNode, NodeProps, SelectableTreeNode, CompositeTreeNode } from '@theia/core/lib/browser';
 import { SourceTreeWidget, TreeElementNode } from '@theia/core/lib/browser/source-tree';
+import { ExpandableTreeNode } from '@theia/core/lib/browser/tree/tree-expansion';
 import { DebugThreadsSource } from './debug-threads-source';
 import { DebugSession } from '../debug-session';
 import { DebugThread } from '../model/debug-thread';
@@ -65,28 +66,105 @@ export class DebugThreadsWidget extends SourceTreeWidget {
         this.toDispose.push(this.threads);
         this.source = this.threads;
 
-        this.toDispose.push(this.viewModel.onDidChange(() => this.updateWidgetSelection()));
+        this.toDispose.push(this.viewModel.onDidChange(() => {
+            this.updateWidgetSelection();
+        }));
         this.toDispose.push(this.model.onSelectionChanged(() => this.updateModelSelection()));
     }
 
     protected updatingSelection = false;
-    protected updateWidgetSelection(): void {
+    protected async updateWidgetSelection(): Promise<void> {
         if (this.updatingSelection) {
             return;
         }
         this.updatingSelection = true;
         try {
+            await this.model.refresh();
+
             const { currentThread } = this.viewModel;
-            if (currentThread) {
-                const node = this.model.getNode(currentThread.id);
-                if (SelectableTreeNode.is(node)) {
-                    this.model.selectNode(node);
+
+            // Check if current selection still exists in the tree
+            const selectedNode = this.model.selectedNodes[0];
+            const selectionStillValid = selectedNode && this.model.getNode(selectedNode.id);
+
+            // Only update selection if:
+            // 1. Current selection is invalid (node no longer in tree), OR
+            // 2. There's a stopped thread to show
+            if (selectionStillValid && (!currentThread || !currentThread.stopped)) {
+                return;
+            }
+
+            // Try to select the current stopped thread, or clear if none
+            if (currentThread && currentThread.stopped) {
+                const node = await this.waitForNode(currentThread);
+
+                // Re-check stopped state after async wait
+                if (!currentThread.stopped) {
+                    return;
                 }
+
+                if (node && SelectableTreeNode.is(node)) {
+                    this.model.selectNode(node);
+
+                    // Set context key
+                    if (TreeElementNode.is(node)) {
+                        if (node.element instanceof DebugThread) {
+                            this.debugCallStackItemTypeKey.set('thread');
+                        } else if (node.element instanceof DebugSession) {
+                            this.debugCallStackItemTypeKey.set('session');
+                        }
+                    }
+                }
+            } else if (!selectionStillValid) {
+                // Selection is stale and no stopped thread to select
+                this.model.clearSelection();
             }
         } finally {
             this.updatingSelection = false;
         }
     }
+
+    /**
+     * Wait for a node to appear in the tree, expanding root children to populate the tree
+     */
+    protected async waitForNode(thread: DebugThread): Promise<TreeNode | undefined> {
+        const maxAttempts = 10;
+        const delayMs = 50;
+        const threadId = thread.id;
+
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            // If thread continued during wait, abort
+            if (!thread.stopped) {
+                return undefined;
+            }
+
+            await this.model.refresh();
+
+            const root = this.model.root;
+
+            // Expand all root's direct children to populate the tree
+            if (root && CompositeTreeNode.is(root)) {
+                for (const child of root.children) {
+                    if (ExpandableTreeNode.is(child) && !child.expanded) {
+                        await this.model.expandNode(child);
+                    }
+                }
+            }
+
+            // Now look directly for the thread node
+            const threadNode = this.model.getNode(threadId);
+            if (threadNode) {
+                return threadNode;
+            }
+
+            if (attempt < maxAttempts - 1) {
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+            }
+        }
+
+        return undefined;
+    }
+
     protected updateModelSelection(): void {
         if (this.updatingSelection) {
             return;

--- a/packages/debug/src/browser/view/debug-view-model.ts
+++ b/packages/debug/src/browser/view/debug-view-model.ts
@@ -96,14 +96,13 @@ export class DebugViewModel implements Disposable {
             this.fireDidChange();
         }));
         this.toDispose.push(this.manager.onDidChange(current => {
-            if (current === this.currentSession) {
-                this.fireDidChange();
-            }
+            // Always fire change to update views, even if session is not current
+            // This ensures threads view updates for all sessions
+            this.fireDidChange();
         }));
         this.toDispose.push(this.manager.onDidChangeBreakpoints(({ session, uri }) => {
-            if (!session || session === this.currentSession) {
-                this.fireDidChangeBreakpoints(uri);
-            }
+            // Fire for all sessions since we now show breakpoints from all active sessions
+            this.fireDidChangeBreakpoints(uri);
         }));
         this.toDispose.push(this.manager.onDidResolveLazyVariable(({ session, variable }) => {
             if (session === this.currentSession) {
@@ -140,15 +139,15 @@ export class DebugViewModel implements Disposable {
     }
 
     get breakpoints(): DebugSourceBreakpoint[] {
-        return this.manager.getBreakpoints(this.currentSession);
+        return this.manager.getBreakpoints();
     }
 
     get functionBreakpoints(): DebugFunctionBreakpoint[] {
-        return this.manager.getFunctionBreakpoints(this.currentSession);
+        return this.manager.getFunctionBreakpoints();
     }
 
     get instructionBreakpoints(): DebugInstructionBreakpoint[] {
-        return this.manager.getInstructionBreakpoints(this.currentSession);
+        return this.manager.getInstructionBreakpoints();
     }
 
     get dataBreakpoints(): DebugDataBreakpoint[] {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Previously only breakpoints from the current session showed as active in the Breakpoints widget. When running multiple sessions (e.g., frontend + backend), breakpoints verified by other sessions incorrectly appeared unverified.
The Threads widget in the debug view is now readonly.

fixes #14882

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
