### PR TITLE
feat: migrate Claude Code to Theia native slash commands and modes

### DIFF
--- a/packages/ai-claude-code/src/browser/claude-code-edit-tool-service.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-edit-tool-service.ts
@@ -19,11 +19,11 @@ import { ChangeSetFileElement, ChangeSetFileElementFactory } from '@theia/ai-cha
 import { ChangeSetElement } from '@theia/ai-chat/lib/common/change-set';
 import { ContentReplacerV1Impl, Replacement } from '@theia/core/lib/common/content-replacer';
 import { URI } from '@theia/core/lib/common/uri';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileEditBackupService } from './claude-code-file-edit-backup-service';
-import { nls } from '@theia/core';
+import { ILogger, nls } from '@theia/core';
 
 export interface EditToolInput {
     file_path: string;
@@ -85,6 +85,9 @@ export class ClaudeCodeEditToolServiceImpl implements ClaudeCodeEditToolService 
     @inject(FileEditBackupService)
     protected readonly backupService: FileEditBackupService;
 
+    @inject(ILogger) @named('claude-code')
+    protected readonly logger: ILogger;
+
     private readonly contentReplacer = new ContentReplacerV1Impl();
 
     async handleEditTool(toolUse: ToolUseBlock, request: MutableChatRequestModel, context: EditToolContext): Promise<void> {
@@ -103,7 +106,7 @@ export class ClaudeCodeEditToolServiceImpl implements ClaudeCodeEditToolService 
                     break;
             }
         } catch (error) {
-            console.error('Error handling edit tool:', error);
+            this.logger.error('Error handling edit tool:', error);
         }
     }
 
@@ -140,7 +143,7 @@ export class ClaudeCodeEditToolServiceImpl implements ClaudeCodeEditToolService 
 
             request.session.changeSet.setTitle(nls.localize('theia/ai/claude-code/changeSetTitle', 'Changes by Claude Code'));
         } catch (error) {
-            console.error('Error handling Edit tool:', error);
+            this.logger.error('Error handling Edit tool:', error);
         }
     }
 
@@ -177,7 +180,7 @@ export class ClaudeCodeEditToolServiceImpl implements ClaudeCodeEditToolService 
 
             request.session.changeSet.setTitle(nls.localize('theia/ai/claude-code/changeSetTitle', 'Changes by Claude Code'));
         } catch (error) {
-            console.error('Error handling MultiEdit tool:', error);
+            this.logger.error('Error handling MultiEdit tool:', error);
         }
     }
 
@@ -237,7 +240,7 @@ export class ClaudeCodeEditToolServiceImpl implements ClaudeCodeEditToolService 
 
             request.session.changeSet.setTitle(nls.localize('theia/ai/claude-code/changeSetTitle', 'Changes by Claude Code'));
         } catch (error) {
-            console.error('Error handling Write tool:', error);
+            this.logger.error('Error handling Write tool:', error);
         }
     }
 
@@ -279,7 +282,7 @@ export class ClaudeCodeEditToolServiceImpl implements ClaudeCodeEditToolService 
         );
 
         if (errors.length > 0) {
-            console.error('Content replacement errors:', errors);
+            this.logger.error('Content replacement errors:', errors);
             return;
         }
 

--- a/packages/ai-claude-code/src/browser/claude-code-file-edit-backup-service.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-file-edit-backup-service.ts
@@ -17,10 +17,11 @@
 import { MutableChatRequestModel } from '@theia/ai-chat';
 import { ChangeSetFileElement } from '@theia/ai-chat/lib/browser/change-set-file-element';
 import { URI } from '@theia/core/lib/common/uri';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { CLAUDE_SESSION_ID_KEY } from './claude-code-chat-agent';
+import { ILogger } from '@theia/core';
 
 export const FileEditBackupService = Symbol('FileEditBackupService');
 
