### PR TITLE
fix: new terminals will be created in the panel of the clicked button

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -534,7 +534,12 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(TerminalCommands.NEW, {
-            execute: () => this.openTerminal()
+            execute: (widget?: Widget) => {
+                const fromWidget = this.withWidget(widget, terminal => terminal);
+                const ref = fromWidget === false ? this.lastUsedTerminal : fromWidget;
+                const widgetOptions = ref ? { ref, mode: 'tab-after' as const } : undefined;
+                return this.openTerminal(widgetOptions);
+            }
         });
 
         commands.registerCommand(TerminalCommands.PROFILE_NEW, {
@@ -555,7 +560,7 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             execute: () => this.openActiveWorkspaceTerminal()
         });
         commands.registerCommand(TerminalCommands.SPLIT, {
-            execute: () => this.splitTerminal(),
+            execute: (widget?: Widget) => this.withWidget(widget, terminal => this.splitTerminal(terminal)),
             isEnabled: w => this.withWidget(w, () => true),
             isVisible: w => this.withWidget(w, () => true),
         });


### PR DESCRIPTION
#### What it does

Previously, clicking the "Add Terminal" button in the bottom panel would always create a terminal widget in the bottom panel of the "current terminal".

Now, clicking the "Add Terminal" button in a bottom panel will create a terminal widget in the same bottom panel, even when the "current terminal" is in another bottom panel.

Fixes [#16527](https://github.com/eclipse-theia/theia/issues/16527)

#### How to test

1. Open a terminal in the bottom panel.
2. Click the split terminal button on the bottom panel to open a second bottom panel.
3. Click on the terminal in the left panel to focus it.
4. Click on the add terminal button on the right panel

#### Follow-ups
In the function `splitTerminal` (line 1003) of `terminal-frontend-contribution.ts`, the result of the `withWidget` call is checked using the `||` operator instead of an explicit `=== false` comparison.
Since `withWidget` returns a value of type `T | false`, using `=== false` would make the condition clearer and more type-safe.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