@@ -80,6 +81,9 @@ export class FileEditBackupServiceImpl implements FileEditBackupService {
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
+    @inject(ILogger) @named('claude-code')
+    protected readonly logger: ILogger;
+
     getLocation(workspaceRoot: URI): URI {
         // This path structure must match the backup hooks in claude-code-service-impl.ts
         // See ensureFileBackupHook() method which creates backups at:
@@ -107,7 +111,7 @@ export class FileEditBackupServiceImpl implements FileEditBackupService {
                 return backupContent.value.toString();
             }
         } catch (error) {
-            console.error('Error reading backup file:', error);
+            this.logger.error('Error reading backup file:', error);
         }
 
         return undefined;

--- a/packages/ai-claude-code/src/browser/claude-code-slash-commands-contribution.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-slash-commands-contribution.ts
@@ -15,9 +15,9 @@
 // *****************************************************************************
 
 import { PromptService } from '@theia/ai-core/lib/common/prompt-service';
-import { DisposableCollection, nls, URI } from '@theia/core';
+import { DisposableCollection, ILogger, nls, URI } from '@theia/core';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileChangeType } from '@theia/filesystem/lib/common/files';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -65,6 +65,9 @@ export class ClaudeCodeSlashCommandsContribution implements FrontendApplicationC
             description: nls.localize('theia/ai/claude-code/resumeCommand/description', 'Resume a session'),
         }
     ];
+
+    @inject(ILogger) @named('claude-code')
+    protected readonly logger: ILogger;
 
     @inject(PromptService)
     protected readonly promptService: PromptService;
@@ -139,7 +142,7 @@ export class ClaudeCodeSlashCommandsContribution implements FrontendApplicationC
                 commandAgents: [CLAUDE_CHAT_AGENT_ID]
             });
         } catch (error) {
-            console.error(`Failed to register dynamic command ${commandName}:`, error);
+            this.logger.error(`Failed to register Claude Code slash command '${commandName}' from ${fileUri}:`, error);
         }
     }
 


### PR DESCRIPTION
#### What it does

This PR migrates Claude Code to use Theia's native slash command and mode infrastructure, replacing custom Monaco-based completion providers with platform-standard implementations.

1. **Native Slash Command Support**: Migrates from a custom Monaco completion provider to Theia's `PromptService` for registering slash commands
   - Static commands (clear, compact, config, init, memory, review, resume) are registered at startup
   - Dynamic commands are loaded from `.claude/commands/*.md` files with live file watching

2. **Dynamic Command Management**: Implements file system watching for `.claude/commands/` directory
   - Automatically registers new commands when `.md` files are added
   - Updates commands when files are modified
   - Removes commands when files are deleted
   - Handles workspace changes by clearing and re-registering commands

3. **Mode Support**: Adds three operational modes to the Claude Code chat agent
   - "Ask before edit" (default): Requests permission for file modifications
   - "Edit automatically": Automatically applies suggested changes
   - "Plan mode": Plans changes without executing them
   - Integrates with Theia's native `ChatAgent.modes` interface

#### How to test

**Testing Slash Commands:**
1. Open the chat view
2. Type `@ClaudeCode /` and verify all static commands appear (clear, compact, config, init, memory, review, resume)
3. Create a `.claude/commands/` directory in your workspace
4. Add a markdown file (e.g., `test.md`) with command description
5. Verify the command appears in the slash command list without restarting
6. Modify the file name and verify the command updates
7. Delete the file and verify the command is removed
8. Switch to a different workspace and verify commands update accordingly

1. Type `@ClaudeCode /` and verify all static commands *work* (clear, compact, config, init, resume, ...)
2. Try if custom commands work

**Testing Modes:**
1. Open the chat view and type `@ClaudeCode`
3. Locate the mode selector (should show three modes)
4. Test "Ask before edit" mode: Send a request that would modify files and verify permission prompts appear
5. Test "Edit automatically" mode: Send a request and verify changes are applied without prompting
6. Test "Plan mode" mode: Send a request and verify it plans without executing

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
